### PR TITLE
[codex] Define Stage B tokenization contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #13: Brad 2-file control_v1 training probe and Stage A review decision.
+- Issue #14: Stage B duration-explicit tokenization spec and tokenizer contract.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -1,6 +1,6 @@
 # Current Status and Plan
 
-작성일: 2026-05-18
+작성일: 2026-05-19
 
 ## Current Focus
 
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-13-control-v1-brad-probe2`
+- `issue-14-stage-b-tokenization-spec`
 
 현재 범위가 아닌 것:
 
@@ -60,6 +60,22 @@ Decision:
 Detail:
 
 - `docs/STAGE_A_BRAD_PROBE2_2026-05-18.md`
+
+## Active Issue #14
+
+Current task:
+
+- define Stage B duration-explicit tokenization
+- keep Stage B separate from Stage A `control_v1` until the tokenizer contract is tested
+- add unit tests for token ranges, chord parsing, quantized note encoding, and roundtrip decoding
+
+First implementation target:
+
+- `scripts/stage_b_tokens.py`
+- `tests/test_stage_b_tokens.py`
+- `docs/STAGE_B_TOKENIZATION_SPEC.md`
+
+Do not start broad training in this issue.
 
 ## Dataset Strategy
 
@@ -186,6 +202,27 @@ Current conclusion:
 - 더 많은 postprocess로 해결할 단계가 아니다.
 - 현 `control_v1` full-song continuation은 solo-line generation representation으로 약하다.
 - next issue는 Stage B tokenization spec/tests로 잡는다.
+
+### 0.5. Issue #14 Stage B tokenizer contract
+
+Status:
+
+- initial tokenizer contract implemented on `issue-14-stage-b-tokenization-spec`
+
+Goal:
+
+- define `stage_b_v1`
+- encode note events as explicit `POSITION + VELOCITY + NOTE_PITCH + NOTE_DURATION`
+- include bar-level chord context with `CHORD_ROOT + CHORD_QUALITY`
+- prove encode/decode roundtrip on tiny deterministic notes
+
+Acceptance:
+
+- Stage B token IDs start after existing Stage A control tokens
+- chord symbols such as `Cm7`, `F7`, `Bbmaj7`, `F#m7b5` parse into stable tokens
+- generated token sequence contains explicit duration tokens
+- roundtrip preserves quantized pitch/start/end on a small example
+- `bash scripts/agent_harness.sh quick` passes
 
 ### 1. Run full jazz piano dataset audit
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,8 @@
   - sustain block/chord block MIDI가 나온 원인과 다음 수정 방향.
 - `STAGE_A_BRAD_PROBE2_2026-05-18.md`
   - Brad 2-file `control_v1` training/generation probe 결과와 Stage B 전환 판단.
+- `STAGE_B_TOKENIZATION_SPEC.md`
+  - duration-explicit, bar-position-aware Stage B tokenization contract.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`

--- a/docs/STAGE_B_TOKENIZATION_SPEC.md
+++ b/docs/STAGE_B_TOKENIZATION_SPEC.md
@@ -1,0 +1,166 @@
+# Stage B Tokenization Spec
+
+작성일: 2026-05-19
+
+## Purpose
+
+Stage B replaces the Stage A `NOTE_ON` / `NOTE_OFF` continuation format for the next model probe.
+
+The Stage A Brad 2-file probe proved that the pipeline can run, but generation still collapsed into empty MIDI, one-note phrases, sparse fragments, or long sustain blocks. The next fix is not more postprocess. The next fix is an explicit symbolic representation.
+
+Stage B must make these musical facts directly visible to the model:
+
+- bar boundary
+- position inside bar
+- chord context
+- note pitch
+- note duration
+- velocity
+
+## Non-Goals
+
+Do not implement these in the first Stage B issue:
+
+- broad generic jazz training
+- full 18-file Brad training
+- DAW/realtime integration
+- natural-language prompting
+- artist-clone product wording
+- compound-word Transformer architecture
+
+The first objective is a tokenizer contract and tiny roundtrip tests.
+
+## Format Name
+
+```text
+stage_b_v1
+```
+
+## Token Families
+
+Stage B keeps existing Stage A control tokens for role and tempo, then adds a separate token range after the Stage A control-token range.
+
+Current implementation file:
+
+```text
+scripts/stage_b_tokens.py
+```
+
+Core families:
+
+| Family | Meaning |
+|---|---|
+| `BAR` | Reuses existing `TOKEN_BAR` |
+| `POSITION_*` | 16th-note grid position inside a 4/4 bar |
+| `CHORD_ROOT_*` | `C`, `C#`, `D`, ..., `B`, or `N` |
+| `CHORD_QUALITY_*` | `maj`, `min`, `dom7`, `maj7`, `min7`, `dim`, `halfdim`, `sus`, `unknown` |
+| `NOTE_PITCH_*` | Piano pitch range `21..108` |
+| `NOTE_DURATION_*` | Explicit duration in 16th-note steps |
+| `VELOCITY_*` | 8 velocity bins |
+| `END` | Existing `TOKEN_END` |
+
+## Sequence Layout
+
+For a target phrase:
+
+```text
+ROLE_LEAD
+TEMPO_*
+BAR
+CHORD_ROOT_*
+CHORD_QUALITY_*
+POSITION_*
+VELOCITY_*
+NOTE_PITCH_*
+NOTE_DURATION_*
+...
+BAR
+CHORD_ROOT_*
+CHORD_QUALITY_*
+...
+END
+```
+
+Notes are encoded as a four-token group:
+
+```text
+POSITION_* VELOCITY_* NOTE_PITCH_* NOTE_DURATION_*
+```
+
+This is intentionally simple. It is not yet optimized for sequence length. The immediate goal is to remove ambiguous `NOTE_OFF` learning from the model path.
+
+## Quantization
+
+Initial defaults:
+
+| Setting | Value |
+|---|---:|
+| time signature | `4/4` only |
+| positions per bar | `16` |
+| max duration steps | `16` |
+| velocity bins | `8` |
+| pitch range | `A0..C8` / MIDI `21..108` |
+
+At 120 BPM:
+
+- 1 bar = 2.0 seconds
+- 1 position step = 0.125 seconds
+- a 0.25 second note becomes `NOTE_DURATION_2`
+
+Long durations are clamped at `NOTE_DURATION_16` in the tokenizer. Musical validity is still checked later by metrics gates.
+
+## Chord Handling
+
+Chord symbols are parsed into root and quality tokens.
+
+Examples:
+
+| Chord | Tokens |
+|---|---|
+| `Cm7` | `CHORD_ROOT_C`, `CHORD_QUALITY_min7` |
+| `F7` | `CHORD_ROOT_F`, `CHORD_QUALITY_dom7` |
+| `Bbmaj7` | `CHORD_ROOT_Bb`, `CHORD_QUALITY_maj7` |
+| `F#m7b5` | `CHORD_ROOT_F#`, `CHORD_QUALITY_halfdim` |
+| missing/unknown | `CHORD_ROOT_N`, `CHORD_QUALITY_unknown` |
+
+For request-conditioned generation, chords come from the request.
+
+For raw MIDI dataset preparation, chord labels may be unavailable. The first Stage B dataset builder can use `N/unknown` for dataset-only probes, then add chord inference or lead-sheet metadata later.
+
+## Why This Should Fix The Current Failure
+
+Stage A failure:
+
+- note duration depends on correct future `NOTE_OFF`
+- bar position is implicit in accumulated `TIME_SHIFT`
+- chord context is mostly hidden in primer MIDI
+- long full-song streams force cropping and weak local context
+
+Stage B response:
+
+- duration is a direct token
+- onset position is a direct token
+- chord is a direct token
+- phrase/window data can be short and stable
+- decoder can build notes without pairing `NOTE_ON` and `NOTE_OFF`
+
+## Acceptance Criteria
+
+Issue #14 is complete when:
+
+- `scripts/stage_b_tokens.py` defines stable Stage B token ranges.
+- Stage B token IDs do not overlap Stage A control tokens.
+- A small note list can encode into `stage_b_v1`.
+- The encoded sequence includes `BAR`, `POSITION`, `CHORD`, `NOTE_PITCH`, `NOTE_DURATION`, and `VELOCITY`.
+- A simple roundtrip test decodes quantized notes with correct pitch/start/end.
+- Current Stage A tests still pass.
+
+## Next Issue After Spec
+
+After this spec and tokenizer contract are merged, the next issue should build:
+
+- phrase/window dataset extraction
+- `prepare_role_dataset.py --sequence_format stage_b_v1`
+- target-only training loss if conditioning is prepended
+- Stage B tiny-overfit smoke
+- Brad 2-file Stage B probe

--- a/scripts/stage_b_tokens.py
+++ b/scripts/stage_b_tokens.py
@@ -1,0 +1,353 @@
+"""Stage B duration-explicit symbolic MIDI tokens.
+
+Stage B is intentionally separate from the Stage A NOTE_ON/NOTE_OFF event
+stream. It uses explicit bar, position, chord, pitch, duration, and velocity
+tokens so a model does not need to infer note endings from NOTE_OFF events.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+import pretty_midi
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPT_DIR / "music_transformer"))
+sys.path.insert(0, str(SCRIPT_DIR / "music_transformer" / "third_party"))
+
+from utilities.constants import TOKEN_BAR, TOKEN_CONTROL_END, TOKEN_END  # noqa: E402
+
+try:
+    from control_tokens import control_prefix_tokens
+except ModuleNotFoundError:
+    from scripts.control_tokens import control_prefix_tokens
+
+
+SEQUENCE_FORMAT_STAGE_B_V1 = "stage_b_v1"
+
+POSITIONS_PER_BAR = 16
+MAX_DURATION_STEPS = 16
+VELOCITY_BINS = 8
+PIANO_PITCH_MIN = 21
+PIANO_PITCH_MAX = 108
+PIANO_PITCH_COUNT = PIANO_PITCH_MAX - PIANO_PITCH_MIN + 1
+
+CHORD_ROOTS = ("C", "C#", "D", "Eb", "E", "F", "F#", "G", "Ab", "A", "Bb", "B", "N")
+CHORD_QUALITIES = ("maj", "min", "dom7", "maj7", "min7", "dim", "halfdim", "sus", "unknown")
+
+TOKEN_POSITION_START = TOKEN_CONTROL_END + 1
+TOKEN_POSITION_END = TOKEN_POSITION_START + POSITIONS_PER_BAR - 1
+TOKEN_CHORD_ROOT_START = TOKEN_POSITION_END + 1
+TOKEN_CHORD_ROOT_END = TOKEN_CHORD_ROOT_START + len(CHORD_ROOTS) - 1
+TOKEN_CHORD_QUALITY_START = TOKEN_CHORD_ROOT_END + 1
+TOKEN_CHORD_QUALITY_END = TOKEN_CHORD_QUALITY_START + len(CHORD_QUALITIES) - 1
+TOKEN_NOTE_PITCH_START = TOKEN_CHORD_QUALITY_END + 1
+TOKEN_NOTE_PITCH_END = TOKEN_NOTE_PITCH_START + PIANO_PITCH_COUNT - 1
+TOKEN_NOTE_DURATION_START = TOKEN_NOTE_PITCH_END + 1
+TOKEN_NOTE_DURATION_END = TOKEN_NOTE_DURATION_START + MAX_DURATION_STEPS - 1
+TOKEN_VELOCITY_START = TOKEN_NOTE_DURATION_END + 1
+TOKEN_VELOCITY_END = TOKEN_VELOCITY_START + VELOCITY_BINS - 1
+
+STAGE_B_TOKEN_START = TOKEN_POSITION_START
+STAGE_B_TOKEN_END = TOKEN_VELOCITY_END
+STAGE_B_VOCAB_SIZE = STAGE_B_TOKEN_END + 1
+
+ROOT_TO_PC = {
+    "C": 0,
+    "C#": 1,
+    "Db": 1,
+    "D": 2,
+    "D#": 3,
+    "Eb": 3,
+    "E": 4,
+    "F": 5,
+    "F#": 6,
+    "Gb": 6,
+    "G": 7,
+    "G#": 8,
+    "Ab": 8,
+    "A": 9,
+    "A#": 10,
+    "Bb": 10,
+    "B": 11,
+}
+
+PC_TO_CANONICAL_ROOT = {
+    0: "C",
+    1: "C#",
+    2: "D",
+    3: "Eb",
+    4: "E",
+    5: "F",
+    6: "F#",
+    7: "G",
+    8: "Ab",
+    9: "A",
+    10: "Bb",
+    11: "B",
+}
+
+
+@dataclass(frozen=True)
+class StageBDecodedNote:
+    pitch: int
+    start: float
+    end: float
+    velocity: int
+
+
+def step_duration_sec(tempo_bpm: float | int) -> float:
+    beat_sec = 60.0 / max(1e-6, float(tempo_bpm))
+    return beat_sec * 4.0 / POSITIONS_PER_BAR
+
+
+def quantize_note_position(note_start_sec: float, tempo_bpm: float | int) -> tuple[int, int]:
+    absolute_step = max(0, int(round(float(note_start_sec) / step_duration_sec(tempo_bpm))))
+    return absolute_step // POSITIONS_PER_BAR, absolute_step % POSITIONS_PER_BAR
+
+
+def quantize_note_duration(duration_sec: float, tempo_bpm: float | int) -> int:
+    steps = int(round(max(0.0, float(duration_sec)) / step_duration_sec(tempo_bpm)))
+    return max(1, min(MAX_DURATION_STEPS, steps))
+
+
+def velocity_bin(velocity: int) -> int:
+    return max(0, min(VELOCITY_BINS - 1, int(velocity) * VELOCITY_BINS // 128))
+
+
+def velocity_from_bin(bin_index: int) -> int:
+    clamped = max(0, min(VELOCITY_BINS - 1, int(bin_index)))
+    return int(round((clamped + 0.5) * 127 / VELOCITY_BINS))
+
+
+def position_token(position: int) -> int:
+    if position < 0 or position >= POSITIONS_PER_BAR:
+        raise ValueError(f"position out of range: {position}")
+    return TOKEN_POSITION_START + int(position)
+
+
+def chord_root_token(root_name: str | None) -> int:
+    root = root_name if root_name in CHORD_ROOTS else "N"
+    return TOKEN_CHORD_ROOT_START + CHORD_ROOTS.index(root)
+
+
+def chord_quality_token(quality: str | None) -> int:
+    normalized = quality if quality in CHORD_QUALITIES else "unknown"
+    return TOKEN_CHORD_QUALITY_START + CHORD_QUALITIES.index(normalized)
+
+
+def note_pitch_token(pitch: int) -> int:
+    if pitch < PIANO_PITCH_MIN or pitch > PIANO_PITCH_MAX:
+        raise ValueError(f"pitch out of piano range: {pitch}")
+    return TOKEN_NOTE_PITCH_START + int(pitch) - PIANO_PITCH_MIN
+
+
+def note_duration_token(duration_steps: int) -> int:
+    if duration_steps < 1 or duration_steps > MAX_DURATION_STEPS:
+        raise ValueError(f"duration steps out of range: {duration_steps}")
+    return TOKEN_NOTE_DURATION_START + int(duration_steps) - 1
+
+
+def note_velocity_token(bin_index: int) -> int:
+    if bin_index < 0 or bin_index >= VELOCITY_BINS:
+        raise ValueError(f"velocity bin out of range: {bin_index}")
+    return TOKEN_VELOCITY_START + int(bin_index)
+
+
+def is_position_token(token: int) -> bool:
+    return TOKEN_POSITION_START <= int(token) <= TOKEN_POSITION_END
+
+
+def is_note_pitch_token(token: int) -> bool:
+    return TOKEN_NOTE_PITCH_START <= int(token) <= TOKEN_NOTE_PITCH_END
+
+
+def is_note_duration_token(token: int) -> bool:
+    return TOKEN_NOTE_DURATION_START <= int(token) <= TOKEN_NOTE_DURATION_END
+
+
+def is_velocity_token(token: int) -> bool:
+    return TOKEN_VELOCITY_START <= int(token) <= TOKEN_VELOCITY_END
+
+
+def position_from_token(token: int) -> int:
+    return int(token) - TOKEN_POSITION_START
+
+
+def pitch_from_token(token: int) -> int:
+    return PIANO_PITCH_MIN + int(token) - TOKEN_NOTE_PITCH_START
+
+
+def duration_steps_from_token(token: int) -> int:
+    return int(token) - TOKEN_NOTE_DURATION_START + 1
+
+
+def velocity_bin_from_token(token: int) -> int:
+    return int(token) - TOKEN_VELOCITY_START
+
+
+def parse_chord_symbol(chord: str | None) -> tuple[str, str]:
+    if not chord:
+        return "N", "unknown"
+
+    match = re.match(r"^\s*([A-Ga-g])([#b]?)(.*)$", chord)
+    if not match:
+        return "N", "unknown"
+
+    root_raw = match.group(1).upper() + match.group(2)
+    root_pc = ROOT_TO_PC.get(root_raw)
+    if root_pc is None:
+        return "N", "unknown"
+
+    suffix = match.group(3).strip().lower().replace(" ", "")
+    root = PC_TO_CANONICAL_ROOT[root_pc]
+
+    if "m7b5" in suffix or "ø" in suffix or "half" in suffix:
+        quality = "halfdim"
+    elif "dim" in suffix or "o" == suffix:
+        quality = "dim"
+    elif "sus" in suffix:
+        quality = "sus"
+    elif "maj7" in suffix or "ma7" in suffix or "Δ" in suffix:
+        quality = "maj7"
+    elif suffix.startswith("m") and "maj" not in suffix:
+        quality = "min7" if "7" in suffix else "min"
+    elif "7" in suffix:
+        quality = "dom7"
+    elif suffix in ("", "maj", "major"):
+        quality = "maj"
+    else:
+        quality = "unknown"
+
+    return root, quality
+
+
+def chord_tokens(chord: str | None) -> list[int]:
+    root, quality = parse_chord_symbol(chord)
+    return [chord_root_token(root), chord_quality_token(quality)]
+
+
+def stage_b_token_name(token: int) -> str:
+    value = int(token)
+    if value == TOKEN_END:
+        return "END"
+    if value == TOKEN_BAR:
+        return "BAR"
+    if is_position_token(value):
+        return f"POSITION_{position_from_token(value)}"
+    if TOKEN_CHORD_ROOT_START <= value <= TOKEN_CHORD_ROOT_END:
+        return f"CHORD_ROOT_{CHORD_ROOTS[value - TOKEN_CHORD_ROOT_START]}"
+    if TOKEN_CHORD_QUALITY_START <= value <= TOKEN_CHORD_QUALITY_END:
+        return f"CHORD_QUALITY_{CHORD_QUALITIES[value - TOKEN_CHORD_QUALITY_START]}"
+    if is_note_pitch_token(value):
+        return f"NOTE_PITCH_{pitch_from_token(value)}"
+    if is_note_duration_token(value):
+        return f"NOTE_DURATION_{duration_steps_from_token(value)}"
+    if is_velocity_token(value):
+        return f"VELOCITY_{velocity_bin_from_token(value)}"
+    return str(value)
+
+
+def build_stage_b_sequence(
+    notes: Sequence[pretty_midi.Note],
+    tempo_bpm: float | int,
+    chords: Sequence[str] | None = None,
+    role: str | None = "lead",
+    bars: int | None = None,
+) -> list[int]:
+    valid_notes = [
+        note
+        for note in notes
+        if PIANO_PITCH_MIN <= int(note.pitch) <= PIANO_PITCH_MAX and float(note.end) > float(note.start)
+    ]
+    quantized: list[tuple[int, int, pretty_midi.Note]] = [
+        (*quantize_note_position(float(note.start), tempo_bpm), note) for note in valid_notes
+    ]
+    max_note_bar = max((bar for bar, _pos, _note in quantized), default=0)
+    total_bars = max(1, int(bars) if bars is not None else max_note_bar + 1)
+
+    tokens = control_prefix_tokens(role=role, tempo_bpm=tempo_bpm)[:2]
+    for bar_index in range(total_bars):
+        chord = chords[bar_index] if chords and bar_index < len(chords) else None
+        tokens.append(TOKEN_BAR)
+        tokens.extend(chord_tokens(chord))
+        bar_notes = sorted(
+            ((position, note) for bar, position, note in quantized if bar == bar_index),
+            key=lambda item: (item[0], item[1].pitch, item[1].start),
+        )
+        for position, note in bar_notes:
+            duration_steps = quantize_note_duration(float(note.end) - float(note.start), tempo_bpm)
+            tokens.extend(
+                [
+                    position_token(position),
+                    note_velocity_token(velocity_bin(int(note.velocity))),
+                    note_pitch_token(int(note.pitch)),
+                    note_duration_token(duration_steps),
+                ]
+            )
+    tokens.append(TOKEN_END)
+    return tokens
+
+
+def decode_stage_b_notes(tokens: Sequence[int], tempo_bpm: float | int) -> list[StageBDecodedNote]:
+    step_sec = step_duration_sec(tempo_bpm)
+    bar_index = -1
+    position = 0
+    velocity = velocity_from_bin(VELOCITY_BINS // 2)
+    pending_pitch: int | None = None
+    decoded: list[StageBDecodedNote] = []
+
+    for raw_token in tokens:
+        token = int(raw_token)
+        if token == TOKEN_END:
+            break
+        if token == TOKEN_BAR:
+            bar_index += 1
+            position = 0
+            pending_pitch = None
+            continue
+        if is_position_token(token):
+            position = position_from_token(token)
+            pending_pitch = None
+            continue
+        if is_velocity_token(token):
+            velocity = velocity_from_bin(velocity_bin_from_token(token))
+            continue
+        if is_note_pitch_token(token):
+            pending_pitch = pitch_from_token(token)
+            continue
+        if is_note_duration_token(token) and pending_pitch is not None and bar_index >= 0:
+            duration_steps = duration_steps_from_token(token)
+            start = (bar_index * POSITIONS_PER_BAR + position) * step_sec
+            end = start + duration_steps * step_sec
+            decoded.append(
+                StageBDecodedNote(
+                    pitch=pending_pitch,
+                    start=start,
+                    end=end,
+                    velocity=velocity,
+                )
+            )
+            pending_pitch = None
+
+    return decoded
+
+
+def decode_stage_b_midi(tokens: Sequence[int], tempo_bpm: float | int = 120.0) -> pretty_midi.PrettyMIDI:
+    midi = pretty_midi.PrettyMIDI(initial_tempo=float(tempo_bpm))
+    piano = pretty_midi.Instrument(program=0, is_drum=False, name="stage_b_piano")
+    for note in decode_stage_b_notes(tokens, tempo_bpm=tempo_bpm):
+        piano.notes.append(
+            pretty_midi.Note(
+                velocity=note.velocity,
+                pitch=note.pitch,
+                start=note.start,
+                end=note.end,
+            )
+        )
+    midi.instruments.append(piano)
+    return midi

--- a/tests/test_stage_b_tokens.py
+++ b/tests/test_stage_b_tokens.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import unittest
+
+import pretty_midi
+
+from scripts.stage_b_tokens import (
+    CHORD_QUALITIES,
+    CHORD_ROOTS,
+    MAX_DURATION_STEPS,
+    SEQUENCE_FORMAT_STAGE_B_V1,
+    STAGE_B_TOKEN_START,
+    STAGE_B_VOCAB_SIZE,
+    TOKEN_CHORD_QUALITY_START,
+    TOKEN_CHORD_ROOT_START,
+    TOKEN_NOTE_DURATION_START,
+    TOKEN_NOTE_PITCH_START,
+    TOKEN_POSITION_START,
+    TOKEN_VELOCITY_START,
+    build_stage_b_sequence,
+    chord_tokens,
+    decode_stage_b_notes,
+    note_duration_token,
+    note_pitch_token,
+    parse_chord_symbol,
+    position_token,
+    quantize_note_duration,
+    stage_b_token_name,
+    velocity_bin,
+)
+from scripts.control_tokens import tempo_control_token
+from utilities.constants import TOKEN_BAR, TOKEN_CONTROL_END, TOKEN_END, TOKEN_ROLE_LEAD
+
+
+class StageBTokensTest(unittest.TestCase):
+    def test_stage_b_token_range_starts_after_stage_a_control_tokens(self) -> None:
+        self.assertEqual(SEQUENCE_FORMAT_STAGE_B_V1, "stage_b_v1")
+        self.assertEqual(STAGE_B_TOKEN_START, TOKEN_CONTROL_END + 1)
+        self.assertGreater(STAGE_B_VOCAB_SIZE, TOKEN_CONTROL_END + 1)
+
+    def test_chord_symbol_parser_normalizes_common_jazz_chords(self) -> None:
+        self.assertEqual(parse_chord_symbol("Cm7"), ("C", "min7"))
+        self.assertEqual(parse_chord_symbol("F7"), ("F", "dom7"))
+        self.assertEqual(parse_chord_symbol("Bbmaj7"), ("Bb", "maj7"))
+        self.assertEqual(parse_chord_symbol("F#m7b5"), ("F#", "halfdim"))
+        self.assertEqual(parse_chord_symbol(None), ("N", "unknown"))
+
+    def test_chord_tokens_are_explicit_root_and_quality_tokens(self) -> None:
+        root_token, quality_token = chord_tokens("Cm7")
+
+        self.assertEqual(root_token, TOKEN_CHORD_ROOT_START + CHORD_ROOTS.index("C"))
+        self.assertEqual(quality_token, TOKEN_CHORD_QUALITY_START + CHORD_QUALITIES.index("min7"))
+
+    def test_build_stage_b_sequence_uses_position_pitch_duration_velocity_tokens(self) -> None:
+        notes = [
+            pretty_midi.Note(velocity=84, pitch=60, start=0.0, end=0.25),
+            pretty_midi.Note(velocity=96, pitch=64, start=0.5, end=0.75),
+        ]
+
+        tokens = build_stage_b_sequence(notes, tempo_bpm=120, chords=["Cm7"], bars=1)
+
+        self.assertEqual(tokens[0], TOKEN_ROLE_LEAD)
+        self.assertEqual(tokens[1], tempo_control_token(120))
+        self.assertEqual(tokens[2], TOKEN_BAR)
+        self.assertIn(position_token(0), tokens)
+        self.assertIn(position_token(4), tokens)
+        self.assertIn(TOKEN_VELOCITY_START + velocity_bin(84), tokens)
+        self.assertIn(note_pitch_token(60), tokens)
+        self.assertIn(note_pitch_token(64), tokens)
+        self.assertIn(note_duration_token(2), tokens)
+        self.assertEqual(tokens[-1], TOKEN_END)
+
+    def test_stage_b_roundtrip_preserves_quantized_note_shape(self) -> None:
+        notes = [
+            pretty_midi.Note(velocity=84, pitch=60, start=0.0, end=0.25),
+            pretty_midi.Note(velocity=96, pitch=64, start=0.5, end=0.75),
+        ]
+
+        tokens = build_stage_b_sequence(notes, tempo_bpm=120, chords=["Cm7"], bars=1)
+        decoded = decode_stage_b_notes(tokens, tempo_bpm=120)
+
+        self.assertEqual([note.pitch for note in decoded], [60, 64])
+        self.assertAlmostEqual(decoded[0].start, 0.0)
+        self.assertAlmostEqual(decoded[0].end, 0.25)
+        self.assertAlmostEqual(decoded[1].start, 0.5)
+        self.assertAlmostEqual(decoded[1].end, 0.75)
+        self.assertTrue(all(note.velocity > 0 for note in decoded))
+
+    def test_duration_quantization_clamps_long_sustain(self) -> None:
+        self.assertEqual(quantize_note_duration(99.0, tempo_bpm=120), MAX_DURATION_STEPS)
+
+    def test_stage_b_token_names_are_debuggable(self) -> None:
+        self.assertEqual(stage_b_token_name(TOKEN_POSITION_START), "POSITION_0")
+        self.assertEqual(stage_b_token_name(TOKEN_NOTE_PITCH_START), "NOTE_PITCH_21")
+        self.assertEqual(stage_b_token_name(TOKEN_NOTE_DURATION_START), "NOTE_DURATION_1")
+        self.assertEqual(stage_b_token_name(TOKEN_VELOCITY_START), "VELOCITY_0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `docs/STAGE_B_TOKENIZATION_SPEC.md` for the Stage B duration-explicit symbolic MIDI representation.
- Add `scripts/stage_b_tokens.py` with a separate Stage B token range after existing Stage A control tokens.
- Add tests for token range stability, chord parsing, explicit position/pitch/duration/velocity encoding, duration clamping, and quantized roundtrip decoding.
- Update active planning docs and `AGENTS.md` to track issue #14.

## Why

The Brad 2-file `control_v1` probe showed that Stage A can run but still produces empty, one-note, sparse, or long-sustain MIDI. Stage B starts the representation fix by making bar position and note duration explicit instead of relying on NOTE_ON/NOTE_OFF pairing.

## Validation

- `./.venv/bin/python -m unittest tests.test_stage_b_tokens`
- `bash scripts/agent_harness.sh quick`

## Next

After this merges, the next branch should wire `stage_b_v1` into dataset preparation with `prepare_role_dataset.py --sequence_format stage_b_v1`, then build a phrase/window dataset path before another training probe.