### PR TITLE
Stage B swing/motif phrase grammar probe 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #57: Stage B 8-bar approach phrase probe.
+- Issue #59: Stage B swing/motif phrase grammar probe.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -164,6 +164,12 @@ For Stage B 8-bar approach/passing-note phrase changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-8bar-approach-phrase
+```
+
+For Stage B swing/motif rhythm phrase changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-swing-motif-phrase
 ```
 
 For Stage B collapse/sampling-sweep changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -131,6 +131,7 @@ Stage B에서 명시하는 것:
 25. Stage B root bias diagnostics
 26. Stage B `tones` vs `tones_tensions` pitch-mode comparison
 27. Stage B 8-bar approach phrase probe
+28. Stage B swing/motif phrase grammar probe
 
 가장 최근 의미 있는 결과:
 
@@ -332,6 +333,8 @@ Stage B에서 명시하는 것:
 - Issue #55 result: 양쪽 모두 strict valid `3/3`이지만, `tones_tensions` 후보는 repeated/dominant pitch risk가 여전히 높다.
 - Issue #57 result: 8-bar `approach_tensions`는 strict valid `3/3`, root ratio `0.000`, approach resolution ratio `1.000`을 만들었다.
 - Issue #57 review premise: 이전보다 나아졌지만 아직 jazz solo가 아니라 다이아토닉 코드톤/근음 기반 초급 melodic exercise처럼 들린다.
+- Issue #59 result: `swing_motif_approach`는 strict valid `3/3`을 유지하면서 syncopated onset ratio를 `0.500`에서 `0.750`으로 올렸다.
+- Issue #59 result: unique bar-position pattern ratio는 `0.125`에서 `0.500`으로 올랐고, most-common duration ratio는 `0.552`에서 `0.380`으로 낮아졌다.
 
 해석:
 
@@ -339,7 +342,37 @@ Stage B에서 명시하는 것:
 - 오히려 `chord_pitch_mode=tones` 때문에 tension이 전혀 없는 안전한 chord-tone-only line이다.
 - `tones_tensions`는 no-tension 문제를 줄였지만, 더 좋은 solo phrase라고 바로 판단할 단계는 아니다.
 - `approach_tensions`는 pitch-level resolution을 만들지만, 이 또한 jazz vocabulary 자체는 아니다.
-- 다음 비교는 pitch filter보다 rhythm/motif/swing-aware phrase grammar 쪽이 맞다.
+- `swing_motif_approach`는 기계적인 grid 반복을 줄였지만, 이 또한 jazz vocabulary 자체는 아니다.
+- 다음 비교는 pitch/rhythm rule을 더 늘리는 것보다 real jazz MIDI phrase statistics와 motif/cadence control 쪽이 맞다.
+
+### Phase 3.10. Swing/Motif Phrase Grammar
+
+목표:
+
+- pitch-only approach/tension constraint의 한계를 확인한다.
+- 같은 checkpoint에서 baseline approach grammar와 swing/motif rhythm grammar를 비교한다.
+- rhythm profile을 candidate ranking과 review export에 넣는다.
+
+현재 결과:
+
+- completed: `jazz_rhythm_position_tokens()`와 `jazz_rhythm_duration_tokens()`를 추가했다.
+- completed: `approach_baseline`과 `swing_motif_approach`를 같은 checkpoint에서 비교했다.
+- latest result: 두 grammar 모두 strict valid `3/3`이다.
+- latest result: syncopated onset ratio는 `0.500`에서 `0.750`으로 좋아졌다.
+- latest result: unique bar-position pattern ratio는 `0.125`에서 `0.500`으로 좋아졌다.
+- latest result: direct MIDI inspection에서 baseline의 반복 IOI/template 문제가 확인됐다.
+
+해석:
+
+- 현재 후보는 one-note/two-note/chord-block failure가 아니다.
+- rhythmic template 반복은 줄었다.
+- 하지만 아직 실제 jazz solo vocabulary라고 볼 근거는 부족하다.
+
+다음 통과 기준:
+
+- generated rhythm profile을 real jazz MIDI window 통계와 비교한다.
+- pitch motif cell, cadence/landing, phrase memory 중 하나를 다음 issue로 분리한다.
+- rule이 아니라 data-derived constraint로 넘어갈지 판단한다.
 
 ### Phase 4. Generic Jazz Base 후보 학습
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-57-stage-b-8bar-approach-phrase`
+- `issue-59-stage-b-swing-motif-phrase`
 
 현재 범위가 아닌 것:
 
@@ -36,57 +36,48 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 ## Latest Probe Result
 
-Issue #57은 manual listening/piano-roll review에서 나온 "이전보다 나아졌지만 아직 재즈가 아니라 초등학교 음악/다이아토닉 코드톤 나열처럼 들린다"는 피드백을 8-bar approach phrase probe로 검증한다.
+Issue #59는 manual listening/piano-roll review에서 나온 "이전보다 나아졌지만 아직 재즈가 아니라 초등학교 음악/다이아토닉 코드톤 나열처럼 들린다"는 피드백을 rhythm/motif grammar 관점에서 검증한다.
 
-Issue #51에서 이미 adjacent same-note collapse는 아니라는 것을 확인했다. Issue #53에서는 실제 root tone, non-root chord tone, tension 비율을 기록했다. Issue #55는 같은 4-bar 조건에서 `tones_tensions`가 tension을 실제로 늘리고 root bias를 줄이는지 확인했다. Issue #57은 8-bar 길이와 approach/resolution 정책을 추가한다.
+Issue #51에서 이미 adjacent same-note collapse는 아니라는 것을 확인했다. Issue #53에서는 실제 root tone, non-root chord tone, tension 비율을 기록했다. Issue #55는 같은 4-bar 조건에서 `tones_tensions`가 tension을 실제로 늘리고 root bias를 줄이는지 확인했다. Issue #57은 8-bar 길이와 approach/resolution 정책을 추가했다. Issue #59는 같은 8-bar approach setup에서 position/duration rhythm pattern을 swing/motif template으로 바꿔 비교한다.
 
 Implemented:
 
-- `inference/app/schemas.py` local phrase probe bars limit `8`
-- `scripts/run_stage_b_generation_probe.py` `approach_tensions` pitch mode
-- `scripts/run_stage_b_generation_probe.py` approach resolution diagnostics
-- `scripts/run_stage_b_pitch_mode_compare.py`
-- `scripts/run_stage_b_pitch_mode_compare.py` named comparison MIDI export
-- `tests/test_request_conditioning.py`
+- `scripts/run_stage_b_generation_probe.py` jazz rhythm position/duration constraints
+- `scripts/run_stage_b_generation_probe.py` rhythm profile diagnostics
+- `scripts/run_stage_b_phrase_grammar_compare.py`
+- `scripts/export_stage_b_review_candidates.py` rhythm-aware ranking fields
 - `tests/test_stage_b_generation_probe.py`
-- `tests/test_stage_b_pitch_mode_compare.py`
-- `scripts/run_stage_b_sampling_sweep.py` root/tension summary fields
-- `scripts/agent_harness.sh stage-b-8bar-approach-phrase`
+- `tests/test_stage_b_phrase_grammar_compare.py`
+- `scripts/run_stage_b_sampling_sweep.py` rhythm summary fields
+- `scripts/agent_harness.sh stage-b-swing-motif-phrase`
 - output files:
-  - `pitch_mode_compare_report.json`
-  - `pitch_mode_compare_report.md`
+  - `phrase_grammar_compare_report.json`
+  - `phrase_grammar_compare_report.md`
   - mode-specific `review_manifest.json`
   - named comparison MIDI files under `compare_named_midi/`
 
 Result:
 
-- source comparison report: `outputs/stage_b_pitch_mode_compare/harness_stage_b_8bar_approach_phrase/pitch_mode_compare_report.json`
-- named review output: `outputs/stage_b_review_candidates/harness_stage_b_8bar_approach_phrase/compare_named_midi/`
+- source comparison report: `outputs/stage_b_phrase_grammar_compare/harness_stage_b_swing_motif_phrase/phrase_grammar_compare_report.json`
+- named review output: `outputs/stage_b_review_candidates/harness_stage_b_swing_motif_phrase/compare_named_midi/`
 - setup: `8` bars, `8` note groups per bar, `64` note groups per sample
-- `tones` strict valid samples: `3/3`
-- `tones_tensions` strict valid samples: `3/3`
-- `approach_tensions` strict valid samples: `3/3`
-- `tones` average root tone ratio: around `0.260`
-- `tones_tensions` average root tone ratio: around `0.198`
-- `approach_tensions` average root tone ratio: `0.000`
-- `tones` average tension ratio: `0.000`
-- `tones_tensions` average tension ratio: around `0.328`
-- `approach_tensions` average tension ratio: around `0.161`
-- `approach_tensions` average approach candidate ratio: around `0.500`
-- `approach_tensions` average approach resolution ratio: `1.000`
-- `tones` average chord-tone ratio: around `0.616`
-- `tones_tensions` average chord-tone ratio: around `0.557`
-- `approach_tensions` average chord-tone ratio: around `0.419`
-- both modes average onset coverage ratio: around `0.500`
+- `approach_baseline` strict valid samples: `3/3`
+- `swing_motif_approach` strict valid samples: `3/3`
+- `approach_baseline` average syncopated onset ratio: `0.500`
+- `swing_motif_approach` average syncopated onset ratio: `0.750`
+- `approach_baseline` average unique bar-position pattern ratio: `0.125`
+- `swing_motif_approach` average unique bar-position pattern ratio: `0.500`
+- `approach_baseline` average most-common duration ratio: `0.552`
+- `swing_motif_approach` average most-common duration ratio: `0.380`
+- `approach_baseline` average most-common IOI ratio: `0.508`
+- `swing_motif_approach` average most-common IOI ratio: `0.476`
 
 Decision:
 
-- 2-bar candidates가 너무 짧았다는 판단은 타당하다.
-- 4-bar 후보는 one-note/two-note failure가 아니라 melody-like sketch로 볼 수 있다.
-- "근음을 계속 치는 느낌"은 실제 root-only collapse라기보다 chord-tone-only, no-tension 라인의 안전한 inside sound에 가깝다.
-- 8-bar `approach_tensions`는 pitch-level resolution을 만들지만, 이것만으로 jazz vocabulary가 생기지는 않는다.
-- 현재 단계는 "broken MIDI"에서 "valid but beginner-like melodic exercise"로 올라온 상태다.
-- 다음 issue는 pitch filter보다 rhythm/motif/swing-aware phrase grammar 비교가 맞다.
+- direct MIDI inspection상 baseline은 bar별 position template과 IOI가 거의 반복된다.
+- `swing_motif_approach`는 syncopation과 bar-to-bar rhythm variation을 올렸다.
+- 이것은 "재즈가 됐다"가 아니라 "mechanical rhythm-grid 문제를 줄였다"는 결과다.
+- 현재 병목은 MIDI validity보다 jazz vocabulary, motif development, phrase ending이다.
 
 Detail:
 
@@ -99,6 +90,7 @@ Detail:
 - `docs/STAGE_B_ROOT_BIAS_DIAGNOSTICS_2026-05-21.md`
 - `docs/STAGE_B_PITCH_MODE_COMPARE_2026-05-21.md`
 - `docs/STAGE_B_8BAR_APPROACH_PHRASE_2026-05-21.md`
+- `docs/STAGE_B_SWING_MOTIF_PHRASE_2026-05-21.md`
 
 ## Active Issue #14
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,8 @@
   - `tones`와 `tones_tensions`를 같은 Stage B 4-bar 조건에서 비교한 결과와 다음 phrase-shape control 판단 기준.
 - `STAGE_B_8BAR_APPROACH_PHRASE_2026-05-21.md`
   - 8-bar `tones`/`tones_tensions`/`approach_tensions` 비교와 beginner-like melodic exercise 상태 진단.
+- `STAGE_B_SWING_MOTIF_PHRASE_2026-05-21.md`
+  - 8-bar `approach_tensions` 위에 swing/motif position-duration grammar를 얹어 기계적인 rhythm-grid 반복을 줄인 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -94,7 +96,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, and 8-bar approach phrase probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, and swing/motif phrase grammar probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_SWING_MOTIF_PHRASE_2026-05-21.md
+++ b/docs/STAGE_B_SWING_MOTIF_PHRASE_2026-05-21.md
@@ -1,0 +1,183 @@
+# Stage B Swing/Motif Phrase Grammar Probe
+
+작성일: 2026-05-21
+
+## Context
+
+Manual piano-roll review after Issue #57 found that the 8-bar `approach_tensions` output is valid MIDI, but still not convincing jazz phrasing.
+
+Observed problem:
+
+- 이전보다 melodic line처럼 보인다.
+- 하지만 근음/코드톤 중심의 단순 선율처럼 들린다.
+- "떴다 떴다 비행기" 같은 beginner exercise 느낌이 남아 있다.
+- 8-bar length와 approach/passing pitch만으로는 jazz vocabulary가 생기지 않는다.
+
+Direct MIDI inspection showed the main rhythmic cause:
+
+- baseline position pattern is almost fixed per bar.
+- baseline IOI mostly alternates between `1` and `3` grid steps.
+- baseline duration is dominated by one duration bucket.
+- pitch가 바뀌어도 rhythm이 반복되므로 solo phrase보다 exercise처럼 들린다.
+
+Issue #59 tests whether a swing/motif-oriented rhythm grammar reduces that mechanical feel.
+
+## Goal
+
+이번 목표는 좋은 jazz solo를 완성하는 것이 아니다.
+
+목표:
+
+- 8-bar `approach_tensions` pitch policy는 유지한다.
+- `POSITION` 선택을 bar마다 바뀌는 syncopated motif template으로 제한한다.
+- `NOTE_DURATION` 선택도 motif별로 다르게 제한한다.
+- baseline과 swing/motif grammar를 같은 checkpoint에서 비교한다.
+- MIDI review 파일명을 명확히 export한다.
+
+## Implementation
+
+Added/changed:
+
+- `jazz_rhythm_position_tokens()`
+- `jazz_rhythm_duration_tokens()`
+- `analyze_stage_b_rhythm_profile()`
+- generation flags:
+  - `--jazz_rhythm_positions`
+  - `--jazz_duration_tokens`
+  - `--jazz_rhythm_profile swing_motif`
+- rhythm summary fields:
+  - `avg_syncopated_onset_ratio`
+  - `avg_unique_bar_position_pattern_ratio`
+  - `avg_duration_diversity_ratio`
+  - `avg_most_common_duration_ratio`
+  - `avg_ioi_diversity_ratio`
+  - `avg_most_common_ioi_ratio`
+- review ranking score now considers rhythm profile.
+- new comparison runner:
+  - `scripts/run_stage_b_phrase_grammar_compare.py`
+- new harness:
+
+```bash
+bash scripts/agent_harness.sh stage-b-swing-motif-phrase
+```
+
+The new mode is:
+
+```text
+swing_motif_approach = approach_tensions pitch grammar + swing_motif position/duration grammar
+```
+
+This is still a constrained generation probe, not learned jazz language.
+
+## Local Result
+
+Report:
+
+```text
+outputs/stage_b_phrase_grammar_compare/harness_stage_b_swing_motif_phrase/phrase_grammar_compare_report.json
+outputs/stage_b_phrase_grammar_compare/harness_stage_b_swing_motif_phrase/phrase_grammar_compare_report.md
+```
+
+Named review MIDI:
+
+```text
+outputs/stage_b_review_candidates/harness_stage_b_swing_motif_phrase/compare_named_midi/
+```
+
+Files:
+
+```text
+01_approach_baseline_rank_01_sample_3.mid
+01_approach_baseline_rank_02_sample_1.mid
+01_approach_baseline_rank_03_sample_2.mid
+02_swing_motif_approach_rank_01_sample_1.mid
+02_swing_motif_approach_rank_02_sample_3.mid
+02_swing_motif_approach_rank_03_sample_2.mid
+```
+
+Summary:
+
+| grammar | strict | root | tension | resolved | sync | bar-var | dur-rep | ioi-var | ioi-rep |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `approach_baseline` | 3/3 | 0.000 | 0.161 | 1.000 | 0.500 | 0.125 | 0.552 | 0.032 | 0.508 |
+| `swing_motif_approach` | 3/3 | 0.000 | 0.172 | 1.000 | 0.750 | 0.500 | 0.380 | 0.063 | 0.476 |
+
+Comparison:
+
+- syncopated onset ratio improved by `+0.250`.
+- unique bar-position pattern ratio improved from `0.125` to `0.500`.
+- most common duration ratio dropped from `0.552` to `0.380`.
+- most common IOI ratio dropped from `0.508` to `0.476`.
+- all samples passed strict review gate in both modes.
+
+## Direct MIDI Structure Check
+
+Top baseline file:
+
+```text
+01_approach_baseline_rank_01_sample_3.mid
+notes: 62
+unique pitches: 9
+duration counts: 3-step duration dominates
+IOI counts: mostly 1-step and 3-step alternation
+bar position patterns: mostly [1, 4, 5, 8, 9, 12, 13, 16]
+```
+
+Top swing/motif file:
+
+```text
+02_swing_motif_approach_rank_01_sample_1.mid
+notes: 63
+unique pitches: 12
+duration counts: 1-step, 2-step, and 3-step durations are more balanced
+IOI counts: 1-step, 2-step, and 3-step gaps all appear
+bar position patterns:
+  bar 1: [0, 3, 5, 7, 10, 11, 13, 15]
+  bar 2: [1, 3, 4, 7, 9, 12, 14, 15, 16]
+  bar 3: [2, 5, 6, 8, 11, 13, 14]
+  bar 4: [2, 4, 5, 8, 10, 12, 13, 15, 16]
+```
+
+This confirms that the previous nursery-rhyme/exercise feel was not only a pitch problem. The rhythm grid itself was too repetitive.
+
+## Interpretation
+
+This is a useful improvement, but not the final musical target.
+
+What improved:
+
+- onset placement is less mechanically repeated
+- duration selection is less dominated by one bucket
+- bar-to-bar rhythm template variation increased
+- exported candidates are long enough to review as phrases
+
+What did not improve enough:
+
+- the pitch vocabulary is still small
+- repeated pitch-set behavior remains high
+- phrase still may sound like a rule-generated line
+- this is not Brad style adaptation
+- this is not evidence that the model learned jazz language
+
+Current diagnosis:
+
+> We reduced the mechanical rhythm-grid problem. The next bottleneck is still jazz vocabulary and motif development, not MIDI validity.
+
+## Decision
+
+Do not broad-train yet only from this result.
+
+Next useful work:
+
+- add motif-level pitch cells instead of only chord/tension classes
+- compare generated rhythm profile against real jazz MIDI phrase windows
+- add cadence/landing constraints for phrase endings
+- then decide whether generic jazz base training is justified
+
+## Validation
+
+```bash
+./.venv/bin/python -m unittest tests.test_stage_b_generation_probe tests.test_stage_b_phrase_grammar_compare tests.test_stage_b_review_export
+./.venv/bin/python -m compileall scripts/run_stage_b_generation_probe.py scripts/run_stage_b_phrase_grammar_compare.py scripts/run_stage_b_sampling_sweep.py scripts/export_stage_b_review_candidates.py tests/test_stage_b_generation_probe.py tests/test_stage_b_phrase_grammar_compare.py
+bash scripts/agent_harness.sh stage-b-swing-motif-phrase
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -56,6 +56,8 @@ Modes:
                 Compare 4-bar tones vs tones_tensions Stage B pitch modes.
   stage-b-8bar-approach-phrase
                 Compare 8-bar tones/tensions/approach Stage B phrase candidates.
+  stage-b-swing-motif-phrase
+                Compare 8-bar baseline approach with swing/motif phrase grammar.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   all           Run demo and tiny-compare.
@@ -96,6 +98,7 @@ run_quick() {
     scripts/run_stage_b_sampling_sweep.py \
     scripts/run_stage_b_coverage_ab_sweep.py \
     scripts/run_stage_b_pitch_mode_compare.py \
+    scripts/run_stage_b_phrase_grammar_compare.py \
     scripts/rank_stage_b_candidates.py \
     scripts/audit_brad_mehldau_dataset.py \
     scripts/audit_jazz_piano_dataset.py \
@@ -569,6 +572,42 @@ run_stage_b_8bar_approach_phrase() {
     --lora_alpha 8
 }
 
+run_stage_b_swing_motif_phrase() {
+  local run_id="${RUN_ID:-harness_stage_b_swing_motif_phrase}"
+  print_header "Stage B swing/motif phrase grammar comparison"
+  "$PYTHON_BIN" scripts/run_stage_b_phrase_grammar_compare.py \
+    --run_id "$run_id" \
+    --issue_number 59 \
+    --max_files 2 \
+    --window_bars 8 \
+    --window_stride_bars 4 \
+    --min_window_target_notes 16 \
+    --epochs 3 \
+    --batch_size 8 \
+    --max_sequence 384 \
+    --num_samples 3 \
+    --bars 8 \
+    --grammar_modes approach_baseline,swing_motif_approach \
+    --coverage_position_window 0 \
+    --chord_pitch_repeat_window 2 \
+    --note_groups_per_bar 8 \
+    --max_simultaneous_notes 2 \
+    --temperature 0.9 \
+    --top_k 2 \
+    --min_valid_samples 1 \
+    --min_strict_valid_samples 1 \
+    --min_best_strict_valid_samples 1 \
+    --max_collapse_warning_sample_rate 0.34 \
+    --require_all_grammar_samples \
+    --copy_review_midi \
+    --n_layers 1 \
+    --num_heads 4 \
+    --d_model 64 \
+    --dim_feedforward 128 \
+    --lora_r 4 \
+    --lora_alpha 8
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -640,6 +679,9 @@ case "$MODE" in
     ;;
   stage-b-8bar-approach-phrase)
     run_stage_b_8bar_approach_phrase
+    ;;
+  stage-b-swing-motif-phrase)
+    run_stage_b_swing_motif_phrase
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/export_stage_b_review_candidates.py
+++ b/scripts/export_stage_b_review_candidates.py
@@ -75,6 +75,7 @@ def score_probe_sample(sample: dict[str, Any]) -> float:
     contour = sample.get("phrase_contour", {})
     pitch_roles = sample.get("pitch_roles", {})
     approach = sample.get("approach_resolution", {})
+    rhythm = sample.get("rhythm_profile", {})
     return round(
         (30.0 if sample.get("strict_valid") else 0.0)
         + (15.0 if sample.get("valid") else 0.0)
@@ -90,6 +91,9 @@ def score_probe_sample(sample: dict[str, Any]) -> float:
         - _float(pitch_roles.get("root_tone_ratio")) * 8.0
         + _float(pitch_roles.get("tension_ratio")) * 4.0
         + _float(approach.get("approach_resolution_ratio")) * 4.0
+        + _float(rhythm.get("syncopated_onset_ratio")) * 4.0
+        + _float(rhythm.get("unique_bar_position_pattern_ratio")) * 4.0
+        - _float(rhythm.get("most_common_ioi_ratio")) * 4.0
         + _float(contour.get("direction_change_ratio")) * 3.0,
         4,
     )
@@ -132,6 +136,7 @@ def candidates_from_generation_probe(report: dict[str, Any]) -> list[dict[str, A
         contour = sample.get("phrase_contour", {})
         pitch_roles = sample.get("pitch_roles", {})
         approach = sample.get("approach_resolution", {})
+        rhythm = sample.get("rhythm_profile", {})
         review_flags: list[str] = []
         if not sample.get("strict_valid"):
             reason = sample.get("failure_reason") or sample.get("diagnostic_failure_reason") or "not_strict_valid"
@@ -169,6 +174,12 @@ def candidates_from_generation_probe(report: dict[str, Any]) -> list[dict[str, A
                 "tension_ratio": _float(pitch_roles.get("tension_ratio")),
                 "approach_candidate_ratio": _float(approach.get("approach_candidate_ratio")),
                 "approach_resolution_ratio": _float(approach.get("approach_resolution_ratio")),
+                "syncopated_onset_ratio": _float(rhythm.get("syncopated_onset_ratio")),
+                "unique_bar_position_pattern_ratio": _float(rhythm.get("unique_bar_position_pattern_ratio")),
+                "duration_diversity_ratio": _float(rhythm.get("duration_diversity_ratio")),
+                "most_common_duration_ratio": _float(rhythm.get("most_common_duration_ratio")),
+                "ioi_diversity_ratio": _float(rhythm.get("ioi_diversity_ratio")),
+                "most_common_ioi_ratio": _float(rhythm.get("most_common_ioi_ratio")),
                 "onset_coverage_ratio": _float(temporal.get("onset_coverage_ratio")),
                 "sustained_coverage_ratio": _float(temporal.get("sustained_coverage_ratio")),
             }
@@ -226,6 +237,12 @@ def compact_candidate(candidate: dict[str, Any], rank: int) -> dict[str, Any]:
         "tension_ratio": _float(candidate.get("tension_ratio")),
         "approach_candidate_ratio": _float(candidate.get("approach_candidate_ratio")),
         "approach_resolution_ratio": _float(candidate.get("approach_resolution_ratio")),
+        "syncopated_onset_ratio": _float(candidate.get("syncopated_onset_ratio")),
+        "unique_bar_position_pattern_ratio": _float(candidate.get("unique_bar_position_pattern_ratio")),
+        "duration_diversity_ratio": _float(candidate.get("duration_diversity_ratio")),
+        "most_common_duration_ratio": _float(candidate.get("most_common_duration_ratio")),
+        "ioi_diversity_ratio": _float(candidate.get("ioi_diversity_ratio")),
+        "most_common_ioi_ratio": _float(candidate.get("most_common_ioi_ratio")),
         "onset_coverage_ratio": _float(candidate.get("onset_coverage_ratio")),
         "sustained_coverage_ratio": _float(candidate.get("sustained_coverage_ratio")),
     }
@@ -269,8 +286,8 @@ def markdown_report(manifest: dict[str, Any]) -> str:
         f"- reviewable only: `{str(manifest['reviewable_only']).lower()}`",
         f"- selected candidates: `{len(manifest['candidates'])}`",
         "",
-        "| review | source rank | mode | groups/bar | sample | score | notes | pitches | chord | root | tension | approach | resolved | dominant | repeat | direction | risk | midi |",
-        "|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|",
+        "| review | source rank | mode | groups/bar | sample | score | notes | pitches | chord | root | tension | approach | resolved | sync | bar-var | ioi-rep | dominant | repeat | direction | risk | midi |",
+        "|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|",
     ]
     for candidate in manifest["candidates"]:
         midi_path = candidate.get("review_midi_relative_path") or candidate.get("midi_path")
@@ -283,11 +300,16 @@ def markdown_report(manifest: dict[str, Any]) -> str:
         table_candidate.setdefault("tension_ratio", 0.0)
         table_candidate.setdefault("approach_candidate_ratio", 0.0)
         table_candidate.setdefault("approach_resolution_ratio", 0.0)
+        table_candidate.setdefault("syncopated_onset_ratio", 0.0)
+        table_candidate.setdefault("unique_bar_position_pattern_ratio", 0.0)
+        table_candidate.setdefault("most_common_ioi_ratio", 0.0)
         lines.append(
             "| {review_rank} | {source_rank} | {mode} | {note_groups_per_bar} | {sample_index} | "
             "{score:.4f} | {note_count} | {unique_pitch_count} | {chord_tone_ratio:.3f} | "
             "{root_tone_ratio:.3f} | {tension_ratio:.3f} | "
             "{approach_candidate_ratio:.3f} | {approach_resolution_ratio:.3f} | "
+            "{syncopated_onset_ratio:.3f} | {unique_bar_position_pattern_ratio:.3f} | "
+            "{most_common_ioi_ratio:.3f} | "
             "{dominant_pitch_ratio:.3f} | {repeated_pitch_ratio:.3f} | {direction_change_ratio:.3f} | "
             "`{risk_flags_text}` | `{display_midi_path}` |".format(
                 **table_candidate

--- a/scripts/run_stage_b_generation_probe.py
+++ b/scripts/run_stage_b_generation_probe.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from collections import Counter
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Sequence
@@ -45,6 +46,7 @@ from scripts.stage_b_tokens import (  # noqa: E402
     TOKEN_CHORD_ROOT_END,
     TOKEN_CHORD_ROOT_START,
     SEQUENCE_FORMAT_STAGE_B_V1,
+    MAX_DURATION_STEPS,
     POSITIONS_PER_BAR,
     PIANO_PITCH_MAX,
     PIANO_PITCH_MIN,
@@ -56,6 +58,7 @@ from scripts.stage_b_tokens import (  # noqa: E402
     is_note_pitch_token,
     is_position_token,
     is_velocity_token,
+    note_duration_token,
     note_pitch_token,
     parse_chord_symbol,
     pitch_from_token,
@@ -560,6 +563,64 @@ def coverage_aware_position_tokens(
     return [TOKEN_POSITION_START + int(position) for position in positions]
 
 
+JAZZ_RHYTHM_POSITION_PATTERNS = {
+    "swing_motif": [
+        [0, 3, 5, 7, 10, 11, 13, 15],
+        [1, 3, 4, 7, 9, 12, 14, 15],
+        [0, 2, 5, 6, 8, 11, 13, 14],
+        [2, 4, 5, 8, 10, 12, 13, 15],
+    ],
+}
+
+JAZZ_RHYTHM_DURATION_PATTERNS = {
+    "swing_motif": [
+        [2, 1, 3, 1, 2, 2, 1, 4],
+        [1, 3, 1, 2, 2, 1, 3, 2],
+        [3, 1, 2, 1, 4, 1, 2, 2],
+        [1, 2, 2, 3, 1, 2, 1, 4],
+    ],
+}
+
+
+def _pattern_value(pattern: Sequence[int], group_index: int, note_groups_per_bar: int) -> int:
+    if not pattern:
+        return 0
+    groups_per_bar = max(1, int(note_groups_per_bar))
+    if groups_per_bar == len(pattern):
+        index = int(group_index) % len(pattern)
+    else:
+        index = min(len(pattern) - 1, int(round(int(group_index) * (len(pattern) - 1) / max(1, groups_per_bar - 1))))
+    return int(pattern[index])
+
+
+def jazz_rhythm_position_tokens(
+    bar_index: int,
+    group_index: int,
+    note_groups_per_bar: int,
+    profile: str = "swing_motif",
+    position_window: int = 0,
+) -> list[int]:
+    patterns = JAZZ_RHYTHM_POSITION_PATTERNS.get(profile, JAZZ_RHYTHM_POSITION_PATTERNS["swing_motif"])
+    pattern = patterns[int(bar_index) % len(patterns)]
+    target = max(0, min(int(POSITIONS_PER_BAR) - 1, _pattern_value(pattern, group_index, note_groups_per_bar)))
+    window = max(0, int(position_window))
+    positions = range(max(0, target - window), min(int(POSITIONS_PER_BAR), target + window + 1))
+    return [TOKEN_POSITION_START + int(position) for position in positions]
+
+
+def jazz_rhythm_duration_tokens(
+    bar_index: int,
+    group_index: int,
+    note_groups_per_bar: int,
+    profile: str = "swing_motif",
+) -> list[int]:
+    patterns = JAZZ_RHYTHM_DURATION_PATTERNS.get(profile, JAZZ_RHYTHM_DURATION_PATTERNS["swing_motif"])
+    pattern = patterns[int(bar_index) % len(patterns)]
+    target = max(1, min(int(MAX_DURATION_STEPS), _pattern_value(pattern, group_index, note_groups_per_bar)))
+    duration_steps = sorted({max(1, min(int(MAX_DURATION_STEPS), target + offset)) for offset in (-1, 0, 1)})
+    return [note_duration_token(step) for step in duration_steps]
+
+
 def chord_pitch_classes(chord: str | None, pitch_mode: str = "tones_tensions") -> set[int]:
     root, quality = parse_chord_symbol(chord)
     root_pc = ROOT_TO_PC.get(root)
@@ -712,6 +773,75 @@ def analyze_stage_b_approach_resolution(
     }
 
 
+def analyze_stage_b_rhythm_profile(
+    tokens: Sequence[int],
+    primer_size: int = 0,
+) -> dict[str, Any]:
+    groups = extract_stage_b_note_groups(tokens, primer_size=primer_size)
+    group_count = int(len(groups))
+    if not groups:
+        return {
+            "note_group_count": 0,
+            "unique_position_count": 0,
+            "unique_position_ratio": 0.0,
+            "syncopated_onset_ratio": 0.0,
+            "unique_bar_position_pattern_count": 0,
+            "unique_bar_position_pattern_ratio": 0.0,
+            "duration_diversity_ratio": 0.0,
+            "most_common_duration_ratio": 0.0,
+            "ioi_diversity_ratio": 0.0,
+            "most_common_ioi_ratio": 0.0,
+            "bar_position_patterns": {},
+        }
+
+    positions = [int(group["position"]) for group in groups]
+    durations = [int(group["duration_steps"]) for group in groups]
+    absolute_positions = [
+        int(group["bar"]) * int(POSITIONS_PER_BAR) + int(group["position"])
+        for group in groups
+    ]
+    ioi_steps = [
+        max(0, absolute_positions[index + 1] - absolute_positions[index])
+        for index in range(len(absolute_positions) - 1)
+    ]
+    strong_positions = {0, 4, 8, 12}
+    syncopated_count = sum(1 for position in positions if position not in strong_positions)
+
+    per_bar_positions: dict[int, list[int]] = {}
+    for group in groups:
+        per_bar_positions.setdefault(int(group["bar"]), []).append(int(group["position"]))
+    bar_patterns = {
+        str(bar): tuple(sorted(values))
+        for bar, values in sorted(per_bar_positions.items())
+    }
+    unique_bar_patterns = set(bar_patterns.values())
+    duration_counts = Counter(durations)
+    ioi_counts = Counter(ioi_steps)
+
+    return {
+        "note_group_count": group_count,
+        "unique_position_count": int(len(set(positions))),
+        "unique_position_ratio": float(len(set(positions)) / group_count),
+        "syncopated_onset_ratio": float(syncopated_count / group_count),
+        "unique_bar_position_pattern_count": int(len(unique_bar_patterns)),
+        "unique_bar_position_pattern_ratio": (
+            float(len(unique_bar_patterns) / len(bar_patterns)) if bar_patterns else 0.0
+        ),
+        "duration_diversity_ratio": float(len(duration_counts) / group_count),
+        "most_common_duration_ratio": (
+            float(max(duration_counts.values()) / group_count) if duration_counts else 0.0
+        ),
+        "ioi_diversity_ratio": float(len(ioi_counts) / max(1, len(ioi_steps))),
+        "most_common_ioi_ratio": (
+            float(max(ioi_counts.values()) / max(1, len(ioi_steps))) if ioi_counts else 0.0
+        ),
+        "bar_position_patterns": {
+            bar: list(pattern)
+            for bar, pattern in bar_patterns.items()
+        },
+    }
+
+
 def chord_aware_pitch_tokens(
     chord: str | None,
     pitch_mode: str = "tones_tensions",
@@ -767,6 +897,9 @@ def generate_stage_b_constrained_tokens(
     chord_aware_pitches: bool = False,
     chord_pitch_mode: str = "tones_tensions",
     chord_pitch_repeat_window: int = 2,
+    jazz_rhythm_positions: bool = False,
+    jazz_duration_tokens: bool = False,
+    jazz_rhythm_profile: str = "swing_motif",
 ) -> list[int]:
     tokens = [int(token) for token in primer_tokens]
     recent_pitches: list[int] = []
@@ -788,7 +921,15 @@ def generate_stage_b_constrained_tokens(
                     tokens.append(TOKEN_END)
                     return tokens
                 allowed = list(allowed_tokens)
-                if coverage_aware_positions and family_index == 0:
+                if jazz_rhythm_positions and family_index == 0:
+                    allowed = jazz_rhythm_position_tokens(
+                        bar_index=bar_index,
+                        group_index=group_index,
+                        note_groups_per_bar=note_groups_per_bar,
+                        profile=jazz_rhythm_profile,
+                        position_window=coverage_position_window,
+                    )
+                elif coverage_aware_positions and family_index == 0:
                     allowed = coverage_aware_position_tokens(
                         group_index,
                         note_groups_per_bar=note_groups_per_bar,
@@ -801,6 +942,13 @@ def generate_stage_b_constrained_tokens(
                         recent_pitches=recent_pitches,
                         repeat_window=chord_pitch_repeat_window,
                         group_index=group_index,
+                    )
+                if jazz_duration_tokens and family_index == 3:
+                    allowed = jazz_rhythm_duration_tokens(
+                        bar_index=bar_index,
+                        group_index=group_index,
+                        note_groups_per_bar=note_groups_per_bar,
+                        profile=jazz_rhythm_profile,
                     )
                 token = next_token_from_model(
                     model,
@@ -903,6 +1051,7 @@ def sample_report(
         chords=request.chord_progression,
         primer_size=primer_size,
     )
+    rhythm_profile = analyze_stage_b_rhythm_profile(tokens, primer_size=primer_size)
     collapse_gate = evaluate_collapse_gate(
         collapse,
         min_unique_pitches=strict_min_unique_pitches,
@@ -941,6 +1090,7 @@ def sample_report(
         "phrase_contour": phrase_contour,
         "pitch_roles": pitch_roles,
         "approach_resolution": approach_resolution,
+        "rhythm_profile": rhythm_profile,
         "collapse_gate": collapse_gate,
         "postprocess": postprocess_report or {"enabled": False},
         "metrics": metrics.to_dict(),
@@ -985,12 +1135,19 @@ def build_probe_summary(
     tension_ratios: list[float] = []
     approach_candidate_ratios: list[float] = []
     approach_resolution_ratios: list[float] = []
+    syncopated_onset_ratios: list[float] = []
+    unique_bar_pattern_ratios: list[float] = []
+    duration_diversity_ratios: list[float] = []
+    most_common_duration_ratios: list[float] = []
+    ioi_diversity_ratios: list[float] = []
+    most_common_ioi_ratios: list[float] = []
     for row in sample_rows:
         collapse = row.get("collapse", {})
         temporal_coverage = row.get("temporal_coverage", {})
         phrase_contour = row.get("phrase_contour", {})
         pitch_roles = row.get("pitch_roles", {})
         approach_resolution = row.get("approach_resolution", {})
+        rhythm_profile = row.get("rhythm_profile", {})
         if collapse.get("collapse_warning"):
             collapse_warning_count += 1
         if not row.get("strict_valid", False):
@@ -1024,6 +1181,14 @@ def build_probe_summary(
         approach_resolution_ratios.append(
             float(approach_resolution.get("approach_resolution_ratio", 0.0) or 0.0)
         )
+        syncopated_onset_ratios.append(float(rhythm_profile.get("syncopated_onset_ratio", 0.0) or 0.0))
+        unique_bar_pattern_ratios.append(
+            float(rhythm_profile.get("unique_bar_position_pattern_ratio", 0.0) or 0.0)
+        )
+        duration_diversity_ratios.append(float(rhythm_profile.get("duration_diversity_ratio", 0.0) or 0.0))
+        most_common_duration_ratios.append(float(rhythm_profile.get("most_common_duration_ratio", 0.0) or 0.0))
+        ioi_diversity_ratios.append(float(rhythm_profile.get("ioi_diversity_ratio", 0.0) or 0.0))
+        most_common_ioi_ratios.append(float(rhythm_profile.get("most_common_ioi_ratio", 0.0) or 0.0))
         if not row["valid"]:
             reason = str(row.get("failure_reason") or "unknown")
             diagnostic_reason = str(row.get("diagnostic_failure_reason") or reason)
@@ -1114,6 +1279,36 @@ def build_probe_summary(
             if approach_resolution_ratios
             else 0.0
         ),
+        "avg_syncopated_onset_ratio": (
+            float(sum(syncopated_onset_ratios) / len(syncopated_onset_ratios))
+            if syncopated_onset_ratios
+            else 0.0
+        ),
+        "avg_unique_bar_position_pattern_ratio": (
+            float(sum(unique_bar_pattern_ratios) / len(unique_bar_pattern_ratios))
+            if unique_bar_pattern_ratios
+            else 0.0
+        ),
+        "avg_duration_diversity_ratio": (
+            float(sum(duration_diversity_ratios) / len(duration_diversity_ratios))
+            if duration_diversity_ratios
+            else 0.0
+        ),
+        "avg_most_common_duration_ratio": (
+            float(sum(most_common_duration_ratios) / len(most_common_duration_ratios))
+            if most_common_duration_ratios
+            else 0.0
+        ),
+        "avg_ioi_diversity_ratio": (
+            float(sum(ioi_diversity_ratios) / len(ioi_diversity_ratios))
+            if ioi_diversity_ratios
+            else 0.0
+        ),
+        "avg_most_common_ioi_ratio": (
+            float(sum(most_common_ioi_ratios) / len(most_common_ioi_ratios))
+            if most_common_ioi_ratios
+            else 0.0
+        ),
     }
 
 
@@ -1161,6 +1356,9 @@ def build_parser() -> argparse.ArgumentParser:
         default="tones_tensions",
     )
     parser.add_argument("--chord_pitch_repeat_window", type=int, default=2)
+    parser.add_argument("--jazz_rhythm_positions", action="store_true")
+    parser.add_argument("--jazz_duration_tokens", action="store_true")
+    parser.add_argument("--jazz_rhythm_profile", choices=("swing_motif",), default="swing_motif")
     parser.add_argument("--postprocess_overlap", action="store_true")
     parser.add_argument("--max_simultaneous_notes", type=int, default=2)
     parser.add_argument("--min_valid_samples", type=int, default=1)
@@ -1240,6 +1438,9 @@ def main() -> int:
         "chord_aware_pitches": bool(args.chord_aware_pitches),
         "chord_pitch_mode": args.chord_pitch_mode,
         "chord_pitch_repeat_window": int(args.chord_pitch_repeat_window),
+        "jazz_rhythm_positions": bool(args.jazz_rhythm_positions),
+        "jazz_duration_tokens": bool(args.jazz_duration_tokens),
+        "jazz_rhythm_profile": args.jazz_rhythm_profile,
         "postprocess_overlap": bool(args.postprocess_overlap),
     }
 
@@ -1302,6 +1503,9 @@ def main() -> int:
                 chord_aware_pitches=args.chord_aware_pitches,
                 chord_pitch_mode=args.chord_pitch_mode,
                 chord_pitch_repeat_window=args.chord_pitch_repeat_window,
+                jazz_rhythm_positions=args.jazz_rhythm_positions,
+                jazz_duration_tokens=args.jazz_duration_tokens,
+                jazz_rhythm_profile=args.jazz_rhythm_profile,
             )
         else:
             generated_tokens = generate_stage_b_tokens(

--- a/scripts/run_stage_b_phrase_grammar_compare.py
+++ b/scripts/run_stage_b_phrase_grammar_compare.py
@@ -1,0 +1,292 @@
+"""Compare Stage B phrase grammar constraints on one tiny checkpoint."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.run_stage_b_pitch_mode_compare import (  # noqa: E402
+    export_named_comparison_midis,
+    export_review_candidates,
+)
+from scripts.run_stage_b_sampling_sweep import (  # noqa: E402
+    probe_command,
+    read_json,
+    row_from_probe_report,
+    run_command,
+    write_json,
+)
+
+VALID_GRAMMAR_MODES = {"approach_baseline", "swing_motif_approach"}
+
+
+def parse_grammar_modes(raw: str) -> list[str]:
+    modes = [mode.strip().lower() for mode in raw.split(",") if mode.strip()]
+    invalid = [mode for mode in modes if mode not in VALID_GRAMMAR_MODES]
+    if invalid:
+        raise ValueError(f"Unknown phrase grammar modes: {invalid}")
+    return modes
+
+
+def config_run_id(base_run_id: str, grammar_mode: str) -> str:
+    return f"{base_run_id}_{grammar_mode}"
+
+
+def best_row(rows: list[dict[str, Any]]) -> dict[str, Any] | None:
+    return max(
+        rows,
+        key=lambda row: (
+            int(row["strict_valid_sample_count"]),
+            float(row["avg_syncopated_onset_ratio"]),
+            float(row["avg_unique_bar_position_pattern_ratio"]),
+            -float(row["avg_most_common_ioi_ratio"]),
+            -float(row["avg_most_common_duration_ratio"]),
+        ),
+        default=None,
+    )
+
+
+def compact_row(row: dict[str, Any] | None) -> dict[str, Any] | None:
+    if row is None:
+        return None
+    return {
+        "grammar_mode": row["grammar_mode"],
+        "run_id": row["run_id"],
+        "strict_valid_sample_count": int(row["strict_valid_sample_count"]),
+        "valid_sample_count": int(row["valid_sample_count"]),
+        "avg_root_tone_ratio": float(row["avg_root_tone_ratio"]),
+        "avg_tension_ratio": float(row["avg_tension_ratio"]),
+        "avg_approach_resolution_ratio": float(row["avg_approach_resolution_ratio"]),
+        "avg_syncopated_onset_ratio": float(row["avg_syncopated_onset_ratio"]),
+        "avg_unique_bar_position_pattern_ratio": float(row["avg_unique_bar_position_pattern_ratio"]),
+        "avg_duration_diversity_ratio": float(row["avg_duration_diversity_ratio"]),
+        "avg_most_common_duration_ratio": float(row["avg_most_common_duration_ratio"]),
+        "avg_ioi_diversity_ratio": float(row["avg_ioi_diversity_ratio"]),
+        "avg_most_common_ioi_ratio": float(row["avg_most_common_ioi_ratio"]),
+    }
+
+
+def build_phrase_grammar_summary(
+    rows: list[dict[str, Any]],
+    min_best_strict_valid_samples: int = 1,
+) -> dict[str, Any]:
+    mode_rows = {
+        mode: [row for row in rows if row.get("grammar_mode") == mode]
+        for mode in sorted(VALID_GRAMMAR_MODES)
+    }
+    best_baseline = best_row(mode_rows["approach_baseline"])
+    best_swing = best_row(mode_rows["swing_motif_approach"])
+    comparison_ready = bool(best_baseline and best_swing)
+    passed_baseline = bool(
+        best_baseline
+        and int(best_baseline["strict_valid_sample_count"]) >= int(min_best_strict_valid_samples)
+    )
+    passed_swing = bool(
+        best_swing
+        and int(best_swing["strict_valid_sample_count"]) >= int(min_best_strict_valid_samples)
+    )
+    baseline_sync = float(best_baseline.get("avg_syncopated_onset_ratio", 0.0)) if best_baseline else 0.0
+    swing_sync = float(best_swing.get("avg_syncopated_onset_ratio", 0.0)) if best_swing else 0.0
+    baseline_ioi = float(best_baseline.get("avg_most_common_ioi_ratio", 0.0)) if best_baseline else 0.0
+    swing_ioi = float(best_swing.get("avg_most_common_ioi_ratio", 0.0)) if best_swing else 0.0
+    return {
+        "config_count": int(len(rows)),
+        "mode_counts": {mode: int(len(mode_rows[mode])) for mode in sorted(VALID_GRAMMAR_MODES)},
+        "best_config": compact_row(best_row(rows)),
+        "best_approach_baseline_config": compact_row(best_baseline),
+        "best_swing_motif_approach_config": compact_row(best_swing),
+        "min_best_strict_valid_samples": int(min_best_strict_valid_samples),
+        "comparison_ready": comparison_ready,
+        "passed_approach_baseline_gate": passed_baseline,
+        "passed_swing_motif_approach_gate": passed_swing,
+        "passed_compare_gate": bool(comparison_ready and passed_baseline and passed_swing),
+        "syncopation_delta_swing_minus_baseline": float(swing_sync - baseline_sync),
+        "most_common_ioi_delta_swing_minus_baseline": float(swing_ioi - baseline_ioi),
+    }
+
+
+def markdown_table(rows: list[dict[str, Any]], summary: dict[str, Any]) -> str:
+    lines = [
+        "# Stage B Phrase Grammar Comparison",
+        "",
+        f"- passed compare gate: `{str(summary['passed_compare_gate']).lower()}`",
+        f"- best baseline config: `{summary['best_approach_baseline_config']}`",
+        f"- best swing/motif config: `{summary['best_swing_motif_approach_config']}`",
+        f"- syncopation delta, swing minus baseline: `{summary['syncopation_delta_swing_minus_baseline']:.3f}`",
+        f"- most-common IOI delta, swing minus baseline: `{summary['most_common_ioi_delta_swing_minus_baseline']:.3f}`",
+        "",
+        "| grammar | samples | strict | root | tension | resolved | sync | bar-var | dur-var | dur-rep | ioi-var | ioi-rep | report |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for row in rows:
+        lines.append(
+            "| {grammar_mode} | {sample_count} | {strict_valid_sample_count} | "
+            "{avg_root_tone_ratio:.3f} | {avg_tension_ratio:.3f} | "
+            "{avg_approach_resolution_ratio:.3f} | {avg_syncopated_onset_ratio:.3f} | "
+            "{avg_unique_bar_position_pattern_ratio:.3f} | {avg_duration_diversity_ratio:.3f} | "
+            "{avg_most_common_duration_ratio:.3f} | {avg_ioi_diversity_ratio:.3f} | "
+            "{avg_most_common_ioi_ratio:.3f} | `{report_path}` |".format(**row)
+        )
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run Stage B phrase grammar comparison")
+    parser.add_argument("--output_root", type=str, default=str(ROOT_DIR / "outputs" / "stage_b_phrase_grammar_compare"))
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--issue_number", type=int, default=59)
+    parser.add_argument("--grammar_modes", type=str, default="approach_baseline,swing_motif_approach")
+    parser.add_argument("--note_groups_per_bar", type=int, default=8)
+    parser.add_argument("--coverage_position_window", type=int, default=0)
+    parser.add_argument("--chord_pitch_repeat_window", type=int, default=2)
+    parser.add_argument("--top_k", type=int, default=2)
+    parser.add_argument("--temperature", type=float, default=0.9)
+    parser.add_argument("--max_files", type=int, default=2)
+    parser.add_argument("--window_bars", type=int, default=8)
+    parser.add_argument("--window_stride_bars", type=int, default=4)
+    parser.add_argument("--min_window_target_notes", type=int, default=16)
+    parser.add_argument("--epochs", type=int, default=3)
+    parser.add_argument("--batch_size", type=int, default=8)
+    parser.add_argument("--max_sequence", type=int, default=384)
+    parser.add_argument("--num_samples", type=int, default=3)
+    parser.add_argument("--bars", type=int, default=8)
+    parser.add_argument("--max_simultaneous_notes", type=int, default=2)
+    parser.add_argument("--min_valid_samples", type=int, default=1)
+    parser.add_argument("--min_strict_valid_samples", type=int, default=1)
+    parser.add_argument("--min_best_strict_valid_samples", type=int, default=1)
+    parser.add_argument("--max_collapse_warning_sample_rate", type=float, default=0.34)
+    parser.add_argument("--strict_min_unique_pitches", type=int, default=3)
+    parser.add_argument("--strict_min_unique_positions", type=int, default=3)
+    parser.add_argument("--strict_min_unique_position_pitch_pairs", type=int, default=4)
+    parser.add_argument("--strict_max_repeated_position_pitch_pair_ratio", type=float, default=0.49)
+    parser.add_argument("--strict_max_postprocess_removal_ratio", type=float, default=0.49)
+    parser.add_argument("--require_all_grammar_samples", action="store_true")
+    parser.add_argument("--review_output_root", type=str, default=str(ROOT_DIR / "outputs" / "stage_b_review_candidates"))
+    parser.add_argument("--review_top_n", type=int, default=3)
+    parser.add_argument("--copy_review_midi", action="store_true")
+    parser.add_argument("--n_layers", type=int, default=1)
+    parser.add_argument("--num_heads", type=int, default=4)
+    parser.add_argument("--d_model", type=int, default=64)
+    parser.add_argument("--dim_feedforward", type=int, default=128)
+    parser.add_argument("--lora_r", type=int, default=4)
+    parser.add_argument("--lora_alpha", type=int, default=8)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now().strftime("%Y%m%d_%H%M%S")
+    compare_dir = Path(args.output_root) / run_id
+    grammar_modes = parse_grammar_modes(args.grammar_modes)
+    if not grammar_modes:
+        raise ValueError("--grammar_modes must not be empty")
+
+    command_results: list[dict[str, Any]] = []
+    rows: list[dict[str, Any]] = []
+    review_exports: dict[str, dict[str, Any]] = {}
+    checkpoint_dir: Path | None = None
+    first_config = True
+
+    for grammar_mode in grammar_modes:
+        mode_run_id = config_run_id(run_id, grammar_mode)
+        probe_args = argparse.Namespace(**vars(args))
+        probe_args.output_root = args.output_root
+        probe_args.constrained_note_groups_per_bar = int(args.note_groups_per_bar)
+        probe_args.coverage_aware_positions = True
+        probe_args.coverage_position_window = int(args.coverage_position_window)
+        probe_args.chord_aware_pitches = True
+        probe_args.chord_pitch_mode = "approach_tensions"
+        probe_args.chord_pitch_repeat_window = int(args.chord_pitch_repeat_window)
+        probe_args.jazz_rhythm_positions = grammar_mode == "swing_motif_approach"
+        probe_args.jazz_duration_tokens = grammar_mode == "swing_motif_approach"
+        probe_args.jazz_rhythm_profile = "swing_motif"
+        cmd = probe_command(
+            probe_args,
+            run_id=mode_run_id,
+            top_k=int(args.top_k),
+            temperature=float(args.temperature),
+            checkpoint_dir=checkpoint_dir,
+            skip_prepare_train=not first_config,
+        )
+        cmd.extend(
+            [
+                "--window_bars",
+                str(args.window_bars),
+                "--window_stride_bars",
+                str(args.window_stride_bars),
+                "--min_window_target_notes",
+                str(args.min_window_target_notes),
+                "--bars",
+                str(args.bars),
+            ]
+        )
+        cmd.extend(["--coverage_aware_positions", "--coverage_position_window", str(args.coverage_position_window)])
+        result = run_command(cmd)
+        command_results.append(result)
+        if result["returncode"] != 0:
+            report = {
+                "run_id": run_id,
+                "failure_reason": f"probe command failed for grammar_mode={grammar_mode}",
+                "command_results": command_results,
+            }
+            write_json(compare_dir / "phrase_grammar_compare_report.json", report)
+            print(json.dumps(report, ensure_ascii=True, indent=2))
+            return int(result["returncode"])
+
+        report_path = Path(args.output_root) / mode_run_id / "report.json"
+        probe_report = read_json(report_path)
+        if checkpoint_dir is None:
+            checkpoint_dir = Path(probe_report["checkpoint_dir"])
+        first_config = False
+        row = row_from_probe_report(int(args.top_k), float(args.temperature), mode_run_id, probe_report)
+        row["grammar_mode"] = grammar_mode
+        row["note_groups_per_bar"] = int(args.note_groups_per_bar)
+        rows.append(row)
+
+        review_output_dir = Path(args.review_output_root) / run_id / grammar_mode
+        review_exports[grammar_mode] = export_review_candidates(
+            report_path=report_path,
+            output_dir=review_output_dir,
+            top_n=int(args.review_top_n),
+            copy_midi=bool(args.copy_review_midi),
+        )
+
+    rows = sorted(rows, key=lambda row: str(row["grammar_mode"]))
+    summary = build_phrase_grammar_summary(
+        rows,
+        min_best_strict_valid_samples=args.min_best_strict_valid_samples,
+    )
+    report = {
+        "run_id": run_id,
+        "run_dir": str(compare_dir),
+        "issue": int(args.issue_number),
+        "grammar_modes": grammar_modes,
+        "note_groups_per_bar": int(args.note_groups_per_bar),
+        "top_k": int(args.top_k),
+        "temperature": float(args.temperature),
+        "summary": summary,
+        "rows": rows,
+        "review_exports": review_exports,
+        "named_comparison_midis": export_named_comparison_midis(
+            review_exports,
+            output_dir=Path(args.review_output_root) / run_id,
+        )
+        if args.copy_review_midi
+        else [],
+        "command_results": command_results,
+    }
+    write_json(compare_dir / "phrase_grammar_compare_report.json", report)
+    (compare_dir / "phrase_grammar_compare_report.md").write_text(markdown_table(rows, summary), encoding="utf-8")
+    print(json.dumps(report, ensure_ascii=True, indent=2))
+    return 0 if summary["passed_compare_gate"] else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_stage_b_sampling_sweep.py
+++ b/scripts/run_stage_b_sampling_sweep.py
@@ -119,6 +119,12 @@ def probe_command(
         cmd.append("--chord_aware_pitches")
         cmd.extend(["--chord_pitch_mode", str(getattr(args, "chord_pitch_mode", "tones_tensions"))])
         cmd.extend(["--chord_pitch_repeat_window", str(getattr(args, "chord_pitch_repeat_window", 2))])
+    if getattr(args, "jazz_rhythm_positions", False):
+        cmd.append("--jazz_rhythm_positions")
+    if getattr(args, "jazz_duration_tokens", False):
+        cmd.append("--jazz_duration_tokens")
+    if getattr(args, "jazz_rhythm_positions", False) or getattr(args, "jazz_duration_tokens", False):
+        cmd.extend(["--jazz_rhythm_profile", str(getattr(args, "jazz_rhythm_profile", "swing_motif"))])
     if skip_prepare_train:
         cmd.extend(["--skip_prepare", "--skip_train"])
     if checkpoint_dir is not None:
@@ -188,6 +194,14 @@ def row_from_probe_report(top_k: int, temperature: float, run_id: str, report: d
         "avg_tension_ratio": float(summary.get("avg_tension_ratio", 0.0) or 0.0),
         "avg_approach_candidate_ratio": float(summary.get("avg_approach_candidate_ratio", 0.0) or 0.0),
         "avg_approach_resolution_ratio": float(summary.get("avg_approach_resolution_ratio", 0.0) or 0.0),
+        "avg_syncopated_onset_ratio": float(summary.get("avg_syncopated_onset_ratio", 0.0) or 0.0),
+        "avg_unique_bar_position_pattern_ratio": float(
+            summary.get("avg_unique_bar_position_pattern_ratio", 0.0) or 0.0
+        ),
+        "avg_duration_diversity_ratio": float(summary.get("avg_duration_diversity_ratio", 0.0) or 0.0),
+        "avg_most_common_duration_ratio": float(summary.get("avg_most_common_duration_ratio", 0.0) or 0.0),
+        "avg_ioi_diversity_ratio": float(summary.get("avg_ioi_diversity_ratio", 0.0) or 0.0),
+        "avg_most_common_ioi_ratio": float(summary.get("avg_most_common_ioi_ratio", 0.0) or 0.0),
         "failure_reasons": summary.get("failure_reasons", {}),
         "diagnostic_failure_reasons": summary.get("diagnostic_failure_reasons", {}),
         "strict_failure_reasons": summary.get("strict_failure_reasons", {}),

--- a/tests/test_stage_b_generation_probe.py
+++ b/tests/test_stage_b_generation_probe.py
@@ -13,6 +13,7 @@ from scripts.run_stage_b_generation_probe import (
     analyze_stage_b_approach_resolution,
     analyze_stage_b_phrase_contour,
     analyze_stage_b_pitch_roles,
+    analyze_stage_b_rhythm_profile,
     analyze_stage_b_temporal_coverage,
     build_probe_summary,
     build_stage_b_primer,
@@ -25,10 +26,13 @@ from scripts.run_stage_b_generation_probe import (
     extract_stage_b_note_groups,
     generate_stage_b_constrained_tokens,
     generate_stage_b_tokens,
+    jazz_rhythm_duration_tokens,
+    jazz_rhythm_position_tokens,
     postprocess_stage_b_midi,
 )
 from scripts.stage_b_tokens import (
     chord_tokens,
+    duration_steps_from_token,
     note_duration_token,
     note_pitch_token,
     note_velocity_token,
@@ -243,6 +247,24 @@ class StageBGenerationProbeTest(unittest.TestCase):
 
         self.assertEqual(positions, [7, 8, 9])
 
+    def test_jazz_rhythm_position_tokens_use_syncopated_patterns(self) -> None:
+        positions = [
+            position_from_token(jazz_rhythm_position_tokens(0, index, note_groups_per_bar=8)[0])
+            for index in range(8)
+        ]
+
+        self.assertEqual(positions, [0, 3, 5, 7, 10, 11, 13, 15])
+
+    def test_jazz_rhythm_duration_tokens_vary_by_group(self) -> None:
+        durations = [
+            [duration_steps_from_token(token) for token in jazz_rhythm_duration_tokens(0, index, note_groups_per_bar=8)]
+            for index in range(8)
+        ]
+
+        for expected, allowed in zip([2, 1, 3, 1, 2, 2, 1, 4], durations, strict=True):
+            self.assertIn(expected, allowed)
+        self.assertGreater(len({tuple(allowed) for allowed in durations}), 1)
+
     def test_chord_aware_pitch_tokens_limit_to_chord_tones(self) -> None:
         tokens = chord_aware_pitch_tokens("Cm7", pitch_mode="tones", repeat_window=0)
         pitch_classes = {pitch_from_token(token) % 12 for token in tokens}
@@ -296,6 +318,36 @@ class StageBGenerationProbeTest(unittest.TestCase):
         self.assertEqual(report["approach_candidate_count"], 1)
         self.assertEqual(report["resolved_approach_count"], 1)
         self.assertAlmostEqual(report["approach_resolution_ratio"], 1.0)
+
+    def test_analyze_stage_b_rhythm_profile_reports_syncopation_and_variation(self) -> None:
+        primer = build_stage_b_primer(["Cmaj7"], bpm=120)
+        tokens = primer + [
+            position_token(0),
+            note_velocity_token(4),
+            note_pitch_token(60),
+            note_duration_token(2),
+            position_token(3),
+            note_velocity_token(4),
+            note_pitch_token(62),
+            note_duration_token(1),
+            TOKEN_BAR,
+            *chord_tokens("Cmaj7"),
+            position_token(1),
+            note_velocity_token(4),
+            note_pitch_token(64),
+            note_duration_token(3),
+            position_token(7),
+            note_velocity_token(4),
+            note_pitch_token(65),
+            note_duration_token(1),
+            TOKEN_END,
+        ]
+
+        report = analyze_stage_b_rhythm_profile(tokens, primer_size=len(primer))
+
+        self.assertEqual(report["note_group_count"], 4)
+        self.assertGreater(report["syncopated_onset_ratio"], 0.5)
+        self.assertEqual(report["unique_bar_position_pattern_count"], 2)
 
     def test_analyze_stage_b_pitch_roles_counts_root_and_tensions(self) -> None:
         primer = build_stage_b_primer(["Cm7", "F7"], bpm=120)

--- a/tests/test_stage_b_phrase_grammar_compare.py
+++ b/tests/test_stage_b_phrase_grammar_compare.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.run_stage_b_phrase_grammar_compare import (
+    build_phrase_grammar_summary,
+    config_run_id,
+    markdown_table,
+    parse_grammar_modes,
+)
+
+
+def row(
+    grammar_mode: str,
+    *,
+    strict: int,
+    sync: float,
+    ioi_rep: float,
+) -> dict:
+    return {
+        "grammar_mode": grammar_mode,
+        "run_id": f"run_{grammar_mode}",
+        "sample_count": 3,
+        "valid_sample_count": strict,
+        "strict_valid_sample_count": strict,
+        "avg_root_tone_ratio": 0.1,
+        "avg_tension_ratio": 0.2,
+        "avg_approach_resolution_ratio": 0.8,
+        "avg_syncopated_onset_ratio": sync,
+        "avg_unique_bar_position_pattern_ratio": 0.5,
+        "avg_duration_diversity_ratio": 0.1,
+        "avg_most_common_duration_ratio": 0.5,
+        "avg_ioi_diversity_ratio": 0.1,
+        "avg_most_common_ioi_ratio": ioi_rep,
+        "report_path": f"outputs/{grammar_mode}/report.json",
+    }
+
+
+class StageBPhraseGrammarCompareTest(unittest.TestCase):
+    def test_parse_grammar_modes_rejects_unknown_mode(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_grammar_modes("approach_baseline,random")
+
+    def test_config_run_id_is_stable(self) -> None:
+        self.assertEqual(
+            config_run_id("run", "swing_motif_approach"),
+            "run_swing_motif_approach",
+        )
+
+    def test_build_phrase_grammar_summary_reports_rhythm_delta(self) -> None:
+        rows = [
+            row("approach_baseline", strict=3, sync=0.50, ioi_rep=0.49),
+            row("swing_motif_approach", strict=3, sync=0.75, ioi_rep=0.35),
+        ]
+
+        summary = build_phrase_grammar_summary(rows)
+
+        self.assertTrue(summary["passed_compare_gate"])
+        self.assertAlmostEqual(summary["syncopation_delta_swing_minus_baseline"], 0.25)
+        self.assertAlmostEqual(summary["most_common_ioi_delta_swing_minus_baseline"], -0.14)
+
+    def test_markdown_table_records_rhythm_columns(self) -> None:
+        rows = [
+            row("approach_baseline", strict=3, sync=0.50, ioi_rep=0.49),
+            row("swing_motif_approach", strict=3, sync=0.75, ioi_rep=0.35),
+        ]
+
+        markdown = markdown_table(rows, build_phrase_grammar_summary(rows))
+
+        self.assertIn("sync", markdown)
+        self.assertIn("ioi-rep", markdown)
+        self.assertIn("swing_motif_approach", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

- 8-bar approach_tensions 조건 위에 swing/motif position-duration grammar를 추가했습니다.
- baseline approach grammar와 swing_motif_approach를 같은 checkpoint에서 비교하는 runner와 하네스를 추가했습니다.
- rhythm profile 지표를 generation report, sampling sweep, review export ranking에 연결했습니다.
- 결과와 판단을 docs/STAGE_B_SWING_MOTIF_PHRASE_2026-05-21.md, docs/CORE_PLAN.md, docs/CURRENT_STATUS_AND_PLAN.md에 기록했습니다.

## 결과

- approach_baseline strict valid samples: 3/3
- swing_motif_approach strict valid samples: 3/3
- syncopated onset ratio: 0.500 -> 0.750
- unique bar-position pattern ratio: 0.125 -> 0.500
- most-common duration ratio: 0.552 -> 0.380
- most-common IOI ratio: 0.508 -> 0.476

## 해석

이번 작업은 재즈 모델 완성이 아니라, 기존 샘플이 동요/연습곡처럼 들리던 원인 중 rhythm-grid 반복을 줄인 probe입니다. pitch vocabulary와 motif development는 아직 다음 병목으로 남아 있습니다.

## 검증

- ./.venv/bin/python -m unittest tests.test_stage_b_generation_probe tests.test_stage_b_phrase_grammar_compare tests.test_stage_b_review_export
- ./.venv/bin/python -m compileall scripts/run_stage_b_generation_probe.py scripts/run_stage_b_phrase_grammar_compare.py scripts/run_stage_b_sampling_sweep.py scripts/export_stage_b_review_candidates.py tests/test_stage_b_generation_probe.py tests/test_stage_b_phrase_grammar_compare.py
- bash scripts/agent_harness.sh quick
- bash scripts/agent_harness.sh stage-b-swing-motif-phrase
- git diff --check

Closes #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added swing/motif phrase grammar probe for Stage B generation with constraint options
  * Introduced rhythm profile metrics (syncopation, pattern diversity, IOI analysis) to generation reporting
  * New phrase grammar comparison capability across baseline and swing/motif modes

* **Documentation**
  * New Stage B swing/motif phrase grammar guide and execution details
  * Updated active documentation index and roadmap

* **Tests**
  * Added rhythm analysis and phrase grammar comparison test coverage

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohhalim/fine_tuning_art-tatum_midi_solo/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->