### PR TITLE
Stage B coverage-aware A/B sweep 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #37: Stage B coverage-aware constrained generation.
+- Issue #39: Stage B coverage-aware A/B sweep.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -186,6 +186,15 @@ bash scripts/agent_harness.sh stage-b-coverage-aware-probe
 
 This probe tests whether constrained `POSITION` selection can improve temporal coverage without
 claiming unconstrained model quality.
+
+For Stage B coverage-aware A/B sweep changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-coverage-ab-sweep
+```
+
+This probe compares plain constrained generation against coverage-aware constrained generation
+across note-group density settings.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -121,13 +121,16 @@ Stage B에서 명시하는 것:
 15. Stage B 2-file Brad generation probe
 16. Stage B temporal coverage diagnostics
 17. Stage B coverage-aware constrained generation probe
+18. Stage B coverage-aware A/B sweep
 
 가장 최근 의미 있는 결과:
 
-- coverage-aware constrained `POSITION` selection: 3 samples 중 3 samples가 grammar/basic/strict review gate 통과
-- 이전 2-file Brad probe 실패 원인은 pitch collapse보다 sparse onset/dead-air 쪽에 가까움
-- avg onset coverage ratio가 `0.167`에서 `0.250`으로 개선됨
-- max longest sustained empty run이 `11` steps에서 `6` steps로 감소함
+- coverage-aware constrained A/B sweep: coverage mode가 groups/bar `4`, `6`, `8` 모두에서 strict `3/3` 통과
+- plain constrained mode는 groups/bar `4`, `6`, `8`에서 각각 strict `0/3`, `1/3`, `2/3`
+- best config는 coverage groups/bar `8`
+- best avg onset coverage ratio: `0.500`
+- best avg sustained coverage ratio: `0.865`
+- best max longest sustained empty run: `1` step
 - 하지만 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않음
 
 중요한 해석:
@@ -146,7 +149,7 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-다음 단계는 coverage-aware constrained generation을 A/B sweep으로 검증하고, note density/coverage/chord-tone tradeoff를 숫자로 잡는 것이다.
+다음 단계는 strict pass/fail 하나가 아니라 temporal coverage, chord-tone ratio, repetition, density를 함께 보는 candidate ranking/report를 만드는 것이다.
 
 ## 6. 다음 단계 로드맵
 
@@ -227,9 +230,9 @@ Stage B에서 명시하는 것:
 
 다음 통과 기준:
 
-- plain constrained vs coverage-aware constrained A/B sweep을 같은 checkpoint 조건에서 비교한다.
-- `note_groups_per_bar=4/6/8`을 비교한다.
-- pass-rate가 좋아져도 이것을 style learning 성공으로 표현하지 않는다.
+- completed: plain constrained vs coverage-aware constrained A/B sweep을 같은 checkpoint 조건에서 비교했다.
+- completed: `note_groups_per_bar=4/6/8`을 비교했다.
+- next: pass-rate가 좋아져도 이것을 style learning 성공으로 표현하지 않고 candidate ranking 기준을 추가한다.
 
 ### Phase 4. Generic Jazz Base 후보 학습
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-37-stage-b-coverage-aware-generation`
+- `issue-39-stage-b-coverage-ab-sweep`
 
 현재 범위가 아닌 것:
 
@@ -36,33 +36,35 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 ## Latest Probe Result
 
-Issue #37에서 Brad Mehldau real MIDI 2파일 Stage B setup으로 coverage-aware constrained generation probe를 실행했다.
+Issue #39에서 Brad Mehldau real MIDI 2파일 Stage B setup으로 plain constrained vs coverage-aware constrained A/B sweep을 실행했다.
 
 Result:
 
-- dataset prepare 성공: Brad 2-file Stage B windows `137`, train `123`, val `14`
-- 3 epoch full tiny model training 성공
-- best observed val loss: `4.0892`
-- generation mode: constrained + coverage-aware `POSITION`
-- grammar gate: `3/3`
-- basic valid: `3/3`
-- strict valid: `3/3`
-- collapse warning: `0/3`
-- avg onset coverage ratio: `0.250`
-- avg sustained coverage ratio: `0.427`
-- avg position span ratio: `0.813`
-- max longest sustained empty run: `6` steps
+- compared configs: `plain/coverage` x groups/bar `4/6/8`
+- all configs grammar gate: `3/3`
+- plain strict valid:
+  - groups/bar `4`: `0/3`
+  - groups/bar `6`: `1/3`
+  - groups/bar `8`: `2/3`
+- coverage strict valid:
+  - groups/bar `4`: `3/3`
+  - groups/bar `6`: `3/3`
+  - groups/bar `8`: `3/3`
+- best config: coverage groups/bar `8`
+- best avg onset coverage ratio: `0.500`
+- best avg sustained coverage ratio: `0.865`
+- best max longest sustained empty run: `1` step
 
 Decision:
 
-- coverage-aware constrained `POSITION` selection은 2-file Brad dead-air failure를 줄이는 데 효과가 있었다.
-- 이전 #35의 basic/strict `0/3`에서 #37은 basic/strict `3/3`으로 개선됐다.
+- coverage-aware constrained `POSITION` selection은 plain constrained보다 안정적으로 temporal coverage를 개선한다.
+- `groups/bar=8`이 temporal coverage는 가장 좋지만 chord-tone ratio는 낮아질 수 있다.
 - 하지만 이것은 unconstrained model quality나 Brad style adaptation 성공이 아니다.
-- 다음은 plain constrained vs coverage-aware constrained A/B sweep으로 안정성을 확인한다.
+- 다음은 strict pass/fail만 보지 말고 coverage, chord-tone ratio, repetition, density를 함께 보는 candidate ranking/report를 만든다.
 
 Detail:
 
-- `docs/STAGE_B_COVERAGE_AWARE_GENERATION_2026-05-20.md`
+- `docs/STAGE_B_COVERAGE_AB_SWEEP_2026-05-20.md`
 
 ## Active Issue #14
 
@@ -881,6 +883,40 @@ Detail:
 
 - `docs/STAGE_B_COVERAGE_AWARE_GENERATION_2026-05-20.md`
 
+### 0.18. Issue #39 Stage B coverage-aware A/B sweep
+
+Status:
+
+- implemented on `issue-39-stage-b-coverage-ab-sweep`
+
+Goal:
+
+- compare plain constrained generation with coverage-aware constrained generation
+- test note group density values `4`, `6`, and `8`
+- record pass-rate and temporal coverage tradeoffs in JSON/Markdown reports
+
+Smoke result:
+
+- output: `outputs/stage_b_coverage_ab_sweep/harness_stage_b_coverage_ab_sweep`
+- configs: `6`
+- all configs grammar gate: `3/3`
+- plain strict valid: `0/3`, `1/3`, `2/3` for groups/bar `4`, `6`, `8`
+- coverage strict valid: `3/3`, `3/3`, `3/3` for groups/bar `4`, `6`, `8`
+- best config: coverage groups/bar `8`
+- best avg onset coverage ratio: `0.500`
+- best avg sustained coverage ratio: `0.865`
+- best max longest sustained empty run: `1` step
+
+Decision:
+
+- coverage-aware `POSITION` selection is consistently better than plain constrained generation for this 2-file Brad setup.
+- More note groups improve temporal coverage, but lower chord-tone ratio can become the next musical-quality issue.
+- Next issue should rank candidate samples/configs with multiple metrics rather than only strict pass/fail.
+
+Detail:
+
+- `docs/STAGE_B_COVERAGE_AB_SWEEP_2026-05-20.md`
+
 ### 1. Run full jazz piano dataset audit
 
 ```bash
@@ -1021,6 +1057,7 @@ Decision:
 - `docs/STAGE_B_2FILE_BRAD_PROBE_2026-05-20.md`
 - `docs/STAGE_B_TEMPORAL_COVERAGE_DIAGNOSTICS_2026-05-20.md`
 - `docs/STAGE_B_COVERAGE_AWARE_GENERATION_2026-05-20.md`
+- `docs/STAGE_B_COVERAGE_AB_SWEEP_2026-05-20.md`
 - `docs/REFERENCES.md`
 - `docs/INFERENCE_MODEL_SPEC.md`
 - `docs/QA_ACCEPTANCE_PLAN.md`
@@ -1091,4 +1128,10 @@ For Stage B coverage-aware constrained generation changes:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-coverage-aware-probe
+```
+
+For Stage B coverage-aware A/B sweep changes:
+
+```bash
+bash scripts/agent_harness.sh stage-b-coverage-ab-sweep
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,8 @@
   - Stage B token-level temporal coverage diagnostics and next coverage-aware generation boundary.
 - `STAGE_B_COVERAGE_AWARE_GENERATION_2026-05-20.md`
   - Stage B coverage-aware constrained `POSITION` generation result and dead-air gate comparison.
+- `STAGE_B_COVERAGE_AB_SWEEP_2026-05-20.md`
+  - Stage B plain-vs-coverage A/B sweep across note-group density settings.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -74,7 +76,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, and coverage-aware constrained probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, and coverage-aware A/B sweep를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_COVERAGE_AB_SWEEP_2026-05-20.md
+++ b/docs/STAGE_B_COVERAGE_AB_SWEEP_2026-05-20.md
@@ -1,0 +1,110 @@
+# Stage B Coverage-Aware A/B Sweep
+
+작성일: 2026-05-20
+
+## Issue
+
+- Issue: #39
+- Branch: `issue-39-stage-b-coverage-ab-sweep`
+- Goal: plain constrained generation과 coverage-aware constrained generation을 같은 2-file Brad setup에서 비교한다.
+
+## Why
+
+Issue #37은 coverage-aware `POSITION` selection이 dead-air failure를 줄일 수 있음을 보였다.
+
+하지만 #37은 단일 설정이었다.
+
+이번 이슈에서는 다음을 비교한다.
+
+- mode: `plain`, `coverage`
+- note groups per bar: `4`, `6`, `8`
+- top_k: `2`
+- temperature: `0.9`
+- samples per config: `3`
+
+## Command
+
+```bash
+bash scripts/agent_harness.sh stage-b-coverage-ab-sweep
+```
+
+Generated outputs:
+
+```text
+outputs/stage_b_coverage_ab_sweep/harness_stage_b_coverage_ab_sweep/ab_sweep_report.json
+outputs/stage_b_coverage_ab_sweep/harness_stage_b_coverage_ab_sweep/ab_sweep_report.md
+```
+
+Generated MIDI/checkpoint artifacts stay local and are not committed.
+
+## Result
+
+Summary:
+
+| Metric | Value |
+|---|---:|
+| configs | 6 |
+| plain configs | 3 |
+| coverage configs | 3 |
+| passed A/B sweep gate | true |
+| best mode | coverage |
+| best groups/bar | 8 |
+| best strict valid samples | 3/3 |
+| best onset coverage | 0.500 |
+| best max longest sustained empty run | 1 |
+
+Detailed rows:
+
+| Mode | Groups/bar | Grammar | Basic valid | Strict valid | Onset | Sustained | Span | Max empty | Avg dead-air | Collapse warning |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| plain | 4 | 3/3 | 0/3 | 0/3 | 0.167 | 0.417 | 0.740 | 11 | 0.811 | 0.000 |
+| coverage | 4 | 3/3 | 3/3 | 3/3 | 0.250 | 0.427 | 0.813 | 6 | 0.429 | 0.000 |
+| plain | 6 | 3/3 | 1/3 | 1/3 | 0.208 | 0.500 | 0.802 | 9 | 0.768 | 0.000 |
+| coverage | 6 | 3/3 | 3/3 | 3/3 | 0.375 | 0.688 | 0.906 | 3 | 0.455 | 0.000 |
+| plain | 8 | 3/3 | 2/3 | 2/3 | 0.240 | 0.604 | 0.875 | 6 | 0.710 | 0.333 |
+| coverage | 8 | 3/3 | 3/3 | 3/3 | 0.500 | 0.865 | 0.938 | 1 | 0.467 | 0.000 |
+
+## Interpretation
+
+Coverage-aware constrained generation clearly improves temporal coverage in this harness.
+
+Most important comparisons:
+
+- plain g4 fails all strict samples because dead-air remains high.
+- coverage g4 fixes the #35/#37 baseline failure.
+- coverage g6 and g8 improve onset/sustained coverage further.
+- coverage g8 gives the best temporal coverage, but chord-tone ratio is lower than g4.
+
+This means density alone is not the final answer.
+
+The next model-quality decision should consider:
+
+- temporal coverage
+- chord-tone ratio
+- pitch diversity
+- repeated pitch/position behavior
+- whether the output still sounds like a playable solo line
+
+## Decision
+
+Do not jump straight to broad generic training yet.
+
+The next issue should add a selection/ranking layer or quality report that chooses candidate MIDI based on multiple metrics instead of only strict pass/fail.
+
+Recommended next issue:
+
+- Stage B candidate ranking report
+- choose best sample/config using temporal coverage, strict validity, chord-tone ratio, repetition, and density
+- keep generation constrained for now
+- only after this is stable, move toward generic jazz base training
+
+## Validation
+
+Commands run:
+
+```bash
+./.venv/bin/python -m unittest tests.test_stage_b_coverage_ab_sweep tests.test_stage_b_sampling_sweep
+./.venv/bin/python -m compileall scripts/run_stage_b_coverage_ab_sweep.py scripts/run_stage_b_sampling_sweep.py scripts/run_stage_b_generation_probe.py
+bash scripts/agent_harness.sh quick
+bash scripts/agent_harness.sh stage-b-coverage-ab-sweep
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -44,6 +44,8 @@ Modes:
                 Run a two-file Brad Stage B generation probe with strict reporting.
   stage-b-coverage-aware-probe
                 Run a two-file Brad Stage B coverage-aware generation probe.
+  stage-b-coverage-ab-sweep
+                Run plain vs coverage-aware Stage B constrained generation sweep.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   all           Run demo and tiny-compare.
@@ -82,6 +84,7 @@ run_quick() {
     scripts/run_stage_b_window_tiny_overfit.py \
     scripts/run_stage_b_generation_probe.py \
     scripts/run_stage_b_sampling_sweep.py \
+    scripts/run_stage_b_coverage_ab_sweep.py \
     scripts/audit_brad_mehldau_dataset.py \
     scripts/audit_jazz_piano_dataset.py \
     scripts/build_jazz_training_manifests.py \
@@ -331,6 +334,36 @@ run_stage_b_coverage_aware_probe() {
     --lora_alpha 8
 }
 
+run_stage_b_coverage_ab_sweep() {
+  local run_id="${RUN_ID:-harness_stage_b_coverage_ab_sweep}"
+  print_header "Stage B coverage-aware A/B sweep"
+  "$PYTHON_BIN" scripts/run_stage_b_coverage_ab_sweep.py \
+    --run_id "$run_id" \
+    --issue_number 39 \
+    --max_files 2 \
+    --epochs 3 \
+    --batch_size 8 \
+    --max_sequence 96 \
+    --num_samples 3 \
+    --modes plain,coverage \
+    --note_groups_per_bar_values 4,6,8 \
+    --coverage_position_window 0 \
+    --max_simultaneous_notes 2 \
+    --temperature 0.9 \
+    --top_k 2 \
+    --min_valid_samples 1 \
+    --min_strict_valid_samples 1 \
+    --min_best_strict_valid_samples 1 \
+    --max_collapse_warning_sample_rate 0.34 \
+    --require_all_grammar_samples \
+    --n_layers 1 \
+    --num_heads 4 \
+    --d_model 64 \
+    --dim_feedforward 128 \
+    --lora_r 4 \
+    --lora_alpha 8
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -384,6 +417,9 @@ case "$MODE" in
     ;;
   stage-b-coverage-aware-probe)
     run_stage_b_coverage_aware_probe
+    ;;
+  stage-b-coverage-ab-sweep)
+    run_stage_b_coverage_ab_sweep
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/run_stage_b_coverage_ab_sweep.py
+++ b/scripts/run_stage_b_coverage_ab_sweep.py
@@ -1,0 +1,257 @@
+"""Compare plain constrained and coverage-aware Stage B generation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.run_stage_b_sampling_sweep import (  # noqa: E402
+    parse_int_list,
+    probe_command,
+    read_json,
+    row_from_probe_report,
+    run_command,
+    suffix_for_float,
+    write_json,
+)
+
+
+def parse_modes(raw: str) -> list[str]:
+    modes = [mode.strip().lower() for mode in raw.split(",") if mode.strip()]
+    invalid = [mode for mode in modes if mode not in {"plain", "coverage"}]
+    if invalid:
+        raise ValueError(f"Unknown coverage sweep modes: {invalid}")
+    return modes
+
+
+def config_run_id(base_run_id: str, mode: str, note_groups_per_bar: int, top_k: int, temperature: float) -> str:
+    return (
+        f"{base_run_id}_{mode}_g{int(note_groups_per_bar)}"
+        f"_k{int(top_k)}_t{suffix_for_float(float(temperature))}"
+    )
+
+
+def row_sort_key(row: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        int(row["strict_valid_sample_count"]),
+        int(row["valid_sample_count"]),
+        float(row["avg_onset_coverage_ratio"]),
+        float(row["avg_sustained_coverage_ratio"]),
+        -float(row["collapse_warning_sample_rate"]),
+        -int(row["max_longest_sustained_empty_run_steps"]),
+    )
+
+
+def best_row(rows: list[dict[str, Any]]) -> dict[str, Any] | None:
+    return max(rows, key=row_sort_key, default=None)
+
+
+def compact_config(row: dict[str, Any] | None) -> dict[str, Any] | None:
+    if row is None:
+        return None
+    return {
+        "mode": row["mode"],
+        "note_groups_per_bar": int(row["note_groups_per_bar"]),
+        "top_k": int(row["top_k"]),
+        "temperature": float(row["temperature"]),
+        "run_id": row["run_id"],
+        "strict_valid_sample_count": int(row["strict_valid_sample_count"]),
+        "valid_sample_count": int(row["valid_sample_count"]),
+        "avg_onset_coverage_ratio": float(row["avg_onset_coverage_ratio"]),
+        "max_longest_sustained_empty_run_steps": int(row["max_longest_sustained_empty_run_steps"]),
+    }
+
+
+def build_ab_summary(
+    rows: list[dict[str, Any]],
+    min_best_strict_valid_samples: int = 1,
+    max_collapse_warning_sample_rate: float = 0.34,
+) -> dict[str, Any]:
+    mode_rows = {
+        "plain": [row for row in rows if row["mode"] == "plain"],
+        "coverage": [row for row in rows if row["mode"] == "coverage"],
+    }
+    best = best_row(rows)
+    best_plain = best_row(mode_rows["plain"])
+    best_coverage = best_row(mode_rows["coverage"])
+    passed_coverage = bool(
+        best_coverage
+        and int(best_coverage["strict_valid_sample_count"]) >= int(min_best_strict_valid_samples)
+        and float(best_coverage["collapse_warning_sample_rate"]) <= float(max_collapse_warning_sample_rate)
+    )
+    passed_comparison = bool(best_plain is not None and best_coverage is not None)
+    return {
+        "config_count": int(len(rows)),
+        "mode_counts": {mode: int(len(mode_rows[mode])) for mode in sorted(mode_rows)},
+        "best_config": compact_config(best),
+        "best_plain_config": compact_config(best_plain),
+        "best_coverage_config": compact_config(best_coverage),
+        "min_best_strict_valid_samples": int(min_best_strict_valid_samples),
+        "max_collapse_warning_sample_rate": float(max_collapse_warning_sample_rate),
+        "passed_coverage_gate": passed_coverage,
+        "passed_comparison_gate": passed_comparison,
+        "passed_ab_sweep_gate": bool(passed_coverage and passed_comparison),
+    }
+
+
+def markdown_table(rows: list[dict[str, Any]], summary: dict[str, Any]) -> str:
+    lines = [
+        "# Stage B Coverage-Aware A/B Sweep",
+        "",
+        f"- passed A/B sweep gate: `{str(summary['passed_ab_sweep_gate']).lower()}`",
+        f"- best plain config: `{summary['best_plain_config']}`",
+        f"- best coverage config: `{summary['best_coverage_config']}`",
+        "",
+        "| mode | groups/bar | samples | grammar | valid | strict | onset | sustained | span | max empty | dead air | collapse | strict pass |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|",
+    ]
+    for row in rows:
+        lines.append(
+            "| {mode} | {note_groups_per_bar} | {sample_count} | {grammar_gate_sample_count} | "
+            "{valid_sample_count} | {strict_valid_sample_count} | {avg_onset_coverage_ratio:.3f} | "
+            "{avg_sustained_coverage_ratio:.3f} | {avg_position_span_ratio:.3f} | "
+            "{max_longest_sustained_empty_run_steps} | {avg_dead_air_ratio:.3f} | "
+            "{collapse_warning_sample_rate:.3f} | {passed_strict_review_gate} |".format(**row)
+        )
+    lines.append("")
+    lines.append("## Failure Reasons")
+    lines.append("")
+    for row in rows:
+        lines.append(
+            f"- `{row['mode']}`, groups `{row['note_groups_per_bar']}`: "
+            f"{row['diagnostic_failure_reasons']}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run Stage B coverage-aware A/B sweep")
+    parser.add_argument("--output_root", type=str, default=str(ROOT_DIR / "outputs" / "stage_b_coverage_ab_sweep"))
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--issue_number", type=int, default=39)
+    parser.add_argument("--modes", type=str, default="plain,coverage")
+    parser.add_argument("--note_groups_per_bar_values", type=str, default="4,6,8")
+    parser.add_argument("--coverage_position_window", type=int, default=0)
+    parser.add_argument("--top_k", type=int, default=2)
+    parser.add_argument("--temperature", type=float, default=0.9)
+    parser.add_argument("--max_files", type=int, default=2)
+    parser.add_argument("--epochs", type=int, default=3)
+    parser.add_argument("--batch_size", type=int, default=8)
+    parser.add_argument("--max_sequence", type=int, default=96)
+    parser.add_argument("--num_samples", type=int, default=3)
+    parser.add_argument("--max_simultaneous_notes", type=int, default=2)
+    parser.add_argument("--min_valid_samples", type=int, default=1)
+    parser.add_argument("--min_strict_valid_samples", type=int, default=1)
+    parser.add_argument("--min_best_strict_valid_samples", type=int, default=1)
+    parser.add_argument("--max_collapse_warning_sample_rate", type=float, default=0.34)
+    parser.add_argument("--strict_min_unique_pitches", type=int, default=3)
+    parser.add_argument("--strict_min_unique_positions", type=int, default=3)
+    parser.add_argument("--strict_min_unique_position_pitch_pairs", type=int, default=4)
+    parser.add_argument("--strict_max_repeated_position_pitch_pair_ratio", type=float, default=0.49)
+    parser.add_argument("--strict_max_postprocess_removal_ratio", type=float, default=0.49)
+    parser.add_argument("--require_all_grammar_samples", action="store_true")
+    parser.add_argument("--n_layers", type=int, default=1)
+    parser.add_argument("--num_heads", type=int, default=4)
+    parser.add_argument("--d_model", type=int, default=64)
+    parser.add_argument("--dim_feedforward", type=int, default=128)
+    parser.add_argument("--lora_r", type=int, default=4)
+    parser.add_argument("--lora_alpha", type=int, default=8)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now().strftime("%Y%m%d_%H%M%S")
+    sweep_dir = Path(args.output_root) / run_id
+    modes = parse_modes(args.modes)
+    note_group_values = parse_int_list(args.note_groups_per_bar_values)
+    if not modes or not note_group_values:
+        raise ValueError("--modes and --note_groups_per_bar_values must not be empty")
+
+    command_results: list[dict[str, Any]] = []
+    rows: list[dict[str, Any]] = []
+    checkpoint_dir: Path | None = None
+    first_config = True
+
+    for note_groups_per_bar in note_group_values:
+        for mode in modes:
+            config_id = config_run_id(
+                run_id,
+                mode=mode,
+                note_groups_per_bar=note_groups_per_bar,
+                top_k=args.top_k,
+                temperature=args.temperature,
+            )
+            probe_args = argparse.Namespace(**vars(args))
+            probe_args.train_top_k = args.top_k
+            probe_args.top_ks = str(args.top_k)
+            probe_args.temperatures = str(args.temperature)
+            probe_args.constrained_note_groups_per_bar = int(note_groups_per_bar)
+            probe_args.coverage_aware_positions = mode == "coverage"
+            probe_args.coverage_position_window = int(args.coverage_position_window)
+            cmd = probe_command(
+                probe_args,
+                run_id=config_id,
+                top_k=int(args.top_k),
+                temperature=float(args.temperature),
+                checkpoint_dir=checkpoint_dir,
+                skip_prepare_train=not first_config,
+            )
+            if mode == "coverage":
+                cmd.extend(["--coverage_aware_positions", "--coverage_position_window", str(args.coverage_position_window)])
+            result = run_command(cmd)
+            command_results.append(result)
+            if result["returncode"] != 0:
+                report = {
+                    "run_id": run_id,
+                    "failure_reason": f"probe command failed for mode={mode}, groups={note_groups_per_bar}",
+                    "command_results": command_results,
+                }
+                write_json(sweep_dir / "ab_sweep_report.json", report)
+                print(json.dumps(report, ensure_ascii=True, indent=2))
+                return int(result["returncode"])
+
+            report_path = Path(args.output_root) / config_id / "report.json"
+            probe_report = read_json(report_path)
+            if checkpoint_dir is None:
+                checkpoint_dir = Path(probe_report["checkpoint_dir"])
+            first_config = False
+            row = row_from_probe_report(int(args.top_k), float(args.temperature), config_id, probe_report)
+            row["mode"] = mode
+            row["note_groups_per_bar"] = int(note_groups_per_bar)
+            rows.append(row)
+
+    rows = sorted(rows, key=lambda row: (int(row["note_groups_per_bar"]), row["mode"]))
+    summary = build_ab_summary(
+        rows,
+        min_best_strict_valid_samples=args.min_best_strict_valid_samples,
+        max_collapse_warning_sample_rate=args.max_collapse_warning_sample_rate,
+    )
+    report = {
+        "run_id": run_id,
+        "run_dir": str(sweep_dir),
+        "issue": int(args.issue_number),
+        "modes": modes,
+        "note_groups_per_bar_values": note_group_values,
+        "top_k": int(args.top_k),
+        "temperature": float(args.temperature),
+        "summary": summary,
+        "rows": rows,
+        "command_results": command_results,
+    }
+    write_json(sweep_dir / "ab_sweep_report.json", report)
+    (sweep_dir / "ab_sweep_report.md").write_text(markdown_table(rows, summary), encoding="utf-8")
+    print(json.dumps(report, ensure_ascii=True, indent=2))
+    return 0 if summary["passed_ab_sweep_gate"] else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_stage_b_generation_probe.py
+++ b/scripts/run_stage_b_generation_probe.py
@@ -872,6 +872,7 @@ def main() -> int:
         "checkpoint_dir": str(checkpoint_dir),
         "sample_vocab_size": int(VOCAB_SIZE),
         "generation_mode": args.generation_mode,
+        "constrained_note_groups_per_bar": int(args.constrained_note_groups_per_bar),
         "coverage_aware_positions": bool(args.coverage_aware_positions),
         "coverage_position_window": int(args.coverage_position_window),
         "postprocess_overlap": bool(args.postprocess_overlap),

--- a/scripts/run_stage_b_sampling_sweep.py
+++ b/scripts/run_stage_b_sampling_sweep.py
@@ -124,10 +124,25 @@ def probe_command(
 
 def row_from_probe_report(top_k: int, temperature: float, run_id: str, report: dict[str, Any]) -> dict[str, Any]:
     summary = report.get("summary", {})
+    samples = report.get("samples", [])
+    dead_air_ratios = [
+        float(sample.get("metrics", {}).get("dead_air_ratio", 0.0) or 0.0)
+        for sample in samples
+        if isinstance(sample, dict)
+    ]
+    chord_tone_ratios = [
+        float(sample.get("metrics", {}).get("chord_tone_ratio", 0.0) or 0.0)
+        for sample in samples
+        if isinstance(sample, dict)
+    ]
     return {
         "run_id": run_id,
         "top_k": int(top_k),
         "temperature": float(temperature),
+        "generation_mode": str(report.get("generation_mode", "")),
+        "coverage_aware_positions": bool(report.get("coverage_aware_positions", False)),
+        "coverage_position_window": int(report.get("coverage_position_window", 0) or 0),
+        "constrained_note_groups_per_bar": int(report.get("constrained_note_groups_per_bar", 0) or 0),
         "sample_count": int(summary.get("sample_count", 0)),
         "grammar_gate_sample_count": int(summary.get("grammar_gate_sample_count", 0)),
         "valid_sample_count": int(summary.get("valid_sample_count", 0)),
@@ -149,6 +164,19 @@ def row_from_probe_report(top_k: int, temperature: float, run_id: str, report: d
         ),
         "avg_postprocess_removal_ratio": float(summary.get("avg_postprocess_removal_ratio", 0.0)),
         "max_postprocess_removal_ratio": float(summary.get("max_postprocess_removal_ratio", 0.0)),
+        "avg_onset_coverage_ratio": float(summary.get("avg_onset_coverage_ratio", 0.0)),
+        "avg_sustained_coverage_ratio": float(summary.get("avg_sustained_coverage_ratio", 0.0)),
+        "avg_position_span_ratio": float(summary.get("avg_position_span_ratio", 0.0)),
+        "max_longest_sustained_empty_run_steps": int(
+            summary.get("max_longest_sustained_empty_run_steps", 0) or 0
+        ),
+        "avg_dead_air_ratio": (
+            float(sum(dead_air_ratios) / len(dead_air_ratios)) if dead_air_ratios else 0.0
+        ),
+        "max_dead_air_ratio": max(dead_air_ratios) if dead_air_ratios else 0.0,
+        "avg_chord_tone_ratio": (
+            float(sum(chord_tone_ratios) / len(chord_tone_ratios)) if chord_tone_ratios else 0.0
+        ),
         "failure_reasons": summary.get("failure_reasons", {}),
         "diagnostic_failure_reasons": summary.get("diagnostic_failure_reasons", {}),
         "strict_failure_reasons": summary.get("strict_failure_reasons", {}),

--- a/tests/test_stage_b_coverage_ab_sweep.py
+++ b/tests/test_stage_b_coverage_ab_sweep.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.run_stage_b_coverage_ab_sweep import (
+    build_ab_summary,
+    config_run_id,
+    markdown_table,
+    parse_modes,
+)
+
+
+class StageBCoverageAbSweepTest(unittest.TestCase):
+    def test_parse_modes_rejects_unknown_mode(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_modes("plain,random")
+
+    def test_config_run_id_is_stable(self) -> None:
+        self.assertEqual(
+            config_run_id("run", mode="coverage", note_groups_per_bar=6, top_k=2, temperature=0.9),
+            "run_coverage_g6_k2_t0p9",
+        )
+
+    def test_build_ab_summary_requires_coverage_success_and_comparison(self) -> None:
+        rows = [
+            {
+                "mode": "plain",
+                "note_groups_per_bar": 4,
+                "run_id": "plain",
+                "top_k": 2,
+                "temperature": 0.9,
+                "valid_sample_count": 0,
+                "strict_valid_sample_count": 0,
+                "avg_onset_coverage_ratio": 0.167,
+                "avg_sustained_coverage_ratio": 0.417,
+                "collapse_warning_sample_rate": 0.0,
+                "max_longest_sustained_empty_run_steps": 11,
+            },
+            {
+                "mode": "coverage",
+                "note_groups_per_bar": 4,
+                "run_id": "coverage",
+                "top_k": 2,
+                "temperature": 0.9,
+                "valid_sample_count": 3,
+                "strict_valid_sample_count": 3,
+                "avg_onset_coverage_ratio": 0.25,
+                "avg_sustained_coverage_ratio": 0.427,
+                "collapse_warning_sample_rate": 0.0,
+                "max_longest_sustained_empty_run_steps": 6,
+            },
+        ]
+
+        summary = build_ab_summary(rows, min_best_strict_valid_samples=1)
+
+        self.assertTrue(summary["passed_ab_sweep_gate"])
+        self.assertEqual(summary["best_coverage_config"]["strict_valid_sample_count"], 3)
+        self.assertEqual(summary["best_plain_config"]["strict_valid_sample_count"], 0)
+
+    def test_build_ab_summary_fails_without_plain_comparison(self) -> None:
+        rows = [
+            {
+                "mode": "coverage",
+                "note_groups_per_bar": 4,
+                "run_id": "coverage",
+                "top_k": 2,
+                "temperature": 0.9,
+                "valid_sample_count": 3,
+                "strict_valid_sample_count": 3,
+                "avg_onset_coverage_ratio": 0.25,
+                "avg_sustained_coverage_ratio": 0.427,
+                "collapse_warning_sample_rate": 0.0,
+                "max_longest_sustained_empty_run_steps": 6,
+            }
+        ]
+
+        summary = build_ab_summary(rows, min_best_strict_valid_samples=1)
+
+        self.assertFalse(summary["passed_ab_sweep_gate"])
+        self.assertFalse(summary["passed_comparison_gate"])
+
+    def test_markdown_table_records_coverage_columns(self) -> None:
+        rows = [
+            {
+                "mode": "coverage",
+                "note_groups_per_bar": 4,
+                "sample_count": 3,
+                "grammar_gate_sample_count": 3,
+                "valid_sample_count": 3,
+                "strict_valid_sample_count": 3,
+                "avg_onset_coverage_ratio": 0.25,
+                "avg_sustained_coverage_ratio": 0.427,
+                "avg_position_span_ratio": 0.813,
+                "max_longest_sustained_empty_run_steps": 6,
+                "avg_dead_air_ratio": 0.429,
+                "collapse_warning_sample_rate": 0.0,
+                "passed_strict_review_gate": True,
+                "diagnostic_failure_reasons": {},
+            }
+        ]
+        summary = {
+            "passed_ab_sweep_gate": True,
+            "best_plain_config": None,
+            "best_coverage_config": {"mode": "coverage", "note_groups_per_bar": 4},
+        }
+
+        markdown = markdown_table(rows, summary)
+
+        self.assertIn("groups/bar", markdown)
+        self.assertIn("dead air", markdown)
+        self.assertIn("coverage", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

- Stage B plain constrained vs coverage-aware constrained generation A/B sweep를 추가했습니다.
- `groups/bar=4,6,8` 설정을 같은 2-file Brad checkpoint 조건에서 비교합니다.
- 결과를 JSON/Markdown report로 남기고, 문서에 현재 판단을 업데이트했습니다.

## 핵심 결과

- plain strict valid:
  - groups/bar `4`: `0/3`
  - groups/bar `6`: `1/3`
  - groups/bar `8`: `2/3`
- coverage strict valid:
  - groups/bar `4`: `3/3`
  - groups/bar `6`: `3/3`
  - groups/bar `8`: `3/3`
- best config: coverage groups/bar `8`
- best avg onset coverage ratio: `0.500`
- best avg sustained coverage ratio: `0.865`
- best max longest sustained empty run: `1` step

## 판단

Coverage-aware POSITION selection은 현재 2-file Brad Stage B setup에서 plain constrained generation보다 안정적으로 temporal coverage를 개선합니다.

다만 groups/bar를 높이면 chord-tone ratio가 낮아질 수 있으므로, 다음 단계는 strict pass/fail 하나가 아니라 temporal coverage, chord-tone ratio, repetition, density를 함께 보는 candidate ranking/report입니다.

## 검증

- `./.venv/bin/python -m unittest tests.test_stage_b_coverage_ab_sweep tests.test_stage_b_sampling_sweep`
- `./.venv/bin/python -m compileall scripts/run_stage_b_coverage_ab_sweep.py scripts/run_stage_b_sampling_sweep.py scripts/run_stage_b_generation_probe.py`
- `bash scripts/agent_harness.sh quick`
- `bash scripts/agent_harness.sh stage-b-coverage-ab-sweep`

Closes #39
