### PR TITLE
[codex] Stage B collapse 진단과 샘플링 sweep 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #24: Stage B stronger multi-sample generation probe.
+- Issue #29: Stage B collapse diagnostics and sampling sweep.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -136,6 +136,12 @@ For Stage B multi-sample review-gate changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-stronger-probe
+```
+
+For Stage B collapse/sampling-sweep changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-collapse-sweep
 ```
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -297,24 +297,31 @@ Stage B에서 명시하는 것:
 
 ## 9. 다음 바로 할 일
 
+완료된 바로 전 작업:
+
+- `Stage B collapse diagnostics and sampling sweep 추가`
+- 결과: `top_k=1`은 collapse warning `3/3`, valid `0/3`
+- 결과: `top_k=2`는 collapse warning `1/3`, valid `1/3`
+- 결론: Stage B grammar가 아니라 note distribution collapse가 현재 병목이다.
+
 다음 issue는 다음 이름이 적절하다.
 
 ```text
-Stage B collapse diagnostics and sampling sweep 추가
+Stage B stricter collapse-aware review gate 추가
 ```
 
 작업 범위:
 
-- current `stage-b-stronger-probe` 결과를 기반으로 collapse metric 추가
-- `report.json`에 collapse diagnostics 추가
-- `top_k`/temperature sweep script 또는 harness mode 추가
-- sample table을 markdown/JSON으로 저장
-- 다음 단계로 갈지 판단하는 pass-rate 기준 정의
+- review gate에 collapse-aware 기준을 추가한다.
+- minimum unique pitch/position/pair 기준을 정한다.
+- collapse warning sample rate 상한을 정한다.
+- sampling sweep이 stricter gate 기준으로 통과/실패를 보고하게 한다.
+- broad training 전 Stage B 2-file Brad probe로 갈 수 있는지 판단한다.
 
 이 작업이 끝난 뒤 판단:
 
-- collapse가 줄고 pass-rate가 안정되면 Stage B 2-file Brad probe로 간다.
-- collapse가 계속되면 tokenization/model/loss/pretrained-base 쪽으로 재검토한다.
+- stricter gate에서도 최소 pass-rate가 유지되면 Stage B 2-file Brad probe로 간다.
+- stricter gate에서 전부 실패하면 sampling/postprocess 문제가 아니라 tokenization/model/loss/pretrained-base 쪽으로 재검토한다.
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-24-stage-b-stronger-multisample-probe`
+- `issue-29-stage-b-collapse-sampling-sweep`
 
 현재 범위가 아닌 것:
 
@@ -244,9 +244,13 @@ Current result:
 - full review gate passed: `true`
 - detail: `docs/STAGE_B_OVERLAP_GATE_2026-05-19.md`
 
-## Active Issue #24
+## Completed Issue #24
 
-Current task:
+Status:
+
+- completed and merged via PR #25
+
+Completed task:
 
 - strengthen the Stage B local generation probe from one sample to multiple samples
 - keep the probe honest by reporting sample-level failures
@@ -266,6 +270,32 @@ Current result:
 - all `3/3` samples passed the Stage B grammar gate
 - `top_k=1` negative control collapsed to `0/3` valid samples
 - detail: `docs/STAGE_B_STRONGER_MULTISAMPLE_PROBE_2026-05-20.md`
+
+## Active Issue #29
+
+Current task:
+
+- add collapse diagnostics to Stage B generated token reports
+- explain invalid samples with repeated position/pitch metrics
+- add a sampling sweep over `top_k` settings
+- compare `top_k=1` collapse against `top_k=2`
+
+First implementation target:
+
+- `scripts/run_stage_b_generation_probe.py`
+- `scripts/run_stage_b_sampling_sweep.py`
+- `scripts/agent_harness.sh stage-b-collapse-sweep`
+- `tests/test_stage_b_generation_probe.py`
+- `tests/test_stage_b_sampling_sweep.py`
+- `docs/STAGE_B_COLLAPSE_SWEEP_2026-05-20.md`
+
+Current result:
+
+- `top_k=1`: valid `0/3`, collapse warning `3/3`, avg repeated position/pitch pair ratio `0.875`
+- `top_k=2`: valid `1/3`, collapse warning `1/3`, avg repeated position/pitch pair ratio `0.292`
+- best config: `top_k=2`, `temperature=0.9`
+- decision: grammar is no longer the immediate bottleneck; note distribution collapse is
+- detail: `docs/STAGE_B_COLLAPSE_SWEEP_2026-05-20.md`
 
 ## Dataset Strategy
 
@@ -605,7 +635,7 @@ Smoke result:
 
 Status:
 
-- implemented on `issue-24-stage-b-stronger-multisample-probe`
+- completed and merged via PR #25
 
 Goal:
 
@@ -636,6 +666,36 @@ Smoke result:
 - passed generation gate: `true`
 - negative control: `top_k=1` collapsed to `0/3` valid samples with `note count too low: 2 < 6`
 - detail: `docs/STAGE_B_STRONGER_MULTISAMPLE_PROBE_2026-05-20.md`
+
+### 0.13. Issue #29 Stage B collapse diagnostics and sampling sweep
+
+Status:
+
+- implemented on `issue-29-stage-b-collapse-sampling-sweep`
+
+Goal:
+
+- detect repeated position/pitch collapse before scaling training
+- report collapse diagnostics per generated sample
+- compare sampling configs by pass-rate, not by one hand-picked MIDI
+
+Acceptance:
+
+- collapse diagnostics unit tests pass
+- sampling sweep summary tests pass
+- `bash scripts/agent_harness.sh quick` passes
+- `bash scripts/agent_harness.sh stage-b-collapse-sweep` passes
+- `report.json` includes collapse warnings and diagnostic failure reasons
+- `sweep_report.json` and `sweep_report.md` compare `top_k=1` and `top_k=2`
+
+Smoke result:
+
+- output: `outputs/stage_b_sampling_sweep/harness_stage_b_collapse_sweep`
+- `top_k=1`: valid `0/3`, collapse warning `3/3`, avg repeated position/pitch pair ratio `0.875`
+- `top_k=2`: valid `1/3`, collapse warning `1/3`, avg repeated position/pitch pair ratio `0.292`
+- best config: `top_k=2`, `temperature=0.9`
+- decision: grammar is no longer the immediate bottleneck; note distribution collapse is
+- detail: `docs/STAGE_B_COLLAPSE_SWEEP_2026-05-20.md`
 
 ### 1. Run full jazz piano dataset audit
 
@@ -772,6 +832,7 @@ Decision:
 - `docs/STAGE_B_CONSTRAINED_TINY_OVERFIT_2026-05-19.md`
 - `docs/STAGE_B_OVERLAP_GATE_2026-05-19.md`
 - `docs/STAGE_B_STRONGER_MULTISAMPLE_PROBE_2026-05-20.md`
+- `docs/STAGE_B_COLLAPSE_SWEEP_2026-05-20.md`
 - `docs/REFERENCES.md`
 - `docs/INFERENCE_MODEL_SPEC.md`
 - `docs/QA_ACCEPTANCE_PLAN.md`
@@ -824,4 +885,10 @@ For Stage B multi-sample review-gate changes:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-stronger-probe
+```
+
+For Stage B collapse/sampling-sweep changes:
+
+```bash
+bash scripts/agent_harness.sh stage-b-collapse-sweep
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,8 @@
   - Stage B constrained output overlap/dedup postprocess and first local review-gate pass.
 - `STAGE_B_STRONGER_MULTISAMPLE_PROBE_2026-05-20.md`
   - Stage B multi-sample constrained probe, pass-rate reporting, and sampling collapse negative control.
+- `STAGE_B_COLLAPSE_SWEEP_2026-05-20.md`
+  - Stage B collapse diagnostics and `top_k` sampling sweep result.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -64,7 +66,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, and 2-file generation probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, and 2-file generation probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_COLLAPSE_SWEEP_2026-05-20.md
+++ b/docs/STAGE_B_COLLAPSE_SWEEP_2026-05-20.md
@@ -1,0 +1,122 @@
+# Stage B Collapse Diagnostics and Sampling Sweep: 2026-05-20
+
+## Purpose
+
+Issue #29 implements `CORE_PLAN.md` Phase 1-2.
+
+Issue #24 showed that Stage B constrained generation can pass grammar and occasionally pass the full MIDI review gate, but it also exposed a collapse mode:
+
+- `top_k=1` generated complete note groups
+- the groups repeated the same position/pitch
+- overlap postprocess removed most notes
+- the sample failed as a solo-line candidate
+
+This issue makes that failure measurable instead of only visible in a piano roll.
+
+## Implementation
+
+Code changes:
+
+- `scripts/run_stage_b_generation_probe.py`
+  - adds token-level note group extraction
+  - adds collapse diagnostics per sample
+  - records repeated pitch ratio
+  - records repeated position/pitch pair ratio
+  - records postprocess removal ratio
+  - records diagnostic failure reasons that include collapse causes
+- `scripts/run_stage_b_sampling_sweep.py`
+  - trains one tiny Stage B checkpoint
+  - reuses the checkpoint across sampling configs
+  - writes `sweep_report.json`
+  - writes `sweep_report.md`
+- `scripts/agent_harness.sh`
+  - adds `stage-b-collapse-sweep`
+- tests
+  - verify collapse detection
+  - verify summary aggregation
+  - verify sweep summary selection
+
+## Commands
+
+```bash
+bash scripts/agent_harness.sh stage-b-collapse-sweep
+```
+
+Equivalent sweep:
+
+```bash
+python scripts/run_stage_b_sampling_sweep.py \
+  --run_id harness_stage_b_collapse_sweep \
+  --issue_number 29 \
+  --top_ks 1,2 \
+  --temperatures 0.9 \
+  --train_top_k 2 \
+  --max_files 1 \
+  --epochs 3 \
+  --batch_size 8 \
+  --max_sequence 96 \
+  --num_samples 3 \
+  --constrained_note_groups_per_bar 4 \
+  --max_simultaneous_notes 2 \
+  --require_all_grammar_samples \
+  --min_best_valid_samples 1 \
+  --n_layers 1 \
+  --num_heads 4 \
+  --d_model 64 \
+  --dim_feedforward 128 \
+  --lora_r 4 \
+  --lora_alpha 8
+```
+
+## Local Result
+
+Output:
+
+```text
+outputs/stage_b_sampling_sweep/harness_stage_b_collapse_sweep
+```
+
+Sweep summary:
+
+| top_k | temp | samples | grammar | valid | valid rate | collapse rate | avg pair repeat | max removal |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 0.900 | 3 | 3 | 0 | 0.000 | 1.000 | 0.875 | 0.750 |
+| 2 | 0.900 | 3 | 3 | 1 | 0.333 | 0.333 | 0.292 | 0.500 |
+
+Best config:
+
+```text
+top_k=2, temperature=0.9
+```
+
+Diagnostic failures:
+
+- `top_k=1`
+  - `note count too low: 2 < 6`
+  - collapse: `single_pitch`, `single_position`, `repeated_position_pitch`, `postprocess_removed_majority`
+- `top_k=2`
+  - one sample failed with note count too low plus repeated position/pitch collapse
+  - one sample failed on dead-air ratio
+  - one sample passed the current review gate
+
+## Decision
+
+Issue #29 confirms that the Stage B grammar path is not the bottleneck anymore.
+
+The bottleneck is note distribution:
+
+- deterministic decoding collapses to a single position/pitch pattern
+- mild stochasticity improves the result but is not stable
+- postprocess hides some overlap, but cannot create a real solo-line
+
+Do not proceed to broad generic jazz training yet.
+
+## Next Step
+
+The next issue should tighten the review gate before scaling data:
+
+- add minimum unique-position or unique-position/pitch thresholds to the review gate
+- require collapse warning rate below a configured threshold
+- keep sampling sweep as the comparison tool
+
+After that, run a Stage B 2-file Brad probe only if the stricter gate is not immediately failing every sample.

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -38,6 +38,8 @@ Modes:
                 Run constrained Stage B generation with overlap postprocess gate.
   stage-b-stronger-probe
                 Run a multi-sample constrained Stage B review-gate probe.
+  stage-b-collapse-sweep
+                Run Stage B top-k sampling sweep with collapse diagnostics.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   all           Run demo and tiny-compare.
@@ -75,6 +77,7 @@ run_quick() {
     scripts/prepare_role_dataset.py \
     scripts/run_stage_b_window_tiny_overfit.py \
     scripts/run_stage_b_generation_probe.py \
+    scripts/run_stage_b_sampling_sweep.py \
     scripts/audit_brad_mehldau_dataset.py \
     scripts/audit_jazz_piano_dataset.py \
     scripts/build_jazz_training_manifests.py \
@@ -234,6 +237,32 @@ run_stage_b_stronger_probe() {
     --lora_alpha 8
 }
 
+run_stage_b_collapse_sweep() {
+  local run_id="${RUN_ID:-harness_stage_b_collapse_sweep}"
+  print_header "Stage B collapse sampling sweep"
+  "$PYTHON_BIN" scripts/run_stage_b_sampling_sweep.py \
+    --run_id "$run_id" \
+    --issue_number 29 \
+    --top_ks 1,2 \
+    --temperatures 0.9 \
+    --train_top_k 2 \
+    --max_files 1 \
+    --epochs 3 \
+    --batch_size 8 \
+    --max_sequence 96 \
+    --num_samples 3 \
+    --constrained_note_groups_per_bar 4 \
+    --max_simultaneous_notes 2 \
+    --require_all_grammar_samples \
+    --min_best_valid_samples 1 \
+    --n_layers 1 \
+    --num_heads 4 \
+    --d_model 64 \
+    --dim_feedforward 128 \
+    --lora_r 4 \
+    --lora_alpha 8
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -278,6 +307,9 @@ case "$MODE" in
     ;;
   stage-b-stronger-probe)
     run_stage_b_stronger_probe
+    ;;
+  stage-b-collapse-sweep)
+    run_stage_b_collapse_sweep
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/run_stage_b_generation_probe.py
+++ b/scripts/run_stage_b_generation_probe.py
@@ -51,6 +51,8 @@ from scripts.stage_b_tokens import (  # noqa: E402
     is_note_pitch_token,
     is_position_token,
     is_velocity_token,
+    pitch_from_token,
+    position_from_token,
     stage_b_token_name,
 )
 from utilities.constants import TOKEN_BAR, TOKEN_END, VOCAB_SIZE  # noqa: E402
@@ -150,6 +152,130 @@ def analyze_stage_b_note_grammar(tokens: Sequence[int], primer_size: int = 0) ->
         "family_counts": family_counts,
         "invalid_tokens_head": invalid_tokens[:12],
         "grammar_valid": bool(complete_groups > 0 and not invalid_tokens and expected_index == 0),
+    }
+
+
+def extract_stage_b_note_groups(tokens: Sequence[int], primer_size: int = 0) -> list[dict[str, int]]:
+    generated = [int(token) for token in tokens[int(primer_size) :]]
+    note_groups: list[dict[str, int]] = []
+    bar_index = 0
+    current_position: int | None = None
+    current_velocity: int | None = None
+    current_pitch: int | None = None
+
+    for token in generated:
+        if int(token) == TOKEN_END:
+            break
+        if int(token) == TOKEN_BAR:
+            bar_index += 1
+            current_position = None
+            current_velocity = None
+            current_pitch = None
+            continue
+        if token_family(token) == "chord":
+            continue
+        if is_position_token(token):
+            current_position = position_from_token(token)
+            current_velocity = None
+            current_pitch = None
+            continue
+        if is_velocity_token(token):
+            current_velocity = int(token)
+            continue
+        if is_note_pitch_token(token):
+            current_pitch = pitch_from_token(token)
+            continue
+        if is_note_duration_token(token) and current_position is not None and current_pitch is not None:
+            note_groups.append(
+                {
+                    "bar": int(bar_index),
+                    "position": int(current_position),
+                    "pitch": int(current_pitch),
+                    "velocity_token": int(current_velocity) if current_velocity is not None else -1,
+                    "duration_token": int(token),
+                }
+            )
+            current_position = None
+            current_velocity = None
+            current_pitch = None
+
+    return note_groups
+
+
+def _counter(values: Sequence[Any]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for value in values:
+        key = str(value)
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def analyze_stage_b_collapse(
+    tokens: Sequence[int],
+    primer_size: int = 0,
+    postprocess_report: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    groups = extract_stage_b_note_groups(tokens, primer_size=primer_size)
+    group_count = int(len(groups))
+    pitches = [group["pitch"] for group in groups]
+    positions = [group["position"] for group in groups]
+    relative_pairs = [(group["position"], group["pitch"]) for group in groups]
+    absolute_pairs = [(group["bar"], group["position"], group["pitch"]) for group in groups]
+    bar_counts = _counter([group["bar"] for group in groups])
+    pitch_counts = _counter(pitches)
+    pair_counts = _counter(relative_pairs)
+
+    unique_pitch_count = len(set(pitches))
+    unique_position_count = len(set(positions))
+    unique_relative_pair_count = len(set(relative_pairs))
+    unique_absolute_pair_count = len(set(absolute_pairs))
+    repeated_pitch_count = max(0, group_count - unique_pitch_count)
+    repeated_position_pitch_pair_count = max(0, group_count - unique_relative_pair_count)
+    repeated_absolute_position_pitch_pair_count = max(0, group_count - unique_absolute_pair_count)
+
+    postprocess = postprocess_report or {}
+    before_note_count = int(postprocess.get("before_note_count", 0) or 0)
+    removed_note_count = int(postprocess.get("removed_note_count", 0) or 0)
+    postprocess_removal_ratio = float(removed_note_count / before_note_count) if before_note_count else 0.0
+
+    repeated_pair_ratio = float(repeated_position_pitch_pair_count / group_count) if group_count else 0.0
+    repeated_pitch_ratio = float(repeated_pitch_count / group_count) if group_count else 0.0
+    repeated_absolute_pair_ratio = (
+        float(repeated_absolute_position_pitch_pair_count / group_count) if group_count else 0.0
+    )
+    max_same_pair_repeats = max(pair_counts.values()) if pair_counts else 0
+    max_same_pitch_repeats = max(pitch_counts.values()) if pitch_counts else 0
+
+    collapse_reasons: list[str] = []
+    if group_count > 0 and unique_pitch_count <= 1:
+        collapse_reasons.append("single_pitch")
+    if group_count > 0 and unique_position_count <= 1:
+        collapse_reasons.append("single_position")
+    if repeated_pair_ratio >= 0.5:
+        collapse_reasons.append("repeated_position_pitch")
+    if postprocess_removal_ratio >= 0.5:
+        collapse_reasons.append("postprocess_removed_majority")
+
+    return {
+        "note_group_count": group_count,
+        "unique_pitch_count": int(unique_pitch_count),
+        "unique_position_count": int(unique_position_count),
+        "unique_position_pitch_pair_count": int(unique_relative_pair_count),
+        "unique_absolute_position_pitch_pair_count": int(unique_absolute_pair_count),
+        "repeated_pitch_count": int(repeated_pitch_count),
+        "repeated_position_pitch_pair_count": int(repeated_position_pitch_pair_count),
+        "repeated_absolute_position_pitch_pair_count": int(repeated_absolute_position_pitch_pair_count),
+        "repeated_pitch_ratio": repeated_pitch_ratio,
+        "repeated_position_pitch_pair_ratio": repeated_pair_ratio,
+        "repeated_absolute_position_pitch_pair_ratio": repeated_absolute_pair_ratio,
+        "max_same_pitch_repeats": int(max_same_pitch_repeats),
+        "max_same_position_pitch_pair_repeats": int(max_same_pair_repeats),
+        "postprocess_removal_ratio": postprocess_removal_ratio,
+        "per_bar_note_counts": {str(key): int(value) for key, value in bar_counts.items()},
+        "pitch_counts_head": dict(sorted(pitch_counts.items(), key=lambda item: (-item[1], item[0]))[:8]),
+        "position_pitch_pair_counts_head": dict(sorted(pair_counts.items(), key=lambda item: (-item[1], item[0]))[:8]),
+        "collapse_warning": bool(collapse_reasons),
+        "collapse_reasons": collapse_reasons,
     }
 
 
@@ -306,9 +432,15 @@ def sample_report(
 ) -> dict[str, Any]:
     raw_generated_tokens = [int(token) for token in tokens[primer_size:]]
     grammar = analyze_stage_b_note_grammar(tokens, primer_size=primer_size)
+    collapse = analyze_stage_b_collapse(tokens, primer_size=primer_size, postprocess_report=postprocess_report)
     metrics = compute_midi_metrics(midi_path, 0, False, request=request)
     valid, reason = validate_metrics(metrics, request.density, bars=request.bars)
     grammar_gate_passed = bool(grammar["complete_note_groups"] > 0 and metrics.note_count > 0)
+    diagnostic_failure_reason = reason
+    if not valid and collapse["collapse_warning"]:
+        diagnostic_failure_reason = (
+            f"{reason}; collapse={','.join(collapse['collapse_reasons'])}" if reason else ",".join(collapse["collapse_reasons"])
+        )
     return {
         "sample_index": int(sample_index),
         "sample_seed": int(sample_seed),
@@ -320,7 +452,9 @@ def sample_report(
         "valid": bool(valid),
         "grammar_gate_passed": grammar_gate_passed,
         "failure_reason": reason,
+        "diagnostic_failure_reason": diagnostic_failure_reason,
         "grammar": grammar,
+        "collapse": collapse,
         "postprocess": postprocess_report or {"enabled": False},
         "metrics": metrics.to_dict(),
         "generated_token_names_head": [stage_b_token_name(token) for token in raw_generated_tokens[:48]],
@@ -344,11 +478,21 @@ def build_probe_summary(
         passed_grammar_gate = bool(grammar_gate_sample_count > 0)
 
     failure_reasons: dict[str, int] = {}
+    diagnostic_failure_reasons: dict[str, int] = {}
+    collapse_warning_count = 0
+    repeated_pair_ratios: list[float] = []
+    postprocess_removal_ratios: list[float] = []
     for row in sample_rows:
-        if row["valid"]:
-            continue
-        reason = str(row.get("failure_reason") or "unknown")
-        failure_reasons[reason] = failure_reasons.get(reason, 0) + 1
+        collapse = row.get("collapse", {})
+        if collapse.get("collapse_warning"):
+            collapse_warning_count += 1
+        repeated_pair_ratios.append(float(collapse.get("repeated_position_pitch_pair_ratio", 0.0) or 0.0))
+        postprocess_removal_ratios.append(float(collapse.get("postprocess_removal_ratio", 0.0) or 0.0))
+        if not row["valid"]:
+            reason = str(row.get("failure_reason") or "unknown")
+            diagnostic_reason = str(row.get("diagnostic_failure_reason") or reason)
+            failure_reasons[reason] = failure_reasons.get(reason, 0) + 1
+            diagnostic_failure_reasons[diagnostic_reason] = diagnostic_failure_reasons.get(diagnostic_reason, 0) + 1
 
     return {
         "sample_count": sample_count,
@@ -363,6 +507,19 @@ def build_probe_summary(
         "passed_generation_gate": bool(valid_sample_count >= int(min_valid_samples)),
         "passed_grammar_gate": passed_grammar_gate,
         "failure_reasons": failure_reasons,
+        "diagnostic_failure_reasons": diagnostic_failure_reasons,
+        "collapse_warning_sample_count": int(collapse_warning_count),
+        "collapse_warning_sample_rate": float(collapse_warning_count / sample_count) if sample_count else 0.0,
+        "avg_repeated_position_pitch_pair_ratio": (
+            float(sum(repeated_pair_ratios) / len(repeated_pair_ratios)) if repeated_pair_ratios else 0.0
+        ),
+        "max_repeated_position_pitch_pair_ratio": max(repeated_pair_ratios) if repeated_pair_ratios else 0.0,
+        "avg_postprocess_removal_ratio": (
+            float(sum(postprocess_removal_ratios) / len(postprocess_removal_ratios))
+            if postprocess_removal_ratios
+            else 0.0
+        ),
+        "max_postprocess_removal_ratio": max(postprocess_removal_ratios) if postprocess_removal_ratios else 0.0,
     }
 
 

--- a/scripts/run_stage_b_sampling_sweep.py
+++ b/scripts/run_stage_b_sampling_sweep.py
@@ -1,0 +1,275 @@
+"""Run a small Stage B sampling sweep against one trained tiny checkpoint."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+PROBE_SCRIPT = ROOT_DIR / "scripts" / "run_stage_b_generation_probe.py"
+
+
+def parse_int_list(raw: str) -> list[int]:
+    return [int(value.strip()) for value in raw.split(",") if value.strip()]
+
+
+def parse_float_list(raw: str) -> list[float]:
+    return [float(value.strip()) for value in raw.split(",") if value.strip()]
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def suffix_for_float(value: float) -> str:
+    return str(value).replace("-", "m").replace(".", "p")
+
+
+def run_command(cmd: list[str]) -> dict[str, Any]:
+    completed = subprocess.run(cmd, cwd=ROOT_DIR, text=True, capture_output=True, check=False)
+    return {
+        "cmd": cmd,
+        "returncode": int(completed.returncode),
+        "stdout_tail": completed.stdout[-4000:],
+        "stderr_tail": completed.stderr[-4000:],
+    }
+
+
+def probe_command(
+    args: argparse.Namespace,
+    run_id: str,
+    top_k: int,
+    temperature: float,
+    checkpoint_dir: Path | None = None,
+    skip_prepare_train: bool = False,
+) -> list[str]:
+    cmd = [
+        sys.executable,
+        str(PROBE_SCRIPT),
+        "--run_id",
+        run_id,
+        "--output_root",
+        str(Path(args.output_root)),
+        "--issue_number",
+        str(args.issue_number),
+        "--max_files",
+        str(args.max_files),
+        "--epochs",
+        str(args.epochs),
+        "--batch_size",
+        str(args.batch_size),
+        "--max_sequence",
+        str(args.max_sequence),
+        "--num_samples",
+        str(args.num_samples),
+        "--generation_mode",
+        "constrained",
+        "--constrained_note_groups_per_bar",
+        str(args.constrained_note_groups_per_bar),
+        "--postprocess_overlap",
+        "--max_simultaneous_notes",
+        str(args.max_simultaneous_notes),
+        "--temperature",
+        str(temperature),
+        "--top_k",
+        str(top_k),
+        "--min_valid_samples",
+        str(args.min_valid_samples),
+        "--n_layers",
+        str(args.n_layers),
+        "--num_heads",
+        str(args.num_heads),
+        "--d_model",
+        str(args.d_model),
+        "--dim_feedforward",
+        str(args.dim_feedforward),
+        "--lora_r",
+        str(args.lora_r),
+        "--lora_alpha",
+        str(args.lora_alpha),
+    ]
+    if args.require_all_grammar_samples:
+        cmd.append("--require_all_grammar_samples")
+    if skip_prepare_train:
+        cmd.extend(["--skip_prepare", "--skip_train"])
+    if checkpoint_dir is not None:
+        cmd.extend(["--checkpoint_dir", str(checkpoint_dir)])
+    return cmd
+
+
+def row_from_probe_report(top_k: int, temperature: float, run_id: str, report: dict[str, Any]) -> dict[str, Any]:
+    summary = report.get("summary", {})
+    return {
+        "run_id": run_id,
+        "top_k": int(top_k),
+        "temperature": float(temperature),
+        "sample_count": int(summary.get("sample_count", 0)),
+        "grammar_gate_sample_count": int(summary.get("grammar_gate_sample_count", 0)),
+        "valid_sample_count": int(summary.get("valid_sample_count", 0)),
+        "grammar_gate_sample_rate": float(summary.get("grammar_gate_sample_rate", 0.0)),
+        "valid_sample_rate": float(summary.get("valid_sample_rate", 0.0)),
+        "collapse_warning_sample_count": int(summary.get("collapse_warning_sample_count", 0)),
+        "collapse_warning_sample_rate": float(summary.get("collapse_warning_sample_rate", 0.0)),
+        "avg_repeated_position_pitch_pair_ratio": float(
+            summary.get("avg_repeated_position_pitch_pair_ratio", 0.0)
+        ),
+        "max_repeated_position_pitch_pair_ratio": float(
+            summary.get("max_repeated_position_pitch_pair_ratio", 0.0)
+        ),
+        "avg_postprocess_removal_ratio": float(summary.get("avg_postprocess_removal_ratio", 0.0)),
+        "max_postprocess_removal_ratio": float(summary.get("max_postprocess_removal_ratio", 0.0)),
+        "failure_reasons": summary.get("failure_reasons", {}),
+        "diagnostic_failure_reasons": summary.get("diagnostic_failure_reasons", {}),
+        "report_path": str(Path(report["run_dir"]) / "report.json"),
+    }
+
+
+def build_sweep_summary(rows: list[dict[str, Any]], min_best_valid_samples: int = 1) -> dict[str, Any]:
+    best_row = max(rows, key=lambda row: (row["valid_sample_count"], row["valid_sample_rate"]), default=None)
+    return {
+        "config_count": int(len(rows)),
+        "best_valid_sample_count": int(best_row["valid_sample_count"]) if best_row else 0,
+        "best_valid_sample_rate": float(best_row["valid_sample_rate"]) if best_row else 0.0,
+        "best_config": {
+            "top_k": int(best_row["top_k"]),
+            "temperature": float(best_row["temperature"]),
+            "run_id": best_row["run_id"],
+        }
+        if best_row
+        else None,
+        "min_best_valid_samples": int(min_best_valid_samples),
+        "passed_sweep_gate": bool(best_row and int(best_row["valid_sample_count"]) >= int(min_best_valid_samples)),
+    }
+
+
+def markdown_table(rows: list[dict[str, Any]], summary: dict[str, Any]) -> str:
+    lines = [
+        "# Stage B Sampling Sweep",
+        "",
+        f"- passed sweep gate: `{str(summary['passed_sweep_gate']).lower()}`",
+        f"- best config: `{summary['best_config']}`",
+        "",
+        "| top_k | temp | samples | grammar | valid | valid_rate | collapse_rate | avg_pair_repeat | max_remove |",
+        "|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for row in rows:
+        lines.append(
+            "| {top_k} | {temperature:.3f} | {sample_count} | {grammar_gate_sample_count} | "
+            "{valid_sample_count} | {valid_sample_rate:.3f} | {collapse_warning_sample_rate:.3f} | "
+            "{avg_repeated_position_pitch_pair_ratio:.3f} | {max_postprocess_removal_ratio:.3f} |".format(**row)
+        )
+    lines.append("")
+    lines.append("## Diagnostic Failures")
+    lines.append("")
+    for row in rows:
+        lines.append(f"- `top_k={row['top_k']}`, `temperature={row['temperature']}`: {row['diagnostic_failure_reasons']}")
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run Stage B sampling sweep")
+    parser.add_argument("--output_root", type=str, default=str(ROOT_DIR / "outputs" / "stage_b_sampling_sweep"))
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--issue_number", type=int, default=29)
+    parser.add_argument("--top_ks", type=str, default="1,2")
+    parser.add_argument("--temperatures", type=str, default="0.9")
+    parser.add_argument("--train_top_k", type=int, default=2)
+    parser.add_argument("--max_files", type=int, default=1)
+    parser.add_argument("--epochs", type=int, default=3)
+    parser.add_argument("--batch_size", type=int, default=8)
+    parser.add_argument("--max_sequence", type=int, default=96)
+    parser.add_argument("--num_samples", type=int, default=3)
+    parser.add_argument("--constrained_note_groups_per_bar", type=int, default=4)
+    parser.add_argument("--max_simultaneous_notes", type=int, default=2)
+    parser.add_argument("--min_valid_samples", type=int, default=1)
+    parser.add_argument("--min_best_valid_samples", type=int, default=1)
+    parser.add_argument("--require_all_grammar_samples", action="store_true")
+    parser.add_argument("--n_layers", type=int, default=1)
+    parser.add_argument("--num_heads", type=int, default=4)
+    parser.add_argument("--d_model", type=int, default=64)
+    parser.add_argument("--dim_feedforward", type=int, default=128)
+    parser.add_argument("--lora_r", type=int, default=4)
+    parser.add_argument("--lora_alpha", type=int, default=8)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now().strftime("%Y%m%d_%H%M%S")
+    sweep_dir = Path(args.output_root) / run_id
+    top_ks = parse_int_list(args.top_ks)
+    temperatures = parse_float_list(args.temperatures)
+    if not top_ks or not temperatures:
+        raise ValueError("--top_ks and --temperatures must not be empty")
+
+    train_temperature = temperatures[0]
+    train_config = (int(args.train_top_k), float(train_temperature))
+    command_results: list[dict[str, Any]] = []
+    rows: list[dict[str, Any]] = []
+    checkpoint_dir: Path | None = None
+    completed_configs: set[tuple[int, float]] = set()
+
+    for top_k in [args.train_top_k] + [value for value in top_ks if value != args.train_top_k]:
+        for temperature in temperatures:
+            config = (int(top_k), float(temperature))
+            config_run_id = f"{run_id}_k{top_k}_t{suffix_for_float(temperature)}"
+            skip_prepare_train = config != train_config
+            cmd = probe_command(
+                args,
+                run_id=config_run_id,
+                top_k=top_k,
+                temperature=temperature,
+                checkpoint_dir=checkpoint_dir,
+                skip_prepare_train=skip_prepare_train,
+            )
+            result = run_command(cmd)
+            command_results.append(result)
+            if result["returncode"] != 0:
+                report = {
+                    "run_id": run_id,
+                    "failure_reason": f"probe command failed for top_k={top_k}, temperature={temperature}",
+                    "command_results": command_results,
+                }
+                write_json(sweep_dir / "sweep_report.json", report)
+                print(json.dumps(report, ensure_ascii=True, indent=2))
+                return int(result["returncode"])
+
+            report_path = Path(args.output_root) / config_run_id / "report.json"
+            probe_report = read_json(report_path)
+            if checkpoint_dir is None:
+                checkpoint_dir = Path(probe_report["checkpoint_dir"])
+            if config not in completed_configs:
+                rows.append(row_from_probe_report(top_k, temperature, config_run_id, probe_report))
+                completed_configs.add(config)
+
+    rows = sorted(rows, key=lambda row: (row["temperature"], row["top_k"]))
+    summary = build_sweep_summary(rows, min_best_valid_samples=args.min_best_valid_samples)
+    report = {
+        "run_id": run_id,
+        "run_dir": str(sweep_dir),
+        "issue": int(args.issue_number),
+        "top_ks": top_ks,
+        "temperatures": temperatures,
+        "summary": summary,
+        "rows": rows,
+        "command_results": command_results,
+    }
+    write_json(sweep_dir / "sweep_report.json", report)
+    (sweep_dir / "sweep_report.md").write_text(markdown_table(rows, summary), encoding="utf-8")
+    print(json.dumps(report, ensure_ascii=True, indent=2))
+    return 0 if summary["passed_sweep_gate"] else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_generation_probe.py
+++ b/tests/test_stage_b_generation_probe.py
@@ -8,6 +8,7 @@ import pretty_midi
 import torch
 
 from scripts.run_stage_b_generation_probe import (
+    analyze_stage_b_collapse,
     analyze_stage_b_note_grammar,
     build_probe_summary,
     build_stage_b_primer,
@@ -197,6 +198,77 @@ class StageBGenerationProbeTest(unittest.TestCase):
 
         self.assertTrue(summary["passed_generation_gate"])
         self.assertFalse(summary["passed_grammar_gate"])
+
+    def test_analyze_stage_b_collapse_flags_repeated_position_pitch_pairs(self) -> None:
+        primer = build_stage_b_primer(["Cm7"], bpm=120)
+        tokens = primer + [
+            position_token(2),
+            note_velocity_token(4),
+            note_pitch_token(68),
+            note_duration_token(2),
+            position_token(2),
+            note_velocity_token(4),
+            note_pitch_token(68),
+            note_duration_token(2),
+            position_token(2),
+            note_velocity_token(4),
+            note_pitch_token(68),
+            note_duration_token(2),
+            TOKEN_END,
+        ]
+
+        report = analyze_stage_b_collapse(
+            tokens,
+            primer_size=len(primer),
+            postprocess_report={"before_note_count": 3, "removed_note_count": 2},
+        )
+
+        self.assertEqual(report["note_group_count"], 3)
+        self.assertEqual(report["unique_pitch_count"], 1)
+        self.assertEqual(report["unique_position_count"], 1)
+        self.assertEqual(report["unique_position_pitch_pair_count"], 1)
+        self.assertAlmostEqual(report["repeated_position_pitch_pair_ratio"], 2 / 3)
+        self.assertAlmostEqual(report["postprocess_removal_ratio"], 2 / 3)
+        self.assertTrue(report["collapse_warning"])
+        self.assertIn("repeated_position_pitch", report["collapse_reasons"])
+        self.assertIn("postprocess_removed_majority", report["collapse_reasons"])
+
+    def test_build_probe_summary_aggregates_collapse_diagnostics(self) -> None:
+        rows = [
+            {
+                "sample_index": 1,
+                "valid": False,
+                "grammar_gate_passed": True,
+                "failure_reason": "note count too low",
+                "diagnostic_failure_reason": "note count too low; collapse=repeated_position_pitch",
+                "collapse": {
+                    "collapse_warning": True,
+                    "repeated_position_pitch_pair_ratio": 0.75,
+                    "postprocess_removal_ratio": 0.5,
+                },
+            },
+            {
+                "sample_index": 2,
+                "valid": True,
+                "grammar_gate_passed": True,
+                "collapse": {
+                    "collapse_warning": False,
+                    "repeated_position_pitch_pair_ratio": 0.25,
+                    "postprocess_removal_ratio": 0.0,
+                },
+            },
+        ]
+
+        summary = build_probe_summary(rows, min_valid_samples=1, require_all_grammar_samples=True)
+
+        self.assertEqual(summary["collapse_warning_sample_count"], 1)
+        self.assertAlmostEqual(summary["collapse_warning_sample_rate"], 0.5)
+        self.assertAlmostEqual(summary["avg_repeated_position_pitch_pair_ratio"], 0.5)
+        self.assertAlmostEqual(summary["max_postprocess_removal_ratio"], 0.5)
+        self.assertEqual(
+            summary["diagnostic_failure_reasons"],
+            {"note count too low; collapse=repeated_position_pitch": 1},
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_stage_b_sampling_sweep.py
+++ b/tests/test_stage_b_sampling_sweep.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.run_stage_b_sampling_sweep import build_sweep_summary, markdown_table
+
+
+class StageBSamplingSweepTest(unittest.TestCase):
+    def test_build_sweep_summary_selects_best_valid_config(self) -> None:
+        rows = [
+            {"run_id": "k1", "top_k": 1, "temperature": 0.9, "valid_sample_count": 0, "valid_sample_rate": 0.0},
+            {"run_id": "k2", "top_k": 2, "temperature": 0.9, "valid_sample_count": 1, "valid_sample_rate": 0.333},
+        ]
+
+        summary = build_sweep_summary(rows, min_best_valid_samples=1)
+
+        self.assertTrue(summary["passed_sweep_gate"])
+        self.assertEqual(summary["best_valid_sample_count"], 1)
+        self.assertEqual(summary["best_config"], {"top_k": 2, "temperature": 0.9, "run_id": "k2"})
+
+    def test_build_sweep_summary_fails_when_no_config_has_valid_samples(self) -> None:
+        rows = [
+            {"run_id": "k1", "top_k": 1, "temperature": 0.9, "valid_sample_count": 0, "valid_sample_rate": 0.0},
+            {"run_id": "k2", "top_k": 2, "temperature": 0.9, "valid_sample_count": 0, "valid_sample_rate": 0.0},
+        ]
+
+        summary = build_sweep_summary(rows, min_best_valid_samples=1)
+
+        self.assertFalse(summary["passed_sweep_gate"])
+
+    def test_markdown_table_records_collapse_columns(self) -> None:
+        rows = [
+            {
+                "top_k": 1,
+                "temperature": 0.9,
+                "sample_count": 3,
+                "grammar_gate_sample_count": 3,
+                "valid_sample_count": 0,
+                "valid_sample_rate": 0.0,
+                "collapse_warning_sample_rate": 1.0,
+                "avg_repeated_position_pitch_pair_ratio": 0.75,
+                "max_postprocess_removal_ratio": 0.5,
+                "diagnostic_failure_reasons": {"collapse": 3},
+            }
+        ]
+        summary = {"passed_sweep_gate": False, "best_config": {"top_k": 1, "temperature": 0.9, "run_id": "k1"}}
+
+        markdown = markdown_table(rows, summary)
+
+        self.assertIn("collapse_rate", markdown)
+        self.assertIn("avg_pair_repeat", markdown)
+        self.assertIn("top_k=1", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약
- Stage B generation report에 position/pitch collapse 진단을 추가했습니다.
- top_k/temperature sampling sweep runner와 harness를 추가했습니다.
- top_k=1 collapse와 top_k=2 개선을 sweep report로 비교하도록 문서화했습니다.

## 검증
- `./.venv/bin/python -m unittest tests.test_stage_b_generation_probe tests.test_stage_b_sampling_sweep`
- `bash scripts/agent_harness.sh stage-b-collapse-sweep`
- `bash scripts/agent_harness.sh quick`

## 로컬 결과
- top_k=1: valid 0/3, collapse warning 3/3, avg repeated position/pitch ratio 0.875
- top_k=2: valid 1/3, collapse warning 1/3, avg repeated position/pitch ratio 0.292
- 결론: Stage B grammar보다 note distribution collapse가 현재 병목입니다.

Closes #29