### PR TITLE
[codex] Stage B 2-file Brad generation probe 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #31: Stage B stricter collapse-aware review gate.
+- Issue #33: Stage B 2-file Brad generation probe.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -168,6 +168,15 @@ bash scripts/agent_harness.sh stage-b-collapse-sweep
 
 For Stage B strict collapse-aware review-gate changes, use the same sweep harness and verify
 `passed_strict_sweep_gate` in the generated report.
+
+For Stage B 2-file Brad generation probe changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-2file-brad-probe
+```
+
+This probe records basic/strict pass-rate. A musical quality failure is a report outcome, not
+automatically a harness failure, unless the script itself crashes or produces no grammar-valid samples.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -299,29 +299,30 @@ Stage B에서 명시하는 것:
 
 완료된 바로 전 작업:
 
-- `Stage B stricter collapse-aware review gate 추가`
-- 결과: `top_k=1`은 collapse warning `3/3`, valid `0/3`
-- 결과: `top_k=2`는 collapse warning `1/3`, basic valid `1/3`, strict valid `1/3`
-- 결론: Stage B grammar가 아니라 note distribution collapse가 현재 병목이지만, strict gate에서도 최소 후보 1개는 유지된다.
+- `Stage B 2-file Brad generation probe 추가`
+- 결과: 2-file Brad Stage B window dataset은 `137` samples, train `123`, val `14`로 정상 생성됐다.
+- 결과: generated samples는 grammar gate `3/3`, collapse warning `0/3`이었다.
+- 결과: basic valid `0/3`, strict valid `0/3`이었다.
+- 결론: Stage B grammar와 collapse는 2-file probe에서 즉시 병목이 아니며, 현재 병목은 dead-air/temporal coverage다.
 
 다음 issue는 다음 이름이 적절하다.
 
 ```text
-Stage B 2-file Brad generation probe 추가
+Stage B temporal coverage diagnostics 추가
 ```
 
 작업 범위:
 
-- one-file tiny smoke를 넘어 Brad 2-file Stage B window dataset으로 generation probe를 실행한다.
-- train/val split과 window count를 report에 남긴다.
-- basic gate와 strict collapse-aware gate를 모두 보고한다.
-- one-file 결과보다 pass-rate가 유지되는지 확인한다.
-- 실패하면 broad training으로 가지 않고 tokenization/model/loss/pretrained-base 후보를 재검토한다.
+- generated Stage B note positions가 2-bar phrase를 얼마나 덮는지 token/MIDI 양쪽에서 측정한다.
+- per-bar occupied position count, earliest/latest position, phrase coverage, longest empty span을 report에 남긴다.
+- dead-air failure가 position sampling 문제인지 duration/postprocess 문제인지 분리한다.
+- coverage-aware constrained generation 실험을 추가하되, 모델 성공처럼 보이게 하는 과한 postprocess는 피한다.
+- 2-file Brad probe에서 basic/strict valid sample을 회복할 수 있는지 확인한다.
 
 이 작업이 끝난 뒤 판단:
 
-- 2-file Brad strict gate에서도 최소 pass-rate가 유지되면 generic jazz base 후보 학습 설계로 간다.
-- 2-file Brad strict gate가 전부 실패하면 sampling/postprocess 문제가 아니라 data scale, representation, loss, pretrained-base 쪽으로 재검토한다.
+- coverage-aware constrained probe로 basic/strict valid sample이 회복되면 Stage B 2-file Brad probe를 다시 고정하고 generic jazz base 후보 학습 설계로 간다.
+- coverage-aware constrained probe에서도 실패하면 data scale, representation, loss, pretrained-base 쪽으로 재검토한다.
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-31-stage-b-strict-collapse-gate`
+- `issue-33-stage-b-2file-brad-probe`
 
 현재 범위가 아닌 것:
 
@@ -735,6 +735,54 @@ Smoke result:
 - passed strict sweep gate: `true`
 - decision: strict gate still preserves one valid candidate, so the next issue can move to a Stage B 2-file Brad probe
 - detail: `docs/STAGE_B_STRICT_COLLAPSE_GATE_2026-05-20.md`
+
+### 0.15. Issue #33 Stage B 2-file Brad generation probe
+
+Status:
+
+- implemented on `issue-33-stage-b-2file-brad-probe`
+
+Goal:
+
+- move from one-file tiny smoke to Brad 2-file Stage B generation probe
+- verify whether grammar/basic/strict pass-rate survives a larger train/val setup
+- decide whether to move toward generic jazz base training or fix another local generation bottleneck
+
+Probe setup:
+
+- input: `./midi_dataset/midi/studio/Brad Mehldau`
+- max files: `2`
+- generated Stage B windows: `137`
+- train samples: `123`
+- val samples: `14`
+- max token id: `544`
+- vocab size: `547`
+- training: 3 epochs, full tiny model path, CPU
+- best observed val loss: `4.0892`
+- generation: constrained, `top_k=2`, temperature `0.9`, 3 samples
+
+Smoke result:
+
+- output: `outputs/stage_b_generation_probe/harness_stage_b_2file_brad_probe`
+- grammar gate: `3/3`
+- basic valid: `0/3`
+- strict valid: `0/3`
+- collapse warning: `0/3`
+- avg repeated position/pitch pair ratio: `0.375`
+- avg postprocess removal ratio: `0.208`
+- failure reason: all samples failed on dead-air ratio near or above `0.800`
+
+Decision:
+
+- Stage B grammar is now stable in this probe.
+- The prior collapse issue is not the immediate failure mode in the 2-file probe.
+- The current bottleneck is temporal coverage/dead-air, especially generated note positions failing to cover the 2-bar phrase densely enough.
+- Do not start generic jazz base training yet.
+- Next issue should add position/dead-air coverage diagnostics and a coverage-aware constrained generation probe.
+
+Detail:
+
+- `docs/STAGE_B_2FILE_BRAD_PROBE_2026-05-20.md`
 
 ### 1. Run full jazz piano dataset audit
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,8 @@
   - Stage B collapse diagnostics and `top_k` sampling sweep result.
 - `STAGE_B_STRICT_COLLAPSE_GATE_2026-05-20.md`
   - Stage B strict collapse-aware review gate and basic-vs-strict sweep result.
+- `STAGE_B_2FILE_BRAD_PROBE_2026-05-20.md`
+  - Stage B Brad 2-file generation probe and dead-air/temporal coverage failure result.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -68,7 +70,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, and 2-file generation probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, and temporal coverage probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_2FILE_BRAD_PROBE_2026-05-20.md
+++ b/docs/STAGE_B_2FILE_BRAD_PROBE_2026-05-20.md
@@ -1,0 +1,120 @@
+# Stage B 2-File Brad Generation Probe
+
+작성일: 2026-05-20
+
+## Goal
+
+Issue #33 checks whether the Stage B generation path still produces reviewable MIDI after moving from a one-file tiny smoke to a Brad Mehldau 2-file setup.
+
+This is still a local model-core probe, not a finished style model.
+
+## Setup
+
+Command:
+
+```bash
+bash scripts/agent_harness.sh stage-b-2file-brad-probe
+```
+
+Dataset:
+
+- input: `./midi_dataset/midi/studio/Brad Mehldau`
+- max files: `2`
+- sequence format: `stage_b_v1`
+- window bars: `2`
+- window stride bars: `2`
+- min target notes per window: `4`
+
+Training/generation:
+
+- epochs: `3`
+- batch size: `8`
+- max sequence: `96`
+- generation mode: constrained
+- note groups per bar: `4`
+- sampling: `top_k=2`, temperature `0.9`
+- samples: `3`
+- overlap postprocess: enabled
+- strict collapse gate: enabled
+
+## Dataset Result
+
+Output:
+
+```text
+outputs/stage_b_generation_probe/harness_stage_b_2file_brad_probe
+```
+
+Prepared records:
+
+- input MIDI files: `2`
+- total Stage B windows: `137`
+- train samples: `123`
+- val samples: `14`
+- tokenized train: `123`
+- tokenized val: `14`
+- max token id: `544`
+- vocab size: `547`
+
+Training:
+
+- epoch 1 val loss: `4.8525`
+- epoch 2 val loss: `4.1989`
+- epoch 3 val loss: `4.0892`
+
+The dataset and model-vocab path are valid.
+
+## Generation Result
+
+| metric | value |
+|---|---:|
+| generated samples | 3 |
+| grammar gate | 3/3 |
+| basic MIDI valid | 0/3 |
+| strict valid | 0/3 |
+| collapse warning | 0/3 |
+| avg repeated position/pitch pair ratio | 0.375 |
+| avg postprocess removal ratio | 0.208 |
+
+Failure reasons:
+
+- sample 1: `dead-air ratio too high: 0.800 >= 0.800`
+- sample 2: `dead-air ratio too high: 0.833 >= 0.800`
+- sample 3: `dead-air ratio too high: 0.800 >= 0.800`
+
+## Interpretation
+
+This is not the same failure as the earlier one-note collapse.
+
+What improved:
+
+- Stage B grammar is stable in the 2-file probe.
+- No sample triggered collapse warning.
+- Unique pitch/position/pair counts are no longer the immediate blocker.
+- Postprocess is not deleting most notes.
+
+What failed:
+
+- All samples still fail the MIDI review gate.
+- The failure is temporal coverage/dead-air, not grammar or collapse.
+- Generated positions are too clustered or do not cover enough of the 2-bar phrase.
+
+## Decision
+
+Do not move to generic jazz base training yet.
+
+The next bottleneck to isolate is temporal coverage:
+
+- per-bar occupied position count
+- earliest/latest generated position
+- longest empty span
+- MIDI phrase coverage
+- whether dead-air comes from position sampling, duration choice, or postprocess removal
+
+## Next Issue
+
+```text
+Stage B temporal coverage diagnostics 추가
+```
+
+The next issue should add explicit coverage diagnostics and then test whether a coverage-aware constrained generation mode can recover at least one basic/strict valid sample without pretending that heavy postprocess is model quality.

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -40,6 +40,8 @@ Modes:
                 Run a multi-sample constrained Stage B review-gate probe.
   stage-b-collapse-sweep
                 Run Stage B top-k sampling sweep with collapse diagnostics.
+  stage-b-2file-brad-probe
+                Run a two-file Brad Stage B generation probe with strict reporting.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   all           Run demo and tiny-compare.
@@ -265,6 +267,36 @@ run_stage_b_collapse_sweep() {
     --lora_alpha 8
 }
 
+run_stage_b_2file_brad_probe() {
+  local run_id="${RUN_ID:-harness_stage_b_2file_brad_probe}"
+  print_header "Stage B 2-file Brad generation probe"
+  "$PYTHON_BIN" scripts/run_stage_b_generation_probe.py \
+    --run_id "$run_id" \
+    --issue_number 33 \
+    --max_files 2 \
+    --epochs 3 \
+    --batch_size 8 \
+    --max_sequence 96 \
+    --num_samples 3 \
+    --generation_mode constrained \
+    --constrained_note_groups_per_bar 4 \
+    --postprocess_overlap \
+    --max_simultaneous_notes 2 \
+    --temperature 0.9 \
+    --top_k 2 \
+    --min_valid_samples 1 \
+    --min_strict_valid_samples 1 \
+    --max_collapse_warning_sample_rate 0.34 \
+    --require_all_grammar_samples \
+    --require_note_groups \
+    --n_layers 1 \
+    --num_heads 4 \
+    --d_model 64 \
+    --dim_feedforward 128 \
+    --lora_r 4 \
+    --lora_alpha 8
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -312,6 +344,9 @@ case "$MODE" in
     ;;
   stage-b-collapse-sweep)
     run_stage_b_collapse_sweep
+    ;;
+  stage-b-2file-brad-probe)
+    run_stage_b_2file_brad_probe
     ;;
   manifest-dry-run)
     run_manifest_dry_run


### PR DESCRIPTION
## 요약
- Stage B 2-file Brad generation probe용 harness mode를 추가했습니다.
- `max_files=2` Brad setup에서 Stage B window dataset, tiny training, constrained generation을 실행했습니다.
- 결과를 docs에 기록하고 다음 병목을 temporal coverage/dead-air로 좁혔습니다.

## 커밋 단위
- `chore: Stage B 2-file Brad probe 하네스 추가`
- `docs: Stage B 2-file Brad probe 결과 기록`

## 검증
- `bash scripts/agent_harness.sh stage-b-2file-brad-probe`
- `bash scripts/agent_harness.sh quick`

## 로컬 결과
- Stage B windows: 137개
- train/val: 123/14
- best val loss: 4.0892
- grammar gate: 3/3
- basic valid: 0/3
- strict valid: 0/3
- collapse warning: 0/3
- 실패 원인: 모든 샘플이 dead-air ratio 기준에서 실패

## 다음 판단
- generic jazz base training으로 아직 가지 않습니다.
- 다음 이슈는 Stage B temporal coverage diagnostics입니다.

Closes #33