### PR TITLE
[codex] Extract Stage B phrase windows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #15: Stage B role dataset preparation path.
+- Issue #16: Stage B phrase-window dataset extraction.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-15-stage-b-role-dataset-prep`
+- `issue-16-stage-b-phrase-window-dataset`
 
 현재 범위가 아닌 것:
 
@@ -98,6 +98,30 @@ Current result:
 - unit tests pass
 - Brad 2-file dry run produced tokenized train/val records
 - detail: `docs/STAGE_B_ROLE_DATASET_PREP_2026-05-19.md`
+
+## Active Issue #16
+
+Current task:
+
+- split Stage B target continuations into short fixed-bar phrase windows
+- keep windowed records target-only for the first contract
+- prove Brad 2-file window dry run produces many short `.npy` records
+- do not start model training yet
+
+First implementation target:
+
+- `prepare_role_dataset.py --stage_b_window_bars`
+- `prepare_role_dataset.py --stage_b_window_stride_bars`
+- `prepare_role_dataset.py --stage_b_min_window_target_notes`
+- unit test with manifest train/val windows
+- local Brad 2-file window dry run under `outputs/`
+
+Current result:
+
+- 2-bar Stage B window path implemented
+- Brad 2-file dry run produced 137 role samples
+- token lengths: min `22`, p50 `77`, max `212`, mean `82.94`
+- detail: `docs/STAGE_B_PHRASE_WINDOW_DATASET_2026-05-19.md`
 
 ## Dataset Strategy
 
@@ -250,7 +274,7 @@ Acceptance:
 
 Status:
 
-- implemented on `issue-15-stage-b-role-dataset-prep`
+- completed and merged via PR #15
 
 Goal:
 
@@ -270,6 +294,34 @@ Dry run result:
 - output: `outputs/issue15_stage_b_probe2/roles_stage_b_probe2`
 - train tokens: `4430`
 - val tokens: `6482`
+
+### 0.7. Issue #16 Stage B phrase-window dataset
+
+Status:
+
+- implemented on `issue-16-stage-b-phrase-window-dataset`
+
+Goal:
+
+- split Stage B target MIDI into fixed-bar windows
+- normalize note times to the window start
+- keep windows only when they have enough target notes
+- keep generated token records short enough for tiny-overfit probes
+
+Acceptance:
+
+- unit test writes multiple Stage B windows from one train/val MIDI pair
+- local Brad 2-file dry run creates windowed tokenized train/val records
+- `bash scripts/agent_harness.sh quick` passes
+
+Dry run result:
+
+- output: `outputs/issue16_stage_b_window_probe2/roles_stage_b_window_probe2`
+- role samples: `137`
+- tokenized train: `123`
+- tokenized val: `14`
+- token length p50: `77`
+- token length max: `212`
 
 ### 1. Run full jazz piano dataset audit
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,8 @@
   - duration-explicit, bar-position-aware Stage B tokenization contract.
 - `STAGE_B_ROLE_DATASET_PREP_2026-05-19.md`
   - `prepare_role_dataset.py --sequence_format stage_b_v1` 연결 결과와 Brad 2-file dry run.
+- `STAGE_B_PHRASE_WINDOW_DATASET_2026-05-19.md`
+  - Stage B 2-bar phrase/window dataset extraction and Brad 2-file dry run.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -52,7 +54,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B tiny-overfit와 2-file probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit와 2-file probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_PHRASE_WINDOW_DATASET_2026-05-19.md
+++ b/docs/STAGE_B_PHRASE_WINDOW_DATASET_2026-05-19.md
@@ -1,0 +1,113 @@
+# Stage B Phrase Window Dataset: 2026-05-19
+
+## Purpose
+
+Build short Stage B phrase/window records instead of training on full target continuations.
+
+Issue #15 made `stage_b_v1` usable from `prepare_role_dataset.py`, but the first Brad dry run still produced full target sequences with thousands of tokens. Issue #16 adds fixed-bar windows so the next training probe can learn short musical phrases first.
+
+## Implementation
+
+Updated:
+
+- `scripts/prepare_role_dataset.py`
+- `tests/test_stage_b_tokens.py`
+
+New options:
+
+```text
+--stage_b_window_bars
+--stage_b_window_stride_bars
+--stage_b_min_window_target_notes
+```
+
+These options are only meaningful with:
+
+```text
+--sequence_format stage_b_v1
+```
+
+Behavior:
+
+- target notes are sliced into fixed bar windows
+- note times are normalized to the window start
+- sparse conditioning MIDI is still written for folder compatibility
+- tokenized records remain target-only Stage B sequences
+- manifest train/val boundaries are preserved
+
+## Local Brad 2-File Window Dry Run
+
+Command:
+
+```bash
+python scripts/prepare_role_dataset.py \
+  --input_dir "./midi_dataset/midi/studio/Brad Mehldau" \
+  --output_dir outputs/issue16_stage_b_window_probe2/roles_stage_b_window_probe2 \
+  --role lead \
+  --sequence_format stage_b_v1 \
+  --stage_b_window_bars 2 \
+  --stage_b_window_stride_bars 2 \
+  --stage_b_min_window_target_notes 4 \
+  --max_files 2 \
+  --overwrite
+```
+
+Result:
+
+| Metric | Value |
+|---|---:|
+| input files | 2 |
+| role samples | 137 |
+| train samples | 123 |
+| val samples | 14 |
+| tokenized train | 123 |
+| tokenized val | 14 |
+
+Token length stats:
+
+| Metric | Tokens |
+|---|---:|
+| min | 22 |
+| p50 | 77 |
+| max | 212 |
+| mean | 82.94 |
+
+Compared with the previous full-target Stage B dry run:
+
+| Run | Train tokens | Val tokens |
+|---|---:|---:|
+| full target | 4430 | 6482 |
+| 2-bar windows | p50 77 | p50 77 |
+
+Example token head:
+
+```text
+ROLE_LEAD
+TEMPO_DANCE
+BAR
+CHORD_ROOT_N
+CHORD_QUALITY_unknown
+POSITION_9
+VELOCITY_4
+NOTE_PITCH_63
+NOTE_DURATION_4
+```
+
+Generated output artifacts remain local under:
+
+```text
+outputs/issue16_stage_b_window_probe2/
+```
+
+## Validation
+
+```bash
+python -m unittest tests.test_stage_b_tokens
+bash scripts/agent_harness.sh quick
+```
+
+## Decision
+
+Stage B now has a short phrase/window dataset path.
+
+The next issue can run a Stage B tiny-overfit using these short tokenized examples, but should still avoid broad generic jazz training until tiny-overfit generation decodes to reviewable MIDI.

--- a/docs/STAGE_B_TOKENIZATION_SPEC.md
+++ b/docs/STAGE_B_TOKENIZATION_SPEC.md
@@ -178,11 +178,27 @@ The first dataset contract is target-only:
 - records do not include `COND_SEP`.
 - chord labels are `N/unknown` unless explicit chord metadata is added later.
 
+Phrase/window extraction:
+
+```bash
+python scripts/prepare_role_dataset.py \
+  --input_dir "./midi_dataset/midi/studio/Brad Mehldau" \
+  --output_dir outputs/issue16_stage_b_window_probe2/roles_stage_b_window_probe2 \
+  --role lead \
+  --sequence_format stage_b_v1 \
+  --stage_b_window_bars 2 \
+  --stage_b_window_stride_bars 2 \
+  --stage_b_min_window_target_notes 4 \
+  --max_files 2 \
+  --overwrite
+```
+
+This produces short tokenized phrase windows rather than full-song target continuations.
+
 ## Next Issue After Spec
 
-After the dataset preparation contract is merged, the next issue should build:
+After the phrase/window dataset contract is merged, the next issue should build:
 
-- phrase/window dataset extraction
 - target-only training loss if conditioning is prepended
 - Stage B tiny-overfit smoke
 - Brad 2-file Stage B probe

--- a/scripts/prepare_role_dataset.py
+++ b/scripts/prepare_role_dataset.py
@@ -10,6 +10,7 @@ Creates:
 
 import argparse
 import json
+import math
 import random
 import shutil
 from pathlib import Path
@@ -188,6 +189,63 @@ def notes_to_midi(notes: Sequence[pretty_midi.Note], tempo_bpm: float) -> pretty
     return midi
 
 
+def bar_duration_sec(tempo_bpm: float) -> float:
+    return 60.0 / max(1e-6, float(tempo_bpm)) * 4.0
+
+
+def slice_notes_to_window(
+    notes: Sequence[pretty_midi.Note],
+    window_start_sec: float,
+    window_end_sec: float,
+) -> List[pretty_midi.Note]:
+    sliced: List[pretty_midi.Note] = []
+    for note in notes:
+        if note.start < window_start_sec or note.start >= window_end_sec:
+            continue
+        start = float(note.start) - window_start_sec
+        end = min(float(note.end), window_end_sec) - window_start_sec
+        if end <= start:
+            continue
+        sliced.append(
+            pretty_midi.Note(
+                velocity=int(note.velocity),
+                pitch=int(note.pitch),
+                start=start,
+                end=end,
+            )
+        )
+    return sorted(sliced, key=lambda note: (note.start, note.pitch))
+
+
+def iter_stage_b_phrase_windows(
+    conditioning: Sequence[pretty_midi.Note],
+    target: Sequence[pretty_midi.Note],
+    tempo_bpm: float,
+    window_bars: int,
+    stride_bars: int,
+    min_window_target_notes: int,
+) -> Iterable[tuple[int, float, float, List[pretty_midi.Note], List[pretty_midi.Note]]]:
+    if window_bars <= 0:
+        yield 0, 0.0, 0.0, list(conditioning), list(target)
+        return
+
+    bar_sec = bar_duration_sec(tempo_bpm)
+    target_end = max((float(note.end) for note in target), default=0.0)
+    total_bars = max(1, int(math.ceil(target_end / bar_sec)))
+    stride = max(1, int(stride_bars))
+    window_index = 0
+    for start_bar in range(0, total_bars, stride):
+        end_bar = start_bar + max(1, int(window_bars))
+        window_start = start_bar * bar_sec
+        window_end = end_bar * bar_sec
+        window_target = slice_notes_to_window(target, window_start, window_end)
+        if len(window_target) < max(1, int(min_window_target_notes)):
+            continue
+        window_conditioning = slice_notes_to_window(conditioning, window_start, window_end)
+        yield window_index, window_start, window_end, window_conditioning, window_target
+        window_index += 1
+
+
 def infer_tempo(pm: pretty_midi.PrettyMIDI) -> float:
     try:
         _, tempi = pm.get_tempo_changes()
@@ -354,6 +412,24 @@ def main(argv: Sequence[str] | None = None) -> None:
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--overwrite", action="store_true")
     parser.add_argument(
+        "--stage_b_window_bars",
+        type=int,
+        default=0,
+        help="If >0 with stage_b_v1, split target MIDI into fixed bar windows.",
+    )
+    parser.add_argument(
+        "--stage_b_window_stride_bars",
+        type=int,
+        default=0,
+        help="Stride in bars for stage_b_v1 windows. Defaults to window length when <=0.",
+    )
+    parser.add_argument(
+        "--stage_b_min_window_target_notes",
+        type=int,
+        default=4,
+        help="Minimum target notes required to keep a stage_b_v1 phrase window.",
+    )
+    parser.add_argument(
         "--sequence_format",
         choices=SEQUENCE_FORMAT_CHOICES_WITH_STAGE_B,
         default=SEQUENCE_FORMAT_CONTROL_V1,
@@ -411,46 +487,68 @@ def main(argv: Sequence[str] | None = None) -> None:
                 target = transpose_notes_if_valid(base_target, semitones)
                 if not conditioning or not target:
                     continue
+                stage_b_window_bars = args.stage_b_window_bars if args.sequence_format == SEQUENCE_FORMAT_STAGE_B_V1 else 0
+                stage_b_stride_bars = (
+                    args.stage_b_window_stride_bars if args.stage_b_window_stride_bars > 0 else stage_b_window_bars
+                )
+                windows = iter_stage_b_phrase_windows(
+                    conditioning,
+                    target,
+                    tempo_bpm=tempo,
+                    window_bars=stage_b_window_bars,
+                    stride_bars=stage_b_stride_bars,
+                    min_window_target_notes=args.stage_b_min_window_target_notes,
+                )
+                for window_index, window_start, window_end, window_conditioning, window_target in windows:
+                    if not window_conditioning:
+                        window_conditioning = build_sparse_conditioning(window_target)
+                    if not window_conditioning or not window_target:
+                        continue
 
-                sample_id = f"{sample_idx:06d}"
-                sample_dir = output_root / sample_id
-                sample_dir.mkdir(parents=True, exist_ok=True)
+                    sample_id = f"{sample_idx:06d}"
+                    sample_dir = output_root / sample_id
+                    sample_dir.mkdir(parents=True, exist_ok=True)
 
-                cond_path = sample_dir / "conditioning.mid"
-                tgt_path = sample_dir / "target.mid"
-                meta_path = sample_dir / "meta.json"
+                    cond_path = sample_dir / "conditioning.mid"
+                    tgt_path = sample_dir / "target.mid"
+                    meta_path = sample_dir / "meta.json"
 
-                notes_to_midi(conditioning, tempo).write(str(cond_path))
-                notes_to_midi(target, tempo).write(str(tgt_path))
+                    notes_to_midi(window_conditioning, tempo).write(str(cond_path))
+                    notes_to_midi(window_target, tempo).write(str(tgt_path))
 
-                control_tokens = control_prefix_tokens(role=args.role, tempo_bpm=tempo)
-                meta = {
-                    "sample_id": sample_id,
-                    "role": args.role,
-                    "source_midi": str(midi_path),
-                    "source_split": source_split if input_mode == "manifest" else None,
-                    "transpose": int(semitones),
-                    "split_pitch": int(args.split_pitch),
-                    "tempo_bpm": float(tempo),
-                    "conditioning_notes": len(conditioning),
-                    "target_notes": len(target),
-                    "sequence_format": args.sequence_format,
-                    "control_tokens": control_tokens,
-                    "control_token_names": token_names(control_tokens),
-                }
-                meta_path.write_text(json.dumps(meta, ensure_ascii=True, indent=2))
+                    control_tokens = control_prefix_tokens(role=args.role, tempo_bpm=tempo)
+                    meta = {
+                        "sample_id": sample_id,
+                        "role": args.role,
+                        "source_midi": str(midi_path),
+                        "source_split": source_split if input_mode == "manifest" else None,
+                        "transpose": int(semitones),
+                        "split_pitch": int(args.split_pitch),
+                        "tempo_bpm": float(tempo),
+                        "conditioning_notes": len(window_conditioning),
+                        "target_notes": len(window_target),
+                        "sequence_format": args.sequence_format,
+                        "control_tokens": control_tokens,
+                        "control_token_names": token_names(control_tokens),
+                        "stage_b_window_bars": int(stage_b_window_bars),
+                        "stage_b_window_stride_bars": int(stage_b_stride_bars),
+                        "window_index": int(window_index),
+                        "window_start_sec": float(window_start),
+                        "window_end_sec": float(window_end),
+                    }
+                    meta_path.write_text(json.dumps(meta, ensure_ascii=True, indent=2))
 
-                record = {
-                    "sample_id": sample_id,
-                    "conditioning_path": cond_path,
-                    "target_path": tgt_path,
-                    "meta_path": meta_path,
-                    "source_split": source_split,
-                }
-                sample_records.append(record)
-                if input_mode == "manifest":
-                    manifest_records[source_split].append(record)
-                sample_idx += 1
+                    record = {
+                        "sample_id": sample_id,
+                        "conditioning_path": cond_path,
+                        "target_path": tgt_path,
+                        "meta_path": meta_path,
+                        "source_split": source_split,
+                    }
+                    sample_records.append(record)
+                    if input_mode == "manifest":
+                        manifest_records[source_split].append(record)
+                    sample_idx += 1
 
     if not sample_records:
         raise ValueError("No usable samples generated. Try lowering split/threshold parameters.")
@@ -500,6 +598,9 @@ def main(argv: Sequence[str] | None = None) -> None:
         "transpose_all_keys": bool(args.transpose_all_keys),
         "transpose_range": int(args.transpose_range),
         "sequence_format": args.sequence_format,
+        "stage_b_window_bars": int(args.stage_b_window_bars),
+        "stage_b_window_stride_bars": int(args.stage_b_window_stride_bars),
+        "stage_b_min_window_target_notes": int(args.stage_b_min_window_target_notes),
         "seed": int(args.seed),
     }
     (output_root / "dataset_summary.json").write_text(

--- a/tests/test_stage_b_tokens.py
+++ b/tests/test_stage_b_tokens.py
@@ -179,6 +179,84 @@ class StageBTokensTest(unittest.TestCase):
         self.assertTrue(any(TOKEN_NOTE_DURATION_START <= int(token) <= TOKEN_NOTE_DURATION_END for token in tokens))
         self.assertNotIn(TOKEN_COND_SEP, tokens.tolist())
 
+    def test_prepare_role_dataset_splits_stage_b_phrase_windows(self) -> None:
+        def source_notes() -> list[pretty_midi.Note]:
+            notes: list[pretty_midi.Note] = []
+            for bar_index in range(4):
+                bar_start = bar_index * 2.0
+                notes.append(pretty_midi.Note(velocity=70, pitch=48 + bar_index, start=bar_start, end=bar_start + 0.25))
+                notes.append(pretty_midi.Note(velocity=90, pitch=66 + bar_index, start=bar_start, end=bar_start + 0.25))
+                notes.append(
+                    pretty_midi.Note(
+                        velocity=92,
+                        pitch=70 + bar_index,
+                        start=bar_start + 0.5,
+                        end=bar_start + 0.75,
+                    )
+                )
+            return notes
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            train_midi = root / "train.mid"
+            val_midi = root / "val.mid"
+            notes_to_midi(source_notes(), 120).write(str(train_midi))
+            notes_to_midi(source_notes(), 120).write(str(val_midi))
+
+            train_manifest = root / "train.txt"
+            val_manifest = root / "val.txt"
+            train_manifest.write_text(f"{train_midi}\n", encoding="utf-8")
+            val_manifest.write_text(f"{val_midi}\n", encoding="utf-8")
+
+            output_dir = root / "roles"
+            with contextlib.redirect_stdout(io.StringIO()):
+                prepare_role_dataset_main(
+                    [
+                        "--train_manifest",
+                        str(train_manifest),
+                        "--val_manifest",
+                        str(val_manifest),
+                        "--output_dir",
+                        str(output_dir),
+                        "--role",
+                        "lead",
+                        "--min_conditioning_notes",
+                        "2",
+                        "--min_target_notes",
+                        "4",
+                        "--sequence_format",
+                        SEQUENCE_FORMAT_STAGE_B_V1,
+                        "--stage_b_window_bars",
+                        "1",
+                        "--stage_b_window_stride_bars",
+                        "1",
+                        "--stage_b_min_window_target_notes",
+                        "2",
+                        "--overwrite",
+                    ]
+                )
+
+            role_root = output_dir / "lead"
+            summary = json.loads((role_root / "dataset_summary.json").read_text(encoding="utf-8"))
+            train_tokens = sorted((role_root / "tokenized" / "train").glob("*.npy"))
+            val_tokens = sorted((role_root / "tokenized" / "val").glob("*.npy"))
+            train_token_lengths = [len(np.load(path)) for path in train_tokens]
+            train_metas = [json.loads(path.read_text(encoding="utf-8")) for path in sorted(role_root.glob("*/meta.json"))[:3]]
+            target_pm = pretty_midi.PrettyMIDI(str(role_root / "000001" / "target.mid"))
+            target_notes = target_pm.instruments[0].notes
+
+        self.assertEqual(summary["sequence_format"], SEQUENCE_FORMAT_STAGE_B_V1)
+        self.assertEqual(summary["stage_b_window_bars"], 1)
+        self.assertEqual(summary["stage_b_window_stride_bars"], 1)
+        self.assertEqual(summary["train_samples"], 4)
+        self.assertEqual(summary["val_samples"], 4)
+        self.assertEqual(len(train_tokens), 4)
+        self.assertEqual(len(val_tokens), 4)
+        self.assertEqual([meta["window_index"] for meta in train_metas], [0, 1, 2])
+        self.assertEqual([meta["target_notes"] for meta in train_metas], [2, 2, 2])
+        self.assertTrue(all(0.0 <= note.start < 2.0 for note in target_notes))
+        self.assertTrue(all(length < 24 for length in train_token_lengths))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Add Stage B fixed-bar phrase/window extraction to `scripts/prepare_role_dataset.py`.
- Add `--stage_b_window_bars`, `--stage_b_window_stride_bars`, and `--stage_b_min_window_target_notes` options.
- Normalize windowed target note times to the window start.
- Add unit coverage proving manifest train/val files produce multiple short Stage B windows.
- Document the Brad 2-file window dry run.

## Why

The previous Stage B role dataset path could produce train/val `.npy` files, but full target continuations were still thousands of tokens long. This PR creates short phrase windows so the next tiny-overfit probe can train on compact, musically scoped examples.

## Validation

- `./.venv/bin/python -m unittest tests.test_stage_b_tokens tests.test_control_tokens`
- `bash scripts/agent_harness.sh quick`
- Local Brad 2-file window dry run:

```bash
./.venv/bin/python scripts/prepare_role_dataset.py \
  --input_dir "./midi_dataset/midi/studio/Brad Mehldau" \
  --output_dir outputs/issue16_stage_b_window_probe2/roles_stage_b_window_probe2 \
  --role lead \
  --sequence_format stage_b_v1 \
  --stage_b_window_bars 2 \
  --stage_b_window_stride_bars 2 \
  --stage_b_min_window_target_notes 4 \
  --max_files 2 \
  --overwrite
```

Dry run result: 137 role samples, 123 train, 14 val, token length p50 77, max 212.

## Next

After this merges, the next branch should run a Stage B tiny-overfit on windowed token records before broad generic jazz training.