### PR TITLE
[codex] Stage B 겹침 제거 게이트 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #20: Stage B grammar-constrained tiny-overfit.
+- Issue #22: Stage B overlap/dedup gate.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -93,6 +93,12 @@ For Stage B constrained note-grammar changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-constrained-probe
+```
+
+For Stage B overlap/dedup gate changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-overlap-gate
 ```
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-20-stage-b-constrained-tiny-overfit`
+- `issue-22-stage-b-overlap-gate`
 
 현재 범위가 아닌 것:
 
@@ -188,7 +188,11 @@ Current result:
 
 ## Active Issue #20
 
-Current task:
+Status:
+
+- completed and merged via PR #21
+
+Completed task:
 
 - add a grammar-constrained Stage B generation mode
 - analyze generated tokens for complete `POSITION + VELOCITY + NOTE_PITCH + NOTE_DURATION` groups
@@ -210,6 +214,31 @@ Current result:
 - full review gate passed: `false`
 - full gate failure reason: `too many simultaneous notes: 3 > 2`
 - decision: Stage B note grammar can now be forced through the model logits, but musical validity still needs overlap/deduplication control
+
+## Active Issue #22
+
+Current task:
+
+- remove duplicate same-onset/same-pitch notes after Stage B decode
+- limit excessive overlapping notes before metrics
+- keep decoded MIDI note count non-zero
+- get constrained Stage B smoke through the full review gate
+
+First implementation target:
+
+- `scripts/run_stage_b_generation_probe.py`
+- `scripts/agent_harness.sh stage-b-overlap-gate`
+- `tests/test_stage_b_generation_probe.py`
+- `docs/STAGE_B_OVERLAP_GATE_2026-05-19.md`
+
+Current result:
+
+- constrained generation still produced 8 complete Stage B note groups
+- postprocess reduced notes from `8` to `6`
+- max simultaneous notes reduced from `3` to `2`
+- grammar gate passed: `true`
+- full review gate passed: `true`
+- detail: `docs/STAGE_B_OVERLAP_GATE_2026-05-19.md`
 
 ## Dataset Strategy
 
@@ -483,7 +512,7 @@ Smoke result:
 
 Status:
 
-- implemented on `issue-20-stage-b-constrained-tiny-overfit`
+- completed and merged via PR #21
 
 Goal:
 
@@ -510,6 +539,40 @@ Smoke result:
 - valid sample count: `0`
 - full gate failure reason: `too many simultaneous notes: 3 > 2`
 - decision: next issue should reduce repeated same-position/same-pitch overlaps before broad training
+
+### 0.11. Issue #22 Stage B overlap/dedup gate
+
+Status:
+
+- implemented on `issue-22-stage-b-overlap-gate`
+
+Goal:
+
+- remove duplicate notes at the same onset/pitch
+- limit active overlapping notes to `max_simultaneous_notes <= 2`
+- verify constrained Stage B decoded MIDI can pass the full review gate
+
+Acceptance:
+
+- overlap/dedup unit tests pass
+- constrained smoke keeps decoded note count above zero
+- constrained smoke reduces max simultaneous notes to `2`
+- constrained smoke passes `validate_metrics`
+- `bash scripts/agent_harness.sh quick` passes
+- `bash scripts/agent_harness.sh stage-b-overlap-gate` passes
+
+Smoke result:
+
+- output: `outputs/stage_b_generation_probe/harness_stage_b_overlap_gate`
+- role samples: `70`
+- complete note groups: `8`
+- before note count: `8`
+- after note count: `6`
+- before max simultaneous notes: `3`
+- after max simultaneous notes: `2`
+- valid sample count: `1`
+- passed generation gate: `true`
+- decision: this is the first Stage B constrained smoke to pass the local review gate, but it is still a constrained/postprocessed diagnostic rather than unconstrained musical generation
 
 ### 1. Run full jazz piano dataset audit
 
@@ -644,6 +707,7 @@ Decision:
 - `docs/STAGE_B_WINDOW_TINY_OVERFIT_2026-05-19.md`
 - `docs/STAGE_B_GENERATION_PROBE_2026-05-19.md`
 - `docs/STAGE_B_CONSTRAINED_TINY_OVERFIT_2026-05-19.md`
+- `docs/STAGE_B_OVERLAP_GATE_2026-05-19.md`
 - `docs/REFERENCES.md`
 - `docs/INFERENCE_MODEL_SPEC.md`
 - `docs/QA_ACCEPTANCE_PLAN.md`
@@ -684,4 +748,10 @@ For Stage B constrained note-grammar changes:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-constrained-probe
+```
+
+For Stage B overlap/dedup gate changes:
+
+```bash
+bash scripts/agent_harness.sh stage-b-overlap-gate
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,8 @@
   - Stage B token generation, MIDI decode, and review-gate probe result.
 - `STAGE_B_CONSTRAINED_TINY_OVERFIT_2026-05-19.md`
   - Stage B constrained note-group generation and grammar-gate result.
+- `STAGE_B_OVERLAP_GATE_2026-05-19.md`
+  - Stage B constrained output overlap/dedup postprocess and first local review-gate pass.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -60,7 +62,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, and 2-file generation probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, and 2-file generation probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_CONSTRAINED_TINY_OVERFIT_2026-05-19.md
+++ b/docs/STAGE_B_CONSTRAINED_TINY_OVERFIT_2026-05-19.md
@@ -121,3 +121,5 @@ Next issue should reduce overlap and repeated-position artifacts before increasi
 - optionally sort or de-overlap constrained generated notes before metrics
 - add a `max_simultaneous_notes <= 2` constrained smoke gate
 - only then try a longer tiny-overfit or a 2-file Stage B probe
+
+Issue #22 implements this overlap gate. With overlap postprocess enabled, the same constrained smoke reduces max simultaneous notes from 3 to 2 and passes the local MIDI review gate.

--- a/docs/STAGE_B_OVERLAP_GATE_2026-05-19.md
+++ b/docs/STAGE_B_OVERLAP_GATE_2026-05-19.md
@@ -1,0 +1,131 @@
+# Stage B Overlap Gate: 2026-05-19
+
+## Purpose
+
+Issue #22 removes the next concrete blocker in Stage B constrained generation.
+
+Issue #20 proved that constrained generation can produce complete Stage B note groups and decode them into MIDI notes. The remaining full-gate failure was overlap:
+
+```text
+too many simultaneous notes: 3 > 2
+```
+
+This issue adds a small postprocess step for constrained diagnostic output:
+
+- remove duplicate notes at the same onset/pitch
+- limit overlapping active notes to a configured maximum
+- report before/after overlap metrics
+
+This is still not broad jazz training. It is a narrow gate check for the Stage B local generation path.
+
+## Implementation
+
+Code changes:
+
+- `scripts/run_stage_b_generation_probe.py`
+  - adds `dedupe_and_limit_notes`
+  - adds `postprocess_stage_b_midi`
+  - adds `--postprocess_overlap`
+  - adds `--max_simultaneous_notes`
+  - records postprocess before/after note counts and max simultaneous notes
+- `scripts/agent_harness.sh`
+  - adds `stage-b-overlap-gate`
+- `tests/test_stage_b_generation_probe.py`
+  - verifies duplicate same-onset/same-pitch notes are removed
+  - verifies max simultaneous notes are limited
+
+## Command
+
+```bash
+bash scripts/agent_harness.sh stage-b-overlap-gate
+```
+
+Equivalent direct command:
+
+```bash
+python scripts/run_stage_b_generation_probe.py \
+  --run_id harness_stage_b_overlap_gate \
+  --max_files 1 \
+  --epochs 1 \
+  --batch_size 8 \
+  --max_sequence 96 \
+  --num_samples 1 \
+  --generation_mode constrained \
+  --constrained_note_groups_per_bar 4 \
+  --postprocess_overlap \
+  --max_simultaneous_notes 2 \
+  --top_k 1 \
+  --require_note_groups \
+  --require_valid_sample \
+  --n_layers 1 \
+  --num_heads 4 \
+  --d_model 64 \
+  --dim_feedforward 128 \
+  --lora_r 4 \
+  --lora_alpha 8
+```
+
+## Local Result
+
+Output:
+
+```text
+outputs/stage_b_generation_probe/harness_stage_b_overlap_gate
+```
+
+Dataset/training:
+
+| Metric | Value |
+|---|---:|
+| role samples | 70 |
+| train records | 63 |
+| val records | 7 |
+| max token id | 544 |
+| epoch 1 train loss | 6.2115 |
+| epoch 1 val loss | 5.9441 |
+
+Postprocess:
+
+| Metric | Value |
+|---|---:|
+| before note count | 8 |
+| after note count | 6 |
+| removed notes | 2 |
+| before max simultaneous notes | 3 |
+| after max simultaneous notes | 2 |
+
+Final metrics:
+
+| Metric | Value |
+|---|---:|
+| complete note groups | 8 |
+| decoded note count | 6 |
+| unique pitch count | 5 |
+| note density | 1.653 |
+| phrase coverage ratio | 0.937 |
+| max simultaneous notes | 2 |
+| passed grammar gate | true |
+| passed generation gate | true |
+
+## Decision
+
+This is the first Stage B constrained smoke that passes the local MIDI review gate.
+
+The result is still diagnostic, not a claim of musical quality:
+
+- generation is constrained by token family
+- overlap postprocess is enabled
+- the training run is only one epoch on one Brad file subset
+- chord-tone ratio is low and not yet used as a hard gate
+
+## Next Step
+
+Do not jump directly to broad training.
+
+The next issue should run a slightly stronger Stage B tiny-overfit probe:
+
+- longer tiny training on the same short window set
+- constrained generation with overlap postprocess
+- multiple seeds/samples
+- require all generated samples to pass grammar gate
+- require at least one sample to pass full review gate without hiding failure cases

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -34,6 +34,8 @@ Modes:
                 Run a one-epoch Stage B decode/generation smoke.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
+  stage-b-overlap-gate
+                Run constrained Stage B generation with overlap postprocess gate.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   all           Run demo and tiny-compare.
@@ -177,6 +179,31 @@ run_stage_b_constrained_probe() {
     --lora_alpha 8
 }
 
+run_stage_b_overlap_gate() {
+  local run_id="${RUN_ID:-harness_stage_b_overlap_gate}"
+  print_header "Stage B overlap gate"
+  "$PYTHON_BIN" scripts/run_stage_b_generation_probe.py \
+    --run_id "$run_id" \
+    --max_files 1 \
+    --epochs 1 \
+    --batch_size 8 \
+    --max_sequence 96 \
+    --num_samples 1 \
+    --generation_mode constrained \
+    --constrained_note_groups_per_bar 4 \
+    --postprocess_overlap \
+    --max_simultaneous_notes 2 \
+    --top_k 1 \
+    --require_note_groups \
+    --require_valid_sample \
+    --n_layers 1 \
+    --num_heads 4 \
+    --d_model 64 \
+    --dim_feedforward 128 \
+    --lora_r 4 \
+    --lora_alpha 8
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -215,6 +242,9 @@ case "$MODE" in
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe
+    ;;
+  stage-b-overlap-gate)
+    run_stage_b_overlap_gate
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/run_stage_b_generation_probe.py
+++ b/scripts/run_stage_b_generation_probe.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Sequence
 
+import pretty_midi
 import torch
 
 
@@ -24,7 +25,7 @@ sys.path.insert(0, str(ROOT_DIR))
 sys.path.insert(0, str(ROOT_DIR / "scripts"))
 sys.path.insert(0, str(ROOT_DIR / "music_transformer"))
 
-from inference.app.metrics import compute_midi_metrics, validate_metrics  # noqa: E402
+from inference.app.metrics import compute_midi_metrics, max_simultaneous_notes, validate_metrics  # noqa: E402
 from inference.app.schemas import GenerationRequest  # noqa: E402
 from scripts.control_tokens import control_prefix_tokens  # noqa: E402
 from scripts.generate import load_model_with_lora  # noqa: E402
@@ -233,6 +234,59 @@ def generate_stage_b_constrained_tokens(
     return tokens[: int(max_sequence)]
 
 
+def dedupe_and_limit_notes(
+    notes: Sequence[pretty_midi.Note],
+    simultaneous_limit: int = 2,
+    time_precision: int = 6,
+) -> list[pretty_midi.Note]:
+    best_by_onset_pitch: dict[tuple[float, int], pretty_midi.Note] = {}
+    for note in notes:
+        if float(note.end) <= float(note.start):
+            continue
+        key = (round(float(note.start), int(time_precision)), int(note.pitch))
+        current = best_by_onset_pitch.get(key)
+        if current is None:
+            best_by_onset_pitch[key] = note
+            continue
+        current_score = (int(current.velocity), float(current.end) - float(current.start))
+        note_score = (int(note.velocity), float(note.end) - float(note.start))
+        if note_score > current_score:
+            best_by_onset_pitch[key] = note
+
+    selected: list[pretty_midi.Note] = []
+    for note in sorted(best_by_onset_pitch.values(), key=lambda n: (float(n.start), -int(n.velocity), int(n.pitch))):
+        active = [chosen for chosen in selected if float(chosen.end) > float(note.start)]
+        if len(active) >= int(simultaneous_limit):
+            continue
+        selected.append(note)
+    return sorted(selected, key=lambda n: (float(n.start), int(n.pitch)))
+
+
+def postprocess_stage_b_midi(
+    midi: pretty_midi.PrettyMIDI,
+    simultaneous_limit: int = 2,
+) -> dict[str, Any]:
+    before_notes: list[pretty_midi.Note] = []
+    after_notes: list[pretty_midi.Note] = []
+
+    for instrument in midi.instruments:
+        if instrument.is_drum:
+            continue
+        before_notes.extend(instrument.notes)
+        instrument.notes = dedupe_and_limit_notes(instrument.notes, simultaneous_limit=simultaneous_limit)
+        after_notes.extend(instrument.notes)
+
+    return {
+        "enabled": True,
+        "simultaneous_limit": int(simultaneous_limit),
+        "before_note_count": int(len(before_notes)),
+        "after_note_count": int(len(after_notes)),
+        "removed_note_count": int(max(0, len(before_notes) - len(after_notes))),
+        "before_max_simultaneous_notes": int(max_simultaneous_notes(before_notes)) if before_notes else 0,
+        "after_max_simultaneous_notes": int(max_simultaneous_notes(after_notes)) if after_notes else 0,
+    }
+
+
 def decode_tokens_to_midi(tokens: Sequence[int], output_path: Path, bpm: float | int) -> Path:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     midi = decode_stage_b_midi(tokens, tempo_bpm=bpm)
@@ -247,6 +301,7 @@ def sample_report(
     target_length: int,
     midi_path: Path,
     request: GenerationRequest,
+    postprocess_report: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     raw_generated_tokens = [int(token) for token in tokens[primer_size:]]
     grammar = analyze_stage_b_note_grammar(tokens, primer_size=primer_size)
@@ -264,6 +319,7 @@ def sample_report(
         "grammar_gate_passed": grammar_gate_passed,
         "failure_reason": reason,
         "grammar": grammar,
+        "postprocess": postprocess_report or {"enabled": False},
         "metrics": metrics.to_dict(),
         "generated_token_names_head": [stage_b_token_name(token) for token in raw_generated_tokens[:48]],
     }
@@ -303,6 +359,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--top_p", type=float, default=None)
     parser.add_argument("--generation_mode", choices=("unconstrained", "constrained"), default="unconstrained")
     parser.add_argument("--constrained_note_groups_per_bar", type=int, default=4)
+    parser.add_argument("--postprocess_overlap", action="store_true")
+    parser.add_argument("--max_simultaneous_notes", type=int, default=2)
     parser.add_argument("--require_note_groups", action="store_true")
     parser.add_argument("--require_valid_sample", action="store_true")
     parser.set_defaults(lora_only=False)
@@ -338,12 +396,13 @@ def main() -> int:
     report: dict[str, Any] = {
         "run_id": run_id,
         "run_dir": str(run_dir),
-        "issue": 20 if args.generation_mode == "constrained" else 18,
+        "issue": 22 if args.postprocess_overlap else 20 if args.generation_mode == "constrained" else 18,
         "sequence_format": SEQUENCE_FORMAT_STAGE_B_V1,
         "request": request.to_dict(),
         "checkpoint_dir": str(checkpoint_dir),
         "sample_vocab_size": int(VOCAB_SIZE),
         "generation_mode": args.generation_mode,
+        "postprocess_overlap": bool(args.postprocess_overlap),
     }
 
     if not args.skip_prepare:
@@ -409,7 +468,15 @@ def main() -> int:
                 top_p=args.top_p,
             )
         midi_path = samples_dir / f"stage_b_sample_{index}.mid"
-        decode_tokens_to_midi(generated_tokens, midi_path, bpm=args.bpm)
+        midi_path.parent.mkdir(parents=True, exist_ok=True)
+        midi = decode_stage_b_midi(generated_tokens, tempo_bpm=args.bpm)
+        postprocess_report = None
+        if args.postprocess_overlap:
+            postprocess_report = postprocess_stage_b_midi(
+                midi,
+                simultaneous_limit=args.max_simultaneous_notes,
+            )
+        midi.write(str(midi_path))
         sample_rows.append(
             sample_report(
                 sample_index=index,
@@ -418,6 +485,7 @@ def main() -> int:
                 target_length=args.max_sequence,
                 midi_path=midi_path,
                 request=request,
+                postprocess_report=postprocess_report,
             )
         )
 

--- a/tests/test_stage_b_generation_probe.py
+++ b/tests/test_stage_b_generation_probe.py
@@ -10,9 +10,11 @@ import torch
 from scripts.run_stage_b_generation_probe import (
     analyze_stage_b_note_grammar,
     build_stage_b_primer,
+    dedupe_and_limit_notes,
     decode_tokens_to_midi,
     generate_stage_b_constrained_tokens,
     generate_stage_b_tokens,
+    postprocess_stage_b_midi,
 )
 from scripts.stage_b_tokens import (
     chord_tokens,
@@ -132,6 +134,40 @@ class StageBGenerationProbeTest(unittest.TestCase):
             decode_tokens_to_midi(tokens, midi_path, bpm=120)
             midi = pretty_midi.PrettyMIDI(str(midi_path))
             self.assertEqual(len(midi.instruments[0].notes), 2)
+
+    def test_dedupe_and_limit_notes_removes_same_onset_pitch_duplicates(self) -> None:
+        notes = [
+            pretty_midi.Note(velocity=64, pitch=60, start=0.0, end=0.25),
+            pretty_midi.Note(velocity=96, pitch=60, start=0.0, end=0.5),
+            pretty_midi.Note(velocity=80, pitch=64, start=0.0, end=0.25),
+        ]
+
+        processed = dedupe_and_limit_notes(notes, simultaneous_limit=2)
+
+        self.assertEqual(len(processed), 2)
+        self.assertEqual([note.pitch for note in processed], [60, 64])
+        self.assertEqual(processed[0].velocity, 96)
+
+    def test_postprocess_stage_b_midi_limits_simultaneous_notes(self) -> None:
+        midi = pretty_midi.PrettyMIDI(initial_tempo=120)
+        piano = pretty_midi.Instrument(program=0, is_drum=False)
+        piano.notes.extend(
+            [
+                pretty_midi.Note(velocity=80, pitch=60, start=0.0, end=0.5),
+                pretty_midi.Note(velocity=82, pitch=64, start=0.0, end=0.5),
+                pretty_midi.Note(velocity=84, pitch=67, start=0.0, end=0.5),
+                pretty_midi.Note(velocity=86, pitch=72, start=0.5, end=0.75),
+            ]
+        )
+        midi.instruments.append(piano)
+
+        report = postprocess_stage_b_midi(midi, simultaneous_limit=2)
+
+        self.assertEqual(report["before_note_count"], 4)
+        self.assertEqual(report["after_note_count"], 3)
+        self.assertEqual(report["before_max_simultaneous_notes"], 3)
+        self.assertEqual(report["after_max_simultaneous_notes"], 2)
+        self.assertEqual(len(midi.instruments[0].notes), 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 요약

- Stage B constrained output에 대한 overlap/dedup postprocess를 추가했습니다.
- 같은 onset/pitch 중복 note를 제거하고, active overlapping note 수를 설정값 이하로 제한합니다.
- `stage-b-overlap-gate` 하네스를 추가해 `--postprocess_overlap --max_simultaneous_notes 2 --require_valid_sample`까지 확인합니다.
- Issue #22 결과 문서를 추가하고 현재 계획 문서를 갱신했습니다.

## 왜 필요한가

Issue #20에서 constrained Stage B generation은 complete note group 8개와 decoded MIDI note 8개를 만들었지만, full review gate는 아래 이유로 실패했습니다.

```text
too many simultaneous notes: 3 > 2
```

이번 PR은 broad training 전에 이 overlap 병목을 제거하는 좁은 gate입니다.

## 검증

- `./.venv/bin/python -m unittest tests.test_stage_b_generation_probe`
- `bash scripts/agent_harness.sh stage-b-overlap-gate`
- `bash scripts/agent_harness.sh quick`

## 로컬 smoke 결과

- complete note groups: 8
- before note count: 8
- after note count: 6
- before max simultaneous notes: 3
- after max simultaneous notes: 2
- grammar gate: true
- generation gate: true
- valid sample count: 1

## 판단

이 PR은 Stage B constrained smoke가 처음으로 local MIDI review gate를 통과하게 만든 변경입니다.

다만 아직 진짜 모델 품질 성공은 아닙니다. constrained generation과 postprocess를 사용한 diagnostic pass입니다. 다음 단계는 같은 조건에서 더 긴 tiny-overfit, 여러 seed/sample, 그리고 2-file Stage B probe를 진행하는 것입니다.