### PR TITLE
feat: Stage A 기본 primer를 64로 고정하고 dead-air 결과를 문서에 반영

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,20 +125,20 @@ python scripts/train_qlora.py \
 python scripts/generate.py \
   --lora_path ./checkpoints/jazz_lora_stage_a \
   --conditioning_midi ./data/roles/lead/000000/conditioning.mid \
-  --primer_max_tokens 128 \
+  --primer_max_tokens 64 \
   --num_samples 10 \
   --length 512 \
   --max_sequence 512 \
-  --output ./samples/stage_a_p128
+  --output ./samples/stage_a_p64
 ```
 
 ### 3-4. 평가
 
 ```bash
 python scripts/eval_offline_metrics.py \
-  --input ./samples/stage_a_p128 \
+  --input ./samples/stage_a_p64 \
   --dead_air_threshold_ms 180 \
-  --output_json ./samples/stage_a_p128/metrics.json
+  --output_json ./samples/stage_a_p64/metrics.json
 ```
 
 핵심 지표 해석:
@@ -152,7 +152,7 @@ python scripts/eval_offline_metrics.py \
 
 아래 스크립트는 dead-air 개선 실험을 자동으로 수행합니다.
 
-- Primer sweep: `96,128,160`
+- Primer sweep: `64,96,128,160`
 - split_pitch sweep: `55,60,64` (1 epoch 재학습)
 - 베스트 후보 자동 선정 + 재검증(`num_samples=20`)
 - 결과 아카이브 생성
@@ -225,14 +225,30 @@ PY
 
 ## 7) 다음 단계 (MVP 이후)
 
-1. dead-air 최적 조합 고정
-2. 베스트 설정으로 재검증(`num_samples=20`)
+1. `primer_max_tokens=64` 기본값으로 Stage A 생성 유지
+2. 베스트 설정으로 재검증(`num_samples=20`) 주기적으로 재실행
 3. KPI 업데이트 (`docs/JAMBOT_MIDI_REFACTOR_PLAN.md`)
 4. 이후 Stage B 확장(컨디셔닝 토큰 강화)
 
 ---
 
-## 8) 참고 문서
+## 8) 최신 실험 결과 (2026-02-20)
+
+Dead-air 스윕 결과, Stage A 기본 생성 파라미터는 아래로 확정했습니다.
+
+- 모델: `checkpoints/jazz_lora_stage_a`
+- 기본 primer: `--primer_max_tokens 64`
+- Dead-air(20샘플): `0.454905`
+- 비교군 p96(20샘플): `0.482452`
+
+비교(20샘플):
+
+| Candidate | Dead-air | Repetition | Note Density |
+|---|---:|---:|---:|
+| p64 (best, 20 samples) | 0.454905 | 0.019829 | 1.040259 |
+| p96 (20 samples) | 0.482452 | 0.013617 | 0.990787 |
+
+## 9) 참고 문서
 
 - 실행 계획: `docs/JAMBOT_MIDI_REFACTOR_PLAN.md`
 - Magenta RT 참고: `docs/MAGENTA_RT_FINETUNING_GUIDE.md`

--- a/docs/JAMBOT_MIDI_REFACTOR_PLAN.md
+++ b/docs/JAMBOT_MIDI_REFACTOR_PLAN.md
@@ -152,12 +152,32 @@
 - d_model: 256~384
 - n_heads: 4~8
 - context/max_length: 256~512
+- primer_max_tokens: 64 (dead-air 스윕 베스트)
 - batch_size: GPU 상황 기준 최적화
 - LoRA rank: 8~16 (초기 권장)
 
 ---
 
-## 7) 실행 순서 (커밋 단위)
+## 7) Dead-Air 스윕 결과 (2026-02-20)
+
+결과 요약:
+- Best candidate: `p64`
+- 고정 모델: `checkpoints/jazz_lora_stage_a`
+- 고정 생성 파라미터: `--primer_max_tokens 64`
+
+핵심 지표:
+- baseline(기존 stage_a): `avg_dead_air_ratio = 0.534149`
+- p64(20샘플): `avg_dead_air_ratio = 0.454905`
+- p96(20샘플): `avg_dead_air_ratio = 0.482452`
+
+결정:
+1. Stage A 기본 생성값은 `primer_max_tokens=64`로 고정한다.
+2. split_pitch 재학습 계열(`sp52/55/...`)은 현재 기준으로 기본값 채택하지 않는다.
+3. Stage B 전까지는 base LoRA(`jazz_lora_stage_a`) + `p64` 조합을 기준선으로 사용한다.
+
+---
+
+## 8) 실행 순서 (커밋 단위)
 
 1. Commit 1
 - `prepare_role_dataset.py`
@@ -185,7 +205,7 @@
 
 ---
 
-## 8) 리스크 및 대응
+## 9) 리스크 및 대응
 
 - 리스크: 스타일은 붙었지만 실시간성이 깨짐
 - 대응: 모델 크기/컨텍스트를 먼저 줄이고 선생성 길이를 고정
@@ -198,11 +218,10 @@
 
 ---
 
-## 9) 최종 산출물 정의
+## 10) 최종 산출물 정의
 
 - RunPod 학습 자동화 스크립트
 - role-conditioned 데이터 파이프라인
 - 로컬 실시간 MIDI 런타임
 - KPI 리포트(TTFN, dead-air, chord-response)
 - 60초 데모 MIDI/영상(포트폴리오용)
-

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -5,8 +5,9 @@ Stage A usage:
     python scripts/generate.py \
       --lora_path ./checkpoints/jazz_lora \
       --conditioning_midi ./data/roles/lead/000000/conditioning.mid \
+      --primer_max_tokens 64 \
       --num_samples 3 \
-      --length 1024 \
+      --length 512 \
       --output ./samples
 """
 
@@ -183,7 +184,12 @@ def main():
 
     # Generation
     parser.add_argument("--conditioning_midi", type=str, default=None)
-    parser.add_argument("--primer_max_tokens", type=int, default=256)
+    parser.add_argument(
+        "--primer_max_tokens",
+        type=int,
+        default=64,
+        help="Number of conditioning tokens to keep. Stage A default is 64 (dead-air best).",
+    )
     parser.add_argument("--append_sep_token", action="store_true", default=True)
     parser.add_argument("--no_append_sep_token", action="store_false", dest="append_sep_token")
     parser.add_argument("--strip_primer_output", action="store_true", default=True)

--- a/scripts/run_dead_air_sweep.sh
+++ b/scripts/run_dead_air_sweep.sh
@@ -19,9 +19,9 @@ fi
 INPUT_DIR="./midi_dataset/midi/studio/Brad Mehldau"
 BASE_LORA="./checkpoints/jazz_lora_stage_a"
 BASE_COND="./data/roles/lead/000000/conditioning.mid"
-BASELINE_METRICS="./samples/stage_a_p128/metrics.json"
+BASELINE_METRICS="./samples/stage_a/metrics.json"
 
-PRIMER_VALUES="96,128,160"
+PRIMER_VALUES="64,96,128,160"
 SPLIT_VALUES="55,60,64"
 
 NUM_SAMPLES=10
@@ -49,8 +49,8 @@ Options:
   --input_dir <path>                  default: ./midi_dataset/midi/studio/Brad Mehldau
   --base_lora <path>                  default: ./checkpoints/jazz_lora_stage_a
   --base_conditioning <path>          default: ./data/roles/lead/000000/conditioning.mid
-  --baseline_metrics <path>           default: ./samples/stage_a_p128/metrics.json
-  --primer_values <csv>               default: 96,128,160
+  --baseline_metrics <path>           default: ./samples/stage_a/metrics.json
+  --primer_values <csv>               default: 64,96,128,160
   --split_values <csv>                default: 55,60,64
   --num_samples <int>                 default: 10
   --reval_samples <int>               default: 20
@@ -279,4 +279,3 @@ echo "Summary Markdown: $SUMMARY_MD"
 echo "Best candidate: $BEST_LABEL"
 echo "Revalidation metrics: ${REVAL_DIR}/metrics.json"
 echo "Archive: $ARCHIVE_NAME"
-

--- a/scripts/runpod_train_stage_a.sh
+++ b/scripts/runpod_train_stage_a.sh
@@ -11,6 +11,7 @@ TRAIN_EPOCHS=3
 BATCH_SIZE=8
 NUM_WORKERS=0
 MAX_SEQUENCE=512
+PRIMER_MAX_TOKENS=64
 TRANSPOSE_ALL_KEYS="false"
 OVERWRITE="false"
 INSTALL_DEPS="false"
@@ -42,6 +43,7 @@ Options:
   --epochs <int>                             (default: 3)
   --batch_size <int>                         (default: 8)
   --max_sequence <int>                       (default: 512)
+  --primer_max_tokens <int>                  (default: 64)
   --num_workers <int>                        (default: 0)
   --transpose_all_keys                       (flag)
   --overwrite                                (flag)
@@ -63,6 +65,7 @@ while [[ $# -gt 0 ]]; do
     --batch_size) BATCH_SIZE="$2"; shift 2 ;;
     --num_workers) NUM_WORKERS="$2"; shift 2 ;;
     --max_sequence) MAX_SEQUENCE="$2"; shift 2 ;;
+    --primer_max_tokens) PRIMER_MAX_TOKENS="$2"; shift 2 ;;
     --transpose_all_keys) TRANSPOSE_ALL_KEYS="true"; shift 1 ;;
     --overwrite) OVERWRITE="true"; shift 1 ;;
     --install_deps) INSTALL_DEPS="true"; shift 1 ;;
@@ -130,6 +133,7 @@ run_generate() {
   "$PYTHON_BIN" scripts/generate.py \
     --lora_path "$CHECKPOINT_DIR" \
     --conditioning_midi "$conditioning_midi" \
+    --primer_max_tokens "$PRIMER_MAX_TOKENS" \
     --length "$MAX_SEQUENCE" \
     --max_sequence "$MAX_SEQUENCE" \
     --num_samples 5 \


### PR DESCRIPTION
feat: Stage A 기본 primer를 64로 고정하고 dead-air 결과를 문서에 반영

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated with latest experimental results and Stage A configuration recommendations
  * Added structured analysis of optimization findings

* **Changes**
  * Adjusted default generation parameters to optimize primer conditioning and sequence length for improved efficiency
  * Added configurable primer_max_tokens option to generation pipeline

<!-- end of auto-generated comment: release notes by coderabbit.ai -->