### PR TITLE
[codex] Stage B 제약 생성 문법 게이트 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #18: Stage B decode/generation probe.
+- Issue #20: Stage B grammar-constrained tiny-overfit.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -87,6 +87,12 @@ For Stage B decode/generation changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-generation-probe
+```
+
+For Stage B constrained note-grammar changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-constrained-probe
 ```
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-18-stage-b-generation-probe`
+- `issue-20-stage-b-constrained-tiny-overfit`
 
 현재 범위가 아닌 것:
 
@@ -157,7 +157,11 @@ Current result:
 
 ## Active Issue #18
 
-Current task:
+Status:
+
+- completed and merged via PR #19
+
+Completed task:
 
 - add a Stage B token generation/decode probe
 - make `MusicTransformer.generate()` able to sample Stage B token IDs by using `sample_vocab_size=VOCAB_SIZE`
@@ -181,6 +185,31 @@ Current result:
 - generated sample failed the review gate with `generated MIDI has no notes`
 - `passed_generation_gate=false`
 - detail: `docs/STAGE_B_GENERATION_PROBE_2026-05-19.md`
+
+## Active Issue #20
+
+Current task:
+
+- add a grammar-constrained Stage B generation mode
+- analyze generated tokens for complete `POSITION + VELOCITY + NOTE_PITCH + NOTE_DURATION` groups
+- separate grammar-gate success from full musical review-gate success
+- require at least one decoded MIDI note before expanding training scope
+
+First implementation target:
+
+- `scripts/run_stage_b_generation_probe.py`
+- `scripts/agent_harness.sh stage-b-constrained-probe`
+- `tests/test_stage_b_generation_probe.py`
+- `docs/STAGE_B_CONSTRAINED_TINY_OVERFIT_2026-05-19.md`
+
+Current result:
+
+- constrained generation produced 8 complete Stage B note groups
+- decoded MIDI note count: `8`
+- grammar gate passed: `true`
+- full review gate passed: `false`
+- full gate failure reason: `too many simultaneous notes: 3 > 2`
+- decision: Stage B note grammar can now be forced through the model logits, but musical validity still needs overlap/deduplication control
 
 ## Dataset Strategy
 
@@ -420,7 +449,7 @@ Smoke result:
 
 Status:
 
-- implemented on `issue-18-stage-b-generation-probe`
+- completed and merged via PR #19
 
 Goal:
 
@@ -449,6 +478,38 @@ Smoke result:
 - valid sample count: `0`
 - failure reason: `generated MIDI has no notes`
 - decision: data/model/decode plumbing works, but generation quality is still not validated
+
+### 0.10. Issue #20 Stage B grammar-constrained tiny-overfit
+
+Status:
+
+- implemented on `issue-20-stage-b-constrained-tiny-overfit`
+
+Goal:
+
+- constrain generated token families into complete Stage B note groups
+- verify decoded MIDI has real notes before broad training
+- record grammar success separately from musical review success
+
+Acceptance:
+
+- grammar analyzer counts complete note groups
+- constrained generation creates `POSITION + VELOCITY + NOTE_PITCH + NOTE_DURATION` groups
+- decoded MIDI has non-zero notes
+- `bash scripts/agent_harness.sh quick` passes
+- `bash scripts/agent_harness.sh stage-b-constrained-probe` passes
+
+Smoke result:
+
+- output: `outputs/stage_b_generation_probe/harness_stage_b_constrained_probe`
+- role samples: `70`
+- generated sample count: `1`
+- complete note groups: `8`
+- decoded note count: `8`
+- grammar gate sample count: `1`
+- valid sample count: `0`
+- full gate failure reason: `too many simultaneous notes: 3 > 2`
+- decision: next issue should reduce repeated same-position/same-pitch overlaps before broad training
 
 ### 1. Run full jazz piano dataset audit
 
@@ -582,6 +643,7 @@ Decision:
 - `docs/STAGE_B_PHRASE_WINDOW_DATASET_2026-05-19.md`
 - `docs/STAGE_B_WINDOW_TINY_OVERFIT_2026-05-19.md`
 - `docs/STAGE_B_GENERATION_PROBE_2026-05-19.md`
+- `docs/STAGE_B_CONSTRAINED_TINY_OVERFIT_2026-05-19.md`
 - `docs/REFERENCES.md`
 - `docs/INFERENCE_MODEL_SPEC.md`
 - `docs/QA_ACCEPTANCE_PLAN.md`
@@ -616,4 +678,10 @@ For Stage B decode/generation changes:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-generation-probe
+```
+
+For Stage B constrained note-grammar changes:
+
+```bash
+bash scripts/agent_harness.sh stage-b-constrained-probe
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,8 @@
   - Stage B phrase windows가 model vocab/training path에 연결되는지 확인한 tiny-overfit smoke.
 - `STAGE_B_GENERATION_PROBE_2026-05-19.md`
   - Stage B token generation, MIDI decode, and review-gate probe result.
+- `STAGE_B_CONSTRAINED_TINY_OVERFIT_2026-05-19.md`
+  - Stage B constrained note-group generation and grammar-gate result.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -58,7 +60,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit와 2-file generation probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, and 2-file generation probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_CONSTRAINED_TINY_OVERFIT_2026-05-19.md
+++ b/docs/STAGE_B_CONSTRAINED_TINY_OVERFIT_2026-05-19.md
@@ -1,0 +1,123 @@
+# Stage B Grammar-Constrained Tiny-Overfit: 2026-05-19
+
+## Purpose
+
+Issue #20 adds a stricter Stage B grammar smoke.
+
+Issue #18 proved that Stage B generation can sample the full vocabulary and decode to MIDI, but the first unconstrained generated sample had zero decoded notes. The missing piece was not another broad training run. The next check was whether the model logits can be sampled under a simple Stage B note grammar:
+
+```text
+POSITION + VELOCITY + NOTE_PITCH + NOTE_DURATION
+```
+
+This issue separates two gates:
+
+- grammar gate: generated tokens contain complete note groups and decode to at least one MIDI note
+- full review gate: decoded MIDI passes the existing musical quality metrics
+
+## Implementation
+
+Code changes:
+
+- `scripts/run_stage_b_generation_probe.py`
+  - adds generated-token grammar analysis
+  - adds `generation_mode=constrained`
+  - constrains model sampling by token family:
+    - `POSITION_*`
+    - `VELOCITY_*`
+    - `NOTE_PITCH_*`
+    - `NOTE_DURATION_*`
+  - reports `grammar_gate_passed`, `passed_grammar_gate`, and `passed_generation_gate` separately
+  - adds `--require_note_groups` for smoke checks
+- `scripts/agent_harness.sh`
+  - adds `stage-b-constrained-probe`
+- `tests/test_stage_b_generation_probe.py`
+  - verifies grammar counting
+  - verifies incomplete groups are reported
+  - verifies constrained generation creates decodable notes
+
+## Command
+
+```bash
+bash scripts/agent_harness.sh stage-b-constrained-probe
+```
+
+Equivalent direct command:
+
+```bash
+python scripts/run_stage_b_generation_probe.py \
+  --run_id harness_stage_b_constrained_probe \
+  --max_files 1 \
+  --epochs 1 \
+  --batch_size 8 \
+  --max_sequence 96 \
+  --num_samples 1 \
+  --generation_mode constrained \
+  --constrained_note_groups_per_bar 4 \
+  --top_k 1 \
+  --require_note_groups \
+  --n_layers 1 \
+  --num_heads 4 \
+  --d_model 64 \
+  --dim_feedforward 128 \
+  --lora_r 4 \
+  --lora_alpha 8
+```
+
+## Local Result
+
+Output:
+
+```text
+outputs/stage_b_generation_probe/harness_stage_b_constrained_probe
+```
+
+Dataset/training:
+
+| Metric | Value |
+|---|---:|
+| role samples | 70 |
+| train records | 63 |
+| val records | 7 |
+| max token id | 544 |
+| epoch 1 train loss | 6.2115 |
+| epoch 1 val loss | 5.9441 |
+
+Grammar result:
+
+| Metric | Value |
+|---|---:|
+| generated samples | 1 |
+| complete note groups | 8 |
+| invalid grammar tokens | 0 |
+| decoded note count | 8 |
+| grammar gate sample count | 1 |
+| passed grammar gate | true |
+
+Full review gate:
+
+| Metric | Value |
+|---|---:|
+| valid samples | 0 |
+| passed generation gate | false |
+| failure reason | too many simultaneous notes: 3 > 2 |
+| note density | 2.204 |
+| phrase coverage ratio | 0.937 |
+| max simultaneous notes | 3 |
+
+## Decision
+
+Stage B can now produce complete note groups when generation is constrained by token family.
+
+This is progress over Issue #18 because decoded MIDI now has real notes. It is still not a musically valid model result because the full review gate failed on overlapping notes.
+
+## Next Step
+
+Do not start broad jazz training yet.
+
+Next issue should reduce overlap and repeated-position artifacts before increasing data size:
+
+- prevent duplicate notes at the same bar/position/pitch
+- optionally sort or de-overlap constrained generated notes before metrics
+- add a `max_simultaneous_notes <= 2` constrained smoke gate
+- only then try a longer tiny-overfit or a 2-file Stage B probe

--- a/docs/STAGE_B_GENERATION_PROBE_2026-05-19.md
+++ b/docs/STAGE_B_GENERATION_PROBE_2026-05-19.md
@@ -127,3 +127,5 @@ Next issue should make the Stage B tiny-overfit probe stricter:
 - use deterministic or constrained token sampling for the first grammar check
 - verify generated tokens contain complete `POSITION + VELOCITY + NOTE_PITCH + NOTE_DURATION` groups
 - require at least one decoded MIDI sample to pass the review gate before expanding data size
+
+Issue #20 implements the constrained grammar check. It produces complete note groups and non-zero decoded notes, but the full review gate still fails because overlapping notes exceed the current max-simultaneous-notes threshold.

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -32,6 +32,8 @@ Modes:
                 Prepare Stage B phrase windows and verify token vocab fit.
   stage-b-generation-probe
                 Run a one-epoch Stage B decode/generation smoke.
+  stage-b-constrained-probe
+                Run a constrained Stage B note-group smoke.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   all           Run demo and tiny-compare.
@@ -153,6 +155,28 @@ run_stage_b_generation_probe() {
     --lora_alpha 8
 }
 
+run_stage_b_constrained_probe() {
+  local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
+  print_header "Stage B constrained probe"
+  "$PYTHON_BIN" scripts/run_stage_b_generation_probe.py \
+    --run_id "$run_id" \
+    --max_files 1 \
+    --epochs 1 \
+    --batch_size 8 \
+    --max_sequence 96 \
+    --num_samples 1 \
+    --generation_mode constrained \
+    --constrained_note_groups_per_bar 4 \
+    --top_k 1 \
+    --require_note_groups \
+    --n_layers 1 \
+    --num_heads 4 \
+    --d_model 64 \
+    --dim_feedforward 128 \
+    --lora_r 4 \
+    --lora_alpha 8
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -188,6 +212,9 @@ case "$MODE" in
     ;;
   stage-b-generation-probe)
     run_stage_b_generation_probe
+    ;;
+  stage-b-constrained-probe)
+    run_stage_b_constrained_probe
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/run_stage_b_generation_probe.py
+++ b/scripts/run_stage_b_generation_probe.py
@@ -31,12 +31,28 @@ from scripts.generate import load_model_with_lora  # noqa: E402
 from scripts.run_stage_a_tiny_overfit import build_train_command, run_command, write_json  # noqa: E402
 from scripts.run_stage_b_window_tiny_overfit import read_json, run_prepare_command, token_stats  # noqa: E402
 from scripts.stage_b_tokens import (  # noqa: E402
+    TOKEN_NOTE_DURATION_END,
+    TOKEN_NOTE_DURATION_START,
+    TOKEN_NOTE_PITCH_END,
+    TOKEN_NOTE_PITCH_START,
+    TOKEN_POSITION_END,
+    TOKEN_POSITION_START,
+    TOKEN_VELOCITY_END,
+    TOKEN_VELOCITY_START,
+    TOKEN_CHORD_QUALITY_END,
+    TOKEN_CHORD_QUALITY_START,
+    TOKEN_CHORD_ROOT_END,
+    TOKEN_CHORD_ROOT_START,
     SEQUENCE_FORMAT_STAGE_B_V1,
     chord_tokens,
     decode_stage_b_midi,
+    is_note_duration_token,
+    is_note_pitch_token,
+    is_position_token,
+    is_velocity_token,
     stage_b_token_name,
 )
-from utilities.constants import TOKEN_END, VOCAB_SIZE  # noqa: E402
+from utilities.constants import TOKEN_BAR, TOKEN_END, VOCAB_SIZE  # noqa: E402
 from utilities.device import get_device  # noqa: E402
 
 
@@ -72,6 +88,151 @@ def generate_stage_b_tokens(
     return [int(token) for token in generated[0].detach().cpu().tolist()]
 
 
+def token_family(token: int) -> str:
+    if int(token) == TOKEN_END:
+        return "end"
+    if int(token) == TOKEN_BAR:
+        return "bar"
+    if TOKEN_CHORD_ROOT_START <= int(token) <= TOKEN_CHORD_ROOT_END:
+        return "chord"
+    if TOKEN_CHORD_QUALITY_START <= int(token) <= TOKEN_CHORD_QUALITY_END:
+        return "chord"
+    if is_position_token(token):
+        return "position"
+    if is_velocity_token(token):
+        return "velocity"
+    if is_note_pitch_token(token):
+        return "pitch"
+    if is_note_duration_token(token):
+        return "duration"
+    return "other"
+
+
+def analyze_stage_b_note_grammar(tokens: Sequence[int], primer_size: int = 0) -> dict[str, Any]:
+    generated = [int(token) for token in tokens[int(primer_size) :]]
+    expected = ["position", "velocity", "pitch", "duration"]
+    expected_index = 0
+    complete_groups = 0
+    invalid_tokens: list[dict[str, Any]] = []
+    family_counts: dict[str, int] = {}
+
+    for offset, token in enumerate(generated):
+        family = token_family(token)
+        family_counts[family] = family_counts.get(family, 0) + 1
+        if family == "end":
+            break
+        if family in {"bar", "chord"}:
+            expected_index = 0
+            continue
+        expected_family = expected[expected_index]
+        if family == expected_family:
+            expected_index += 1
+            if expected_index == len(expected):
+                complete_groups += 1
+                expected_index = 0
+            continue
+        invalid_tokens.append(
+            {
+                "offset": int(offset),
+                "token": int(token),
+                "token_name": stage_b_token_name(token),
+                "family": family,
+                "expected": expected_family,
+            }
+        )
+        expected_index = 1 if family == "position" else 0
+
+    return {
+        "complete_note_groups": int(complete_groups),
+        "incomplete_group_position": int(expected_index),
+        "invalid_token_count": int(len(invalid_tokens)),
+        "family_counts": family_counts,
+        "invalid_tokens_head": invalid_tokens[:12],
+        "grammar_valid": bool(complete_groups > 0 and not invalid_tokens and expected_index == 0),
+    }
+
+
+def choose_allowed_token(
+    logits: torch.Tensor,
+    allowed_tokens: Sequence[int],
+    temperature: float,
+    top_k: int | None,
+) -> int:
+    allowed = torch.tensor([int(token) for token in allowed_tokens], dtype=torch.long, device=logits.device)
+    allowed_logits = logits.index_select(0, allowed)
+    if float(temperature) <= 0.0:
+        raise ValueError("temperature must be positive")
+    allowed_logits = allowed_logits / float(temperature)
+    if top_k is not None and int(top_k) > 0:
+        k = min(int(top_k), int(allowed_logits.numel()))
+        top_values, top_indices = torch.topk(allowed_logits, k=k)
+        if k == 1:
+            return int(allowed[int(top_indices[0])].item())
+        probs = torch.softmax(top_values, dim=-1)
+        sampled = torch.multinomial(probs, num_samples=1)
+        return int(allowed[int(top_indices[int(sampled.item())])].item())
+    probs = torch.softmax(allowed_logits, dim=-1)
+    sampled = torch.multinomial(probs, num_samples=1)
+    return int(allowed[int(sampled.item())].item())
+
+
+def next_token_from_model(
+    model: Any,
+    tokens: Sequence[int],
+    allowed_tokens: Sequence[int],
+    temperature: float,
+    top_k: int | None,
+) -> int:
+    device = get_device()
+    input_tokens = torch.tensor([[int(token) for token in tokens]], dtype=torch.long, device=device)
+    with torch.no_grad():
+        logits = model(input_tokens)[0, -1, :]
+    return choose_allowed_token(logits, allowed_tokens, temperature=temperature, top_k=top_k)
+
+
+def generate_stage_b_constrained_tokens(
+    model: Any,
+    primer_tokens: Sequence[int],
+    chords: Sequence[str],
+    bpm: float | int,
+    bars: int,
+    note_groups_per_bar: int,
+    max_sequence: int,
+    temperature: float,
+    top_k: int | None,
+) -> list[int]:
+    tokens = [int(token) for token in primer_tokens]
+    families = [
+        range(TOKEN_POSITION_START, TOKEN_POSITION_END + 1),
+        range(TOKEN_VELOCITY_START, TOKEN_VELOCITY_END + 1),
+        range(TOKEN_NOTE_PITCH_START, TOKEN_NOTE_PITCH_END + 1),
+        range(TOKEN_NOTE_DURATION_START, TOKEN_NOTE_DURATION_END + 1),
+    ]
+
+    for bar_index in range(max(1, int(bars))):
+        if bar_index > 0:
+            chord = chords[bar_index % len(chords)] if chords else None
+            tokens.append(TOKEN_BAR)
+            tokens.extend(chord_tokens(chord))
+        for _group_index in range(max(1, int(note_groups_per_bar))):
+            for allowed_tokens in families:
+                if len(tokens) >= int(max_sequence) - 1:
+                    tokens.append(TOKEN_END)
+                    return tokens
+                tokens.append(
+                    next_token_from_model(
+                        model,
+                        tokens=tokens,
+                        allowed_tokens=list(allowed_tokens),
+                        temperature=temperature,
+                        top_k=top_k,
+                    )
+                )
+
+    tokens.append(TOKEN_END)
+    return tokens[: int(max_sequence)]
+
+
 def decode_tokens_to_midi(tokens: Sequence[int], output_path: Path, bpm: float | int) -> Path:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     midi = decode_stage_b_midi(tokens, tempo_bpm=bpm)
@@ -88,8 +249,10 @@ def sample_report(
     request: GenerationRequest,
 ) -> dict[str, Any]:
     raw_generated_tokens = [int(token) for token in tokens[primer_size:]]
+    grammar = analyze_stage_b_note_grammar(tokens, primer_size=primer_size)
     metrics = compute_midi_metrics(midi_path, 0, False, request=request)
     valid, reason = validate_metrics(metrics, request.density, bars=request.bars)
+    grammar_gate_passed = bool(grammar["complete_note_groups"] > 0 and metrics.note_count > 0)
     return {
         "sample_index": int(sample_index),
         "midi_path": str(midi_path),
@@ -98,7 +261,9 @@ def sample_report(
         "ended_early": bool(len(tokens) < int(target_length)),
         "hit_end_token": bool(TOKEN_END in raw_generated_tokens),
         "valid": bool(valid),
+        "grammar_gate_passed": grammar_gate_passed,
         "failure_reason": reason,
+        "grammar": grammar,
         "metrics": metrics.to_dict(),
         "generated_token_names_head": [stage_b_token_name(token) for token in raw_generated_tokens[:48]],
     }
@@ -136,6 +301,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--temperature", type=float, default=0.9)
     parser.add_argument("--top_k", type=int, default=32)
     parser.add_argument("--top_p", type=float, default=None)
+    parser.add_argument("--generation_mode", choices=("unconstrained", "constrained"), default="unconstrained")
+    parser.add_argument("--constrained_note_groups_per_bar", type=int, default=4)
+    parser.add_argument("--require_note_groups", action="store_true")
     parser.add_argument("--require_valid_sample", action="store_true")
     parser.set_defaults(lora_only=False)
     return parser
@@ -170,11 +338,12 @@ def main() -> int:
     report: dict[str, Any] = {
         "run_id": run_id,
         "run_dir": str(run_dir),
-        "issue": 18,
+        "issue": 20 if args.generation_mode == "constrained" else 18,
         "sequence_format": SEQUENCE_FORMAT_STAGE_B_V1,
         "request": request.to_dict(),
         "checkpoint_dir": str(checkpoint_dir),
         "sample_vocab_size": int(VOCAB_SIZE),
+        "generation_mode": args.generation_mode,
     }
 
     if not args.skip_prepare:
@@ -218,14 +387,27 @@ def main() -> int:
 
     sample_rows: list[dict[str, Any]] = []
     for index in range(1, int(args.num_samples) + 1):
-        generated_tokens = generate_stage_b_tokens(
-            model=model,
-            primer_tokens=primer_tokens,
-            target_length=args.max_sequence,
-            temperature=args.temperature,
-            top_k=args.top_k,
-            top_p=args.top_p,
-        )
+        if args.generation_mode == "constrained":
+            generated_tokens = generate_stage_b_constrained_tokens(
+                model=model,
+                primer_tokens=primer_tokens,
+                chords=chords,
+                bpm=args.bpm,
+                bars=args.bars,
+                note_groups_per_bar=args.constrained_note_groups_per_bar,
+                max_sequence=args.max_sequence,
+                temperature=args.temperature,
+                top_k=args.top_k,
+            )
+        else:
+            generated_tokens = generate_stage_b_tokens(
+                model=model,
+                primer_tokens=primer_tokens,
+                target_length=args.max_sequence,
+                temperature=args.temperature,
+                top_k=args.top_k,
+                top_p=args.top_p,
+            )
         midi_path = samples_dir / f"stage_b_sample_{index}.mid"
         decode_tokens_to_midi(generated_tokens, midi_path, bpm=args.bpm)
         sample_rows.append(
@@ -241,13 +423,17 @@ def main() -> int:
 
     report["samples"] = sample_rows
     report["valid_sample_count"] = sum(1 for row in sample_rows if row["valid"])
+    report["grammar_gate_sample_count"] = sum(1 for row in sample_rows if row["grammar_gate_passed"])
     report["sample_count"] = len(sample_rows)
     report["passed_generation_gate"] = bool(report["valid_sample_count"] > 0)
+    report["passed_grammar_gate"] = bool(report["grammar_gate_sample_count"] > 0)
     if not report["passed_generation_gate"]:
         report["failure_reason"] = "No Stage B generated sample passed the MIDI review gate"
 
     write_json(run_dir / "report.json", report)
     print(json.dumps(report, ensure_ascii=True, indent=2))
+    if args.require_note_groups and not report["passed_grammar_gate"]:
+        return 4
     if args.require_valid_sample and not report["passed_generation_gate"]:
         return 3
     return 0

--- a/tests/test_stage_b_generation_probe.py
+++ b/tests/test_stage_b_generation_probe.py
@@ -8,8 +8,10 @@ import pretty_midi
 import torch
 
 from scripts.run_stage_b_generation_probe import (
+    analyze_stage_b_note_grammar,
     build_stage_b_primer,
     decode_tokens_to_midi,
+    generate_stage_b_constrained_tokens,
     generate_stage_b_tokens,
 )
 from scripts.stage_b_tokens import (
@@ -30,6 +32,11 @@ class FakeStageBModel:
     def generate(self, **kwargs):
         self.sample_vocab_size = kwargs["sample_vocab_size"]
         return torch.tensor([self.returned_tokens], dtype=torch.long)
+
+
+class FakeConstrainedModel:
+    def __call__(self, tokens):
+        return torch.zeros((1, tokens.shape[1], VOCAB_SIZE), dtype=torch.float32)
 
 
 class StageBGenerationProbeTest(unittest.TestCase):
@@ -75,6 +82,56 @@ class StageBGenerationProbeTest(unittest.TestCase):
             self.assertEqual(notes[0].pitch, 60)
             self.assertAlmostEqual(notes[0].start, 0.0)
             self.assertAlmostEqual(notes[0].end, 0.25)
+
+    def test_analyze_stage_b_note_grammar_counts_complete_groups(self) -> None:
+        primer = build_stage_b_primer(["Cm7"], bpm=120)
+        tokens = primer + [
+            position_token(0),
+            note_velocity_token(4),
+            note_pitch_token(60),
+            note_duration_token(2),
+            TOKEN_END,
+        ]
+
+        report = analyze_stage_b_note_grammar(tokens, primer_size=len(primer))
+
+        self.assertEqual(report["complete_note_groups"], 1)
+        self.assertEqual(report["invalid_token_count"], 0)
+        self.assertTrue(report["grammar_valid"])
+
+    def test_analyze_stage_b_note_grammar_reports_incomplete_groups(self) -> None:
+        primer = build_stage_b_primer(["Cm7"], bpm=120)
+        tokens = primer + [position_token(0), note_pitch_token(60), TOKEN_END]
+
+        report = analyze_stage_b_note_grammar(tokens, primer_size=len(primer))
+
+        self.assertEqual(report["complete_note_groups"], 0)
+        self.assertGreater(report["invalid_token_count"], 0)
+        self.assertFalse(report["grammar_valid"])
+
+    def test_constrained_generation_creates_decodable_note_groups(self) -> None:
+        primer = build_stage_b_primer(["Cm7", "F7"], bpm=120)
+
+        tokens = generate_stage_b_constrained_tokens(
+            model=FakeConstrainedModel(),
+            primer_tokens=primer,
+            chords=["Cm7", "F7"],
+            bpm=120,
+            bars=2,
+            note_groups_per_bar=1,
+            max_sequence=64,
+            temperature=1.0,
+            top_k=1,
+        )
+
+        report = analyze_stage_b_note_grammar(tokens, primer_size=len(primer))
+        self.assertEqual(report["complete_note_groups"], 2)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            midi_path = Path(tmp_dir) / "constrained.mid"
+            decode_tokens_to_midi(tokens, midi_path, bpm=120)
+            midi = pretty_midi.PrettyMIDI(str(midi_path))
+            self.assertEqual(len(midi.instruments[0].notes), 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 요약

- Stage B 생성 결과를 `POSITION + VELOCITY + NOTE_PITCH + NOTE_DURATION` 문법으로 분석하는 grammar analyzer를 추가했습니다.
- 모델 logits를 사용하되 token family를 제한하는 `generation_mode=constrained` 경로를 추가했습니다.
- 기존 full review gate와 별도로 `passed_grammar_gate`를 기록하도록 report를 확장했습니다.
- `stage-b-constrained-probe` 하네스와 관련 unit test, Issue #20 문서를 추가했습니다.

## 왜 필요한가

Issue #18에서 Stage B generation/decode plumbing은 연결됐지만 unconstrained 생성은 완성된 note group을 만들지 못해 decoded MIDI note가 0개였습니다.

이번 PR은 broad training 전에 더 낮은 단계의 질문을 먼저 확인합니다.

```text
Stage B가 최소한 완성된 note group을 만들 수 있는가?
```

## 검증

- `./.venv/bin/python -m unittest tests.test_stage_b_generation_probe`
- `bash scripts/agent_harness.sh quick`
- `bash scripts/agent_harness.sh stage-b-constrained-probe`
- `bash scripts/agent_harness.sh stage-b-generation-probe`

## 로컬 constrained smoke 결과

- role samples: 70
- complete note groups: 8
- decoded note count: 8
- grammar gate sample count: 1
- passed grammar gate: true
- valid sample count: 0
- passed generation gate: false
- full gate failure reason: `too many simultaneous notes: 3 > 2`

## 판단

Stage B는 constrained mode에서 완성된 note group을 만들고 MIDI note로 복원할 수 있습니다. 하지만 아직 full musical review gate는 통과하지 못했습니다.

다음 이슈에서는 broad training으로 가지 말고, 같은 position/pitch 반복과 note overlap을 줄여 `max_simultaneous_notes <= 2`를 먼저 통과시키는 쪽이 맞습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added grammar-constrained generation mode for Stage B testing with note group validation and overlap detection

* **Documentation**
  * Added detailed documentation on grammar-constrained testing results and implementation status
  * Updated project roadmap reflecting Stage B grammar constraint completion and next optimization steps

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohhalim/fine_tuning_art-tatum_midi_solo/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->