### PR TITLE
Stage B ranking harmonic/repetition gate 수정

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #41: Stage B candidate ranking report.
+- Issue #43: Stage B candidate ranking harmonic/repetition gate.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -1,6 +1,6 @@
 # Core Plan
 
-작성일: 2026-05-20
+작성일: 2026-05-21
 
 이 문서는 이 저장소의 기준 문서다.
 
@@ -123,17 +123,16 @@ Stage B에서 명시하는 것:
 17. Stage B coverage-aware constrained generation probe
 18. Stage B coverage-aware A/B sweep
 19. Stage B candidate ranking report
+20. Stage B ranking harmonic/repetition gate
 
 가장 최근 의미 있는 결과:
 
-- candidate ranking report가 A/B sweep의 sample-level MIDI 후보를 score로 정렬함
-- top candidate: coverage groups/bar `8`, sample `1`
-- top candidate score: `91.080`
-- top candidate onset coverage: `0.500`
-- top candidate sustained coverage: `0.906`
-- top candidate dead-air ratio: `0.467`
-- top candidate chord-tone ratio: `0.313`
-- 하지만 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않음
+- Issue #41 ranking은 coverage groups/bar `8`, sample `1`을 top candidate로 올렸다.
+- piano-roll review 결과, 이 sample은 solo-line으로 보기 어려웠다.
+- Issue #43은 candidate MIDI를 직접 읽어 harmonic/repetition diagnostics를 추가했다.
+- latest ranking result: candidates `18`, strict candidates `12`, viable unflagged candidates `0`, flagged candidates `18`
+- 현재 결과는 "좋은 MIDI 후보를 찾았다"가 아니라 "기존 strict/ranking 기준이 아직 너무 관대했다"는 증거다.
+- 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
 
@@ -151,7 +150,7 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-다음 단계는 top ranked MIDI 후보를 실제로 듣고 piano roll로 확인하는 것이다. 귀로도 약하면 chord-aware pitch filtering 또는 chord-tone/tension-aware ranking을 먼저 한다.
+다음 단계는 generation-side harmony control이다. 우선 chord-aware pitch constrained generation 또는 chord-tone/tension-aware pitch candidate filter를 검증한다.
 
 ## 6. 다음 단계 로드맵
 
@@ -235,6 +234,25 @@ Stage B에서 명시하는 것:
 - completed: plain constrained vs coverage-aware constrained A/B sweep을 같은 checkpoint 조건에서 비교했다.
 - completed: `note_groups_per_bar=4/6/8`을 비교했다.
 - next: pass-rate가 좋아져도 이것을 style learning 성공으로 표현하지 않고 candidate ranking 기준을 추가한다.
+
+### Phase 3.6. Harmonic Candidate Gate and Pitch Control
+
+목표:
+
+- strict gate를 통과했지만 실제 piano roll에서 solo-line이 아닌 후보를 걸러낸다.
+- bar-level chord-tone ratio, dominant pitch ratio, repeated pitch ratio, repeated onset-template ratio를 ranking에 반영한다.
+- ranking만 보정하지 않고 generation-side pitch/harmony 제어로 넘어갈 기준을 만든다.
+
+현재 결과:
+
+- completed: ranking이 candidate MIDI를 직접 읽어 harmonic/repetition diagnostics를 계산한다.
+- completed: low chord-tone/repeated pitch/mechanical template 후보에 review flags를 붙인다.
+- latest result: `18` candidates 중 viable unflagged candidate `0`.
+
+다음 통과 기준:
+
+- chord-aware pitch constrained generation에서 viable unflagged candidate가 최소 1개 이상 나온다.
+- 그 후보는 piano roll에서 one-note/two-note/chord-block/long-sustain/repeated-template 실패가 없어야 한다.
 
 ### Phase 4. Generic Jazz Base 후보 학습
 
@@ -339,21 +357,21 @@ Stage B에서 명시하는 것:
 다음 issue는 다음 이름이 적절하다.
 
 ```text
-Stage B coverage-aware constrained generation 추가
+Stage B chord-aware pitch constrained generation 추가
 ```
 
 작업 범위:
 
-- constrained generation에서 position family만 coverage-aware 후보군을 줄 수 있는지 실험한다.
-- 각 bar에 최소 onset position 수를 강제하거나 권장하는 옵션을 만든다.
-- duration/pitch/velocity는 여전히 model logits에서 뽑아 model behavior를 유지한다.
-- dead-air ratio와 onset/sustained coverage가 개선되는지 2-file Brad probe에서 비교한다.
+- constrained generation에서 pitch 후보군을 현재 bar chord에 맞게 제한하거나 가중한다.
+- chord tones와 허용 tension을 구분한다.
+- dominant pitch repetition과 low pitch variety를 동시에 줄인다.
+- temporal coverage는 유지하면서 bar-level chord-tone ratio가 개선되는지 비교한다.
 - 과한 postprocess로 모델 성공처럼 보이게 만들지 않는다.
 
 이 작업이 끝난 뒤 판단:
 
-- coverage-aware constrained probe로 basic/strict valid sample이 회복되면 Stage B 2-file Brad probe를 다시 고정하고 generic jazz base 후보 학습 설계로 간다.
-- coverage-aware constrained probe에서도 실패하면 data scale, representation, loss, pretrained-base 쪽으로 재검토한다.
+- chord-aware pitch probe에서 viable unflagged candidate가 나오면 Stage B 2-file Brad probe를 다시 고정하고 generic jazz base 후보 학습 설계로 간다.
+- chord-aware pitch probe에서도 실패하면 data scale, representation, loss, pretrained-base 쪽으로 재검토한다.
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -1,6 +1,6 @@
 # Current Status and Plan
 
-작성일: 2026-05-20
+작성일: 2026-05-21
 
 ## Current Focus
 
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-41-stage-b-candidate-ranking`
+- `issue-43-stage-b-ranking-harmonic-gate`
 
 현재 범위가 아닌 것:
 
@@ -36,32 +36,53 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 ## Latest Probe Result
 
-Issue #41에서 Stage B A/B sweep 결과를 기반으로 generated MIDI candidate ranking report를 만들었다.
+Issue #43에서 Stage B candidate ranking을 다시 검토했다.
+
+Issue #41의 top candidate는 숫자상 strict valid였지만, piano roll 확인 결과 solo-line으로 보기 어려웠다.
+
+Observed top-candidate failure:
+
+- note count는 `16`이지만 unique pitches는 `3`뿐이었다.
+- `G#4`, `F#4`, `D5` 중심의 반복 패턴이었다.
+- onset template이 bar마다 기계적으로 반복됐다.
+- bar-level chord-tone ratio가 낮은 구간이 있었다.
+- 따라서 "strict valid"와 "ranking score high"만으로 listening candidate라고 볼 수 없다.
 
 Result:
 
-- candidate ranking harness 실행 성공
-- ranking input: coverage A/B sweep report
-- top candidate: coverage groups/bar `8`, sample `1`
-- top candidate score: `91.080`
-- top candidate strict valid: `true`
-- top candidate note count: `16`
-- top candidate onset coverage ratio: `0.500`
-- top candidate sustained coverage ratio: `0.906`
-- top candidate dead-air ratio: `0.467`
-- top candidate chord-tone ratio: `0.313`
+- ranking script가 MIDI 파일을 직접 읽어 harmonic/repetition diagnostics를 계산한다.
+- 새 diagnostics:
+  - bar-level chord-tone ratio
+  - minimum per-bar chord-tone ratio
+  - dominant pitch ratio
+  - repeated pitch ratio
+  - repeated onset-template ratio
+- review flags:
+  - `low_chord_tone_ratio`
+  - `low_bar_chord_tone_ratio`
+  - `dominant_pitch_repetition`
+  - `low_pitch_variety`
+  - `repeated_onset_template`
+- latest harness result:
+  - candidates: `18`
+  - strict candidates: `12`
+  - viable unflagged candidates: `0`
+  - flagged candidates: `18`
 
 Decision:
 
-- candidate ranking은 listening/piano-roll review 우선순위를 정하는 데 쓸 수 있다.
-- top ranked candidates는 coverage groups/bar `8`에 집중된다.
-- 하지만 이것은 unconstrained model quality나 Brad style adaptation 성공이 아니다.
-- 다음은 top ranked MIDI 후보를 실제로 듣고 piano roll로 확인한다.
-- 만약 화성감이 약하면 chord-aware pitch filtering 또는 chord-tone/tension-aware ranking을 먼저 한다.
+- 현재 Stage B generated MIDI는 아직 좋은 listening candidate가 아니다.
+- ranking은 "좋은 샘플을 찾았다"가 아니라 "현재 샘플들이 왜 아직 탈락인지 설명한다"는 용도다.
+- 다음 작업은 ranking을 더 꾸미는 것이 아니라 generation-side fix다.
+- 우선 후보:
+  - chord-aware pitch constrained generation
+  - chord-tone/tension-aware pitch candidate filter
+  - bar-level harmonic coverage gate
 
 Detail:
 
 - `docs/STAGE_B_CANDIDATE_RANKING_2026-05-20.md`
+- `docs/STAGE_B_RANKING_HARMONIC_GATE_2026-05-21.md`
 
 ## Active Issue #14
 
@@ -949,6 +970,42 @@ Decision:
 Detail:
 
 - `docs/STAGE_B_CANDIDATE_RANKING_2026-05-20.md`
+
+### 0.20. Issue #43 Stage B ranking harmonic/repetition gate
+
+Status:
+
+- implemented on `issue-43-stage-b-ranking-harmonic-gate`
+
+Goal:
+
+- stop ranking from promoting MIDI that only looks good by temporal coverage
+- read each candidate MIDI directly before scoring
+- flag low chord-tone, repeated pitch, and repeated bar-template failures
+
+Review trigger:
+
+- Issue #41 ranked coverage groups/bar `8`, sample `1` as top candidate.
+- Piano-roll review showed it was not a usable solo-line candidate.
+- The sample had too little pitch variety and too much repeated mechanical structure.
+
+Latest harness result:
+
+- candidate count: `18`
+- valid candidates: `12`
+- strict candidates: `12`
+- viable candidates without review flags: `0`
+- flagged candidates: `18`
+
+Decision:
+
+- Do not treat any current Stage B candidate as a good listening sample.
+- The ranking report is now honest: strict-valid MIDI can still be musically invalid.
+- Next issue should fix generation-side pitch/harmony behavior, not just ranking.
+
+Detail:
+
+- `docs/STAGE_B_RANKING_HARMONIC_GATE_2026-05-21.md`
 
 ### 1. Run full jazz piano dataset audit
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,8 @@
   - Stage B plain-vs-coverage A/B sweep across note-group density settings.
 - `STAGE_B_CANDIDATE_RANKING_2026-05-20.md`
   - Stage B generated MIDI candidate ranking report for listening/review priority.
+- `STAGE_B_RANKING_HARMONIC_GATE_2026-05-21.md`
+  - Stage B ranking이 low chord-tone/repeated pitch/mechanical pattern MIDI를 좋은 후보로 올리지 않도록 고친 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -78,7 +80,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, and candidate ranking을 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, and harmonic/repetition gate를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_CANDIDATE_RANKING_2026-05-20.md
+++ b/docs/STAGE_B_CANDIDATE_RANKING_2026-05-20.md
@@ -117,6 +117,14 @@ Do not start broad generic jazz training yet unless the top ranked candidates ar
 
 If the top candidates still sound harmonically weak, the next issue should be chord-aware pitch candidate filtering or chord-tone/tension-aware ranking.
 
+## Follow-up Correction
+
+Issue #43 performed that piano-roll review and found the top ranked candidate was not a usable solo-line candidate.
+
+The original ranking over-weighted temporal coverage and did not penalize repeated pitch, repeated bar templates, or low per-bar chord-tone coverage strongly enough.
+
+Use `docs/STAGE_B_RANKING_HARMONIC_GATE_2026-05-21.md` as the current interpretation of this result.
+
 ## Validation
 
 Commands run:

--- a/docs/STAGE_B_RANKING_HARMONIC_GATE_2026-05-21.md
+++ b/docs/STAGE_B_RANKING_HARMONIC_GATE_2026-05-21.md
@@ -1,0 +1,127 @@
+# Stage B Ranking Harmonic Gate
+
+작성일: 2026-05-21
+
+## Issue
+
+- Issue: #43
+- Branch: `issue-43-stage-b-ranking-harmonic-gate`
+- Goal: Stage B candidate ranking이 low chord-tone, repeated pitch, mechanical onset pattern MIDI를 좋은 후보로 올리지 않게 한다.
+
+## Why
+
+Issue #41 ranking은 coverage-aware A/B sweep의 generated MIDI candidates를 score로 정렬했다.
+
+그 결과 top candidate는 다음 파일이었다.
+
+```text
+outputs/stage_b_coverage_ab_sweep/harness_stage_b_candidate_ranking_ab_sweep_coverage_g8_k2_t0p9/samples/stage_b_sample_1.mid
+```
+
+하지만 piano-roll review 결과 이 MIDI는 solo-line 후보로 보기 어려웠다.
+
+Observed failure:
+
+- note count는 `16`이었지만 unique pitch는 `3`뿐이었다.
+- dominant pitches가 반복됐다.
+- bar마다 onset template이 기계적으로 반복됐다.
+- bar-level chord-tone coverage가 약한 구간이 있었다.
+- strict-valid MIDI가 곧 musical candidate라는 뜻이 아니었다.
+
+이 문제는 evaluator failure다.
+
+파일이 존재하고 strict gate를 통과해도, 한두 pitch 반복이나 긴 sustain/chord block이면 reviewable MIDI로 취급하면 안 된다.
+
+## Implementation
+
+`scripts/rank_stage_b_candidates.py`가 각 candidate MIDI를 직접 읽어 추가 diagnostics를 계산한다.
+
+Added diagnostics:
+
+- `bar_chord_tone_ratio`
+- `min_bar_chord_tone_ratio`
+- `dominant_pitch_ratio`
+- `repeated_pitch_ratio`
+- `onset_template_repetition_ratio`
+
+Added review flags:
+
+- `low_chord_tone_ratio`
+- `low_bar_chord_tone_ratio`
+- `dominant_pitch_repetition`
+- `low_pitch_variety`
+- `repeated_onset_template`
+
+Ranking now prefers candidates in this order:
+
+1. reviewable candidate
+2. strict-valid candidate
+3. valid candidate
+4. candidate without harmonic red flags
+5. score
+
+The score also penalizes:
+
+- low chord-tone ratio
+- low per-bar chord-tone ratio
+- dominant pitch repetition
+- repeated pitch ratio
+- repeated onset template
+
+## Harness Result
+
+Command:
+
+```bash
+bash scripts/agent_harness.sh stage-b-candidate-ranking
+```
+
+Latest summary:
+
+| Metric | Value |
+|---|---:|
+| candidates | 18 |
+| valid candidates | 12 |
+| strict candidates | 12 |
+| viable unflagged candidates | 0 |
+| flagged candidates | 18 |
+
+The previous misleading top candidate is now flagged with:
+
+- `low_chord_tone_ratio`
+- `low_bar_chord_tone_ratio`
+- `dominant_pitch_repetition`
+- `low_pitch_variety`
+
+## Decision
+
+Current Stage B output is not yet a good listening candidate.
+
+This issue improves the truthfulness of the ranking report. It does not improve the model itself.
+
+The next issue should modify generation behavior, not just ranking.
+
+Recommended next issue:
+
+```text
+Stage B chord-aware pitch constrained generation 추가
+```
+
+Target:
+
+- preserve the coverage-aware `POSITION` improvement
+- constrain or weight `NOTE_PITCH` choices by current bar chord
+- allow chord tones plus limited tensions
+- reduce repeated dominant pitch collapse
+- require at least one viable unflagged generated sample before moving to generic jazz base training
+
+## Validation
+
+Commands run:
+
+```bash
+./.venv/bin/python -m unittest tests.test_stage_b_candidate_ranking
+./.venv/bin/python -m compileall scripts/rank_stage_b_candidates.py
+bash scripts/agent_harness.sh quick
+bash scripts/agent_harness.sh stage-b-candidate-ranking
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -373,7 +373,7 @@ run_stage_b_candidate_ranking() {
   print_header "Stage B candidate ranking"
   "$PYTHON_BIN" scripts/run_stage_b_coverage_ab_sweep.py \
     --run_id "$sweep_run_id" \
-    --issue_number 41 \
+    --issue_number 43 \
     --max_files 2 \
     --epochs 3 \
     --batch_size 8 \
@@ -398,7 +398,7 @@ run_stage_b_candidate_ranking() {
     --lora_alpha 8
   "$PYTHON_BIN" scripts/rank_stage_b_candidates.py \
     --run_id "$run_id" \
-    --issue_number 41 \
+    --issue_number 43 \
     --ab_sweep_report "outputs/stage_b_coverage_ab_sweep/${sweep_run_id}/ab_sweep_report.json" \
     --top_n 12 \
     --min_top_strict_candidates 1

--- a/scripts/rank_stage_b_candidates.py
+++ b/scripts/rank_stage_b_candidates.py
@@ -4,12 +4,29 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+import pretty_midi
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.stage_b_tokens import POSITIONS_PER_BAR, ROOT_TO_PC, parse_chord_symbol  # noqa: E402
+
+QUALITY_INTERVALS = {
+    "maj": {0, 4, 7},
+    "maj7": {0, 4, 7, 11},
+    "min": {0, 3, 7},
+    "min7": {0, 3, 7, 10},
+    "dom7": {0, 4, 7, 10},
+    "dim": {0, 3, 6},
+    "halfdim": {0, 3, 6, 10},
+    "sus": {0, 5, 7},
+    "unknown": {0, 4, 7},
+}
 
 
 def read_json(path: Path) -> dict[str, Any]:
@@ -35,49 +52,204 @@ def _int(value: Any, default: int = 0) -> int:
         return default
 
 
+def beats_per_bar(time_signature: str | None) -> int:
+    if not time_signature:
+        return 4
+    numerator = str(time_signature).split("/", maxsplit=1)[0]
+    return max(1, _int(numerator, default=4))
+
+
+def chord_pitch_classes(chord: str | None) -> set[int]:
+    root, quality = parse_chord_symbol(chord)
+    root_pc = ROOT_TO_PC.get(root, 0)
+    intervals = QUALITY_INTERVALS.get(quality, QUALITY_INTERVALS["unknown"])
+    return {(root_pc + interval) % 12 for interval in intervals}
+
+
+def analyze_midi_candidate(
+    midi_path: str | None,
+    request: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not midi_path:
+        return {"analysis_available": False, "reason": "missing midi path"}
+    path = Path(str(midi_path))
+    if not path.is_absolute():
+        path = ROOT_DIR / path
+    if not path.exists():
+        return {"analysis_available": False, "reason": f"missing midi file: {path}"}
+
+    request = request or {}
+    chords = [str(chord) for chord in request.get("chord_progression", []) if str(chord)]
+    bpm = max(1e-6, _float(request.get("bpm"), default=124.0))
+    bar_duration = beats_per_bar(request.get("time_signature")) * (60.0 / bpm)
+    step_duration = bar_duration / int(POSITIONS_PER_BAR)
+
+    pm = pretty_midi.PrettyMIDI(str(path))
+    notes = sorted(
+        [note for instrument in pm.instruments if not instrument.is_drum for note in instrument.notes],
+        key=lambda note: (float(note.start), int(note.pitch), float(note.end)),
+    )
+    if not notes:
+        return {"analysis_available": True, "note_count": 0, "review_flags": ["empty_midi"]}
+
+    pitch_counts: dict[int, int] = {}
+    per_bar_counts: dict[int, int] = {}
+    per_bar_chord_hits: dict[int, int] = {}
+    per_bar_positions: dict[int, list[int]] = {}
+    chord_hits = 0
+
+    for note in notes:
+        pitch = int(note.pitch)
+        pitch_counts[pitch] = pitch_counts.get(pitch, 0) + 1
+        bar = max(0, int(float(note.start) // max(1e-6, bar_duration)))
+        position = int(round((float(note.start) - (bar * bar_duration)) / max(1e-6, step_duration)))
+        position = max(0, min(int(POSITIONS_PER_BAR) - 1, position))
+        per_bar_counts[bar] = per_bar_counts.get(bar, 0) + 1
+        per_bar_positions.setdefault(bar, []).append(position)
+        if chords:
+            pcs = chord_pitch_classes(chords[min(bar, len(chords) - 1)])
+            if pitch % 12 in pcs:
+                chord_hits += 1
+                per_bar_chord_hits[bar] = per_bar_chord_hits.get(bar, 0) + 1
+
+    note_count = len(notes)
+    per_bar_ratios = {
+        str(bar): (per_bar_chord_hits.get(bar, 0) / count if count else 0.0)
+        for bar, count in sorted(per_bar_counts.items())
+    }
+    position_templates = [tuple(positions) for _, positions in sorted(per_bar_positions.items())]
+    repeated_template_ratio = 0.0
+    if len(position_templates) > 1:
+        first_template = position_templates[0]
+        repeated = sum(1 for template in position_templates[1:] if template == first_template)
+        repeated_template_ratio = repeated / max(1, len(position_templates) - 1)
+
+    dominant_pitch_count = max(pitch_counts.values()) if pitch_counts else 0
+    unique_pitch_count = len(pitch_counts)
+    repeated_pitch_ratio = 1.0 - (unique_pitch_count / note_count)
+    chord_tone_ratio = chord_hits / note_count if chords else 0.0
+    min_bar_chord_tone_ratio = min(per_bar_ratios.values()) if per_bar_ratios else chord_tone_ratio
+    dominant_pitch_ratio = dominant_pitch_count / note_count if note_count else 0.0
+    review_flags = review_flags_for_diagnostics(
+        chord_tone_ratio=chord_tone_ratio,
+        min_bar_chord_tone_ratio=min_bar_chord_tone_ratio,
+        dominant_pitch_ratio=dominant_pitch_ratio,
+        repeated_pitch_ratio=repeated_pitch_ratio,
+        onset_template_repetition_ratio=repeated_template_ratio,
+    )
+
+    return {
+        "analysis_available": True,
+        "note_count": int(note_count),
+        "unique_pitch_count": int(unique_pitch_count),
+        "dominant_pitch": int(max(pitch_counts, key=pitch_counts.get)),
+        "dominant_pitch_count": int(dominant_pitch_count),
+        "dominant_pitch_ratio": dominant_pitch_ratio,
+        "repeated_pitch_ratio": repeated_pitch_ratio,
+        "bar_chord_tone_count": int(chord_hits),
+        "bar_chord_tone_ratio": chord_tone_ratio,
+        "min_bar_chord_tone_ratio": min_bar_chord_tone_ratio,
+        "per_bar_chord_tone_ratio": per_bar_ratios,
+        "onset_template_repetition_ratio": repeated_template_ratio,
+        "review_flags": review_flags,
+    }
+
+
+def review_flags_for_diagnostics(
+    chord_tone_ratio: float,
+    min_bar_chord_tone_ratio: float,
+    dominant_pitch_ratio: float,
+    repeated_pitch_ratio: float,
+    onset_template_repetition_ratio: float,
+) -> list[str]:
+    flags: list[str] = []
+    if float(chord_tone_ratio) < 0.30:
+        flags.append("low_chord_tone_ratio")
+    if float(min_bar_chord_tone_ratio) < 0.20:
+        flags.append("low_bar_chord_tone_ratio")
+    if float(dominant_pitch_ratio) > 0.55:
+        flags.append("dominant_pitch_repetition")
+    if float(repeated_pitch_ratio) > 0.70:
+        flags.append("low_pitch_variety")
+    if float(onset_template_repetition_ratio) > 0.90:
+        flags.append("repeated_onset_template")
+    return flags
+
+
 def score_candidate(sample: dict[str, Any]) -> dict[str, Any]:
     metrics = sample.get("metrics", {})
     collapse = sample.get("collapse", {})
     temporal = sample.get("temporal_coverage", {})
+    harmonic = sample.get("harmonic_diagnostics", {})
     valid = bool(sample.get("valid"))
     strict_valid = bool(sample.get("strict_valid"))
     grammar_valid = bool(sample.get("grammar_gate_passed"))
     dead_air_ratio = _float(metrics.get("dead_air_ratio"))
     repetition_score = _float(metrics.get("repetition_score"))
-    chord_tone_ratio = _float(metrics.get("chord_tone_ratio"))
+    metric_chord_tone_ratio = _float(metrics.get("chord_tone_ratio"))
+    bar_chord_tone_ratio = _float(harmonic.get("bar_chord_tone_ratio"), default=metric_chord_tone_ratio)
+    chord_tone_ratio = min(metric_chord_tone_ratio, bar_chord_tone_ratio)
+    min_bar_chord_tone_ratio = _float(harmonic.get("min_bar_chord_tone_ratio"), default=chord_tone_ratio)
     unique_pitch_count = _int(metrics.get("unique_pitch_count"))
     onset_coverage_ratio = _float(temporal.get("onset_coverage_ratio"))
     sustained_coverage_ratio = _float(temporal.get("sustained_coverage_ratio"))
     position_span_ratio = _float(temporal.get("position_span_ratio"))
     collapse_warning = bool(collapse.get("collapse_warning"))
     postprocess_removal_ratio = _float(collapse.get("postprocess_removal_ratio"))
+    repeated_pitch_ratio = max(
+        _float(collapse.get("repeated_pitch_ratio")),
+        _float(harmonic.get("repeated_pitch_ratio")),
+    )
+    dominant_pitch_ratio = _float(harmonic.get("dominant_pitch_ratio"))
+    onset_template_repetition_ratio = _float(harmonic.get("onset_template_repetition_ratio"))
 
     components = {
-        "strict_valid_bonus": 40.0 if strict_valid else 0.0,
-        "valid_bonus": 20.0 if valid else 0.0,
-        "grammar_bonus": 10.0 if grammar_valid else 0.0,
-        "onset_coverage_bonus": onset_coverage_ratio * 20.0,
-        "sustained_coverage_bonus": sustained_coverage_ratio * 10.0,
-        "position_span_bonus": position_span_ratio * 5.0,
-        "chord_tone_bonus": chord_tone_ratio * 10.0,
+        "strict_valid_bonus": 30.0 if strict_valid else 0.0,
+        "valid_bonus": 15.0 if valid else 0.0,
+        "grammar_bonus": 8.0 if grammar_valid else 0.0,
+        "onset_coverage_bonus": onset_coverage_ratio * 12.0,
+        "sustained_coverage_bonus": sustained_coverage_ratio * 6.0,
+        "position_span_bonus": position_span_ratio * 3.0,
+        "chord_tone_bonus": chord_tone_ratio * 30.0,
+        "min_bar_chord_tone_bonus": min_bar_chord_tone_ratio * 15.0,
         "pitch_diversity_bonus": min(unique_pitch_count, 6) * 2.0,
-        "dead_air_penalty": dead_air_ratio * -20.0,
+        "dead_air_penalty": dead_air_ratio * -15.0,
         "repetition_penalty": repetition_score * -8.0,
         "postprocess_penalty": postprocess_removal_ratio * -10.0,
         "collapse_warning_penalty": -25.0 if collapse_warning else 0.0,
+        "low_chord_tone_penalty": -30.0
+        if chord_tone_ratio < 0.25
+        else (-15.0 if chord_tone_ratio < 0.40 else 0.0),
+        "low_bar_chord_tone_penalty": -25.0
+        if min_bar_chord_tone_ratio < 0.20
+        else (-12.0 if min_bar_chord_tone_ratio < 0.30 else 0.0),
+        "repeated_pitch_penalty": repeated_pitch_ratio * -20.0,
+        "dominant_pitch_penalty": max(0.0, dominant_pitch_ratio - 0.45) * -40.0,
+        "onset_template_penalty": onset_template_repetition_ratio * -12.0,
     }
     score = round(sum(components.values()), 4)
     return {"score": score, "score_components": components}
 
 
-def candidate_from_sample(row: dict[str, Any], sample: dict[str, Any], report_path: Path) -> dict[str, Any]:
+def candidate_from_sample(
+    row: dict[str, Any],
+    sample: dict[str, Any],
+    report_path: Path,
+    request: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     metrics = sample.get("metrics", {})
     temporal = sample.get("temporal_coverage", {})
     collapse = sample.get("collapse", {})
-    scored = score_candidate(sample)
+    harmonic = analyze_midi_candidate(sample.get("midi_path"), request=request)
+    sample_with_diagnostics = dict(sample)
+    sample_with_diagnostics["harmonic_diagnostics"] = harmonic
+    scored = score_candidate(sample_with_diagnostics)
     return {
         "score": scored["score"],
         "score_components": scored["score_components"],
+        "review_flags": harmonic.get("review_flags", []),
+        "reviewable": bool(sample.get("strict_valid")) and not harmonic.get("review_flags", []),
+        "harmonic_diagnostics": harmonic,
         "mode": row.get("mode"),
         "note_groups_per_bar": _int(row.get("note_groups_per_bar")),
         "run_id": row.get("run_id"),
@@ -94,6 +266,14 @@ def candidate_from_sample(row: dict[str, Any], sample: dict[str, Any], report_pa
         "dead_air_ratio": _float(metrics.get("dead_air_ratio")),
         "repetition_score": _float(metrics.get("repetition_score")),
         "chord_tone_ratio": _float(metrics.get("chord_tone_ratio")),
+        "bar_chord_tone_ratio": _float(harmonic.get("bar_chord_tone_ratio")),
+        "min_bar_chord_tone_ratio": _float(harmonic.get("min_bar_chord_tone_ratio")),
+        "dominant_pitch_ratio": _float(harmonic.get("dominant_pitch_ratio")),
+        "repeated_pitch_ratio": max(
+            _float(collapse.get("repeated_pitch_ratio")),
+            _float(harmonic.get("repeated_pitch_ratio")),
+        ),
+        "onset_template_repetition_ratio": _float(harmonic.get("onset_template_repetition_ratio")),
         "onset_coverage_ratio": _float(temporal.get("onset_coverage_ratio")),
         "sustained_coverage_ratio": _float(temporal.get("sustained_coverage_ratio")),
         "position_span_ratio": _float(temporal.get("position_span_ratio")),
@@ -114,8 +294,9 @@ def collect_candidates(ab_report: dict[str, Any]) -> tuple[list[dict[str, Any]],
             warnings.append(f"missing report: {report_path}")
             continue
         probe_report = read_json(report_path)
+        request = probe_report.get("request", {})
         for sample in probe_report.get("samples", []):
-            candidates.append(candidate_from_sample(row, sample, report_path))
+            candidates.append(candidate_from_sample(row, sample, report_path, request=request))
     return candidates, warnings
 
 
@@ -123,11 +304,14 @@ def rank_candidates(candidates: list[dict[str, Any]], top_n: int) -> list[dict[s
     ranked = sorted(
         candidates,
         key=lambda candidate: (
-            float(candidate["score"]),
+            bool(candidate.get("reviewable", True)),
             bool(candidate["strict_valid"]),
             bool(candidate["valid"]),
+            "low_chord_tone_ratio" not in candidate.get("review_flags", []),
+            "low_bar_chord_tone_ratio" not in candidate.get("review_flags", []),
+            float(candidate["score"]),
             float(candidate["onset_coverage_ratio"]),
-            float(candidate["chord_tone_ratio"]),
+            float(candidate.get("bar_chord_tone_ratio", candidate.get("chord_tone_ratio", 0.0))),
             -float(candidate["dead_air_ratio"]),
         ),
         reverse=True,
@@ -142,12 +326,18 @@ def build_summary(candidates: list[dict[str, Any]], top_candidates: list[dict[st
     strict_candidates = [candidate for candidate in candidates if candidate["strict_valid"]]
     valid_candidates = [candidate for candidate in candidates if candidate["valid"]]
     top_strict = [candidate for candidate in top_candidates if candidate["strict_valid"]]
+    flagged_candidates = [candidate for candidate in candidates if candidate.get("review_flags")]
+    viable_candidates = [candidate for candidate in candidates if candidate.get("reviewable")]
+    top_viable = [candidate for candidate in top_candidates if candidate.get("reviewable")]
     return {
         "candidate_count": int(len(candidates)),
         "valid_candidate_count": int(len(valid_candidates)),
         "strict_candidate_count": int(len(strict_candidates)),
+        "viable_candidate_count": int(len(viable_candidates)),
         "top_candidate_count": int(len(top_candidates)),
         "top_strict_candidate_count": int(len(top_strict)),
+        "top_viable_candidate_count": int(len(top_viable)),
+        "flagged_candidate_count": int(len(flagged_candidates)),
         "best_candidate": top_candidates[0] if top_candidates else None,
     }
 
@@ -160,23 +350,25 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- candidate count: `{summary['candidate_count']}`",
         f"- valid candidates: `{summary['valid_candidate_count']}`",
         f"- strict candidates: `{summary['strict_candidate_count']}`",
+        f"- viable candidates without review flags: `{summary['viable_candidate_count']}`",
         "",
-        "| rank | score | mode | groups/bar | sample | strict | notes | onset | sustained | dead-air | chord-tone | MIDI |",
-        "|---:|---:|---|---:|---:|:---:|---:|---:|---:|---:|---:|---|",
+        "| rank | score | mode | groups/bar | sample | strict | reviewable | notes | onset | sustained | dead-air | chord-tone | bar chord | flags | MIDI |",
+        "|---:|---:|---|---:|---:|:---:|:---:|---:|---:|---:|---:|---:|---:|---|---|",
     ]
     for candidate in report["top_candidates"]:
         lines.append(
             "| {rank} | {score:.3f} | {mode} | {note_groups_per_bar} | {sample_index} | "
-            "{strict_valid} | {note_count} | {onset_coverage_ratio:.3f} | "
+            "{strict_valid} | {reviewable} | {note_count} | {onset_coverage_ratio:.3f} | "
             "{sustained_coverage_ratio:.3f} | {dead_air_ratio:.3f} | "
-            "{chord_tone_ratio:.3f} | `{midi_path}` |".format(**candidate)
+            "{chord_tone_ratio:.3f} | {bar_chord_tone_ratio:.3f} | "
+            "{review_flags} | `{midi_path}` |".format(**candidate)
         )
     lines.append("")
     lines.append("## Scoring Note")
     lines.append("")
     lines.append("This score is a review-prioritization heuristic, not a musical-quality claim.")
-    lines.append("It rewards strict validity, temporal coverage, chord-tone ratio, and pitch diversity.")
-    lines.append("It penalizes dead-air, repetition, postprocess removal, and collapse warnings.")
+    lines.append("It rewards strict validity, temporal coverage, bar-aware chord-tone ratio, and pitch diversity.")
+    lines.append("It penalizes dead-air, repetition, postprocess removal, collapse warnings, repeated pitch dominance, low per-bar chord tones, and repeated onset templates.")
     return "\n".join(lines) + "\n"
 
 

--- a/tests/test_stage_b_candidate_ranking.py
+++ b/tests/test_stage_b_candidate_ranking.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import unittest
 
-from scripts.rank_stage_b_candidates import build_summary, rank_candidates, score_candidate
+from scripts.rank_stage_b_candidates import (
+    build_summary,
+    review_flags_for_diagnostics,
+    rank_candidates,
+    score_candidate,
+)
 
 
 class StageBCandidateRankingTest(unittest.TestCase):
@@ -69,12 +74,79 @@ class StageBCandidateRankingTest(unittest.TestCase):
         self.assertEqual(ranked[0]["score"], 20.0)
         self.assertEqual(ranked[0]["rank"], 1)
 
+    def test_score_candidate_penalizes_low_bar_chord_and_repeated_pitch(self) -> None:
+        repetitive = {
+            "valid": True,
+            "strict_valid": True,
+            "grammar_gate_passed": True,
+            "metrics": {
+                "dead_air_ratio": 0.45,
+                "repetition_score": 0.1,
+                "chord_tone_ratio": 0.31,
+                "unique_pitch_count": 3,
+            },
+            "temporal_coverage": {
+                "onset_coverage_ratio": 0.5,
+                "sustained_coverage_ratio": 0.9,
+                "position_span_ratio": 0.9,
+            },
+            "collapse": {"collapse_warning": False, "postprocess_removal_ratio": 0.0},
+            "harmonic_diagnostics": {
+                "bar_chord_tone_ratio": 0.18,
+                "min_bar_chord_tone_ratio": 0.0,
+                "dominant_pitch_ratio": 0.56,
+                "repeated_pitch_ratio": 0.81,
+                "onset_template_repetition_ratio": 1.0,
+            },
+        }
+        balanced = {
+            "valid": True,
+            "strict_valid": True,
+            "grammar_gate_passed": True,
+            "metrics": {
+                "dead_air_ratio": 0.45,
+                "repetition_score": 0.1,
+                "chord_tone_ratio": 0.5,
+                "unique_pitch_count": 5,
+            },
+            "temporal_coverage": {
+                "onset_coverage_ratio": 0.38,
+                "sustained_coverage_ratio": 0.7,
+                "position_span_ratio": 0.9,
+            },
+            "collapse": {"collapse_warning": False, "postprocess_removal_ratio": 0.0},
+            "harmonic_diagnostics": {
+                "bar_chord_tone_ratio": 0.5,
+                "min_bar_chord_tone_ratio": 0.35,
+                "dominant_pitch_ratio": 0.35,
+                "repeated_pitch_ratio": 0.45,
+                "onset_template_repetition_ratio": 0.0,
+            },
+        }
+
+        self.assertLess(score_candidate(repetitive)["score"], score_candidate(balanced)["score"])
+
+    def test_review_flags_mark_harmonic_and_template_failures(self) -> None:
+        flags = review_flags_for_diagnostics(
+            chord_tone_ratio=0.18,
+            min_bar_chord_tone_ratio=0.0,
+            dominant_pitch_ratio=0.56,
+            repeated_pitch_ratio=0.81,
+            onset_template_repetition_ratio=1.0,
+        )
+
+        self.assertIn("low_chord_tone_ratio", flags)
+        self.assertIn("low_bar_chord_tone_ratio", flags)
+        self.assertIn("dominant_pitch_repetition", flags)
+        self.assertIn("low_pitch_variety", flags)
+        self.assertIn("repeated_onset_template", flags)
+
     def test_build_summary_counts_strict_candidates(self) -> None:
         candidates = [
             {"valid": True, "strict_valid": True},
             {"valid": True, "strict_valid": False},
         ]
-        top = [{"valid": True, "strict_valid": True}]
+        top = [{"valid": True, "strict_valid": True, "reviewable": True}]
 
         summary = build_summary(candidates, top)
 
@@ -82,6 +154,35 @@ class StageBCandidateRankingTest(unittest.TestCase):
         self.assertEqual(summary["valid_candidate_count"], 2)
         self.assertEqual(summary["strict_candidate_count"], 1)
         self.assertEqual(summary["top_strict_candidate_count"], 1)
+        self.assertEqual(summary["top_viable_candidate_count"], 1)
+
+    def test_rank_candidates_prefers_reviewable_candidate_over_flagged_score(self) -> None:
+        candidates = [
+            {
+                "score": 30.0,
+                "reviewable": False,
+                "review_flags": ["low_chord_tone_ratio"],
+                "strict_valid": True,
+                "valid": True,
+                "onset_coverage_ratio": 0.5,
+                "bar_chord_tone_ratio": 0.1,
+                "dead_air_ratio": 0.4,
+            },
+            {
+                "score": 20.0,
+                "reviewable": True,
+                "review_flags": [],
+                "strict_valid": True,
+                "valid": True,
+                "onset_coverage_ratio": 0.3,
+                "bar_chord_tone_ratio": 0.5,
+                "dead_air_ratio": 0.5,
+            },
+        ]
+
+        ranked = rank_candidates(candidates, top_n=2)
+
+        self.assertTrue(ranked[0]["reviewable"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 요약

- Stage B candidate ranking이 temporal coverage를 과대평가해 나쁜 MIDI를 좋은 후보로 올리던 문제를 수정했습니다.
- candidate MIDI를 직접 읽어 bar-level chord-tone, dominant pitch, repeated pitch, repeated onset-template diagnostics를 계산합니다.
- strict-valid라도 review flag가 있으면 reviewable candidate로 보지 않도록 ranking과 문서를 정리했습니다.

## 핵심 결과

- latest ranking candidates: 18
- strict candidates: 12
- viable unflagged candidates: 0
- flagged candidates: 18

이 결과는 현재 Stage B output이 아직 좋은 listening candidate가 아니라는 뜻입니다. 이번 PR은 모델 품질 개선이 아니라, 평가와 ranking이 더 이상 거짓 양성 후보를 올리지 않게 하는 작업입니다.

## 변경 사항

- scripts/rank_stage_b_candidates.py: MIDI 직접 분석 diagnostics, harmonic/repetition review flags, scoring penalty 및 ranking priority 수정
- tests/test_stage_b_candidate_ranking.py: harmonic/repetition flag와 reviewable 우선순위 테스트 추가
- scripts/agent_harness.sh: candidate-ranking harness issue 번호를 #43으로 변경
- docs: #43 결과 문서 추가, CORE_PLAN/CURRENT_STATUS/docs index/#41 follow-up correction 업데이트

## 검증

- ./.venv/bin/python -m unittest tests.test_stage_b_candidate_ranking
- ./.venv/bin/python -m compileall scripts/rank_stage_b_candidates.py
- bash scripts/agent_harness.sh quick
- bash scripts/agent_harness.sh stage-b-candidate-ranking

Closes #43