### PR TITLE
[codex] Stage B 다중 샘플 프로브 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #22: Stage B overlap/dedup gate.
+- Issue #24: Stage B stronger multi-sample generation probe.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -99,6 +99,12 @@ For Stage B overlap/dedup gate changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-overlap-gate
+```
+
+For Stage B multi-sample review-gate changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-stronger-probe
 ```
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -1,6 +1,6 @@
 # Current Status and Plan
 
-작성일: 2026-05-19
+작성일: 2026-05-20
 
 ## Current Focus
 
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-22-stage-b-overlap-gate`
+- `issue-24-stage-b-stronger-multisample-probe`
 
 현재 범위가 아닌 것:
 
@@ -215,9 +215,13 @@ Current result:
 - full gate failure reason: `too many simultaneous notes: 3 > 2`
 - decision: Stage B note grammar can now be forced through the model logits, but musical validity still needs overlap/deduplication control
 
-## Active Issue #22
+## Completed Issue #22
 
-Current task:
+Status:
+
+- completed and merged via PR #23
+
+Completed task:
 
 - remove duplicate same-onset/same-pitch notes after Stage B decode
 - limit excessive overlapping notes before metrics
@@ -239,6 +243,29 @@ Current result:
 - grammar gate passed: `true`
 - full review gate passed: `true`
 - detail: `docs/STAGE_B_OVERLAP_GATE_2026-05-19.md`
+
+## Active Issue #24
+
+Current task:
+
+- strengthen the Stage B local generation probe from one sample to multiple samples
+- keep the probe honest by reporting sample-level failures
+- compare deterministic `top_k=1` collapse against `top_k=2`
+- do not claim musical quality from a single passing MIDI file
+
+First implementation target:
+
+- `scripts/run_stage_b_generation_probe.py`
+- `scripts/agent_harness.sh stage-b-stronger-probe`
+- `tests/test_stage_b_generation_probe.py`
+- `docs/STAGE_B_STRONGER_MULTISAMPLE_PROBE_2026-05-20.md`
+
+Current result:
+
+- `top_k=2`: `1/3` samples passed the full MIDI review gate
+- all `3/3` samples passed the Stage B grammar gate
+- `top_k=1` negative control collapsed to `0/3` valid samples
+- detail: `docs/STAGE_B_STRONGER_MULTISAMPLE_PROBE_2026-05-20.md`
 
 ## Dataset Strategy
 
@@ -544,7 +571,7 @@ Smoke result:
 
 Status:
 
-- implemented on `issue-22-stage-b-overlap-gate`
+- completed and merged via PR #23
 
 Goal:
 
@@ -573,6 +600,42 @@ Smoke result:
 - valid sample count: `1`
 - passed generation gate: `true`
 - decision: this is the first Stage B constrained smoke to pass the local review gate, but it is still a constrained/postprocessed diagnostic rather than unconstrained musical generation
+
+### 0.12. Issue #24 Stage B stronger multi-sample probe
+
+Status:
+
+- implemented on `issue-24-stage-b-stronger-multisample-probe`
+
+Goal:
+
+- strengthen the single-sample Stage B overlap gate
+- record sample-level seeds
+- report grammar and full review pass rates
+- require all samples to pass grammar gate
+- require at least one sample to pass the full MIDI review gate
+
+Acceptance:
+
+- multi-sample summary unit tests pass
+- `bash scripts/agent_harness.sh quick` passes
+- `bash scripts/agent_harness.sh stage-b-stronger-probe` passes
+- report includes `sample_count`, `valid_sample_rate`, `grammar_gate_sample_rate`, and failure reason counts
+
+Smoke result:
+
+- output: `outputs/stage_b_generation_probe/harness_stage_b_stronger_probe`
+- role samples: `70`
+- epoch 3 val loss: `5.0104`
+- generated samples: `3`
+- grammar gate sample count: `3`
+- valid sample count: `1`
+- valid sample rate: `0.333`
+- grammar gate sample rate: `1.000`
+- passed grammar gate: `true`
+- passed generation gate: `true`
+- negative control: `top_k=1` collapsed to `0/3` valid samples with `note count too low: 2 < 6`
+- detail: `docs/STAGE_B_STRONGER_MULTISAMPLE_PROBE_2026-05-20.md`
 
 ### 1. Run full jazz piano dataset audit
 
@@ -708,6 +771,7 @@ Decision:
 - `docs/STAGE_B_GENERATION_PROBE_2026-05-19.md`
 - `docs/STAGE_B_CONSTRAINED_TINY_OVERFIT_2026-05-19.md`
 - `docs/STAGE_B_OVERLAP_GATE_2026-05-19.md`
+- `docs/STAGE_B_STRONGER_MULTISAMPLE_PROBE_2026-05-20.md`
 - `docs/REFERENCES.md`
 - `docs/INFERENCE_MODEL_SPEC.md`
 - `docs/QA_ACCEPTANCE_PLAN.md`
@@ -754,4 +818,10 @@ For Stage B overlap/dedup gate changes:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-overlap-gate
+```
+
+For Stage B multi-sample review-gate changes:
+
+```bash
+bash scripts/agent_harness.sh stage-b-stronger-probe
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Docs Index
 
-작성일: 2026-05-18
+작성일: 2026-05-20
 
 이 디렉터리는 현재 jazz piano MIDI fine-tuning probe를 진행하기 위한 기준 문서만 전면에 둔다. 백엔드/API/ERD/제품 MVP 문서는 `docs/archive/`로 이동했다.
 
@@ -36,6 +36,8 @@
   - Stage B constrained note-group generation and grammar-gate result.
 - `STAGE_B_OVERLAP_GATE_2026-05-19.md`
   - Stage B constrained output overlap/dedup postprocess and first local review-gate pass.
+- `STAGE_B_STRONGER_MULTISAMPLE_PROBE_2026-05-20.md`
+  - Stage B multi-sample constrained probe, pass-rate reporting, and sampling collapse negative control.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -62,7 +64,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, and 2-file generation probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, and 2-file generation probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_STRONGER_MULTISAMPLE_PROBE_2026-05-20.md
+++ b/docs/STAGE_B_STRONGER_MULTISAMPLE_PROBE_2026-05-20.md
@@ -1,0 +1,163 @@
+# Stage B Stronger Multi-Sample Probe: 2026-05-20
+
+## Purpose
+
+Issue #24 strengthens the previous Stage B overlap gate.
+
+Issue #22 proved that one constrained/postprocessed Stage B sample can pass the local MIDI review gate. That was useful, but too weak: one lucky sample can hide collapse. This probe records sample-level seeds, grammar pass rates, valid sample rates, and configurable minimum pass thresholds.
+
+This is still a diagnostic tiny-overfit probe. It is not a claim that the model is a musical jazz solo generator.
+
+## Implementation
+
+Code changes:
+
+- `scripts/run_stage_b_generation_probe.py`
+  - records `sample_seed` for each generated sample
+  - adds `build_probe_summary`
+  - reports `valid_sample_rate` and `grammar_gate_sample_rate`
+  - supports `--min_valid_samples`
+  - supports `--require_all_grammar_samples`
+  - supports `--issue_number` for issue-specific reports
+- `scripts/agent_harness.sh`
+  - adds `stage-b-stronger-probe`
+- `tests/test_stage_b_generation_probe.py`
+  - verifies multi-sample threshold summaries
+  - verifies all-sample grammar gating
+
+## Command
+
+```bash
+bash scripts/agent_harness.sh stage-b-stronger-probe
+```
+
+Equivalent direct command:
+
+```bash
+python scripts/run_stage_b_generation_probe.py \
+  --run_id harness_stage_b_stronger_probe \
+  --issue_number 24 \
+  --max_files 1 \
+  --epochs 3 \
+  --batch_size 8 \
+  --max_sequence 96 \
+  --num_samples 3 \
+  --generation_mode constrained \
+  --constrained_note_groups_per_bar 4 \
+  --postprocess_overlap \
+  --max_simultaneous_notes 2 \
+  --top_k 2 \
+  --require_note_groups \
+  --require_all_grammar_samples \
+  --require_valid_sample \
+  --min_valid_samples 1 \
+  --n_layers 1 \
+  --num_heads 4 \
+  --d_model 64 \
+  --dim_feedforward 128 \
+  --lora_r 4 \
+  --lora_alpha 8
+```
+
+## Local Result
+
+Output:
+
+```text
+outputs/stage_b_generation_probe/harness_stage_b_stronger_probe
+```
+
+Dataset/training:
+
+| Metric | Value |
+|---|---:|
+| role samples | 70 |
+| train records | 63 |
+| val records | 7 |
+| max token id | 544 |
+| vocab size | 547 |
+| epoch 1 train loss | 6.1389 |
+| epoch 1 val loss | 5.5753 |
+| epoch 2 train loss | 5.3942 |
+| epoch 2 val loss | 5.1037 |
+| epoch 3 train loss | 5.1207 |
+| epoch 3 val loss | 5.0104 |
+
+Multi-sample gate:
+
+| Metric | Value |
+|---|---:|
+| samples | 3 |
+| grammar gate samples | 3 |
+| grammar gate sample rate | 1.000 |
+| valid samples | 1 |
+| valid sample rate | 0.333 |
+| min valid samples | 1 |
+| require all grammar samples | true |
+| passed grammar gate | true |
+| passed generation gate | true |
+
+Sample outcomes:
+
+| Sample | Seed | Valid | Notes After Postprocess | Failure |
+|---:|---:|:---:|---:|---|
+| 1 | 17 | false | 4 | note count too low: 4 < 6 |
+| 2 | 18 | true | 8 | none |
+| 3 | 19 | false | 8 | dead-air ratio too high: 0.857 >= 0.800 |
+
+Valid sample #2:
+
+| Metric | Value |
+|---|---:|
+| note count | 8 |
+| unique pitch count | 4 |
+| phrase coverage ratio | 0.875 |
+| dead-air ratio | 0.714 |
+| max simultaneous notes | 2 |
+| chord-tone ratio | 0.500 |
+
+## Negative Control
+
+The same 3-epoch checkpoint with `top_k=1` collapsed:
+
+```text
+outputs/stage_b_generation_probe/harness_stage_b_stronger_probe_topk1_failure
+```
+
+Result:
+
+| Metric | Value |
+|---|---:|
+| samples | 3 |
+| grammar gate samples | 3 |
+| valid samples | 0 |
+| notes after postprocess | 2 each |
+| failure reason | note count too low: 2 < 6 |
+
+This matters because grammar correctness alone is insufficient. The model can emit complete Stage B note groups while still repeating the same onset/pitch enough that postprocess removes most of the phrase.
+
+## Decision
+
+Issue #24 improves the review harness, but the model quality is still weak.
+
+What is now proven:
+
+- Stage B token grammar can be enforced across multiple samples.
+- The local probe can report pass rates instead of a single lucky file.
+- At least one sample from the stronger setting can pass the current MIDI review gate.
+
+What is not proven:
+
+- stable musical solo-line generation
+- good chord following
+- useful diversity
+- reliable sampling across stricter thresholds
+
+## Next Step
+
+The next issue should stop relying on postprocess alone and improve the generated note distribution:
+
+- add repetition/collapse diagnostics for repeated position-pitch pairs
+- add a minimum unique-pitch or unique-position gate before declaring review success
+- compare `top_k=1`, `top_k=2`, and a small temperature sweep on the same checkpoint
+- consider conditioning or loss changes only after the collapse pattern is measured

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -36,6 +36,8 @@ Modes:
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
                 Run constrained Stage B generation with overlap postprocess gate.
+  stage-b-stronger-probe
+                Run a multi-sample constrained Stage B review-gate probe.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   all           Run demo and tiny-compare.
@@ -204,6 +206,34 @@ run_stage_b_overlap_gate() {
     --lora_alpha 8
 }
 
+run_stage_b_stronger_probe() {
+  local run_id="${RUN_ID:-harness_stage_b_stronger_probe}"
+  print_header "Stage B stronger multi-sample probe"
+  "$PYTHON_BIN" scripts/run_stage_b_generation_probe.py \
+    --run_id "$run_id" \
+    --issue_number 24 \
+    --max_files 1 \
+    --epochs 3 \
+    --batch_size 8 \
+    --max_sequence 96 \
+    --num_samples 3 \
+    --generation_mode constrained \
+    --constrained_note_groups_per_bar 4 \
+    --postprocess_overlap \
+    --max_simultaneous_notes 2 \
+    --top_k 2 \
+    --require_note_groups \
+    --require_all_grammar_samples \
+    --require_valid_sample \
+    --min_valid_samples 1 \
+    --n_layers 1 \
+    --num_heads 4 \
+    --d_model 64 \
+    --dim_feedforward 128 \
+    --lora_r 4 \
+    --lora_alpha 8
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -245,6 +275,9 @@ case "$MODE" in
     ;;
   stage-b-overlap-gate)
     run_stage_b_overlap_gate
+    ;;
+  stage-b-stronger-probe)
+    run_stage_b_stronger_probe
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/run_stage_b_generation_probe.py
+++ b/scripts/run_stage_b_generation_probe.py
@@ -296,6 +296,7 @@ def decode_tokens_to_midi(tokens: Sequence[int], output_path: Path, bpm: float |
 
 def sample_report(
     sample_index: int,
+    sample_seed: int,
     tokens: Sequence[int],
     primer_size: int,
     target_length: int,
@@ -310,6 +311,7 @@ def sample_report(
     grammar_gate_passed = bool(grammar["complete_note_groups"] > 0 and metrics.note_count > 0)
     return {
         "sample_index": int(sample_index),
+        "sample_seed": int(sample_seed),
         "midi_path": str(midi_path),
         "token_count": int(len(tokens)),
         "generated_token_count": int(len(raw_generated_tokens)),
@@ -322,6 +324,45 @@ def sample_report(
         "postprocess": postprocess_report or {"enabled": False},
         "metrics": metrics.to_dict(),
         "generated_token_names_head": [stage_b_token_name(token) for token in raw_generated_tokens[:48]],
+    }
+
+
+def build_probe_summary(
+    sample_rows: Sequence[dict[str, Any]],
+    min_valid_samples: int = 1,
+    require_all_grammar_samples: bool = False,
+) -> dict[str, Any]:
+    sample_count = int(len(sample_rows))
+    valid_indices = [int(row["sample_index"]) for row in sample_rows if row["valid"]]
+    grammar_indices = [int(row["sample_index"]) for row in sample_rows if row["grammar_gate_passed"]]
+    valid_sample_count = int(len(valid_indices))
+    grammar_gate_sample_count = int(len(grammar_indices))
+
+    if require_all_grammar_samples:
+        passed_grammar_gate = bool(sample_count > 0 and grammar_gate_sample_count == sample_count)
+    else:
+        passed_grammar_gate = bool(grammar_gate_sample_count > 0)
+
+    failure_reasons: dict[str, int] = {}
+    for row in sample_rows:
+        if row["valid"]:
+            continue
+        reason = str(row.get("failure_reason") or "unknown")
+        failure_reasons[reason] = failure_reasons.get(reason, 0) + 1
+
+    return {
+        "sample_count": sample_count,
+        "valid_sample_count": valid_sample_count,
+        "grammar_gate_sample_count": grammar_gate_sample_count,
+        "valid_sample_rate": float(valid_sample_count / sample_count) if sample_count else 0.0,
+        "grammar_gate_sample_rate": float(grammar_gate_sample_count / sample_count) if sample_count else 0.0,
+        "valid_sample_indices": valid_indices,
+        "grammar_gate_sample_indices": grammar_indices,
+        "min_valid_samples": int(min_valid_samples),
+        "require_all_grammar_samples": bool(require_all_grammar_samples),
+        "passed_generation_gate": bool(valid_sample_count >= int(min_valid_samples)),
+        "passed_grammar_gate": passed_grammar_gate,
+        "failure_reasons": failure_reasons,
     }
 
 
@@ -348,6 +389,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--lora_alpha", type=int, default=8)
     parser.add_argument("--skip_prepare", action="store_true")
     parser.add_argument("--skip_train", action="store_true")
+    parser.add_argument("--issue_number", type=int, default=None)
     parser.add_argument("--num_samples", type=int, default=2)
     parser.add_argument("--bpm", type=int, default=124)
     parser.add_argument("--bars", type=int, default=2)
@@ -361,6 +403,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--constrained_note_groups_per_bar", type=int, default=4)
     parser.add_argument("--postprocess_overlap", action="store_true")
     parser.add_argument("--max_simultaneous_notes", type=int, default=2)
+    parser.add_argument("--min_valid_samples", type=int, default=1)
+    parser.add_argument("--require_all_grammar_samples", action="store_true")
     parser.add_argument("--require_note_groups", action="store_true")
     parser.add_argument("--require_valid_sample", action="store_true")
     parser.set_defaults(lora_only=False)
@@ -393,10 +437,14 @@ def main() -> int:
     )
     request.validate()
 
+    issue_number = args.issue_number
+    if issue_number is None:
+        issue_number = 22 if args.postprocess_overlap else 20 if args.generation_mode == "constrained" else 18
+
     report: dict[str, Any] = {
         "run_id": run_id,
         "run_dir": str(run_dir),
-        "issue": 22 if args.postprocess_overlap else 20 if args.generation_mode == "constrained" else 18,
+        "issue": int(issue_number),
         "sequence_format": SEQUENCE_FORMAT_STAGE_B_V1,
         "request": request.to_dict(),
         "checkpoint_dir": str(checkpoint_dir),
@@ -446,6 +494,8 @@ def main() -> int:
 
     sample_rows: list[dict[str, Any]] = []
     for index in range(1, int(args.num_samples) + 1):
+        sample_seed = int(args.seed) + index - 1
+        torch.manual_seed(sample_seed)
         if args.generation_mode == "constrained":
             generated_tokens = generate_stage_b_constrained_tokens(
                 model=model,
@@ -480,6 +530,7 @@ def main() -> int:
         sample_rows.append(
             sample_report(
                 sample_index=index,
+                sample_seed=sample_seed,
                 tokens=generated_tokens,
                 primer_size=len(primer_tokens),
                 target_length=args.max_sequence,
@@ -490,13 +541,24 @@ def main() -> int:
         )
 
     report["samples"] = sample_rows
-    report["valid_sample_count"] = sum(1 for row in sample_rows if row["valid"])
-    report["grammar_gate_sample_count"] = sum(1 for row in sample_rows if row["grammar_gate_passed"])
-    report["sample_count"] = len(sample_rows)
-    report["passed_generation_gate"] = bool(report["valid_sample_count"] > 0)
-    report["passed_grammar_gate"] = bool(report["grammar_gate_sample_count"] > 0)
+    summary = build_probe_summary(
+        sample_rows,
+        min_valid_samples=args.min_valid_samples,
+        require_all_grammar_samples=args.require_all_grammar_samples,
+    )
+    report["summary"] = summary
+    report["valid_sample_count"] = summary["valid_sample_count"]
+    report["grammar_gate_sample_count"] = summary["grammar_gate_sample_count"]
+    report["sample_count"] = summary["sample_count"]
+    report["passed_generation_gate"] = summary["passed_generation_gate"]
+    report["passed_grammar_gate"] = summary["passed_grammar_gate"]
     if not report["passed_generation_gate"]:
-        report["failure_reason"] = "No Stage B generated sample passed the MIDI review gate"
+        report["failure_reason"] = (
+            f"Only {summary['valid_sample_count']} Stage B generated samples passed the MIDI review gate; "
+            f"required {summary['min_valid_samples']}"
+        )
+    if not report["passed_grammar_gate"]:
+        report["failure_reason"] = "Stage B generated samples did not satisfy the configured grammar gate"
 
     write_json(run_dir / "report.json", report)
     print(json.dumps(report, ensure_ascii=True, indent=2))

--- a/tests/test_stage_b_generation_probe.py
+++ b/tests/test_stage_b_generation_probe.py
@@ -9,6 +9,7 @@ import torch
 
 from scripts.run_stage_b_generation_probe import (
     analyze_stage_b_note_grammar,
+    build_probe_summary,
     build_stage_b_primer,
     dedupe_and_limit_notes,
     decode_tokens_to_midi,
@@ -168,6 +169,34 @@ class StageBGenerationProbeTest(unittest.TestCase):
         self.assertEqual(report["before_max_simultaneous_notes"], 3)
         self.assertEqual(report["after_max_simultaneous_notes"], 2)
         self.assertEqual(len(midi.instruments[0].notes), 3)
+
+    def test_build_probe_summary_tracks_multisample_thresholds(self) -> None:
+        rows = [
+            {"sample_index": 1, "valid": True, "grammar_gate_passed": True},
+            {"sample_index": 2, "valid": False, "grammar_gate_passed": True, "failure_reason": "too sparse"},
+            {"sample_index": 3, "valid": True, "grammar_gate_passed": True},
+        ]
+
+        summary = build_probe_summary(rows, min_valid_samples=2, require_all_grammar_samples=True)
+
+        self.assertEqual(summary["sample_count"], 3)
+        self.assertEqual(summary["valid_sample_count"], 2)
+        self.assertEqual(summary["grammar_gate_sample_count"], 3)
+        self.assertEqual(summary["valid_sample_indices"], [1, 3])
+        self.assertTrue(summary["passed_generation_gate"])
+        self.assertTrue(summary["passed_grammar_gate"])
+        self.assertEqual(summary["failure_reasons"], {"too sparse": 1})
+
+    def test_build_probe_summary_can_require_all_grammar_samples(self) -> None:
+        rows = [
+            {"sample_index": 1, "valid": True, "grammar_gate_passed": True},
+            {"sample_index": 2, "valid": True, "grammar_gate_passed": False},
+        ]
+
+        summary = build_probe_summary(rows, min_valid_samples=1, require_all_grammar_samples=True)
+
+        self.assertTrue(summary["passed_generation_gate"])
+        self.assertFalse(summary["passed_grammar_gate"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 요약

- Stage B generation probe에 샘플별 seed, pass-rate summary, 최소 valid sample 기준을 추가했습니다.
- `stage-b-stronger-probe` 하네스를 추가해 constrained + overlap postprocess 결과를 3개 샘플로 검증합니다.
- `top_k=1` collapse negative control과 `top_k=2` multi-sample 결과를 문서화했습니다.

## 검증

- `./.venv/bin/python -m unittest tests.test_stage_b_generation_probe`
- `bash scripts/agent_harness.sh stage-b-stronger-probe`
- `bash scripts/agent_harness.sh quick`

## 로컬 결과

- `top_k=2`: grammar gate `3/3`, full review gate `1/3`
- `top_k=1` negative control: grammar gate `3/3`, full review gate `0/3`
- 결론: Stage B 문법은 여러 샘플에서 강제 가능하지만, 아직 안정적인 musical solo-line 품질은 아님

Closes #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated repository documentation to reflect new Stage B stronger multi-sample probe focus (Issue `#24`)

* **New Features**
  * Added `stage-b-stronger-probe` harness mode with enhanced multi-sample generation probe capabilities
  * Enhanced probe with per-sample seeding, configurable sample validity thresholds, and improved gate reporting

* **Tests**
  * Added tests for multi-sample probe summary aggregation logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohhalim/fine_tuning_art-tatum_midi_solo/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->