### PR TITLE
[codex] Stage B temporal coverage diagnostics 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #33: Stage B 2-file Brad generation probe.
+- Issue #35: Stage B temporal coverage diagnostics.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -299,7 +299,7 @@ Stage B에서 명시하는 것:
 
 완료된 바로 전 작업:
 
-- `Stage B 2-file Brad generation probe 추가`
+- `Stage B temporal coverage diagnostics 추가`
 - 결과: 2-file Brad Stage B window dataset은 `137` samples, train `123`, val `14`로 정상 생성됐다.
 - 결과: generated samples는 grammar gate `3/3`, collapse warning `0/3`이었다.
 - 결과: basic valid `0/3`, strict valid `0/3`이었다.
@@ -309,16 +309,16 @@ Stage B에서 명시하는 것:
 다음 issue는 다음 이름이 적절하다.
 
 ```text
-Stage B temporal coverage diagnostics 추가
+Stage B coverage-aware constrained generation 추가
 ```
 
 작업 범위:
 
-- generated Stage B note positions가 2-bar phrase를 얼마나 덮는지 token/MIDI 양쪽에서 측정한다.
-- per-bar occupied position count, earliest/latest position, phrase coverage, longest empty span을 report에 남긴다.
-- dead-air failure가 position sampling 문제인지 duration/postprocess 문제인지 분리한다.
-- coverage-aware constrained generation 실험을 추가하되, 모델 성공처럼 보이게 하는 과한 postprocess는 피한다.
-- 2-file Brad probe에서 basic/strict valid sample을 회복할 수 있는지 확인한다.
+- constrained generation에서 position family만 coverage-aware 후보군을 줄 수 있는지 실험한다.
+- 각 bar에 최소 onset position 수를 강제하거나 권장하는 옵션을 만든다.
+- duration/pitch/velocity는 여전히 model logits에서 뽑아 model behavior를 유지한다.
+- dead-air ratio와 onset/sustained coverage가 개선되는지 2-file Brad probe에서 비교한다.
+- 과한 postprocess로 모델 성공처럼 보이게 만들지 않는다.
 
 이 작업이 끝난 뒤 판단:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -303,7 +303,8 @@ Stage B에서 명시하는 것:
 - 결과: 2-file Brad Stage B window dataset은 `137` samples, train `123`, val `14`로 정상 생성됐다.
 - 결과: generated samples는 grammar gate `3/3`, collapse warning `0/3`이었다.
 - 결과: basic valid `0/3`, strict valid `0/3`이었다.
-- 결론: Stage B grammar와 collapse는 2-file probe에서 즉시 병목이 아니며, 현재 병목은 dead-air/temporal coverage다.
+- 결과: avg onset coverage `0.167`, avg sustained coverage `0.417`, max longest sustained empty run `11` steps였다.
+- 결론: Stage B grammar와 collapse는 2-file probe에서 즉시 병목이 아니며, 현재 병목은 sparse onset과 long empty span으로 인한 dead-air/temporal coverage다.
 
 다음 issue는 다음 이름이 적절하다.
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -788,6 +788,52 @@ Detail:
 
 - `docs/STAGE_B_2FILE_BRAD_PROBE_2026-05-20.md`
 
+### 0.16. Issue #35 Stage B temporal coverage diagnostics
+
+Status:
+
+- implemented on `issue-35-stage-b-temporal-coverage-diagnostics`
+
+Goal:
+
+- explain why the 2-file Brad probe fails dead-air despite passing grammar and collapse checks
+- add token-level temporal coverage diagnostics to each sample report
+- aggregate coverage summary fields across samples
+
+Implemented diagnostics:
+
+- unique onset position count
+- onset coverage ratio
+- sustained coverage ratio
+- earliest/latest absolute position
+- position span ratio
+- head/tail empty steps
+- longest onset empty run
+- longest sustained empty run
+- per-bar unique onset positions
+- per-bar onset coverage ratio
+
+Smoke result:
+
+- output: `outputs/stage_b_generation_probe/harness_stage_b_2file_brad_probe`
+- grammar gate: `3/3`
+- basic valid: `0/3`
+- strict valid: `0/3`
+- avg onset coverage ratio: `0.167`
+- avg sustained coverage ratio: `0.417`
+- avg position span ratio: `0.740`
+- max longest sustained empty run: `11` steps
+
+Decision:
+
+- dead-air failure is explained by sparse onset coverage and long empty spans.
+- MIDI phrase coverage alone is not enough because notes can span much of the phrase while onsets remain sparse.
+- Next issue should test coverage-aware constrained generation, not broad training.
+
+Detail:
+
+- `docs/STAGE_B_TEMPORAL_COVERAGE_DIAGNOSTICS_2026-05-20.md`
+
 ### 1. Run full jazz piano dataset audit
 
 ```bash

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -770,13 +770,17 @@ Smoke result:
 - collapse warning: `0/3`
 - avg repeated position/pitch pair ratio: `0.375`
 - avg postprocess removal ratio: `0.208`
+- avg onset coverage ratio: `0.167`
+- avg sustained coverage ratio: `0.417`
+- avg position span ratio: `0.740`
+- max longest sustained empty run: `11` steps
 - failure reason: all samples failed on dead-air ratio near or above `0.800`
 
 Decision:
 
 - Stage B grammar is now stable in this probe.
 - The prior collapse issue is not the immediate failure mode in the 2-file probe.
-- The current bottleneck is temporal coverage/dead-air, especially generated note positions failing to cover the 2-bar phrase densely enough.
+- The current bottleneck is temporal coverage/dead-air, especially sparse onsets and long empty spans inside the 2-bar phrase.
 - Do not start generic jazz base training yet.
 - Next issue should add position/dead-air coverage diagnostics and a coverage-aware constrained generation probe.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,8 @@
   - Stage B strict collapse-aware review gate and basic-vs-strict sweep result.
 - `STAGE_B_2FILE_BRAD_PROBE_2026-05-20.md`
   - Stage B Brad 2-file generation probe and dead-air/temporal coverage failure result.
+- `STAGE_B_TEMPORAL_COVERAGE_DIAGNOSTICS_2026-05-20.md`
+  - Stage B token-level temporal coverage diagnostics and next coverage-aware generation boundary.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`

--- a/docs/STAGE_B_2FILE_BRAD_PROBE_2026-05-20.md
+++ b/docs/STAGE_B_2FILE_BRAD_PROBE_2026-05-20.md
@@ -75,6 +75,10 @@ The dataset and model-vocab path are valid.
 | collapse warning | 0/3 |
 | avg repeated position/pitch pair ratio | 0.375 |
 | avg postprocess removal ratio | 0.208 |
+| avg onset coverage ratio | 0.167 |
+| avg sustained coverage ratio | 0.417 |
+| avg position span ratio | 0.740 |
+| max longest sustained empty run | 11 steps |
 
 Failure reasons:
 
@@ -97,7 +101,34 @@ What failed:
 
 - All samples still fail the MIDI review gate.
 - The failure is temporal coverage/dead-air, not grammar or collapse.
-- Generated positions are too clustered or do not cover enough of the 2-bar phrase.
+- Generated onsets cover only about `16.7%` of the 32 available 16th-note positions.
+- Sustained-note coverage improves to about `41.7%`, but the longest empty sustained gap still reaches `11` steps.
+- One sample reaches only `0.625` position span ratio because the second bar tail is mostly empty.
+- Generated positions are too clustered or do not cover enough of the 2-bar phrase, even when pitch/pair collapse is not flagged.
+
+## Temporal Coverage Detail
+
+The issue #35 diagnostics added token-level coverage fields to each sample:
+
+- `unique_onset_position_count`
+- `onset_coverage_ratio`
+- `sustained_coverage_ratio`
+- `position_span_ratio`
+- `head_empty_steps`
+- `tail_empty_steps`
+- `longest_onset_empty_run_steps`
+- `longest_sustained_empty_run_steps`
+- `per_bar_unique_onset_positions`
+
+Observed summary:
+
+| sample | onset coverage | sustained coverage | position span | longest sustained empty run |
+|---:|---:|---:|---:|---:|
+| 1 | 0.156 | 0.344 | 0.844 | 11 |
+| 2 | 0.188 | 0.469 | 0.625 | 9 |
+| 3 | 0.156 | 0.438 | 0.750 | 5 |
+
+This explains why MIDI phrase coverage can look moderate while dead-air still fails: the notes span much of the phrase, but onset placement is sparse and leaves long gaps.
 
 ## Decision
 
@@ -110,6 +141,8 @@ The next bottleneck to isolate is temporal coverage:
 - longest empty span
 - MIDI phrase coverage
 - whether dead-air comes from position sampling, duration choice, or postprocess removal
+
+Based on the coverage diagnostics, the next implementation should test coverage-aware constrained generation rather than increasing dataset scale immediately.
 
 ## Next Issue
 

--- a/docs/STAGE_B_TEMPORAL_COVERAGE_DIAGNOSTICS_2026-05-20.md
+++ b/docs/STAGE_B_TEMPORAL_COVERAGE_DIAGNOSTICS_2026-05-20.md
@@ -1,0 +1,113 @@
+# Stage B Temporal Coverage Diagnostics
+
+작성일: 2026-05-20
+
+## Goal
+
+Issue #35 explains why the Stage B 2-file Brad probe fails the MIDI review gate even though grammar and collapse checks are now stable.
+
+The observed failure is dead-air:
+
+- grammar gate: `3/3`
+- collapse warning: `0/3`
+- basic MIDI valid: `0/3`
+- strict valid: `0/3`
+
+This means the next bottleneck is not one-note collapse. It is temporal coverage.
+
+## Added Diagnostics
+
+Each generated sample now includes `temporal_coverage` in `report.json`.
+
+Fields:
+
+- `unique_onset_position_count`
+- `onset_coverage_ratio`
+- `sustained_coverage_ratio`
+- `earliest_absolute_position`
+- `latest_absolute_position`
+- `position_span_steps`
+- `position_span_ratio`
+- `head_empty_steps`
+- `tail_empty_steps`
+- `longest_onset_empty_run_steps`
+- `longest_sustained_empty_run_steps`
+- `per_bar_unique_onset_positions`
+- `per_bar_onset_coverage_ratio`
+
+The probe summary aggregates:
+
+- `avg_onset_coverage_ratio`
+- `avg_sustained_coverage_ratio`
+- `avg_position_span_ratio`
+- `max_longest_sustained_empty_run_steps`
+
+## Validation
+
+Commands:
+
+```bash
+./.venv/bin/python -m unittest tests.test_stage_b_generation_probe
+bash scripts/agent_harness.sh stage-b-2file-brad-probe
+bash scripts/agent_harness.sh quick
+```
+
+Result:
+
+- targeted Stage B generation probe tests: passed
+- 2-file Brad probe harness: passed as an execution/reporting probe
+- quick harness: passed
+
+## Probe Result
+
+Output:
+
+```text
+outputs/stage_b_generation_probe/harness_stage_b_2file_brad_probe
+```
+
+Summary:
+
+| metric | value |
+|---|---:|
+| grammar gate | 3/3 |
+| basic MIDI valid | 0/3 |
+| strict valid | 0/3 |
+| collapse warning | 0/3 |
+| avg onset coverage ratio | 0.167 |
+| avg sustained coverage ratio | 0.417 |
+| avg position span ratio | 0.740 |
+| max longest sustained empty run | 11 steps |
+
+Per sample:
+
+| sample | onset coverage | sustained coverage | position span | longest sustained empty run |
+|---:|---:|---:|---:|---:|
+| 1 | 0.156 | 0.344 | 0.844 | 11 |
+| 2 | 0.188 | 0.469 | 0.625 | 9 |
+| 3 | 0.156 | 0.438 | 0.750 | 5 |
+
+## Interpretation
+
+The generated phrases contain complete Stage B note groups and avoid the previous repeated position/pitch collapse.
+
+However, onsets occupy only about one sixth of the available 2-bar 16th-note grid positions. Sustained coverage is higher, but long empty spans remain. This explains why phrase coverage can look moderate while dead-air still fails.
+
+The model is choosing a small number of position buckets repeatedly enough to sound sparse, but not repeatedly enough to trigger the collapse gate.
+
+## Decision
+
+Do not move to generic jazz base training yet.
+
+The next issue should test coverage-aware constrained generation:
+
+- guide or constrain only `POSITION_*` selection
+- keep pitch, duration, and velocity model-driven
+- compare plain constrained generation against coverage-aware constrained generation
+- require report-level improvement in dead-air and temporal coverage before scaling data
+
+Next issue:
+
+```text
+Stage B coverage-aware constrained generation 추가
+```

--- a/scripts/run_stage_b_generation_probe.py
+++ b/scripts/run_stage_b_generation_probe.py
@@ -45,8 +45,10 @@ from scripts.stage_b_tokens import (  # noqa: E402
     TOKEN_CHORD_ROOT_END,
     TOKEN_CHORD_ROOT_START,
     SEQUENCE_FORMAT_STAGE_B_V1,
+    POSITIONS_PER_BAR,
     chord_tokens,
     decode_stage_b_midi,
+    duration_steps_from_token,
     is_note_duration_token,
     is_note_pitch_token,
     is_position_token,
@@ -201,6 +203,7 @@ def extract_stage_b_note_groups(tokens: Sequence[int], primer_size: int = 0) -> 
                     "pitch": int(current_pitch),
                     "velocity_token": int(current_velocity) if current_velocity is not None else -1,
                     "duration_token": int(token),
+                    "duration_steps": int(duration_steps_from_token(token)),
                 }
             )
             current_position = None
@@ -216,6 +219,80 @@ def _counter(values: Sequence[Any]) -> dict[str, int]:
         key = str(value)
         counts[key] = counts.get(key, 0) + 1
     return counts
+
+
+def _longest_false_run(values: Sequence[bool]) -> int:
+    longest = 0
+    current = 0
+    for value in values:
+        if value:
+            current = 0
+            continue
+        current += 1
+        longest = max(longest, current)
+    return longest
+
+
+def analyze_stage_b_temporal_coverage(
+    tokens: Sequence[int],
+    primer_size: int = 0,
+    bars: int = 2,
+) -> dict[str, Any]:
+    groups = extract_stage_b_note_groups(tokens, primer_size=primer_size)
+    total_bars = max(1, int(bars))
+    total_positions = total_bars * int(POSITIONS_PER_BAR)
+    onset_occupied = [False] * total_positions
+    sustained_occupied = [False] * total_positions
+    per_bar_positions: dict[int, set[int]] = {bar: set() for bar in range(total_bars)}
+    absolute_positions: list[int] = []
+
+    for group in groups:
+        bar = int(group["bar"])
+        position = int(group["position"])
+        if bar < 0 or bar >= total_bars:
+            continue
+        absolute_position = bar * int(POSITIONS_PER_BAR) + position
+        absolute_positions.append(absolute_position)
+        per_bar_positions.setdefault(bar, set()).add(position)
+        if 0 <= absolute_position < total_positions:
+            onset_occupied[absolute_position] = True
+            duration_steps = max(1, int(group.get("duration_steps", 1)))
+            for step in range(absolute_position, min(total_positions, absolute_position + duration_steps)):
+                sustained_occupied[step] = True
+
+    unique_absolute_positions = sorted(set(absolute_positions))
+    earliest_position = unique_absolute_positions[0] if unique_absolute_positions else None
+    latest_position = unique_absolute_positions[-1] if unique_absolute_positions else None
+    span_steps = (
+        int(latest_position - earliest_position + 1)
+        if earliest_position is not None and latest_position is not None
+        else 0
+    )
+
+    return {
+        "bars": total_bars,
+        "positions_per_bar": int(POSITIONS_PER_BAR),
+        "total_positions": int(total_positions),
+        "note_group_count": int(len(groups)),
+        "unique_onset_position_count": int(len(unique_absolute_positions)),
+        "onset_coverage_ratio": float(len(unique_absolute_positions) / total_positions),
+        "sustained_coverage_ratio": float(sum(1 for value in sustained_occupied if value) / total_positions),
+        "earliest_absolute_position": earliest_position,
+        "latest_absolute_position": latest_position,
+        "position_span_steps": span_steps,
+        "position_span_ratio": float(span_steps / total_positions) if total_positions else 0.0,
+        "head_empty_steps": int(earliest_position) if earliest_position is not None else total_positions,
+        "tail_empty_steps": int(total_positions - latest_position - 1) if latest_position is not None else total_positions,
+        "longest_onset_empty_run_steps": int(_longest_false_run(onset_occupied)),
+        "longest_sustained_empty_run_steps": int(_longest_false_run(sustained_occupied)),
+        "per_bar_unique_onset_positions": {
+            str(bar): int(len(per_bar_positions.get(bar, set()))) for bar in range(total_bars)
+        },
+        "per_bar_onset_coverage_ratio": {
+            str(bar): float(len(per_bar_positions.get(bar, set())) / int(POSITIONS_PER_BAR))
+            for bar in range(total_bars)
+        },
+    }
 
 
 def analyze_stage_b_collapse(

--- a/scripts/run_stage_b_generation_probe.py
+++ b/scripts/run_stage_b_generation_probe.py
@@ -571,6 +571,7 @@ def sample_report(
     raw_generated_tokens = [int(token) for token in tokens[primer_size:]]
     grammar = analyze_stage_b_note_grammar(tokens, primer_size=primer_size)
     collapse = analyze_stage_b_collapse(tokens, primer_size=primer_size, postprocess_report=postprocess_report)
+    temporal_coverage = analyze_stage_b_temporal_coverage(tokens, primer_size=primer_size, bars=request.bars)
     collapse_gate = evaluate_collapse_gate(
         collapse,
         min_unique_pitches=strict_min_unique_pitches,
@@ -605,6 +606,7 @@ def sample_report(
         "diagnostic_failure_reason": diagnostic_failure_reason,
         "grammar": grammar,
         "collapse": collapse,
+        "temporal_coverage": temporal_coverage,
         "collapse_gate": collapse_gate,
         "postprocess": postprocess_report or {"enabled": False},
         "metrics": metrics.to_dict(),
@@ -638,8 +640,13 @@ def build_probe_summary(
     collapse_warning_count = 0
     repeated_pair_ratios: list[float] = []
     postprocess_removal_ratios: list[float] = []
+    onset_coverage_ratios: list[float] = []
+    sustained_coverage_ratios: list[float] = []
+    position_span_ratios: list[float] = []
+    longest_sustained_empty_runs: list[int] = []
     for row in sample_rows:
         collapse = row.get("collapse", {})
+        temporal_coverage = row.get("temporal_coverage", {})
         if collapse.get("collapse_warning"):
             collapse_warning_count += 1
         if not row.get("strict_valid", False):
@@ -654,6 +661,12 @@ def build_probe_summary(
                 strict_failure_reasons[str(strict_reason)] = strict_failure_reasons.get(str(strict_reason), 0) + 1
         repeated_pair_ratios.append(float(collapse.get("repeated_position_pitch_pair_ratio", 0.0) or 0.0))
         postprocess_removal_ratios.append(float(collapse.get("postprocess_removal_ratio", 0.0) or 0.0))
+        onset_coverage_ratios.append(float(temporal_coverage.get("onset_coverage_ratio", 0.0) or 0.0))
+        sustained_coverage_ratios.append(float(temporal_coverage.get("sustained_coverage_ratio", 0.0) or 0.0))
+        position_span_ratios.append(float(temporal_coverage.get("position_span_ratio", 0.0) or 0.0))
+        longest_sustained_empty_runs.append(
+            int(temporal_coverage.get("longest_sustained_empty_run_steps", 0) or 0)
+        )
         if not row["valid"]:
             reason = str(row.get("failure_reason") or "unknown")
             diagnostic_reason = str(row.get("diagnostic_failure_reason") or reason)
@@ -707,6 +720,20 @@ def build_probe_summary(
             else 0.0
         ),
         "max_postprocess_removal_ratio": max(postprocess_removal_ratios) if postprocess_removal_ratios else 0.0,
+        "avg_onset_coverage_ratio": (
+            float(sum(onset_coverage_ratios) / len(onset_coverage_ratios)) if onset_coverage_ratios else 0.0
+        ),
+        "avg_sustained_coverage_ratio": (
+            float(sum(sustained_coverage_ratios) / len(sustained_coverage_ratios))
+            if sustained_coverage_ratios
+            else 0.0
+        ),
+        "avg_position_span_ratio": (
+            float(sum(position_span_ratios) / len(position_span_ratios)) if position_span_ratios else 0.0
+        ),
+        "max_longest_sustained_empty_run_steps": (
+            max(longest_sustained_empty_runs) if longest_sustained_empty_runs else 0
+        ),
     }
 
 

--- a/tests/test_stage_b_generation_probe.py
+++ b/tests/test_stage_b_generation_probe.py
@@ -10,6 +10,7 @@ import torch
 from scripts.run_stage_b_generation_probe import (
     analyze_stage_b_collapse,
     analyze_stage_b_note_grammar,
+    analyze_stage_b_temporal_coverage,
     build_probe_summary,
     build_stage_b_primer,
     dedupe_and_limit_notes,
@@ -233,6 +234,38 @@ class StageBGenerationProbeTest(unittest.TestCase):
         self.assertTrue(report["collapse_warning"])
         self.assertIn("repeated_position_pitch", report["collapse_reasons"])
         self.assertIn("postprocess_removed_majority", report["collapse_reasons"])
+
+    def test_analyze_stage_b_temporal_coverage_reports_empty_spans(self) -> None:
+        primer = build_stage_b_primer(["Cm7", "F7"], bpm=120)
+        tokens = primer + [
+            position_token(0),
+            note_velocity_token(4),
+            note_pitch_token(60),
+            note_duration_token(2),
+            position_token(8),
+            note_velocity_token(4),
+            note_pitch_token(64),
+            note_duration_token(2),
+            TOKEN_BAR,
+            *chord_tokens("F7"),
+            position_token(12),
+            note_velocity_token(4),
+            note_pitch_token(67),
+            note_duration_token(4),
+            TOKEN_END,
+        ]
+
+        report = analyze_stage_b_temporal_coverage(tokens, primer_size=len(primer), bars=2)
+
+        self.assertEqual(report["note_group_count"], 3)
+        self.assertEqual(report["unique_onset_position_count"], 3)
+        self.assertAlmostEqual(report["onset_coverage_ratio"], 3 / 32)
+        self.assertAlmostEqual(report["sustained_coverage_ratio"], 8 / 32)
+        self.assertEqual(report["earliest_absolute_position"], 0)
+        self.assertEqual(report["latest_absolute_position"], 28)
+        self.assertEqual(report["position_span_steps"], 29)
+        self.assertEqual(report["tail_empty_steps"], 3)
+        self.assertEqual(report["per_bar_unique_onset_positions"], {"0": 2, "1": 1})
 
     def test_build_probe_summary_aggregates_collapse_diagnostics(self) -> None:
         rows = [

--- a/tests/test_stage_b_generation_probe.py
+++ b/tests/test_stage_b_generation_probe.py
@@ -280,6 +280,12 @@ class StageBGenerationProbeTest(unittest.TestCase):
                     "repeated_position_pitch_pair_ratio": 0.75,
                     "postprocess_removal_ratio": 0.5,
                 },
+                "temporal_coverage": {
+                    "onset_coverage_ratio": 0.10,
+                    "sustained_coverage_ratio": 0.20,
+                    "position_span_ratio": 0.50,
+                    "longest_sustained_empty_run_steps": 8,
+                },
             },
             {
                 "sample_index": 2,
@@ -290,6 +296,12 @@ class StageBGenerationProbeTest(unittest.TestCase):
                     "repeated_position_pitch_pair_ratio": 0.25,
                     "postprocess_removal_ratio": 0.0,
                 },
+                "temporal_coverage": {
+                    "onset_coverage_ratio": 0.20,
+                    "sustained_coverage_ratio": 0.30,
+                    "position_span_ratio": 0.75,
+                    "longest_sustained_empty_run_steps": 4,
+                },
             },
         ]
 
@@ -299,6 +311,10 @@ class StageBGenerationProbeTest(unittest.TestCase):
         self.assertAlmostEqual(summary["collapse_warning_sample_rate"], 0.5)
         self.assertAlmostEqual(summary["avg_repeated_position_pitch_pair_ratio"], 0.5)
         self.assertAlmostEqual(summary["max_postprocess_removal_ratio"], 0.5)
+        self.assertAlmostEqual(summary["avg_onset_coverage_ratio"], 0.15)
+        self.assertAlmostEqual(summary["avg_sustained_coverage_ratio"], 0.25)
+        self.assertAlmostEqual(summary["avg_position_span_ratio"], 0.625)
+        self.assertEqual(summary["max_longest_sustained_empty_run_steps"], 8)
         self.assertEqual(
             summary["diagnostic_failure_reasons"],
             {"note count too low; collapse=repeated_position_pitch": 1},


### PR DESCRIPTION
## 요약
- Stage B generation probe에 token-level temporal coverage diagnostics를 추가했습니다.
- sample report에 onset/sustained coverage, position span, head/tail empty steps, longest empty run을 기록합니다.
- 2-file Brad probe 결과를 다시 실행해 dead-air 병목이 sparse onset과 long empty span임을 문서화했습니다.
- 다음 작업을 coverage-aware constrained generation으로 좁혔습니다.

## 커밋 단위
- `feat: Stage B token temporal coverage 진단 추가`
- `feat: Stage B coverage 진단을 probe report에 연결`
- `docs: Stage B temporal coverage probe 결과 기록`
- `docs: Stage B temporal coverage 진단 완료 상태 정리`

## 검증
- `./.venv/bin/python -m unittest tests.test_stage_b_generation_probe`
- `bash scripts/agent_harness.sh stage-b-2file-brad-probe`
- `bash scripts/agent_harness.sh quick`

## 로컬 결과
- grammar gate: 3/3
- basic valid: 0/3
- strict valid: 0/3
- avg onset coverage ratio: 0.167
- avg sustained coverage ratio: 0.417
- avg position span ratio: 0.740
- max longest sustained empty run: 11 steps

## 다음 판단
- generic jazz base training으로 아직 가지 않습니다.
- 다음 이슈는 Stage B coverage-aware constrained generation입니다.

Closes #35