### PR TITLE
Stage B root bias 진단 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #51: Stage B phrase contour/repeated-pitch diagnostics.
+- Issue #53: Stage B root bias diagnostics and tension pitch comparison.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -128,6 +128,7 @@ Stage B에서 명시하는 것:
 22. Stage B coverage_chord candidate review export
 23. Stage B longer 4-bar coverage_chord phrase probe
 24. Stage B phrase contour/repeated-pitch diagnostics
+25. Stage B root bias diagnostics
 
 가장 최근 의미 있는 결과:
 
@@ -142,6 +143,7 @@ Stage B에서 명시하는 것:
 - Issue #49 extends the same coverage+chord-aware setup to a `4` bar probe with `32` note groups per sample and exports direct review candidates from the generation probe report.
 - Issue #49 fixes the length problem structurally, but repeated-pitch dependence remains a listening-review risk.
 - Issue #51 shows this is not adjacent same-note collapse: adjacent repeated pitch ratio is `0.000`, average direction change ratio is around `0.689`, and max longest same pitch run is `1`.
+- Issue #53 shows the perceived "root-heavy" line is not pure root collapse: average root tone ratio is around `0.271`, top candidate root ratio is around `0.219`, but tension ratio is `0.000`.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -308,6 +310,28 @@ Stage B에서 명시하는 것:
 - 현재 후보는 한 음을 길게 반복하는 collapse가 아니다.
 - 제한된 chord-tone pitch set을 많이 재사용하는 상태다.
 - 다음 manual review는 이 pitch reuse가 motif로 들리는지, constrained cycling으로 들리는지 판단해야 한다.
+
+### Phase 3.9. Root Bias and Tension Diagnostics
+
+목표:
+
+- "근음을 계속 친다"는 청취 피드백을 수치화한다.
+- root tone, non-root chord tone, tension, non-chord tone 비율을 분리해서 본다.
+- root collapse인지, chord-tone-only 안전함인지 판단한다.
+
+현재 결과:
+
+- completed: generated sample report에 `pitch_roles`를 추가했다.
+- completed: review export에 `root`, `tension` columns를 추가했다.
+- latest result: average root tone ratio는 약 `0.271`이다.
+- latest result: top candidate root tone ratio는 약 `0.219`이다.
+- latest result: tension ratio는 `0.000`이다.
+
+해석:
+
+- 현재 후보는 root-only collapse가 아니다.
+- 오히려 `chord_pitch_mode=tones` 때문에 tension이 전혀 없는 안전한 chord-tone-only line이다.
+- 다음 비교는 `tones` vs `tones_tensions`가 맞다.
 
 ### Phase 4. Generic Jazz Base 후보 학습
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-51-stage-b-phrase-contour-diagnostics`
+- `issue-53-stage-b-root-bias-diagnostics`
 
 현재 범위가 아닌 것:
 
@@ -36,16 +36,16 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 ## Latest Probe Result
 
-Issue #51은 Issue #49 이후 남은 repeated-pitch risk를 더 구체적으로 설명한다.
+Issue #53은 manual listening/piano-roll review에서 나온 "멜로디 같긴 하지만 근음을 계속 치는 느낌"을 root bias로 수치화한다.
 
-Issue #49는 manual piano-roll review에서 나온 "유효하긴 하지만 너무 짧고 만들다 만 단어처럼 느껴진다"는 피드백을 반영해 `4` bar phrase 후보를 만들었다.
-
-그 결과 길이 문제는 구조적으로 해결됐지만, repeated pitch ratio가 `0.719`로 높게 남았다. Issue #51은 이것이 인접 반복 실패인지, 제한된 pitch set 재사용인지 구분한다.
+Issue #51에서 이미 adjacent same-note collapse는 아니라는 것을 확인했다. Issue #53은 실제로 root tone을 얼마나 치는지, non-root chord tone과 tension 비율이 어떤지 기록한다.
 
 Implemented:
 
 - `scripts/run_stage_b_generation_probe.py` phrase contour diagnostics
+- `scripts/run_stage_b_generation_probe.py` pitch-role diagnostics
 - `scripts/export_stage_b_review_candidates.py` repeated-pitch/contour risk flags
+- `scripts/export_stage_b_review_candidates.py` root/tension columns
 - `tests/test_stage_b_generation_probe.py` phrase contour tests
 - `tests/test_stage_b_review_export.py` risk flag tests
 - `scripts/agent_harness.sh stage-b-longer-phrase-probe`
@@ -68,6 +68,9 @@ Result:
 - adjacent repeated pitch ratio: `0.000`
 - average direction change ratio: around `0.689`
 - max longest same pitch run: `1`
+- average root tone ratio: around `0.271`
+- top candidate root tone ratio: around `0.219`
+- tension ratio: `0.000`
 
 Decision:
 
@@ -75,7 +78,7 @@ Decision:
 - 다음 review는 4-bar exported candidates를 기준으로 한다.
 - 4-bar 후보가 여전히 단편적이면 broad training으로 가지 않고 phrase/motif-level constraint 또는 pretrained symbolic base를 검토한다.
 - 4-bar 후보가 최소한 solo-line phrase sketch로 들리면 generic jazz base 후보 학습 설계로 넘어갈 수 있다.
-- 현재 남은 핵심 리스크는 adjacent same-note collapse가 아니라 제한된 pitch set을 과하게 재사용하는 느낌이다.
+- "근음을 계속 치는 느낌"은 실제 root-only collapse라기보다 chord-tone-only, no-tension 라인의 안전한 inside sound일 가능성이 높다.
 
 Detail:
 
@@ -85,6 +88,7 @@ Detail:
 - `docs/STAGE_B_CANDIDATE_REVIEW_EXPORT_2026-05-21.md`
 - `docs/STAGE_B_LONGER_PHRASE_PROBE_2026-05-21.md`
 - `docs/STAGE_B_PHRASE_CONTOUR_DIAGNOSTICS_2026-05-21.md`
+- `docs/STAGE_B_ROOT_BIAS_DIAGNOSTICS_2026-05-21.md`
 
 ## Active Issue #14
 
@@ -1190,6 +1194,42 @@ Detail:
 
 - `docs/STAGE_B_PHRASE_CONTOUR_DIAGNOSTICS_2026-05-21.md`
 
+### 0.25. Issue #53 Stage B root bias diagnostics
+
+Status:
+
+- implemented on `issue-53-stage-b-root-bias-diagnostics`
+
+Review trigger:
+
+- Manual review said the 4-bar candidates are melody-like.
+- The main concern was that it feels like it keeps hitting root notes.
+- Before changing generation, this needs to be measured.
+
+Goal:
+
+- add pitch-role diagnostics to generated sample reports
+- expose root tone ratio, non-root chord tone ratio, and tension ratio in review export
+- decide whether the perceived root bias is actual root overuse or broader chord-tone-only behavior
+
+Latest local result:
+
+- average root tone ratio: around `0.271`
+- top review candidate root tone ratio: around `0.219`
+- chord tone ratio: around `0.938-1.000`
+- tension ratio: `0.000`
+- adjacent repeated pitch ratio: `0.000`
+
+Decision:
+
+- The current issue is not pure root collapse.
+- The stronger diagnosis is "safe chord-tone-only line with no tensions."
+- Next generation comparison should test `chord_pitch_mode=tones_tensions` against current `tones`.
+
+Detail:
+
+- `docs/STAGE_B_ROOT_BIAS_DIAGNOSTICS_2026-05-21.md`
+
 ### 1. Run full jazz piano dataset audit
 
 ```bash
@@ -1337,6 +1377,7 @@ Decision:
 - `docs/STAGE_B_CANDIDATE_REVIEW_EXPORT_2026-05-21.md`
 - `docs/STAGE_B_LONGER_PHRASE_PROBE_2026-05-21.md`
 - `docs/STAGE_B_PHRASE_CONTOUR_DIAGNOSTICS_2026-05-21.md`
+- `docs/STAGE_B_ROOT_BIAS_DIAGNOSTICS_2026-05-21.md`
 - `docs/REFERENCES.md`
 - `docs/INFERENCE_MODEL_SPEC.md`
 - `docs/QA_ACCEPTANCE_PLAN.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,6 +62,8 @@
   - 2-bar 후보가 너무 짧다는 piano-roll review를 반영해 4-bar `coverage_chord` phrase 후보를 생성/export하는 probe.
 - `STAGE_B_PHRASE_CONTOUR_DIAGNOSTICS_2026-05-21.md`
   - 4-bar 후보의 repeated-pitch risk가 adjacent collapse인지 제한된 pitch-set 재사용인지 구분하는 contour diagnostics.
+- `STAGE_B_ROOT_BIAS_DIAGNOSTICS_2026-05-21.md`
+  - "근음을 계속 치는 느낌"을 root-tone ratio와 tension ratio로 분리해 진단하는 문서.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -88,7 +90,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, and phrase contour diagnostics를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, and root-bias diagnostics를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_ROOT_BIAS_DIAGNOSTICS_2026-05-21.md
+++ b/docs/STAGE_B_ROOT_BIAS_DIAGNOSTICS_2026-05-21.md
@@ -1,0 +1,120 @@
+# Stage B Root Bias Diagnostics
+
+작성일: 2026-05-21
+
+## Issue
+
+- Issue: #53
+- Branch: `issue-53-stage-b-root-bias-diagnostics`
+- Goal: "근음을 계속 치는 느낌"을 root tone ratio와 tension ratio로 분리해 진단한다.
+
+## Why
+
+Manual review of the 4-bar candidates changed the diagnosis.
+
+The output is no longer obviously broken.
+
+Current listening feedback:
+
+- melody-like enough to review
+- not a one-note or two-note failure
+- not adjacent same-note collapse
+- but it feels like the line keeps leaning on roots
+
+Before changing the generator again, this needs a numeric answer.
+
+## Implementation
+
+Added `pitch_roles` diagnostics to Stage B sample reports:
+
+- `root_tone_count`
+- `root_tone_ratio`
+- `chord_tone_count`
+- `chord_tone_ratio`
+- `non_root_chord_tone_count`
+- `non_root_chord_tone_ratio`
+- `tension_count`
+- `tension_ratio`
+- `non_chord_tone_count`
+- `non_chord_tone_ratio`
+- `per_bar_root_tone_ratio`
+
+Updated review export:
+
+- root ratio column
+- tension ratio column
+- root-bias risk flag support
+
+## Latest Result
+
+Command:
+
+```bash
+bash scripts/agent_harness.sh stage-b-longer-phrase-probe
+```
+
+Result:
+
+| Metric | Value |
+|---|---:|
+| generated samples | 3 |
+| strict valid samples | 3 |
+| average root tone ratio | 0.271 |
+| top candidate root tone ratio | 0.219 |
+| chord tone ratio | 0.938-1.000 |
+| tension ratio | 0.000 |
+| adjacent repeated pitch ratio | 0.000 |
+| average direction change ratio | 0.689 |
+
+Top exported candidates:
+
+| rank | root | tension | risk |
+|---:|---:|---:|---|
+| 1 | 0.219 | 0.000 | `high_repeated_pitch_ratio` |
+| 2 | 0.312 | 0.000 | `high_repeated_pitch_ratio`, `high_dominant_pitch_ratio` |
+| 3 | 0.281 | 0.000 | `high_repeated_pitch_ratio` |
+
+## Interpretation
+
+The output is not pure root collapse.
+
+The stronger diagnosis is:
+
+> current `coverage_chord` output is a safe chord-tone-only line with no tensions.
+
+So the listener can reasonably hear it as root-heavy or too inside, even when the actual root ratio is not extreme.
+
+The current pitch constraint uses:
+
+```text
+--chord_pitch_mode tones
+```
+
+That means allowed pitches are only chord tones. Tensions are not available during constrained pitch selection.
+
+## Decision Boundary
+
+Do not start broad training only because the output is melody-like.
+
+Next technical comparison should be:
+
+```text
+tones vs tones_tensions
+```
+
+Expected question:
+
+- Does `tones_tensions` reduce root/chord-tone stiffness?
+- Does it preserve enough chord compatibility?
+- Does it create more melodic color without falling back into random non-chord pitches?
+
+## Validation
+
+Commands run:
+
+```bash
+./.venv/bin/python -m unittest tests.test_stage_b_generation_probe tests.test_stage_b_review_export
+./.venv/bin/python -m compileall scripts/run_stage_b_generation_probe.py scripts/export_stage_b_review_candidates.py tests/test_stage_b_generation_probe.py tests/test_stage_b_review_export.py
+bash scripts/agent_harness.sh stage-b-longer-phrase-probe
+bash scripts/agent_harness.sh quick
+```

--- a/scripts/export_stage_b_review_candidates.py
+++ b/scripts/export_stage_b_review_candidates.py
@@ -73,6 +73,7 @@ def score_probe_sample(sample: dict[str, Any]) -> float:
     collapse = sample.get("collapse", {})
     temporal = sample.get("temporal_coverage", {})
     contour = sample.get("phrase_contour", {})
+    pitch_roles = sample.get("pitch_roles", {})
     return round(
         (30.0 if sample.get("strict_valid") else 0.0)
         + (15.0 if sample.get("valid") else 0.0)
@@ -85,6 +86,8 @@ def score_probe_sample(sample: dict[str, Any]) -> float:
         - _float(collapse.get("repeated_position_pitch_pair_ratio")) * 15.0
         - _float(collapse.get("repeated_pitch_ratio")) * 10.0
         - _float(contour.get("adjacent_repeated_pitch_ratio")) * 8.0
+        - _float(pitch_roles.get("root_tone_ratio")) * 8.0
+        + _float(pitch_roles.get("tension_ratio")) * 4.0
         + _float(contour.get("direction_change_ratio")) * 3.0,
         4,
     )
@@ -93,10 +96,12 @@ def score_probe_sample(sample: dict[str, Any]) -> float:
 def risk_flags_from_generation_sample(sample: dict[str, Any]) -> list[str]:
     collapse = sample.get("collapse", {})
     contour = sample.get("phrase_contour", {})
+    pitch_roles = sample.get("pitch_roles", {})
     note_group_count = max(1, _int(collapse.get("note_group_count")))
     dominant_pitch_ratio = _float(collapse.get("max_same_pitch_repeats")) / note_group_count
     repeated_pitch_ratio = _float(collapse.get("repeated_pitch_ratio"))
     adjacent_repeated_pitch_ratio = _float(contour.get("adjacent_repeated_pitch_ratio"))
+    root_tone_ratio = _float(pitch_roles.get("root_tone_ratio"))
 
     flags: list[str] = []
     if repeated_pitch_ratio >= 0.65:
@@ -105,6 +110,8 @@ def risk_flags_from_generation_sample(sample: dict[str, Any]) -> list[str]:
         flags.append("high_dominant_pitch_ratio")
     if adjacent_repeated_pitch_ratio >= 0.40:
         flags.append("adjacent_pitch_repetition")
+    if root_tone_ratio >= 0.35:
+        flags.append("high_root_tone_ratio")
     for reason in contour.get("contour_warning_reasons", []) or []:
         flags.append(f"contour:{reason}")
     return flags
@@ -121,6 +128,7 @@ def candidates_from_generation_probe(report: dict[str, Any]) -> list[dict[str, A
         collapse = sample.get("collapse", {})
         temporal = sample.get("temporal_coverage", {})
         contour = sample.get("phrase_contour", {})
+        pitch_roles = sample.get("pitch_roles", {})
         review_flags: list[str] = []
         if not sample.get("strict_valid"):
             reason = sample.get("failure_reason") or sample.get("diagnostic_failure_reason") or "not_strict_valid"
@@ -153,6 +161,9 @@ def candidates_from_generation_probe(report: dict[str, Any]) -> list[dict[str, A
                 "adjacent_repeated_pitch_ratio": _float(contour.get("adjacent_repeated_pitch_ratio")),
                 "direction_change_ratio": _float(contour.get("direction_change_ratio")),
                 "longest_same_pitch_run": _int(contour.get("longest_same_pitch_run")),
+                "root_tone_ratio": _float(pitch_roles.get("root_tone_ratio")),
+                "non_root_chord_tone_ratio": _float(pitch_roles.get("non_root_chord_tone_ratio")),
+                "tension_ratio": _float(pitch_roles.get("tension_ratio")),
                 "onset_coverage_ratio": _float(temporal.get("onset_coverage_ratio")),
                 "sustained_coverage_ratio": _float(temporal.get("sustained_coverage_ratio")),
             }
@@ -205,6 +216,9 @@ def compact_candidate(candidate: dict[str, Any], rank: int) -> dict[str, Any]:
         "adjacent_repeated_pitch_ratio": _float(candidate.get("adjacent_repeated_pitch_ratio")),
         "direction_change_ratio": _float(candidate.get("direction_change_ratio")),
         "longest_same_pitch_run": _int(candidate.get("longest_same_pitch_run")),
+        "root_tone_ratio": _float(candidate.get("root_tone_ratio")),
+        "non_root_chord_tone_ratio": _float(candidate.get("non_root_chord_tone_ratio")),
+        "tension_ratio": _float(candidate.get("tension_ratio")),
         "onset_coverage_ratio": _float(candidate.get("onset_coverage_ratio")),
         "sustained_coverage_ratio": _float(candidate.get("sustained_coverage_ratio")),
     }
@@ -248,8 +262,8 @@ def markdown_report(manifest: dict[str, Any]) -> str:
         f"- reviewable only: `{str(manifest['reviewable_only']).lower()}`",
         f"- selected candidates: `{len(manifest['candidates'])}`",
         "",
-        "| review | source rank | mode | groups/bar | sample | score | notes | pitches | chord | dominant | repeat | adjacent repeat | direction | risk | midi |",
-        "|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|",
+        "| review | source rank | mode | groups/bar | sample | score | notes | pitches | chord | root | tension | dominant | repeat | direction | risk | midi |",
+        "|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|",
     ]
     for candidate in manifest["candidates"]:
         midi_path = candidate.get("review_midi_relative_path") or candidate.get("midi_path")
@@ -258,11 +272,13 @@ def markdown_report(manifest: dict[str, Any]) -> str:
         table_candidate["risk_flags_text"] = ", ".join(candidate.get("risk_flags", []) or [])
         table_candidate.setdefault("adjacent_repeated_pitch_ratio", 0.0)
         table_candidate.setdefault("direction_change_ratio", 0.0)
+        table_candidate.setdefault("root_tone_ratio", 0.0)
+        table_candidate.setdefault("tension_ratio", 0.0)
         lines.append(
             "| {review_rank} | {source_rank} | {mode} | {note_groups_per_bar} | {sample_index} | "
             "{score:.4f} | {note_count} | {unique_pitch_count} | {chord_tone_ratio:.3f} | "
-            "{dominant_pitch_ratio:.3f} | {repeated_pitch_ratio:.3f} | "
-            "{adjacent_repeated_pitch_ratio:.3f} | {direction_change_ratio:.3f} | "
+            "{root_tone_ratio:.3f} | {tension_ratio:.3f} | "
+            "{dominant_pitch_ratio:.3f} | {repeated_pitch_ratio:.3f} | {direction_change_ratio:.3f} | "
             "`{risk_flags_text}` | `{display_midi_path}` |".format(
                 **table_candidate
             )

--- a/scripts/run_stage_b_generation_probe.py
+++ b/scripts/run_stage_b_generation_probe.py
@@ -573,6 +573,63 @@ def chord_pitch_classes(chord: str | None, pitch_mode: str = "tones_tensions") -
     return {(root_pc + interval) % 12 for interval in intervals}
 
 
+def chord_root_pitch_class(chord: str | None) -> int | None:
+    root, _quality = parse_chord_symbol(chord)
+    return ROOT_TO_PC.get(root)
+
+
+def analyze_stage_b_pitch_roles(
+    tokens: Sequence[int],
+    chords: Sequence[str],
+    primer_size: int = 0,
+) -> dict[str, Any]:
+    groups = extract_stage_b_note_groups(tokens, primer_size=primer_size)
+    group_count = int(len(groups))
+    root_hits = 0
+    chord_tone_hits = 0
+    tension_hits = 0
+    non_chord_hits = 0
+    per_bar_counts: dict[int, int] = {}
+    per_bar_root_hits: dict[int, int] = {}
+
+    for group in groups:
+        bar = int(group["bar"])
+        pitch_class = int(group["pitch"]) % 12
+        chord = chords[bar % len(chords)] if chords else None
+        root_pc = chord_root_pitch_class(chord)
+        chord_tones = chord_pitch_classes(chord, pitch_mode="tones")
+        tones_with_tensions = chord_pitch_classes(chord, pitch_mode="tones_tensions")
+        per_bar_counts[bar] = per_bar_counts.get(bar, 0) + 1
+        if root_pc is not None and pitch_class == root_pc:
+            root_hits += 1
+            per_bar_root_hits[bar] = per_bar_root_hits.get(bar, 0) + 1
+        if pitch_class in chord_tones:
+            chord_tone_hits += 1
+        elif pitch_class in tones_with_tensions:
+            tension_hits += 1
+        else:
+            non_chord_hits += 1
+
+    non_root_chord_tone_hits = max(0, chord_tone_hits - root_hits)
+    return {
+        "note_group_count": group_count,
+        "root_tone_count": int(root_hits),
+        "root_tone_ratio": float(root_hits / group_count) if group_count else 0.0,
+        "chord_tone_count": int(chord_tone_hits),
+        "chord_tone_ratio": float(chord_tone_hits / group_count) if group_count else 0.0,
+        "non_root_chord_tone_count": int(non_root_chord_tone_hits),
+        "non_root_chord_tone_ratio": float(non_root_chord_tone_hits / group_count) if group_count else 0.0,
+        "tension_count": int(tension_hits),
+        "tension_ratio": float(tension_hits / group_count) if group_count else 0.0,
+        "non_chord_tone_count": int(non_chord_hits),
+        "non_chord_tone_ratio": float(non_chord_hits / group_count) if group_count else 0.0,
+        "per_bar_root_tone_ratio": {
+            str(bar): float(per_bar_root_hits.get(bar, 0) / count if count else 0.0)
+            for bar, count in sorted(per_bar_counts.items())
+        },
+    }
+
+
 def chord_aware_pitch_tokens(
     chord: str | None,
     pitch_mode: str = "tones_tensions",
@@ -741,6 +798,7 @@ def sample_report(
     collapse = analyze_stage_b_collapse(tokens, primer_size=primer_size, postprocess_report=postprocess_report)
     temporal_coverage = analyze_stage_b_temporal_coverage(tokens, primer_size=primer_size, bars=request.bars)
     phrase_contour = analyze_stage_b_phrase_contour(tokens, primer_size=primer_size)
+    pitch_roles = analyze_stage_b_pitch_roles(tokens, chords=request.chord_progression, primer_size=primer_size)
     collapse_gate = evaluate_collapse_gate(
         collapse,
         min_unique_pitches=strict_min_unique_pitches,
@@ -777,6 +835,7 @@ def sample_report(
         "collapse": collapse,
         "temporal_coverage": temporal_coverage,
         "phrase_contour": phrase_contour,
+        "pitch_roles": pitch_roles,
         "collapse_gate": collapse_gate,
         "postprocess": postprocess_report or {"enabled": False},
         "metrics": metrics.to_dict(),
@@ -817,10 +876,13 @@ def build_probe_summary(
     adjacent_repeated_pitch_ratios: list[float] = []
     direction_change_ratios: list[float] = []
     longest_same_pitch_runs: list[int] = []
+    root_tone_ratios: list[float] = []
+    tension_ratios: list[float] = []
     for row in sample_rows:
         collapse = row.get("collapse", {})
         temporal_coverage = row.get("temporal_coverage", {})
         phrase_contour = row.get("phrase_contour", {})
+        pitch_roles = row.get("pitch_roles", {})
         if collapse.get("collapse_warning"):
             collapse_warning_count += 1
         if not row.get("strict_valid", False):
@@ -846,6 +908,8 @@ def build_probe_summary(
         )
         direction_change_ratios.append(float(phrase_contour.get("direction_change_ratio", 0.0) or 0.0))
         longest_same_pitch_runs.append(int(phrase_contour.get("longest_same_pitch_run", 0) or 0))
+        root_tone_ratios.append(float(pitch_roles.get("root_tone_ratio", 0.0) or 0.0))
+        tension_ratios.append(float(pitch_roles.get("tension_ratio", 0.0) or 0.0))
         if not row["valid"]:
             reason = str(row.get("failure_reason") or "unknown")
             diagnostic_reason = str(row.get("diagnostic_failure_reason") or reason)
@@ -922,6 +986,10 @@ def build_probe_summary(
             float(sum(direction_change_ratios) / len(direction_change_ratios)) if direction_change_ratios else 0.0
         ),
         "max_longest_same_pitch_run": max(longest_same_pitch_runs) if longest_same_pitch_runs else 0,
+        "avg_root_tone_ratio": (
+            float(sum(root_tone_ratios) / len(root_tone_ratios)) if root_tone_ratios else 0.0
+        ),
+        "avg_tension_ratio": float(sum(tension_ratios) / len(tension_ratios)) if tension_ratios else 0.0,
     }
 
 

--- a/tests/test_stage_b_generation_probe.py
+++ b/tests/test_stage_b_generation_probe.py
@@ -11,6 +11,7 @@ from scripts.run_stage_b_generation_probe import (
     analyze_stage_b_collapse,
     analyze_stage_b_note_grammar,
     analyze_stage_b_phrase_contour,
+    analyze_stage_b_pitch_roles,
     analyze_stage_b_temporal_coverage,
     build_probe_summary,
     build_stage_b_primer,
@@ -256,6 +257,39 @@ class StageBGenerationProbeTest(unittest.TestCase):
     def test_chord_pitch_classes_can_include_tensions(self) -> None:
         self.assertEqual(chord_pitch_classes("Cmaj7", pitch_mode="tones"), {0, 4, 7, 11})
         self.assertIn(2, chord_pitch_classes("Cmaj7", pitch_mode="tones_tensions"))
+
+    def test_analyze_stage_b_pitch_roles_counts_root_and_tensions(self) -> None:
+        primer = build_stage_b_primer(["Cm7", "F7"], bpm=120)
+        tokens = primer + [
+            position_token(0),
+            note_velocity_token(4),
+            note_pitch_token(60),
+            note_duration_token(1),
+            position_token(1),
+            note_velocity_token(4),
+            note_pitch_token(63),
+            note_duration_token(1),
+            TOKEN_BAR,
+            *chord_tokens("F7"),
+            position_token(0),
+            note_velocity_token(4),
+            note_pitch_token(65),
+            note_duration_token(1),
+            position_token(1),
+            note_velocity_token(4),
+            note_pitch_token(67),
+            note_duration_token(1),
+            TOKEN_END,
+        ]
+
+        report = analyze_stage_b_pitch_roles(tokens, chords=["Cm7", "F7"], primer_size=len(primer))
+
+        self.assertEqual(report["note_group_count"], 4)
+        self.assertEqual(report["root_tone_count"], 2)
+        self.assertAlmostEqual(report["root_tone_ratio"], 0.5)
+        self.assertEqual(report["non_root_chord_tone_count"], 1)
+        self.assertEqual(report["tension_count"], 1)
+        self.assertEqual(report["per_bar_root_tone_ratio"], {"0": 0.5, "1": 0.5})
 
     def test_chord_aware_constrained_generation_limits_pitch_by_bar_chord(self) -> None:
         primer = build_stage_b_primer(["Cm7", "F7"], bpm=120)

--- a/tests/test_stage_b_review_export.py
+++ b/tests/test_stage_b_review_export.py
@@ -93,6 +93,11 @@ class StageBReviewExportTest(unittest.TestCase):
                         "contour_warning": False,
                         "contour_warning_reasons": [],
                     },
+                    "pitch_roles": {
+                        "root_tone_ratio": 0.5,
+                        "non_root_chord_tone_ratio": 0.40625,
+                        "tension_ratio": 0.0,
+                    },
                 },
                 {
                     "sample_index": 2,
@@ -114,6 +119,8 @@ class StageBReviewExportTest(unittest.TestCase):
         self.assertEqual(selected[0]["note_groups_per_bar"], 8)
         self.assertEqual(selected[0]["note_count"], 32)
         self.assertIn("high_repeated_pitch_ratio", selected[0]["risk_flags"])
+        self.assertIn("high_root_tone_ratio", selected[0]["risk_flags"])
+        self.assertAlmostEqual(selected[0]["root_tone_ratio"], 0.5)
         self.assertGreater(selected[0]["score"], 80.0)
 
     def test_build_review_manifest_copies_midi(self) -> None:
@@ -176,6 +183,8 @@ class StageBReviewExportTest(unittest.TestCase):
                     "repeated_pitch_ratio": 0.25,
                     "adjacent_repeated_pitch_ratio": 0.0,
                     "direction_change_ratio": 0.0,
+                    "root_tone_ratio": 0.0,
+                    "tension_ratio": 0.0,
                     "risk_flags": [],
                     "midi_path": "sample.mid",
                 }


### PR DESCRIPTION
## 요약
- 4-bar 후보가 멜로디처럼 들리지만 근음을 계속 치는 느낌이 있다는 리뷰를 반영했습니다.
- generation probe sample report에 pitch_roles를 추가했습니다.
- review export에 root/tension columns와 root bias risk flag를 추가했습니다.
- docs/CORE_PLAN.md와 CURRENT_STATUS_AND_PLAN.md에 root-bias 해석을 반영했습니다.

## 결과
- avg root tone ratio: 0.271
- top candidate root tone ratio: 0.219
- tension ratio: 0.000
- chord tone ratio: 0.938-1.000
- adjacent repeated pitch ratio: 0.000

## 해석
- 현재 후보는 root-only collapse가 아닙니다.
- 더 정확한 진단은 tension이 없는 chord-tone-only 안전한 라인입니다.
- 다음 비교는 chord_pitch_mode=tones vs tones_tensions가 맞습니다.

## 검증
- ./.venv/bin/python -m unittest tests.test_stage_b_generation_probe tests.test_stage_b_review_export
- ./.venv/bin/python -m compileall scripts/run_stage_b_generation_probe.py scripts/export_stage_b_review_candidates.py tests/test_stage_b_generation_probe.py tests/test_stage_b_review_export.py
- bash scripts/agent_harness.sh stage-b-longer-phrase-probe
- bash scripts/agent_harness.sh quick

Closes #53