### PR TITLE
[codex] Prepare Stage B role datasets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #14: Stage B duration-explicit tokenization spec and tokenizer contract.
+- Issue #15: Stage B role dataset preparation path.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-14-stage-b-tokenization-spec`
+- `issue-15-stage-b-role-dataset-prep`
 
 현재 범위가 아닌 것:
 
@@ -76,6 +76,28 @@ First implementation target:
 - `docs/STAGE_B_TOKENIZATION_SPEC.md`
 
 Do not start broad training in this issue.
+
+## Active Issue #15
+
+Current task:
+
+- wire `stage_b_v1` into `scripts/prepare_role_dataset.py`
+- produce tokenized train/val records from existing role dataset preparation
+- keep Stage B tokenized records target-only for the first contract
+- do not start model training yet
+
+First implementation target:
+
+- `prepare_role_dataset.py --sequence_format stage_b_v1`
+- unit test with explicit train/val manifests
+- local Brad 2-file dry run under `outputs/`
+
+Current result:
+
+- `stage_b_v1` prepare path implemented
+- unit tests pass
+- Brad 2-file dry run produced tokenized train/val records
+- detail: `docs/STAGE_B_ROLE_DATASET_PREP_2026-05-19.md`
 
 ## Dataset Strategy
 
@@ -207,7 +229,7 @@ Current conclusion:
 
 Status:
 
-- initial tokenizer contract implemented on `issue-14-stage-b-tokenization-spec`
+- completed and merged via PR #14
 
 Goal:
 
@@ -223,6 +245,31 @@ Acceptance:
 - generated token sequence contains explicit duration tokens
 - roundtrip preserves quantized pitch/start/end on a small example
 - `bash scripts/agent_harness.sh quick` passes
+
+### 0.6. Issue #15 Stage B role dataset preparation
+
+Status:
+
+- implemented on `issue-15-stage-b-role-dataset-prep`
+
+Goal:
+
+- let `prepare_role_dataset.py` accept `--sequence_format stage_b_v1`
+- encode target MIDI notes with explicit `POSITION + VELOCITY + NOTE_PITCH + NOTE_DURATION`
+- preserve manifest train/val boundaries
+- avoid using `COND_SEP` or Stage A NOTE_ON/OFF tokens in Stage B records
+
+Acceptance:
+
+- unit test writes Stage B train/val `.npy` files from tiny MIDI manifests
+- a local Brad 2-file dry run writes tokenized Stage B train/val records
+- `bash scripts/agent_harness.sh quick` passes
+
+Dry run result:
+
+- output: `outputs/issue15_stage_b_probe2/roles_stage_b_probe2`
+- train tokens: `4430`
+- val tokens: `6482`
 
 ### 1. Run full jazz piano dataset audit
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,8 @@
   - Brad 2-file `control_v1` training/generation probe 결과와 Stage B 전환 판단.
 - `STAGE_B_TOKENIZATION_SPEC.md`
   - duration-explicit, bar-position-aware Stage B tokenization contract.
+- `STAGE_B_ROLE_DATASET_PREP_2026-05-19.md`
+  - `prepare_role_dataset.py --sequence_format stage_b_v1` 연결 결과와 Brad 2-file dry run.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`

--- a/docs/STAGE_B_ROLE_DATASET_PREP_2026-05-19.md
+++ b/docs/STAGE_B_ROLE_DATASET_PREP_2026-05-19.md
@@ -1,0 +1,97 @@
+# Stage B Role Dataset Prep: 2026-05-19
+
+## Purpose
+
+Wire `stage_b_v1` into the existing role dataset preparation path.
+
+This is not a training run. The goal is to prove that real MIDI files can become Stage B tokenized train/val records before building phrase/window extraction.
+
+## Implementation
+
+Updated:
+
+- `scripts/prepare_role_dataset.py`
+- `scripts/stage_b_tokens.py`
+- `tests/test_stage_b_tokens.py`
+
+New prepare mode:
+
+```bash
+python scripts/prepare_role_dataset.py \
+  --sequence_format stage_b_v1
+```
+
+The first Stage B dataset contract is target-only:
+
+- `conditioning.mid` is still written for folder compatibility.
+- tokenized `.npy` records encode `target.mid`.
+- records use explicit `POSITION + VELOCITY + NOTE_PITCH + NOTE_DURATION` groups.
+- records do not include `COND_SEP`.
+- chord labels are `N/unknown` until chord metadata or inference is added.
+
+## Local Brad 2-File Dry Run
+
+Command:
+
+```bash
+python scripts/prepare_role_dataset.py \
+  --input_dir "./midi_dataset/midi/studio/Brad Mehldau" \
+  --output_dir outputs/issue15_stage_b_probe2/roles_stage_b_probe2 \
+  --role lead \
+  --sequence_format stage_b_v1 \
+  --max_files 2 \
+  --overwrite
+```
+
+Result:
+
+| Metric | Value |
+|---|---:|
+| input files | 2 |
+| role samples | 2 |
+| train samples | 1 |
+| val samples | 1 |
+| tokenized train | 1 |
+| tokenized val | 1 |
+
+Token lengths:
+
+| Split | File | Tokens |
+|---|---|---:|
+| train | `000000.npy` | 4430 |
+| val | `000000.npy` | 6482 |
+
+Example token head:
+
+```text
+ROLE_LEAD
+TEMPO_DANCE
+BAR
+CHORD_ROOT_N
+CHORD_QUALITY_unknown
+POSITION_11
+VELOCITY_3
+NOTE_PITCH_63
+NOTE_DURATION_2
+```
+
+Generated output artifacts remain local under:
+
+```text
+outputs/issue15_stage_b_probe2/
+```
+
+## Validation
+
+```bash
+python -m unittest tests.test_stage_b_tokens tests.test_control_tokens
+bash scripts/agent_harness.sh quick
+```
+
+Both passed.
+
+## Decision
+
+`stage_b_v1` can now produce train/val `.npy` files from the existing role dataset builder.
+
+Next work should not train the model yet. The next issue should build phrase/window extraction so Stage B examples are short musical phrases instead of full target continuations.

--- a/docs/STAGE_B_TOKENIZATION_SPEC.md
+++ b/docs/STAGE_B_TOKENIZATION_SPEC.md
@@ -155,12 +155,34 @@ Issue #14 is complete when:
 - A simple roundtrip test decodes quantized notes with correct pitch/start/end.
 - Current Stage A tests still pass.
 
+## Dataset Preparation
+
+Issue #15 wires `stage_b_v1` into the existing role dataset preparation entrypoint.
+
+Example:
+
+```bash
+python scripts/prepare_role_dataset.py \
+  --input_dir "./midi_dataset/midi/studio/Brad Mehldau" \
+  --output_dir outputs/issue15_stage_b_probe2/roles_stage_b_probe2 \
+  --role lead \
+  --sequence_format stage_b_v1 \
+  --max_files 2 \
+  --overwrite
+```
+
+The first dataset contract is target-only:
+
+- `conditioning.mid` is still written for compatibility with the role dataset folder shape.
+- tokenized `.npy` records contain `stage_b_v1` target-note tokens.
+- records do not include `COND_SEP`.
+- chord labels are `N/unknown` unless explicit chord metadata is added later.
+
 ## Next Issue After Spec
 
-After this spec and tokenizer contract are merged, the next issue should build:
+After the dataset preparation contract is merged, the next issue should build:
 
 - phrase/window dataset extraction
-- `prepare_role_dataset.py --sequence_format stage_b_v1`
 - target-only training loss if conditioning is prepended
 - Stage B tiny-overfit smoke
 - Brad 2-file Stage B probe

--- a/scripts/prepare_role_dataset.py
+++ b/scripts/prepare_role_dataset.py
@@ -37,6 +37,7 @@ try:
         control_prefix_tokens,
         token_names,
     )
+    from stage_b_tokens import SEQUENCE_FORMAT_STAGE_B_V1, build_stage_b_sequence
 except ModuleNotFoundError:
     from scripts.control_tokens import (
         SEQUENCE_FORMAT_CHOICES,
@@ -47,6 +48,10 @@ except ModuleNotFoundError:
         control_prefix_tokens,
         token_names,
     )
+    from scripts.stage_b_tokens import SEQUENCE_FORMAT_STAGE_B_V1, build_stage_b_sequence
+
+
+SEQUENCE_FORMAT_CHOICES_WITH_STAGE_B = SEQUENCE_FORMAT_CHOICES + (SEQUENCE_FORMAT_STAGE_B_V1,)
 
 
 def find_midi_files(input_dir: Path) -> List[Path]:
@@ -255,6 +260,15 @@ def encode_midi_simple(file_path: str) -> List[int]:
     return events
 
 
+def load_midi_notes(file_path: str | Path) -> List[pretty_midi.Note]:
+    midi = pretty_midi.PrettyMIDI(midi_file=str(file_path))
+    notes: List[pretty_midi.Note] = []
+    for inst in midi.instruments:
+        if not inst.is_drum:
+            notes.extend(inst.notes)
+    return sorted(notes, key=lambda note: (note.start, note.pitch))
+
+
 def build_training_sequence(
     cond_tokens: Sequence[int],
     tgt_tokens: Sequence[int],
@@ -274,6 +288,18 @@ def build_training_sequence(
     raise ValueError(f"Unsupported sequence_format: {sequence_format}")
 
 
+def build_stage_b_record_sequence(record: dict, meta: dict, default_role: str) -> list[int]:
+    target_notes = load_midi_notes(record["target_path"])
+    if not target_notes:
+        return []
+    return build_stage_b_sequence(
+        target_notes,
+        tempo_bpm=float(meta.get("tempo_bpm", 120.0)),
+        chords=meta.get("chord_progression"),
+        role=str(meta.get("role", default_role)),
+    )
+
+
 def write_tokenized_records(
     records: Sequence[dict],
     split_name: str,
@@ -285,23 +311,27 @@ def write_tokenized_records(
     saved = 0
     for i, record in enumerate(records):
         try:
-            cond_tokens = encode_midi_simple(str(record["conditioning_path"]))
-            tgt_tokens = encode_midi_simple(str(record["target_path"]))
+            meta = json.loads(Path(record["meta_path"]).read_text())
+            if sequence_format == SEQUENCE_FORMAT_STAGE_B_V1:
+                seq = build_stage_b_record_sequence(record, meta=meta, default_role=default_role)
+            else:
+                cond_tokens = encode_midi_simple(str(record["conditioning_path"]))
+                tgt_tokens = encode_midi_simple(str(record["target_path"]))
+                if not cond_tokens or not tgt_tokens:
+                    continue
+                seq = build_training_sequence(
+                    cond_tokens,
+                    tgt_tokens,
+                    meta=meta,
+                    sequence_format=sequence_format,
+                    default_role=default_role,
+                )
         except Exception as e:
             print(f"Tokenize skip ({split_name}): {record['sample_id']} ({e})")
             continue
 
-        if not cond_tokens or not tgt_tokens:
+        if not seq:
             continue
-
-        meta = json.loads(Path(record["meta_path"]).read_text())
-        seq = build_training_sequence(
-            cond_tokens,
-            tgt_tokens,
-            meta=meta,
-            sequence_format=sequence_format,
-            default_role=default_role,
-        )
         np.save(split_dir / f"{i:06d}.npy", np.array(seq, dtype=np.int32))
         saved += 1
     return saved
@@ -325,7 +355,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     parser.add_argument("--overwrite", action="store_true")
     parser.add_argument(
         "--sequence_format",
-        choices=SEQUENCE_FORMAT_CHOICES,
+        choices=SEQUENCE_FORMAT_CHOICES_WITH_STAGE_B,
         default=SEQUENCE_FORMAT_CONTROL_V1,
         help="Token sequence format for conditioning/target training examples.",
     )

--- a/scripts/stage_b_tokens.py
+++ b/scripts/stage_b_tokens.py
@@ -19,7 +19,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(SCRIPT_DIR / "music_transformer"))
 sys.path.insert(0, str(SCRIPT_DIR / "music_transformer" / "third_party"))
 
-from utilities.constants import TOKEN_BAR, TOKEN_CONTROL_END, TOKEN_END  # noqa: E402
+from utilities.constants import CONTROL_TOKEN_NAMES, TOKEN_BAR, TOKEN_CONTROL_END, TOKEN_END  # noqa: E402
 
 try:
     from control_tokens import control_prefix_tokens
@@ -233,6 +233,8 @@ def chord_tokens(chord: str | None) -> list[int]:
 
 def stage_b_token_name(token: int) -> str:
     value = int(token)
+    if value in CONTROL_TOKEN_NAMES:
+        return CONTROL_TOKEN_NAMES[value]
     if value == TOKEN_END:
         return "END"
     if value == TOKEN_BAR:
@@ -258,15 +260,25 @@ def build_stage_b_sequence(
     chords: Sequence[str] | None = None,
     role: str | None = "lead",
     bars: int | None = None,
+    normalize_start: bool = True,
 ) -> list[int]:
     valid_notes = [
         note
         for note in notes
         if PIANO_PITCH_MIN <= int(note.pitch) <= PIANO_PITCH_MAX and float(note.end) > float(note.start)
     ]
-    quantized: list[tuple[int, int, pretty_midi.Note]] = [
-        (*quantize_note_position(float(note.start), tempo_bpm), note) for note in valid_notes
+    note_steps = [
+        (max(0, int(round(float(note.start) / step_duration_sec(tempo_bpm)))), note)
+        for note in valid_notes
     ]
+    first_bar_offset = 0
+    if normalize_start and note_steps:
+        first_step = min(step for step, _note in note_steps)
+        first_bar_offset = (first_step // POSITIONS_PER_BAR) * POSITIONS_PER_BAR
+    quantized: list[tuple[int, int, pretty_midi.Note]] = []
+    for absolute_step, note in note_steps:
+        relative_step = max(0, absolute_step - first_bar_offset)
+        quantized.append((relative_step // POSITIONS_PER_BAR, relative_step % POSITIONS_PER_BAR, note))
     max_note_bar = max((bar for bar, _pos, _note in quantized), default=0)
     total_bars = max(1, int(bars) if bars is not None else max_note_bar + 1)
 

--- a/tests/test_stage_b_tokens.py
+++ b/tests/test_stage_b_tokens.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+import contextlib
+import io
+import json
+import tempfile
 import unittest
+from pathlib import Path
 
+import numpy as np
 import pretty_midi
 
+from scripts.prepare_role_dataset import main as prepare_role_dataset_main, notes_to_midi
 from scripts.stage_b_tokens import (
     CHORD_QUALITIES,
     CHORD_ROOTS,
@@ -14,7 +21,10 @@ from scripts.stage_b_tokens import (
     TOKEN_CHORD_QUALITY_START,
     TOKEN_CHORD_ROOT_START,
     TOKEN_NOTE_DURATION_START,
+    TOKEN_NOTE_DURATION_END,
     TOKEN_NOTE_PITCH_START,
+    TOKEN_NOTE_PITCH_END,
+    TOKEN_POSITION_END,
     TOKEN_POSITION_START,
     TOKEN_VELOCITY_START,
     build_stage_b_sequence,
@@ -29,7 +39,7 @@ from scripts.stage_b_tokens import (
     velocity_bin,
 )
 from scripts.control_tokens import tempo_control_token
-from utilities.constants import TOKEN_BAR, TOKEN_CONTROL_END, TOKEN_END, TOKEN_ROLE_LEAD
+from utilities.constants import TOKEN_BAR, TOKEN_COND_SEP, TOKEN_CONTROL_END, TOKEN_END, TOKEN_ROLE_LEAD
 
 
 class StageBTokensTest(unittest.TestCase):
@@ -86,14 +96,88 @@ class StageBTokensTest(unittest.TestCase):
         self.assertAlmostEqual(decoded[1].end, 0.75)
         self.assertTrue(all(note.velocity > 0 for note in decoded))
 
+    def test_stage_b_sequence_normalizes_to_first_bar_without_losing_position(self) -> None:
+        notes = [
+            pretty_midi.Note(velocity=84, pitch=60, start=4.5, end=4.75),
+        ]
+
+        tokens = build_stage_b_sequence(notes, tempo_bpm=120, chords=["Cm7"])
+        decoded = decode_stage_b_notes(tokens, tempo_bpm=120)
+
+        self.assertEqual(tokens[2], TOKEN_BAR)
+        self.assertIn(position_token(4), tokens)
+        self.assertAlmostEqual(decoded[0].start, 0.5)
+        self.assertAlmostEqual(decoded[0].end, 0.75)
+
     def test_duration_quantization_clamps_long_sustain(self) -> None:
         self.assertEqual(quantize_note_duration(99.0, tempo_bpm=120), MAX_DURATION_STEPS)
 
     def test_stage_b_token_names_are_debuggable(self) -> None:
+        self.assertEqual(stage_b_token_name(TOKEN_ROLE_LEAD), "ROLE_LEAD")
+        self.assertEqual(stage_b_token_name(TOKEN_BAR), "BAR")
         self.assertEqual(stage_b_token_name(TOKEN_POSITION_START), "POSITION_0")
         self.assertEqual(stage_b_token_name(TOKEN_NOTE_PITCH_START), "NOTE_PITCH_21")
         self.assertEqual(stage_b_token_name(TOKEN_NOTE_DURATION_START), "NOTE_DURATION_1")
         self.assertEqual(stage_b_token_name(TOKEN_VELOCITY_START), "VELOCITY_0")
+
+    def test_prepare_role_dataset_writes_stage_b_v1_tokens(self) -> None:
+        def source_notes() -> list[pretty_midi.Note]:
+            notes: list[pretty_midi.Note] = []
+            for index in range(3):
+                start = index * 0.25
+                notes.append(pretty_midi.Note(velocity=80, pitch=48 + index, start=start, end=start + 0.1))
+            for index in range(8):
+                start = 4.0 + index * 0.25
+                notes.append(pretty_midi.Note(velocity=90, pitch=66 + index, start=start, end=start + 0.125))
+            return notes
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            train_midi = root / "train.mid"
+            val_midi = root / "val.mid"
+            notes_to_midi(source_notes(), 124).write(str(train_midi))
+            notes_to_midi(source_notes(), 124).write(str(val_midi))
+
+            train_manifest = root / "train.txt"
+            val_manifest = root / "val.txt"
+            train_manifest.write_text(f"{train_midi}\n", encoding="utf-8")
+            val_manifest.write_text(f"{val_midi}\n", encoding="utf-8")
+
+            output_dir = root / "roles"
+            with contextlib.redirect_stdout(io.StringIO()):
+                prepare_role_dataset_main(
+                    [
+                        "--train_manifest",
+                        str(train_manifest),
+                        "--val_manifest",
+                        str(val_manifest),
+                        "--output_dir",
+                        str(output_dir),
+                        "--role",
+                        "lead",
+                        "--min_conditioning_notes",
+                        "2",
+                        "--min_target_notes",
+                        "8",
+                        "--sequence_format",
+                        SEQUENCE_FORMAT_STAGE_B_V1,
+                        "--overwrite",
+                    ]
+                )
+
+            role_root = output_dir / "lead"
+            summary = json.loads((role_root / "dataset_summary.json").read_text(encoding="utf-8"))
+            tokens = np.load(role_root / "tokenized" / "train" / "000000.npy")
+
+        self.assertEqual(summary["sequence_format"], SEQUENCE_FORMAT_STAGE_B_V1)
+        self.assertEqual(summary["tokenized_train"], 1)
+        self.assertEqual(summary["tokenized_val"], 1)
+        self.assertEqual(tokens[0], TOKEN_ROLE_LEAD)
+        self.assertEqual(tokens[2], TOKEN_BAR)
+        self.assertTrue(any(TOKEN_POSITION_START <= int(token) <= TOKEN_POSITION_END for token in tokens))
+        self.assertTrue(any(TOKEN_NOTE_PITCH_START <= int(token) <= TOKEN_NOTE_PITCH_END for token in tokens))
+        self.assertTrue(any(TOKEN_NOTE_DURATION_START <= int(token) <= TOKEN_NOTE_DURATION_END for token in tokens))
+        self.assertNotIn(TOKEN_COND_SEP, tokens.tolist())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Wire `stage_b_v1` into `scripts/prepare_role_dataset.py`.
- Add target-only Stage B tokenized record generation from existing `target.mid` files.
- Preserve the existing role dataset folder shape while avoiding Stage A `COND_SEP` in Stage B records.
- Normalize Stage B target notes to the first occupied bar so long source offsets do not create leading empty bars.
- Add unit coverage for Stage B dataset preparation and document the Brad 2-file dry run.

## Why

PR #14 defined the Stage B tokenization contract. This PR makes that contract usable by the current dataset preparation path so the next work can move to phrase/window extraction instead of hand-built token fixtures.

## Validation

- `./.venv/bin/python -m unittest tests.test_stage_b_tokens tests.test_control_tokens`
- `bash scripts/agent_harness.sh quick`
- Local Brad 2-file dry run:

```bash
./.venv/bin/python scripts/prepare_role_dataset.py \
  --input_dir "./midi_dataset/midi/studio/Brad Mehldau" \
  --output_dir outputs/issue15_stage_b_probe2/roles_stage_b_probe2 \
  --role lead \
  --sequence_format stage_b_v1 \
  --max_files 2 \
  --overwrite
```

Dry run result: train 1, val 1, tokenized train 1, tokenized val 1.

## Next

After this merges, the next branch should implement phrase/window extraction for Stage B before any model training run.