### PR TITLE
Stage B candidate ranking report 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #39: Stage B coverage-aware A/B sweep.
+- Issue #41: Stage B candidate ranking report.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -195,6 +195,14 @@ bash scripts/agent_harness.sh stage-b-coverage-ab-sweep
 
 This probe compares plain constrained generation against coverage-aware constrained generation
 across note-group density settings.
+
+For Stage B candidate ranking changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-candidate-ranking
+```
+
+This harness generates an A/B sweep and ranks generated MIDI candidates for listening/review priority.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -122,15 +122,17 @@ Stage B에서 명시하는 것:
 16. Stage B temporal coverage diagnostics
 17. Stage B coverage-aware constrained generation probe
 18. Stage B coverage-aware A/B sweep
+19. Stage B candidate ranking report
 
 가장 최근 의미 있는 결과:
 
-- coverage-aware constrained A/B sweep: coverage mode가 groups/bar `4`, `6`, `8` 모두에서 strict `3/3` 통과
-- plain constrained mode는 groups/bar `4`, `6`, `8`에서 각각 strict `0/3`, `1/3`, `2/3`
-- best config는 coverage groups/bar `8`
-- best avg onset coverage ratio: `0.500`
-- best avg sustained coverage ratio: `0.865`
-- best max longest sustained empty run: `1` step
+- candidate ranking report가 A/B sweep의 sample-level MIDI 후보를 score로 정렬함
+- top candidate: coverage groups/bar `8`, sample `1`
+- top candidate score: `91.080`
+- top candidate onset coverage: `0.500`
+- top candidate sustained coverage: `0.906`
+- top candidate dead-air ratio: `0.467`
+- top candidate chord-tone ratio: `0.313`
 - 하지만 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않음
 
 중요한 해석:
@@ -149,7 +151,7 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-다음 단계는 strict pass/fail 하나가 아니라 temporal coverage, chord-tone ratio, repetition, density를 함께 보는 candidate ranking/report를 만드는 것이다.
+다음 단계는 top ranked MIDI 후보를 실제로 듣고 piano roll로 확인하는 것이다. 귀로도 약하면 chord-aware pitch filtering 또는 chord-tone/tension-aware ranking을 먼저 한다.
 
 ## 6. 다음 단계 로드맵
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-39-stage-b-coverage-ab-sweep`
+- `issue-41-stage-b-candidate-ranking`
 
 현재 범위가 아닌 것:
 
@@ -36,35 +36,32 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 ## Latest Probe Result
 
-Issue #39에서 Brad Mehldau real MIDI 2파일 Stage B setup으로 plain constrained vs coverage-aware constrained A/B sweep을 실행했다.
+Issue #41에서 Stage B A/B sweep 결과를 기반으로 generated MIDI candidate ranking report를 만들었다.
 
 Result:
 
-- compared configs: `plain/coverage` x groups/bar `4/6/8`
-- all configs grammar gate: `3/3`
-- plain strict valid:
-  - groups/bar `4`: `0/3`
-  - groups/bar `6`: `1/3`
-  - groups/bar `8`: `2/3`
-- coverage strict valid:
-  - groups/bar `4`: `3/3`
-  - groups/bar `6`: `3/3`
-  - groups/bar `8`: `3/3`
-- best config: coverage groups/bar `8`
-- best avg onset coverage ratio: `0.500`
-- best avg sustained coverage ratio: `0.865`
-- best max longest sustained empty run: `1` step
+- candidate ranking harness 실행 성공
+- ranking input: coverage A/B sweep report
+- top candidate: coverage groups/bar `8`, sample `1`
+- top candidate score: `91.080`
+- top candidate strict valid: `true`
+- top candidate note count: `16`
+- top candidate onset coverage ratio: `0.500`
+- top candidate sustained coverage ratio: `0.906`
+- top candidate dead-air ratio: `0.467`
+- top candidate chord-tone ratio: `0.313`
 
 Decision:
 
-- coverage-aware constrained `POSITION` selection은 plain constrained보다 안정적으로 temporal coverage를 개선한다.
-- `groups/bar=8`이 temporal coverage는 가장 좋지만 chord-tone ratio는 낮아질 수 있다.
+- candidate ranking은 listening/piano-roll review 우선순위를 정하는 데 쓸 수 있다.
+- top ranked candidates는 coverage groups/bar `8`에 집중된다.
 - 하지만 이것은 unconstrained model quality나 Brad style adaptation 성공이 아니다.
-- 다음은 strict pass/fail만 보지 말고 coverage, chord-tone ratio, repetition, density를 함께 보는 candidate ranking/report를 만든다.
+- 다음은 top ranked MIDI 후보를 실제로 듣고 piano roll로 확인한다.
+- 만약 화성감이 약하면 chord-aware pitch filtering 또는 chord-tone/tension-aware ranking을 먼저 한다.
 
 Detail:
 
-- `docs/STAGE_B_COVERAGE_AB_SWEEP_2026-05-20.md`
+- `docs/STAGE_B_CANDIDATE_RANKING_2026-05-20.md`
 
 ## Active Issue #14
 
@@ -917,6 +914,42 @@ Detail:
 
 - `docs/STAGE_B_COVERAGE_AB_SWEEP_2026-05-20.md`
 
+### 0.19. Issue #41 Stage B candidate ranking report
+
+Status:
+
+- implemented on `issue-41-stage-b-candidate-ranking`
+
+Goal:
+
+- rank generated MIDI candidates from A/B sweep reports
+- include strict validity, temporal coverage, dead-air, chord-tone ratio, repetition, pitch diversity, and collapse warning in the score
+- produce JSON/Markdown reports for listening/review priority
+
+Smoke result:
+
+- output: `outputs/stage_b_candidate_ranking/harness_stage_b_candidate_ranking`
+- top candidate: coverage groups/bar `8`, sample `1`
+- score: `91.080`
+- strict valid: `true`
+- note count: `16`
+- onset coverage ratio: `0.500`
+- sustained coverage ratio: `0.906`
+- dead-air ratio: `0.467`
+- chord-tone ratio: `0.313`
+
+Decision:
+
+- Use this report to choose which generated MIDI files to inspect by ear and piano roll.
+- The score is a review-prioritization heuristic, not a musical-quality claim.
+- Next issue depends on listening review:
+  - if rhythm/shape is acceptable but harmony is weak, add chord-aware pitch filtering/ranking
+  - if the line is still mechanically patterned, revisit generation constraints before broad training
+
+Detail:
+
+- `docs/STAGE_B_CANDIDATE_RANKING_2026-05-20.md`
+
 ### 1. Run full jazz piano dataset audit
 
 ```bash
@@ -1058,6 +1091,7 @@ Decision:
 - `docs/STAGE_B_TEMPORAL_COVERAGE_DIAGNOSTICS_2026-05-20.md`
 - `docs/STAGE_B_COVERAGE_AWARE_GENERATION_2026-05-20.md`
 - `docs/STAGE_B_COVERAGE_AB_SWEEP_2026-05-20.md`
+- `docs/STAGE_B_CANDIDATE_RANKING_2026-05-20.md`
 - `docs/REFERENCES.md`
 - `docs/INFERENCE_MODEL_SPEC.md`
 - `docs/QA_ACCEPTANCE_PLAN.md`
@@ -1134,4 +1168,10 @@ For Stage B coverage-aware A/B sweep changes:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-coverage-ab-sweep
+```
+
+For Stage B candidate ranking changes:
+
+```bash
+bash scripts/agent_harness.sh stage-b-candidate-ranking
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,8 @@
   - Stage B coverage-aware constrained `POSITION` generation result and dead-air gate comparison.
 - `STAGE_B_COVERAGE_AB_SWEEP_2026-05-20.md`
   - Stage B plain-vs-coverage A/B sweep across note-group density settings.
+- `STAGE_B_CANDIDATE_RANKING_2026-05-20.md`
+  - Stage B generated MIDI candidate ranking report for listening/review priority.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -76,7 +78,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, and coverage-aware A/B sweep를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, and candidate ranking을 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_CANDIDATE_RANKING_2026-05-20.md
+++ b/docs/STAGE_B_CANDIDATE_RANKING_2026-05-20.md
@@ -1,0 +1,129 @@
+# Stage B Candidate Ranking
+
+작성일: 2026-05-20
+
+## Issue
+
+- Issue: #41
+- Branch: `issue-41-stage-b-candidate-ranking`
+- Goal: Stage B generated MIDI candidates를 strict pass/fail 하나가 아니라 여러 지표로 ranking한다.
+
+## Why
+
+Issue #39에서 coverage-aware constrained generation은 plain constrained generation보다 temporal coverage를 안정적으로 개선했다.
+
+하지만 tradeoff가 있었다.
+
+- coverage groups/bar `8`은 temporal coverage가 가장 좋다.
+- coverage groups/bar `4`는 chord-tone ratio가 더 높을 수 있다.
+- strict gate 통과만으로 어떤 MIDI를 먼저 들어야 하는지 결정하기 어렵다.
+
+따라서 candidate ranking report가 필요하다.
+
+## Implementation
+
+Added:
+
+- `scripts/rank_stage_b_candidates.py`
+- `tests/test_stage_b_candidate_ranking.py`
+- `bash scripts/agent_harness.sh stage-b-candidate-ranking`
+
+The ranking script reads an A/B sweep report, then loads each config-level `report.json` and ranks sample-level MIDI candidates.
+
+Inputs:
+
+```text
+outputs/stage_b_coverage_ab_sweep/<run_id>/ab_sweep_report.json
+```
+
+Outputs:
+
+```text
+outputs/stage_b_candidate_ranking/<run_id>/candidate_rank_report.json
+outputs/stage_b_candidate_ranking/<run_id>/candidate_rank_report.md
+```
+
+Generated MIDI artifacts remain local and are not committed.
+
+## Scoring
+
+The score is a review-prioritization heuristic.
+
+It rewards:
+
+- strict validity
+- basic validity
+- grammar validity
+- onset coverage
+- sustained coverage
+- position span
+- chord-tone ratio
+- pitch diversity
+
+It penalizes:
+
+- dead-air ratio
+- repetition score
+- postprocess removal ratio
+- collapse warning
+
+This score is not a musical-quality claim.
+
+## Harness Result
+
+Command:
+
+```bash
+bash scripts/agent_harness.sh stage-b-candidate-ranking
+```
+
+Top candidate:
+
+| Field | Value |
+|---|---:|
+| mode | coverage |
+| groups/bar | 8 |
+| sample index | 1 |
+| score | 91.080 |
+| strict valid | true |
+| note count | 16 |
+| unique pitches | 3 |
+| onset coverage | 0.500 |
+| sustained coverage | 0.906 |
+| position span | 0.938 |
+| longest sustained empty run | 1 |
+| dead-air ratio | 0.467 |
+| repetition score | 0.154 |
+| chord-tone ratio | 0.313 |
+
+Top candidate MIDI path:
+
+```text
+outputs/stage_b_coverage_ab_sweep/harness_stage_b_candidate_ranking_ab_sweep_coverage_g8_k2_t0p9/samples/stage_b_sample_1.mid
+```
+
+Top ranking pattern:
+
+- ranks 1-3: coverage groups/bar `8`
+- ranks 4-6: coverage groups/bar `6`
+- ranks 7-9: coverage groups/bar `4`
+- lower ranks include plain configs that passed strict gate but had worse dead-air/postprocess behavior
+
+## Decision
+
+The next review step should be listening/piano-roll inspection of top ranked candidates.
+
+Do not start broad generic jazz training yet unless the top ranked candidates are at least structurally acceptable by ear and piano roll.
+
+If the top candidates still sound harmonically weak, the next issue should be chord-aware pitch candidate filtering or chord-tone/tension-aware ranking.
+
+## Validation
+
+Commands run:
+
+```bash
+./.venv/bin/python -m unittest tests.test_stage_b_candidate_ranking
+./.venv/bin/python -m compileall scripts/rank_stage_b_candidates.py
+bash scripts/agent_harness.sh quick
+bash scripts/agent_harness.sh stage-b-candidate-ranking
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -46,6 +46,8 @@ Modes:
                 Run a two-file Brad Stage B coverage-aware generation probe.
   stage-b-coverage-ab-sweep
                 Run plain vs coverage-aware Stage B constrained generation sweep.
+  stage-b-candidate-ranking
+                Run coverage A/B sweep and rank generated MIDI candidates.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   all           Run demo and tiny-compare.
@@ -85,6 +87,7 @@ run_quick() {
     scripts/run_stage_b_generation_probe.py \
     scripts/run_stage_b_sampling_sweep.py \
     scripts/run_stage_b_coverage_ab_sweep.py \
+    scripts/rank_stage_b_candidates.py \
     scripts/audit_brad_mehldau_dataset.py \
     scripts/audit_jazz_piano_dataset.py \
     scripts/build_jazz_training_manifests.py \
@@ -364,6 +367,43 @@ run_stage_b_coverage_ab_sweep() {
     --lora_alpha 8
 }
 
+run_stage_b_candidate_ranking() {
+  local run_id="${RUN_ID:-harness_stage_b_candidate_ranking}"
+  local sweep_run_id="${run_id}_ab_sweep"
+  print_header "Stage B candidate ranking"
+  "$PYTHON_BIN" scripts/run_stage_b_coverage_ab_sweep.py \
+    --run_id "$sweep_run_id" \
+    --issue_number 41 \
+    --max_files 2 \
+    --epochs 3 \
+    --batch_size 8 \
+    --max_sequence 96 \
+    --num_samples 3 \
+    --modes plain,coverage \
+    --note_groups_per_bar_values 4,6,8 \
+    --coverage_position_window 0 \
+    --max_simultaneous_notes 2 \
+    --temperature 0.9 \
+    --top_k 2 \
+    --min_valid_samples 1 \
+    --min_strict_valid_samples 1 \
+    --min_best_strict_valid_samples 1 \
+    --max_collapse_warning_sample_rate 0.34 \
+    --require_all_grammar_samples \
+    --n_layers 1 \
+    --num_heads 4 \
+    --d_model 64 \
+    --dim_feedforward 128 \
+    --lora_r 4 \
+    --lora_alpha 8
+  "$PYTHON_BIN" scripts/rank_stage_b_candidates.py \
+    --run_id "$run_id" \
+    --issue_number 41 \
+    --ab_sweep_report "outputs/stage_b_coverage_ab_sweep/${sweep_run_id}/ab_sweep_report.json" \
+    --top_n 12 \
+    --min_top_strict_candidates 1
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -420,6 +460,9 @@ case "$MODE" in
     ;;
   stage-b-coverage-ab-sweep)
     run_stage_b_coverage_ab_sweep
+    ;;
+  stage-b-candidate-ranking)
+    run_stage_b_candidate_ranking
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/rank_stage_b_candidates.py
+++ b/scripts/rank_stage_b_candidates.py
@@ -1,0 +1,229 @@
+"""Rank Stage B generated MIDI candidates from an A/B sweep report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def score_candidate(sample: dict[str, Any]) -> dict[str, Any]:
+    metrics = sample.get("metrics", {})
+    collapse = sample.get("collapse", {})
+    temporal = sample.get("temporal_coverage", {})
+    valid = bool(sample.get("valid"))
+    strict_valid = bool(sample.get("strict_valid"))
+    grammar_valid = bool(sample.get("grammar_gate_passed"))
+    dead_air_ratio = _float(metrics.get("dead_air_ratio"))
+    repetition_score = _float(metrics.get("repetition_score"))
+    chord_tone_ratio = _float(metrics.get("chord_tone_ratio"))
+    unique_pitch_count = _int(metrics.get("unique_pitch_count"))
+    onset_coverage_ratio = _float(temporal.get("onset_coverage_ratio"))
+    sustained_coverage_ratio = _float(temporal.get("sustained_coverage_ratio"))
+    position_span_ratio = _float(temporal.get("position_span_ratio"))
+    collapse_warning = bool(collapse.get("collapse_warning"))
+    postprocess_removal_ratio = _float(collapse.get("postprocess_removal_ratio"))
+
+    components = {
+        "strict_valid_bonus": 40.0 if strict_valid else 0.0,
+        "valid_bonus": 20.0 if valid else 0.0,
+        "grammar_bonus": 10.0 if grammar_valid else 0.0,
+        "onset_coverage_bonus": onset_coverage_ratio * 20.0,
+        "sustained_coverage_bonus": sustained_coverage_ratio * 10.0,
+        "position_span_bonus": position_span_ratio * 5.0,
+        "chord_tone_bonus": chord_tone_ratio * 10.0,
+        "pitch_diversity_bonus": min(unique_pitch_count, 6) * 2.0,
+        "dead_air_penalty": dead_air_ratio * -20.0,
+        "repetition_penalty": repetition_score * -8.0,
+        "postprocess_penalty": postprocess_removal_ratio * -10.0,
+        "collapse_warning_penalty": -25.0 if collapse_warning else 0.0,
+    }
+    score = round(sum(components.values()), 4)
+    return {"score": score, "score_components": components}
+
+
+def candidate_from_sample(row: dict[str, Any], sample: dict[str, Any], report_path: Path) -> dict[str, Any]:
+    metrics = sample.get("metrics", {})
+    temporal = sample.get("temporal_coverage", {})
+    collapse = sample.get("collapse", {})
+    scored = score_candidate(sample)
+    return {
+        "score": scored["score"],
+        "score_components": scored["score_components"],
+        "mode": row.get("mode"),
+        "note_groups_per_bar": _int(row.get("note_groups_per_bar")),
+        "run_id": row.get("run_id"),
+        "sample_index": _int(sample.get("sample_index")),
+        "midi_path": sample.get("midi_path"),
+        "report_path": str(report_path),
+        "valid": bool(sample.get("valid")),
+        "strict_valid": bool(sample.get("strict_valid")),
+        "grammar_gate_passed": bool(sample.get("grammar_gate_passed")),
+        "failure_reason": sample.get("failure_reason"),
+        "diagnostic_failure_reason": sample.get("diagnostic_failure_reason"),
+        "note_count": _int(metrics.get("note_count")),
+        "unique_pitch_count": _int(metrics.get("unique_pitch_count")),
+        "dead_air_ratio": _float(metrics.get("dead_air_ratio")),
+        "repetition_score": _float(metrics.get("repetition_score")),
+        "chord_tone_ratio": _float(metrics.get("chord_tone_ratio")),
+        "onset_coverage_ratio": _float(temporal.get("onset_coverage_ratio")),
+        "sustained_coverage_ratio": _float(temporal.get("sustained_coverage_ratio")),
+        "position_span_ratio": _float(temporal.get("position_span_ratio")),
+        "longest_sustained_empty_run_steps": _int(temporal.get("longest_sustained_empty_run_steps")),
+        "collapse_warning": bool(collapse.get("collapse_warning")),
+        "postprocess_removal_ratio": _float(collapse.get("postprocess_removal_ratio")),
+    }
+
+
+def collect_candidates(ab_report: dict[str, Any]) -> tuple[list[dict[str, Any]], list[str]]:
+    candidates: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    for row in ab_report.get("rows", []):
+        report_path = Path(str(row.get("report_path", "")))
+        if not report_path.is_absolute():
+            report_path = ROOT_DIR / report_path
+        if not report_path.exists():
+            warnings.append(f"missing report: {report_path}")
+            continue
+        probe_report = read_json(report_path)
+        for sample in probe_report.get("samples", []):
+            candidates.append(candidate_from_sample(row, sample, report_path))
+    return candidates, warnings
+
+
+def rank_candidates(candidates: list[dict[str, Any]], top_n: int) -> list[dict[str, Any]]:
+    ranked = sorted(
+        candidates,
+        key=lambda candidate: (
+            float(candidate["score"]),
+            bool(candidate["strict_valid"]),
+            bool(candidate["valid"]),
+            float(candidate["onset_coverage_ratio"]),
+            float(candidate["chord_tone_ratio"]),
+            -float(candidate["dead_air_ratio"]),
+        ),
+        reverse=True,
+    )
+    top = ranked[: max(1, int(top_n))]
+    for index, candidate in enumerate(top, start=1):
+        candidate["rank"] = index
+    return top
+
+
+def build_summary(candidates: list[dict[str, Any]], top_candidates: list[dict[str, Any]]) -> dict[str, Any]:
+    strict_candidates = [candidate for candidate in candidates if candidate["strict_valid"]]
+    valid_candidates = [candidate for candidate in candidates if candidate["valid"]]
+    top_strict = [candidate for candidate in top_candidates if candidate["strict_valid"]]
+    return {
+        "candidate_count": int(len(candidates)),
+        "valid_candidate_count": int(len(valid_candidates)),
+        "strict_candidate_count": int(len(strict_candidates)),
+        "top_candidate_count": int(len(top_candidates)),
+        "top_strict_candidate_count": int(len(top_strict)),
+        "best_candidate": top_candidates[0] if top_candidates else None,
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    lines = [
+        "# Stage B Candidate Ranking",
+        "",
+        f"- candidate count: `{summary['candidate_count']}`",
+        f"- valid candidates: `{summary['valid_candidate_count']}`",
+        f"- strict candidates: `{summary['strict_candidate_count']}`",
+        "",
+        "| rank | score | mode | groups/bar | sample | strict | notes | onset | sustained | dead-air | chord-tone | MIDI |",
+        "|---:|---:|---|---:|---:|:---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for candidate in report["top_candidates"]:
+        lines.append(
+            "| {rank} | {score:.3f} | {mode} | {note_groups_per_bar} | {sample_index} | "
+            "{strict_valid} | {note_count} | {onset_coverage_ratio:.3f} | "
+            "{sustained_coverage_ratio:.3f} | {dead_air_ratio:.3f} | "
+            "{chord_tone_ratio:.3f} | `{midi_path}` |".format(**candidate)
+        )
+    lines.append("")
+    lines.append("## Scoring Note")
+    lines.append("")
+    lines.append("This score is a review-prioritization heuristic, not a musical-quality claim.")
+    lines.append("It rewards strict validity, temporal coverage, chord-tone ratio, and pitch diversity.")
+    lines.append("It penalizes dead-air, repetition, postprocess removal, and collapse warnings.")
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Rank Stage B candidate MIDI samples from an A/B sweep")
+    parser.add_argument(
+        "--ab_sweep_report",
+        type=str,
+        default=str(
+            ROOT_DIR
+            / "outputs"
+            / "stage_b_coverage_ab_sweep"
+            / "harness_stage_b_coverage_ab_sweep"
+            / "ab_sweep_report.json"
+        ),
+    )
+    parser.add_argument("--output_root", type=str, default=str(ROOT_DIR / "outputs" / "stage_b_candidate_ranking"))
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--issue_number", type=int, default=41)
+    parser.add_argument("--top_n", type=int, default=12)
+    parser.add_argument("--min_top_strict_candidates", type=int, default=1)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now().strftime("%Y%m%d_%H%M%S")
+    run_dir = Path(args.output_root) / run_id
+    ab_report_path = Path(args.ab_sweep_report)
+    ab_report = read_json(ab_report_path)
+    candidates, warnings = collect_candidates(ab_report)
+    top_candidates = rank_candidates(candidates, top_n=args.top_n)
+    summary = build_summary(candidates, top_candidates)
+    report = {
+        "run_id": run_id,
+        "run_dir": str(run_dir),
+        "issue": int(args.issue_number),
+        "ab_sweep_report": str(ab_report_path),
+        "summary": summary,
+        "warnings": warnings,
+        "top_candidates": top_candidates,
+    }
+    write_json(run_dir / "candidate_rank_report.json", report)
+    (run_dir / "candidate_rank_report.md").write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps(report, ensure_ascii=True, indent=2))
+    return 0 if int(summary["top_strict_candidate_count"]) >= int(args.min_top_strict_candidates) else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_candidate_ranking.py
+++ b/tests/test_stage_b_candidate_ranking.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.rank_stage_b_candidates import build_summary, rank_candidates, score_candidate
+
+
+class StageBCandidateRankingTest(unittest.TestCase):
+    def test_score_candidate_rewards_strict_temporal_and_chord_tone_quality(self) -> None:
+        weak = {
+            "valid": False,
+            "strict_valid": False,
+            "grammar_gate_passed": True,
+            "metrics": {
+                "dead_air_ratio": 0.8,
+                "repetition_score": 0.5,
+                "chord_tone_ratio": 0.2,
+                "unique_pitch_count": 2,
+            },
+            "temporal_coverage": {
+                "onset_coverage_ratio": 0.1,
+                "sustained_coverage_ratio": 0.3,
+                "position_span_ratio": 0.5,
+            },
+            "collapse": {"collapse_warning": True, "postprocess_removal_ratio": 0.5},
+        }
+        strong = {
+            "valid": True,
+            "strict_valid": True,
+            "grammar_gate_passed": True,
+            "metrics": {
+                "dead_air_ratio": 0.4,
+                "repetition_score": 0.1,
+                "chord_tone_ratio": 0.5,
+                "unique_pitch_count": 4,
+            },
+            "temporal_coverage": {
+                "onset_coverage_ratio": 0.5,
+                "sustained_coverage_ratio": 0.8,
+                "position_span_ratio": 0.9,
+            },
+            "collapse": {"collapse_warning": False, "postprocess_removal_ratio": 0.0},
+        }
+
+        self.assertGreater(score_candidate(strong)["score"], score_candidate(weak)["score"])
+
+    def test_rank_candidates_orders_by_score(self) -> None:
+        candidates = [
+            {
+                "score": 10.0,
+                "strict_valid": False,
+                "valid": True,
+                "onset_coverage_ratio": 0.2,
+                "chord_tone_ratio": 0.4,
+                "dead_air_ratio": 0.7,
+            },
+            {
+                "score": 20.0,
+                "strict_valid": True,
+                "valid": True,
+                "onset_coverage_ratio": 0.5,
+                "chord_tone_ratio": 0.3,
+                "dead_air_ratio": 0.4,
+            },
+        ]
+
+        ranked = rank_candidates(candidates, top_n=2)
+
+        self.assertEqual(ranked[0]["score"], 20.0)
+        self.assertEqual(ranked[0]["rank"], 1)
+
+    def test_build_summary_counts_strict_candidates(self) -> None:
+        candidates = [
+            {"valid": True, "strict_valid": True},
+            {"valid": True, "strict_valid": False},
+        ]
+        top = [{"valid": True, "strict_valid": True}]
+
+        summary = build_summary(candidates, top)
+
+        self.assertEqual(summary["candidate_count"], 2)
+        self.assertEqual(summary["valid_candidate_count"], 2)
+        self.assertEqual(summary["strict_candidate_count"], 1)
+        self.assertEqual(summary["top_strict_candidate_count"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

- Stage B A/B sweep 결과에서 sample-level generated MIDI 후보를 ranking하는 report를 추가했습니다.
- score는 strict validity, temporal coverage, chord-tone ratio, pitch diversity를 보상하고 dead-air, repetition, postprocess removal, collapse warning을 감점합니다.
- 점수는 음악적 정답이 아니라 listening/piano-roll review 우선순위용 heuristic으로 문서화했습니다.

## 핵심 결과

- ranking harness: `bash scripts/agent_harness.sh stage-b-candidate-ranking`
- top candidate: coverage groups/bar `8`, sample `1`
- score: `91.080`
- strict valid: `true`
- note count: `16`
- onset coverage: `0.500`
- sustained coverage: `0.906`
- dead-air ratio: `0.467`
- chord-tone ratio: `0.313`

## 다음 판단

다음 단계는 top ranked MIDI 후보를 실제로 듣고 piano roll로 확인하는 것입니다.

귀로 들었을 때 화성감이 약하면 chord-aware pitch filtering 또는 chord-tone/tension-aware ranking을 먼저 해야 합니다.

## 검증

- `./.venv/bin/python -m unittest tests.test_stage_b_candidate_ranking`
- `./.venv/bin/python -m compileall scripts/rank_stage_b_candidates.py`
- `bash scripts/agent_harness.sh quick`
- `bash scripts/agent_harness.sh stage-b-candidate-ranking`

Closes #41


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Stage B candidate ranking capability with multi-metric scoring (coverage, chord-tone ratio, pitch diversity) and penalty assessments.
  * New harness mode for executing candidate ranking analysis against A/B sweep results.

* **Documentation**
  * Updated workflow documentation to include candidate ranking stage before model training decisions.
  * Added candidate ranking report documentation with scoring methodology and review guidance.
  * Updated project status and execution order references to reflect new ranking stage.

* **Tests**
  * Added test coverage for candidate scoring, ranking, and summary generation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohhalim/fine_tuning_art-tatum_midi_solo/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->