### PR TITLE
[codex] Document Brad control_v1 probe and tighten Stage A gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #12: Manifest dry-run and control_v1 preparation validation from latest main.
+- Issue #13: Brad 2-file control_v1 training probe and Stage A review decision.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-8-brad-mehldau-control-v1-training-probe`
+- `issue-13-control-v1-brad-probe2`
 
 현재 범위가 아닌 것:
 
@@ -33,6 +33,33 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 - sparse/medium 일부에서 chord-tone 반응이 약함
 
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
+
+## Latest Probe Result
+
+Issue #13에서 Brad Mehldau real MIDI 2파일로 `control_v1` prepare/train/generate probe를 실행했다.
+
+Result:
+
+- dataset prepare 성공: train 1 sample, val 1 sample
+- 5 epoch full-checkpoint training 성공
+- 100 epoch full-checkpoint training 성공
+- best observed val loss: `4.1306` at epoch `70`
+- generation 실패:
+  - 5 epoch `top_k=1`: all 0 notes
+  - 5 epoch `top_k=32`: 0/1/2-note outputs
+  - 100 epoch `top_k=1`: repeated one-note outputs
+  - 100 epoch `top_k=32`: long sustain or only 5 notes
+
+Decision:
+
+- Stage A `control_v1`은 runnable pipeline으로는 검증됐다.
+- 하지만 reviewable jazz solo MIDI generator로는 실패했다.
+- broad generic jazz training으로 바로 넘어가지 않는다.
+- 다음은 Stage B duration-explicit, bar-position-aware tokenization과 phrase/window dataset 설계다.
+
+Detail:
+
+- `docs/STAGE_A_BRAD_PROBE2_2026-05-18.md`
 
 ## Dataset Strategy
 
@@ -150,6 +177,16 @@ Decision:
 
 ## Next Execution Plan
 
+### 0. Completed Issue #13 review point
+
+Brad 2-file `control_v1` probe는 완료됐다.
+
+Current conclusion:
+
+- 더 많은 postprocess로 해결할 단계가 아니다.
+- 현 `control_v1` full-song continuation은 solo-line generation representation으로 약하다.
+- next issue는 Stage B tokenization spec/tests로 잡는다.
+
 ### 1. Run full jazz piano dataset audit
 
 ```bash
@@ -215,11 +252,9 @@ python scripts/prepare_role_dataset.py \
   --overwrite
 ```
 
-Expected result:
+Status:
 
-- `data/roles_probe2/lead/dataset_summary.json`
-- `data/roles_probe2/lead/tokenized/train/*.npy`
-- `data/roles_probe2/lead/tokenized/val/*.npy`
+- completed in issue #13 under `outputs/issue13_control_v1_brad_probe2/roles_probe2`
 
 ### 3. Train 2-file control_v1 probe
 
@@ -233,16 +268,20 @@ python scripts/train_stage_a_full.py \
   --max_sequence 512
 ```
 
-Goal:
+Status:
 
-- verify loader/checkpoint path
-- verify control-aware crop does not crash
-- generate a sample checkpoint
-- avoid spending GPU time before the local contract is clear
+- completed in issue #13
+- e5 and e100 checkpoints generated locally under `outputs/issue13_control_v1_brad_probe2/`
+- generated artifacts are not committed
 
 ### 4. Generate and inspect samples
 
 Use the trained checkpoint with `scripts/generate.py` or the inference wrapper.
+
+Status:
+
+- completed in issue #13
+- all generated samples failed the review gate
 
 The sample is not valid unless it passes:
 
@@ -257,15 +296,15 @@ The sample is not valid unless it passes:
 
 ### 5. Review point
 
-Pause for review after the 2-file probe generates MIDI.
+Review completed after the 2-file probe generated MIDI.
 
-At that point decide:
+Decision:
 
-- continue to `max_files=5`
-- run full 18-file Brad probe
-- build generic non-Brad manifest for jazz pianist base
-- change crop/windowing
+- do not continue to `max_files=5` on current `control_v1`
+- do not run full 18-file Brad probe on current `control_v1`
+- do not start broad generic non-Brad training yet
 - move to duration-explicit tokenization
+- create phrase/window dataset before the next training run
 
 ## Active References
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,8 @@
   - tiny-overfit smoke 실행 방법과 통과/실패 판단 기준.
 - `STAGE_A_CODE_REVIEW_2026-05-18.md`
   - sustain block/chord block MIDI가 나온 원인과 다음 수정 방향.
+- `STAGE_A_BRAD_PROBE2_2026-05-18.md`
+  - Brad 2-file `control_v1` training/generation probe 결과와 Stage B 전환 판단.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -44,9 +46,9 @@
 
 1. Full jazz piano corpus audit 결과를 기준으로 generic base 후보 데이터를 확인한다.
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
-3. `max_files=2`로 `control_v1` prepare/training probe를 실행해 tokenizer와 training loop를 먼저 검증한다.
-4. 생성 MIDI를 note count, unique pitch, phrase coverage, max duration, simultaneous notes 기준으로 검증한다.
-5. MIDI가 여전히 sustain/chord block이면 broad training 전에 duration-explicit tokenization으로 넘어간다.
+3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
+4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
+5. Stage B tiny-overfit와 2-file probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_A_BRAD_PROBE2_2026-05-18.md
+++ b/docs/STAGE_A_BRAD_PROBE2_2026-05-18.md
@@ -1,0 +1,184 @@
+# Stage A Brad Probe 2: 2026-05-18
+
+## Purpose
+
+This probe checks whether the current Stage A `control_v1` path can learn reviewable jazz solo MIDI from two real Brad Mehldau MIDI files.
+
+The goal is not to prove style quality. The goal is narrower:
+
+- verify role dataset preparation from real Brad files
+- verify full-checkpoint training runs
+- verify generation produces valid MIDI notes
+- decide whether to continue `control_v1` broad training or move to Stage B tokenization
+
+## Dataset
+
+Command:
+
+```bash
+python scripts/prepare_role_dataset.py \
+  --input_dir "./midi_dataset/midi/studio/Brad Mehldau" \
+  --output_dir outputs/issue13_control_v1_brad_probe2/roles_probe2 \
+  --role lead \
+  --sequence_format control_v1 \
+  --max_files 2 \
+  --overwrite
+```
+
+Result:
+
+| Metric | Value |
+|---|---:|
+| input files | 2 |
+| role samples | 2 |
+| train samples | 1 |
+| val samples | 1 |
+| tokenized train | 1 |
+| tokenized val | 1 |
+
+Source files:
+
+| Sample | Source | Conditioning notes | Target notes |
+|---|---|---:|---:|
+| `000000` | `From This Moment On.midi` | 1122 | 1514 |
+| `000001` | `Ron's Place.midi` | 690 | 1007 |
+
+## Training Runs
+
+Both runs used:
+
+- `scripts/train_stage_a_full.py`
+- `control_v1`
+- batch size `1`
+- `max_sequence=192`
+- model size `n_layers=2`, `num_heads=4`, `d_model=128`, `dim_feedforward=256`
+- seed `17`
+
+### 5 Epoch Probe
+
+Output:
+
+```text
+outputs/issue13_control_v1_brad_probe2/checkpoints_probe2_e5
+```
+
+| Epoch | Train loss | Val loss |
+|---:|---:|---:|
+| 1 | 6.1791 | 6.0357 |
+| 5 | 5.5781 | 5.5039 |
+
+### 100 Epoch Probe
+
+Output:
+
+```text
+outputs/issue13_control_v1_brad_probe2/checkpoints_probe2_e100
+```
+
+| Epoch | Train loss | Val loss |
+|---:|---:|---:|
+| 1 | 6.1791 | 6.0357 |
+| 10 | 4.8474 | 4.9899 |
+| 50 | 2.8408 | 4.4941 |
+| 70 | 3.2461 | 4.1306 |
+| 100 | 2.5513 | 4.6690 |
+
+Best observed val loss was `4.1306` at epoch `70`.
+
+## Generation Results
+
+The generated files are local artifacts under:
+
+```text
+outputs/issue13_control_v1_brad_probe2/
+```
+
+They are not committed.
+
+### 5 Epoch, `top_k=1`
+
+All three generated samples had zero notes.
+
+| File | Valid | Reason | Notes |
+|---|---|---|---:|
+| `jazz_sample_1.mid` | no | generated MIDI has no notes | 0 |
+| `jazz_sample_2.mid` | no | generated MIDI has no notes | 0 |
+| `jazz_sample_3.mid` | no | generated MIDI has no notes | 0 |
+
+### 5 Epoch, `top_k=32`
+
+The samples were still not reviewable.
+
+| File | Valid | Reason | Notes |
+|---|---|---|---:|
+| `jazz_sample_1.mid` | no | generated MIDI has no notes | 0 |
+| `jazz_sample_2.mid` | no | note count too low | 1 |
+| `jazz_sample_3.mid` | no | note count too low | 2 |
+
+### 100 Epoch, `top_k=1`
+
+All three deterministic samples collapsed to a one-note phrase.
+
+| File | Valid | Reason | Notes | Unique pitches |
+|---|---|---|---:|---:|
+| `jazz_sample_1.mid` | no | note count too low | 1 | 1 |
+| `jazz_sample_2.mid` | no | note count too low | 1 | 1 |
+| `jazz_sample_3.mid` | no | note count too low | 1 | 1 |
+
+### 100 Epoch, `top_k=32`
+
+This was the strongest run, but it still failed the Stage A review gate.
+
+| File | Valid | Reason | Notes | Unique pitches | Coverage | Max duration ratio | Max simultaneous |
+|---|---|---|---:|---:|---:|---:|---:|
+| `jazz_sample_1.mid` | no | note duration too long | 6 | 6 | 1.000 | 0.705 | 3 |
+| `jazz_sample_2.mid` | no | note duration too long | 6 | 5 | 0.832 | 0.677 | 3 |
+| `jazz_sample_3.mid` | no | note count too low | 5 | 5 | 1.000 | 0.276 | 2 |
+
+`jazz_sample_3.mid` previously slipped through the medium numeric gate because the old minimum was only four notes for two bars. The gate now requires at least six notes for a two-bar medium phrase.
+
+## Quality Gate Change
+
+Changed medium density minimum note count from `2.0` notes per bar to `3.0` notes per bar.
+
+For the default two-bar phrase:
+
+- old medium minimum: 4 notes
+- new medium minimum: 6 notes
+
+This prevents five-note two-bar MIDI files from being treated as reviewable solo-line samples.
+
+## Decision
+
+The current Stage A `control_v1` path is validated as a runnable pipeline, but not as a usable jazz solo generator.
+
+What worked:
+
+- real Brad files can be converted into role-conditioned samples
+- tokenized train/val records are produced
+- full-checkpoint training runs locally
+- checkpoint generation runs
+- metrics and gates catch empty, one-note, long-duration, and too-sparse outputs
+
+What failed:
+
+- 5-epoch generation produced no usable notes
+- 100-epoch deterministic generation collapsed to one note
+- sampled generation still produced long sustain blocks or too few notes
+- the output is not a solo line and is not useful for musical review
+
+## Next Move
+
+Do not expand to broad generic jazz training on the current `control_v1` representation yet.
+
+The next technical issue should be Stage B tokenization:
+
+- explicit `BAR`
+- explicit `POSITION`
+- explicit `CHORD`
+- explicit `NOTE_PITCH`
+- explicit `NOTE_DURATION`
+- optional `VELOCITY`
+- phrase/window dataset instead of full-song target continuation
+
+The failure mode points to representation and dataset-windowing, not to another postprocess tweak.

--- a/inference/app/metrics.py
+++ b/inference/app/metrics.py
@@ -18,7 +18,7 @@ DENSITY_MIN = {
 
 MIN_NOTES_PER_BAR = {
     "sparse": 1.5,
-    "medium": 2.0,
+    "medium": 3.0,
     "dense": 4.0,
 }
 

--- a/tests/test_request_conditioning.py
+++ b/tests/test_request_conditioning.py
@@ -154,6 +154,32 @@ class RequestConditioningTest(unittest.TestCase):
         self.assertFalse(valid)
         self.assertIn("unique pitch count too low", str(reason))
 
+    def test_medium_validation_rejects_five_note_two_bar_phrase(self) -> None:
+        metrics = GenerationMetrics(
+            generation_time_ms=100,
+            note_count=5,
+            duration_sec=4.0,
+            note_density=1.25,
+            dead_air_ratio=0.2,
+            repetition_score=0.0,
+            pitch_min=60,
+            pitch_max=74,
+            fallback_used=False,
+            unique_pitch_count=5,
+            unique_pitch_class_count=4,
+            expected_duration_sec=4.0,
+            phrase_coverage_ratio=1.0,
+            max_note_duration_sec=1.0,
+            max_note_duration_ratio=0.25,
+            long_note_ratio=0.0,
+            max_simultaneous_notes=2,
+        )
+
+        valid, reason = validate_metrics(metrics, "medium", bars=2)
+
+        self.assertFalse(valid)
+        self.assertIn("note count too low", str(reason))
+
     def test_medium_validation_rejects_clustered_phrase_with_low_coverage(self) -> None:
         metrics = GenerationMetrics(
             generation_time_ms=100,
@@ -231,9 +257,9 @@ class RequestConditioningTest(unittest.TestCase):
     def test_medium_validation_rejects_dead_air_at_threshold(self) -> None:
         metrics = GenerationMetrics(
             generation_time_ms=100,
-            note_count=4,
+            note_count=6,
             duration_sec=3.0,
-            note_density=1.33,
+            note_density=2.0,
             dead_air_ratio=0.8,
             repetition_score=0.0,
             pitch_min=60,


### PR DESCRIPTION
## Summary

- Document the Brad 2-file `control_v1` Stage A probe result in `docs/STAGE_A_BRAD_PROBE2_2026-05-18.md`.
- Update the current status docs to record that Stage A is runnable but not producing reviewable jazz solo MIDI.
- Tighten the medium-density MIDI quality gate from 2.0 to 3.0 notes per bar so a two-bar medium phrase now requires at least six notes.
- Add a regression test so five-note two-bar MIDI samples no longer pass as reviewable output.

## Why

The Brad 2-file probe showed that the current `control_v1` path can prepare data, train, and generate files, but the generated MIDI still collapses into empty, one-note, too-sparse, or long-sustain outputs. This PR records that decision point and prevents weak five-note samples from being accepted by the review gate.

## Validation

- `./.venv/bin/python -m unittest tests.test_request_conditioning`
- `bash scripts/agent_harness.sh quick`
- `bash scripts/agent_harness.sh demo`

## Next

After this merges, the next branch should start Stage B tokenization work: explicit `BAR`, `POSITION`, `CHORD`, `NOTE_PITCH`, `NOTE_DURATION`, optional `VELOCITY`, and phrase/window dataset preparation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Stage A probe validation results and findings.
  * Updated tracking information with probe decision and next execution plan.

* **Bug Fixes**
  * Increased minimum note density requirement for "medium" setting from 2.0 to 3.0 notes per bar.

* **Tests**
  * Added validation test for note count threshold enforcement.
  * Updated existing validation test parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohhalim/fine_tuning_art-tatum_midi_solo/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->