### PR TITLE
Stage B pitch mode 비교 probe 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #53: Stage B root bias diagnostics and tension pitch comparison.
+- Issue #55: Stage B tones vs tones_tensions pitch-mode comparison.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -129,6 +129,7 @@ Stage B에서 명시하는 것:
 23. Stage B longer 4-bar coverage_chord phrase probe
 24. Stage B phrase contour/repeated-pitch diagnostics
 25. Stage B root bias diagnostics
+26. Stage B `tones` vs `tones_tensions` pitch-mode comparison
 
 가장 최근 의미 있는 결과:
 
@@ -326,12 +327,15 @@ Stage B에서 명시하는 것:
 - latest result: average root tone ratio는 약 `0.271`이다.
 - latest result: top candidate root tone ratio는 약 `0.219`이다.
 - latest result: tension ratio는 `0.000`이다.
+- Issue #55 result: `tones_tensions`는 root tone ratio를 약 `0.271`에서 `0.135`로 낮췄고, tension ratio를 `0.000`에서 `0.313`으로 올렸다.
+- Issue #55 result: 양쪽 모두 strict valid `3/3`이지만, `tones_tensions` 후보는 repeated/dominant pitch risk가 여전히 높다.
 
 해석:
 
 - 현재 후보는 root-only collapse가 아니다.
 - 오히려 `chord_pitch_mode=tones` 때문에 tension이 전혀 없는 안전한 chord-tone-only line이다.
-- 다음 비교는 `tones` vs `tones_tensions`가 맞다.
+- `tones_tensions`는 no-tension 문제를 줄였지만, 더 좋은 solo phrase라고 바로 판단할 단계는 아니다.
+- 다음 비교는 unrestricted tension보다 passing/approach pitch policy 또는 motif/contour constraint 쪽이 맞다.
 
 ### Phase 4. Generic Jazz Base 후보 학습
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-53-stage-b-root-bias-diagnostics`
+- `issue-55-stage-b-tension-compare`
 
 현재 범위가 아닌 것:
 
@@ -36,49 +36,45 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 ## Latest Probe Result
 
-Issue #53은 manual listening/piano-roll review에서 나온 "멜로디 같긴 하지만 근음을 계속 치는 느낌"을 root bias로 수치화한다.
+Issue #55는 manual listening/piano-roll review에서 나온 "멜로디 같긴 하지만 근음/코드음에 너무 안전하게 붙어있는 느낌"을 `tones` vs `tones_tensions` 비교로 검증한다.
 
-Issue #51에서 이미 adjacent same-note collapse는 아니라는 것을 확인했다. Issue #53은 실제로 root tone을 얼마나 치는지, non-root chord tone과 tension 비율이 어떤지 기록한다.
+Issue #51에서 이미 adjacent same-note collapse는 아니라는 것을 확인했다. Issue #53에서는 실제 root tone, non-root chord tone, tension 비율을 기록했다. Issue #55는 같은 4-bar 조건에서 `tones_tensions`가 tension을 실제로 늘리고 root bias를 줄이는지 확인한다.
 
 Implemented:
 
-- `scripts/run_stage_b_generation_probe.py` phrase contour diagnostics
-- `scripts/run_stage_b_generation_probe.py` pitch-role diagnostics
-- `scripts/export_stage_b_review_candidates.py` repeated-pitch/contour risk flags
-- `scripts/export_stage_b_review_candidates.py` root/tension columns
-- `tests/test_stage_b_generation_probe.py` phrase contour tests
-- `tests/test_stage_b_review_export.py` risk flag tests
-- `scripts/agent_harness.sh stage-b-longer-phrase-probe`
+- `scripts/run_stage_b_pitch_mode_compare.py`
+- `tests/test_stage_b_pitch_mode_compare.py`
+- `scripts/run_stage_b_sampling_sweep.py` root/tension summary fields
+- `scripts/agent_harness.sh stage-b-pitch-mode-compare`
 - output files:
-  - `review_manifest.json`
-  - `review_candidates.md`
-  - copied review MIDI files under `midi/`
+  - `pitch_mode_compare_report.json`
+  - `pitch_mode_compare_report.md`
+  - mode-specific `review_manifest.json`
+  - mode-specific copied review MIDI files under `midi/`
 
 Result:
 
-- source generation report: `outputs/stage_b_generation_probe/harness_stage_b_longer_phrase_probe/report.json`
-- review output: `outputs/stage_b_review_candidates/harness_stage_b_longer_phrase_probe`
+- source comparison report: `outputs/stage_b_pitch_mode_compare/harness_stage_b_pitch_mode_compare/pitch_mode_compare_report.json`
+- tones review output: `outputs/stage_b_review_candidates/harness_stage_b_pitch_mode_compare/tones`
+- tones+tensions review output: `outputs/stage_b_review_candidates/harness_stage_b_pitch_mode_compare/tones_tensions`
 - setup: `4` bars, `8` note groups per bar, `32` note groups per sample
-- generated samples: `3`
-- strict valid samples: `3`
-- grammar-valid samples: `3`
-- average onset coverage ratio: around `0.500`
-- average sustained coverage ratio: around `0.680`
-- repeated pitch ratio: around `0.719`
-- adjacent repeated pitch ratio: `0.000`
-- average direction change ratio: around `0.689`
-- max longest same pitch run: `1`
-- average root tone ratio: around `0.271`
-- top candidate root tone ratio: around `0.219`
-- tension ratio: `0.000`
+- `tones` strict valid samples: `3/3`
+- `tones_tensions` strict valid samples: `3/3`
+- `tones` average root tone ratio: around `0.271`
+- `tones_tensions` average root tone ratio: around `0.135`
+- `tones` average tension ratio: `0.000`
+- `tones_tensions` average tension ratio: around `0.313`
+- `tones` average chord-tone ratio: around `0.927`
+- `tones_tensions` average chord-tone ratio: around `0.667`
+- both modes average onset coverage ratio: around `0.500`
 
 Decision:
 
 - 2-bar candidates가 너무 짧았다는 판단은 타당하다.
-- 다음 review는 4-bar exported candidates를 기준으로 한다.
-- 4-bar 후보가 여전히 단편적이면 broad training으로 가지 않고 phrase/motif-level constraint 또는 pretrained symbolic base를 검토한다.
-- 4-bar 후보가 최소한 solo-line phrase sketch로 들리면 generic jazz base 후보 학습 설계로 넘어갈 수 있다.
-- "근음을 계속 치는 느낌"은 실제 root-only collapse라기보다 chord-tone-only, no-tension 라인의 안전한 inside sound일 가능성이 높다.
+- 4-bar 후보는 one-note/two-note failure가 아니라 melody-like sketch로 볼 수 있다.
+- "근음을 계속 치는 느낌"은 실제 root-only collapse라기보다 chord-tone-only, no-tension 라인의 안전한 inside sound에 가깝다.
+- `tones_tensions`는 no-tension 문제를 줄였지만, repeated/dominant pitch risk가 남아 있어 broad training 전 phrase-shape control이 먼저다.
+- 다음 issue는 passing/approach pitch policy 또는 motif/contour constraint 비교가 맞다.
 
 Detail:
 
@@ -89,6 +85,7 @@ Detail:
 - `docs/STAGE_B_LONGER_PHRASE_PROBE_2026-05-21.md`
 - `docs/STAGE_B_PHRASE_CONTOUR_DIAGNOSTICS_2026-05-21.md`
 - `docs/STAGE_B_ROOT_BIAS_DIAGNOSTICS_2026-05-21.md`
+- `docs/STAGE_B_PITCH_MODE_COMPARE_2026-05-21.md`
 
 ## Active Issue #14
 
@@ -1219,16 +1216,22 @@ Latest local result:
 - chord tone ratio: around `0.938-1.000`
 - tension ratio: `0.000`
 - adjacent repeated pitch ratio: `0.000`
+- `tones_tensions` comparison result:
+  - root tone ratio: around `0.135`
+  - tension ratio: around `0.313`
+  - strict valid samples: `3/3`
 
 Decision:
 
 - The current issue is not pure root collapse.
 - The stronger diagnosis is "safe chord-tone-only line with no tensions."
-- Next generation comparison should test `chord_pitch_mode=tones_tensions` against current `tones`.
+- `chord_pitch_mode=tones_tensions` reduces root/no-tension stiffness, but repeated pitch-set behavior remains.
+- Next generation comparison should test passing/approach pitch or contour/motif constraints against the current `tones_tensions` baseline.
 
 Detail:
 
 - `docs/STAGE_B_ROOT_BIAS_DIAGNOSTICS_2026-05-21.md`
+- `docs/STAGE_B_PITCH_MODE_COMPARE_2026-05-21.md`
 
 ### 1. Run full jazz piano dataset audit
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,6 +64,8 @@
   - 4-bar 후보의 repeated-pitch risk가 adjacent collapse인지 제한된 pitch-set 재사용인지 구분하는 contour diagnostics.
 - `STAGE_B_ROOT_BIAS_DIAGNOSTICS_2026-05-21.md`
   - "근음을 계속 치는 느낌"을 root-tone ratio와 tension ratio로 분리해 진단하는 문서.
+- `STAGE_B_PITCH_MODE_COMPARE_2026-05-21.md`
+  - `tones`와 `tones_tensions`를 같은 Stage B 4-bar 조건에서 비교한 결과와 다음 phrase-shape control 판단 기준.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -90,7 +92,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, and root-bias diagnostics를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, and pitch-mode comparison을 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_PITCH_MODE_COMPARE_2026-05-21.md
+++ b/docs/STAGE_B_PITCH_MODE_COMPARE_2026-05-21.md
@@ -1,0 +1,144 @@
+# Stage B Pitch Mode Compare
+
+작성일: 2026-05-21
+
+## Context
+
+Manual piano-roll review에서 4-bar 후보는 one-note/two-note failure는 아니고, 멜로디처럼 보이지만 너무 안전한 chord-tone line처럼 들린다는 피드백이 있었다.
+
+Issue #53에서 root bias를 측정한 결과:
+
+- average root tone ratio: about `0.271`
+- top candidate root tone ratio: about `0.219`
+- tension ratio: `0.000`
+
+따라서 다음 질문은 "근음만 치는 collapse인가?"가 아니라:
+
+> `tones_tensions`를 허용하면 root/chord-tone stiffness가 줄고 더 solo-line처럼 들을 만한 후보가 나오는가?
+
+## Scope
+
+Issue #55:
+
+- 같은 tiny checkpoint로 `tones`와 `tones_tensions`를 비교한다.
+- 기존 4-bar longer phrase 조건을 유지한다.
+- 각 mode별 root/tension/chord-tone ratio를 report에 남긴다.
+- 각 mode별 manual review MIDI를 따로 export한다.
+
+Non-goals:
+
+- broad training
+- generic jazz base training
+- pretrained model integration
+- DAW/API/backend work
+
+## Implementation
+
+Added:
+
+- `scripts/run_stage_b_pitch_mode_compare.py`
+- `tests/test_stage_b_pitch_mode_compare.py`
+- `scripts/agent_harness.sh stage-b-pitch-mode-compare`
+- `scripts/run_stage_b_sampling_sweep.py` row summary fields:
+  - `avg_root_tone_ratio`
+  - `avg_tension_ratio`
+
+Harness:
+
+```bash
+bash scripts/agent_harness.sh stage-b-pitch-mode-compare
+```
+
+The harness:
+
+1. trains/prepares once for the first pitch mode
+2. reuses the same checkpoint for the second pitch mode
+3. writes a combined comparison report
+4. exports review MIDI under mode-specific directories
+
+## Local Result
+
+Run:
+
+```text
+RUN_ID=harness_stage_b_pitch_mode_compare
+```
+
+Report:
+
+```text
+outputs/stage_b_pitch_mode_compare/harness_stage_b_pitch_mode_compare/pitch_mode_compare_report.json
+outputs/stage_b_pitch_mode_compare/harness_stage_b_pitch_mode_compare/pitch_mode_compare_report.md
+```
+
+Review MIDI:
+
+```text
+outputs/stage_b_review_candidates/harness_stage_b_pitch_mode_compare/tones/midi/
+outputs/stage_b_review_candidates/harness_stage_b_pitch_mode_compare/tones_tensions/midi/
+```
+
+Summary:
+
+| pitch mode | strict samples | chord | root | tension | onset | sustained | collapse |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `tones` | 3/3 | 0.927 | 0.271 | 0.000 | 0.500 | 0.682 | 0.000 |
+| `tones_tensions` | 3/3 | 0.667 | 0.135 | 0.313 | 0.500 | 0.667 | 0.000 |
+
+Deltas, `tones_tensions - tones`:
+
+- root tone ratio: `-0.135`
+- tension ratio: `+0.313`
+
+## Interpretation
+
+`tones_tensions` did what it was supposed to do numerically:
+
+- root-tone usage dropped by about half
+- tension usage appeared
+- strict MIDI validity stayed at 3/3
+- temporal coverage stayed comparable
+
+But it is not automatically better musically:
+
+- chord-tone ratio drops because tensions are counted separately from chord tones
+- top review candidates still carry `high_repeated_pitch_ratio`
+- `tones_tensions` candidates also show stronger dominant-pitch risk than the best `tones` candidate
+
+Current diagnosis:
+
+> `tones` sounds safe and inside, while `tones_tensions` is harmonically less stiff but still mechanically constrained by the current pitch-selection policy.
+
+## Review Instruction
+
+Manual listening should compare mode pairs, not isolated files.
+
+Listen in this order:
+
+1. `outputs/stage_b_review_candidates/harness_stage_b_pitch_mode_compare/tones/midi/rank_01_coverage_chord_g8_s3.mid`
+2. `outputs/stage_b_review_candidates/harness_stage_b_pitch_mode_compare/tones_tensions/midi/rank_01_coverage_chord_g8_s3.mid`
+3. compare whether the second file sounds more like a phrase or only more chromatic/tension-heavy
+
+Review question:
+
+- Is `tones_tensions` more solo-like, or just less inside?
+- Does the line still sound like it is selecting from a small pitch set?
+- Is repeated-pitch feel worse than the previous `tones` candidate?
+
+## Decision
+
+Do not jump to broad training yet.
+
+The next useful step is phrase-shape control:
+
+- either add passing/approach pitch policy instead of unrestricted tensions
+- or add motif/contour constraints that reduce repeated pitch-class cycling
+- then compare against this `tones_tensions` baseline
+
+## Validation
+
+```bash
+./.venv/bin/python -m unittest tests.test_stage_b_pitch_mode_compare tests.test_stage_b_generation_probe tests.test_stage_b_review_export
+./.venv/bin/python -m compileall scripts/run_stage_b_pitch_mode_compare.py scripts/run_stage_b_sampling_sweep.py scripts/agent_harness.sh tests/test_stage_b_pitch_mode_compare.py
+bash scripts/agent_harness.sh stage-b-pitch-mode-compare
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -52,6 +52,8 @@ Modes:
                 Run coverage/chord-aware Stage B sweep and rank candidates.
   stage-b-longer-phrase-probe
                 Run a 4-bar coverage/chord-aware Stage B probe and export review MIDI.
+  stage-b-pitch-mode-compare
+                Compare 4-bar tones vs tones_tensions Stage B pitch modes.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   all           Run demo and tiny-compare.
@@ -91,6 +93,7 @@ run_quick() {
     scripts/run_stage_b_generation_probe.py \
     scripts/run_stage_b_sampling_sweep.py \
     scripts/run_stage_b_coverage_ab_sweep.py \
+    scripts/run_stage_b_pitch_mode_compare.py \
     scripts/rank_stage_b_candidates.py \
     scripts/audit_brad_mehldau_dataset.py \
     scripts/audit_jazz_piano_dataset.py \
@@ -492,6 +495,42 @@ run_stage_b_longer_phrase_probe() {
     --copy_midi
 }
 
+run_stage_b_pitch_mode_compare() {
+  local run_id="${RUN_ID:-harness_stage_b_pitch_mode_compare}"
+  print_header "Stage B tones vs tones_tensions pitch-mode comparison"
+  "$PYTHON_BIN" scripts/run_stage_b_pitch_mode_compare.py \
+    --run_id "$run_id" \
+    --issue_number 55 \
+    --max_files 2 \
+    --window_bars 4 \
+    --window_stride_bars 2 \
+    --min_window_target_notes 8 \
+    --epochs 3 \
+    --batch_size 8 \
+    --max_sequence 192 \
+    --num_samples 3 \
+    --bars 4 \
+    --pitch_modes tones,tones_tensions \
+    --coverage_position_window 0 \
+    --chord_pitch_repeat_window 2 \
+    --note_groups_per_bar 8 \
+    --max_simultaneous_notes 2 \
+    --temperature 0.9 \
+    --top_k 2 \
+    --min_valid_samples 1 \
+    --min_strict_valid_samples 1 \
+    --min_best_strict_valid_samples 1 \
+    --max_collapse_warning_sample_rate 0.34 \
+    --require_all_grammar_samples \
+    --copy_review_midi \
+    --n_layers 1 \
+    --num_heads 4 \
+    --d_model 64 \
+    --dim_feedforward 128 \
+    --lora_r 4 \
+    --lora_alpha 8
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -557,6 +596,9 @@ case "$MODE" in
     ;;
   stage-b-longer-phrase-probe)
     run_stage_b_longer_phrase_probe
+    ;;
+  stage-b-pitch-mode-compare)
+    run_stage_b_pitch_mode_compare
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/run_stage_b_pitch_mode_compare.py
+++ b/scripts/run_stage_b_pitch_mode_compare.py
@@ -1,0 +1,317 @@
+"""Compare Stage B chord-aware pitch modes on one tiny checkpoint."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.export_stage_b_review_candidates import (  # noqa: E402
+    build_review_manifest,
+    markdown_report as review_markdown_report,
+    write_json as write_review_json,
+)
+from scripts.run_stage_b_sampling_sweep import (  # noqa: E402
+    probe_command,
+    read_json,
+    row_from_probe_report,
+    run_command,
+    suffix_for_float,
+    write_json,
+)
+
+VALID_PITCH_MODES = {"tones", "tones_tensions"}
+
+
+def parse_pitch_modes(raw: str) -> list[str]:
+    modes = [mode.strip().lower() for mode in raw.split(",") if mode.strip()]
+    invalid = [mode for mode in modes if mode not in VALID_PITCH_MODES]
+    if invalid:
+        raise ValueError(f"Unknown pitch modes: {invalid}")
+    return modes
+
+
+def config_run_id(
+    base_run_id: str,
+    pitch_mode: str,
+    note_groups_per_bar: int,
+    top_k: int,
+    temperature: float,
+) -> str:
+    return (
+        f"{base_run_id}_coverage_chord_{pitch_mode}_g{int(note_groups_per_bar)}"
+        f"_k{int(top_k)}_t{suffix_for_float(float(temperature))}"
+    )
+
+
+def best_row(rows: list[dict[str, Any]]) -> dict[str, Any] | None:
+    return max(
+        rows,
+        key=lambda row: (
+            int(row["strict_valid_sample_count"]),
+            int(row["valid_sample_count"]),
+            float(row["avg_tension_ratio"]),
+            -float(row["avg_root_tone_ratio"]),
+            -float(row["collapse_warning_sample_rate"]),
+        ),
+        default=None,
+    )
+
+
+def compact_row(row: dict[str, Any] | None) -> dict[str, Any] | None:
+    if row is None:
+        return None
+    return {
+        "pitch_mode": row["pitch_mode"],
+        "run_id": row["run_id"],
+        "strict_valid_sample_count": int(row["strict_valid_sample_count"]),
+        "valid_sample_count": int(row["valid_sample_count"]),
+        "avg_chord_tone_ratio": float(row["avg_chord_tone_ratio"]),
+        "avg_root_tone_ratio": float(row["avg_root_tone_ratio"]),
+        "avg_tension_ratio": float(row["avg_tension_ratio"]),
+        "avg_onset_coverage_ratio": float(row["avg_onset_coverage_ratio"]),
+        "avg_sustained_coverage_ratio": float(row["avg_sustained_coverage_ratio"]),
+    }
+
+
+def build_pitch_mode_summary(
+    rows: list[dict[str, Any]],
+    min_best_strict_valid_samples: int = 1,
+) -> dict[str, Any]:
+    mode_rows = {mode: [row for row in rows if row.get("pitch_mode") == mode] for mode in sorted(VALID_PITCH_MODES)}
+    best_tones = best_row(mode_rows["tones"])
+    best_tensions = best_row(mode_rows["tones_tensions"])
+    best = best_row(rows)
+    comparison_ready = bool(best_tones and best_tensions)
+    tones_root = float(best_tones.get("avg_root_tone_ratio", 0.0)) if best_tones else 0.0
+    tensions_root = float(best_tensions.get("avg_root_tone_ratio", 0.0)) if best_tensions else 0.0
+    tones_tension = float(best_tones.get("avg_tension_ratio", 0.0)) if best_tones else 0.0
+    tensions_tension = float(best_tensions.get("avg_tension_ratio", 0.0)) if best_tensions else 0.0
+    passed_tones = bool(
+        best_tones
+        and int(best_tones["strict_valid_sample_count"]) >= int(min_best_strict_valid_samples)
+    )
+    passed_tensions = bool(
+        best_tensions
+        and int(best_tensions["strict_valid_sample_count"]) >= int(min_best_strict_valid_samples)
+    )
+    return {
+        "config_count": int(len(rows)),
+        "mode_counts": {mode: int(len(mode_rows[mode])) for mode in sorted(VALID_PITCH_MODES)},
+        "best_config": compact_row(best),
+        "best_tones_config": compact_row(best_tones),
+        "best_tones_tensions_config": compact_row(best_tensions),
+        "min_best_strict_valid_samples": int(min_best_strict_valid_samples),
+        "comparison_ready": comparison_ready,
+        "passed_tones_gate": passed_tones,
+        "passed_tones_tensions_gate": passed_tensions,
+        "passed_compare_gate": bool(comparison_ready and passed_tones and passed_tensions),
+        "root_tone_ratio_delta_tensions_minus_tones": float(tensions_root - tones_root),
+        "tension_ratio_delta_tensions_minus_tones": float(tensions_tension - tones_tension),
+    }
+
+
+def markdown_table(rows: list[dict[str, Any]], summary: dict[str, Any]) -> str:
+    lines = [
+        "# Stage B Pitch Mode Comparison",
+        "",
+        f"- passed compare gate: `{str(summary['passed_compare_gate']).lower()}`",
+        f"- best tones config: `{summary['best_tones_config']}`",
+        f"- best tones+tensions config: `{summary['best_tones_tensions_config']}`",
+        f"- root delta, tensions minus tones: `{summary['root_tone_ratio_delta_tensions_minus_tones']:.3f}`",
+        f"- tension delta, tensions minus tones: `{summary['tension_ratio_delta_tensions_minus_tones']:.3f}`",
+        "",
+        "| pitch mode | samples | valid | strict | chord | root | tension | onset | sustained | collapse | strict pass | report |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|---|",
+    ]
+    for row in rows:
+        lines.append(
+            "| {pitch_mode} | {sample_count} | {valid_sample_count} | {strict_valid_sample_count} | "
+            "{avg_chord_tone_ratio:.3f} | {avg_root_tone_ratio:.3f} | {avg_tension_ratio:.3f} | "
+            "{avg_onset_coverage_ratio:.3f} | {avg_sustained_coverage_ratio:.3f} | "
+            "{collapse_warning_sample_rate:.3f} | {passed_strict_review_gate} | `{report_path}` |".format(**row)
+        )
+    lines.append("")
+    lines.append("## Diagnostic Failures")
+    lines.append("")
+    for row in rows:
+        lines.append(f"- `{row['pitch_mode']}`: {row['diagnostic_failure_reasons']}")
+    return "\n".join(lines) + "\n"
+
+
+def export_review_candidates(
+    report_path: Path,
+    output_dir: Path,
+    top_n: int,
+    copy_midi: bool,
+) -> dict[str, Any]:
+    manifest = build_review_manifest(
+        ranking_report_path=report_path,
+        output_dir=output_dir,
+        top_n=top_n,
+        mode="coverage_chord",
+        reviewable_only=True,
+        copy_midi=copy_midi,
+    )
+    write_review_json(output_dir / "review_manifest.json", manifest)
+    (output_dir / "review_candidates.md").write_text(review_markdown_report(manifest), encoding="utf-8")
+    return manifest
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run Stage B tones vs tones_tensions comparison")
+    parser.add_argument("--output_root", type=str, default=str(ROOT_DIR / "outputs" / "stage_b_pitch_mode_compare"))
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--issue_number", type=int, default=55)
+    parser.add_argument("--pitch_modes", type=str, default="tones,tones_tensions")
+    parser.add_argument("--note_groups_per_bar", type=int, default=8)
+    parser.add_argument("--coverage_position_window", type=int, default=0)
+    parser.add_argument("--chord_pitch_repeat_window", type=int, default=2)
+    parser.add_argument("--top_k", type=int, default=2)
+    parser.add_argument("--temperature", type=float, default=0.9)
+    parser.add_argument("--max_files", type=int, default=2)
+    parser.add_argument("--window_bars", type=int, default=4)
+    parser.add_argument("--window_stride_bars", type=int, default=2)
+    parser.add_argument("--min_window_target_notes", type=int, default=8)
+    parser.add_argument("--epochs", type=int, default=3)
+    parser.add_argument("--batch_size", type=int, default=8)
+    parser.add_argument("--max_sequence", type=int, default=192)
+    parser.add_argument("--num_samples", type=int, default=3)
+    parser.add_argument("--bars", type=int, default=4)
+    parser.add_argument("--max_simultaneous_notes", type=int, default=2)
+    parser.add_argument("--min_valid_samples", type=int, default=1)
+    parser.add_argument("--min_strict_valid_samples", type=int, default=1)
+    parser.add_argument("--min_best_strict_valid_samples", type=int, default=1)
+    parser.add_argument("--max_collapse_warning_sample_rate", type=float, default=0.34)
+    parser.add_argument("--strict_min_unique_pitches", type=int, default=3)
+    parser.add_argument("--strict_min_unique_positions", type=int, default=3)
+    parser.add_argument("--strict_min_unique_position_pitch_pairs", type=int, default=4)
+    parser.add_argument("--strict_max_repeated_position_pitch_pair_ratio", type=float, default=0.49)
+    parser.add_argument("--strict_max_postprocess_removal_ratio", type=float, default=0.49)
+    parser.add_argument("--require_all_grammar_samples", action="store_true")
+    parser.add_argument("--review_output_root", type=str, default=str(ROOT_DIR / "outputs" / "stage_b_review_candidates"))
+    parser.add_argument("--review_top_n", type=int, default=3)
+    parser.add_argument("--copy_review_midi", action="store_true")
+    parser.add_argument("--n_layers", type=int, default=1)
+    parser.add_argument("--num_heads", type=int, default=4)
+    parser.add_argument("--d_model", type=int, default=64)
+    parser.add_argument("--dim_feedforward", type=int, default=128)
+    parser.add_argument("--lora_r", type=int, default=4)
+    parser.add_argument("--lora_alpha", type=int, default=8)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now().strftime("%Y%m%d_%H%M%S")
+    compare_dir = Path(args.output_root) / run_id
+    pitch_modes = parse_pitch_modes(args.pitch_modes)
+    if not pitch_modes:
+        raise ValueError("--pitch_modes must not be empty")
+
+    command_results: list[dict[str, Any]] = []
+    rows: list[dict[str, Any]] = []
+    review_exports: dict[str, dict[str, Any]] = {}
+    checkpoint_dir: Path | None = None
+    first_config = True
+
+    for pitch_mode in pitch_modes:
+        mode_run_id = config_run_id(
+            run_id,
+            pitch_mode=pitch_mode,
+            note_groups_per_bar=args.note_groups_per_bar,
+            top_k=args.top_k,
+            temperature=args.temperature,
+        )
+        probe_args = argparse.Namespace(**vars(args))
+        probe_args.output_root = args.output_root
+        probe_args.constrained_note_groups_per_bar = int(args.note_groups_per_bar)
+        probe_args.coverage_aware_positions = True
+        probe_args.coverage_position_window = int(args.coverage_position_window)
+        probe_args.chord_aware_pitches = True
+        probe_args.chord_pitch_mode = pitch_mode
+        probe_args.chord_pitch_repeat_window = int(args.chord_pitch_repeat_window)
+        cmd = probe_command(
+            probe_args,
+            run_id=mode_run_id,
+            top_k=int(args.top_k),
+            temperature=float(args.temperature),
+            checkpoint_dir=checkpoint_dir,
+            skip_prepare_train=not first_config,
+        )
+        cmd.extend(
+            [
+                "--window_bars",
+                str(args.window_bars),
+                "--window_stride_bars",
+                str(args.window_stride_bars),
+                "--min_window_target_notes",
+                str(args.min_window_target_notes),
+                "--bars",
+                str(args.bars),
+            ]
+        )
+        cmd.extend(["--coverage_aware_positions", "--coverage_position_window", str(args.coverage_position_window)])
+        result = run_command(cmd)
+        command_results.append(result)
+        if result["returncode"] != 0:
+            report = {
+                "run_id": run_id,
+                "failure_reason": f"probe command failed for pitch_mode={pitch_mode}",
+                "command_results": command_results,
+            }
+            write_json(compare_dir / "pitch_mode_compare_report.json", report)
+            print(json.dumps(report, ensure_ascii=True, indent=2))
+            return int(result["returncode"])
+
+        report_path = Path(args.output_root) / mode_run_id / "report.json"
+        probe_report = read_json(report_path)
+        if checkpoint_dir is None:
+            checkpoint_dir = Path(probe_report["checkpoint_dir"])
+        first_config = False
+        row = row_from_probe_report(int(args.top_k), float(args.temperature), mode_run_id, probe_report)
+        row["pitch_mode"] = pitch_mode
+        row["note_groups_per_bar"] = int(args.note_groups_per_bar)
+        rows.append(row)
+
+        review_output_dir = Path(args.review_output_root) / run_id / pitch_mode
+        review_exports[pitch_mode] = export_review_candidates(
+            report_path=report_path,
+            output_dir=review_output_dir,
+            top_n=int(args.review_top_n),
+            copy_midi=bool(args.copy_review_midi),
+        )
+
+    rows = sorted(rows, key=lambda row: str(row["pitch_mode"]))
+    summary = build_pitch_mode_summary(
+        rows,
+        min_best_strict_valid_samples=args.min_best_strict_valid_samples,
+    )
+    report = {
+        "run_id": run_id,
+        "run_dir": str(compare_dir),
+        "issue": int(args.issue_number),
+        "pitch_modes": pitch_modes,
+        "note_groups_per_bar": int(args.note_groups_per_bar),
+        "top_k": int(args.top_k),
+        "temperature": float(args.temperature),
+        "summary": summary,
+        "rows": rows,
+        "review_exports": review_exports,
+        "command_results": command_results,
+    }
+    write_json(compare_dir / "pitch_mode_compare_report.json", report)
+    (compare_dir / "pitch_mode_compare_report.md").write_text(markdown_table(rows, summary), encoding="utf-8")
+    print(json.dumps(report, ensure_ascii=True, indent=2))
+    return 0 if summary["passed_compare_gate"] else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_stage_b_sampling_sweep.py
+++ b/scripts/run_stage_b_sampling_sweep.py
@@ -184,6 +184,8 @@ def row_from_probe_report(top_k: int, temperature: float, run_id: str, report: d
         "avg_chord_tone_ratio": (
             float(sum(chord_tone_ratios) / len(chord_tone_ratios)) if chord_tone_ratios else 0.0
         ),
+        "avg_root_tone_ratio": float(summary.get("avg_root_tone_ratio", 0.0) or 0.0),
+        "avg_tension_ratio": float(summary.get("avg_tension_ratio", 0.0) or 0.0),
         "failure_reasons": summary.get("failure_reasons", {}),
         "diagnostic_failure_reasons": summary.get("diagnostic_failure_reasons", {}),
         "strict_failure_reasons": summary.get("strict_failure_reasons", {}),

--- a/tests/test_stage_b_pitch_mode_compare.py
+++ b/tests/test_stage_b_pitch_mode_compare.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.run_stage_b_pitch_mode_compare import (
+    build_pitch_mode_summary,
+    config_run_id,
+    markdown_table,
+    parse_pitch_modes,
+)
+
+
+def row(
+    pitch_mode: str,
+    *,
+    strict: int,
+    valid: int,
+    root: float,
+    tension: float,
+) -> dict:
+    return {
+        "pitch_mode": pitch_mode,
+        "run_id": f"run_{pitch_mode}",
+        "sample_count": 3,
+        "valid_sample_count": valid,
+        "strict_valid_sample_count": strict,
+        "avg_chord_tone_ratio": 1.0 - tension,
+        "avg_root_tone_ratio": root,
+        "avg_tension_ratio": tension,
+        "avg_onset_coverage_ratio": 0.5,
+        "avg_sustained_coverage_ratio": 0.75,
+        "collapse_warning_sample_rate": 0.0,
+        "passed_strict_review_gate": True,
+        "diagnostic_failure_reasons": {},
+        "report_path": f"outputs/{pitch_mode}/report.json",
+    }
+
+
+class StageBPitchModeCompareTest(unittest.TestCase):
+    def test_parse_pitch_modes_rejects_unknown_mode(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_pitch_modes("tones,chromatic")
+
+    def test_parse_pitch_modes_accepts_expected_modes(self) -> None:
+        self.assertEqual(parse_pitch_modes("tones,tones_tensions"), ["tones", "tones_tensions"])
+
+    def test_config_run_id_is_stable(self) -> None:
+        self.assertEqual(
+            config_run_id("run", pitch_mode="tones_tensions", note_groups_per_bar=8, top_k=2, temperature=0.9),
+            "run_coverage_chord_tones_tensions_g8_k2_t0p9",
+        )
+
+    def test_build_pitch_mode_summary_reports_deltas(self) -> None:
+        rows = [
+            row("tones", strict=3, valid=3, root=0.28, tension=0.0),
+            row("tones_tensions", strict=3, valid=3, root=0.20, tension=0.22),
+        ]
+
+        summary = build_pitch_mode_summary(rows, min_best_strict_valid_samples=1)
+
+        self.assertTrue(summary["passed_compare_gate"])
+        self.assertAlmostEqual(summary["root_tone_ratio_delta_tensions_minus_tones"], -0.08)
+        self.assertAlmostEqual(summary["tension_ratio_delta_tensions_minus_tones"], 0.22)
+        self.assertEqual(summary["best_tones_tensions_config"]["avg_tension_ratio"], 0.22)
+
+    def test_build_pitch_mode_summary_fails_without_tension_mode(self) -> None:
+        summary = build_pitch_mode_summary([row("tones", strict=3, valid=3, root=0.28, tension=0.0)])
+
+        self.assertFalse(summary["passed_compare_gate"])
+        self.assertFalse(summary["comparison_ready"])
+
+    def test_markdown_table_records_pitch_role_columns(self) -> None:
+        rows = [
+            row("tones", strict=3, valid=3, root=0.28, tension=0.0),
+            row("tones_tensions", strict=3, valid=3, root=0.20, tension=0.22),
+        ]
+        summary = build_pitch_mode_summary(rows)
+
+        markdown = markdown_table(rows, summary)
+
+        self.assertIn("pitch mode", markdown)
+        self.assertIn("root", markdown)
+        self.assertIn("tension", markdown)
+        self.assertIn("tones_tensions", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약
- 같은 tiny checkpoint에서 `tones`와 `tones_tensions`를 비교하는 Stage B pitch-mode compare probe를 추가했습니다.
- mode별 root/tension/chord-tone ratio를 comparison report에 기록합니다.
- mode별 review MIDI export를 분리했습니다.
- CORE_PLAN과 CURRENT_STATUS_AND_PLAN에 결과와 다음 판단 기준을 반영했습니다.

## 결과
- `tones`: strict valid `3/3`, root `0.271`, tension `0.000`, chord `0.927`
- `tones_tensions`: strict valid `3/3`, root `0.135`, tension `0.313`, chord `0.667`
- root delta: `-0.135`
- tension delta: `+0.313`

## 해석
- `tones_tensions`는 no-tension/chord-tone-only 문제를 줄입니다.
- 하지만 repeated/dominant pitch risk가 여전히 있어, 이것만으로 더 좋은 solo phrase라고 판단하면 안 됩니다.
- 다음 단계는 passing/approach pitch policy 또는 motif/contour constraint 비교입니다.

## 검증
- ./.venv/bin/python -m unittest tests.test_stage_b_pitch_mode_compare tests.test_stage_b_generation_probe tests.test_stage_b_review_export
- ./.venv/bin/python -m compileall scripts/run_stage_b_pitch_mode_compare.py scripts/run_stage_b_sampling_sweep.py scripts/agent_harness.sh tests/test_stage_b_pitch_mode_compare.py
- bash scripts/agent_harness.sh stage-b-pitch-mode-compare
- bash scripts/agent_harness.sh quick

Closes #55