### PR TITLE
Stage B coverage_chord 후보 리뷰 패키지 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #45: Stage B chord-aware pitch constrained generation.
+- Issue #47: Stage B coverage_chord candidate review package.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -125,6 +125,7 @@ Stage B에서 명시하는 것:
 19. Stage B candidate ranking report
 20. Stage B ranking harmonic/repetition gate
 21. Stage B chord-aware pitch constrained generation
+22. Stage B coverage_chord candidate review export
 
 가장 최근 의미 있는 결과:
 
@@ -134,6 +135,7 @@ Stage B에서 명시하는 것:
 - Issue #45 result: candidates `27`, strict candidates `21`, viable unflagged candidates `9`, flagged candidates `18`
 - top candidate: `coverage_chord`, groups/bar `4`, sample `2`, score `96.6964`
 - top candidate harmonic diagnostics: chord-tone `0.750`, bar chord-tone `0.875`, min bar chord-tone `0.800`, dominant pitch `0.375`, repeated pitch `0.250`
+- Issue #47 exported the top 6 `coverage_chord` MIDI candidates to `outputs/stage_b_review_candidates/harness_stage_b_chord_aware_probe`
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -152,7 +154,7 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-다음 단계는 manual listening/piano-roll review다. `coverage_chord` top candidates가 귀로도 solo-line 후보라면 generic jazz base 후보 학습 설계로 넘어가고, 아니면 rhythm/motif-level constraint 또는 pretrained symbolic base를 먼저 검토한다.
+다음 단계는 manual listening/piano-roll review다. `outputs/stage_b_review_candidates/harness_stage_b_chord_aware_probe/midi/`의 top candidates가 귀로도 solo-line 후보라면 generic jazz base 후보 학습 설계로 넘어가고, 아니면 rhythm/motif-level constraint 또는 pretrained symbolic base를 먼저 검토한다.
 
 ## 6. 다음 단계 로드맵
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-45-stage-b-chord-aware-pitch`
+- `issue-47-stage-b-review-package`
 
 현재 범위가 아닌 것:
 
@@ -36,57 +36,47 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 ## Latest Probe Result
 
-Issue #45에서 Stage B constrained generation에 chord-aware pitch 후보군을 추가했다.
+Issue #47에서 Issue #45의 `coverage_chord` top candidates를 manual listening review용 package로 export하는 도구를 추가했다.
 
-Issue #43은 이전 top candidate가 strict-valid였어도 solo-line으로 보기 어렵다는 점을 확인했다.
+Issue #45는 chord-aware pitch 후보군으로 viable unflagged candidates를 `9`개 만들었다.
 
-Issue #45는 ranking을 더 꾸미지 않고 generation-side pitch 후보군을 고쳤다.
+Issue #47은 이 후보들을 실제로 들어볼 수 있게 review manifest/markdown과 복사된 MIDI 목록을 만든다.
 
 Implemented:
 
-- `--chord_aware_pitches`
-- `--chord_pitch_mode tones|tones_tensions`
-- `--chord_pitch_repeat_window`
-- A/B mode: `coverage_chord`
-- harness: `bash scripts/agent_harness.sh stage-b-chord-aware-probe`
+- `scripts/export_stage_b_review_candidates.py`
+- `tests/test_stage_b_review_export.py`
+- output files:
+  - `review_manifest.json`
+  - `review_candidates.md`
+  - copied review MIDI files under `midi/`
 
 Result:
 
-- candidate count: `27`
-- strict candidates: `21`
-- viable unflagged candidates: `9`
-- flagged candidates: `18`
-- top candidate mode: `coverage_chord`
-- top candidate groups/bar: `4`
-- top candidate note count: `8`
-- top candidate unique pitches: `6`
-- top candidate chord-tone ratio: `0.750`
-- top candidate bar chord-tone ratio: `0.875`
-- top candidate min bar chord-tone ratio: `0.800`
-- top candidate dominant pitch ratio: `0.375`
-- top candidate repeated pitch ratio: `0.250`
-- top candidate review flags: `[]`
-
-Important comparison:
-
-- coverage g8 avg chord-tone ratio: `0.229`
-- coverage_chord g8 avg chord-tone ratio: `0.646`
-- coverage g8 avg repeated position/pitch ratio: `0.167`
-- coverage_chord g8 avg repeated position/pitch ratio: `0.021`
+- source ranking report: `outputs/stage_b_candidate_ranking/harness_stage_b_chord_aware_probe/candidate_rank_report.json`
+- review output: `outputs/stage_b_review_candidates/harness_stage_b_chord_aware_probe`
+- selected candidates: `6`
+- copied MIDI files:
+  - `midi/rank_01_coverage_chord_g4_s2.mid`
+  - `midi/rank_02_coverage_chord_g6_s1.mid`
+  - `midi/rank_03_coverage_chord_g8_s1.mid`
+  - `midi/rank_04_coverage_chord_g6_s2.mid`
+  - `midi/rank_05_coverage_chord_g8_s3.mid`
+  - `midi/rank_06_coverage_chord_g8_s2.mid`
 
 Decision:
 
-- chord-aware pitch constraint는 #43의 harmonic/repetition failure를 크게 줄였다.
-- 이것은 아직 Brad style learning 성공이 아니다.
-- 다음은 top `coverage_chord` MIDI를 실제로 듣고 piano roll로 확인하는 review point다.
-- 귀로도 구조가 괜찮으면 generic jazz base 후보 학습 설계로 넘어갈 수 있다.
-- 귀로 여전히 기계적이면 rhythm/motif-level constraint 또는 pretrained symbolic base 검토가 먼저다.
+- 이제 자동 metric 단계에서 할 일은 충분하다.
+- 다음 판단은 사람이 들어야 한다.
+- top review MIDI가 solo-line으로 들리면 generic jazz base 후보 학습 설계로 넘어갈 수 있다.
+- 여전히 기계적이면 rhythm/motif-level constraint 또는 pretrained symbolic base 검토가 먼저다.
 
 Detail:
 
 - `docs/STAGE_B_CANDIDATE_RANKING_2026-05-20.md`
 - `docs/STAGE_B_RANKING_HARMONIC_GATE_2026-05-21.md`
 - `docs/STAGE_B_CHORD_AWARE_PITCH_2026-05-21.md`
+- `docs/STAGE_B_CANDIDATE_REVIEW_EXPORT_2026-05-21.md`
 
 ## Active Issue #14
 
@@ -1058,6 +1048,42 @@ Decision:
 Detail:
 
 - `docs/STAGE_B_CHORD_AWARE_PITCH_2026-05-21.md`
+
+### 0.22. Issue #47 Stage B coverage_chord candidate review package
+
+Status:
+
+- implemented on `issue-47-stage-b-review-package`
+
+Goal:
+
+- export top `coverage_chord` ranked candidates for manual listening review
+- keep generated MIDI artifacts out of git
+- make the next decision about broad training based on actual listening/piano-roll review
+
+Output:
+
+- `outputs/stage_b_review_candidates/harness_stage_b_chord_aware_probe/review_manifest.json`
+- `outputs/stage_b_review_candidates/harness_stage_b_chord_aware_probe/review_candidates.md`
+- copied MIDI files under `outputs/stage_b_review_candidates/harness_stage_b_chord_aware_probe/midi/`
+
+Selected candidates:
+
+- `rank_01_coverage_chord_g4_s2.mid`
+- `rank_02_coverage_chord_g6_s1.mid`
+- `rank_03_coverage_chord_g8_s1.mid`
+- `rank_04_coverage_chord_g6_s2.mid`
+- `rank_05_coverage_chord_g8_s3.mid`
+- `rank_06_coverage_chord_g8_s2.mid`
+
+Decision:
+
+- This is now a manual review boundary.
+- The next technical issue should wait until these MIDI files are heard or inspected in piano roll.
+
+Detail:
+
+- `docs/STAGE_B_CANDIDATE_REVIEW_EXPORT_2026-05-21.md`
 
 ### 1. Run full jazz piano dataset audit
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,8 @@
   - Stage B ranking이 low chord-tone/repeated pitch/mechanical pattern MIDI를 좋은 후보로 올리지 않도록 고친 결과.
 - `STAGE_B_CHORD_AWARE_PITCH_2026-05-21.md`
   - Stage B constrained generation에서 chord-aware pitch 후보군을 적용한 결과와 reviewable candidate 회복.
+- `STAGE_B_CANDIDATE_REVIEW_EXPORT_2026-05-21.md`
+  - Stage B `coverage_chord` top candidates를 manual listening review용 manifest/markdown으로 export하는 도구.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -82,7 +84,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, and chord-aware pitch probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, and candidate review export를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_CANDIDATE_REVIEW_EXPORT_2026-05-21.md
+++ b/docs/STAGE_B_CANDIDATE_REVIEW_EXPORT_2026-05-21.md
@@ -1,0 +1,94 @@
+# Stage B Candidate Review Export
+
+작성일: 2026-05-21
+
+## Issue
+
+- Issue: #47
+- Branch: `issue-47-stage-b-review-package`
+- Goal: Issue #45에서 생긴 top `coverage_chord` candidates를 manual listening/piano-roll review용 package로 export한다.
+
+## Why
+
+Issue #45는 first reviewable Stage B candidates를 만들었다.
+
+하지만 다음 단계는 broad training이 아니다.
+
+지금 필요한 판단은 metric이 아니라 실제 청취와 piano-roll review다.
+
+따라서 ranking report에서 top candidates를 추출해, 사람이 바로 열어볼 수 있는 review manifest와 MIDI copy를 만든다.
+
+## Implementation
+
+Added:
+
+- `scripts/export_stage_b_review_candidates.py`
+- `tests/test_stage_b_review_export.py`
+
+The script reads:
+
+```text
+outputs/stage_b_candidate_ranking/harness_stage_b_chord_aware_probe/candidate_rank_report.json
+```
+
+It writes:
+
+```text
+outputs/stage_b_review_candidates/harness_stage_b_chord_aware_probe/review_manifest.json
+outputs/stage_b_review_candidates/harness_stage_b_chord_aware_probe/review_candidates.md
+outputs/stage_b_review_candidates/harness_stage_b_chord_aware_probe/midi/*.mid
+```
+
+Generated output files are local artifacts and are not committed.
+
+## Command
+
+```bash
+./.venv/bin/python scripts/export_stage_b_review_candidates.py \
+  --ranking_report outputs/stage_b_candidate_ranking/harness_stage_b_chord_aware_probe/candidate_rank_report.json \
+  --run_id harness_stage_b_chord_aware_probe \
+  --top_n 6 \
+  --mode coverage_chord \
+  --copy_midi
+```
+
+## Export Result
+
+Selected candidates:
+
+| review | source rank | mode | groups/bar | sample | score | notes | pitches | chord | bar chord | repeat | midi |
+|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| 1 | 1 | coverage_chord | 4 | 2 | 96.6964 | 8 | 6 | 0.750 | 0.875 | 0.250 | `rank_01_coverage_chord_g4_s2.mid` |
+| 2 | 2 | coverage_chord | 6 | 1 | 95.3410 | 12 | 8 | 0.667 | 0.917 | 0.333 | `rank_02_coverage_chord_g6_s1.mid` |
+| 3 | 3 | coverage_chord | 8 | 1 | 94.1554 | 16 | 7 | 0.688 | 0.938 | 0.562 | `rank_03_coverage_chord_g8_s1.mid` |
+| 4 | 4 | coverage_chord | 6 | 2 | 92.7577 | 12 | 6 | 0.667 | 0.917 | 0.500 | `rank_04_coverage_chord_g6_s2.mid` |
+| 5 | 5 | coverage_chord | 8 | 3 | 92.5208 | 16 | 7 | 0.625 | 0.938 | 0.562 | `rank_05_coverage_chord_g8_s3.mid` |
+| 6 | 6 | coverage_chord | 8 | 2 | 92.0929 | 16 | 7 | 0.625 | 0.938 | 0.562 | `rank_06_coverage_chord_g8_s2.mid` |
+
+## Review Checklist
+
+Listen and inspect for:
+
+- solo-line shape
+- phrase contour
+- over-mechanical rhythm
+- excessive high-register bias
+- chord-tone correctness sounding too constrained
+- one-note/two-note/chord-block/long-sustain failure
+
+## Decision Boundary
+
+If the top candidates sound like usable solo-line sketches, the next issue can design the generic jazz base training probe.
+
+If they still sound mechanical, do not start broad training. Work on rhythm/motif-level behavior or evaluate a pretrained symbolic MIDI base first.
+
+## Validation
+
+Commands run:
+
+```bash
+./.venv/bin/python -m unittest tests.test_stage_b_review_export
+./.venv/bin/python -m compileall scripts/export_stage_b_review_candidates.py tests/test_stage_b_review_export.py
+./.venv/bin/python scripts/export_stage_b_review_candidates.py --ranking_report outputs/stage_b_candidate_ranking/harness_stage_b_chord_aware_probe/candidate_rank_report.json --run_id harness_stage_b_chord_aware_probe --top_n 6 --mode coverage_chord --copy_midi
+bash scripts/agent_harness.sh quick
+```

--- a/scripts/export_stage_b_review_candidates.py
+++ b/scripts/export_stage_b_review_candidates.py
@@ -1,0 +1,239 @@
+"""Export Stage B ranked MIDI candidates for manual listening review."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+DEFAULT_RANKING_REPORT = (
+    ROOT_DIR
+    / "outputs"
+    / "stage_b_candidate_ranking"
+    / "harness_stage_b_chord_aware_probe"
+    / "candidate_rank_report.json"
+)
+DEFAULT_OUTPUT_ROOT = ROOT_DIR / "outputs" / "stage_b_review_candidates"
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def candidate_sort_key(candidate: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        bool(candidate.get("reviewable")),
+        bool(candidate.get("strict_valid")),
+        -len(candidate.get("review_flags", []) or []),
+        _float(candidate.get("score")),
+        _float(candidate.get("bar_chord_tone_ratio")),
+        -_float(candidate.get("repeated_pitch_ratio")),
+    )
+
+
+def select_review_candidates(
+    report: dict[str, Any],
+    top_n: int,
+    mode: str | None = "coverage_chord",
+    reviewable_only: bool = True,
+) -> list[dict[str, Any]]:
+    candidates = list(report.get("top_candidates", []))
+    if mode:
+        candidates = [candidate for candidate in candidates if candidate.get("mode") == mode]
+    if reviewable_only:
+        candidates = [candidate for candidate in candidates if candidate.get("reviewable")]
+    candidates = sorted(candidates, key=candidate_sort_key, reverse=True)
+    return candidates[: max(1, int(top_n))]
+
+
+def compact_candidate(candidate: dict[str, Any], rank: int) -> dict[str, Any]:
+    return {
+        "review_rank": int(rank),
+        "source_rank": _int(candidate.get("rank")),
+        "mode": candidate.get("mode"),
+        "note_groups_per_bar": _int(candidate.get("note_groups_per_bar")),
+        "sample_index": _int(candidate.get("sample_index")),
+        "score": _float(candidate.get("score")),
+        "reviewable": bool(candidate.get("reviewable")),
+        "review_flags": list(candidate.get("review_flags", []) or []),
+        "midi_path": candidate.get("midi_path"),
+        "note_count": _int(candidate.get("note_count")),
+        "unique_pitch_count": _int(candidate.get("unique_pitch_count")),
+        "chord_tone_ratio": _float(candidate.get("chord_tone_ratio")),
+        "bar_chord_tone_ratio": _float(candidate.get("bar_chord_tone_ratio")),
+        "min_bar_chord_tone_ratio": _float(candidate.get("min_bar_chord_tone_ratio")),
+        "dominant_pitch_ratio": _float(candidate.get("dominant_pitch_ratio")),
+        "repeated_pitch_ratio": _float(candidate.get("repeated_pitch_ratio")),
+        "onset_coverage_ratio": _float(candidate.get("onset_coverage_ratio")),
+        "sustained_coverage_ratio": _float(candidate.get("sustained_coverage_ratio")),
+    }
+
+
+def copy_candidate_midi(candidate: dict[str, Any], output_dir: Path) -> dict[str, Any]:
+    source = candidate.get("midi_path")
+    if not source:
+        return {"copied": False, "reason": "missing midi_path"}
+    source_path = Path(str(source))
+    if not source_path.is_absolute():
+        source_path = ROOT_DIR / source_path
+    if not source_path.exists():
+        return {"copied": False, "reason": f"missing source midi: {source_path}"}
+
+    target_dir = output_dir / "midi"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_name = (
+        f"rank_{int(candidate['review_rank']):02d}_"
+        f"{candidate['mode']}_g{int(candidate['note_groups_per_bar'])}_"
+        f"s{int(candidate['sample_index'])}.mid"
+    )
+    target_path = target_dir / target_name
+    shutil.copy2(source_path, target_path)
+    return {
+        "copied": True,
+        "source_path": str(source_path),
+        "review_midi_path": str(target_path),
+        "review_midi_relative_path": str(target_path.relative_to(output_dir)),
+    }
+
+
+def markdown_report(manifest: dict[str, Any]) -> str:
+    lines = [
+        "# Stage B Candidate Listening Review",
+        "",
+        f"- source ranking report: `{manifest['source_ranking_report']}`",
+        f"- generated at: `{manifest['generated_at']}`",
+        f"- mode filter: `{manifest['mode_filter']}`",
+        f"- reviewable only: `{str(manifest['reviewable_only']).lower()}`",
+        f"- selected candidates: `{len(manifest['candidates'])}`",
+        "",
+        "| review | source rank | mode | groups/bar | sample | score | notes | pitches | chord | bar chord | min bar | dominant | repeat | midi |",
+        "|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for candidate in manifest["candidates"]:
+        midi_path = candidate.get("review_midi_relative_path") or candidate.get("midi_path")
+        table_candidate = dict(candidate)
+        table_candidate["display_midi_path"] = midi_path
+        lines.append(
+            "| {review_rank} | {source_rank} | {mode} | {note_groups_per_bar} | {sample_index} | "
+            "{score:.4f} | {note_count} | {unique_pitch_count} | {chord_tone_ratio:.3f} | "
+            "{bar_chord_tone_ratio:.3f} | {min_bar_chord_tone_ratio:.3f} | "
+            "{dominant_pitch_ratio:.3f} | {repeated_pitch_ratio:.3f} | `{display_midi_path}` |".format(
+                **table_candidate
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Review Checklist",
+            "",
+            "- solo-line shape",
+            "- phrase contour",
+            "- over-mechanical rhythm",
+            "- excessive high-register bias",
+            "- chord-tone correctness sounding too constrained",
+            "- one-note/two-note/chord-block/long-sustain failure",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def build_review_manifest(
+    ranking_report_path: Path,
+    output_dir: Path,
+    top_n: int,
+    mode: str | None,
+    reviewable_only: bool,
+    copy_midi: bool,
+) -> dict[str, Any]:
+    report = read_json(ranking_report_path)
+    selected = select_review_candidates(
+        report,
+        top_n=top_n,
+        mode=mode,
+        reviewable_only=reviewable_only,
+    )
+    candidates = [compact_candidate(candidate, rank=index + 1) for index, candidate in enumerate(selected)]
+    warnings: list[str] = []
+    if copy_midi:
+        for candidate in candidates:
+            copy_result = copy_candidate_midi(candidate, output_dir)
+            candidate.update(copy_result)
+            if not copy_result.get("copied"):
+                warnings.append(str(copy_result.get("reason", "copy failed")))
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "source_ranking_report": str(ranking_report_path),
+        "output_dir": str(output_dir),
+        "mode_filter": mode,
+        "reviewable_only": bool(reviewable_only),
+        "top_n": int(top_n),
+        "candidate_count": int(len(candidates)),
+        "warnings": warnings,
+        "candidates": candidates,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Export Stage B candidates for manual listening review")
+    parser.add_argument("--ranking_report", type=str, default=str(DEFAULT_RANKING_REPORT))
+    parser.add_argument("--output_dir", type=str, default=None)
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--top_n", type=int, default=6)
+    parser.add_argument("--mode", type=str, default="coverage_chord")
+    parser.add_argument("--include_flagged", action="store_true")
+    parser.add_argument("--copy_midi", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    ranking_report_path = Path(args.ranking_report)
+    if not ranking_report_path.is_absolute():
+        ranking_report_path = ROOT_DIR / ranking_report_path
+    run_id = args.run_id or ranking_report_path.parent.name
+    output_dir = Path(args.output_dir) if args.output_dir else DEFAULT_OUTPUT_ROOT / run_id
+    if not output_dir.is_absolute():
+        output_dir = ROOT_DIR / output_dir
+
+    manifest = build_review_manifest(
+        ranking_report_path=ranking_report_path,
+        output_dir=output_dir,
+        top_n=args.top_n,
+        mode=args.mode or None,
+        reviewable_only=not args.include_flagged,
+        copy_midi=bool(args.copy_midi),
+    )
+    write_json(output_dir / "review_manifest.json", manifest)
+    (output_dir / "review_candidates.md").write_text(markdown_report(manifest), encoding="utf-8")
+    print(json.dumps(manifest, ensure_ascii=True, indent=2))
+    return 0 if manifest["candidate_count"] > 0 else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_review_export.py
+++ b/tests/test_stage_b_review_export.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.export_stage_b_review_candidates import (
+    build_review_manifest,
+    markdown_report,
+    select_review_candidates,
+)
+
+
+def candidate(
+    *,
+    rank: int,
+    mode: str = "coverage_chord",
+    reviewable: bool = True,
+    score: float = 10.0,
+    midi_path: str = "sample.mid",
+) -> dict:
+    return {
+        "rank": rank,
+        "mode": mode,
+        "note_groups_per_bar": 4,
+        "sample_index": rank,
+        "score": score,
+        "reviewable": reviewable,
+        "review_flags": [] if reviewable else ["low_chord_tone_ratio"],
+        "midi_path": midi_path,
+        "strict_valid": True,
+        "note_count": 8,
+        "unique_pitch_count": 5,
+        "chord_tone_ratio": 0.75,
+        "bar_chord_tone_ratio": 0.875,
+        "min_bar_chord_tone_ratio": 0.8,
+        "dominant_pitch_ratio": 0.3,
+        "repeated_pitch_ratio": 0.25,
+        "onset_coverage_ratio": 0.25,
+        "sustained_coverage_ratio": 0.5,
+    }
+
+
+class StageBReviewExportTest(unittest.TestCase):
+    def test_select_review_candidates_filters_mode_and_reviewable(self) -> None:
+        report = {
+            "top_candidates": [
+                candidate(rank=1, mode="coverage", reviewable=True, score=99),
+                candidate(rank=2, mode="coverage_chord", reviewable=False, score=98),
+                candidate(rank=3, mode="coverage_chord", reviewable=True, score=97),
+            ]
+        }
+
+        selected = select_review_candidates(report, top_n=2)
+
+        self.assertEqual(len(selected), 1)
+        self.assertEqual(selected[0]["rank"], 3)
+
+    def test_build_review_manifest_copies_midi(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            source = root / "source.mid"
+            source.write_bytes(b"MThd")
+            report_path = root / "candidate_rank_report.json"
+            report_path.write_text(
+                (
+                    '{"top_candidates": ['
+                    '{"rank": 1, "mode": "coverage_chord", "note_groups_per_bar": 4, '
+                    '"sample_index": 2, "score": 96.6, "reviewable": true, '
+                    '"review_flags": [], "midi_path": "'
+                    + str(source)
+                    + '", "strict_valid": true, "note_count": 8, '
+                    '"unique_pitch_count": 6, "chord_tone_ratio": 0.75, '
+                    '"bar_chord_tone_ratio": 0.875, "min_bar_chord_tone_ratio": 0.8, '
+                    '"dominant_pitch_ratio": 0.375, "repeated_pitch_ratio": 0.25, '
+                    '"onset_coverage_ratio": 0.25, "sustained_coverage_ratio": 0.53}'
+                    "]}"
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = build_review_manifest(
+                ranking_report_path=report_path,
+                output_dir=root / "review",
+                top_n=3,
+                mode="coverage_chord",
+                reviewable_only=True,
+                copy_midi=True,
+            )
+
+            self.assertEqual(manifest["candidate_count"], 1)
+            self.assertTrue(manifest["candidates"][0]["copied"])
+            self.assertTrue((root / "review" / manifest["candidates"][0]["review_midi_relative_path"]).exists())
+
+    def test_markdown_report_contains_review_checklist(self) -> None:
+        manifest = {
+            "source_ranking_report": "report.json",
+            "generated_at": "2026-05-21T00:00:00Z",
+            "mode_filter": "coverage_chord",
+            "reviewable_only": True,
+            "candidates": [
+                {
+                    "review_rank": 1,
+                    "source_rank": 1,
+                    "mode": "coverage_chord",
+                    "note_groups_per_bar": 4,
+                    "sample_index": 2,
+                    "score": 96.6,
+                    "note_count": 8,
+                    "unique_pitch_count": 6,
+                    "chord_tone_ratio": 0.75,
+                    "bar_chord_tone_ratio": 0.875,
+                    "min_bar_chord_tone_ratio": 0.8,
+                    "dominant_pitch_ratio": 0.375,
+                    "repeated_pitch_ratio": 0.25,
+                    "midi_path": "sample.mid",
+                }
+            ],
+        }
+
+        markdown = markdown_report(manifest)
+
+        self.assertIn("coverage_chord", markdown)
+        self.assertIn("Review Checklist", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

- Issue #45에서 생성된 coverage_chord top candidates를 manual listening/piano-roll review용 package로 export하는 도구를 추가했습니다.
- ranking report에서 reviewable 후보를 필터링하고, manifest/markdown을 생성하며, 옵션으로 MIDI 파일을 review folder에 복사합니다.
- generated MIDI output은 git에 커밋하지 않습니다.

## 변경 사항

- scripts/export_stage_b_review_candidates.py
  - candidate_rank_report.json 읽기
  - reviewable/mode/top N 필터링
  - review_manifest.json 생성
  - review_candidates.md 생성
  - --copy_midi 옵션으로 MIDI 복사
- tests/test_stage_b_review_export.py
  - 후보 필터링, MIDI copy, markdown 생성 테스트
- docs
  - Issue #47 결과와 review boundary 문서화
  - CORE_PLAN / CURRENT_STATUS / docs index 업데이트

## 실제 export 결과

명령:

./.venv/bin/python scripts/export_stage_b_review_candidates.py --ranking_report outputs/stage_b_candidate_ranking/harness_stage_b_chord_aware_probe/candidate_rank_report.json --run_id harness_stage_b_chord_aware_probe --top_n 6 --mode coverage_chord --copy_midi

생성 위치:

outputs/stage_b_review_candidates/harness_stage_b_chord_aware_probe

복사된 후보:

- rank_01_coverage_chord_g4_s2.mid
- rank_02_coverage_chord_g6_s1.mid
- rank_03_coverage_chord_g8_s1.mid
- rank_04_coverage_chord_g6_s2.mid
- rank_05_coverage_chord_g8_s3.mid
- rank_06_coverage_chord_g8_s2.mid

## 해석

이제 자동 metric 단계에서 다음으로 넘어가기 전 필요한 것은 실제 청취와 piano-roll review입니다. 이 PR은 broad training을 시작하지 않고, 사람이 판단할 review package를 만드는 작업입니다.

## 검증

- ./.venv/bin/python -m unittest tests.test_stage_b_review_export
- ./.venv/bin/python -m compileall scripts/export_stage_b_review_candidates.py tests/test_stage_b_review_export.py
- ./.venv/bin/python scripts/export_stage_b_review_candidates.py --ranking_report outputs/stage_b_candidate_ranking/harness_stage_b_chord_aware_probe/candidate_rank_report.json --run_id harness_stage_b_chord_aware_probe --top_n 6 --mode coverage_chord --copy_midi
- bash scripts/agent_harness.sh quick

Closes #47