### PR TITLE
Stage B coverage-aware constrained generation 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #35: Stage B temporal coverage diagnostics.
+- Issue #37: Stage B coverage-aware constrained generation.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -177,6 +177,15 @@ bash scripts/agent_harness.sh stage-b-2file-brad-probe
 
 This probe records basic/strict pass-rate. A musical quality failure is a report outcome, not
 automatically a harness failure, unless the script itself crashes or produces no grammar-valid samples.
+
+For Stage B coverage-aware constrained generation changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-coverage-aware-probe
+```
+
+This probe tests whether constrained `POSITION` selection can improve temporal coverage without
+claiming unconstrained model quality.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -116,17 +116,23 @@ Stage B에서 명시하는 것:
 10. Stage B grammar-constrained generation
 11. Stage B overlap/dedup postprocess gate
 12. Stage B multi-sample review-gate probe
+13. Stage B collapse diagnostics and sampling sweep
+14. Stage B strict collapse-aware review gate
+15. Stage B 2-file Brad generation probe
+16. Stage B temporal coverage diagnostics
+17. Stage B coverage-aware constrained generation probe
 
 가장 최근 의미 있는 결과:
 
-- `top_k=2`: 3 samples 중 1 sample이 full MIDI review gate 통과
-- `top_k=1`: 3 samples 모두 grammar는 맞지만 note count가 낮아 실패
-- Stage B grammar는 강제 가능함
-- 하지만 musical solo-line 품질은 아직 안정적이지 않음
+- coverage-aware constrained `POSITION` selection: 3 samples 중 3 samples가 grammar/basic/strict review gate 통과
+- 이전 2-file Brad probe 실패 원인은 pitch collapse보다 sparse onset/dead-air 쪽에 가까움
+- avg onset coverage ratio가 `0.167`에서 `0.250`으로 개선됨
+- max longest sustained empty run이 `11` steps에서 `6` steps로 감소함
+- 하지만 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않음
 
 중요한 해석:
 
-> 지금은 "모델이 된다"가 아니라 "어떤 조건에서 무너지는지 측정할 수 있게 됐다"가 성과다.
+> 지금은 "모델이 된다"가 아니라 "어떤 representation/generation constraint에서 reviewable MIDI가 되는지 측정할 수 있게 됐다"가 성과다.
 
 ## 5. 현재 가장 큰 위험
 
@@ -139,8 +145,8 @@ Stage B에서 명시하는 것:
 - overlap postprocess 후 review gate를 일부 통과한다.
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
-따라서 다음 단계는 broad training이 아니다.
-다음 단계는 collapse를 숫자로 잡는 것이다.
+따라서 다음 단계도 곧바로 broad training이 아니다.
+다음 단계는 coverage-aware constrained generation을 A/B sweep으로 검증하고, note density/coverage/chord-tone tradeoff를 숫자로 잡는 것이다.
 
 ## 6. 다음 단계 로드맵
 
@@ -205,6 +211,25 @@ Stage B에서 명시하는 것:
 
 - postprocess를 더 세게 하지 않는다.
 - tokenization 또는 model/data scale 문제로 본다.
+
+### Phase 3.5. Temporal Coverage and Coverage-Aware Generation
+
+목표:
+
+- 2-file Brad probe의 dead-air failure를 token-level temporal coverage로 설명한다.
+- sparse onset, tail/head empty span, sustained empty run을 sample report에 기록한다.
+- constrained generation의 `POSITION` 선택만 coverage-aware로 바꿔 review gate 통과 가능성을 검증한다.
+
+현재 결과:
+
+- temporal diagnostics: grammar `3/3`, basic `0/3`, strict `0/3`, max longest sustained empty run `11`
+- coverage-aware constrained generation: grammar `3/3`, basic `3/3`, strict `3/3`, max longest sustained empty run `6`
+
+다음 통과 기준:
+
+- plain constrained vs coverage-aware constrained A/B sweep을 같은 checkpoint 조건에서 비교한다.
+- `note_groups_per_bar=4/6/8`을 비교한다.
+- pass-rate가 좋아져도 이것을 style learning 성공으로 표현하지 않는다.
 
 ### Phase 4. Generic Jazz Base 후보 학습
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-33-stage-b-2file-brad-probe`
+- `issue-37-stage-b-coverage-aware-generation`
 
 현재 범위가 아닌 것:
 
@@ -36,30 +36,33 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 ## Latest Probe Result
 
-Issue #13에서 Brad Mehldau real MIDI 2파일로 `control_v1` prepare/train/generate probe를 실행했다.
+Issue #37에서 Brad Mehldau real MIDI 2파일 Stage B setup으로 coverage-aware constrained generation probe를 실행했다.
 
 Result:
 
-- dataset prepare 성공: train 1 sample, val 1 sample
-- 5 epoch full-checkpoint training 성공
-- 100 epoch full-checkpoint training 성공
-- best observed val loss: `4.1306` at epoch `70`
-- generation 실패:
-  - 5 epoch `top_k=1`: all 0 notes
-  - 5 epoch `top_k=32`: 0/1/2-note outputs
-  - 100 epoch `top_k=1`: repeated one-note outputs
-  - 100 epoch `top_k=32`: long sustain or only 5 notes
+- dataset prepare 성공: Brad 2-file Stage B windows `137`, train `123`, val `14`
+- 3 epoch full tiny model training 성공
+- best observed val loss: `4.0892`
+- generation mode: constrained + coverage-aware `POSITION`
+- grammar gate: `3/3`
+- basic valid: `3/3`
+- strict valid: `3/3`
+- collapse warning: `0/3`
+- avg onset coverage ratio: `0.250`
+- avg sustained coverage ratio: `0.427`
+- avg position span ratio: `0.813`
+- max longest sustained empty run: `6` steps
 
 Decision:
 
-- Stage A `control_v1`은 runnable pipeline으로는 검증됐다.
-- 하지만 reviewable jazz solo MIDI generator로는 실패했다.
-- broad generic jazz training으로 바로 넘어가지 않는다.
-- 다음은 Stage B duration-explicit, bar-position-aware tokenization과 phrase/window dataset 설계다.
+- coverage-aware constrained `POSITION` selection은 2-file Brad dead-air failure를 줄이는 데 효과가 있었다.
+- 이전 #35의 basic/strict `0/3`에서 #37은 basic/strict `3/3`으로 개선됐다.
+- 하지만 이것은 unconstrained model quality나 Brad style adaptation 성공이 아니다.
+- 다음은 plain constrained vs coverage-aware constrained A/B sweep으로 안정성을 확인한다.
 
 Detail:
 
-- `docs/STAGE_A_BRAD_PROBE2_2026-05-18.md`
+- `docs/STAGE_B_COVERAGE_AWARE_GENERATION_2026-05-20.md`
 
 ## Active Issue #14
 
@@ -671,7 +674,7 @@ Smoke result:
 
 Status:
 
-- implemented on `issue-29-stage-b-collapse-sampling-sweep`
+- completed and merged via PR #30
 
 Goal:
 
@@ -701,7 +704,7 @@ Smoke result:
 
 Status:
 
-- implemented on `issue-31-stage-b-strict-collapse-gate`
+- completed and merged via PR #32
 
 Goal:
 
@@ -740,7 +743,7 @@ Smoke result:
 
 Status:
 
-- implemented on `issue-33-stage-b-2file-brad-probe`
+- completed and merged via PR #34
 
 Goal:
 
@@ -792,7 +795,7 @@ Detail:
 
 Status:
 
-- implemented on `issue-35-stage-b-temporal-coverage-diagnostics`
+- completed and merged via PR #36
 
 Goal:
 
@@ -833,6 +836,50 @@ Decision:
 Detail:
 
 - `docs/STAGE_B_TEMPORAL_COVERAGE_DIAGNOSTICS_2026-05-20.md`
+
+### 0.17. Issue #37 Stage B coverage-aware constrained generation
+
+Status:
+
+- implemented on `issue-37-stage-b-coverage-aware-generation`
+
+Goal:
+
+- reduce the Stage B 2-file Brad dead-air failure without broad training
+- make only constrained `POSITION` selection coverage-aware
+- keep pitch, duration, and velocity sampled from model logits
+- compare the result against #35 temporal coverage diagnostics
+
+Implementation:
+
+- added coverage-aware position helper for constrained note groups
+- added `--coverage_aware_positions`
+- added `--coverage_position_window`
+- added harness mode `stage-b-coverage-aware-probe`
+
+Smoke result:
+
+- output: `outputs/stage_b_generation_probe/harness_stage_b_coverage_aware_probe`
+- grammar gate: `3/3`
+- basic valid: `3/3`
+- strict valid: `3/3`
+- collapse warning: `0/3`
+- avg onset coverage ratio: `0.250`
+- avg sustained coverage ratio: `0.427`
+- avg position span ratio: `0.813`
+- max longest sustained empty run: `6` steps
+- avg postprocess removal ratio: `0.000`
+
+Decision:
+
+- coverage-aware constrained `POSITION` selection is a useful local generation constraint.
+- It fixes the current 2-file Brad probe's dead-air gate failure under this harness.
+- It still does not prove unconstrained generation or personalized Brad style.
+- Next issue should run an A/B sweep: plain constrained vs coverage-aware constrained, with `note_groups_per_bar` variants.
+
+Detail:
+
+- `docs/STAGE_B_COVERAGE_AWARE_GENERATION_2026-05-20.md`
 
 ### 1. Run full jazz piano dataset audit
 
@@ -970,6 +1017,10 @@ Decision:
 - `docs/STAGE_B_OVERLAP_GATE_2026-05-19.md`
 - `docs/STAGE_B_STRONGER_MULTISAMPLE_PROBE_2026-05-20.md`
 - `docs/STAGE_B_COLLAPSE_SWEEP_2026-05-20.md`
+- `docs/STAGE_B_STRICT_COLLAPSE_GATE_2026-05-20.md`
+- `docs/STAGE_B_2FILE_BRAD_PROBE_2026-05-20.md`
+- `docs/STAGE_B_TEMPORAL_COVERAGE_DIAGNOSTICS_2026-05-20.md`
+- `docs/STAGE_B_COVERAGE_AWARE_GENERATION_2026-05-20.md`
 - `docs/REFERENCES.md`
 - `docs/INFERENCE_MODEL_SPEC.md`
 - `docs/QA_ACCEPTANCE_PLAN.md`
@@ -1028,4 +1079,16 @@ For Stage B collapse/sampling-sweep changes:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-collapse-sweep
+```
+
+For Stage B 2-file Brad generation changes:
+
+```bash
+bash scripts/agent_harness.sh stage-b-2file-brad-probe
+```
+
+For Stage B coverage-aware constrained generation changes:
+
+```bash
+bash scripts/agent_harness.sh stage-b-coverage-aware-probe
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,8 @@
   - Stage B Brad 2-file generation probe and dead-air/temporal coverage failure result.
 - `STAGE_B_TEMPORAL_COVERAGE_DIAGNOSTICS_2026-05-20.md`
   - Stage B token-level temporal coverage diagnostics and next coverage-aware generation boundary.
+- `STAGE_B_COVERAGE_AWARE_GENERATION_2026-05-20.md`
+  - Stage B coverage-aware constrained `POSITION` generation result and dead-air gate comparison.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -72,7 +74,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, and temporal coverage probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, and coverage-aware constrained probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_COVERAGE_AWARE_GENERATION_2026-05-20.md
+++ b/docs/STAGE_B_COVERAGE_AWARE_GENERATION_2026-05-20.md
@@ -1,0 +1,153 @@
+# Stage B Coverage-Aware Generation
+
+작성일: 2026-05-20
+
+## Issue
+
+- Issue: #37
+- Branch: `issue-37-stage-b-coverage-aware-generation`
+- Goal: Stage B 2-file Brad probe에서 발생한 dead-air failure를 broad training 전에 constrained generation 수준에서 줄일 수 있는지 검증한다.
+
+## Background
+
+Issue #35의 temporal coverage diagnostics는 다음을 보여줬다.
+
+- grammar gate: `3/3`
+- basic valid: `0/3`
+- strict valid: `0/3`
+- collapse warning: `0/3`
+- avg onset coverage ratio: `0.167`
+- avg sustained coverage ratio: `0.417`
+- avg position span ratio: `0.740`
+- max longest sustained empty run: `11` steps
+
+해석:
+
+- Stage B grammar와 pitch/position collapse가 즉시 실패 원인은 아니었다.
+- 실패 원인은 sparse onset과 긴 empty span이었다.
+- broad generic training으로 넘어가기 전에, constrained generation의 `POSITION` 선택만 coverage-aware로 바꿔 효과를 확인해야 했다.
+
+## Implementation
+
+추가한 핵심 기능:
+
+- `coverage_aware_position_tokens(group_index, note_groups_per_bar, position_window=0)`
+- `generate_stage_b_constrained_tokens(..., coverage_aware_positions=True)`
+- CLI flags:
+  - `--coverage_aware_positions`
+  - `--coverage_position_window`
+- harness mode:
+  - `bash scripts/agent_harness.sh stage-b-coverage-aware-probe`
+
+의도적으로 하지 않은 것:
+
+- pitch/duration/velocity를 rule-based로 덮어쓰기
+- postprocess를 더 세게 해서 gate만 통과시키기
+- broad dataset training 시작
+
+이번 변경은 `POSITION` 후보만 coverage-aware로 제한하고, 나머지 token family는 기존 model logits sampling을 유지한다.
+
+## Probe Setup
+
+Command:
+
+```bash
+bash scripts/agent_harness.sh stage-b-coverage-aware-probe
+```
+
+Generated report:
+
+```text
+outputs/stage_b_generation_probe/harness_stage_b_coverage_aware_probe/report.json
+```
+
+Setup:
+
+- input: `./midi_dataset/midi/studio/Brad Mehldau`
+- max files: `2`
+- generated Stage B windows: `137`
+- train samples: `123`
+- val samples: `14`
+- max token id: `544`
+- vocab size: `547`
+- training: 3 epochs, full tiny model path, CPU
+- best observed val loss: `4.0892`
+- generation mode: `constrained`
+- coverage-aware positions: `true`
+- coverage position window: `0`
+- constrained note groups per bar: `4`
+- top_k: `2`
+- temperature: `0.9`
+- samples: `3`
+
+## Result
+
+Summary:
+
+| Metric | Value |
+|---|---:|
+| sample count | 3 |
+| grammar gate sample count | 3 |
+| basic valid sample count | 3 |
+| strict valid sample count | 3 |
+| collapse warning sample count | 0 |
+| passed generation gate | true |
+| passed strict review gate | true |
+| avg onset coverage ratio | 0.250 |
+| avg sustained coverage ratio | 0.427 |
+| avg position span ratio | 0.813 |
+| max longest sustained empty run | 6 |
+| avg repeated position/pitch pair ratio | 0.250 |
+| max repeated position/pitch pair ratio | 0.375 |
+| avg postprocess removal ratio | 0.000 |
+
+Per-sample:
+
+| Sample | Valid | Strict | Notes | Unique pitches | Onset coverage | Sustained coverage | Dead-air ratio | Chord-tone ratio |
+|---:|---|---|---:|---:|---:|---:|---:|---:|
+| 1 | true | true | 8 | 3 | 0.250 | 0.469 | 0.429 | 0.500 |
+| 2 | true | true | 8 | 3 | 0.250 | 0.438 | 0.429 | 0.375 |
+| 3 | true | true | 8 | 3 | 0.250 | 0.375 | 0.429 | 0.375 |
+
+## Comparison With Issue #35
+
+| Metric | #35 temporal diagnostics | #37 coverage-aware |
+|---|---:|---:|
+| grammar gate | 3/3 | 3/3 |
+| basic valid | 0/3 | 3/3 |
+| strict valid | 0/3 | 3/3 |
+| collapse warning | 0/3 | 0/3 |
+| avg onset coverage ratio | 0.167 | 0.250 |
+| avg sustained coverage ratio | 0.417 | 0.427 |
+| avg position span ratio | 0.740 | 0.813 |
+| max longest sustained empty run | 11 | 6 |
+
+## Decision
+
+Coverage-aware constrained `POSITION` selection is a useful local fix for the dead-air failure mode.
+
+It proves:
+
+- the 2-file Brad Stage B setup can produce grammar-valid, basic-valid, and strict-valid MIDI samples
+- the previous failure was strongly tied to temporal sparsity
+- temporal coverage should be part of future generation review reports
+
+It does not prove:
+
+- unconstrained model generation quality
+- Brad Mehldau style adaptation quality
+- generic jazz base readiness
+- production-quality improvisation
+
+## Next Boundary
+
+Next issue should not jump directly to full broad training.
+
+Recommended next issue:
+
+- compare plain constrained vs coverage-aware generation in an explicit A/B sweep
+- test `note_groups_per_bar` values such as `4`, `6`, and `8`
+- measure pass-rate, coverage, repetition, and chord-tone behavior together
+- keep generated MIDI artifacts local
+
+If the A/B sweep remains stable, then move to generic jazz base preparation/training with Stage B windows.

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -42,6 +42,8 @@ Modes:
                 Run Stage B top-k sampling sweep with collapse diagnostics.
   stage-b-2file-brad-probe
                 Run a two-file Brad Stage B generation probe with strict reporting.
+  stage-b-coverage-aware-probe
+                Run a two-file Brad Stage B coverage-aware generation probe.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   all           Run demo and tiny-compare.
@@ -297,6 +299,38 @@ run_stage_b_2file_brad_probe() {
     --lora_alpha 8
 }
 
+run_stage_b_coverage_aware_probe() {
+  local run_id="${RUN_ID:-harness_stage_b_coverage_aware_probe}"
+  print_header "Stage B coverage-aware generation probe"
+  "$PYTHON_BIN" scripts/run_stage_b_generation_probe.py \
+    --run_id "$run_id" \
+    --issue_number 37 \
+    --max_files 2 \
+    --epochs 3 \
+    --batch_size 8 \
+    --max_sequence 96 \
+    --num_samples 3 \
+    --generation_mode constrained \
+    --coverage_aware_positions \
+    --coverage_position_window 0 \
+    --constrained_note_groups_per_bar 4 \
+    --postprocess_overlap \
+    --max_simultaneous_notes 2 \
+    --temperature 0.9 \
+    --top_k 2 \
+    --min_valid_samples 1 \
+    --min_strict_valid_samples 1 \
+    --max_collapse_warning_sample_rate 0.34 \
+    --require_all_grammar_samples \
+    --require_note_groups \
+    --n_layers 1 \
+    --num_heads 4 \
+    --d_model 64 \
+    --dim_feedforward 128 \
+    --lora_r 4 \
+    --lora_alpha 8
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -347,6 +381,9 @@ case "$MODE" in
     ;;
   stage-b-2file-brad-probe)
     run_stage_b_2file_brad_probe
+    ;;
+  stage-b-coverage-aware-probe)
+    run_stage_b_coverage_aware_probe
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/run_stage_b_generation_probe.py
+++ b/scripts/run_stage_b_generation_probe.py
@@ -450,6 +450,22 @@ def next_token_from_model(
     return choose_allowed_token(logits, allowed_tokens, temperature=temperature, top_k=top_k)
 
 
+def coverage_aware_position_tokens(
+    group_index: int,
+    note_groups_per_bar: int,
+    position_window: int = 0,
+) -> list[int]:
+    groups_per_bar = max(1, int(note_groups_per_bar))
+    cluster_count = max(1, (groups_per_bar + 1) // 2)
+    cluster_index = int(group_index) // 2
+    pair_offset = int(group_index) % 2
+    anchor = int(round(cluster_index * int(POSITIONS_PER_BAR) / cluster_count))
+    target = min(int(POSITIONS_PER_BAR) - 1, anchor + pair_offset)
+    window = max(0, int(position_window))
+    positions = range(max(0, target - window), min(int(POSITIONS_PER_BAR), target + window + 1))
+    return [TOKEN_POSITION_START + int(position) for position in positions]
+
+
 def generate_stage_b_constrained_tokens(
     model: Any,
     primer_tokens: Sequence[int],

--- a/scripts/run_stage_b_generation_probe.py
+++ b/scripts/run_stage_b_generation_probe.py
@@ -476,6 +476,8 @@ def generate_stage_b_constrained_tokens(
     max_sequence: int,
     temperature: float,
     top_k: int | None,
+    coverage_aware_positions: bool = False,
+    coverage_position_window: int = 0,
 ) -> list[int]:
     tokens = [int(token) for token in primer_tokens]
     families = [
@@ -490,16 +492,23 @@ def generate_stage_b_constrained_tokens(
             chord = chords[bar_index % len(chords)] if chords else None
             tokens.append(TOKEN_BAR)
             tokens.extend(chord_tokens(chord))
-        for _group_index in range(max(1, int(note_groups_per_bar))):
-            for allowed_tokens in families:
+        for group_index in range(max(1, int(note_groups_per_bar))):
+            for family_index, allowed_tokens in enumerate(families):
                 if len(tokens) >= int(max_sequence) - 1:
                     tokens.append(TOKEN_END)
                     return tokens
+                allowed = list(allowed_tokens)
+                if coverage_aware_positions and family_index == 0:
+                    allowed = coverage_aware_position_tokens(
+                        group_index,
+                        note_groups_per_bar=note_groups_per_bar,
+                        position_window=coverage_position_window,
+                    )
                 tokens.append(
                     next_token_from_model(
                         model,
                         tokens=tokens,
-                        allowed_tokens=list(allowed_tokens),
+                        allowed_tokens=allowed,
                         temperature=temperature,
                         top_k=top_k,
                     )
@@ -788,6 +797,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--top_p", type=float, default=None)
     parser.add_argument("--generation_mode", choices=("unconstrained", "constrained"), default="unconstrained")
     parser.add_argument("--constrained_note_groups_per_bar", type=int, default=4)
+    parser.add_argument("--coverage_aware_positions", action="store_true")
+    parser.add_argument("--coverage_position_window", type=int, default=0)
     parser.add_argument("--postprocess_overlap", action="store_true")
     parser.add_argument("--max_simultaneous_notes", type=int, default=2)
     parser.add_argument("--min_valid_samples", type=int, default=1)
@@ -861,6 +872,8 @@ def main() -> int:
         "checkpoint_dir": str(checkpoint_dir),
         "sample_vocab_size": int(VOCAB_SIZE),
         "generation_mode": args.generation_mode,
+        "coverage_aware_positions": bool(args.coverage_aware_positions),
+        "coverage_position_window": int(args.coverage_position_window),
         "postprocess_overlap": bool(args.postprocess_overlap),
     }
 
@@ -918,6 +931,8 @@ def main() -> int:
                 max_sequence=args.max_sequence,
                 temperature=args.temperature,
                 top_k=args.top_k,
+                coverage_aware_positions=args.coverage_aware_positions,
+                coverage_position_window=args.coverage_position_window,
             )
         else:
             generated_tokens = generate_stage_b_tokens(

--- a/tests/test_stage_b_generation_probe.py
+++ b/tests/test_stage_b_generation_probe.py
@@ -13,6 +13,7 @@ from scripts.run_stage_b_generation_probe import (
     analyze_stage_b_temporal_coverage,
     build_probe_summary,
     build_stage_b_primer,
+    coverage_aware_position_tokens,
     dedupe_and_limit_notes,
     decode_tokens_to_midi,
     evaluate_collapse_gate,
@@ -26,6 +27,7 @@ from scripts.stage_b_tokens import (
     note_pitch_token,
     note_velocity_token,
     position_token,
+    position_from_token,
 )
 from utilities.constants import TOKEN_BAR, TOKEN_END, TOKEN_ROLE_LEAD, VOCAB_SIZE
 
@@ -138,6 +140,22 @@ class StageBGenerationProbeTest(unittest.TestCase):
             decode_tokens_to_midi(tokens, midi_path, bpm=120)
             midi = pretty_midi.PrettyMIDI(str(midi_path))
             self.assertEqual(len(midi.instruments[0].notes), 2)
+
+    def test_coverage_aware_position_tokens_spread_onset_pairs(self) -> None:
+        positions = [
+            position_from_token(coverage_aware_position_tokens(index, note_groups_per_bar=4)[0])
+            for index in range(4)
+        ]
+
+        self.assertEqual(positions, [0, 1, 8, 9])
+
+    def test_coverage_aware_position_tokens_can_include_small_window(self) -> None:
+        positions = [
+            position_from_token(token)
+            for token in coverage_aware_position_tokens(2, note_groups_per_bar=4, position_window=1)
+        ]
+
+        self.assertEqual(positions, [7, 8, 9])
 
     def test_dedupe_and_limit_notes_removes_same_onset_pitch_duplicates(self) -> None:
         notes = [

--- a/tests/test_stage_b_generation_probe.py
+++ b/tests/test_stage_b_generation_probe.py
@@ -141,6 +141,28 @@ class StageBGenerationProbeTest(unittest.TestCase):
             midi = pretty_midi.PrettyMIDI(str(midi_path))
             self.assertEqual(len(midi.instruments[0].notes), 2)
 
+    def test_coverage_aware_constrained_generation_spreads_positions(self) -> None:
+        primer = build_stage_b_primer(["Cm7"], bpm=120)
+
+        tokens = generate_stage_b_constrained_tokens(
+            model=FakeConstrainedModel(),
+            primer_tokens=primer,
+            chords=["Cm7"],
+            bpm=120,
+            bars=1,
+            note_groups_per_bar=4,
+            max_sequence=64,
+            temperature=1.0,
+            top_k=1,
+            coverage_aware_positions=True,
+        )
+
+        coverage = analyze_stage_b_temporal_coverage(tokens, primer_size=len(primer), bars=1)
+
+        self.assertEqual(coverage["per_bar_unique_onset_positions"], {"0": 4})
+        self.assertEqual(coverage["earliest_absolute_position"], 0)
+        self.assertEqual(coverage["latest_absolute_position"], 9)
+
     def test_coverage_aware_position_tokens_spread_onset_pairs(self) -> None:
         positions = [
             position_from_token(coverage_aware_position_tokens(index, note_groups_per_bar=4)[0])


### PR DESCRIPTION
## 요약

- Stage B constrained generation에 coverage-aware POSITION 선택 모드를 추가했습니다.
- `--coverage_aware_positions`, `--coverage_position_window` 옵션과 `stage-b-coverage-aware-probe` 하네스를 추가했습니다.
- Issue #35에서 확인한 dead-air/temporal coverage 실패를 #37 결과 문서와 core plan에 반영했습니다.

## 결과

- harness: `bash scripts/agent_harness.sh stage-b-coverage-aware-probe`
- grammar gate: `3/3`
- basic valid: `3/3`
- strict valid: `3/3`
- collapse warning: `0/3`
- avg onset coverage ratio: `0.250`
- avg sustained coverage ratio: `0.427`
- avg position span ratio: `0.813`
- max longest sustained empty run: `6` steps

## 판단

coverage-aware constrained POSITION selection은 현재 2-file Brad Stage B probe의 dead-air failure를 줄이는 데 효과가 있었습니다.

다만 이 PR은 unconstrained model quality나 Brad style adaptation 성공을 주장하지 않습니다. 다음 단계는 plain constrained vs coverage-aware constrained A/B sweep입니다.

## 검증

- `./.venv/bin/python -m unittest tests.test_stage_b_generation_probe`
- `bash scripts/agent_harness.sh stage-b-coverage-aware-probe`
- `bash scripts/agent_harness.sh quick`

Closes #37
