### PR TITLE
[codex] Stage B 생성 디코드 프로브 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #17: Stage B window tiny-overfit smoke.
+- Issue #18: Stage B decode/generation probe.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -81,6 +81,12 @@ For Stage B window dataset/model-vocab changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-window-prepare
+```
+
+For Stage B decode/generation changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-generation-probe
 ```
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-17-stage-b-window-tiny-overfit`
+- `issue-18-stage-b-generation-probe`
 
 현재 범위가 아닌 것:
 
@@ -125,7 +125,11 @@ Current result:
 
 ## Active Issue #17
 
-Current task:
+Status:
+
+- completed and merged via PR #17
+
+Completed task:
 
 - connect Stage B phrase/window records to the model training path
 - move Stage B token ranges into shared model constants
@@ -150,6 +154,33 @@ Current result:
 - train loss: `6.1135`
 - val loss: `5.8195`
 - detail: `docs/STAGE_B_WINDOW_TINY_OVERFIT_2026-05-19.md`
+
+## Active Issue #18
+
+Current task:
+
+- add a Stage B token generation/decode probe
+- make `MusicTransformer.generate()` able to sample Stage B token IDs by using `sample_vocab_size=VOCAB_SIZE`
+- decode generated Stage B tokens back to MIDI
+- run existing MIDI metrics/gates on decoded output
+- report invalid outputs honestly instead of treating MIDI file creation as success
+
+First implementation target:
+
+- `music_transformer/model/music_transformer.py`
+- `scripts/run_stage_b_generation_probe.py`
+- `scripts/agent_harness.sh stage-b-generation-probe`
+- tests for Stage B primer, full-vocab sampling, and MIDI decode
+
+Current result:
+
+- one Brad file Stage B window prepare succeeded
+- one-epoch tiny training succeeded
+- generation sampled with `sample_vocab_size=547`
+- decoded MIDI file was created
+- generated sample failed the review gate with `generated MIDI has no notes`
+- `passed_generation_gate=false`
+- detail: `docs/STAGE_B_GENERATION_PROBE_2026-05-19.md`
 
 ## Dataset Strategy
 
@@ -355,7 +386,7 @@ Dry run result:
 
 Status:
 
-- implemented on `issue-17-stage-b-window-tiny-overfit`
+- completed and merged via PR #17
 
 Goal:
 
@@ -384,6 +415,40 @@ Smoke result:
 - vocab size: `547`
 - epoch 1 train loss: `6.1135`
 - epoch 1 val loss: `5.8195`
+
+### 0.9. Issue #18 Stage B decode/generation probe
+
+Status:
+
+- implemented on `issue-18-stage-b-generation-probe`
+
+Goal:
+
+- make generation capable of emitting Stage B token IDs above `TOKEN_END`
+- decode generated Stage B tokens into MIDI
+- apply the same metrics gate used after the Stage A failure
+- document whether the first Stage B generation smoke is musically valid
+
+Acceptance:
+
+- `MusicTransformer.generate(..., sample_vocab_size=VOCAB_SIZE)` can sample the full Stage B vocabulary
+- generated Stage B tokens can be decoded into a MIDI file
+- invalid output is reported as invalid, not as a successful sample
+- `bash scripts/agent_harness.sh quick` passes
+- `bash scripts/agent_harness.sh stage-b-generation-probe` passes
+
+Smoke result:
+
+- output: `outputs/stage_b_generation_probe/harness_stage_b_generation_probe`
+- role samples: `70`
+- max token id in prepared records: `544`
+- sample vocab size: `547`
+- epoch 1 train loss: `6.2115`
+- epoch 1 val loss: `5.9441`
+- generated sample count: `1`
+- valid sample count: `0`
+- failure reason: `generated MIDI has no notes`
+- decision: data/model/decode plumbing works, but generation quality is still not validated
 
 ### 1. Run full jazz piano dataset audit
 
@@ -516,6 +581,7 @@ Decision:
 - `docs/STAGE_B_ROLE_DATASET_PREP_2026-05-19.md`
 - `docs/STAGE_B_PHRASE_WINDOW_DATASET_2026-05-19.md`
 - `docs/STAGE_B_WINDOW_TINY_OVERFIT_2026-05-19.md`
+- `docs/STAGE_B_GENERATION_PROBE_2026-05-19.md`
 - `docs/REFERENCES.md`
 - `docs/INFERENCE_MODEL_SPEC.md`
 - `docs/QA_ACCEPTANCE_PLAN.md`
@@ -544,4 +610,10 @@ For Stage B window dataset/model-vocab changes:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-window-prepare
+```
+
+For Stage B decode/generation changes:
+
+```bash
+bash scripts/agent_harness.sh stage-b-generation-probe
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,8 @@
   - Stage B 2-bar phrase/window dataset extraction and Brad 2-file dry run.
 - `STAGE_B_WINDOW_TINY_OVERFIT_2026-05-19.md`
   - Stage B phrase windows가 model vocab/training path에 연결되는지 확인한 tiny-overfit smoke.
+- `STAGE_B_GENERATION_PROBE_2026-05-19.md`
+  - Stage B token generation, MIDI decode, and review-gate probe result.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`

--- a/docs/STAGE_B_GENERATION_PROBE_2026-05-19.md
+++ b/docs/STAGE_B_GENERATION_PROBE_2026-05-19.md
@@ -1,0 +1,129 @@
+# Stage B Generation Probe: 2026-05-19
+
+## Purpose
+
+Issue #18 adds the first Stage B decode/generation probe.
+
+Issue #17 proved that Stage B phrase/window records fit the model vocabulary and can enter the training path. That was still only data/model plumbing. Issue #18 checks the next boundary:
+
+- can the model generation path emit Stage B token IDs?
+- can generated Stage B tokens decode back to MIDI?
+- does the decoded MIDI pass the same review gate that rejected Stage A outputs?
+
+This is not a musical success claim. The first smoke is expected to be weak because it trains only one epoch on one Brad file subset.
+
+## Important Finding
+
+Before this issue, `MusicTransformer.generate()` sampled only logits below `TOKEN_END`.
+
+That was acceptable for legacy Stage A event tokens, but Stage B tokens live above the Stage A control-token range. In practice, the model could train on Stage B token IDs but generation could not emit them.
+
+Issue #18 adds:
+
+```text
+sample_vocab_size
+```
+
+Default behavior still samples up to `TOKEN_END` for older Stage A generation. Stage B probe passes `sample_vocab_size=VOCAB_SIZE`, so the model can sample the full Stage B vocabulary.
+
+## Implementation
+
+Code changes:
+
+- `music_transformer/model/music_transformer.py`
+  - adds optional `sample_vocab_size`
+  - keeps default `TOKEN_END` behavior for Stage A compatibility
+  - lets Stage B generation sample up to `VOCAB_SIZE`
+- `scripts/generate.py`
+  - forwards optional `sample_vocab_size` to model generation
+- `scripts/run_stage_b_generation_probe.py`
+  - prepares Stage B phrase windows
+  - optionally trains a tiny full-model checkpoint
+  - builds a Stage B primer from role, tempo, first bar, and chord tokens
+  - samples Stage B tokens with `sample_vocab_size=VOCAB_SIZE`
+  - decodes tokens through `decode_stage_b_midi`
+  - computes existing MIDI metrics and gate result
+  - writes `report.json`
+- `scripts/agent_harness.sh`
+  - adds `stage-b-generation-probe`
+- `tests/test_stage_b_generation_probe.py`
+  - verifies primer shape
+  - verifies generation uses full `VOCAB_SIZE`
+  - verifies Stage B tokens write a MIDI note
+
+## Command
+
+```bash
+bash scripts/agent_harness.sh stage-b-generation-probe
+```
+
+Equivalent direct command:
+
+```bash
+python scripts/run_stage_b_generation_probe.py \
+  --run_id harness_stage_b_generation_probe \
+  --max_files 1 \
+  --epochs 1 \
+  --batch_size 8 \
+  --max_sequence 96 \
+  --num_samples 1 \
+  --n_layers 1 \
+  --num_heads 4 \
+  --d_model 64 \
+  --dim_feedforward 128 \
+  --lora_r 4 \
+  --lora_alpha 8
+```
+
+## Local Result
+
+Output:
+
+```text
+outputs/stage_b_generation_probe/harness_stage_b_generation_probe
+```
+
+Dataset/training:
+
+| Metric | Value |
+|---|---:|
+| role samples | 70 |
+| train records | 63 |
+| val records | 7 |
+| max token id | 544 |
+| sample vocab size | 547 |
+| epoch 1 train loss | 6.2115 |
+| epoch 1 val loss | 5.9441 |
+
+Generation:
+
+| Metric | Value |
+|---|---:|
+| generated samples | 1 |
+| valid samples | 0 |
+| generated token count | 13 |
+| decoded note count | 0 |
+| passed generation gate | false |
+
+Failure reason:
+
+```text
+generated MIDI has no notes
+```
+
+## Decision
+
+Issue #18 validates the Stage B generation/decode plumbing, but not musical quality.
+
+The first generated sample is invalid. That is still useful: the pipeline now catches the failure in a report instead of pretending a `.mid` file is enough.
+
+## Next Step
+
+Do not start broad jazz training yet.
+
+Next issue should make the Stage B tiny-overfit probe stricter:
+
+- train long enough to overfit a very small Stage B window set
+- use deterministic or constrained token sampling for the first grammar check
+- verify generated tokens contain complete `POSITION + VELOCITY + NOTE_PITCH + NOTE_DURATION` groups
+- require at least one decoded MIDI sample to pass the review gate before expanding data size

--- a/docs/STAGE_B_TOKENIZATION_SPEC.md
+++ b/docs/STAGE_B_TOKENIZATION_SPEC.md
@@ -214,3 +214,5 @@ After the tiny-overfit smoke proves model-vocab compatibility, the next issue sh
 - train a tiny Stage B checkpoint long enough to overfit a short window set
 - decode Stage B tokens back to MIDI
 - apply the same invalid-output gates used after the Stage A failure
+
+Issue #18 adds this first decode/generation probe. It validates the plumbing, but the first one-epoch smoke still generates an invalid empty MIDI sample. The next step is not broad training. The next step is a stricter Stage B tiny-overfit grammar probe that forces or learns complete note groups before dataset size increases.

--- a/docs/STAGE_B_WINDOW_TINY_OVERFIT_2026-05-19.md
+++ b/docs/STAGE_B_WINDOW_TINY_OVERFIT_2026-05-19.md
@@ -107,9 +107,11 @@ Stage B window records now fit the model vocabulary, and the training entrypoint
 
 This only validates the data/model plumbing. It does not prove that the model can generate reviewable jazz MIDI yet.
 
-Next issue should add a Stage B decode/generation probe:
+Follow-up issue #18 adds a Stage B decode/generation probe:
 
 - train a tiny Stage B checkpoint for enough epochs to overfit a tiny window set
 - decode generated Stage B tokens back to MIDI
 - reject one-note, two-note, long-sustain, and chord-block outputs
 - compare generated MIDI against the same review gates used after the Stage A failure
+
+The first Issue #18 smoke validates the decode/generation plumbing, but it still produces no valid MIDI notes after one epoch.

--- a/music_transformer/model/music_transformer.py
+++ b/music_transformer/model/music_transformer.py
@@ -146,6 +146,7 @@ class MusicTransformer(nn.Module):
         temperature=1.0,
         top_k=None,
         top_p=None,
+        sample_vocab_size=None,
     ):
         """
         ----------
@@ -157,6 +158,9 @@ class MusicTransformer(nn.Module):
         """
 
         assert (not self.training), "Cannot generate while in training mode"
+        sample_vocab_size = int(sample_vocab_size or TOKEN_END)
+        if sample_vocab_size <= 0 or sample_vocab_size > VOCAB_SIZE:
+            raise ValueError(f"sample_vocab_size out of range: {sample_vocab_size}")
 
         print("Generating sequence of max length:", target_seq_length)
 
@@ -171,7 +175,7 @@ class MusicTransformer(nn.Module):
         cur_i = num_primer
         while(cur_i < target_seq_length):
             # gen_seq_batch     = gen_seq.clone()
-            logits = self.forward(gen_seq[..., :cur_i])[..., :TOKEN_END]
+            logits = self.forward(gen_seq[..., :cur_i])[..., :sample_vocab_size]
             token_logits = logits[:, cur_i - 1, :]
             token_probs = _sample_probs_from_logits(
                 token_logits,
@@ -190,7 +194,7 @@ class MusicTransformer(nn.Module):
                 top_res, top_i = torch.topk(token_probs, beam)
 
                 beam_rows = top_i // VOCAB_SIZE
-                beam_cols = top_i % VOCAB_SIZE
+                beam_cols = top_i % sample_vocab_size
 
                 gen_seq = gen_seq[beam_rows, :]
                 gen_seq[..., cur_i] = beam_cols

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -30,6 +30,8 @@ Modes:
   control-tiny  Run control_v1 full-model tiny-overfit smoke.
   stage-b-window-prepare
                 Prepare Stage B phrase windows and verify token vocab fit.
+  stage-b-generation-probe
+                Run a one-epoch Stage B decode/generation smoke.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   all           Run demo and tiny-compare.
@@ -66,6 +68,7 @@ run_quick() {
     scripts/stage_b_tokens.py \
     scripts/prepare_role_dataset.py \
     scripts/run_stage_b_window_tiny_overfit.py \
+    scripts/run_stage_b_generation_probe.py \
     scripts/audit_brad_mehldau_dataset.py \
     scripts/audit_jazz_piano_dataset.py \
     scripts/build_jazz_training_manifests.py \
@@ -132,6 +135,24 @@ run_stage_b_window_prepare() {
     --prepare_only
 }
 
+run_stage_b_generation_probe() {
+  local run_id="${RUN_ID:-harness_stage_b_generation_probe}"
+  print_header "Stage B generation probe"
+  "$PYTHON_BIN" scripts/run_stage_b_generation_probe.py \
+    --run_id "$run_id" \
+    --max_files 1 \
+    --epochs 1 \
+    --batch_size 8 \
+    --max_sequence 96 \
+    --num_samples 1 \
+    --n_layers 1 \
+    --num_heads 4 \
+    --d_model 64 \
+    --dim_feedforward 128 \
+    --lora_r 4 \
+    --lora_alpha 8
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -164,6 +185,9 @@ case "$MODE" in
     ;;
   stage-b-window-prepare)
     run_stage_b_window_prepare
+    ;;
+  stage-b-generation-probe)
+    run_stage_b_generation_probe
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -258,6 +258,7 @@ def generate_once(
     temperature: float,
     top_k: int | None,
     top_p: float | None,
+    sample_vocab_size: int | None = None,
 ) -> List[int]:
     device = get_device()
     primer = primer.to(device)
@@ -271,6 +272,7 @@ def generate_once(
             temperature=temperature,
             top_k=top_k,
             top_p=top_p,
+            sample_vocab_size=sample_vocab_size,
         )
 
     sequence = generated[0].detach().cpu().tolist()

--- a/scripts/run_stage_b_generation_probe.py
+++ b/scripts/run_stage_b_generation_probe.py
@@ -1,0 +1,257 @@
+"""
+Run a Stage B decode/generation probe.
+
+This script prepares short stage_b_v1 phrase windows, optionally trains a tiny
+checkpoint, samples Stage B tokens with the full model vocabulary, decodes those
+tokens back to MIDI, and records whether the output passes the existing MIDI
+quality gates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Sequence
+
+import torch
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+sys.path.insert(0, str(ROOT_DIR / "scripts"))
+sys.path.insert(0, str(ROOT_DIR / "music_transformer"))
+
+from inference.app.metrics import compute_midi_metrics, validate_metrics  # noqa: E402
+from inference.app.schemas import GenerationRequest  # noqa: E402
+from scripts.control_tokens import control_prefix_tokens  # noqa: E402
+from scripts.generate import load_model_with_lora  # noqa: E402
+from scripts.run_stage_a_tiny_overfit import build_train_command, run_command, write_json  # noqa: E402
+from scripts.run_stage_b_window_tiny_overfit import read_json, run_prepare_command, token_stats  # noqa: E402
+from scripts.stage_b_tokens import (  # noqa: E402
+    SEQUENCE_FORMAT_STAGE_B_V1,
+    chord_tokens,
+    decode_stage_b_midi,
+    stage_b_token_name,
+)
+from utilities.constants import TOKEN_END, VOCAB_SIZE  # noqa: E402
+from utilities.device import get_device  # noqa: E402
+
+
+def parse_chords(raw_chords: str) -> list[str]:
+    return [chord.strip() for chord in raw_chords.split(",") if chord.strip()]
+
+
+def build_stage_b_primer(chords: Sequence[str], bpm: float | int, role: str = "lead") -> list[int]:
+    first_chord = chords[0] if chords else None
+    return control_prefix_tokens(role=role, tempo_bpm=bpm) + chord_tokens(first_chord)
+
+
+def generate_stage_b_tokens(
+    model: Any,
+    primer_tokens: Sequence[int],
+    target_length: int,
+    temperature: float,
+    top_k: int | None,
+    top_p: float | None,
+) -> list[int]:
+    primer = torch.tensor([int(token) for token in primer_tokens], dtype=torch.long, device=get_device())
+    with torch.no_grad():
+        generated = model.generate(
+            primer=primer,
+            target_seq_length=int(target_length),
+            beam=0,
+            beam_chance=1.0,
+            temperature=float(temperature),
+            top_k=top_k,
+            top_p=top_p,
+            sample_vocab_size=VOCAB_SIZE,
+        )
+    return [int(token) for token in generated[0].detach().cpu().tolist()]
+
+
+def decode_tokens_to_midi(tokens: Sequence[int], output_path: Path, bpm: float | int) -> Path:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    midi = decode_stage_b_midi(tokens, tempo_bpm=bpm)
+    midi.write(str(output_path))
+    return output_path
+
+
+def sample_report(
+    sample_index: int,
+    tokens: Sequence[int],
+    primer_size: int,
+    target_length: int,
+    midi_path: Path,
+    request: GenerationRequest,
+) -> dict[str, Any]:
+    raw_generated_tokens = [int(token) for token in tokens[primer_size:]]
+    metrics = compute_midi_metrics(midi_path, 0, False, request=request)
+    valid, reason = validate_metrics(metrics, request.density, bars=request.bars)
+    return {
+        "sample_index": int(sample_index),
+        "midi_path": str(midi_path),
+        "token_count": int(len(tokens)),
+        "generated_token_count": int(len(raw_generated_tokens)),
+        "ended_early": bool(len(tokens) < int(target_length)),
+        "hit_end_token": bool(TOKEN_END in raw_generated_tokens),
+        "valid": bool(valid),
+        "failure_reason": reason,
+        "metrics": metrics.to_dict(),
+        "generated_token_names_head": [stage_b_token_name(token) for token in raw_generated_tokens[:48]],
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run Stage B generation/decode probe")
+    parser.add_argument("--input_dir", type=str, default="./midi_dataset/midi/studio/Brad Mehldau")
+    parser.add_argument("--output_root", type=str, default=str(ROOT_DIR / "outputs" / "stage_b_generation_probe"))
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--checkpoint_dir", type=str, default=None)
+    parser.add_argument("--max_files", type=int, default=1)
+    parser.add_argument("--window_bars", type=int, default=2)
+    parser.add_argument("--window_stride_bars", type=int, default=2)
+    parser.add_argument("--min_window_target_notes", type=int, default=4)
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--batch_size", type=int, default=8)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--seed", type=int, default=17)
+    parser.add_argument("--max_sequence", type=int, default=128)
+    parser.add_argument("--n_layers", type=int, default=1)
+    parser.add_argument("--num_heads", type=int, default=4)
+    parser.add_argument("--d_model", type=int, default=64)
+    parser.add_argument("--dim_feedforward", type=int, default=128)
+    parser.add_argument("--lora_r", type=int, default=4)
+    parser.add_argument("--lora_alpha", type=int, default=8)
+    parser.add_argument("--skip_prepare", action="store_true")
+    parser.add_argument("--skip_train", action="store_true")
+    parser.add_argument("--num_samples", type=int, default=2)
+    parser.add_argument("--bpm", type=int, default=124)
+    parser.add_argument("--bars", type=int, default=2)
+    parser.add_argument("--chords", type=str, default="Cm7,Fm7,Bb7,Ebmaj7")
+    parser.add_argument("--density", type=str, default="medium")
+    parser.add_argument("--energy", type=str, default="mid")
+    parser.add_argument("--temperature", type=float, default=0.9)
+    parser.add_argument("--top_k", type=int, default=32)
+    parser.add_argument("--top_p", type=float, default=None)
+    parser.add_argument("--require_valid_sample", action="store_true")
+    parser.set_defaults(lora_only=False)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    torch.manual_seed(int(args.seed))
+
+    run_id = args.run_id or datetime.now().strftime("%Y%m%d_%H%M%S")
+    run_dir = Path(args.output_root) / run_id
+    roles_dir = run_dir / "roles"
+    role_root = roles_dir / "lead"
+    tokenized_dir = role_root / "tokenized"
+    checkpoint_dir = Path(args.checkpoint_dir) if args.checkpoint_dir else run_dir / "checkpoints"
+    samples_dir = run_dir / "samples"
+
+    chords = parse_chords(args.chords)
+    request = GenerationRequest(
+        bpm=int(args.bpm),
+        chord_progression=chords,
+        bars=int(args.bars),
+        density=args.density,
+        energy=args.energy,
+        temperature=float(args.temperature),
+        top_k=args.top_k,
+        top_p=args.top_p,
+        seed=int(args.seed),
+    )
+    request.validate()
+
+    report: dict[str, Any] = {
+        "run_id": run_id,
+        "run_dir": str(run_dir),
+        "issue": 18,
+        "sequence_format": SEQUENCE_FORMAT_STAGE_B_V1,
+        "request": request.to_dict(),
+        "checkpoint_dir": str(checkpoint_dir),
+        "sample_vocab_size": int(VOCAB_SIZE),
+    }
+
+    if not args.skip_prepare:
+        prepare_result = run_prepare_command(args, roles_dir)
+        report["prepare_result"] = prepare_result
+        if prepare_result["returncode"] != 0:
+            write_json(run_dir / "report.json", report)
+            print(json.dumps(report, ensure_ascii=True, indent=2))
+            return int(prepare_result["returncode"])
+        report["dataset_summary"] = read_json(role_root / "dataset_summary.json")
+        report["token_stats"] = token_stats(tokenized_dir)
+        if not report["token_stats"]["fits_vocab"]:
+            report["failure_reason"] = "Stage B tokenized records do not fit model VOCAB_SIZE"
+            write_json(run_dir / "report.json", report)
+            print(json.dumps(report, ensure_ascii=True, indent=2))
+            return 2
+
+    if not args.skip_train:
+        train_result = run_command(build_train_command(args, tokenized_dir, checkpoint_dir), ROOT_DIR)
+        report["train_result"] = train_result
+        if train_result["returncode"] != 0:
+            write_json(run_dir / "report.json", report)
+            print(json.dumps(report, ensure_ascii=True, indent=2))
+            return int(train_result["returncode"])
+
+    model = load_model_with_lora(
+        lora_path=str(checkpoint_dir),
+        prefer_full_checkpoint=True,
+        n_layers=args.n_layers,
+        num_heads=args.num_heads,
+        d_model=args.d_model,
+        dim_feedforward=args.dim_feedforward,
+        max_sequence=args.max_sequence,
+        lora_r=args.lora_r,
+        lora_alpha=args.lora_alpha,
+    )
+
+    primer_tokens = build_stage_b_primer(chords, args.bpm)
+    report["primer_tokens"] = [int(token) for token in primer_tokens]
+    report["primer_token_names"] = [stage_b_token_name(token) for token in primer_tokens]
+
+    sample_rows: list[dict[str, Any]] = []
+    for index in range(1, int(args.num_samples) + 1):
+        generated_tokens = generate_stage_b_tokens(
+            model=model,
+            primer_tokens=primer_tokens,
+            target_length=args.max_sequence,
+            temperature=args.temperature,
+            top_k=args.top_k,
+            top_p=args.top_p,
+        )
+        midi_path = samples_dir / f"stage_b_sample_{index}.mid"
+        decode_tokens_to_midi(generated_tokens, midi_path, bpm=args.bpm)
+        sample_rows.append(
+            sample_report(
+                sample_index=index,
+                tokens=generated_tokens,
+                primer_size=len(primer_tokens),
+                target_length=args.max_sequence,
+                midi_path=midi_path,
+                request=request,
+            )
+        )
+
+    report["samples"] = sample_rows
+    report["valid_sample_count"] = sum(1 for row in sample_rows if row["valid"])
+    report["sample_count"] = len(sample_rows)
+    report["passed_generation_gate"] = bool(report["valid_sample_count"] > 0)
+    if not report["passed_generation_gate"]:
+        report["failure_reason"] = "No Stage B generated sample passed the MIDI review gate"
+
+    write_json(run_dir / "report.json", report)
+    print(json.dumps(report, ensure_ascii=True, indent=2))
+    if args.require_valid_sample and not report["passed_generation_gate"]:
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_generation_probe.py
+++ b/tests/test_stage_b_generation_probe.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import pretty_midi
+import torch
+
+from scripts.run_stage_b_generation_probe import (
+    build_stage_b_primer,
+    decode_tokens_to_midi,
+    generate_stage_b_tokens,
+)
+from scripts.stage_b_tokens import (
+    chord_tokens,
+    note_duration_token,
+    note_pitch_token,
+    note_velocity_token,
+    position_token,
+)
+from utilities.constants import TOKEN_BAR, TOKEN_END, TOKEN_ROLE_LEAD, VOCAB_SIZE
+
+
+class FakeStageBModel:
+    def __init__(self, returned_tokens: list[int]) -> None:
+        self.returned_tokens = returned_tokens
+        self.sample_vocab_size: int | None = None
+
+    def generate(self, **kwargs):
+        self.sample_vocab_size = kwargs["sample_vocab_size"]
+        return torch.tensor([self.returned_tokens], dtype=torch.long)
+
+
+class StageBGenerationProbeTest(unittest.TestCase):
+    def test_build_stage_b_primer_contains_bar_and_first_chord(self) -> None:
+        primer = build_stage_b_primer(["Cm7", "F7"], bpm=124)
+
+        self.assertEqual(primer[0], TOKEN_ROLE_LEAD)
+        self.assertEqual(primer[2], TOKEN_BAR)
+        self.assertEqual(primer[3:5], chord_tokens("Cm7"))
+
+    def test_generation_uses_full_stage_b_vocab_size(self) -> None:
+        returned_tokens = build_stage_b_primer(["Cm7"], bpm=124) + [TOKEN_END]
+        model = FakeStageBModel(returned_tokens)
+
+        tokens = generate_stage_b_tokens(
+            model=model,
+            primer_tokens=returned_tokens[:-1],
+            target_length=16,
+            temperature=0.9,
+            top_k=32,
+            top_p=None,
+        )
+
+        self.assertEqual(tokens, returned_tokens)
+        self.assertEqual(model.sample_vocab_size, VOCAB_SIZE)
+
+    def test_decode_tokens_to_midi_writes_stage_b_notes(self) -> None:
+        tokens = build_stage_b_primer(["Cm7"], bpm=120) + [
+            position_token(0),
+            note_velocity_token(4),
+            note_pitch_token(60),
+            note_duration_token(2),
+            TOKEN_END,
+        ]
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            midi_path = Path(tmp_dir) / "decoded.mid"
+
+            decode_tokens_to_midi(tokens, midi_path, bpm=120)
+
+            midi = pretty_midi.PrettyMIDI(str(midi_path))
+            notes = midi.instruments[0].notes
+            self.assertEqual(len(notes), 1)
+            self.assertEqual(notes[0].pitch, 60)
+            self.assertAlmostEqual(notes[0].start, 0.0)
+            self.assertAlmostEqual(notes[0].end, 0.25)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

- `MusicTransformer.generate()`가 Stage B 토큰 범위까지 샘플링할 수 있도록 `sample_vocab_size` 옵션을 추가했습니다.
- Stage B 토큰을 생성한 뒤 MIDI로 decode하고 기존 MIDI metrics/review gate를 적용하는 probe script를 추가했습니다.
- `stage-b-generation-probe` 하네스와 관련 unit test, Issue #18 문서를 추가했습니다.
- 첫 smoke 결과를 성공으로 포장하지 않고 `passed_generation_gate=false`로 기록했습니다.

## 핵심 발견

기존 generation path는 logits를 `TOKEN_END`까지만 잘라 샘플링했습니다. Stage B 토큰은 그보다 높은 ID 범위에 있으므로, 모델이 Stage B 토큰으로 학습되더라도 generation에서는 Stage B 토큰을 제대로 낼 수 없었습니다.

이번 PR에서는 Stage A 기본 동작은 유지하고, Stage B probe에서만 `sample_vocab_size=VOCAB_SIZE`를 사용합니다.

## 검증

- `./.venv/bin/python -m unittest tests.test_stage_b_generation_probe tests.test_stage_b_tokens tests.test_stage_b_window_tiny_overfit`
- `bash scripts/agent_harness.sh quick`
- `bash scripts/agent_harness.sh stage-b-generation-probe`

## 로컬 smoke 결과

- role samples: 70
- max token id: 544
- sample vocab size: 547
- epoch 1 train loss: 6.2115
- epoch 1 val loss: 5.9441
- generated sample count: 1
- valid sample count: 0
- failure reason: `generated MIDI has no notes`

## 판단

이 PR은 Stage B data/model/decode plumbing 검증입니다. 아직 음악적으로 성공한 모델은 아닙니다. 다음 이슈에서는 더 작은 Stage B window set을 충분히 overfit하거나 constrained token grammar를 적용해서 완성된 note group을 생성하는지 먼저 확인해야 합니다.