### PR TITLE
[codex] Stage B 엄격 collapse-aware review gate 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #29: Stage B collapse diagnostics and sampling sweep.
+- Issue #31: Stage B stricter collapse-aware review gate.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -26,18 +26,26 @@ Allowed without additional permission:
 - run local tests and local scripts
 - create local commits after a coherent validated change
 - update docs that describe the current implementation or experiment result
+- create GitHub issues that follow `docs/CORE_PLAN.md`
+- create focused issue branches from latest `main`
+- push Codex-created issue branches
+- create PRs for Codex-created issue branches
+- merge Codex-created PRs when the Conditional Auto-Merge Policy is satisfied
 
 Must ask first:
 
-- any `git push`, including same-branch upstream push
-- pull request creation or PR metadata updates
-- GitHub issue creation or issue metadata updates
 - merging pull requests that were not created by Codex in the current task flow
 - deployment
 - external uploads
 - destructive cleanup of generated files, checkpoints, datasets, or user-created outputs
+- raw dataset, checkpoint, or generated artifact upload
+- cloud/GPU spend
+- secrets, credentials, or repository settings changes
+- merge conflict resolution that rewrites or discards user work
 
-If the user says "PR 올려", "이슈 만들어", "배포해", or equivalent, that counts as explicit permission for that requested remote action only.
+If the user says "자동으로 진행해", "플랜대로 계속해", or equivalent, that counts as permission to repeat the issue -> branch -> commit -> push -> PR -> safe auto-merge loop within `docs/CORE_PLAN.md` until a critical blocker appears.
+
+If the Codex host UI still asks for tool approval, that is a runtime permission gate outside this repo policy. Within this repository policy, plan-scoped GitHub issue/branch/PR/merge work is already allowed without re-asking the user.
 
 ## Conditional Auto-Merge Policy
 
@@ -143,6 +151,9 @@ For Stage B collapse/sampling-sweep changes, run:
 ```bash
 bash scripts/agent_harness.sh stage-b-collapse-sweep
 ```
+
+For Stage B strict collapse-aware review-gate changes, use the same sweep harness and verify
+`passed_strict_sweep_gate` in the generated report.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,20 @@ Local commits are allowed when all are true:
 - relevant validation commands pass, or failures are documented in the final response
 - the commit message is specific and conventional
 
+Commit cadence:
+
+- Prefer frequent commits at small validated boundaries instead of one large end-of-issue commit.
+- Commit after each coherent unit such as tests added, implementation wired, docs updated, or harness result recorded.
+- Do not create noisy checkpoint commits for broken or unvalidated work unless the user explicitly asks for a work-in-progress snapshot.
+- When a PR is already open, push additional focused commits to the same issue branch rather than amending or squashing history.
+
+Commit messages:
+
+- Write commit messages in Korean unless the user asks otherwise.
+- Keep the prefix conventional, but make the subject specific enough to explain the change.
+- Prefer messages like `feat: Stage B strict gate 결과를 sweep summary에 연결` over vague messages like `update` or `fix`.
+- For larger changes, use a multi-line commit body that records why the change was needed and which validation was run.
+
 Preferred commit prefixes:
 
 - `docs:`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -299,29 +299,29 @@ Stage B에서 명시하는 것:
 
 완료된 바로 전 작업:
 
-- `Stage B collapse diagnostics and sampling sweep 추가`
+- `Stage B stricter collapse-aware review gate 추가`
 - 결과: `top_k=1`은 collapse warning `3/3`, valid `0/3`
-- 결과: `top_k=2`는 collapse warning `1/3`, valid `1/3`
-- 결론: Stage B grammar가 아니라 note distribution collapse가 현재 병목이다.
+- 결과: `top_k=2`는 collapse warning `1/3`, basic valid `1/3`, strict valid `1/3`
+- 결론: Stage B grammar가 아니라 note distribution collapse가 현재 병목이지만, strict gate에서도 최소 후보 1개는 유지된다.
 
 다음 issue는 다음 이름이 적절하다.
 
 ```text
-Stage B stricter collapse-aware review gate 추가
+Stage B 2-file Brad generation probe 추가
 ```
 
 작업 범위:
 
-- review gate에 collapse-aware 기준을 추가한다.
-- minimum unique pitch/position/pair 기준을 정한다.
-- collapse warning sample rate 상한을 정한다.
-- sampling sweep이 stricter gate 기준으로 통과/실패를 보고하게 한다.
-- broad training 전 Stage B 2-file Brad probe로 갈 수 있는지 판단한다.
+- one-file tiny smoke를 넘어 Brad 2-file Stage B window dataset으로 generation probe를 실행한다.
+- train/val split과 window count를 report에 남긴다.
+- basic gate와 strict collapse-aware gate를 모두 보고한다.
+- one-file 결과보다 pass-rate가 유지되는지 확인한다.
+- 실패하면 broad training으로 가지 않고 tokenization/model/loss/pretrained-base 후보를 재검토한다.
 
 이 작업이 끝난 뒤 판단:
 
-- stricter gate에서도 최소 pass-rate가 유지되면 Stage B 2-file Brad probe로 간다.
-- stricter gate에서 전부 실패하면 sampling/postprocess 문제가 아니라 tokenization/model/loss/pretrained-base 쪽으로 재검토한다.
+- 2-file Brad strict gate에서도 최소 pass-rate가 유지되면 generic jazz base 후보 학습 설계로 간다.
+- 2-file Brad strict gate가 전부 실패하면 sampling/postprocess 문제가 아니라 data scale, representation, loss, pretrained-base 쪽으로 재검토한다.
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-29-stage-b-collapse-sampling-sweep`
+- `issue-31-stage-b-strict-collapse-gate`
 
 현재 범위가 아닌 것:
 
@@ -696,6 +696,45 @@ Smoke result:
 - best config: `top_k=2`, `temperature=0.9`
 - decision: grammar is no longer the immediate bottleneck; note distribution collapse is
 - detail: `docs/STAGE_B_COLLAPSE_SWEEP_2026-05-20.md`
+
+### 0.14. Issue #31 Stage B stricter collapse-aware review gate
+
+Status:
+
+- implemented on `issue-31-stage-b-strict-collapse-gate`
+
+Goal:
+
+- separate basic MIDI validity from stricter collapse-aware sample validity
+- require minimum unique pitch, position, and position/pitch pair diversity
+- cap collapse warning sample rate during sampling sweep
+- prevent one-note, repeated same-position/pitch, or postprocess-heavy outputs from being counted as strong progress
+
+Strict gate defaults:
+
+- minimum unique pitches: `3`
+- minimum unique positions: `3`
+- minimum unique position/pitch pairs: `4`
+- max repeated position/pitch pair ratio: `0.49`
+- max postprocess removal ratio: `0.49`
+- max collapse warning sample rate: `0.34`
+
+Acceptance:
+
+- strict collapse gate unit tests pass
+- sampling sweep summary distinguishes basic and strict gate pass/fail
+- `bash scripts/agent_harness.sh stage-b-collapse-sweep` passes
+- `bash scripts/agent_harness.sh quick` passes
+
+Smoke result:
+
+- output: `outputs/stage_b_sampling_sweep/harness_stage_b_collapse_sweep`
+- `top_k=1`: basic valid `0/3`, strict valid `0/3`, collapse warning `3/3`
+- `top_k=2`: basic valid `1/3`, strict valid `1/3`, collapse warning `1/3`
+- best config: `top_k=2`, `temperature=0.9`
+- passed strict sweep gate: `true`
+- decision: strict gate still preserves one valid candidate, so the next issue can move to a Stage B 2-file Brad probe
+- detail: `docs/STAGE_B_STRICT_COLLAPSE_GATE_2026-05-20.md`
 
 ### 1. Run full jazz piano dataset audit
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,8 @@
   - Stage B multi-sample constrained probe, pass-rate reporting, and sampling collapse negative control.
 - `STAGE_B_COLLAPSE_SWEEP_2026-05-20.md`
   - Stage B collapse diagnostics and `top_k` sampling sweep result.
+- `STAGE_B_STRICT_COLLAPSE_GATE_2026-05-20.md`
+  - Stage B strict collapse-aware review gate and basic-vs-strict sweep result.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -66,7 +68,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, and 2-file generation probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, and 2-file generation probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_STRICT_COLLAPSE_GATE_2026-05-20.md
+++ b/docs/STAGE_B_STRICT_COLLAPSE_GATE_2026-05-20.md
@@ -1,0 +1,95 @@
+# Stage B Strict Collapse Gate
+
+작성일: 2026-05-20
+
+## Goal
+
+Issue #31 adds a stricter collapse-aware review gate on top of the existing Stage B MIDI review gate.
+
+The purpose is to stop treating a generated MIDI as strong progress when it only passes after heavy postprocess or when token generation collapses into repeated position/pitch events.
+
+## Gate Layers
+
+The Stage B probe now reports three related gates:
+
+- grammar gate: generated tokens form complete Stage B note groups
+- basic MIDI gate: decoded MIDI passes the existing metrics validation
+- strict collapse gate: the sample also has enough position/pitch diversity and low postprocess damage
+
+The sampling sweep reports both:
+
+- `passed_basic_sweep_gate`
+- `passed_strict_sweep_gate`
+
+`passed_sweep_gate` now follows the stricter gate.
+
+## Strict Defaults
+
+Per-sample strict gate defaults:
+
+- minimum unique pitches: `3`
+- minimum unique positions: `3`
+- minimum unique position/pitch pairs: `4`
+- max repeated position/pitch pair ratio: `0.49`
+- max postprocess removal ratio: `0.49`
+
+Per-sweep strict default:
+
+- max collapse warning sample rate: `0.34`
+
+These numbers are intentionally small because the current probe only generates three samples from a tiny one-file checkpoint. They are not final musical quality thresholds.
+
+## Local Validation
+
+Commands:
+
+```bash
+./.venv/bin/python -m unittest tests.test_stage_b_generation_probe tests.test_stage_b_sampling_sweep
+bash scripts/agent_harness.sh stage-b-collapse-sweep
+bash scripts/agent_harness.sh quick
+```
+
+Result:
+
+- targeted unit tests: passed
+- stage-b-collapse-sweep: passed
+- quick harness: passed
+
+## Sweep Result
+
+Output:
+
+```text
+outputs/stage_b_sampling_sweep/harness_stage_b_collapse_sweep
+```
+
+Summary:
+
+| top_k | temperature | grammar | basic valid | strict valid | collapse warning | strict pass |
+|---:|---:|---:|---:|---:|---:|:---:|
+| 1 | 0.9 | 3/3 | 0/3 | 0/3 | 3/3 | false |
+| 2 | 0.9 | 3/3 | 1/3 | 1/3 | 1/3 | true |
+
+Best config:
+
+```text
+top_k=2, temperature=0.9
+```
+
+## Interpretation
+
+`top_k=1` is now clearly rejected by both the basic MIDI gate and the strict collapse gate.
+
+`top_k=2` still keeps one reviewable candidate under the stricter gate. This is not enough to claim musical quality, but it is enough to move from one-file tiny smoke to a 2-file Brad Stage B probe.
+
+The current bottleneck remains note distribution collapse, not Stage B grammar.
+
+## Next Step
+
+Next issue:
+
+```text
+Stage B 2-file Brad generation probe 추가
+```
+
+That issue should verify whether the one-file result survives a slightly broader Brad train/val setup before any generic jazz base training is started.

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -242,7 +242,7 @@ run_stage_b_collapse_sweep() {
   print_header "Stage B collapse sampling sweep"
   "$PYTHON_BIN" scripts/run_stage_b_sampling_sweep.py \
     --run_id "$run_id" \
-    --issue_number 29 \
+    --issue_number 31 \
     --top_ks 1,2 \
     --temperatures 0.9 \
     --train_top_k 2 \
@@ -255,6 +255,8 @@ run_stage_b_collapse_sweep() {
     --max_simultaneous_notes 2 \
     --require_all_grammar_samples \
     --min_best_valid_samples 1 \
+    --min_best_strict_valid_samples 1 \
+    --max_collapse_warning_sample_rate 0.34 \
     --n_layers 1 \
     --num_heads 4 \
     --d_model 64 \

--- a/scripts/run_stage_b_generation_probe.py
+++ b/scripts/run_stage_b_generation_probe.py
@@ -59,6 +59,14 @@ from utilities.constants import TOKEN_BAR, TOKEN_END, VOCAB_SIZE  # noqa: E402
 from utilities.device import get_device  # noqa: E402
 
 
+DEFAULT_STRICT_MIN_UNIQUE_PITCHES = 3
+DEFAULT_STRICT_MIN_UNIQUE_POSITIONS = 3
+DEFAULT_STRICT_MIN_UNIQUE_POSITION_PITCH_PAIRS = 4
+DEFAULT_STRICT_MAX_REPEATED_POSITION_PITCH_PAIR_RATIO = 0.49
+DEFAULT_STRICT_MAX_POSTPROCESS_REMOVAL_RATIO = 0.49
+DEFAULT_STRICT_MAX_COLLAPSE_WARNING_SAMPLE_RATE = 0.34
+
+
 def parse_chords(raw_chords: str) -> list[str]:
     return [chord.strip() for chord in raw_chords.split(",") if chord.strip()]
 
@@ -279,6 +287,54 @@ def analyze_stage_b_collapse(
     }
 
 
+def evaluate_collapse_gate(
+    collapse: dict[str, Any],
+    min_unique_pitches: int = DEFAULT_STRICT_MIN_UNIQUE_PITCHES,
+    min_unique_positions: int = DEFAULT_STRICT_MIN_UNIQUE_POSITIONS,
+    min_unique_position_pitch_pairs: int = DEFAULT_STRICT_MIN_UNIQUE_POSITION_PITCH_PAIRS,
+    max_repeated_position_pitch_pair_ratio: float = DEFAULT_STRICT_MAX_REPEATED_POSITION_PITCH_PAIR_RATIO,
+    max_postprocess_removal_ratio: float = DEFAULT_STRICT_MAX_POSTPROCESS_REMOVAL_RATIO,
+) -> dict[str, Any]:
+    reasons: list[str] = []
+    unique_pitch_count = int(collapse.get("unique_pitch_count", 0) or 0)
+    unique_position_count = int(collapse.get("unique_position_count", 0) or 0)
+    unique_pair_count = int(collapse.get("unique_position_pitch_pair_count", 0) or 0)
+    repeated_pair_ratio = float(collapse.get("repeated_position_pitch_pair_ratio", 0.0) or 0.0)
+    postprocess_removal_ratio = float(collapse.get("postprocess_removal_ratio", 0.0) or 0.0)
+
+    if unique_pitch_count < int(min_unique_pitches):
+        reasons.append(f"unique pitch count too low: {unique_pitch_count} < {int(min_unique_pitches)}")
+    if unique_position_count < int(min_unique_positions):
+        reasons.append(f"unique position count too low: {unique_position_count} < {int(min_unique_positions)}")
+    if unique_pair_count < int(min_unique_position_pitch_pairs):
+        reasons.append(
+            f"unique position/pitch pair count too low: {unique_pair_count} < "
+            f"{int(min_unique_position_pitch_pairs)}"
+        )
+    if repeated_pair_ratio > float(max_repeated_position_pitch_pair_ratio):
+        reasons.append(
+            "repeated position/pitch pair ratio too high: "
+            f"{repeated_pair_ratio:.3f} > {float(max_repeated_position_pitch_pair_ratio):.3f}"
+        )
+    if postprocess_removal_ratio > float(max_postprocess_removal_ratio):
+        reasons.append(
+            "postprocess removal ratio too high: "
+            f"{postprocess_removal_ratio:.3f} > {float(max_postprocess_removal_ratio):.3f}"
+        )
+
+    return {
+        "passed": not reasons,
+        "failure_reasons": reasons,
+        "thresholds": {
+            "min_unique_pitches": int(min_unique_pitches),
+            "min_unique_positions": int(min_unique_positions),
+            "min_unique_position_pitch_pairs": int(min_unique_position_pitch_pairs),
+            "max_repeated_position_pitch_pair_ratio": float(max_repeated_position_pitch_pair_ratio),
+            "max_postprocess_removal_ratio": float(max_postprocess_removal_ratio),
+        },
+    }
+
+
 def choose_allowed_token(
     logits: torch.Tensor,
     allowed_tokens: Sequence[int],
@@ -429,18 +485,34 @@ def sample_report(
     midi_path: Path,
     request: GenerationRequest,
     postprocess_report: dict[str, Any] | None = None,
+    strict_min_unique_pitches: int = DEFAULT_STRICT_MIN_UNIQUE_PITCHES,
+    strict_min_unique_positions: int = DEFAULT_STRICT_MIN_UNIQUE_POSITIONS,
+    strict_min_unique_position_pitch_pairs: int = DEFAULT_STRICT_MIN_UNIQUE_POSITION_PITCH_PAIRS,
+    strict_max_repeated_position_pitch_pair_ratio: float = DEFAULT_STRICT_MAX_REPEATED_POSITION_PITCH_PAIR_RATIO,
+    strict_max_postprocess_removal_ratio: float = DEFAULT_STRICT_MAX_POSTPROCESS_REMOVAL_RATIO,
 ) -> dict[str, Any]:
     raw_generated_tokens = [int(token) for token in tokens[primer_size:]]
     grammar = analyze_stage_b_note_grammar(tokens, primer_size=primer_size)
     collapse = analyze_stage_b_collapse(tokens, primer_size=primer_size, postprocess_report=postprocess_report)
+    collapse_gate = evaluate_collapse_gate(
+        collapse,
+        min_unique_pitches=strict_min_unique_pitches,
+        min_unique_positions=strict_min_unique_positions,
+        min_unique_position_pitch_pairs=strict_min_unique_position_pitch_pairs,
+        max_repeated_position_pitch_pair_ratio=strict_max_repeated_position_pitch_pair_ratio,
+        max_postprocess_removal_ratio=strict_max_postprocess_removal_ratio,
+    )
     metrics = compute_midi_metrics(midi_path, 0, False, request=request)
     valid, reason = validate_metrics(metrics, request.density, bars=request.bars)
     grammar_gate_passed = bool(grammar["complete_note_groups"] > 0 and metrics.note_count > 0)
+    strict_valid = bool(valid and grammar_gate_passed and collapse_gate["passed"])
     diagnostic_failure_reason = reason
     if not valid and collapse["collapse_warning"]:
         diagnostic_failure_reason = (
             f"{reason}; collapse={','.join(collapse['collapse_reasons'])}" if reason else ",".join(collapse["collapse_reasons"])
         )
+    if valid and not collapse_gate["passed"]:
+        diagnostic_failure_reason = "; ".join(collapse_gate["failure_reasons"])
     return {
         "sample_index": int(sample_index),
         "sample_seed": int(sample_seed),
@@ -450,11 +522,13 @@ def sample_report(
         "ended_early": bool(len(tokens) < int(target_length)),
         "hit_end_token": bool(TOKEN_END in raw_generated_tokens),
         "valid": bool(valid),
+        "strict_valid": strict_valid,
         "grammar_gate_passed": grammar_gate_passed,
         "failure_reason": reason,
         "diagnostic_failure_reason": diagnostic_failure_reason,
         "grammar": grammar,
         "collapse": collapse,
+        "collapse_gate": collapse_gate,
         "postprocess": postprocess_report or {"enabled": False},
         "metrics": metrics.to_dict(),
         "generated_token_names_head": [stage_b_token_name(token) for token in raw_generated_tokens[:48]],
@@ -464,12 +538,16 @@ def sample_report(
 def build_probe_summary(
     sample_rows: Sequence[dict[str, Any]],
     min_valid_samples: int = 1,
+    min_strict_valid_samples: int = 1,
     require_all_grammar_samples: bool = False,
+    max_collapse_warning_sample_rate: float = DEFAULT_STRICT_MAX_COLLAPSE_WARNING_SAMPLE_RATE,
 ) -> dict[str, Any]:
     sample_count = int(len(sample_rows))
     valid_indices = [int(row["sample_index"]) for row in sample_rows if row["valid"]]
+    strict_valid_indices = [int(row["sample_index"]) for row in sample_rows if row.get("strict_valid")]
     grammar_indices = [int(row["sample_index"]) for row in sample_rows if row["grammar_gate_passed"]]
     valid_sample_count = int(len(valid_indices))
+    strict_valid_sample_count = int(len(strict_valid_indices))
     grammar_gate_sample_count = int(len(grammar_indices))
 
     if require_all_grammar_samples:
@@ -479,6 +557,7 @@ def build_probe_summary(
 
     failure_reasons: dict[str, int] = {}
     diagnostic_failure_reasons: dict[str, int] = {}
+    strict_failure_reasons: dict[str, int] = {}
     collapse_warning_count = 0
     repeated_pair_ratios: list[float] = []
     postprocess_removal_ratios: list[float] = []
@@ -486,6 +565,16 @@ def build_probe_summary(
         collapse = row.get("collapse", {})
         if collapse.get("collapse_warning"):
             collapse_warning_count += 1
+        if not row.get("strict_valid", False):
+            if not row.get("valid", False):
+                strict_reason = f"midi_review_gate_failed: {row.get('failure_reason') or 'unknown'}"
+                strict_failure_reasons[strict_reason] = strict_failure_reasons.get(strict_reason, 0) + 1
+            if not row.get("grammar_gate_passed", False):
+                strict_failure_reasons["grammar_gate_failed"] = (
+                    strict_failure_reasons.get("grammar_gate_failed", 0) + 1
+                )
+            for strict_reason in row.get("collapse_gate", {}).get("failure_reasons", []):
+                strict_failure_reasons[str(strict_reason)] = strict_failure_reasons.get(str(strict_reason), 0) + 1
         repeated_pair_ratios.append(float(collapse.get("repeated_position_pitch_pair_ratio", 0.0) or 0.0))
         postprocess_removal_ratios.append(float(collapse.get("postprocess_removal_ratio", 0.0) or 0.0))
         if not row["valid"]:
@@ -494,22 +583,43 @@ def build_probe_summary(
             failure_reasons[reason] = failure_reasons.get(reason, 0) + 1
             diagnostic_failure_reasons[diagnostic_reason] = diagnostic_failure_reasons.get(diagnostic_reason, 0) + 1
 
+    collapse_warning_rate = float(collapse_warning_count / sample_count) if sample_count else 0.0
+    passed_generation_gate = bool(valid_sample_count >= int(min_valid_samples))
+    passed_strict_generation_gate = bool(strict_valid_sample_count >= int(min_strict_valid_samples))
+    passed_collapse_rate_gate = bool(
+        sample_count > 0 and collapse_warning_rate <= float(max_collapse_warning_sample_rate)
+    )
+
     return {
         "sample_count": sample_count,
         "valid_sample_count": valid_sample_count,
+        "strict_valid_sample_count": strict_valid_sample_count,
         "grammar_gate_sample_count": grammar_gate_sample_count,
         "valid_sample_rate": float(valid_sample_count / sample_count) if sample_count else 0.0,
+        "strict_valid_sample_rate": float(strict_valid_sample_count / sample_count) if sample_count else 0.0,
         "grammar_gate_sample_rate": float(grammar_gate_sample_count / sample_count) if sample_count else 0.0,
         "valid_sample_indices": valid_indices,
+        "strict_valid_sample_indices": strict_valid_indices,
         "grammar_gate_sample_indices": grammar_indices,
         "min_valid_samples": int(min_valid_samples),
+        "min_strict_valid_samples": int(min_strict_valid_samples),
+        "max_collapse_warning_sample_rate": float(max_collapse_warning_sample_rate),
         "require_all_grammar_samples": bool(require_all_grammar_samples),
-        "passed_generation_gate": bool(valid_sample_count >= int(min_valid_samples)),
+        "passed_generation_gate": passed_generation_gate,
+        "passed_strict_generation_gate": passed_strict_generation_gate,
         "passed_grammar_gate": passed_grammar_gate,
+        "passed_strict_review_gate": bool(
+            passed_generation_gate
+            and passed_strict_generation_gate
+            and passed_grammar_gate
+            and passed_collapse_rate_gate
+        ),
         "failure_reasons": failure_reasons,
         "diagnostic_failure_reasons": diagnostic_failure_reasons,
+        "strict_failure_reasons": strict_failure_reasons,
         "collapse_warning_sample_count": int(collapse_warning_count),
-        "collapse_warning_sample_rate": float(collapse_warning_count / sample_count) if sample_count else 0.0,
+        "collapse_warning_sample_rate": collapse_warning_rate,
+        "passed_collapse_rate_gate": passed_collapse_rate_gate,
         "avg_repeated_position_pitch_pair_ratio": (
             float(sum(repeated_pair_ratios) / len(repeated_pair_ratios)) if repeated_pair_ratios else 0.0
         ),
@@ -561,9 +671,33 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--postprocess_overlap", action="store_true")
     parser.add_argument("--max_simultaneous_notes", type=int, default=2)
     parser.add_argument("--min_valid_samples", type=int, default=1)
+    parser.add_argument("--min_strict_valid_samples", type=int, default=1)
+    parser.add_argument("--strict_min_unique_pitches", type=int, default=DEFAULT_STRICT_MIN_UNIQUE_PITCHES)
+    parser.add_argument("--strict_min_unique_positions", type=int, default=DEFAULT_STRICT_MIN_UNIQUE_POSITIONS)
+    parser.add_argument(
+        "--strict_min_unique_position_pitch_pairs",
+        type=int,
+        default=DEFAULT_STRICT_MIN_UNIQUE_POSITION_PITCH_PAIRS,
+    )
+    parser.add_argument(
+        "--strict_max_repeated_position_pitch_pair_ratio",
+        type=float,
+        default=DEFAULT_STRICT_MAX_REPEATED_POSITION_PITCH_PAIR_RATIO,
+    )
+    parser.add_argument(
+        "--strict_max_postprocess_removal_ratio",
+        type=float,
+        default=DEFAULT_STRICT_MAX_POSTPROCESS_REMOVAL_RATIO,
+    )
+    parser.add_argument(
+        "--max_collapse_warning_sample_rate",
+        type=float,
+        default=DEFAULT_STRICT_MAX_COLLAPSE_WARNING_SAMPLE_RATE,
+    )
     parser.add_argument("--require_all_grammar_samples", action="store_true")
     parser.add_argument("--require_note_groups", action="store_true")
     parser.add_argument("--require_valid_sample", action="store_true")
+    parser.add_argument("--require_strict_valid_sample", action="store_true")
     parser.set_defaults(lora_only=False)
     return parser
 
@@ -694,6 +828,11 @@ def main() -> int:
                 midi_path=midi_path,
                 request=request,
                 postprocess_report=postprocess_report,
+                strict_min_unique_pitches=args.strict_min_unique_pitches,
+                strict_min_unique_positions=args.strict_min_unique_positions,
+                strict_min_unique_position_pitch_pairs=args.strict_min_unique_position_pitch_pairs,
+                strict_max_repeated_position_pitch_pair_ratio=args.strict_max_repeated_position_pitch_pair_ratio,
+                strict_max_postprocess_removal_ratio=args.strict_max_postprocess_removal_ratio,
             )
         )
 
@@ -701,7 +840,9 @@ def main() -> int:
     summary = build_probe_summary(
         sample_rows,
         min_valid_samples=args.min_valid_samples,
+        min_strict_valid_samples=args.min_strict_valid_samples,
         require_all_grammar_samples=args.require_all_grammar_samples,
+        max_collapse_warning_sample_rate=args.max_collapse_warning_sample_rate,
     )
     report["summary"] = summary
     report["valid_sample_count"] = summary["valid_sample_count"]
@@ -709,10 +850,21 @@ def main() -> int:
     report["sample_count"] = summary["sample_count"]
     report["passed_generation_gate"] = summary["passed_generation_gate"]
     report["passed_grammar_gate"] = summary["passed_grammar_gate"]
+    report["passed_strict_review_gate"] = summary["passed_strict_review_gate"]
     if not report["passed_generation_gate"]:
         report["failure_reason"] = (
             f"Only {summary['valid_sample_count']} Stage B generated samples passed the MIDI review gate; "
             f"required {summary['min_valid_samples']}"
+        )
+    if not summary["passed_strict_generation_gate"]:
+        report["strict_failure_reason"] = (
+            f"Only {summary['strict_valid_sample_count']} Stage B generated samples passed the strict collapse gate; "
+            f"required {summary['min_strict_valid_samples']}"
+        )
+    if not summary["passed_collapse_rate_gate"]:
+        report["strict_failure_reason"] = (
+            f"Collapse warning sample rate {summary['collapse_warning_sample_rate']:.3f} exceeded "
+            f"{summary['max_collapse_warning_sample_rate']:.3f}"
         )
     if not report["passed_grammar_gate"]:
         report["failure_reason"] = "Stage B generated samples did not satisfy the configured grammar gate"
@@ -723,6 +875,8 @@ def main() -> int:
         return 4
     if args.require_valid_sample and not report["passed_generation_gate"]:
         return 3
+    if args.require_strict_valid_sample and not report["passed_strict_review_gate"]:
+        return 5
     return 0
 
 

--- a/scripts/run_stage_b_sampling_sweep.py
+++ b/scripts/run_stage_b_sampling_sweep.py
@@ -86,6 +86,20 @@ def probe_command(
         str(top_k),
         "--min_valid_samples",
         str(args.min_valid_samples),
+        "--min_strict_valid_samples",
+        str(args.min_strict_valid_samples),
+        "--max_collapse_warning_sample_rate",
+        str(args.max_collapse_warning_sample_rate),
+        "--strict_min_unique_pitches",
+        str(args.strict_min_unique_pitches),
+        "--strict_min_unique_positions",
+        str(args.strict_min_unique_positions),
+        "--strict_min_unique_position_pitch_pairs",
+        str(args.strict_min_unique_position_pitch_pairs),
+        "--strict_max_repeated_position_pitch_pair_ratio",
+        str(args.strict_max_repeated_position_pitch_pair_ratio),
+        "--strict_max_postprocess_removal_ratio",
+        str(args.strict_max_postprocess_removal_ratio),
         "--n_layers",
         str(args.n_layers),
         "--num_heads",
@@ -117,10 +131,16 @@ def row_from_probe_report(top_k: int, temperature: float, run_id: str, report: d
         "sample_count": int(summary.get("sample_count", 0)),
         "grammar_gate_sample_count": int(summary.get("grammar_gate_sample_count", 0)),
         "valid_sample_count": int(summary.get("valid_sample_count", 0)),
+        "strict_valid_sample_count": int(summary.get("strict_valid_sample_count", 0)),
         "grammar_gate_sample_rate": float(summary.get("grammar_gate_sample_rate", 0.0)),
         "valid_sample_rate": float(summary.get("valid_sample_rate", 0.0)),
+        "strict_valid_sample_rate": float(summary.get("strict_valid_sample_rate", 0.0)),
         "collapse_warning_sample_count": int(summary.get("collapse_warning_sample_count", 0)),
         "collapse_warning_sample_rate": float(summary.get("collapse_warning_sample_rate", 0.0)),
+        "max_collapse_warning_sample_rate": float(summary.get("max_collapse_warning_sample_rate", 0.0)),
+        "passed_collapse_rate_gate": bool(summary.get("passed_collapse_rate_gate", False)),
+        "passed_strict_generation_gate": bool(summary.get("passed_strict_generation_gate", False)),
+        "passed_strict_review_gate": bool(summary.get("passed_strict_review_gate", False)),
         "avg_repeated_position_pitch_pair_ratio": float(
             summary.get("avg_repeated_position_pitch_pair_ratio", 0.0)
         ),
@@ -131,16 +151,39 @@ def row_from_probe_report(top_k: int, temperature: float, run_id: str, report: d
         "max_postprocess_removal_ratio": float(summary.get("max_postprocess_removal_ratio", 0.0)),
         "failure_reasons": summary.get("failure_reasons", {}),
         "diagnostic_failure_reasons": summary.get("diagnostic_failure_reasons", {}),
+        "strict_failure_reasons": summary.get("strict_failure_reasons", {}),
         "report_path": str(Path(report["run_dir"]) / "report.json"),
     }
 
 
-def build_sweep_summary(rows: list[dict[str, Any]], min_best_valid_samples: int = 1) -> dict[str, Any]:
-    best_row = max(rows, key=lambda row: (row["valid_sample_count"], row["valid_sample_rate"]), default=None)
+def build_sweep_summary(
+    rows: list[dict[str, Any]],
+    min_best_valid_samples: int = 1,
+    min_best_strict_valid_samples: int = 1,
+    max_collapse_warning_sample_rate: float = 0.34,
+) -> dict[str, Any]:
+    best_row = max(
+        rows,
+        key=lambda row: (
+            row["strict_valid_sample_count"],
+            row["valid_sample_count"],
+            -row["collapse_warning_sample_rate"],
+            row["valid_sample_rate"],
+        ),
+        default=None,
+    )
+    passed_basic = bool(best_row and int(best_row["valid_sample_count"]) >= int(min_best_valid_samples))
+    passed_strict = bool(
+        best_row
+        and int(best_row["strict_valid_sample_count"]) >= int(min_best_strict_valid_samples)
+        and float(best_row["collapse_warning_sample_rate"]) <= float(max_collapse_warning_sample_rate)
+    )
     return {
         "config_count": int(len(rows)),
         "best_valid_sample_count": int(best_row["valid_sample_count"]) if best_row else 0,
         "best_valid_sample_rate": float(best_row["valid_sample_rate"]) if best_row else 0.0,
+        "best_strict_valid_sample_count": int(best_row["strict_valid_sample_count"]) if best_row else 0,
+        "best_strict_valid_sample_rate": float(best_row["strict_valid_sample_rate"]) if best_row else 0.0,
         "best_config": {
             "top_k": int(best_row["top_k"]),
             "temperature": float(best_row["temperature"]),
@@ -149,7 +192,11 @@ def build_sweep_summary(rows: list[dict[str, Any]], min_best_valid_samples: int 
         if best_row
         else None,
         "min_best_valid_samples": int(min_best_valid_samples),
-        "passed_sweep_gate": bool(best_row and int(best_row["valid_sample_count"]) >= int(min_best_valid_samples)),
+        "min_best_strict_valid_samples": int(min_best_strict_valid_samples),
+        "max_collapse_warning_sample_rate": float(max_collapse_warning_sample_rate),
+        "passed_basic_sweep_gate": passed_basic,
+        "passed_strict_sweep_gate": passed_strict,
+        "passed_sweep_gate": passed_strict,
     }
 
 
@@ -158,15 +205,19 @@ def markdown_table(rows: list[dict[str, Any]], summary: dict[str, Any]) -> str:
         "# Stage B Sampling Sweep",
         "",
         f"- passed sweep gate: `{str(summary['passed_sweep_gate']).lower()}`",
+        f"- passed basic sweep gate: `{str(summary['passed_basic_sweep_gate']).lower()}`",
+        f"- passed strict sweep gate: `{str(summary['passed_strict_sweep_gate']).lower()}`",
         f"- best config: `{summary['best_config']}`",
         "",
-        "| top_k | temp | samples | grammar | valid | valid_rate | collapse_rate | avg_pair_repeat | max_remove |",
-        "|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+        "| top_k | temp | samples | grammar | valid | strict_valid | valid_rate | strict_rate | collapse_rate | strict_pass | avg_pair_repeat | max_remove |",
+        "|---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|---:|---:|",
     ]
     for row in rows:
         lines.append(
             "| {top_k} | {temperature:.3f} | {sample_count} | {grammar_gate_sample_count} | "
-            "{valid_sample_count} | {valid_sample_rate:.3f} | {collapse_warning_sample_rate:.3f} | "
+            "{valid_sample_count} | {strict_valid_sample_count} | {valid_sample_rate:.3f} | "
+            "{strict_valid_sample_rate:.3f} | {collapse_warning_sample_rate:.3f} | "
+            "{passed_strict_review_gate} | "
             "{avg_repeated_position_pitch_pair_ratio:.3f} | {max_postprocess_removal_ratio:.3f} |".format(**row)
         )
     lines.append("")
@@ -174,6 +225,11 @@ def markdown_table(rows: list[dict[str, Any]], summary: dict[str, Any]) -> str:
     lines.append("")
     for row in rows:
         lines.append(f"- `top_k={row['top_k']}`, `temperature={row['temperature']}`: {row['diagnostic_failure_reasons']}")
+    lines.append("")
+    lines.append("## Strict Gate Failures")
+    lines.append("")
+    for row in rows:
+        lines.append(f"- `top_k={row['top_k']}`, `temperature={row['temperature']}`: {row['strict_failure_reasons']}")
     return "\n".join(lines) + "\n"
 
 
@@ -194,6 +250,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--max_simultaneous_notes", type=int, default=2)
     parser.add_argument("--min_valid_samples", type=int, default=1)
     parser.add_argument("--min_best_valid_samples", type=int, default=1)
+    parser.add_argument("--min_strict_valid_samples", type=int, default=1)
+    parser.add_argument("--min_best_strict_valid_samples", type=int, default=1)
+    parser.add_argument("--max_collapse_warning_sample_rate", type=float, default=0.34)
+    parser.add_argument("--strict_min_unique_pitches", type=int, default=3)
+    parser.add_argument("--strict_min_unique_positions", type=int, default=3)
+    parser.add_argument("--strict_min_unique_position_pitch_pairs", type=int, default=4)
+    parser.add_argument("--strict_max_repeated_position_pitch_pair_ratio", type=float, default=0.49)
+    parser.add_argument("--strict_max_postprocess_removal_ratio", type=float, default=0.49)
     parser.add_argument("--require_all_grammar_samples", action="store_true")
     parser.add_argument("--n_layers", type=int, default=1)
     parser.add_argument("--num_heads", type=int, default=4)
@@ -254,7 +318,12 @@ def main() -> int:
                 completed_configs.add(config)
 
     rows = sorted(rows, key=lambda row: (row["temperature"], row["top_k"]))
-    summary = build_sweep_summary(rows, min_best_valid_samples=args.min_best_valid_samples)
+    summary = build_sweep_summary(
+        rows,
+        min_best_valid_samples=args.min_best_valid_samples,
+        min_best_strict_valid_samples=args.min_best_strict_valid_samples,
+        max_collapse_warning_sample_rate=args.max_collapse_warning_sample_rate,
+    )
     report = {
         "run_id": run_id,
         "run_dir": str(sweep_dir),

--- a/tests/test_stage_b_generation_probe.py
+++ b/tests/test_stage_b_generation_probe.py
@@ -14,6 +14,7 @@ from scripts.run_stage_b_generation_probe import (
     build_stage_b_primer,
     dedupe_and_limit_notes,
     decode_tokens_to_midi,
+    evaluate_collapse_gate,
     generate_stage_b_constrained_tokens,
     generate_stage_b_tokens,
     postprocess_stage_b_midi,
@@ -268,6 +269,69 @@ class StageBGenerationProbeTest(unittest.TestCase):
         self.assertEqual(
             summary["diagnostic_failure_reasons"],
             {"note count too low; collapse=repeated_position_pitch": 1},
+        )
+
+    def test_evaluate_collapse_gate_reports_strict_failures(self) -> None:
+        collapse = {
+            "unique_pitch_count": 1,
+            "unique_position_count": 1,
+            "unique_position_pitch_pair_count": 1,
+            "repeated_position_pitch_pair_ratio": 0.75,
+            "postprocess_removal_ratio": 0.5,
+        }
+
+        gate = evaluate_collapse_gate(collapse)
+
+        self.assertFalse(gate["passed"])
+        self.assertIn("unique pitch count too low: 1 < 3", gate["failure_reasons"])
+        self.assertIn(
+            "repeated position/pitch pair ratio too high: 0.750 > 0.490",
+            gate["failure_reasons"],
+        )
+
+    def test_build_probe_summary_tracks_strict_review_gate(self) -> None:
+        rows = [
+            {
+                "sample_index": 1,
+                "valid": True,
+                "strict_valid": True,
+                "grammar_gate_passed": True,
+                "collapse": {
+                    "collapse_warning": False,
+                    "repeated_position_pitch_pair_ratio": 0.25,
+                    "postprocess_removal_ratio": 0.0,
+                },
+            },
+            {
+                "sample_index": 2,
+                "valid": False,
+                "strict_valid": False,
+                "grammar_gate_passed": True,
+                "failure_reason": "note count too low",
+                "collapse": {
+                    "collapse_warning": True,
+                    "repeated_position_pitch_pair_ratio": 0.75,
+                    "postprocess_removal_ratio": 0.5,
+                },
+            },
+        ]
+
+        summary = build_probe_summary(
+            rows,
+            min_valid_samples=1,
+            min_strict_valid_samples=1,
+            require_all_grammar_samples=True,
+            max_collapse_warning_sample_rate=0.5,
+        )
+
+        self.assertEqual(summary["strict_valid_sample_count"], 1)
+        self.assertEqual(summary["strict_valid_sample_indices"], [1])
+        self.assertTrue(summary["passed_strict_generation_gate"])
+        self.assertTrue(summary["passed_collapse_rate_gate"])
+        self.assertTrue(summary["passed_strict_review_gate"])
+        self.assertEqual(
+            summary["strict_failure_reasons"],
+            {"midi_review_gate_failed: note count too low": 1},
         )
 
 

--- a/tests/test_stage_b_sampling_sweep.py
+++ b/tests/test_stage_b_sampling_sweep.py
@@ -8,24 +8,88 @@ from scripts.run_stage_b_sampling_sweep import build_sweep_summary, markdown_tab
 class StageBSamplingSweepTest(unittest.TestCase):
     def test_build_sweep_summary_selects_best_valid_config(self) -> None:
         rows = [
-            {"run_id": "k1", "top_k": 1, "temperature": 0.9, "valid_sample_count": 0, "valid_sample_rate": 0.0},
-            {"run_id": "k2", "top_k": 2, "temperature": 0.9, "valid_sample_count": 1, "valid_sample_rate": 0.333},
+            {
+                "run_id": "k1",
+                "top_k": 1,
+                "temperature": 0.9,
+                "valid_sample_count": 0,
+                "strict_valid_sample_count": 0,
+                "valid_sample_rate": 0.0,
+                "strict_valid_sample_rate": 0.0,
+                "collapse_warning_sample_rate": 1.0,
+            },
+            {
+                "run_id": "k2",
+                "top_k": 2,
+                "temperature": 0.9,
+                "valid_sample_count": 1,
+                "strict_valid_sample_count": 1,
+                "valid_sample_rate": 0.333,
+                "strict_valid_sample_rate": 0.333,
+                "collapse_warning_sample_rate": 0.333,
+            },
         ]
 
         summary = build_sweep_summary(rows, min_best_valid_samples=1)
 
         self.assertTrue(summary["passed_sweep_gate"])
+        self.assertTrue(summary["passed_strict_sweep_gate"])
         self.assertEqual(summary["best_valid_sample_count"], 1)
+        self.assertEqual(summary["best_strict_valid_sample_count"], 1)
         self.assertEqual(summary["best_config"], {"top_k": 2, "temperature": 0.9, "run_id": "k2"})
 
     def test_build_sweep_summary_fails_when_no_config_has_valid_samples(self) -> None:
         rows = [
-            {"run_id": "k1", "top_k": 1, "temperature": 0.9, "valid_sample_count": 0, "valid_sample_rate": 0.0},
-            {"run_id": "k2", "top_k": 2, "temperature": 0.9, "valid_sample_count": 0, "valid_sample_rate": 0.0},
+            {
+                "run_id": "k1",
+                "top_k": 1,
+                "temperature": 0.9,
+                "valid_sample_count": 0,
+                "strict_valid_sample_count": 0,
+                "valid_sample_rate": 0.0,
+                "strict_valid_sample_rate": 0.0,
+                "collapse_warning_sample_rate": 1.0,
+            },
+            {
+                "run_id": "k2",
+                "top_k": 2,
+                "temperature": 0.9,
+                "valid_sample_count": 0,
+                "strict_valid_sample_count": 0,
+                "valid_sample_rate": 0.0,
+                "strict_valid_sample_rate": 0.0,
+                "collapse_warning_sample_rate": 0.667,
+            },
         ]
 
         summary = build_sweep_summary(rows, min_best_valid_samples=1)
 
+        self.assertFalse(summary["passed_sweep_gate"])
+        self.assertFalse(summary["passed_strict_sweep_gate"])
+
+    def test_build_sweep_summary_fails_when_collapse_rate_exceeds_cap(self) -> None:
+        rows = [
+            {
+                "run_id": "k2",
+                "top_k": 2,
+                "temperature": 0.9,
+                "valid_sample_count": 2,
+                "strict_valid_sample_count": 1,
+                "valid_sample_rate": 0.667,
+                "strict_valid_sample_rate": 0.333,
+                "collapse_warning_sample_rate": 0.667,
+            }
+        ]
+
+        summary = build_sweep_summary(
+            rows,
+            min_best_valid_samples=1,
+            min_best_strict_valid_samples=1,
+            max_collapse_warning_sample_rate=0.34,
+        )
+
+        self.assertTrue(summary["passed_basic_sweep_gate"])
+        self.assertFalse(summary["passed_strict_sweep_gate"])
         self.assertFalse(summary["passed_sweep_gate"])
 
     def test_markdown_table_records_collapse_columns(self) -> None:
@@ -36,19 +100,30 @@ class StageBSamplingSweepTest(unittest.TestCase):
                 "sample_count": 3,
                 "grammar_gate_sample_count": 3,
                 "valid_sample_count": 0,
+                "strict_valid_sample_count": 0,
                 "valid_sample_rate": 0.0,
+                "strict_valid_sample_rate": 0.0,
                 "collapse_warning_sample_rate": 1.0,
+                "passed_strict_review_gate": False,
                 "avg_repeated_position_pitch_pair_ratio": 0.75,
                 "max_postprocess_removal_ratio": 0.5,
                 "diagnostic_failure_reasons": {"collapse": 3},
+                "strict_failure_reasons": {"midi_review_gate_failed": 3},
             }
         ]
-        summary = {"passed_sweep_gate": False, "best_config": {"top_k": 1, "temperature": 0.9, "run_id": "k1"}}
+        summary = {
+            "passed_sweep_gate": False,
+            "passed_basic_sweep_gate": False,
+            "passed_strict_sweep_gate": False,
+            "best_config": {"top_k": 1, "temperature": 0.9, "run_id": "k1"},
+        }
 
         markdown = markdown_table(rows, summary)
 
         self.assertIn("collapse_rate", markdown)
+        self.assertIn("strict_valid", markdown)
         self.assertIn("avg_pair_repeat", markdown)
+        self.assertIn("Strict Gate Failures", markdown)
         self.assertIn("top_k=1", markdown)
 
 


### PR DESCRIPTION
## 요약
- Stage B generation probe에 strict collapse-aware gate를 추가했습니다.
- basic MIDI gate와 strict gate를 분리해 `strict_valid_sample_count`, `passed_strict_review_gate`, `strict_failure_reasons`를 보고합니다.
- sampling sweep에서 basic/strict sweep gate를 구분하고, `passed_sweep_gate`는 strict gate 기준을 따르도록 바꿨습니다.
- AGENTS.md를 업데이트해 CORE_PLAN 범위의 이슈/브랜치/PR/안전한 자동 머지는 추가 확인 없이 진행하도록 정리했습니다.

## 검증
- `./.venv/bin/python -m unittest tests.test_stage_b_generation_probe tests.test_stage_b_sampling_sweep`
- `bash scripts/agent_harness.sh stage-b-collapse-sweep`
- `bash scripts/agent_harness.sh quick`

## 로컬 결과
- top_k=1: basic valid 0/3, strict valid 0/3, collapse warning 3/3
- top_k=2: basic valid 1/3, strict valid 1/3, collapse warning 1/3
- strict sweep gate: 통과

## 다음 판단
- strict gate에서도 최소 후보가 유지되므로 다음 이슈는 Stage B 2-file Brad generation probe로 이동합니다.

Closes #31