### PR TITLE
Stage B 8-bar approach phrase probe 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #55: Stage B tones vs tones_tensions pitch-mode comparison.
+- Issue #57: Stage B 8-bar approach phrase probe.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -158,6 +158,12 @@ For Stage B multi-sample review-gate changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-stronger-probe
+```
+
+For Stage B 8-bar approach/passing-note phrase changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-8bar-approach-phrase
 ```
 
 For Stage B collapse/sampling-sweep changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -130,6 +130,7 @@ Stage B에서 명시하는 것:
 24. Stage B phrase contour/repeated-pitch diagnostics
 25. Stage B root bias diagnostics
 26. Stage B `tones` vs `tones_tensions` pitch-mode comparison
+27. Stage B 8-bar approach phrase probe
 
 가장 최근 의미 있는 결과:
 
@@ -329,13 +330,16 @@ Stage B에서 명시하는 것:
 - latest result: tension ratio는 `0.000`이다.
 - Issue #55 result: `tones_tensions`는 root tone ratio를 약 `0.271`에서 `0.135`로 낮췄고, tension ratio를 `0.000`에서 `0.313`으로 올렸다.
 - Issue #55 result: 양쪽 모두 strict valid `3/3`이지만, `tones_tensions` 후보는 repeated/dominant pitch risk가 여전히 높다.
+- Issue #57 result: 8-bar `approach_tensions`는 strict valid `3/3`, root ratio `0.000`, approach resolution ratio `1.000`을 만들었다.
+- Issue #57 review premise: 이전보다 나아졌지만 아직 jazz solo가 아니라 다이아토닉 코드톤/근음 기반 초급 melodic exercise처럼 들린다.
 
 해석:
 
 - 현재 후보는 root-only collapse가 아니다.
 - 오히려 `chord_pitch_mode=tones` 때문에 tension이 전혀 없는 안전한 chord-tone-only line이다.
 - `tones_tensions`는 no-tension 문제를 줄였지만, 더 좋은 solo phrase라고 바로 판단할 단계는 아니다.
-- 다음 비교는 unrestricted tension보다 passing/approach pitch policy 또는 motif/contour constraint 쪽이 맞다.
+- `approach_tensions`는 pitch-level resolution을 만들지만, 이 또한 jazz vocabulary 자체는 아니다.
+- 다음 비교는 pitch filter보다 rhythm/motif/swing-aware phrase grammar 쪽이 맞다.
 
 ### Phase 4. Generic Jazz Base 후보 학습
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-55-stage-b-tension-compare`
+- `issue-57-stage-b-8bar-approach-phrase`
 
 현재 범위가 아닌 것:
 
@@ -36,36 +36,47 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 ## Latest Probe Result
 
-Issue #55는 manual listening/piano-roll review에서 나온 "멜로디 같긴 하지만 근음/코드음에 너무 안전하게 붙어있는 느낌"을 `tones` vs `tones_tensions` 비교로 검증한다.
+Issue #57은 manual listening/piano-roll review에서 나온 "이전보다 나아졌지만 아직 재즈가 아니라 초등학교 음악/다이아토닉 코드톤 나열처럼 들린다"는 피드백을 8-bar approach phrase probe로 검증한다.
 
-Issue #51에서 이미 adjacent same-note collapse는 아니라는 것을 확인했다. Issue #53에서는 실제 root tone, non-root chord tone, tension 비율을 기록했다. Issue #55는 같은 4-bar 조건에서 `tones_tensions`가 tension을 실제로 늘리고 root bias를 줄이는지 확인한다.
+Issue #51에서 이미 adjacent same-note collapse는 아니라는 것을 확인했다. Issue #53에서는 실제 root tone, non-root chord tone, tension 비율을 기록했다. Issue #55는 같은 4-bar 조건에서 `tones_tensions`가 tension을 실제로 늘리고 root bias를 줄이는지 확인했다. Issue #57은 8-bar 길이와 approach/resolution 정책을 추가한다.
 
 Implemented:
 
+- `inference/app/schemas.py` local phrase probe bars limit `8`
+- `scripts/run_stage_b_generation_probe.py` `approach_tensions` pitch mode
+- `scripts/run_stage_b_generation_probe.py` approach resolution diagnostics
 - `scripts/run_stage_b_pitch_mode_compare.py`
+- `scripts/run_stage_b_pitch_mode_compare.py` named comparison MIDI export
+- `tests/test_request_conditioning.py`
+- `tests/test_stage_b_generation_probe.py`
 - `tests/test_stage_b_pitch_mode_compare.py`
 - `scripts/run_stage_b_sampling_sweep.py` root/tension summary fields
-- `scripts/agent_harness.sh stage-b-pitch-mode-compare`
+- `scripts/agent_harness.sh stage-b-8bar-approach-phrase`
 - output files:
   - `pitch_mode_compare_report.json`
   - `pitch_mode_compare_report.md`
   - mode-specific `review_manifest.json`
-  - mode-specific copied review MIDI files under `midi/`
+  - named comparison MIDI files under `compare_named_midi/`
 
 Result:
 
-- source comparison report: `outputs/stage_b_pitch_mode_compare/harness_stage_b_pitch_mode_compare/pitch_mode_compare_report.json`
-- tones review output: `outputs/stage_b_review_candidates/harness_stage_b_pitch_mode_compare/tones`
-- tones+tensions review output: `outputs/stage_b_review_candidates/harness_stage_b_pitch_mode_compare/tones_tensions`
-- setup: `4` bars, `8` note groups per bar, `32` note groups per sample
+- source comparison report: `outputs/stage_b_pitch_mode_compare/harness_stage_b_8bar_approach_phrase/pitch_mode_compare_report.json`
+- named review output: `outputs/stage_b_review_candidates/harness_stage_b_8bar_approach_phrase/compare_named_midi/`
+- setup: `8` bars, `8` note groups per bar, `64` note groups per sample
 - `tones` strict valid samples: `3/3`
 - `tones_tensions` strict valid samples: `3/3`
-- `tones` average root tone ratio: around `0.271`
-- `tones_tensions` average root tone ratio: around `0.135`
+- `approach_tensions` strict valid samples: `3/3`
+- `tones` average root tone ratio: around `0.260`
+- `tones_tensions` average root tone ratio: around `0.198`
+- `approach_tensions` average root tone ratio: `0.000`
 - `tones` average tension ratio: `0.000`
-- `tones_tensions` average tension ratio: around `0.313`
-- `tones` average chord-tone ratio: around `0.927`
-- `tones_tensions` average chord-tone ratio: around `0.667`
+- `tones_tensions` average tension ratio: around `0.328`
+- `approach_tensions` average tension ratio: around `0.161`
+- `approach_tensions` average approach candidate ratio: around `0.500`
+- `approach_tensions` average approach resolution ratio: `1.000`
+- `tones` average chord-tone ratio: around `0.616`
+- `tones_tensions` average chord-tone ratio: around `0.557`
+- `approach_tensions` average chord-tone ratio: around `0.419`
 - both modes average onset coverage ratio: around `0.500`
 
 Decision:
@@ -73,8 +84,9 @@ Decision:
 - 2-bar candidates가 너무 짧았다는 판단은 타당하다.
 - 4-bar 후보는 one-note/two-note failure가 아니라 melody-like sketch로 볼 수 있다.
 - "근음을 계속 치는 느낌"은 실제 root-only collapse라기보다 chord-tone-only, no-tension 라인의 안전한 inside sound에 가깝다.
-- `tones_tensions`는 no-tension 문제를 줄였지만, repeated/dominant pitch risk가 남아 있어 broad training 전 phrase-shape control이 먼저다.
-- 다음 issue는 passing/approach pitch policy 또는 motif/contour constraint 비교가 맞다.
+- 8-bar `approach_tensions`는 pitch-level resolution을 만들지만, 이것만으로 jazz vocabulary가 생기지는 않는다.
+- 현재 단계는 "broken MIDI"에서 "valid but beginner-like melodic exercise"로 올라온 상태다.
+- 다음 issue는 pitch filter보다 rhythm/motif/swing-aware phrase grammar 비교가 맞다.
 
 Detail:
 
@@ -86,6 +98,7 @@ Detail:
 - `docs/STAGE_B_PHRASE_CONTOUR_DIAGNOSTICS_2026-05-21.md`
 - `docs/STAGE_B_ROOT_BIAS_DIAGNOSTICS_2026-05-21.md`
 - `docs/STAGE_B_PITCH_MODE_COMPARE_2026-05-21.md`
+- `docs/STAGE_B_8BAR_APPROACH_PHRASE_2026-05-21.md`
 
 ## Active Issue #14
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,6 +66,8 @@
   - "근음을 계속 치는 느낌"을 root-tone ratio와 tension ratio로 분리해 진단하는 문서.
 - `STAGE_B_PITCH_MODE_COMPARE_2026-05-21.md`
   - `tones`와 `tones_tensions`를 같은 Stage B 4-bar 조건에서 비교한 결과와 다음 phrase-shape control 판단 기준.
+- `STAGE_B_8BAR_APPROACH_PHRASE_2026-05-21.md`
+  - 8-bar `tones`/`tones_tensions`/`approach_tensions` 비교와 beginner-like melodic exercise 상태 진단.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -92,7 +94,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, and pitch-mode comparison을 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, and 8-bar approach phrase probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_8BAR_APPROACH_PHRASE_2026-05-21.md
+++ b/docs/STAGE_B_8BAR_APPROACH_PHRASE_2026-05-21.md
@@ -1,0 +1,150 @@
+# Stage B 8-Bar Approach Phrase Probe
+
+작성일: 2026-05-21
+
+## Context
+
+Manual review after Issue #55:
+
+- 이전보다 확실히 좋아졌다.
+- MIDI는 멜로디처럼 이어진다.
+- 하지만 아직 jazz solo라기보다는 초등학교 음악, 또는 "떴다 떴다 비행기" 같은 단순 선율 느낌이다.
+- 근음과 다이아토닉 코드 구성음을 누르면서 나열하는 chord-scale exercise처럼 들린다.
+- tension이 수치상 들어갔을 수는 있지만, 귀에는 jazz vocabulary처럼 잘 느껴지지 않는다.
+- 4-bar는 phrase가 시작하다 끝나는 느낌이라 더 긴 sample이 필요하다.
+
+Issue #57은 이 피드백을 기준으로 8-bar phrase와 approach/passing-note policy를 검증한다.
+
+## Goal
+
+이번 목표는 "좋은 재즈 솔로"가 아니다.
+
+목표:
+
+- 8-bar로 더 긴 phrase 후보를 만든다.
+- 기존 `tones`, `tones_tensions`와 새 `approach_tensions`를 비교한다.
+- tension을 단순 허용음이 아니라 코드톤으로 향하는 approach/passing 역할로 제한한다.
+- mode별 MIDI 파일명을 명확히 export해서 manual review를 쉽게 한다.
+
+## Implementation
+
+Added/changed:
+
+- `chord_pitch_mode=approach_tensions`
+- `chord_approach_pitch_classes()`
+- `analyze_stage_b_approach_resolution()`
+- `approach_resolution` fields in sample reports
+- summary fields:
+  - `avg_approach_candidate_ratio`
+  - `avg_approach_resolution_ratio`
+- named comparison MIDI export:
+  - `compare_named_midi/01_approach_tensions_...mid`
+  - `compare_named_midi/02_tones_...mid`
+  - `compare_named_midi/03_tones_tensions_...mid`
+- harness:
+
+```bash
+bash scripts/agent_harness.sh stage-b-8bar-approach-phrase
+```
+
+The `approach_tensions` mode uses a pair rule:
+
+- first note in each position pair: non-chord approach/passing class near a non-root chord tone
+- second note in each position pair: nearby non-root chord tone resolution
+
+This is still a deterministic probe policy, not learned jazz language.
+
+## Local Result
+
+Report:
+
+```text
+outputs/stage_b_pitch_mode_compare/harness_stage_b_8bar_approach_phrase/pitch_mode_compare_report.json
+outputs/stage_b_pitch_mode_compare/harness_stage_b_8bar_approach_phrase/pitch_mode_compare_report.md
+```
+
+Named review MIDI:
+
+```text
+outputs/stage_b_review_candidates/harness_stage_b_8bar_approach_phrase/compare_named_midi/
+```
+
+Files:
+
+```text
+01_approach_tensions_rank_01_sample_3.mid
+01_approach_tensions_rank_02_sample_1.mid
+01_approach_tensions_rank_03_sample_2.mid
+02_tones_rank_01_sample_3.mid
+02_tones_rank_02_sample_2.mid
+02_tones_rank_03_sample_1.mid
+03_tones_tensions_rank_01_sample_1.mid
+03_tones_tensions_rank_02_sample_3.mid
+03_tones_tensions_rank_03_sample_2.mid
+```
+
+Summary:
+
+| pitch mode | strict | chord | root | tension | approach | resolved | sustained |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `tones` | 3/3 | 0.616 | 0.260 | 0.000 | 0.000 | 0.000 | 0.917 |
+| `tones_tensions` | 3/3 | 0.557 | 0.198 | 0.328 | 0.312 | 0.283 | 0.904 |
+| `approach_tensions` | 3/3 | 0.419 | 0.000 | 0.161 | 0.500 | 1.000 | 0.917 |
+
+## Interpretation
+
+The 8-bar probe is structurally successful:
+
+- all three modes produced strict-valid MIDI
+- all three modes cover the 8-bar phrase
+- named review files are available
+- `approach_tensions` eliminated root-tone usage in this run
+- `approach_tensions` produced measurable approach/resolution pairs
+
+But this is not enough to claim jazz phrasing:
+
+- `approach_tensions` is still a rule-imposed pair pattern
+- repeated pitch-set behavior remains high
+- the phrase may still sound like a mechanical exercise
+- real jazz vocabulary requires rhythm/motif/swing/phrase memory, not only pitch-class filtering
+
+Current diagnosis:
+
+> We have moved from "broken MIDI" to "valid but beginner-like melodic exercise."
+
+That is progress, but not the target.
+
+## Manual Review Request
+
+Listen to the named files in this order:
+
+1. `02_tones_rank_01_sample_3.mid`
+2. `03_tones_tensions_rank_01_sample_1.mid`
+3. `01_approach_tensions_rank_01_sample_3.mid`
+
+Review questions:
+
+- Does 8-bar length feel less unfinished than 4-bar?
+- Does `approach_tensions` sound more like jazz phrasing, or only like forced chromatic exercise?
+- Is `tones_tensions` still too nursery-rhyme/simple?
+- Which mode is the best starting point for the next musical constraint?
+
+## Decision
+
+Do not broad-train yet based only on this.
+
+Next useful work:
+
+- add rhythm/motif cells instead of pitch-only constraints
+- add syncopation or swing-aware position templates
+- compare generated line against real MIDI phrase statistics
+- then decide whether generic jazz base training is justified
+
+## Validation
+
+```bash
+./.venv/bin/python -m unittest tests.test_request_conditioning tests.test_stage_b_generation_probe tests.test_stage_b_pitch_mode_compare
+./.venv/bin/python -m unittest tests.test_stage_b_generation_probe tests.test_stage_b_pitch_mode_compare tests.test_stage_b_review_export tests.test_stage_b_coverage_ab_sweep
+./.venv/bin/python -m compileall inference/app/schemas.py scripts/run_stage_b_generation_probe.py scripts/run_stage_b_pitch_mode_compare.py tests/test_request_conditioning.py
+bash scripts/agent_harness.sh stage-b-8bar-approach-phrase
+```

--- a/inference/app/schemas.py
+++ b/inference/app/schemas.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 VALID_SECTIONS = {"intro", "build", "breakdown", "drop"}
 VALID_ENERGIES = {"low", "mid", "high"}
 VALID_DENSITIES = {"sparse", "medium", "dense"}
+MAX_REQUEST_BARS = 8
 
 
 @dataclass
@@ -30,8 +31,8 @@ class GenerationRequest:
     def validate(self) -> None:
         if not (40 <= int(self.bpm) <= 240):
             raise ValueError("bpm must be between 40 and 240")
-        if not (1 <= int(self.bars) <= 4):
-            raise ValueError("bars must be between 1 and 4 for MVP")
+        if not (1 <= int(self.bars) <= MAX_REQUEST_BARS):
+            raise ValueError(f"bars must be between 1 and {MAX_REQUEST_BARS} for local phrase probes")
         if not self.chord_progression:
             raise ValueError("chord_progression must not be empty")
         if self.section not in VALID_SECTIONS:

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -54,6 +54,8 @@ Modes:
                 Run a 4-bar coverage/chord-aware Stage B probe and export review MIDI.
   stage-b-pitch-mode-compare
                 Compare 4-bar tones vs tones_tensions Stage B pitch modes.
+  stage-b-8bar-approach-phrase
+                Compare 8-bar tones/tensions/approach Stage B phrase candidates.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   all           Run demo and tiny-compare.
@@ -531,6 +533,42 @@ run_stage_b_pitch_mode_compare() {
     --lora_alpha 8
 }
 
+run_stage_b_8bar_approach_phrase() {
+  local run_id="${RUN_ID:-harness_stage_b_8bar_approach_phrase}"
+  print_header "Stage B 8-bar approach phrase comparison"
+  "$PYTHON_BIN" scripts/run_stage_b_pitch_mode_compare.py \
+    --run_id "$run_id" \
+    --issue_number 57 \
+    --max_files 2 \
+    --window_bars 8 \
+    --window_stride_bars 4 \
+    --min_window_target_notes 16 \
+    --epochs 3 \
+    --batch_size 8 \
+    --max_sequence 384 \
+    --num_samples 3 \
+    --bars 8 \
+    --pitch_modes tones,tones_tensions,approach_tensions \
+    --coverage_position_window 0 \
+    --chord_pitch_repeat_window 2 \
+    --note_groups_per_bar 8 \
+    --max_simultaneous_notes 2 \
+    --temperature 0.9 \
+    --top_k 2 \
+    --min_valid_samples 1 \
+    --min_strict_valid_samples 1 \
+    --min_best_strict_valid_samples 1 \
+    --max_collapse_warning_sample_rate 0.34 \
+    --require_all_grammar_samples \
+    --copy_review_midi \
+    --n_layers 1 \
+    --num_heads 4 \
+    --d_model 64 \
+    --dim_feedforward 128 \
+    --lora_r 4 \
+    --lora_alpha 8
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -599,6 +637,9 @@ case "$MODE" in
     ;;
   stage-b-pitch-mode-compare)
     run_stage_b_pitch_mode_compare
+    ;;
+  stage-b-8bar-approach-phrase)
+    run_stage_b_8bar_approach_phrase
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/export_stage_b_review_candidates.py
+++ b/scripts/export_stage_b_review_candidates.py
@@ -74,6 +74,7 @@ def score_probe_sample(sample: dict[str, Any]) -> float:
     temporal = sample.get("temporal_coverage", {})
     contour = sample.get("phrase_contour", {})
     pitch_roles = sample.get("pitch_roles", {})
+    approach = sample.get("approach_resolution", {})
     return round(
         (30.0 if sample.get("strict_valid") else 0.0)
         + (15.0 if sample.get("valid") else 0.0)
@@ -88,6 +89,7 @@ def score_probe_sample(sample: dict[str, Any]) -> float:
         - _float(contour.get("adjacent_repeated_pitch_ratio")) * 8.0
         - _float(pitch_roles.get("root_tone_ratio")) * 8.0
         + _float(pitch_roles.get("tension_ratio")) * 4.0
+        + _float(approach.get("approach_resolution_ratio")) * 4.0
         + _float(contour.get("direction_change_ratio")) * 3.0,
         4,
     )
@@ -129,6 +131,7 @@ def candidates_from_generation_probe(report: dict[str, Any]) -> list[dict[str, A
         temporal = sample.get("temporal_coverage", {})
         contour = sample.get("phrase_contour", {})
         pitch_roles = sample.get("pitch_roles", {})
+        approach = sample.get("approach_resolution", {})
         review_flags: list[str] = []
         if not sample.get("strict_valid"):
             reason = sample.get("failure_reason") or sample.get("diagnostic_failure_reason") or "not_strict_valid"
@@ -164,6 +167,8 @@ def candidates_from_generation_probe(report: dict[str, Any]) -> list[dict[str, A
                 "root_tone_ratio": _float(pitch_roles.get("root_tone_ratio")),
                 "non_root_chord_tone_ratio": _float(pitch_roles.get("non_root_chord_tone_ratio")),
                 "tension_ratio": _float(pitch_roles.get("tension_ratio")),
+                "approach_candidate_ratio": _float(approach.get("approach_candidate_ratio")),
+                "approach_resolution_ratio": _float(approach.get("approach_resolution_ratio")),
                 "onset_coverage_ratio": _float(temporal.get("onset_coverage_ratio")),
                 "sustained_coverage_ratio": _float(temporal.get("sustained_coverage_ratio")),
             }
@@ -219,6 +224,8 @@ def compact_candidate(candidate: dict[str, Any], rank: int) -> dict[str, Any]:
         "root_tone_ratio": _float(candidate.get("root_tone_ratio")),
         "non_root_chord_tone_ratio": _float(candidate.get("non_root_chord_tone_ratio")),
         "tension_ratio": _float(candidate.get("tension_ratio")),
+        "approach_candidate_ratio": _float(candidate.get("approach_candidate_ratio")),
+        "approach_resolution_ratio": _float(candidate.get("approach_resolution_ratio")),
         "onset_coverage_ratio": _float(candidate.get("onset_coverage_ratio")),
         "sustained_coverage_ratio": _float(candidate.get("sustained_coverage_ratio")),
     }
@@ -262,8 +269,8 @@ def markdown_report(manifest: dict[str, Any]) -> str:
         f"- reviewable only: `{str(manifest['reviewable_only']).lower()}`",
         f"- selected candidates: `{len(manifest['candidates'])}`",
         "",
-        "| review | source rank | mode | groups/bar | sample | score | notes | pitches | chord | root | tension | dominant | repeat | direction | risk | midi |",
-        "|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|",
+        "| review | source rank | mode | groups/bar | sample | score | notes | pitches | chord | root | tension | approach | resolved | dominant | repeat | direction | risk | midi |",
+        "|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|",
     ]
     for candidate in manifest["candidates"]:
         midi_path = candidate.get("review_midi_relative_path") or candidate.get("midi_path")
@@ -274,10 +281,13 @@ def markdown_report(manifest: dict[str, Any]) -> str:
         table_candidate.setdefault("direction_change_ratio", 0.0)
         table_candidate.setdefault("root_tone_ratio", 0.0)
         table_candidate.setdefault("tension_ratio", 0.0)
+        table_candidate.setdefault("approach_candidate_ratio", 0.0)
+        table_candidate.setdefault("approach_resolution_ratio", 0.0)
         lines.append(
             "| {review_rank} | {source_rank} | {mode} | {note_groups_per_bar} | {sample_index} | "
             "{score:.4f} | {note_count} | {unique_pitch_count} | {chord_tone_ratio:.3f} | "
             "{root_tone_ratio:.3f} | {tension_ratio:.3f} | "
+            "{approach_candidate_ratio:.3f} | {approach_resolution_ratio:.3f} | "
             "{dominant_pitch_ratio:.3f} | {repeated_pitch_ratio:.3f} | {direction_change_ratio:.3f} | "
             "`{risk_flags_text}` | `{display_midi_path}` |".format(
                 **table_candidate

--- a/scripts/run_stage_b_coverage_ab_sweep.py
+++ b/scripts/run_stage_b_coverage_ab_sweep.py
@@ -162,7 +162,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--modes", type=str, default="plain,coverage")
     parser.add_argument("--note_groups_per_bar_values", type=str, default="4,6,8")
     parser.add_argument("--coverage_position_window", type=int, default=0)
-    parser.add_argument("--chord_pitch_mode", choices=("tones", "tones_tensions"), default="tones")
+    parser.add_argument("--chord_pitch_mode", choices=("tones", "tones_tensions", "approach_tensions"), default="tones")
     parser.add_argument("--chord_pitch_repeat_window", type=int, default=2)
     parser.add_argument("--top_k", type=int, default=2)
     parser.add_argument("--temperature", type=float, default=0.9)

--- a/scripts/run_stage_b_generation_probe.py
+++ b/scripts/run_stage_b_generation_probe.py
@@ -566,7 +566,7 @@ def chord_pitch_classes(chord: str | None, pitch_mode: str = "tones_tensions") -
     if root_pc is None:
         return set(range(12))
     intervals = set(CHORD_TONE_INTERVALS.get(quality, CHORD_TONE_INTERVALS["unknown"]))
-    if pitch_mode == "tones_tensions":
+    if pitch_mode in {"tones_tensions", "approach_tensions"}:
         intervals.update(TENSION_INTERVALS.get(quality, set()))
     elif pitch_mode != "tones":
         raise ValueError(f"unknown chord pitch mode: {pitch_mode}")
@@ -576,6 +576,24 @@ def chord_pitch_classes(chord: str | None, pitch_mode: str = "tones_tensions") -
 def chord_root_pitch_class(chord: str | None) -> int | None:
     root, _quality = parse_chord_symbol(chord)
     return ROOT_TO_PC.get(root)
+
+
+def non_root_chord_pitch_classes(chord: str | None) -> set[int]:
+    chord_tones = set(chord_pitch_classes(chord, pitch_mode="tones"))
+    root_pc = chord_root_pitch_class(chord)
+    if root_pc is not None and len(chord_tones) > 1:
+        chord_tones.discard(root_pc)
+    return chord_tones
+
+
+def chord_approach_pitch_classes(chord: str | None) -> set[int]:
+    target_pitch_classes = non_root_chord_pitch_classes(chord)
+    approach_pitch_classes: set[int] = set()
+    for pitch_class in target_pitch_classes:
+        for step in (-2, -1, 1, 2):
+            approach_pitch_classes.add((pitch_class + step) % 12)
+    approach_pitch_classes.difference_update(chord_pitch_classes(chord, pitch_mode="tones"))
+    return approach_pitch_classes or (chord_pitch_classes(chord, pitch_mode="tones_tensions") - chord_pitch_classes(chord, pitch_mode="tones"))
 
 
 def analyze_stage_b_pitch_roles(
@@ -630,13 +648,85 @@ def analyze_stage_b_pitch_roles(
     }
 
 
+def analyze_stage_b_approach_resolution(
+    tokens: Sequence[int],
+    chords: Sequence[str],
+    primer_size: int = 0,
+    max_resolution_step: int = 2,
+) -> dict[str, Any]:
+    groups = extract_stage_b_note_groups(tokens, primer_size=primer_size)
+    approach_candidates = 0
+    resolved_approaches = 0
+    unresolved_approaches = 0
+    resolution_distances: list[int] = []
+
+    for index, group in enumerate(groups[:-1]):
+        pitch = int(group["pitch"])
+        pitch_class = pitch % 12
+        bar = int(group["bar"])
+        chord = chords[bar % len(chords)] if chords else None
+        chord_tones = chord_pitch_classes(chord, pitch_mode="tones")
+        if pitch_class in chord_tones:
+            continue
+
+        next_group = groups[index + 1]
+        next_pitch = int(next_group["pitch"])
+        next_bar = int(next_group["bar"])
+        next_chord = chords[next_bar % len(chords)] if chords else None
+        next_chord_tones = chord_pitch_classes(next_chord, pitch_mode="tones")
+        distance = abs(next_pitch - pitch)
+        is_near_resolution = 1 <= distance <= int(max_resolution_step)
+        is_resolved = is_near_resolution and (next_pitch % 12) in next_chord_tones
+
+        near_current_tone = any(
+            min((pitch_class - target) % 12, (target - pitch_class) % 12) <= int(max_resolution_step)
+            for target in chord_tones
+        )
+        near_next_tone = any(
+            min((pitch_class - target) % 12, (target - pitch_class) % 12) <= int(max_resolution_step)
+            for target in next_chord_tones
+        )
+        if not (near_current_tone or near_next_tone):
+            continue
+
+        approach_candidates += 1
+        if is_resolved:
+            resolved_approaches += 1
+            resolution_distances.append(distance)
+        else:
+            unresolved_approaches += 1
+
+    group_count = int(len(groups))
+    return {
+        "note_group_count": group_count,
+        "approach_candidate_count": int(approach_candidates),
+        "approach_candidate_ratio": float(approach_candidates / group_count) if group_count else 0.0,
+        "resolved_approach_count": int(resolved_approaches),
+        "unresolved_approach_count": int(unresolved_approaches),
+        "approach_resolution_ratio": (
+            float(resolved_approaches / approach_candidates) if approach_candidates else 0.0
+        ),
+        "avg_resolution_distance": (
+            float(sum(resolution_distances) / len(resolution_distances)) if resolution_distances else 0.0
+        ),
+    }
+
+
 def chord_aware_pitch_tokens(
     chord: str | None,
     pitch_mode: str = "tones_tensions",
     recent_pitches: Sequence[int] | None = None,
     repeat_window: int = 2,
+    group_index: int | None = None,
 ) -> list[int]:
-    pitch_classes = chord_pitch_classes(chord, pitch_mode=pitch_mode)
+    if pitch_mode == "approach_tensions":
+        resolving_group = bool(group_index is not None and int(group_index) % 2 == 1)
+        if resolving_group:
+            pitch_classes = non_root_chord_pitch_classes(chord)
+        else:
+            pitch_classes = chord_approach_pitch_classes(chord)
+    else:
+        pitch_classes = chord_pitch_classes(chord, pitch_mode=pitch_mode)
     tokens = [
         note_pitch_token(pitch)
         for pitch in range(int(PIANO_PITCH_MIN), int(PIANO_PITCH_MAX) + 1)
@@ -644,6 +734,14 @@ def chord_aware_pitch_tokens(
     ]
     if not tokens:
         return list(range(TOKEN_NOTE_PITCH_START, TOKEN_NOTE_PITCH_END + 1))
+
+    if pitch_mode == "approach_tensions" and recent_pitches and group_index is not None and int(group_index) % 2 == 1:
+        last_pitch = int(list(recent_pitches)[-1])
+        near_resolution_tokens = [
+            token for token in tokens if 1 <= abs(pitch_from_token(token) - last_pitch) <= 2
+        ]
+        if near_resolution_tokens:
+            tokens = near_resolution_tokens
 
     window = max(0, int(repeat_window))
     if not recent_pitches or window == 0:
@@ -702,6 +800,7 @@ def generate_stage_b_constrained_tokens(
                         pitch_mode=chord_pitch_mode,
                         recent_pitches=recent_pitches,
                         repeat_window=chord_pitch_repeat_window,
+                        group_index=group_index,
                     )
                 token = next_token_from_model(
                     model,
@@ -799,6 +898,11 @@ def sample_report(
     temporal_coverage = analyze_stage_b_temporal_coverage(tokens, primer_size=primer_size, bars=request.bars)
     phrase_contour = analyze_stage_b_phrase_contour(tokens, primer_size=primer_size)
     pitch_roles = analyze_stage_b_pitch_roles(tokens, chords=request.chord_progression, primer_size=primer_size)
+    approach_resolution = analyze_stage_b_approach_resolution(
+        tokens,
+        chords=request.chord_progression,
+        primer_size=primer_size,
+    )
     collapse_gate = evaluate_collapse_gate(
         collapse,
         min_unique_pitches=strict_min_unique_pitches,
@@ -836,6 +940,7 @@ def sample_report(
         "temporal_coverage": temporal_coverage,
         "phrase_contour": phrase_contour,
         "pitch_roles": pitch_roles,
+        "approach_resolution": approach_resolution,
         "collapse_gate": collapse_gate,
         "postprocess": postprocess_report or {"enabled": False},
         "metrics": metrics.to_dict(),
@@ -878,11 +983,14 @@ def build_probe_summary(
     longest_same_pitch_runs: list[int] = []
     root_tone_ratios: list[float] = []
     tension_ratios: list[float] = []
+    approach_candidate_ratios: list[float] = []
+    approach_resolution_ratios: list[float] = []
     for row in sample_rows:
         collapse = row.get("collapse", {})
         temporal_coverage = row.get("temporal_coverage", {})
         phrase_contour = row.get("phrase_contour", {})
         pitch_roles = row.get("pitch_roles", {})
+        approach_resolution = row.get("approach_resolution", {})
         if collapse.get("collapse_warning"):
             collapse_warning_count += 1
         if not row.get("strict_valid", False):
@@ -910,6 +1018,12 @@ def build_probe_summary(
         longest_same_pitch_runs.append(int(phrase_contour.get("longest_same_pitch_run", 0) or 0))
         root_tone_ratios.append(float(pitch_roles.get("root_tone_ratio", 0.0) or 0.0))
         tension_ratios.append(float(pitch_roles.get("tension_ratio", 0.0) or 0.0))
+        approach_candidate_ratios.append(
+            float(approach_resolution.get("approach_candidate_ratio", 0.0) or 0.0)
+        )
+        approach_resolution_ratios.append(
+            float(approach_resolution.get("approach_resolution_ratio", 0.0) or 0.0)
+        )
         if not row["valid"]:
             reason = str(row.get("failure_reason") or "unknown")
             diagnostic_reason = str(row.get("diagnostic_failure_reason") or reason)
@@ -990,6 +1104,16 @@ def build_probe_summary(
             float(sum(root_tone_ratios) / len(root_tone_ratios)) if root_tone_ratios else 0.0
         ),
         "avg_tension_ratio": float(sum(tension_ratios) / len(tension_ratios)) if tension_ratios else 0.0,
+        "avg_approach_candidate_ratio": (
+            float(sum(approach_candidate_ratios) / len(approach_candidate_ratios))
+            if approach_candidate_ratios
+            else 0.0
+        ),
+        "avg_approach_resolution_ratio": (
+            float(sum(approach_resolution_ratios) / len(approach_resolution_ratios))
+            if approach_resolution_ratios
+            else 0.0
+        ),
     }
 
 
@@ -1031,7 +1155,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--coverage_aware_positions", action="store_true")
     parser.add_argument("--coverage_position_window", type=int, default=0)
     parser.add_argument("--chord_aware_pitches", action="store_true")
-    parser.add_argument("--chord_pitch_mode", choices=("tones", "tones_tensions"), default="tones_tensions")
+    parser.add_argument(
+        "--chord_pitch_mode",
+        choices=("tones", "tones_tensions", "approach_tensions"),
+        default="tones_tensions",
+    )
     parser.add_argument("--chord_pitch_repeat_window", type=int, default=2)
     parser.add_argument("--postprocess_overlap", action="store_true")
     parser.add_argument("--max_simultaneous_notes", type=int, default=2)

--- a/scripts/run_stage_b_pitch_mode_compare.py
+++ b/scripts/run_stage_b_pitch_mode_compare.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -27,7 +28,7 @@ from scripts.run_stage_b_sampling_sweep import (  # noqa: E402
     write_json,
 )
 
-VALID_PITCH_MODES = {"tones", "tones_tensions"}
+VALID_PITCH_MODES = {"tones", "tones_tensions", "approach_tensions"}
 
 
 def parse_pitch_modes(raw: str) -> list[str]:
@@ -76,6 +77,8 @@ def compact_row(row: dict[str, Any] | None) -> dict[str, Any] | None:
         "avg_chord_tone_ratio": float(row["avg_chord_tone_ratio"]),
         "avg_root_tone_ratio": float(row["avg_root_tone_ratio"]),
         "avg_tension_ratio": float(row["avg_tension_ratio"]),
+        "avg_approach_candidate_ratio": float(row.get("avg_approach_candidate_ratio", 0.0)),
+        "avg_approach_resolution_ratio": float(row.get("avg_approach_resolution_ratio", 0.0)),
         "avg_onset_coverage_ratio": float(row["avg_onset_coverage_ratio"]),
         "avg_sustained_coverage_ratio": float(row["avg_sustained_coverage_ratio"]),
     }
@@ -88,6 +91,7 @@ def build_pitch_mode_summary(
     mode_rows = {mode: [row for row in rows if row.get("pitch_mode") == mode] for mode in sorted(VALID_PITCH_MODES)}
     best_tones = best_row(mode_rows["tones"])
     best_tensions = best_row(mode_rows["tones_tensions"])
+    best_approach = best_row(mode_rows["approach_tensions"])
     best = best_row(rows)
     comparison_ready = bool(best_tones and best_tensions)
     tones_root = float(best_tones.get("avg_root_tone_ratio", 0.0)) if best_tones else 0.0
@@ -102,17 +106,28 @@ def build_pitch_mode_summary(
         best_tensions
         and int(best_tensions["strict_valid_sample_count"]) >= int(min_best_strict_valid_samples)
     )
+    passed_approach = bool(
+        best_approach
+        and int(best_approach["strict_valid_sample_count"]) >= int(min_best_strict_valid_samples)
+    )
     return {
         "config_count": int(len(rows)),
         "mode_counts": {mode: int(len(mode_rows[mode])) for mode in sorted(VALID_PITCH_MODES)},
         "best_config": compact_row(best),
         "best_tones_config": compact_row(best_tones),
         "best_tones_tensions_config": compact_row(best_tensions),
+        "best_approach_tensions_config": compact_row(best_approach),
         "min_best_strict_valid_samples": int(min_best_strict_valid_samples),
         "comparison_ready": comparison_ready,
         "passed_tones_gate": passed_tones,
         "passed_tones_tensions_gate": passed_tensions,
-        "passed_compare_gate": bool(comparison_ready and passed_tones and passed_tensions),
+        "passed_approach_tensions_gate": passed_approach,
+        "passed_compare_gate": bool(
+            comparison_ready
+            and passed_tones
+            and passed_tensions
+            and (not mode_rows["approach_tensions"] or passed_approach)
+        ),
         "root_tone_ratio_delta_tensions_minus_tones": float(tensions_root - tones_root),
         "tension_ratio_delta_tensions_minus_tones": float(tensions_tension - tones_tension),
     }
@@ -125,16 +140,18 @@ def markdown_table(rows: list[dict[str, Any]], summary: dict[str, Any]) -> str:
         f"- passed compare gate: `{str(summary['passed_compare_gate']).lower()}`",
         f"- best tones config: `{summary['best_tones_config']}`",
         f"- best tones+tensions config: `{summary['best_tones_tensions_config']}`",
+        f"- best approach+tensions config: `{summary['best_approach_tensions_config']}`",
         f"- root delta, tensions minus tones: `{summary['root_tone_ratio_delta_tensions_minus_tones']:.3f}`",
         f"- tension delta, tensions minus tones: `{summary['tension_ratio_delta_tensions_minus_tones']:.3f}`",
         "",
-        "| pitch mode | samples | valid | strict | chord | root | tension | onset | sustained | collapse | strict pass | report |",
-        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|---|",
+        "| pitch mode | samples | valid | strict | chord | root | tension | approach | resolved | onset | sustained | collapse | strict pass | report |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|---|",
     ]
     for row in rows:
         lines.append(
             "| {pitch_mode} | {sample_count} | {valid_sample_count} | {strict_valid_sample_count} | "
             "{avg_chord_tone_ratio:.3f} | {avg_root_tone_ratio:.3f} | {avg_tension_ratio:.3f} | "
+            "{avg_approach_candidate_ratio:.3f} | {avg_approach_resolution_ratio:.3f} | "
             "{avg_onset_coverage_ratio:.3f} | {avg_sustained_coverage_ratio:.3f} | "
             "{collapse_warning_sample_rate:.3f} | {passed_strict_review_gate} | `{report_path}` |".format(**row)
         )
@@ -163,6 +180,38 @@ def export_review_candidates(
     write_review_json(output_dir / "review_manifest.json", manifest)
     (output_dir / "review_candidates.md").write_text(review_markdown_report(manifest), encoding="utf-8")
     return manifest
+
+
+def export_named_comparison_midis(review_exports: dict[str, dict[str, Any]], output_dir: Path) -> list[dict[str, Any]]:
+    named_dir = output_dir / "compare_named_midi"
+    named_dir.mkdir(parents=True, exist_ok=True)
+    copied: list[dict[str, Any]] = []
+    for mode_index, mode in enumerate(sorted(review_exports), start=1):
+        manifest = review_exports[mode]
+        for candidate in manifest.get("candidates", []):
+            source = candidate.get("review_midi_path") or candidate.get("midi_path")
+            if not source:
+                continue
+            source_path = Path(str(source))
+            if not source_path.is_absolute():
+                source_path = ROOT_DIR / source_path
+            if not source_path.exists():
+                continue
+            target_name = (
+                f"{mode_index:02d}_{mode}_rank_{int(candidate['review_rank']):02d}_"
+                f"sample_{int(candidate['sample_index'])}.mid"
+            )
+            target_path = named_dir / target_name
+            shutil.copy2(source_path, target_path)
+            copied.append(
+                {
+                    "mode": mode,
+                    "review_rank": int(candidate["review_rank"]),
+                    "source_path": str(source_path),
+                    "named_midi_path": str(target_path),
+                }
+            )
+    return copied
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -305,6 +354,12 @@ def main() -> int:
         "summary": summary,
         "rows": rows,
         "review_exports": review_exports,
+        "named_comparison_midis": export_named_comparison_midis(
+            review_exports,
+            output_dir=Path(args.review_output_root) / run_id,
+        )
+        if args.copy_review_midi
+        else [],
         "command_results": command_results,
     }
     write_json(compare_dir / "pitch_mode_compare_report.json", report)

--- a/scripts/run_stage_b_sampling_sweep.py
+++ b/scripts/run_stage_b_sampling_sweep.py
@@ -186,6 +186,8 @@ def row_from_probe_report(top_k: int, temperature: float, run_id: str, report: d
         ),
         "avg_root_tone_ratio": float(summary.get("avg_root_tone_ratio", 0.0) or 0.0),
         "avg_tension_ratio": float(summary.get("avg_tension_ratio", 0.0) or 0.0),
+        "avg_approach_candidate_ratio": float(summary.get("avg_approach_candidate_ratio", 0.0) or 0.0),
+        "avg_approach_resolution_ratio": float(summary.get("avg_approach_resolution_ratio", 0.0) or 0.0),
         "failure_reasons": summary.get("failure_reasons", {}),
         "diagnostic_failure_reasons": summary.get("diagnostic_failure_reasons", {}),
         "strict_failure_reasons": summary.get("strict_failure_reasons", {}),

--- a/tests/test_request_conditioning.py
+++ b/tests/test_request_conditioning.py
@@ -59,6 +59,15 @@ class RequestConditioningTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "temperature"):
             request.validate()
 
+    def test_eight_bar_phrase_probe_request_is_allowed(self) -> None:
+        request = GenerationRequest(
+            bpm=120,
+            chord_progression=["Cm7", "Fm7", "Bb7", "Ebmaj7"],
+            bars=8,
+        )
+
+        request.validate()
+
     def test_candidate_score_penalizes_density_target_miss(self) -> None:
         sparse_candidate = SimpleNamespace(
             note_density=1.03,

--- a/tests/test_stage_b_generation_probe.py
+++ b/tests/test_stage_b_generation_probe.py
@@ -10,6 +10,7 @@ import torch
 from scripts.run_stage_b_generation_probe import (
     analyze_stage_b_collapse,
     analyze_stage_b_note_grammar,
+    analyze_stage_b_approach_resolution,
     analyze_stage_b_phrase_contour,
     analyze_stage_b_pitch_roles,
     analyze_stage_b_temporal_coverage,
@@ -257,6 +258,44 @@ class StageBGenerationProbeTest(unittest.TestCase):
     def test_chord_pitch_classes_can_include_tensions(self) -> None:
         self.assertEqual(chord_pitch_classes("Cmaj7", pitch_mode="tones"), {0, 4, 7, 11})
         self.assertIn(2, chord_pitch_classes("Cmaj7", pitch_mode="tones_tensions"))
+
+    def test_approach_tension_pitch_tokens_pair_approach_and_resolution(self) -> None:
+        approach_tokens = chord_aware_pitch_tokens("Cmaj7", pitch_mode="approach_tensions", group_index=0)
+        approach_pitch_classes = {pitch_from_token(token) % 12 for token in approach_tokens}
+
+        self.assertNotIn(4, approach_pitch_classes)
+        self.assertIn(3, approach_pitch_classes)
+
+        resolution_tokens = chord_aware_pitch_tokens(
+            "Cmaj7",
+            pitch_mode="approach_tensions",
+            recent_pitches=[63],
+            repeat_window=0,
+            group_index=1,
+        )
+        resolution_pitches = {pitch_from_token(token) for token in resolution_tokens}
+
+        self.assertEqual(resolution_pitches, {64})
+
+    def test_analyze_stage_b_approach_resolution_counts_resolved_approach(self) -> None:
+        primer = build_stage_b_primer(["Cmaj7"], bpm=120)
+        tokens = primer + [
+            position_token(0),
+            note_velocity_token(4),
+            note_pitch_token(63),
+            note_duration_token(1),
+            position_token(1),
+            note_velocity_token(4),
+            note_pitch_token(64),
+            note_duration_token(1),
+            TOKEN_END,
+        ]
+
+        report = analyze_stage_b_approach_resolution(tokens, chords=["Cmaj7"], primer_size=len(primer))
+
+        self.assertEqual(report["approach_candidate_count"], 1)
+        self.assertEqual(report["resolved_approach_count"], 1)
+        self.assertAlmostEqual(report["approach_resolution_ratio"], 1.0)
 
     def test_analyze_stage_b_pitch_roles_counts_root_and_tensions(self) -> None:
         primer = build_stage_b_primer(["Cm7", "F7"], bpm=120)

--- a/tests/test_stage_b_pitch_mode_compare.py
+++ b/tests/test_stage_b_pitch_mode_compare.py
@@ -27,6 +27,8 @@ def row(
         "avg_chord_tone_ratio": 1.0 - tension,
         "avg_root_tone_ratio": root,
         "avg_tension_ratio": tension,
+        "avg_approach_candidate_ratio": tension,
+        "avg_approach_resolution_ratio": 0.5 if tension else 0.0,
         "avg_onset_coverage_ratio": 0.5,
         "avg_sustained_coverage_ratio": 0.75,
         "collapse_warning_sample_rate": 0.0,
@@ -42,7 +44,10 @@ class StageBPitchModeCompareTest(unittest.TestCase):
             parse_pitch_modes("tones,chromatic")
 
     def test_parse_pitch_modes_accepts_expected_modes(self) -> None:
-        self.assertEqual(parse_pitch_modes("tones,tones_tensions"), ["tones", "tones_tensions"])
+        self.assertEqual(
+            parse_pitch_modes("tones,tones_tensions,approach_tensions"),
+            ["tones", "tones_tensions", "approach_tensions"],
+        )
 
     def test_config_run_id_is_stable(self) -> None:
         self.assertEqual(
@@ -54,6 +59,7 @@ class StageBPitchModeCompareTest(unittest.TestCase):
         rows = [
             row("tones", strict=3, valid=3, root=0.28, tension=0.0),
             row("tones_tensions", strict=3, valid=3, root=0.20, tension=0.22),
+            row("approach_tensions", strict=3, valid=3, root=0.18, tension=0.25),
         ]
 
         summary = build_pitch_mode_summary(rows, min_best_strict_valid_samples=1)
@@ -62,6 +68,7 @@ class StageBPitchModeCompareTest(unittest.TestCase):
         self.assertAlmostEqual(summary["root_tone_ratio_delta_tensions_minus_tones"], -0.08)
         self.assertAlmostEqual(summary["tension_ratio_delta_tensions_minus_tones"], 0.22)
         self.assertEqual(summary["best_tones_tensions_config"]["avg_tension_ratio"], 0.22)
+        self.assertEqual(summary["best_approach_tensions_config"]["pitch_mode"], "approach_tensions")
 
     def test_build_pitch_mode_summary_fails_without_tension_mode(self) -> None:
         summary = build_pitch_mode_summary([row("tones", strict=3, valid=3, root=0.28, tension=0.0)])


### PR DESCRIPTION
## 요약
- 8-bar phrase review를 위해 Stage B `approach_tensions` pitch mode를 추가했습니다.
- tension을 단순 허용음이 아니라 접근음/해결음 pair로 제한하는 probe를 추가했습니다.
- approach candidate/resolution ratio를 sample report와 summary에 기록합니다.
- mode가 파일명에 드러나는 named comparison MIDI export를 추가했습니다.
- manual review 피드백: 이전보다 나아졌지만 아직 jazz solo가 아니라 beginner-like melodic exercise 상태라는 판단을 문서화했습니다.

## 결과
- `tones`: strict `3/3`, root `0.260`, tension `0.000`, chord `0.616`
- `tones_tensions`: strict `3/3`, root `0.198`, tension `0.328`, approach resolved `0.283`
- `approach_tensions`: strict `3/3`, root `0.000`, tension `0.161`, approach resolved `1.000`
- named MIDI: `outputs/stage_b_review_candidates/harness_stage_b_8bar_approach_phrase/compare_named_midi/`

## 해석
- 8-bar generation은 구조적으로 성공했습니다.
- `approach_tensions`는 pitch-level resolution을 만들지만, 이것만으로 jazz vocabulary가 생기지는 않습니다.
- 다음 단계는 pitch filter가 아니라 rhythm/motif/swing-aware phrase grammar 비교입니다.

## 검증
- ./.venv/bin/python -m unittest tests.test_request_conditioning tests.test_stage_b_generation_probe tests.test_stage_b_pitch_mode_compare tests.test_stage_b_review_export tests.test_stage_b_coverage_ab_sweep
- ./.venv/bin/python -m compileall inference/app/schemas.py scripts/run_stage_b_generation_probe.py scripts/run_stage_b_pitch_mode_compare.py scripts/run_stage_b_sampling_sweep.py scripts/run_stage_b_coverage_ab_sweep.py scripts/export_stage_b_review_candidates.py tests/test_request_conditioning.py tests/test_stage_b_generation_probe.py tests/test_stage_b_pitch_mode_compare.py
- bash scripts/agent_harness.sh stage-b-8bar-approach-phrase
- bash scripts/agent_harness.sh quick

Closes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended generation capability to support up to 8-bar phrases (previously limited to 4 bars).
  * Added approach tension analysis for chord-aware phrase generation and evaluation.

* **Documentation**
  * Added comprehensive Stage B 8-bar approach phrase probe documentation with validation metrics and analysis results.
  * Updated active documentation references and current execution roadmap to reflect latest probe outcomes.

* **Tests**
  * Added validation tests for 8-bar phrase requests and approach tension pitch selection behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohhalim/fine_tuning_art-tatum_midi_solo/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->