### PR TITLE
Stage B phrase contour 진단 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #49: Stage B longer coverage_chord phrase probe.
+- Issue #51: Stage B phrase contour/repeated-pitch diagnostics.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -127,6 +127,7 @@ Stage B에서 명시하는 것:
 21. Stage B chord-aware pitch constrained generation
 22. Stage B coverage_chord candidate review export
 23. Stage B longer 4-bar coverage_chord phrase probe
+24. Stage B phrase contour/repeated-pitch diagnostics
 
 가장 최근 의미 있는 결과:
 
@@ -140,6 +141,7 @@ Stage B에서 명시하는 것:
 - Manual piano-roll review found that these candidates can look like melodic fragments, but are still too short and feel unfinished.
 - Issue #49 extends the same coverage+chord-aware setup to a `4` bar probe with `32` note groups per sample and exports direct review candidates from the generation probe report.
 - Issue #49 fixes the length problem structurally, but repeated-pitch dependence remains a listening-review risk.
+- Issue #51 shows this is not adjacent same-note collapse: adjacent repeated pitch ratio is `0.000`, average direction change ratio is around `0.689`, and max longest same pitch run is `1`.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -285,6 +287,27 @@ Stage B에서 명시하는 것:
 - exported 4-bar candidates를 piano roll과 귀로 확인한다.
 - 단편이 아니라 최소한 call/continuation/landing 느낌의 phrase sketch인지 본다.
 - 여전히 짧거나 기계적이면 broad generic training 전 phrase/motif-level constraint를 먼저 설계한다.
+
+### Phase 3.8. Phrase Contour Diagnostics
+
+목표:
+
+- repeated pitch ratio 하나만 보고 샘플을 오판하지 않는다.
+- adjacent same-note collapse, long same-pitch run, low direction change, low interval variety를 분리해서 본다.
+- 후보를 자동 탈락시키기보다 review export에서 risk flag로 표시한다.
+
+현재 결과:
+
+- completed: generated sample report에 `phrase_contour`를 추가했다.
+- completed: review export에 `risk_flags`를 추가했다.
+- latest result: repeated pitch ratio는 높지만 adjacent repeated pitch ratio는 `0.000`이다.
+- latest result: direction change ratio는 약 `0.689`이고 longest same pitch run은 `1`이다.
+
+해석:
+
+- 현재 후보는 한 음을 길게 반복하는 collapse가 아니다.
+- 제한된 chord-tone pitch set을 많이 재사용하는 상태다.
+- 다음 manual review는 이 pitch reuse가 motif로 들리는지, constrained cycling으로 들리는지 판단해야 한다.
 
 ### Phase 4. Generic Jazz Base 후보 학습
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-49-stage-b-longer-phrase-probe`
+- `issue-51-stage-b-phrase-contour-diagnostics`
 
 현재 범위가 아닌 것:
 
@@ -36,16 +36,18 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 ## Latest Probe Result
 
-Issue #49는 manual piano-roll review에서 나온 "유효하긴 하지만 너무 짧고 만들다 만 단어처럼 느껴진다"는 피드백을 반영한다.
+Issue #51은 Issue #49 이후 남은 repeated-pitch risk를 더 구체적으로 설명한다.
 
-Issue #45는 chord-aware pitch 후보군으로 viable unflagged candidates를 `9`개 만들었고, Issue #47은 그 후보들을 review package로 export했다. 하지만 exported candidates는 `2` bar 기준이고, 일부 후보는 solo-line fragment처럼 보일 수 있어도 phrase로는 짧았다.
+Issue #49는 manual piano-roll review에서 나온 "유효하긴 하지만 너무 짧고 만들다 만 단어처럼 느껴진다"는 피드백을 반영해 `4` bar phrase 후보를 만들었다.
 
-Issue #49는 같은 coverage+chord-aware 방향을 `4` bar phrase probe로 늘린다.
+그 결과 길이 문제는 구조적으로 해결됐지만, repeated pitch ratio가 `0.719`로 높게 남았다. Issue #51은 이것이 인접 반복 실패인지, 제한된 pitch set 재사용인지 구분한다.
 
 Implemented:
 
-- `scripts/export_stage_b_review_candidates.py` generation probe report input support
-- `tests/test_stage_b_review_export.py` generation probe report selection test
+- `scripts/run_stage_b_generation_probe.py` phrase contour diagnostics
+- `scripts/export_stage_b_review_candidates.py` repeated-pitch/contour risk flags
+- `tests/test_stage_b_generation_probe.py` phrase contour tests
+- `tests/test_stage_b_review_export.py` risk flag tests
 - `scripts/agent_harness.sh stage-b-longer-phrase-probe`
 - output files:
   - `review_manifest.json`
@@ -63,6 +65,9 @@ Result:
 - average onset coverage ratio: around `0.500`
 - average sustained coverage ratio: around `0.680`
 - repeated pitch ratio: around `0.719`
+- adjacent repeated pitch ratio: `0.000`
+- average direction change ratio: around `0.689`
+- max longest same pitch run: `1`
 
 Decision:
 
@@ -70,7 +75,7 @@ Decision:
 - 다음 review는 4-bar exported candidates를 기준으로 한다.
 - 4-bar 후보가 여전히 단편적이면 broad training으로 가지 않고 phrase/motif-level constraint 또는 pretrained symbolic base를 검토한다.
 - 4-bar 후보가 최소한 solo-line phrase sketch로 들리면 generic jazz base 후보 학습 설계로 넘어갈 수 있다.
-- 현재 남은 핵심 리스크는 길이가 아니라 repeated-pitch dependence가 motif처럼 들리는지, 기계적 반복처럼 들리는지다.
+- 현재 남은 핵심 리스크는 adjacent same-note collapse가 아니라 제한된 pitch set을 과하게 재사용하는 느낌이다.
 
 Detail:
 
@@ -79,6 +84,7 @@ Detail:
 - `docs/STAGE_B_CHORD_AWARE_PITCH_2026-05-21.md`
 - `docs/STAGE_B_CANDIDATE_REVIEW_EXPORT_2026-05-21.md`
 - `docs/STAGE_B_LONGER_PHRASE_PROBE_2026-05-21.md`
+- `docs/STAGE_B_PHRASE_CONTOUR_DIAGNOSTICS_2026-05-21.md`
 
 ## Active Issue #14
 
@@ -1138,6 +1144,52 @@ Detail:
 
 - `docs/STAGE_B_LONGER_PHRASE_PROBE_2026-05-21.md`
 
+### 0.24. Issue #51 Stage B phrase contour/repeated-pitch diagnostics
+
+Status:
+
+- implemented on `issue-51-stage-b-phrase-contour-diagnostics`
+
+Review trigger:
+
+- Issue #49 fixed the phrase length problem structurally.
+- However, exported 4-bar candidates still had repeated pitch ratio around `0.719`.
+- That number alone did not say whether the sample was adjacent same-note collapse, motif reuse, or chord-tone set reuse.
+
+Goal:
+
+- add phrase contour diagnostics to each Stage B generated sample
+- expose repeated-pitch risk in review export without dropping the candidate
+- make the manual review question more precise
+
+Implemented diagnostics:
+
+- adjacent repeated pitch ratio
+- direction change ratio
+- longest same pitch run
+- unique interval count
+- stepwise/leap motion ratio
+- contour warning reasons
+- review export `risk_flags`
+
+Latest local result:
+
+- repeated pitch ratio: around `0.719`
+- adjacent repeated pitch ratio: `0.000`
+- average direction change ratio: around `0.689`
+- max longest same pitch run: `1`
+- risk flags: `high_repeated_pitch_ratio`, plus `high_dominant_pitch_ratio` for one sample
+
+Decision:
+
+- The current 4-bar candidates are not adjacent same-note collapse.
+- They still reuse a limited pitch set heavily.
+- The next listening review should judge whether that reuse sounds like motif/inside playing or like constrained mechanical pitch cycling.
+
+Detail:
+
+- `docs/STAGE_B_PHRASE_CONTOUR_DIAGNOSTICS_2026-05-21.md`
+
 ### 1. Run full jazz piano dataset audit
 
 ```bash
@@ -1284,6 +1336,7 @@ Decision:
 - `docs/STAGE_B_CHORD_AWARE_PITCH_2026-05-21.md`
 - `docs/STAGE_B_CANDIDATE_REVIEW_EXPORT_2026-05-21.md`
 - `docs/STAGE_B_LONGER_PHRASE_PROBE_2026-05-21.md`
+- `docs/STAGE_B_PHRASE_CONTOUR_DIAGNOSTICS_2026-05-21.md`
 - `docs/REFERENCES.md`
 - `docs/INFERENCE_MODEL_SPEC.md`
 - `docs/QA_ACCEPTANCE_PLAN.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,8 @@
   - Stage B `coverage_chord` top candidates를 manual listening review용 manifest/markdown으로 export하는 도구.
 - `STAGE_B_LONGER_PHRASE_PROBE_2026-05-21.md`
   - 2-bar 후보가 너무 짧다는 piano-roll review를 반영해 4-bar `coverage_chord` phrase 후보를 생성/export하는 probe.
+- `STAGE_B_PHRASE_CONTOUR_DIAGNOSTICS_2026-05-21.md`
+  - 4-bar 후보의 repeated-pitch risk가 adjacent collapse인지 제한된 pitch-set 재사용인지 구분하는 contour diagnostics.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -86,7 +88,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, and longer 4-bar phrase probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, and phrase contour diagnostics를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_PHRASE_CONTOUR_DIAGNOSTICS_2026-05-21.md
+++ b/docs/STAGE_B_PHRASE_CONTOUR_DIAGNOSTICS_2026-05-21.md
@@ -1,0 +1,132 @@
+# Stage B Phrase Contour Diagnostics
+
+작성일: 2026-05-21
+
+## Issue
+
+- Issue: #51
+- Branch: `issue-51-stage-b-phrase-contour-diagnostics`
+- Goal: 4-bar `coverage_chord` 후보의 repeated-pitch risk를 더 구체적으로 설명한다.
+
+## Why
+
+Issue #49는 2-bar 후보가 너무 짧고 미완성처럼 보이는 문제를 4-bar probe로 해결했다.
+
+하지만 새 후보의 repeated pitch ratio가 약 `0.719`로 높았다.
+
+이 값만 보면 두 가지를 구분할 수 없다.
+
+- 같은 음을 바로 이어서 반복하는 collapse
+- 제한된 chord-tone pitch set을 많이 재사용하는 motif-like pattern
+
+이 둘은 다르게 다뤄야 한다.
+
+Adjacent same-note collapse라면 generation constraint를 고쳐야 한다.
+Pitch-set reuse라면 실제 청취에서 motif로 들리는지 먼저 판단해야 한다.
+
+## Implementation
+
+Added:
+
+- `analyze_stage_b_phrase_contour()`
+- `phrase_contour` block in Stage B sample reports
+- `avg_adjacent_repeated_pitch_ratio`
+- `avg_direction_change_ratio`
+- `max_longest_same_pitch_run`
+- review export `risk_flags`
+
+The review exporter now surfaces risk without dropping candidates.
+
+Example flags:
+
+- `high_repeated_pitch_ratio`
+- `high_dominant_pitch_ratio`
+- `adjacent_pitch_repetition`
+- `contour:long_same_pitch_run`
+- `contour:low_direction_change`
+- `contour:low_interval_variety`
+
+## Diagnostics
+
+Per sample contour fields:
+
+| Field | Meaning |
+|---|---|
+| `adjacent_repeated_pitch_ratio` | Consecutive same-pitch interval ratio |
+| `direction_change_ratio` | How often melodic direction changes after removing zero intervals |
+| `longest_same_pitch_run` | Longest adjacent same-pitch run |
+| `unique_interval_count` | Number of distinct non-zero melodic intervals |
+| `pitch_span` | Max pitch minus min pitch |
+| `stepwise_motion_ratio` | Non-zero intervals within 1-2 semitones |
+| `leap_motion_ratio` | Non-zero intervals at 5+ semitones |
+
+## Latest Result
+
+Command:
+
+```bash
+bash scripts/agent_harness.sh stage-b-longer-phrase-probe
+```
+
+Result:
+
+| Metric | Value |
+|---|---:|
+| generated samples | 3 |
+| strict valid samples | 3 |
+| repeated pitch ratio | 0.719 |
+| adjacent repeated pitch ratio | 0.000 |
+| avg direction change ratio | 0.689 |
+| max longest same pitch run | 1 |
+| collapse warning samples | 0 |
+
+Review export now marks the top candidates with risk flags:
+
+| candidate | risk |
+|---|---|
+| `rank_01_coverage_chord_g8_s3.mid` | `high_repeated_pitch_ratio` |
+| `rank_02_coverage_chord_g8_s2.mid` | `high_repeated_pitch_ratio`, `high_dominant_pitch_ratio` |
+| `rank_03_coverage_chord_g8_s1.mid` | `high_repeated_pitch_ratio` |
+
+## Interpretation
+
+This is not adjacent same-note collapse.
+
+The model is not producing `C C C C` style adjacent repeated notes in the longer phrase probe.
+
+The remaining issue is narrower:
+
+- the pitch set is still constrained
+- chord-tone ratio is high
+- direction changes are frequent
+- adjacent repeated pitch is zero
+- but the same few chord-tone pitches are reused across the 4 bars
+
+So the next review question is:
+
+> Does the repeated pitch reuse sound like motif/inside playing, or does it sound like constrained pitch cycling?
+
+## Decision Boundary
+
+If the 4-bar candidates sound musical enough:
+
+- proceed to generic jazz base training design
+- keep the current contour diagnostics as review metadata
+
+If they sound mechanical:
+
+- do not start broad training yet
+- consider motif-level generation controls
+- consider a stronger pretrained symbolic MIDI base
+- consider allowing controlled non-chord tension tones instead of chord tones only
+
+## Validation
+
+Commands run:
+
+```bash
+./.venv/bin/python -m unittest tests.test_stage_b_generation_probe tests.test_stage_b_review_export
+./.venv/bin/python -m compileall scripts/run_stage_b_generation_probe.py scripts/export_stage_b_review_candidates.py tests/test_stage_b_generation_probe.py tests/test_stage_b_review_export.py
+bash scripts/agent_harness.sh quick
+bash scripts/agent_harness.sh stage-b-longer-phrase-probe
+```

--- a/scripts/export_stage_b_review_candidates.py
+++ b/scripts/export_stage_b_review_candidates.py
@@ -72,6 +72,7 @@ def score_probe_sample(sample: dict[str, Any]) -> float:
     metrics = sample.get("metrics", {})
     collapse = sample.get("collapse", {})
     temporal = sample.get("temporal_coverage", {})
+    contour = sample.get("phrase_contour", {})
     return round(
         (30.0 if sample.get("strict_valid") else 0.0)
         + (15.0 if sample.get("valid") else 0.0)
@@ -82,9 +83,31 @@ def score_probe_sample(sample: dict[str, Any]) -> float:
         + min(_int(metrics.get("unique_pitch_count")), 8) * 2.0
         - _float(metrics.get("dead_air_ratio")) * 10.0
         - _float(collapse.get("repeated_position_pitch_pair_ratio")) * 15.0
-        - _float(collapse.get("repeated_pitch_ratio")) * 10.0,
+        - _float(collapse.get("repeated_pitch_ratio")) * 10.0
+        - _float(contour.get("adjacent_repeated_pitch_ratio")) * 8.0
+        + _float(contour.get("direction_change_ratio")) * 3.0,
         4,
     )
+
+
+def risk_flags_from_generation_sample(sample: dict[str, Any]) -> list[str]:
+    collapse = sample.get("collapse", {})
+    contour = sample.get("phrase_contour", {})
+    note_group_count = max(1, _int(collapse.get("note_group_count")))
+    dominant_pitch_ratio = _float(collapse.get("max_same_pitch_repeats")) / note_group_count
+    repeated_pitch_ratio = _float(collapse.get("repeated_pitch_ratio"))
+    adjacent_repeated_pitch_ratio = _float(contour.get("adjacent_repeated_pitch_ratio"))
+
+    flags: list[str] = []
+    if repeated_pitch_ratio >= 0.65:
+        flags.append("high_repeated_pitch_ratio")
+    if dominant_pitch_ratio >= 0.25:
+        flags.append("high_dominant_pitch_ratio")
+    if adjacent_repeated_pitch_ratio >= 0.40:
+        flags.append("adjacent_pitch_repetition")
+    for reason in contour.get("contour_warning_reasons", []) or []:
+        flags.append(f"contour:{reason}")
+    return flags
 
 
 def candidates_from_generation_probe(report: dict[str, Any]) -> list[dict[str, Any]]:
@@ -97,12 +120,17 @@ def candidates_from_generation_probe(report: dict[str, Any]) -> list[dict[str, A
         metrics = sample.get("metrics", {})
         collapse = sample.get("collapse", {})
         temporal = sample.get("temporal_coverage", {})
+        contour = sample.get("phrase_contour", {})
         review_flags: list[str] = []
         if not sample.get("strict_valid"):
             reason = sample.get("failure_reason") or sample.get("diagnostic_failure_reason") or "not_strict_valid"
             review_flags.append(str(reason))
         if collapse.get("collapse_warning"):
             review_flags.extend(str(reason) for reason in collapse.get("collapse_reasons", []))
+        risk_flags = risk_flags_from_generation_sample(sample)
+        dominant_pitch_ratio = _float(collapse.get("max_same_pitch_repeats")) / max(
+            1, _int(collapse.get("note_group_count"))
+        )
         candidates.append(
             {
                 "rank": _int(sample.get("sample_index")),
@@ -112,6 +140,7 @@ def candidates_from_generation_probe(report: dict[str, Any]) -> list[dict[str, A
                 "score": score_probe_sample(sample),
                 "reviewable": bool(sample.get("strict_valid")) and not review_flags,
                 "review_flags": review_flags,
+                "risk_flags": risk_flags,
                 "midi_path": sample.get("midi_path"),
                 "strict_valid": bool(sample.get("strict_valid")),
                 "note_count": _int(metrics.get("note_count")),
@@ -119,9 +148,11 @@ def candidates_from_generation_probe(report: dict[str, Any]) -> list[dict[str, A
                 "chord_tone_ratio": _float(metrics.get("chord_tone_ratio")),
                 "bar_chord_tone_ratio": _float(metrics.get("chord_tone_ratio")),
                 "min_bar_chord_tone_ratio": _float(metrics.get("chord_tone_ratio")),
-                "dominant_pitch_ratio": _float(collapse.get("max_same_pitch_repeats"))
-                / max(1, _int(collapse.get("note_group_count"))),
+                "dominant_pitch_ratio": dominant_pitch_ratio,
                 "repeated_pitch_ratio": _float(collapse.get("repeated_pitch_ratio")),
+                "adjacent_repeated_pitch_ratio": _float(contour.get("adjacent_repeated_pitch_ratio")),
+                "direction_change_ratio": _float(contour.get("direction_change_ratio")),
+                "longest_same_pitch_run": _int(contour.get("longest_same_pitch_run")),
                 "onset_coverage_ratio": _float(temporal.get("onset_coverage_ratio")),
                 "sustained_coverage_ratio": _float(temporal.get("sustained_coverage_ratio")),
             }
@@ -162,6 +193,7 @@ def compact_candidate(candidate: dict[str, Any], rank: int) -> dict[str, Any]:
         "score": _float(candidate.get("score")),
         "reviewable": bool(candidate.get("reviewable")),
         "review_flags": list(candidate.get("review_flags", []) or []),
+        "risk_flags": list(candidate.get("risk_flags", []) or []),
         "midi_path": candidate.get("midi_path"),
         "note_count": _int(candidate.get("note_count")),
         "unique_pitch_count": _int(candidate.get("unique_pitch_count")),
@@ -170,6 +202,9 @@ def compact_candidate(candidate: dict[str, Any], rank: int) -> dict[str, Any]:
         "min_bar_chord_tone_ratio": _float(candidate.get("min_bar_chord_tone_ratio")),
         "dominant_pitch_ratio": _float(candidate.get("dominant_pitch_ratio")),
         "repeated_pitch_ratio": _float(candidate.get("repeated_pitch_ratio")),
+        "adjacent_repeated_pitch_ratio": _float(candidate.get("adjacent_repeated_pitch_ratio")),
+        "direction_change_ratio": _float(candidate.get("direction_change_ratio")),
+        "longest_same_pitch_run": _int(candidate.get("longest_same_pitch_run")),
         "onset_coverage_ratio": _float(candidate.get("onset_coverage_ratio")),
         "sustained_coverage_ratio": _float(candidate.get("sustained_coverage_ratio")),
     }
@@ -213,18 +248,22 @@ def markdown_report(manifest: dict[str, Any]) -> str:
         f"- reviewable only: `{str(manifest['reviewable_only']).lower()}`",
         f"- selected candidates: `{len(manifest['candidates'])}`",
         "",
-        "| review | source rank | mode | groups/bar | sample | score | notes | pitches | chord | bar chord | min bar | dominant | repeat | midi |",
-        "|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+        "| review | source rank | mode | groups/bar | sample | score | notes | pitches | chord | dominant | repeat | adjacent repeat | direction | risk | midi |",
+        "|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|",
     ]
     for candidate in manifest["candidates"]:
         midi_path = candidate.get("review_midi_relative_path") or candidate.get("midi_path")
         table_candidate = dict(candidate)
         table_candidate["display_midi_path"] = midi_path
+        table_candidate["risk_flags_text"] = ", ".join(candidate.get("risk_flags", []) or [])
+        table_candidate.setdefault("adjacent_repeated_pitch_ratio", 0.0)
+        table_candidate.setdefault("direction_change_ratio", 0.0)
         lines.append(
             "| {review_rank} | {source_rank} | {mode} | {note_groups_per_bar} | {sample_index} | "
             "{score:.4f} | {note_count} | {unique_pitch_count} | {chord_tone_ratio:.3f} | "
-            "{bar_chord_tone_ratio:.3f} | {min_bar_chord_tone_ratio:.3f} | "
-            "{dominant_pitch_ratio:.3f} | {repeated_pitch_ratio:.3f} | `{display_midi_path}` |".format(
+            "{dominant_pitch_ratio:.3f} | {repeated_pitch_ratio:.3f} | "
+            "{adjacent_repeated_pitch_ratio:.3f} | {direction_change_ratio:.3f} | "
+            "`{risk_flags_text}` | `{display_midi_path}` |".format(
                 **table_candidate
             )
         )

--- a/scripts/run_stage_b_generation_probe.py
+++ b/scripts/run_stage_b_generation_probe.py
@@ -393,6 +393,71 @@ def analyze_stage_b_collapse(
     }
 
 
+def _sign(value: int) -> int:
+    if value > 0:
+        return 1
+    if value < 0:
+        return -1
+    return 0
+
+
+def analyze_stage_b_phrase_contour(
+    tokens: Sequence[int],
+    primer_size: int = 0,
+) -> dict[str, Any]:
+    groups = sorted(
+        extract_stage_b_note_groups(tokens, primer_size=primer_size),
+        key=lambda group: (int(group["bar"]), int(group["position"])),
+    )
+    pitches = [int(group["pitch"]) for group in groups]
+    intervals = [pitches[index + 1] - pitches[index] for index in range(max(0, len(pitches) - 1))]
+    interval_count = len(intervals)
+    nonzero_intervals = [interval for interval in intervals if interval != 0]
+    signs = [_sign(interval) for interval in nonzero_intervals]
+    direction_changes = sum(1 for index in range(1, len(signs)) if signs[index] != signs[index - 1])
+
+    longest_same_pitch_run = 0
+    current_same_pitch_run = 0
+    previous_pitch: int | None = None
+    for pitch in pitches:
+        current_same_pitch_run = current_same_pitch_run + 1 if pitch == previous_pitch else 1
+        longest_same_pitch_run = max(longest_same_pitch_run, current_same_pitch_run)
+        previous_pitch = pitch
+
+    adjacent_repeated_pitch_count = sum(1 for interval in intervals if interval == 0)
+    stepwise_count = sum(1 for interval in nonzero_intervals if abs(interval) <= 2)
+    leap_count = sum(1 for interval in nonzero_intervals if abs(interval) >= 5)
+
+    warning_reasons: list[str] = []
+    if interval_count > 0 and adjacent_repeated_pitch_count / interval_count >= 0.4:
+        warning_reasons.append("adjacent_pitch_repetition")
+    if longest_same_pitch_run >= 4:
+        warning_reasons.append("long_same_pitch_run")
+    if interval_count >= 8 and len(set(nonzero_intervals)) <= 2:
+        warning_reasons.append("low_interval_variety")
+    if len(signs) >= 8 and direction_changes / max(1, len(signs) - 1) <= 0.15:
+        warning_reasons.append("low_direction_change")
+
+    return {
+        "note_group_count": int(len(groups)),
+        "interval_count": int(interval_count),
+        "unique_interval_count": int(len(set(nonzero_intervals))),
+        "pitch_span": int(max(pitches) - min(pitches)) if pitches else 0,
+        "adjacent_repeated_pitch_count": int(adjacent_repeated_pitch_count),
+        "adjacent_repeated_pitch_ratio": (
+            float(adjacent_repeated_pitch_count / interval_count) if interval_count else 0.0
+        ),
+        "nonzero_interval_ratio": float(len(nonzero_intervals) / interval_count) if interval_count else 0.0,
+        "direction_change_count": int(direction_changes),
+        "direction_change_ratio": float(direction_changes / max(1, len(signs) - 1)) if signs else 0.0,
+        "stepwise_motion_ratio": float(stepwise_count / interval_count) if interval_count else 0.0,
+        "leap_motion_ratio": float(leap_count / interval_count) if interval_count else 0.0,
+        "longest_same_pitch_run": int(longest_same_pitch_run),
+        "contour_warning": bool(warning_reasons),
+        "contour_warning_reasons": warning_reasons,
+    }
+
+
 def evaluate_collapse_gate(
     collapse: dict[str, Any],
     min_unique_pitches: int = DEFAULT_STRICT_MIN_UNIQUE_PITCHES,
@@ -675,6 +740,7 @@ def sample_report(
     grammar = analyze_stage_b_note_grammar(tokens, primer_size=primer_size)
     collapse = analyze_stage_b_collapse(tokens, primer_size=primer_size, postprocess_report=postprocess_report)
     temporal_coverage = analyze_stage_b_temporal_coverage(tokens, primer_size=primer_size, bars=request.bars)
+    phrase_contour = analyze_stage_b_phrase_contour(tokens, primer_size=primer_size)
     collapse_gate = evaluate_collapse_gate(
         collapse,
         min_unique_pitches=strict_min_unique_pitches,
@@ -710,6 +776,7 @@ def sample_report(
         "grammar": grammar,
         "collapse": collapse,
         "temporal_coverage": temporal_coverage,
+        "phrase_contour": phrase_contour,
         "collapse_gate": collapse_gate,
         "postprocess": postprocess_report or {"enabled": False},
         "metrics": metrics.to_dict(),
@@ -747,9 +814,13 @@ def build_probe_summary(
     sustained_coverage_ratios: list[float] = []
     position_span_ratios: list[float] = []
     longest_sustained_empty_runs: list[int] = []
+    adjacent_repeated_pitch_ratios: list[float] = []
+    direction_change_ratios: list[float] = []
+    longest_same_pitch_runs: list[int] = []
     for row in sample_rows:
         collapse = row.get("collapse", {})
         temporal_coverage = row.get("temporal_coverage", {})
+        phrase_contour = row.get("phrase_contour", {})
         if collapse.get("collapse_warning"):
             collapse_warning_count += 1
         if not row.get("strict_valid", False):
@@ -770,6 +841,11 @@ def build_probe_summary(
         longest_sustained_empty_runs.append(
             int(temporal_coverage.get("longest_sustained_empty_run_steps", 0) or 0)
         )
+        adjacent_repeated_pitch_ratios.append(
+            float(phrase_contour.get("adjacent_repeated_pitch_ratio", 0.0) or 0.0)
+        )
+        direction_change_ratios.append(float(phrase_contour.get("direction_change_ratio", 0.0) or 0.0))
+        longest_same_pitch_runs.append(int(phrase_contour.get("longest_same_pitch_run", 0) or 0))
         if not row["valid"]:
             reason = str(row.get("failure_reason") or "unknown")
             diagnostic_reason = str(row.get("diagnostic_failure_reason") or reason)
@@ -837,6 +913,15 @@ def build_probe_summary(
         "max_longest_sustained_empty_run_steps": (
             max(longest_sustained_empty_runs) if longest_sustained_empty_runs else 0
         ),
+        "avg_adjacent_repeated_pitch_ratio": (
+            float(sum(adjacent_repeated_pitch_ratios) / len(adjacent_repeated_pitch_ratios))
+            if adjacent_repeated_pitch_ratios
+            else 0.0
+        ),
+        "avg_direction_change_ratio": (
+            float(sum(direction_change_ratios) / len(direction_change_ratios)) if direction_change_ratios else 0.0
+        ),
+        "max_longest_same_pitch_run": max(longest_same_pitch_runs) if longest_same_pitch_runs else 0,
     }
 
 

--- a/tests/test_stage_b_generation_probe.py
+++ b/tests/test_stage_b_generation_probe.py
@@ -10,6 +10,7 @@ import torch
 from scripts.run_stage_b_generation_probe import (
     analyze_stage_b_collapse,
     analyze_stage_b_note_grammar,
+    analyze_stage_b_phrase_contour,
     analyze_stage_b_temporal_coverage,
     build_probe_summary,
     build_stage_b_primer,
@@ -120,6 +121,63 @@ class StageBGenerationProbeTest(unittest.TestCase):
         self.assertEqual(report["complete_note_groups"], 0)
         self.assertGreater(report["invalid_token_count"], 0)
         self.assertFalse(report["grammar_valid"])
+
+    def test_analyze_stage_b_phrase_contour_reports_repeated_pitch_risk(self) -> None:
+        primer = build_stage_b_primer(["Cm7"], bpm=120)
+        tokens = primer + [
+            position_token(0),
+            note_velocity_token(4),
+            note_pitch_token(60),
+            note_duration_token(1),
+            position_token(1),
+            note_velocity_token(4),
+            note_pitch_token(60),
+            note_duration_token(1),
+            position_token(2),
+            note_velocity_token(4),
+            note_pitch_token(60),
+            note_duration_token(1),
+            position_token(3),
+            note_velocity_token(4),
+            note_pitch_token(60),
+            note_duration_token(1),
+            TOKEN_END,
+        ]
+
+        report = analyze_stage_b_phrase_contour(tokens, primer_size=len(primer))
+
+        self.assertEqual(report["longest_same_pitch_run"], 4)
+        self.assertEqual(report["adjacent_repeated_pitch_count"], 3)
+        self.assertTrue(report["contour_warning"])
+        self.assertIn("long_same_pitch_run", report["contour_warning_reasons"])
+
+    def test_analyze_stage_b_phrase_contour_reports_direction_changes(self) -> None:
+        primer = build_stage_b_primer(["Cm7"], bpm=120)
+        tokens = primer + [
+            position_token(0),
+            note_velocity_token(4),
+            note_pitch_token(60),
+            note_duration_token(1),
+            position_token(1),
+            note_velocity_token(4),
+            note_pitch_token(64),
+            note_duration_token(1),
+            position_token(2),
+            note_velocity_token(4),
+            note_pitch_token(62),
+            note_duration_token(1),
+            position_token(3),
+            note_velocity_token(4),
+            note_pitch_token(67),
+            note_duration_token(1),
+            TOKEN_END,
+        ]
+
+        report = analyze_stage_b_phrase_contour(tokens, primer_size=len(primer))
+
+        self.assertEqual(report["pitch_span"], 7)
+        self.assertEqual(report["direction_change_count"], 2)
+        self.assertGreater(report["direction_change_ratio"], 0.0)
 
     def test_constrained_generation_creates_decodable_note_groups(self) -> None:
         primer = build_stage_b_primer(["Cm7", "F7"], bpm=120)

--- a/tests/test_stage_b_review_export.py
+++ b/tests/test_stage_b_review_export.py
@@ -86,6 +86,13 @@ class StageBReviewExportTest(unittest.TestCase):
                         "onset_coverage_ratio": 0.5,
                         "sustained_coverage_ratio": 0.6875,
                     },
+                    "phrase_contour": {
+                        "adjacent_repeated_pitch_ratio": 0.05,
+                        "direction_change_ratio": 0.4,
+                        "longest_same_pitch_run": 2,
+                        "contour_warning": False,
+                        "contour_warning_reasons": [],
+                    },
                 },
                 {
                     "sample_index": 2,
@@ -106,6 +113,7 @@ class StageBReviewExportTest(unittest.TestCase):
         self.assertEqual(selected[0]["mode"], "coverage_chord")
         self.assertEqual(selected[0]["note_groups_per_bar"], 8)
         self.assertEqual(selected[0]["note_count"], 32)
+        self.assertIn("high_repeated_pitch_ratio", selected[0]["risk_flags"])
         self.assertGreater(selected[0]["score"], 80.0)
 
     def test_build_review_manifest_copies_midi(self) -> None:
@@ -166,6 +174,9 @@ class StageBReviewExportTest(unittest.TestCase):
                     "min_bar_chord_tone_ratio": 0.8,
                     "dominant_pitch_ratio": 0.375,
                     "repeated_pitch_ratio": 0.25,
+                    "adjacent_repeated_pitch_ratio": 0.0,
+                    "direction_change_ratio": 0.0,
+                    "risk_flags": [],
                     "midi_path": "sample.mid",
                 }
             ],


### PR DESCRIPTION
## 요약
- 4-bar coverage_chord 후보의 repeated pitch risk를 더 구체적으로 설명하는 phrase contour diagnostics를 추가했습니다.
- generation probe sample report에 phrase_contour 블록을 기록합니다.
- review export에 risk_flags를 추가해 후보를 버리지 않고 manual review 위험 신호를 보여줍니다.
- docs/CORE_PLAN.md와 CURRENT_STATUS_AND_PLAN.md에 Issue #51 판단을 반영했습니다.

## 결과
- repeated pitch ratio: 약 0.719
- adjacent repeated pitch ratio: 0.000
- avg direction change ratio: 약 0.689
- max longest same pitch run: 1
- top review candidates risk: high_repeated_pitch_ratio, 일부 high_dominant_pitch_ratio

## 해석
- 현재 4-bar 후보는 adjacent same-note collapse는 아닙니다.
- 남은 리스크는 제한된 chord-tone pitch set을 4마디 동안 많이 재사용하는 것입니다.
- 다음 manual review는 이것이 motif처럼 들리는지 constrained pitch cycling처럼 들리는지 판단해야 합니다.

## 검증
- ./.venv/bin/python -m unittest tests.test_stage_b_generation_probe tests.test_stage_b_review_export
- ./.venv/bin/python -m compileall scripts/run_stage_b_generation_probe.py scripts/export_stage_b_review_candidates.py tests/test_stage_b_generation_probe.py tests/test_stage_b_review_export.py
- bash scripts/agent_harness.sh stage-b-longer-phrase-probe
- bash scripts/agent_harness.sh quick

Closes #51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added phrase contour diagnostics to Stage B analysis for improved detection of repeated-pitch patterns and differentiation between adjacent collapse vs. limited pitch-set reuse.
  * Introduced new metrics: adjacent repeated-pitch ratio, direction-change ratio, and longest same-pitch run for enhanced pitch analysis.
  * Review candidates now display risk flags and contour-based metrics.

* **Documentation**
  * Updated diagnostic documentation and workflow reference with new contour analysis methodology.

* **Tests**
  * Added test coverage for phrase contour analysis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohhalim/fine_tuning_art-tatum_midi_solo/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->