### PR TITLE
[codex] Add manifest prepare dry-run harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #9: Manifest-driven role dataset preparation for generic jazz and Brad adaptation splits.
+- Issue #12: Manifest dry-run and control_v1 preparation validation from latest main.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ scripts/
   train_qlora.py                  # lower-level training implementation
   generate.py                     # checkpoint-based MIDI generation
   run_control_v1_tiny_overfit.py  # control_v1 tiny-overfit smoke
+  run_manifest_prepare_smoke.py   # audit -> manifest -> prepare dry-run
   agent_harness.sh                # local validation harness
 
 inference/app/
@@ -109,6 +110,12 @@ python scripts/build_jazz_training_manifests.py
 ```
 
 Generated manifest files are written under `data/manifests/` and are not committed.
+
+Run a small end-to-end dry-run:
+
+```bash
+bash scripts/agent_harness.sh manifest-dry-run
+```
 
 ## Prepare Data
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -77,6 +77,7 @@ Decision:
 - Brad Mehldau dataset audit script
 - full jazz piano dataset audit script
 - audit-based training manifest split builder
+- manifest-based role dataset preparation smoke
 
 ## Full Jazz Piano Dataset Audit
 
@@ -190,6 +191,19 @@ python scripts/prepare_role_dataset.py \
   --sequence_format control_v1 \
   --overwrite
 ```
+
+For a small local contract check before broad training:
+
+```bash
+bash scripts/agent_harness.sh manifest-dry-run
+```
+
+Current smoke result:
+
+- `audit_max_files`: 100
+- generated generic manifest split: train 57, val 10
+- smoke prepare subset: train 4, val 2
+- tokenized output: train 4, val 2
 
 ```bash
 python scripts/prepare_role_dataset.py \

--- a/docs/DATASET_STRATEGY.md
+++ b/docs/DATASET_STRATEGY.md
@@ -196,6 +196,26 @@ python scripts/prepare_role_dataset.py \
 
 In manifest mode, `prepare_role_dataset.py` preserves the explicit train/val boundary and does not reshuffle all candidate files into a new split.
 
+Before broad training, run the small local contract check:
+
+```bash
+bash scripts/agent_harness.sh manifest-dry-run
+```
+
+This writes generated smoke artifacts under `outputs/manifest_prepare_smoke/` and should not be committed.
+
+Current smoke result:
+
+| Step | Result |
+|---|---:|
+| audit max files | 100 |
+| generic manifest train files | 57 |
+| generic manifest val files | 10 |
+| smoke prepare train files | 4 |
+| smoke prepare val files | 2 |
+| tokenized train records | 4 |
+| tokenized val records | 2 |
+
 ## Current Model Order
 
 1. Run full dataset audit. Completed for `midi_dataset/midi`.

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -28,6 +28,8 @@ Modes:
   tiny-prepare  Verify tiny-overfit dataset preparation only.
   tiny-compare  Compare full-model tiny training with random-base LoRA-only.
   control-tiny  Run control_v1 full-model tiny-overfit smoke.
+  manifest-dry-run
+                Run audit -> manifest -> prepare_role_dataset smoke.
   all           Run demo and tiny-compare.
 
 Environment:
@@ -62,6 +64,7 @@ run_quick() {
     scripts/audit_brad_mehldau_dataset.py \
     scripts/audit_jazz_piano_dataset.py \
     scripts/build_jazz_training_manifests.py \
+    scripts/run_manifest_prepare_smoke.py \
     scripts/train_stage_a_full.py \
     scripts/train_stage_a_adapter.py \
     inference/app \
@@ -115,6 +118,17 @@ run_control_tiny() {
     --run_id "$run_id"
 }
 
+run_manifest_dry_run() {
+  local run_id="${RUN_ID:-harness_manifest_prepare}"
+  print_header "Manifest prepare dry-run"
+  "$PYTHON_BIN" scripts/run_manifest_prepare_smoke.py \
+    --run_id "$run_id" \
+    --audit_max_files 100 \
+    --train_files 4 \
+    --val_files 2 \
+    --overwrite
+}
+
 case "$MODE" in
   status)
     run_status
@@ -133,6 +147,9 @@ case "$MODE" in
     ;;
   control-tiny)
     run_control_tiny
+    ;;
+  manifest-dry-run)
+    run_manifest_dry_run
     ;;
   all)
     run_demo

--- a/scripts/prepare_role_dataset.py
+++ b/scripts/prepare_role_dataset.py
@@ -456,7 +456,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     summary = {
         "role": args.role,
         "input_mode": input_mode,
-        "input_dir": str(input_dir),
+        "input_dir": str(input_dir) if input_mode == "directory" else None,
         "train_manifest": args.train_manifest,
         "val_manifest": args.val_manifest,
         "input_file_count": total_input_files,

--- a/scripts/run_manifest_prepare_smoke.py
+++ b/scripts/run_manifest_prepare_smoke.py
@@ -1,0 +1,169 @@
+"""
+Run a small audit -> manifest -> role-dataset preparation smoke test.
+
+This is a local contract check before broad training. It verifies that the
+manifest split builder and prepare_role_dataset.py agree on train/val inputs
+and produce tokenized control_v1 records.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def run_command(command: Sequence[str]) -> None:
+    print("+ " + " ".join(str(part) for part in command))
+    subprocess.run(command, cwd=ROOT_DIR, check=True)
+
+
+def read_manifest_paths(path: Path) -> list[str]:
+    return [
+        line.strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+
+def write_limited_manifest(source: Path, target: Path, limit: int) -> int:
+    paths = read_manifest_paths(source)
+    selected = paths[: max(0, int(limit))]
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("".join(f"{path}\n" for path in selected), encoding="utf-8")
+    return len(selected)
+
+
+def count_npy_files(path: Path) -> int:
+    return len(sorted(path.glob("*.npy")))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run manifest-based role dataset preparation smoke")
+    parser.add_argument("--output_root", type=str, default="./outputs/manifest_prepare_smoke")
+    parser.add_argument("--run_id", type=str, default="default")
+    parser.add_argument("--audit_max_files", type=int, default=100)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--train_files", type=int, default=4)
+    parser.add_argument("--val_files", type=int, default=2)
+    parser.add_argument("--sequence_format", type=str, default="control_v1")
+    parser.add_argument("--overwrite", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_dir = Path(args.output_root) / args.run_id
+    if run_dir.exists():
+        if not args.overwrite:
+            raise FileExistsError(f"Run directory already exists: {run_dir}. Use --overwrite.")
+        shutil.rmtree(run_dir)
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    audit_dir = run_dir / "audit"
+    manifests_dir = run_dir / "manifests"
+    smoke_manifests_dir = run_dir / "smoke_manifests"
+    roles_dir = run_dir / "roles"
+
+    audit_json = audit_dir / "jazz_piano_dataset_audit.json"
+    audit_md = audit_dir / "jazz_piano_dataset_audit.md"
+    run_command(
+        [
+            sys.executable,
+            "scripts/audit_jazz_piano_dataset.py",
+            "--max_files",
+            str(args.audit_max_files),
+            "--output_json",
+            str(audit_json),
+            "--output_md",
+            str(audit_md),
+        ]
+    )
+
+    run_command(
+        [
+            sys.executable,
+            "scripts/build_jazz_training_manifests.py",
+            "--audit_json",
+            str(audit_json),
+            "--output_dir",
+            str(manifests_dir),
+            "--seed",
+            str(args.seed),
+        ]
+    )
+
+    train_manifest = smoke_manifests_dir / "generic_jazz_train.txt"
+    val_manifest = smoke_manifests_dir / "generic_jazz_val.txt"
+    train_selected = write_limited_manifest(
+        manifests_dir / "generic_jazz_train.txt",
+        train_manifest,
+        args.train_files,
+    )
+    val_selected = write_limited_manifest(
+        manifests_dir / "generic_jazz_val.txt",
+        val_manifest,
+        args.val_files,
+    )
+    if train_selected <= 0:
+        raise ValueError("Smoke train manifest is empty")
+    if val_selected <= 0:
+        raise ValueError("Smoke val manifest is empty")
+
+    run_command(
+        [
+            sys.executable,
+            "scripts/prepare_role_dataset.py",
+            "--train_manifest",
+            str(train_manifest),
+            "--val_manifest",
+            str(val_manifest),
+            "--output_dir",
+            str(roles_dir),
+            "--role",
+            "lead",
+            "--sequence_format",
+            str(args.sequence_format),
+            "--overwrite",
+        ]
+    )
+
+    role_root = roles_dir / "lead"
+    dataset_summary_path = role_root / "dataset_summary.json"
+    dataset_summary = json.loads(dataset_summary_path.read_text(encoding="utf-8"))
+    tokenized_train = count_npy_files(role_root / "tokenized" / "train")
+    tokenized_val = count_npy_files(role_root / "tokenized" / "val")
+    if tokenized_train <= 0:
+        raise ValueError("No tokenized train records produced")
+    if tokenized_val <= 0:
+        raise ValueError("No tokenized val records produced")
+
+    summary = {
+        "run_dir": str(run_dir),
+        "audit_json": str(audit_json),
+        "manifests_dir": str(manifests_dir),
+        "smoke_train_manifest": str(train_manifest),
+        "smoke_val_manifest": str(val_manifest),
+        "roles_dir": str(roles_dir),
+        "audit_max_files": int(args.audit_max_files),
+        "selected_train_files": int(train_selected),
+        "selected_val_files": int(val_selected),
+        "tokenized_train": int(tokenized_train),
+        "tokenized_val": int(tokenized_val),
+        "dataset_summary": dataset_summary,
+    }
+    summary_path = run_dir / "manifest_prepare_smoke_summary.json"
+    summary_path.write_text(json.dumps(summary, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_control_tokens.py
+++ b/tests/test_control_tokens.py
@@ -163,6 +163,7 @@ class ControlTokensTest(unittest.TestCase):
             metas = [json.loads(path.read_text(encoding="utf-8")) for path in sorted(role_root.glob("*/meta.json"))]
 
         self.assertEqual(summary["input_mode"], "manifest")
+        self.assertIsNone(summary["input_dir"])
         self.assertEqual(summary["input_split_file_counts"], {"train": 1, "val": 1})
         self.assertEqual(summary["train_samples"], 1)
         self.assertEqual(summary["val_samples"], 1)

--- a/tests/test_manifest_prepare_smoke.py
+++ b/tests/test_manifest_prepare_smoke.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.run_manifest_prepare_smoke import read_manifest_paths, write_limited_manifest
+
+
+class ManifestPrepareSmokeTest(unittest.TestCase):
+    def test_read_manifest_paths_skips_comments_and_blanks(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            manifest = Path(tmp_dir) / "manifest.txt"
+            manifest.write_text(
+                """
+# comment
+a.mid
+
+b.midi
+""".strip(),
+                encoding="utf-8",
+            )
+
+            paths = read_manifest_paths(manifest)
+
+        self.assertEqual(paths, ["a.mid", "b.midi"])
+
+    def test_write_limited_manifest_keeps_requested_prefix(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            source = root / "source.txt"
+            target = root / "nested" / "target.txt"
+            source.write_text("a.mid\nb.mid\nc.mid\n", encoding="utf-8")
+
+            count = write_limited_manifest(source, target, 2)
+
+            self.assertEqual(count, 2)
+            self.assertEqual(target.read_text(encoding="utf-8"), "a.mid\nb.mid\n")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `scripts/run_manifest_prepare_smoke.py` to validate the local audit -> manifest -> role dataset preparation contract.
- Add `bash scripts/agent_harness.sh manifest-dry-run` for repeatable smoke execution.
- Verify that a limited generic train/val manifest produces tokenized `control_v1` train/val records.
- Record the current dry-run result in docs and keep generated outputs under `outputs/`.
- Clean up manifest-mode `dataset_summary.input_dir` so it is `null` instead of the unused default Brad path.

## Validation

- `./.venv/bin/python -m unittest tests.test_control_tokens tests.test_manifest_prepare_smoke`
- `bash scripts/agent_harness.sh quick`
- `RUN_ID=issue12_smoke bash scripts/agent_harness.sh manifest-dry-run`

## Dry-run result

- audit max files: 100
- generic manifest split: train 57, val 10
- smoke prepare subset: train 4, val 2
- tokenized output: train 4, val 2

Generated artifacts are under `outputs/manifest_prepare_smoke/` and are not committed.