### PR TITLE
Stage B chord-aware pitch constrained generation 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #43: Stage B candidate ranking harmonic/repetition gate.
+- Issue #45: Stage B chord-aware pitch constrained generation.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -203,6 +203,14 @@ bash scripts/agent_harness.sh stage-b-candidate-ranking
 ```
 
 This harness generates an A/B sweep and ranks generated MIDI candidates for listening/review priority.
+
+For Stage B chord-aware pitch constrained generation changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-chord-aware-probe
+```
+
+This harness compares plain, coverage-aware, and coverage+chord-aware constrained generation, then ranks the generated MIDI candidates.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -124,14 +124,16 @@ Stage B에서 명시하는 것:
 18. Stage B coverage-aware A/B sweep
 19. Stage B candidate ranking report
 20. Stage B ranking harmonic/repetition gate
+21. Stage B chord-aware pitch constrained generation
 
 가장 최근 의미 있는 결과:
 
-- Issue #41 ranking은 coverage groups/bar `8`, sample `1`을 top candidate로 올렸다.
-- piano-roll review 결과, 이 sample은 solo-line으로 보기 어려웠다.
 - Issue #43은 candidate MIDI를 직접 읽어 harmonic/repetition diagnostics를 추가했다.
-- latest ranking result: candidates `18`, strict candidates `12`, viable unflagged candidates `0`, flagged candidates `18`
-- 현재 결과는 "좋은 MIDI 후보를 찾았다"가 아니라 "기존 strict/ranking 기준이 아직 너무 관대했다"는 증거다.
+- Issue #43 result: candidates `18`, strict candidates `12`, viable unflagged candidates `0`, flagged candidates `18`
+- Issue #45는 constrained generation에서 `NOTE_PITCH` 후보군을 current bar chord 기준으로 제한했다.
+- Issue #45 result: candidates `27`, strict candidates `21`, viable unflagged candidates `9`, flagged candidates `18`
+- top candidate: `coverage_chord`, groups/bar `4`, sample `2`, score `96.6964`
+- top candidate harmonic diagnostics: chord-tone `0.750`, bar chord-tone `0.875`, min bar chord-tone `0.800`, dominant pitch `0.375`, repeated pitch `0.250`
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -150,7 +152,7 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-다음 단계는 generation-side harmony control이다. 우선 chord-aware pitch constrained generation 또는 chord-tone/tension-aware pitch candidate filter를 검증한다.
+다음 단계는 manual listening/piano-roll review다. `coverage_chord` top candidates가 귀로도 solo-line 후보라면 generic jazz base 후보 학습 설계로 넘어가고, 아니면 rhythm/motif-level constraint 또는 pretrained symbolic base를 먼저 검토한다.
 
 ## 6. 다음 단계 로드맵
 
@@ -248,11 +250,13 @@ Stage B에서 명시하는 것:
 - completed: ranking이 candidate MIDI를 직접 읽어 harmonic/repetition diagnostics를 계산한다.
 - completed: low chord-tone/repeated pitch/mechanical template 후보에 review flags를 붙인다.
 - latest result: `18` candidates 중 viable unflagged candidate `0`.
+- completed: chord-aware pitch constrained generation을 추가했다.
+- latest chord-aware result: `27` candidates 중 viable unflagged candidate `9`.
 
 다음 통과 기준:
 
-- chord-aware pitch constrained generation에서 viable unflagged candidate가 최소 1개 이상 나온다.
-- 그 후보는 piano roll에서 one-note/two-note/chord-block/long-sustain/repeated-template 실패가 없어야 한다.
+- generated top candidate를 실제로 듣고 piano roll로 확인한다.
+- 그 후보가 one-note/two-note/chord-block/long-sustain/repeated-template 실패가 없어야 한다.
 
 ### Phase 4. Generic Jazz Base 후보 학습
 
@@ -354,7 +358,7 @@ Stage B에서 명시하는 것:
 - 결과: avg onset coverage `0.167`, avg sustained coverage `0.417`, max longest sustained empty run `11` steps였다.
 - 결론: Stage B grammar와 collapse는 2-file probe에서 즉시 병목이 아니며, 현재 병목은 sparse onset과 long empty span으로 인한 dead-air/temporal coverage다.
 
-다음 issue는 다음 이름이 적절하다.
+완료된 바로 전 작업:
 
 ```text
 Stage B chord-aware pitch constrained generation 추가
@@ -370,8 +374,10 @@ Stage B chord-aware pitch constrained generation 추가
 
 이 작업이 끝난 뒤 판단:
 
-- chord-aware pitch probe에서 viable unflagged candidate가 나오면 Stage B 2-file Brad probe를 다시 고정하고 generic jazz base 후보 학습 설계로 간다.
-- chord-aware pitch probe에서도 실패하면 data scale, representation, loss, pretrained-base 쪽으로 재검토한다.
+- chord-aware pitch probe에서 viable unflagged candidate가 `9`개 나왔다.
+- 바로 broad training으로 가지 않고 top `coverage_chord` MIDI를 귀와 piano roll로 리뷰한다.
+- 리뷰가 괜찮으면 generic jazz base 후보 학습 설계로 넘어간다.
+- 리뷰가 여전히 기계적이면 rhythm/motif-level constraint 또는 pretrained symbolic base를 먼저 검토한다.
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-43-stage-b-ranking-harmonic-gate`
+- `issue-45-stage-b-chord-aware-pitch`
 
 현재 범위가 아닌 것:
 
@@ -36,53 +36,57 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 ## Latest Probe Result
 
-Issue #43에서 Stage B candidate ranking을 다시 검토했다.
+Issue #45에서 Stage B constrained generation에 chord-aware pitch 후보군을 추가했다.
 
-Issue #41의 top candidate는 숫자상 strict valid였지만, piano roll 확인 결과 solo-line으로 보기 어려웠다.
+Issue #43은 이전 top candidate가 strict-valid였어도 solo-line으로 보기 어렵다는 점을 확인했다.
 
-Observed top-candidate failure:
+Issue #45는 ranking을 더 꾸미지 않고 generation-side pitch 후보군을 고쳤다.
 
-- note count는 `16`이지만 unique pitches는 `3`뿐이었다.
-- `G#4`, `F#4`, `D5` 중심의 반복 패턴이었다.
-- onset template이 bar마다 기계적으로 반복됐다.
-- bar-level chord-tone ratio가 낮은 구간이 있었다.
-- 따라서 "strict valid"와 "ranking score high"만으로 listening candidate라고 볼 수 없다.
+Implemented:
+
+- `--chord_aware_pitches`
+- `--chord_pitch_mode tones|tones_tensions`
+- `--chord_pitch_repeat_window`
+- A/B mode: `coverage_chord`
+- harness: `bash scripts/agent_harness.sh stage-b-chord-aware-probe`
 
 Result:
 
-- ranking script가 MIDI 파일을 직접 읽어 harmonic/repetition diagnostics를 계산한다.
-- 새 diagnostics:
-  - bar-level chord-tone ratio
-  - minimum per-bar chord-tone ratio
-  - dominant pitch ratio
-  - repeated pitch ratio
-  - repeated onset-template ratio
-- review flags:
-  - `low_chord_tone_ratio`
-  - `low_bar_chord_tone_ratio`
-  - `dominant_pitch_repetition`
-  - `low_pitch_variety`
-  - `repeated_onset_template`
-- latest harness result:
-  - candidates: `18`
-  - strict candidates: `12`
-  - viable unflagged candidates: `0`
-  - flagged candidates: `18`
+- candidate count: `27`
+- strict candidates: `21`
+- viable unflagged candidates: `9`
+- flagged candidates: `18`
+- top candidate mode: `coverage_chord`
+- top candidate groups/bar: `4`
+- top candidate note count: `8`
+- top candidate unique pitches: `6`
+- top candidate chord-tone ratio: `0.750`
+- top candidate bar chord-tone ratio: `0.875`
+- top candidate min bar chord-tone ratio: `0.800`
+- top candidate dominant pitch ratio: `0.375`
+- top candidate repeated pitch ratio: `0.250`
+- top candidate review flags: `[]`
+
+Important comparison:
+
+- coverage g8 avg chord-tone ratio: `0.229`
+- coverage_chord g8 avg chord-tone ratio: `0.646`
+- coverage g8 avg repeated position/pitch ratio: `0.167`
+- coverage_chord g8 avg repeated position/pitch ratio: `0.021`
 
 Decision:
 
-- 현재 Stage B generated MIDI는 아직 좋은 listening candidate가 아니다.
-- ranking은 "좋은 샘플을 찾았다"가 아니라 "현재 샘플들이 왜 아직 탈락인지 설명한다"는 용도다.
-- 다음 작업은 ranking을 더 꾸미는 것이 아니라 generation-side fix다.
-- 우선 후보:
-  - chord-aware pitch constrained generation
-  - chord-tone/tension-aware pitch candidate filter
-  - bar-level harmonic coverage gate
+- chord-aware pitch constraint는 #43의 harmonic/repetition failure를 크게 줄였다.
+- 이것은 아직 Brad style learning 성공이 아니다.
+- 다음은 top `coverage_chord` MIDI를 실제로 듣고 piano roll로 확인하는 review point다.
+- 귀로도 구조가 괜찮으면 generic jazz base 후보 학습 설계로 넘어갈 수 있다.
+- 귀로 여전히 기계적이면 rhythm/motif-level constraint 또는 pretrained symbolic base 검토가 먼저다.
 
 Detail:
 
 - `docs/STAGE_B_CANDIDATE_RANKING_2026-05-20.md`
 - `docs/STAGE_B_RANKING_HARMONIC_GATE_2026-05-21.md`
+- `docs/STAGE_B_CHORD_AWARE_PITCH_2026-05-21.md`
 
 ## Active Issue #14
 
@@ -1006,6 +1010,54 @@ Decision:
 Detail:
 
 - `docs/STAGE_B_RANKING_HARMONIC_GATE_2026-05-21.md`
+
+### 0.21. Issue #45 Stage B chord-aware pitch constrained generation
+
+Status:
+
+- implemented on `issue-45-stage-b-chord-aware-pitch`
+
+Goal:
+
+- fix the generation-side pitch/harmony failure revealed by Issue #43
+- constrain `NOTE_PITCH` candidates by current bar chord
+- preserve coverage-aware `POSITION` generation
+- reduce repeated pitch and low bar-level chord-tone failures
+
+Latest harness result:
+
+- command: `bash scripts/agent_harness.sh stage-b-chord-aware-probe`
+- candidate count: `27`
+- strict candidates: `21`
+- viable candidates without review flags: `9`
+- flagged candidates: `18`
+- best mode: `coverage_chord`
+- best candidate score: `96.6964`
+- best candidate reviewable: `true`
+
+Best candidate:
+
+- mode: `coverage_chord`
+- groups/bar: `4`
+- sample index: `2`
+- note count: `8`
+- unique pitch count: `6`
+- chord-tone ratio: `0.750`
+- bar chord-tone ratio: `0.875`
+- min bar chord-tone ratio: `0.800`
+- dominant pitch ratio: `0.375`
+- repeated pitch ratio: `0.250`
+- MIDI path: `outputs/stage_b_coverage_ab_sweep/harness_stage_b_chord_aware_probe_ab_sweep_coverage_chord_g4_k2_t0p9/samples/stage_b_sample_2.mid`
+
+Decision:
+
+- This is the first Stage B probe where candidate ranking finds unflagged reviewable MIDI candidates.
+- Do not call this a personalized jazz model yet.
+- Next step is manual listening/piano-roll review of top `coverage_chord` candidates.
+
+Detail:
+
+- `docs/STAGE_B_CHORD_AWARE_PITCH_2026-05-21.md`
 
 ### 1. Run full jazz piano dataset audit
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,8 @@
   - Stage B generated MIDI candidate ranking report for listening/review priority.
 - `STAGE_B_RANKING_HARMONIC_GATE_2026-05-21.md`
   - Stage B ranking이 low chord-tone/repeated pitch/mechanical pattern MIDI를 좋은 후보로 올리지 않도록 고친 결과.
+- `STAGE_B_CHORD_AWARE_PITCH_2026-05-21.md`
+  - Stage B constrained generation에서 chord-aware pitch 후보군을 적용한 결과와 reviewable candidate 회복.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -80,7 +82,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, and harmonic/repetition gate를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, and chord-aware pitch probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_CHORD_AWARE_PITCH_2026-05-21.md
+++ b/docs/STAGE_B_CHORD_AWARE_PITCH_2026-05-21.md
@@ -1,0 +1,155 @@
+# Stage B Chord-Aware Pitch Constraint
+
+작성일: 2026-05-21
+
+## Issue
+
+- Issue: #45
+- Branch: `issue-45-stage-b-chord-aware-pitch`
+- Goal: Stage B constrained generation에서 `NOTE_PITCH` 후보군을 현재 bar chord에 맞게 제한해 harmonic/repetition gate를 통과하는 candidate를 만든다.
+
+## Why
+
+Issue #43은 기존 Stage B ranking이 나쁜 MIDI를 좋은 후보로 올리던 문제를 수정했다.
+
+그 결과는 엄격했다.
+
+- candidates: `18`
+- strict candidates: `12`
+- viable unflagged candidates: `0`
+- flagged candidates: `18`
+
+즉, temporal coverage와 strict MIDI gate만으로는 아직 reviewable solo-line candidate를 고를 수 없었다.
+
+Issue #45는 ranking을 더 꾸미지 않고 generation-side pitch selection을 고친다.
+
+## Implementation
+
+Added to `scripts/run_stage_b_generation_probe.py`:
+
+- `--chord_aware_pitches`
+- `--chord_pitch_mode tones|tones_tensions`
+- `--chord_pitch_repeat_window`
+
+Generation behavior:
+
+- `POSITION`은 기존 coverage-aware option을 유지할 수 있다.
+- `VELOCITY`와 `DURATION`은 기존 constrained family sampling을 유지한다.
+- `NOTE_PITCH` family에서만 current bar chord에 맞는 pitch token 후보군을 만든다.
+- `tones` mode는 chord tones만 허용한다.
+- `tones_tensions` mode는 chord tones plus limited tensions를 허용한다.
+- recent exact pitch repeat window로 직전 pitch 반복을 줄인다.
+
+Added to sweep/harness:
+
+- `coverage_chord` mode
+- `bash scripts/agent_harness.sh stage-b-chord-aware-probe`
+
+The harness runs:
+
+```text
+plain
+coverage
+coverage_chord
+```
+
+Then it runs candidate ranking over the generated MIDI candidates.
+
+## Harness Result
+
+Command:
+
+```bash
+bash scripts/agent_harness.sh stage-b-chord-aware-probe
+```
+
+Ranking summary:
+
+| Metric | Value |
+|---|---:|
+| candidates | 27 |
+| valid candidates | 21 |
+| strict candidates | 21 |
+| viable unflagged candidates | 9 |
+| flagged candidates | 18 |
+
+Best candidate:
+
+| Field | Value |
+|---|---:|
+| mode | coverage_chord |
+| groups/bar | 4 |
+| sample index | 2 |
+| score | 96.6964 |
+| note count | 8 |
+| unique pitch count | 6 |
+| chord-tone ratio | 0.750 |
+| bar chord-tone ratio | 0.875 |
+| min bar chord-tone ratio | 0.800 |
+| dominant pitch ratio | 0.375 |
+| repeated pitch ratio | 0.250 |
+| onset coverage | 0.250 |
+| sustained coverage | 0.531 |
+
+Top candidate MIDI:
+
+```text
+outputs/stage_b_coverage_ab_sweep/harness_stage_b_chord_aware_probe_ab_sweep_coverage_chord_g4_k2_t0p9/samples/stage_b_sample_2.mid
+```
+
+## Comparison
+
+Coverage-only vs coverage+chord-aware:
+
+| groups/bar | mode | strict | avg chord-tone | avg repeated position/pitch | onset | sustained | max empty |
+|---:|---|---:|---:|---:|---:|---:|---:|
+| 4 | coverage | 3 | 0.417 | 0.250 | 0.250 | 0.427 | 6 |
+| 4 | coverage_chord | 3 | 0.708 | 0.042 | 0.250 | 0.438 | 5 |
+| 6 | coverage | 3 | 0.306 | 0.194 | 0.375 | 0.688 | 3 |
+| 6 | coverage_chord | 3 | 0.639 | 0.000 | 0.375 | 0.667 | 3 |
+| 8 | coverage | 3 | 0.229 | 0.167 | 0.500 | 0.865 | 1 |
+| 8 | coverage_chord | 3 | 0.646 | 0.021 | 0.500 | 0.844 | 2 |
+
+## Decision
+
+This is the first Stage B probe where ranking finds unflagged reviewable candidates.
+
+This still does not prove:
+
+- Brad style learning
+- generic jazz base quality
+- unconstrained generation quality
+- live improvisation readiness
+
+It proves a narrower point:
+
+> Coverage-aware timing plus chord-aware pitch constraints can produce generated MIDI candidates that pass the current harmonic/repetition review flags.
+
+## Next Step
+
+Manual listening and piano-roll review is now required.
+
+Listen to the top `coverage_chord` candidates and check:
+
+- solo-line shape
+- phrase contour
+- over-mechanical rhythm
+- excessive high-register bias
+- whether chord-tone correctness sounds too constrained or usable
+
+If the candidates are acceptable by ear, the next issue can design the generic jazz base training probe.
+
+If they are still mechanical, the next issue should target rhythm/motif-level behavior before broad training.
+
+## Validation
+
+Commands run:
+
+```bash
+./.venv/bin/python -m unittest tests.test_stage_b_generation_probe
+./.venv/bin/python -m unittest tests.test_stage_b_coverage_ab_sweep tests.test_stage_b_generation_probe
+./.venv/bin/python -m compileall scripts/run_stage_b_generation_probe.py tests/test_stage_b_generation_probe.py
+./.venv/bin/python -m compileall scripts/run_stage_b_coverage_ab_sweep.py scripts/run_stage_b_sampling_sweep.py scripts/run_stage_b_generation_probe.py
+bash scripts/agent_harness.sh quick
+bash scripts/agent_harness.sh stage-b-chord-aware-probe
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -48,6 +48,8 @@ Modes:
                 Run plain vs coverage-aware Stage B constrained generation sweep.
   stage-b-candidate-ranking
                 Run coverage A/B sweep and rank generated MIDI candidates.
+  stage-b-chord-aware-probe
+                Run coverage/chord-aware Stage B sweep and rank candidates.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   all           Run demo and tiny-compare.
@@ -404,6 +406,45 @@ run_stage_b_candidate_ranking() {
     --min_top_strict_candidates 1
 }
 
+run_stage_b_chord_aware_probe() {
+  local run_id="${RUN_ID:-harness_stage_b_chord_aware_probe}"
+  local sweep_run_id="${run_id}_ab_sweep"
+  print_header "Stage B chord-aware pitch probe"
+  "$PYTHON_BIN" scripts/run_stage_b_coverage_ab_sweep.py \
+    --run_id "$sweep_run_id" \
+    --issue_number 45 \
+    --max_files 2 \
+    --epochs 3 \
+    --batch_size 8 \
+    --max_sequence 96 \
+    --num_samples 3 \
+    --modes plain,coverage,coverage_chord \
+    --note_groups_per_bar_values 4,6,8 \
+    --coverage_position_window 0 \
+    --chord_pitch_mode tones \
+    --chord_pitch_repeat_window 2 \
+    --max_simultaneous_notes 2 \
+    --temperature 0.9 \
+    --top_k 2 \
+    --min_valid_samples 1 \
+    --min_strict_valid_samples 1 \
+    --min_best_strict_valid_samples 1 \
+    --max_collapse_warning_sample_rate 0.34 \
+    --require_all_grammar_samples \
+    --n_layers 1 \
+    --num_heads 4 \
+    --d_model 64 \
+    --dim_feedforward 128 \
+    --lora_r 4 \
+    --lora_alpha 8
+  "$PYTHON_BIN" scripts/rank_stage_b_candidates.py \
+    --run_id "$run_id" \
+    --issue_number 45 \
+    --ab_sweep_report "outputs/stage_b_coverage_ab_sweep/${sweep_run_id}/ab_sweep_report.json" \
+    --top_n 12 \
+    --min_top_strict_candidates 1
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -463,6 +504,9 @@ case "$MODE" in
     ;;
   stage-b-candidate-ranking)
     run_stage_b_candidate_ranking
+    ;;
+  stage-b-chord-aware-probe)
+    run_stage_b_chord_aware_probe
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/run_stage_b_coverage_ab_sweep.py
+++ b/scripts/run_stage_b_coverage_ab_sweep.py
@@ -23,13 +23,23 @@ from scripts.run_stage_b_sampling_sweep import (  # noqa: E402
     write_json,
 )
 
+VALID_MODES = {"plain", "coverage", "chord", "coverage_chord"}
+
 
 def parse_modes(raw: str) -> list[str]:
     modes = [mode.strip().lower() for mode in raw.split(",") if mode.strip()]
-    invalid = [mode for mode in modes if mode not in {"plain", "coverage"}]
+    invalid = [mode for mode in modes if mode not in VALID_MODES]
     if invalid:
         raise ValueError(f"Unknown coverage sweep modes: {invalid}")
     return modes
+
+
+def mode_has_coverage(mode: str) -> bool:
+    return mode in {"coverage", "coverage_chord"}
+
+
+def mode_has_chord_aware_pitches(mode: str) -> bool:
+    return mode in {"chord", "coverage_chord"}
 
 
 def config_run_id(base_run_id: str, mode: str, note_groups_per_bar: int, top_k: int, temperature: float) -> str:
@@ -75,28 +85,36 @@ def build_ab_summary(
     min_best_strict_valid_samples: int = 1,
     max_collapse_warning_sample_rate: float = 0.34,
 ) -> dict[str, Any]:
-    mode_rows = {
-        "plain": [row for row in rows if row["mode"] == "plain"],
-        "coverage": [row for row in rows if row["mode"] == "coverage"],
-    }
+    mode_names = sorted(VALID_MODES | {str(row.get("mode", "")) for row in rows if row.get("mode")})
+    mode_rows = {mode: [row for row in rows if row["mode"] == mode] for mode in mode_names}
     best = best_row(rows)
     best_plain = best_row(mode_rows["plain"])
     best_coverage = best_row(mode_rows["coverage"])
+    best_chord = best_row([row for row in rows if mode_has_chord_aware_pitches(str(row["mode"]))])
+    best_coverage_chord = best_row(mode_rows["coverage_chord"])
     passed_coverage = bool(
         best_coverage
         and int(best_coverage["strict_valid_sample_count"]) >= int(min_best_strict_valid_samples)
         and float(best_coverage["collapse_warning_sample_rate"]) <= float(max_collapse_warning_sample_rate)
     )
+    passed_chord = bool(
+        best_chord
+        and int(best_chord["strict_valid_sample_count"]) >= int(min_best_strict_valid_samples)
+        and float(best_chord["collapse_warning_sample_rate"]) <= float(max_collapse_warning_sample_rate)
+    )
     passed_comparison = bool(best_plain is not None and best_coverage is not None)
     return {
         "config_count": int(len(rows)),
-        "mode_counts": {mode: int(len(mode_rows[mode])) for mode in sorted(mode_rows)},
+        "mode_counts": {mode: int(len(mode_rows[mode])) for mode in mode_names},
         "best_config": compact_config(best),
         "best_plain_config": compact_config(best_plain),
         "best_coverage_config": compact_config(best_coverage),
+        "best_chord_config": compact_config(best_chord),
+        "best_coverage_chord_config": compact_config(best_coverage_chord),
         "min_best_strict_valid_samples": int(min_best_strict_valid_samples),
         "max_collapse_warning_sample_rate": float(max_collapse_warning_sample_rate),
         "passed_coverage_gate": passed_coverage,
+        "passed_chord_gate": passed_chord,
         "passed_comparison_gate": passed_comparison,
         "passed_ab_sweep_gate": bool(passed_coverage and passed_comparison),
     }
@@ -109,17 +127,21 @@ def markdown_table(rows: list[dict[str, Any]], summary: dict[str, Any]) -> str:
         f"- passed A/B sweep gate: `{str(summary['passed_ab_sweep_gate']).lower()}`",
         f"- best plain config: `{summary['best_plain_config']}`",
         f"- best coverage config: `{summary['best_coverage_config']}`",
+        f"- best chord-aware config: `{summary.get('best_chord_config')}`",
+        f"- best coverage+chord config: `{summary.get('best_coverage_chord_config')}`",
         "",
-        "| mode | groups/bar | samples | grammar | valid | strict | onset | sustained | span | max empty | dead air | collapse | strict pass |",
-        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|",
+        "| mode | groups/bar | chord | samples | grammar | valid | strict | onset | sustained | span | max empty | dead air | collapse | strict pass |",
+        "|---|---:|:---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|",
     ]
     for row in rows:
+        table_row = dict(row)
+        table_row["chord_aware_pitches"] = bool(row.get("chord_aware_pitches", False))
         lines.append(
-            "| {mode} | {note_groups_per_bar} | {sample_count} | {grammar_gate_sample_count} | "
+            "| {mode} | {note_groups_per_bar} | {chord_aware_pitches} | {sample_count} | {grammar_gate_sample_count} | "
             "{valid_sample_count} | {strict_valid_sample_count} | {avg_onset_coverage_ratio:.3f} | "
             "{avg_sustained_coverage_ratio:.3f} | {avg_position_span_ratio:.3f} | "
             "{max_longest_sustained_empty_run_steps} | {avg_dead_air_ratio:.3f} | "
-            "{collapse_warning_sample_rate:.3f} | {passed_strict_review_gate} |".format(**row)
+            "{collapse_warning_sample_rate:.3f} | {passed_strict_review_gate} |".format(**table_row)
         )
     lines.append("")
     lines.append("## Failure Reasons")
@@ -140,6 +162,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--modes", type=str, default="plain,coverage")
     parser.add_argument("--note_groups_per_bar_values", type=str, default="4,6,8")
     parser.add_argument("--coverage_position_window", type=int, default=0)
+    parser.add_argument("--chord_pitch_mode", choices=("tones", "tones_tensions"), default="tones")
+    parser.add_argument("--chord_pitch_repeat_window", type=int, default=2)
     parser.add_argument("--top_k", type=int, default=2)
     parser.add_argument("--temperature", type=float, default=0.9)
     parser.add_argument("--max_files", type=int, default=2)
@@ -195,8 +219,11 @@ def main() -> int:
             probe_args.top_ks = str(args.top_k)
             probe_args.temperatures = str(args.temperature)
             probe_args.constrained_note_groups_per_bar = int(note_groups_per_bar)
-            probe_args.coverage_aware_positions = mode == "coverage"
+            probe_args.coverage_aware_positions = mode_has_coverage(mode)
             probe_args.coverage_position_window = int(args.coverage_position_window)
+            probe_args.chord_aware_pitches = mode_has_chord_aware_pitches(mode)
+            probe_args.chord_pitch_mode = args.chord_pitch_mode
+            probe_args.chord_pitch_repeat_window = int(args.chord_pitch_repeat_window)
             cmd = probe_command(
                 probe_args,
                 run_id=config_id,
@@ -205,7 +232,7 @@ def main() -> int:
                 checkpoint_dir=checkpoint_dir,
                 skip_prepare_train=not first_config,
             )
-            if mode == "coverage":
+            if mode_has_coverage(mode):
                 cmd.extend(["--coverage_aware_positions", "--coverage_position_window", str(args.coverage_position_window)])
             result = run_command(cmd)
             command_results.append(result)

--- a/scripts/run_stage_b_generation_probe.py
+++ b/scripts/run_stage_b_generation_probe.py
@@ -46,6 +46,9 @@ from scripts.stage_b_tokens import (  # noqa: E402
     TOKEN_CHORD_ROOT_START,
     SEQUENCE_FORMAT_STAGE_B_V1,
     POSITIONS_PER_BAR,
+    PIANO_PITCH_MAX,
+    PIANO_PITCH_MIN,
+    ROOT_TO_PC,
     chord_tokens,
     decode_stage_b_midi,
     duration_steps_from_token,
@@ -53,6 +56,8 @@ from scripts.stage_b_tokens import (  # noqa: E402
     is_note_pitch_token,
     is_position_token,
     is_velocity_token,
+    note_pitch_token,
+    parse_chord_symbol,
     pitch_from_token,
     position_from_token,
     stage_b_token_name,
@@ -67,6 +72,30 @@ DEFAULT_STRICT_MIN_UNIQUE_POSITION_PITCH_PAIRS = 4
 DEFAULT_STRICT_MAX_REPEATED_POSITION_PITCH_PAIR_RATIO = 0.49
 DEFAULT_STRICT_MAX_POSTPROCESS_REMOVAL_RATIO = 0.49
 DEFAULT_STRICT_MAX_COLLAPSE_WARNING_SAMPLE_RATE = 0.34
+
+CHORD_TONE_INTERVALS = {
+    "maj": {0, 4, 7},
+    "maj7": {0, 4, 7, 11},
+    "min": {0, 3, 7},
+    "min7": {0, 3, 7, 10},
+    "dom7": {0, 4, 7, 10},
+    "dim": {0, 3, 6},
+    "halfdim": {0, 3, 6, 10},
+    "sus": {0, 5, 7},
+    "unknown": {0, 4, 7},
+}
+
+TENSION_INTERVALS = {
+    "maj": {2, 9},
+    "maj7": {2, 6, 9},
+    "min": {2, 5, 10},
+    "min7": {2, 5},
+    "dom7": {2, 5, 9},
+    "dim": {9},
+    "halfdim": {2, 5},
+    "sus": {2, 10},
+    "unknown": set(),
+}
 
 
 def parse_chords(raw_chords: str) -> list[str]:
@@ -466,6 +495,43 @@ def coverage_aware_position_tokens(
     return [TOKEN_POSITION_START + int(position) for position in positions]
 
 
+def chord_pitch_classes(chord: str | None, pitch_mode: str = "tones_tensions") -> set[int]:
+    root, quality = parse_chord_symbol(chord)
+    root_pc = ROOT_TO_PC.get(root)
+    if root_pc is None:
+        return set(range(12))
+    intervals = set(CHORD_TONE_INTERVALS.get(quality, CHORD_TONE_INTERVALS["unknown"]))
+    if pitch_mode == "tones_tensions":
+        intervals.update(TENSION_INTERVALS.get(quality, set()))
+    elif pitch_mode != "tones":
+        raise ValueError(f"unknown chord pitch mode: {pitch_mode}")
+    return {(root_pc + interval) % 12 for interval in intervals}
+
+
+def chord_aware_pitch_tokens(
+    chord: str | None,
+    pitch_mode: str = "tones_tensions",
+    recent_pitches: Sequence[int] | None = None,
+    repeat_window: int = 2,
+) -> list[int]:
+    pitch_classes = chord_pitch_classes(chord, pitch_mode=pitch_mode)
+    tokens = [
+        note_pitch_token(pitch)
+        for pitch in range(int(PIANO_PITCH_MIN), int(PIANO_PITCH_MAX) + 1)
+        if pitch % 12 in pitch_classes
+    ]
+    if not tokens:
+        return list(range(TOKEN_NOTE_PITCH_START, TOKEN_NOTE_PITCH_END + 1))
+
+    window = max(0, int(repeat_window))
+    if not recent_pitches or window == 0:
+        return tokens
+
+    blocked = set(int(pitch) for pitch in list(recent_pitches)[-window:])
+    filtered = [token for token in tokens if pitch_from_token(token) not in blocked]
+    return filtered or tokens
+
+
 def generate_stage_b_constrained_tokens(
     model: Any,
     primer_tokens: Sequence[int],
@@ -478,8 +544,12 @@ def generate_stage_b_constrained_tokens(
     top_k: int | None,
     coverage_aware_positions: bool = False,
     coverage_position_window: int = 0,
+    chord_aware_pitches: bool = False,
+    chord_pitch_mode: str = "tones_tensions",
+    chord_pitch_repeat_window: int = 2,
 ) -> list[int]:
     tokens = [int(token) for token in primer_tokens]
+    recent_pitches: list[int] = []
     families = [
         range(TOKEN_POSITION_START, TOKEN_POSITION_END + 1),
         range(TOKEN_VELOCITY_START, TOKEN_VELOCITY_END + 1),
@@ -488,8 +558,8 @@ def generate_stage_b_constrained_tokens(
     ]
 
     for bar_index in range(max(1, int(bars))):
+        chord = chords[bar_index % len(chords)] if chords else None
         if bar_index > 0:
-            chord = chords[bar_index % len(chords)] if chords else None
             tokens.append(TOKEN_BAR)
             tokens.extend(chord_tokens(chord))
         for group_index in range(max(1, int(note_groups_per_bar))):
@@ -504,15 +574,23 @@ def generate_stage_b_constrained_tokens(
                         note_groups_per_bar=note_groups_per_bar,
                         position_window=coverage_position_window,
                     )
-                tokens.append(
-                    next_token_from_model(
-                        model,
-                        tokens=tokens,
-                        allowed_tokens=allowed,
-                        temperature=temperature,
-                        top_k=top_k,
+                if chord_aware_pitches and family_index == 2:
+                    allowed = chord_aware_pitch_tokens(
+                        chord,
+                        pitch_mode=chord_pitch_mode,
+                        recent_pitches=recent_pitches,
+                        repeat_window=chord_pitch_repeat_window,
                     )
+                token = next_token_from_model(
+                    model,
+                    tokens=tokens,
+                    allowed_tokens=allowed,
+                    temperature=temperature,
+                    top_k=top_k,
                 )
+                tokens.append(token)
+                if family_index == 2 and is_note_pitch_token(token):
+                    recent_pitches.append(pitch_from_token(token))
 
     tokens.append(TOKEN_END)
     return tokens[: int(max_sequence)]
@@ -799,6 +877,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--constrained_note_groups_per_bar", type=int, default=4)
     parser.add_argument("--coverage_aware_positions", action="store_true")
     parser.add_argument("--coverage_position_window", type=int, default=0)
+    parser.add_argument("--chord_aware_pitches", action="store_true")
+    parser.add_argument("--chord_pitch_mode", choices=("tones", "tones_tensions"), default="tones_tensions")
+    parser.add_argument("--chord_pitch_repeat_window", type=int, default=2)
     parser.add_argument("--postprocess_overlap", action="store_true")
     parser.add_argument("--max_simultaneous_notes", type=int, default=2)
     parser.add_argument("--min_valid_samples", type=int, default=1)
@@ -875,6 +956,9 @@ def main() -> int:
         "constrained_note_groups_per_bar": int(args.constrained_note_groups_per_bar),
         "coverage_aware_positions": bool(args.coverage_aware_positions),
         "coverage_position_window": int(args.coverage_position_window),
+        "chord_aware_pitches": bool(args.chord_aware_pitches),
+        "chord_pitch_mode": args.chord_pitch_mode,
+        "chord_pitch_repeat_window": int(args.chord_pitch_repeat_window),
         "postprocess_overlap": bool(args.postprocess_overlap),
     }
 
@@ -934,6 +1018,9 @@ def main() -> int:
                 top_k=args.top_k,
                 coverage_aware_positions=args.coverage_aware_positions,
                 coverage_position_window=args.coverage_position_window,
+                chord_aware_pitches=args.chord_aware_pitches,
+                chord_pitch_mode=args.chord_pitch_mode,
+                chord_pitch_repeat_window=args.chord_pitch_repeat_window,
             )
         else:
             generated_tokens = generate_stage_b_tokens(

--- a/scripts/run_stage_b_sampling_sweep.py
+++ b/scripts/run_stage_b_sampling_sweep.py
@@ -115,6 +115,10 @@ def probe_command(
     ]
     if args.require_all_grammar_samples:
         cmd.append("--require_all_grammar_samples")
+    if getattr(args, "chord_aware_pitches", False):
+        cmd.append("--chord_aware_pitches")
+        cmd.extend(["--chord_pitch_mode", str(getattr(args, "chord_pitch_mode", "tones_tensions"))])
+        cmd.extend(["--chord_pitch_repeat_window", str(getattr(args, "chord_pitch_repeat_window", 2))])
     if skip_prepare_train:
         cmd.extend(["--skip_prepare", "--skip_train"])
     if checkpoint_dir is not None:
@@ -142,6 +146,9 @@ def row_from_probe_report(top_k: int, temperature: float, run_id: str, report: d
         "generation_mode": str(report.get("generation_mode", "")),
         "coverage_aware_positions": bool(report.get("coverage_aware_positions", False)),
         "coverage_position_window": int(report.get("coverage_position_window", 0) or 0),
+        "chord_aware_pitches": bool(report.get("chord_aware_pitches", False)),
+        "chord_pitch_mode": str(report.get("chord_pitch_mode", "")),
+        "chord_pitch_repeat_window": int(report.get("chord_pitch_repeat_window", 0) or 0),
         "constrained_note_groups_per_bar": int(report.get("constrained_note_groups_per_bar", 0) or 0),
         "sample_count": int(summary.get("sample_count", 0)),
         "grammar_gate_sample_count": int(summary.get("grammar_gate_sample_count", 0)),

--- a/tests/test_stage_b_coverage_ab_sweep.py
+++ b/tests/test_stage_b_coverage_ab_sweep.py
@@ -6,6 +6,8 @@ from scripts.run_stage_b_coverage_ab_sweep import (
     build_ab_summary,
     config_run_id,
     markdown_table,
+    mode_has_chord_aware_pitches,
+    mode_has_coverage,
     parse_modes,
 )
 
@@ -14,6 +16,11 @@ class StageBCoverageAbSweepTest(unittest.TestCase):
     def test_parse_modes_rejects_unknown_mode(self) -> None:
         with self.assertRaises(ValueError):
             parse_modes("plain,random")
+
+    def test_parse_modes_accepts_chord_aware_modes(self) -> None:
+        self.assertEqual(parse_modes("plain,coverage_chord"), ["plain", "coverage_chord"])
+        self.assertTrue(mode_has_coverage("coverage_chord"))
+        self.assertTrue(mode_has_chord_aware_pitches("coverage_chord"))
 
     def test_config_run_id_is_stable(self) -> None:
         self.assertEqual(
@@ -49,12 +56,27 @@ class StageBCoverageAbSweepTest(unittest.TestCase):
                 "collapse_warning_sample_rate": 0.0,
                 "max_longest_sustained_empty_run_steps": 6,
             },
+            {
+                "mode": "coverage_chord",
+                "note_groups_per_bar": 4,
+                "run_id": "coverage_chord",
+                "top_k": 2,
+                "temperature": 0.9,
+                "valid_sample_count": 2,
+                "strict_valid_sample_count": 2,
+                "avg_onset_coverage_ratio": 0.25,
+                "avg_sustained_coverage_ratio": 0.5,
+                "collapse_warning_sample_rate": 0.0,
+                "max_longest_sustained_empty_run_steps": 5,
+            },
         ]
 
         summary = build_ab_summary(rows, min_best_strict_valid_samples=1)
 
         self.assertTrue(summary["passed_ab_sweep_gate"])
+        self.assertTrue(summary["passed_chord_gate"])
         self.assertEqual(summary["best_coverage_config"]["strict_valid_sample_count"], 3)
+        self.assertEqual(summary["best_coverage_chord_config"]["strict_valid_sample_count"], 2)
         self.assertEqual(summary["best_plain_config"]["strict_valid_sample_count"], 0)
 
     def test_build_ab_summary_fails_without_plain_comparison(self) -> None:
@@ -96,12 +118,15 @@ class StageBCoverageAbSweepTest(unittest.TestCase):
                 "collapse_warning_sample_rate": 0.0,
                 "passed_strict_review_gate": True,
                 "diagnostic_failure_reasons": {},
+                "chord_aware_pitches": True,
             }
         ]
         summary = {
             "passed_ab_sweep_gate": True,
             "best_plain_config": None,
             "best_coverage_config": {"mode": "coverage", "note_groups_per_bar": 4},
+            "best_chord_config": {"mode": "coverage", "note_groups_per_bar": 4},
+            "best_coverage_chord_config": None,
         }
 
         markdown = markdown_table(rows, summary)
@@ -109,6 +134,7 @@ class StageBCoverageAbSweepTest(unittest.TestCase):
         self.assertIn("groups/bar", markdown)
         self.assertIn("dead air", markdown)
         self.assertIn("coverage", markdown)
+        self.assertIn("chord", markdown)
 
 
 if __name__ == "__main__":

--- a/tests/test_stage_b_generation_probe.py
+++ b/tests/test_stage_b_generation_probe.py
@@ -13,10 +13,13 @@ from scripts.run_stage_b_generation_probe import (
     analyze_stage_b_temporal_coverage,
     build_probe_summary,
     build_stage_b_primer,
+    chord_aware_pitch_tokens,
+    chord_pitch_classes,
     coverage_aware_position_tokens,
     dedupe_and_limit_notes,
     decode_tokens_to_midi,
     evaluate_collapse_gate,
+    extract_stage_b_note_groups,
     generate_stage_b_constrained_tokens,
     generate_stage_b_tokens,
     postprocess_stage_b_midi,
@@ -26,6 +29,7 @@ from scripts.stage_b_tokens import (
     note_duration_token,
     note_pitch_token,
     note_velocity_token,
+    pitch_from_token,
     position_token,
     position_from_token,
 )
@@ -178,6 +182,51 @@ class StageBGenerationProbeTest(unittest.TestCase):
         ]
 
         self.assertEqual(positions, [7, 8, 9])
+
+    def test_chord_aware_pitch_tokens_limit_to_chord_tones(self) -> None:
+        tokens = chord_aware_pitch_tokens("Cm7", pitch_mode="tones", repeat_window=0)
+        pitch_classes = {pitch_from_token(token) % 12 for token in tokens}
+
+        self.assertEqual(pitch_classes, {0, 3, 7, 10})
+
+    def test_chord_aware_pitch_tokens_can_avoid_recent_exact_pitches(self) -> None:
+        tokens = chord_aware_pitch_tokens("Cm7", pitch_mode="tones", recent_pitches=[72], repeat_window=2)
+
+        self.assertNotIn(note_pitch_token(72), tokens)
+        self.assertIn(note_pitch_token(60), tokens)
+
+    def test_chord_pitch_classes_can_include_tensions(self) -> None:
+        self.assertEqual(chord_pitch_classes("Cmaj7", pitch_mode="tones"), {0, 4, 7, 11})
+        self.assertIn(2, chord_pitch_classes("Cmaj7", pitch_mode="tones_tensions"))
+
+    def test_chord_aware_constrained_generation_limits_pitch_by_bar_chord(self) -> None:
+        primer = build_stage_b_primer(["Cm7", "F7"], bpm=120)
+
+        tokens = generate_stage_b_constrained_tokens(
+            model=FakeConstrainedModel(),
+            primer_tokens=primer,
+            chords=["Cm7", "F7"],
+            bpm=120,
+            bars=2,
+            note_groups_per_bar=3,
+            max_sequence=96,
+            temperature=1.0,
+            top_k=1,
+            coverage_aware_positions=True,
+            chord_aware_pitches=True,
+            chord_pitch_mode="tones",
+            chord_pitch_repeat_window=2,
+        )
+
+        groups = extract_stage_b_note_groups(tokens, primer_size=len(primer))
+        allowed_by_bar = {
+            0: chord_pitch_classes("Cm7", pitch_mode="tones"),
+            1: chord_pitch_classes("F7", pitch_mode="tones"),
+        }
+
+        self.assertGreaterEqual(len(groups), 6)
+        for group in groups:
+            self.assertIn(group["pitch"] % 12, allowed_by_bar[group["bar"]])
 
     def test_dedupe_and_limit_notes_removes_same_onset_pitch_duplicates(self) -> None:
         notes = [


### PR DESCRIPTION
## 요약

- Stage B constrained generation에 chord-aware NOTE_PITCH 후보군을 추가했습니다.
- 기존 coverage-aware POSITION 개선은 유지하면서, current bar chord 기준으로 pitch token을 제한할 수 있습니다.
- plain / coverage / coverage_chord 모드를 같은 checkpoint 조건에서 비교하고 candidate ranking까지 실행하는 하네스를 추가했습니다.

## 핵심 결과

- candidates: 27
- strict candidates: 21
- viable unflagged candidates: 9
- flagged candidates: 18
- best candidate: coverage_chord, groups/bar 4, sample 2
- best candidate score: 96.6964
- best candidate chord-tone ratio: 0.750
- best candidate bar chord-tone ratio: 0.875
- best candidate min bar chord-tone ratio: 0.800
- best candidate dominant pitch ratio: 0.375
- best candidate repeated pitch ratio: 0.250

## 변경 사항

- scripts/run_stage_b_generation_probe.py
  - --chord_aware_pitches 추가
  - --chord_pitch_mode tones|tones_tensions 추가
  - --chord_pitch_repeat_window 추가
  - chord-aware pitch token 후보군 및 recent exact pitch repeat 회피 추가
- scripts/run_stage_b_coverage_ab_sweep.py
  - coverage_chord mode 추가
  - chord-aware config summary 추가
- scripts/run_stage_b_sampling_sweep.py
  - probe command에 chord-aware pitch 옵션 전달
- scripts/agent_harness.sh
  - stage-b-chord-aware-probe 추가
- docs
  - Issue #45 결과와 다음 review point 문서화

## 해석

이 PR은 Brad style model 성공을 의미하지 않습니다. 다만 Issue #43에서 0개였던 viable unflagged candidate가 9개로 회복되어, 이제 manual listening/piano-roll review를 할 수 있는 후보가 생겼다는 의미입니다.

## 검증

- ./.venv/bin/python -m unittest tests.test_stage_b_generation_probe
- ./.venv/bin/python -m unittest tests.test_stage_b_coverage_ab_sweep tests.test_stage_b_generation_probe
- ./.venv/bin/python -m compileall scripts/run_stage_b_generation_probe.py tests/test_stage_b_generation_probe.py
- ./.venv/bin/python -m compileall scripts/run_stage_b_coverage_ab_sweep.py scripts/run_stage_b_sampling_sweep.py scripts/run_stage_b_generation_probe.py
- bash scripts/agent_harness.sh quick
- bash scripts/agent_harness.sh stage-b-chord-aware-probe

Closes #45