### PR TITLE
Stage B 4마디 coverage_chord phrase probe 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #47: Stage B coverage_chord candidate review package.
+- Issue #49: Stage B longer coverage_chord phrase probe.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -211,6 +211,14 @@ bash scripts/agent_harness.sh stage-b-chord-aware-probe
 ```
 
 This harness compares plain, coverage-aware, and coverage+chord-aware constrained generation, then ranks the generated MIDI candidates.
+
+For Stage B longer phrase-generation changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-longer-phrase-probe
+```
+
+This harness tests a 4-bar coverage+chord-aware constrained phrase and exports the top review MIDI candidates. It exists because short 2-bar candidates can be valid but still feel unfinished.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -126,6 +126,7 @@ Stage B에서 명시하는 것:
 20. Stage B ranking harmonic/repetition gate
 21. Stage B chord-aware pitch constrained generation
 22. Stage B coverage_chord candidate review export
+23. Stage B longer 4-bar coverage_chord phrase probe
 
 가장 최근 의미 있는 결과:
 
@@ -136,6 +137,9 @@ Stage B에서 명시하는 것:
 - top candidate: `coverage_chord`, groups/bar `4`, sample `2`, score `96.6964`
 - top candidate harmonic diagnostics: chord-tone `0.750`, bar chord-tone `0.875`, min bar chord-tone `0.800`, dominant pitch `0.375`, repeated pitch `0.250`
 - Issue #47 exported the top 6 `coverage_chord` MIDI candidates to `outputs/stage_b_review_candidates/harness_stage_b_chord_aware_probe`
+- Manual piano-roll review found that these candidates can look like melodic fragments, but are still too short and feel unfinished.
+- Issue #49 extends the same coverage+chord-aware setup to a `4` bar probe with `32` note groups per sample and exports direct review candidates from the generation probe report.
+- Issue #49 fixes the length problem structurally, but repeated-pitch dependence remains a listening-review risk.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -154,7 +158,7 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-다음 단계는 manual listening/piano-roll review다. `outputs/stage_b_review_candidates/harness_stage_b_chord_aware_probe/midi/`의 top candidates가 귀로도 solo-line 후보라면 generic jazz base 후보 학습 설계로 넘어가고, 아니면 rhythm/motif-level constraint 또는 pretrained symbolic base를 먼저 검토한다.
+다음 단계는 manual listening/piano-roll review다. 이제 우선순위 review 대상은 짧은 2-bar package가 아니라 `outputs/stage_b_review_candidates/harness_stage_b_longer_phrase_probe/midi/`의 4-bar candidates다. 이 후보가 귀로도 solo-line phrase sketch라면 generic jazz base 후보 학습 설계로 넘어가고, 아니면 phrase/motif-level constraint 또는 pretrained symbolic base를 먼저 검토한다.
 
 ## 6. 다음 단계 로드맵
 
@@ -259,6 +263,28 @@ Stage B에서 명시하는 것:
 
 - generated top candidate를 실제로 듣고 piano roll로 확인한다.
 - 그 후보가 one-note/two-note/chord-block/long-sustain/repeated-template 실패가 없어야 한다.
+
+### Phase 3.7. Longer Phrase Review
+
+목표:
+
+- 2-bar 후보가 "만들다 만 단어"처럼 들리는 문제를 직접 검증한다.
+- 같은 coverage+chord-aware 제약을 유지하되, review 후보를 `4` bar로 늘린다.
+- 단순 note count 증가가 아니라 phrase로 들을 수 있는 길이와 coverage를 확보한다.
+
+현재 결과:
+
+- completed: `4` bar generation probe를 실행했다.
+- completed: sample마다 `32` complete note groups를 생성했다.
+- completed: `3/3` samples가 grammar/basic/strict gate를 통과했다.
+- completed: generation probe report를 review export 입력으로 직접 사용할 수 있게 했다.
+- current risk: repeated pitch ratio가 높기 때문에 motif로 들리는지 기계적 재사용으로 들리는지 확인해야 한다.
+
+다음 통과 기준:
+
+- exported 4-bar candidates를 piano roll과 귀로 확인한다.
+- 단편이 아니라 최소한 call/continuation/landing 느낌의 phrase sketch인지 본다.
+- 여전히 짧거나 기계적이면 broad generic training 전 phrase/motif-level constraint를 먼저 설계한다.
 
 ### Phase 4. Generic Jazz Base 후보 학습
 
@@ -377,7 +403,9 @@ Stage B chord-aware pitch constrained generation 추가
 이 작업이 끝난 뒤 판단:
 
 - chord-aware pitch probe에서 viable unflagged candidate가 `9`개 나왔다.
-- 바로 broad training으로 가지 않고 top `coverage_chord` MIDI를 귀와 piano roll로 리뷰한다.
+- 바로 broad training으로 가지 않고 top `coverage_chord` MIDI를 귀와 piano roll로 리뷰했다.
+- 2-bar 후보는 melodic fragment일 수는 있어도 너무 짧고 미완성처럼 느껴졌다.
+- 그래서 다음 작업은 4-bar longer phrase probe로 잡았다.
 - 리뷰가 괜찮으면 generic jazz base 후보 학습 설계로 넘어간다.
 - 리뷰가 여전히 기계적이면 rhythm/motif-level constraint 또는 pretrained symbolic base를 먼저 검토한다.
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-47-stage-b-review-package`
+- `issue-49-stage-b-longer-phrase-probe`
 
 현재 범위가 아닌 것:
 
@@ -36,16 +36,17 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 ## Latest Probe Result
 
-Issue #47에서 Issue #45의 `coverage_chord` top candidates를 manual listening review용 package로 export하는 도구를 추가했다.
+Issue #49는 manual piano-roll review에서 나온 "유효하긴 하지만 너무 짧고 만들다 만 단어처럼 느껴진다"는 피드백을 반영한다.
 
-Issue #45는 chord-aware pitch 후보군으로 viable unflagged candidates를 `9`개 만들었다.
+Issue #45는 chord-aware pitch 후보군으로 viable unflagged candidates를 `9`개 만들었고, Issue #47은 그 후보들을 review package로 export했다. 하지만 exported candidates는 `2` bar 기준이고, 일부 후보는 solo-line fragment처럼 보일 수 있어도 phrase로는 짧았다.
 
-Issue #47은 이 후보들을 실제로 들어볼 수 있게 review manifest/markdown과 복사된 MIDI 목록을 만든다.
+Issue #49는 같은 coverage+chord-aware 방향을 `4` bar phrase probe로 늘린다.
 
 Implemented:
 
-- `scripts/export_stage_b_review_candidates.py`
-- `tests/test_stage_b_review_export.py`
+- `scripts/export_stage_b_review_candidates.py` generation probe report input support
+- `tests/test_stage_b_review_export.py` generation probe report selection test
+- `scripts/agent_harness.sh stage-b-longer-phrase-probe`
 - output files:
   - `review_manifest.json`
   - `review_candidates.md`
@@ -53,23 +54,23 @@ Implemented:
 
 Result:
 
-- source ranking report: `outputs/stage_b_candidate_ranking/harness_stage_b_chord_aware_probe/candidate_rank_report.json`
-- review output: `outputs/stage_b_review_candidates/harness_stage_b_chord_aware_probe`
-- selected candidates: `6`
-- copied MIDI files:
-  - `midi/rank_01_coverage_chord_g4_s2.mid`
-  - `midi/rank_02_coverage_chord_g6_s1.mid`
-  - `midi/rank_03_coverage_chord_g8_s1.mid`
-  - `midi/rank_04_coverage_chord_g6_s2.mid`
-  - `midi/rank_05_coverage_chord_g8_s3.mid`
-  - `midi/rank_06_coverage_chord_g8_s2.mid`
+- source generation report: `outputs/stage_b_generation_probe/harness_stage_b_longer_phrase_probe/report.json`
+- review output: `outputs/stage_b_review_candidates/harness_stage_b_longer_phrase_probe`
+- setup: `4` bars, `8` note groups per bar, `32` note groups per sample
+- generated samples: `3`
+- strict valid samples: `3`
+- grammar-valid samples: `3`
+- average onset coverage ratio: around `0.500`
+- average sustained coverage ratio: around `0.680`
+- repeated pitch ratio: around `0.719`
 
 Decision:
 
-- 이제 자동 metric 단계에서 할 일은 충분하다.
-- 다음 판단은 사람이 들어야 한다.
-- top review MIDI가 solo-line으로 들리면 generic jazz base 후보 학습 설계로 넘어갈 수 있다.
-- 여전히 기계적이면 rhythm/motif-level constraint 또는 pretrained symbolic base 검토가 먼저다.
+- 2-bar candidates가 너무 짧았다는 판단은 타당하다.
+- 다음 review는 4-bar exported candidates를 기준으로 한다.
+- 4-bar 후보가 여전히 단편적이면 broad training으로 가지 않고 phrase/motif-level constraint 또는 pretrained symbolic base를 검토한다.
+- 4-bar 후보가 최소한 solo-line phrase sketch로 들리면 generic jazz base 후보 학습 설계로 넘어갈 수 있다.
+- 현재 남은 핵심 리스크는 길이가 아니라 repeated-pitch dependence가 motif처럼 들리는지, 기계적 반복처럼 들리는지다.
 
 Detail:
 
@@ -77,6 +78,7 @@ Detail:
 - `docs/STAGE_B_RANKING_HARMONIC_GATE_2026-05-21.md`
 - `docs/STAGE_B_CHORD_AWARE_PITCH_2026-05-21.md`
 - `docs/STAGE_B_CANDIDATE_REVIEW_EXPORT_2026-05-21.md`
+- `docs/STAGE_B_LONGER_PHRASE_PROBE_2026-05-21.md`
 
 ## Active Issue #14
 
@@ -1085,6 +1087,57 @@ Detail:
 
 - `docs/STAGE_B_CANDIDATE_REVIEW_EXPORT_2026-05-21.md`
 
+### 0.23. Issue #49 Stage B longer coverage_chord phrase probe
+
+Status:
+
+- implemented on `issue-49-stage-b-longer-phrase-probe`
+
+Review trigger:
+
+- Issue #47 review candidates were valid enough to inspect, but too short.
+- Piano-roll review showed fragments that may be melodic, but felt unfinished as phrases.
+- The next probe should not ask whether a MIDI file exists; it should ask whether the candidate has enough phrase length to review.
+
+Goal:
+
+- run a `4` bar coverage+chord-aware constrained probe
+- increase generated note groups from `8-16` notes to `32` note groups per sample
+- export the generated samples directly from the generation probe report
+- keep the claim limited to "longer review candidates", not "finished jazz solo model"
+
+Probe setup:
+
+- max files: `2`
+- window bars: `4`
+- window stride bars: `2`
+- minimum window target notes: `8`
+- generation bars: `4`
+- constrained note groups per bar: `8`
+- pitch mode: chord tones
+- position mode: coverage-aware
+- samples: `3`
+
+Latest local result:
+
+- generated samples: `3`
+- strict valid samples: `3`
+- grammar valid samples: `3`
+- note groups per sample: `32`
+- average onset coverage ratio: around `0.500`
+- average sustained coverage ratio: around `0.680`
+- max longest sustained empty run: `2` steps
+
+Decision:
+
+- This directly addresses the "too short / unfinished word" failure mode.
+- The next manual review should open the exported 4-bar MIDI candidates, not the previous 2-bar package.
+- If these still feel like fragments, the next issue should move to phrase/motif-level structure rather than simply adding more notes.
+
+Detail:
+
+- `docs/STAGE_B_LONGER_PHRASE_PROBE_2026-05-21.md`
+
 ### 1. Run full jazz piano dataset audit
 
 ```bash
@@ -1227,6 +1280,10 @@ Decision:
 - `docs/STAGE_B_COVERAGE_AWARE_GENERATION_2026-05-20.md`
 - `docs/STAGE_B_COVERAGE_AB_SWEEP_2026-05-20.md`
 - `docs/STAGE_B_CANDIDATE_RANKING_2026-05-20.md`
+- `docs/STAGE_B_RANKING_HARMONIC_GATE_2026-05-21.md`
+- `docs/STAGE_B_CHORD_AWARE_PITCH_2026-05-21.md`
+- `docs/STAGE_B_CANDIDATE_REVIEW_EXPORT_2026-05-21.md`
+- `docs/STAGE_B_LONGER_PHRASE_PROBE_2026-05-21.md`
 - `docs/REFERENCES.md`
 - `docs/INFERENCE_MODEL_SPEC.md`
 - `docs/QA_ACCEPTANCE_PLAN.md`
@@ -1309,4 +1366,10 @@ For Stage B candidate ranking changes:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-candidate-ranking
+```
+
+For Stage B longer phrase review candidates:
+
+```bash
+bash scripts/agent_harness.sh stage-b-longer-phrase-probe
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,8 @@
   - Stage B constrained generation에서 chord-aware pitch 후보군을 적용한 결과와 reviewable candidate 회복.
 - `STAGE_B_CANDIDATE_REVIEW_EXPORT_2026-05-21.md`
   - Stage B `coverage_chord` top candidates를 manual listening review용 manifest/markdown으로 export하는 도구.
+- `STAGE_B_LONGER_PHRASE_PROBE_2026-05-21.md`
+  - 2-bar 후보가 너무 짧다는 piano-roll review를 반영해 4-bar `coverage_chord` phrase 후보를 생성/export하는 probe.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -84,7 +86,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, and candidate review export를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, and longer 4-bar phrase probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_LONGER_PHRASE_PROBE_2026-05-21.md
+++ b/docs/STAGE_B_LONGER_PHRASE_PROBE_2026-05-21.md
@@ -1,0 +1,190 @@
+# Stage B Longer Phrase Probe
+
+작성일: 2026-05-21
+
+## Issue
+
+- Issue: #49
+- Branch: `issue-49-stage-b-longer-phrase-probe`
+- Goal: 2-bar `coverage_chord` 후보가 너무 짧고 미완성처럼 느껴지는 문제를 4-bar phrase probe로 다시 검증한다.
+
+## Why
+
+Issue #45와 #47은 처음으로 reviewable `coverage_chord` MIDI 후보를 만들고 export했다.
+
+하지만 manual piano-roll review에서 중요한 문제가 남았다.
+
+- MIDI 파일은 valid하다.
+- note count와 chord-tone ratio도 이전보다 낫다.
+- melodic fragment처럼 보일 수는 있다.
+- 그러나 2-bar 기준이라 phrase가 아니라 "만들다 만 단어"처럼 느껴진다.
+
+따라서 이번 이슈의 기준은 "파일이 생성됐는가"가 아니다.
+
+이번 기준:
+
+- 최소 4마디 길이
+- bar마다 충분한 onset coverage
+- sample마다 32 note groups
+- one-note/two-note/chord-block/long-sustain 실패 제외
+- exported MIDI를 실제로 듣고 phrase sketch인지 판단 가능해야 함
+
+## Implementation
+
+Added or updated:
+
+- `scripts/agent_harness.sh stage-b-longer-phrase-probe`
+- `scripts/export_stage_b_review_candidates.py`
+- `tests/test_stage_b_review_export.py`
+
+The review exporter now accepts two report shapes:
+
+- candidate ranking report with `top_candidates`
+- generation probe report with `samples`
+
+This lets the longer phrase probe export review candidates directly from:
+
+```text
+outputs/stage_b_generation_probe/harness_stage_b_longer_phrase_probe/report.json
+```
+
+Generated review package:
+
+```text
+outputs/stage_b_review_candidates/harness_stage_b_longer_phrase_probe/review_manifest.json
+outputs/stage_b_review_candidates/harness_stage_b_longer_phrase_probe/review_candidates.md
+outputs/stage_b_review_candidates/harness_stage_b_longer_phrase_probe/midi/*.mid
+```
+
+Generated artifacts are local outputs and are not committed.
+
+## Harness Command
+
+```bash
+bash scripts/agent_harness.sh stage-b-longer-phrase-probe
+```
+
+Equivalent generation setup:
+
+```bash
+./.venv/bin/python scripts/run_stage_b_generation_probe.py \
+  --run_id harness_stage_b_longer_phrase_probe \
+  --issue_number 49 \
+  --max_files 2 \
+  --window_bars 4 \
+  --window_stride_bars 2 \
+  --min_window_target_notes 8 \
+  --epochs 3 \
+  --batch_size 8 \
+  --max_sequence 192 \
+  --num_samples 3 \
+  --bars 4 \
+  --generation_mode constrained \
+  --coverage_aware_positions \
+  --coverage_position_window 0 \
+  --chord_aware_pitches \
+  --chord_pitch_mode tones \
+  --chord_pitch_repeat_window 2 \
+  --constrained_note_groups_per_bar 8 \
+  --postprocess_overlap \
+  --max_simultaneous_notes 2 \
+  --temperature 0.9 \
+  --top_k 2 \
+  --min_valid_samples 1 \
+  --min_strict_valid_samples 1 \
+  --max_collapse_warning_sample_rate 0.34 \
+  --require_all_grammar_samples \
+  --require_note_groups \
+  --n_layers 1 \
+  --num_heads 4 \
+  --d_model 64 \
+  --dim_feedforward 128 \
+  --lora_r 4 \
+  --lora_alpha 8
+```
+
+## Probe Result
+
+Local manual probe result before this doc:
+
+| Metric | Value |
+|---|---:|
+| generated samples | 3 |
+| strict valid samples | 3 |
+| grammar valid samples | 3 |
+| bars | 4 |
+| note groups per bar | 8 |
+| note groups per sample | 32 |
+| avg onset coverage ratio | 0.500 |
+| avg sustained coverage ratio | 0.682 |
+| avg position span ratio | 0.969 |
+| max longest sustained empty run | 2 |
+| collapse warning samples | 0 |
+| repeated pitch ratio | 0.719 |
+
+Sample 1 metrics:
+
+| Metric | Value |
+|---|---:|
+| note count | 32 |
+| unique pitch count | 9 |
+| chord-tone ratio | 0.906 |
+| phrase coverage ratio | 0.984 |
+| dead-air ratio | 0.484 |
+| max simultaneous notes | 2 |
+
+## Review Checklist
+
+Open the exported 4-bar MIDI candidates and check:
+
+- Does it feel like a phrase, not a fragment?
+- Is there a beginning, continuation, and landing?
+- Does the line avoid one repeated pitch as the main idea?
+- Is the high repeated-pitch ratio musically acceptable as motif, or just mechanical reuse?
+- Does chord-tone correctness sound too constrained or robotic?
+- Is the rhythm still too grid/mechanical?
+- Does the high register bias make it unusable as a jazz piano solo?
+
+## Current Interpretation
+
+This probe fixes the length problem structurally, but it does not prove musical phrase quality.
+
+The important remaining risk is repeated-pitch dependence:
+
+- note count is now high enough for review
+- bar coverage is regular and complete
+- chord-tone ratio is high
+- repeated pitch ratio is also high, around `0.719`
+
+So the review question changed from:
+
+> "Is this too short to judge?"
+
+to:
+
+> "Does this 4-bar line sound like a motif/phrase, or just a mechanically repeated pitch pattern?"
+
+## Decision Boundary
+
+If the 4-bar candidates sound like usable phrase sketches:
+
+- move to generic jazz base training design
+- keep Brad subset for later adaptation/holdout
+- avoid claiming Brad style yet
+
+If the 4-bar candidates still sound like fragments:
+
+- do not start broad training
+- add phrase/motif-level constraints or evaluate a pretrained symbolic MIDI base
+- do not keep adding postprocess and call it model quality
+
+## Validation
+
+Required validation:
+
+```bash
+./.venv/bin/python -m unittest tests.test_stage_b_review_export
+./.venv/bin/python -m compileall scripts/export_stage_b_review_candidates.py tests/test_stage_b_review_export.py
+bash scripts/agent_harness.sh quick
+bash scripts/agent_harness.sh stage-b-longer-phrase-probe
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -50,6 +50,8 @@ Modes:
                 Run coverage A/B sweep and rank generated MIDI candidates.
   stage-b-chord-aware-probe
                 Run coverage/chord-aware Stage B sweep and rank candidates.
+  stage-b-longer-phrase-probe
+                Run a 4-bar coverage/chord-aware Stage B probe and export review MIDI.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   all           Run demo and tiny-compare.
@@ -445,6 +447,51 @@ run_stage_b_chord_aware_probe() {
     --min_top_strict_candidates 1
 }
 
+run_stage_b_longer_phrase_probe() {
+  local run_id="${RUN_ID:-harness_stage_b_longer_phrase_probe}"
+  print_header "Stage B longer coverage/chord-aware phrase probe"
+  "$PYTHON_BIN" scripts/run_stage_b_generation_probe.py \
+    --run_id "$run_id" \
+    --issue_number 49 \
+    --max_files 2 \
+    --window_bars 4 \
+    --window_stride_bars 2 \
+    --min_window_target_notes 8 \
+    --epochs 3 \
+    --batch_size 8 \
+    --max_sequence 192 \
+    --num_samples 3 \
+    --bars 4 \
+    --generation_mode constrained \
+    --coverage_aware_positions \
+    --coverage_position_window 0 \
+    --chord_aware_pitches \
+    --chord_pitch_mode tones \
+    --chord_pitch_repeat_window 2 \
+    --constrained_note_groups_per_bar 8 \
+    --postprocess_overlap \
+    --max_simultaneous_notes 2 \
+    --temperature 0.9 \
+    --top_k 2 \
+    --min_valid_samples 1 \
+    --min_strict_valid_samples 1 \
+    --max_collapse_warning_sample_rate 0.34 \
+    --require_all_grammar_samples \
+    --require_note_groups \
+    --n_layers 1 \
+    --num_heads 4 \
+    --d_model 64 \
+    --dim_feedforward 128 \
+    --lora_r 4 \
+    --lora_alpha 8
+  "$PYTHON_BIN" scripts/export_stage_b_review_candidates.py \
+    --source_report "outputs/stage_b_generation_probe/${run_id}/report.json" \
+    --run_id "$run_id" \
+    --top_n 3 \
+    --mode coverage_chord \
+    --copy_midi
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -507,6 +554,9 @@ case "$MODE" in
     ;;
   stage-b-chord-aware-probe)
     run_stage_b_chord_aware_probe
+    ;;
+  stage-b-longer-phrase-probe)
+    run_stage_b_longer_phrase_probe
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/export_stage_b_review_candidates.py
+++ b/scripts/export_stage_b_review_candidates.py
@@ -56,13 +56,94 @@ def candidate_sort_key(candidate: dict[str, Any]) -> tuple[Any, ...]:
     )
 
 
+def mode_from_probe_report(report: dict[str, Any]) -> str:
+    coverage = bool(report.get("coverage_aware_positions", False))
+    chord = bool(report.get("chord_aware_pitches", False))
+    if coverage and chord:
+        return "coverage_chord"
+    if coverage:
+        return "coverage"
+    if chord:
+        return "chord"
+    return "plain"
+
+
+def score_probe_sample(sample: dict[str, Any]) -> float:
+    metrics = sample.get("metrics", {})
+    collapse = sample.get("collapse", {})
+    temporal = sample.get("temporal_coverage", {})
+    return round(
+        (30.0 if sample.get("strict_valid") else 0.0)
+        + (15.0 if sample.get("valid") else 0.0)
+        + (8.0 if sample.get("grammar_gate_passed") else 0.0)
+        + _float(metrics.get("chord_tone_ratio")) * 30.0
+        + _float(temporal.get("onset_coverage_ratio")) * 12.0
+        + _float(temporal.get("sustained_coverage_ratio")) * 6.0
+        + min(_int(metrics.get("unique_pitch_count")), 8) * 2.0
+        - _float(metrics.get("dead_air_ratio")) * 10.0
+        - _float(collapse.get("repeated_position_pitch_pair_ratio")) * 15.0
+        - _float(collapse.get("repeated_pitch_ratio")) * 10.0,
+        4,
+    )
+
+
+def candidates_from_generation_probe(report: dict[str, Any]) -> list[dict[str, Any]]:
+    mode = mode_from_probe_report(report)
+    note_groups_per_bar = _int(report.get("constrained_note_groups_per_bar"))
+    candidates: list[dict[str, Any]] = []
+    for sample in report.get("samples", []):
+        if not isinstance(sample, dict):
+            continue
+        metrics = sample.get("metrics", {})
+        collapse = sample.get("collapse", {})
+        temporal = sample.get("temporal_coverage", {})
+        review_flags: list[str] = []
+        if not sample.get("strict_valid"):
+            reason = sample.get("failure_reason") or sample.get("diagnostic_failure_reason") or "not_strict_valid"
+            review_flags.append(str(reason))
+        if collapse.get("collapse_warning"):
+            review_flags.extend(str(reason) for reason in collapse.get("collapse_reasons", []))
+        candidates.append(
+            {
+                "rank": _int(sample.get("sample_index")),
+                "mode": mode,
+                "note_groups_per_bar": note_groups_per_bar,
+                "sample_index": _int(sample.get("sample_index")),
+                "score": score_probe_sample(sample),
+                "reviewable": bool(sample.get("strict_valid")) and not review_flags,
+                "review_flags": review_flags,
+                "midi_path": sample.get("midi_path"),
+                "strict_valid": bool(sample.get("strict_valid")),
+                "note_count": _int(metrics.get("note_count")),
+                "unique_pitch_count": _int(metrics.get("unique_pitch_count")),
+                "chord_tone_ratio": _float(metrics.get("chord_tone_ratio")),
+                "bar_chord_tone_ratio": _float(metrics.get("chord_tone_ratio")),
+                "min_bar_chord_tone_ratio": _float(metrics.get("chord_tone_ratio")),
+                "dominant_pitch_ratio": _float(collapse.get("max_same_pitch_repeats"))
+                / max(1, _int(collapse.get("note_group_count"))),
+                "repeated_pitch_ratio": _float(collapse.get("repeated_pitch_ratio")),
+                "onset_coverage_ratio": _float(temporal.get("onset_coverage_ratio")),
+                "sustained_coverage_ratio": _float(temporal.get("sustained_coverage_ratio")),
+            }
+        )
+    return candidates
+
+
+def candidate_rows(report: dict[str, Any]) -> list[dict[str, Any]]:
+    if "top_candidates" in report:
+        return list(report.get("top_candidates", []))
+    if "samples" in report:
+        return candidates_from_generation_probe(report)
+    return []
+
+
 def select_review_candidates(
     report: dict[str, Any],
     top_n: int,
     mode: str | None = "coverage_chord",
     reviewable_only: bool = True,
 ) -> list[dict[str, Any]]:
-    candidates = list(report.get("top_candidates", []))
+    candidates = candidate_rows(report)
     if mode:
         candidates = [candidate for candidate in candidates if candidate.get("mode") == mode]
     if reviewable_only:
@@ -122,10 +203,11 @@ def copy_candidate_midi(candidate: dict[str, Any], output_dir: Path) -> dict[str
 
 
 def markdown_report(manifest: dict[str, Any]) -> str:
+    source_report = manifest.get("source_report") or manifest["source_ranking_report"]
     lines = [
         "# Stage B Candidate Listening Review",
         "",
-        f"- source ranking report: `{manifest['source_ranking_report']}`",
+        f"- source report: `{source_report}`",
         f"- generated at: `{manifest['generated_at']}`",
         f"- mode filter: `{manifest['mode_filter']}`",
         f"- reviewable only: `{str(manifest['reviewable_only']).lower()}`",
@@ -154,7 +236,9 @@ def markdown_report(manifest: dict[str, Any]) -> str:
             "- solo-line shape",
             "- phrase contour",
             "- over-mechanical rhythm",
+            "- excessive repeated-pitch dependence",
             "- excessive high-register bias",
+            "- too-short fragment rather than phrase",
             "- chord-tone correctness sounding too constrained",
             "- one-note/two-note/chord-block/long-sustain failure",
         ]
@@ -188,6 +272,7 @@ def build_review_manifest(
 
     return {
         "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "source_report": str(ranking_report_path),
         "source_ranking_report": str(ranking_report_path),
         "output_dir": str(output_dir),
         "mode_filter": mode,
@@ -202,6 +287,7 @@ def build_review_manifest(
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Export Stage B candidates for manual listening review")
     parser.add_argument("--ranking_report", type=str, default=str(DEFAULT_RANKING_REPORT))
+    parser.add_argument("--source_report", type=str, default=None)
     parser.add_argument("--output_dir", type=str, default=None)
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--top_n", type=int, default=6)
@@ -213,7 +299,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main() -> int:
     args = build_parser().parse_args()
-    ranking_report_path = Path(args.ranking_report)
+    ranking_report_path = Path(args.source_report or args.ranking_report)
     if not ranking_report_path.is_absolute():
         ranking_report_path = ROOT_DIR / ranking_report_path
     run_id = args.run_id or ranking_report_path.parent.name

--- a/tests/test_stage_b_review_export.py
+++ b/tests/test_stage_b_review_export.py
@@ -56,6 +56,58 @@ class StageBReviewExportTest(unittest.TestCase):
         self.assertEqual(len(selected), 1)
         self.assertEqual(selected[0]["rank"], 3)
 
+    def test_select_review_candidates_accepts_generation_probe_report(self) -> None:
+        report = {
+            "coverage_aware_positions": True,
+            "chord_aware_pitches": True,
+            "constrained_note_groups_per_bar": 8,
+            "samples": [
+                {
+                    "sample_index": 1,
+                    "valid": True,
+                    "strict_valid": True,
+                    "grammar_gate_passed": True,
+                    "midi_path": "outputs/stage_b_generation_probe/run/samples/stage_b_sample_1.mid",
+                    "metrics": {
+                        "note_count": 32,
+                        "unique_pitch_count": 9,
+                        "chord_tone_ratio": 0.90625,
+                        "dead_air_ratio": 0.48,
+                    },
+                    "collapse": {
+                        "collapse_warning": False,
+                        "collapse_reasons": [],
+                        "note_group_count": 32,
+                        "max_same_pitch_repeats": 7,
+                        "repeated_pitch_ratio": 0.71875,
+                        "repeated_position_pitch_pair_ratio": 0.125,
+                    },
+                    "temporal_coverage": {
+                        "onset_coverage_ratio": 0.5,
+                        "sustained_coverage_ratio": 0.6875,
+                    },
+                },
+                {
+                    "sample_index": 2,
+                    "valid": False,
+                    "strict_valid": False,
+                    "grammar_gate_passed": True,
+                    "failure_reason": "note count too low",
+                    "metrics": {"note_count": 2},
+                    "collapse": {"collapse_warning": False, "collapse_reasons": []},
+                    "temporal_coverage": {},
+                },
+            ],
+        }
+
+        selected = select_review_candidates(report, top_n=3)
+
+        self.assertEqual(len(selected), 1)
+        self.assertEqual(selected[0]["mode"], "coverage_chord")
+        self.assertEqual(selected[0]["note_groups_per_bar"], 8)
+        self.assertEqual(selected[0]["note_count"], 32)
+        self.assertGreater(selected[0]["score"], 80.0)
+
     def test_build_review_manifest_copies_midi(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)
@@ -94,6 +146,7 @@ class StageBReviewExportTest(unittest.TestCase):
 
     def test_markdown_report_contains_review_checklist(self) -> None:
         manifest = {
+            "source_report": "report.json",
             "source_ranking_report": "report.json",
             "generated_at": "2026-05-21T00:00:00Z",
             "mode_filter": "coverage_chord",


### PR DESCRIPTION
## 요약
- 2-bar coverage_chord 후보가 너무 짧고 미완성처럼 느껴진다는 리뷰를 반영했습니다.
- 4-bar coverage+chord-aware constrained generation 하네스를 추가했습니다.
- generation probe report를 review export 입력으로 직접 사용할 수 있게 했습니다.
- docs/CORE_PLAN.md와 CURRENT_STATUS_AND_PLAN.md에 현재 판단과 다음 리뷰 기준을 정리했습니다.

## 결과
- samples: 3
- strict valid samples: 3/3
- grammar valid samples: 3/3
- note groups per sample: 32
- avg onset coverage ratio: 0.500
- avg sustained coverage ratio: 0.682
- remaining risk: repeated pitch ratio 약 0.719로, motif인지 기계적 반복인지 manual review 필요

## 검증
- ./.venv/bin/python -m unittest tests.test_stage_b_review_export
- ./.venv/bin/python -m compileall scripts/export_stage_b_review_candidates.py tests/test_stage_b_review_export.py
- bash scripts/agent_harness.sh quick
- bash scripts/agent_harness.sh stage-b-longer-phrase-probe

Closes #49