### PR TITLE
Stage B 실제 phrase reference 통계 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #59: Stage B swing/motif phrase grammar probe.
+- Issue #61: Stage B real jazz phrase reference statistics.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -170,6 +170,12 @@ For Stage B swing/motif rhythm phrase changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-swing-motif-phrase
+```
+
+For Stage B real phrase reference statistics changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-reference-stats
 ```
 
 For Stage B collapse/sampling-sweep changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -132,6 +132,7 @@ Stage B에서 명시하는 것:
 26. Stage B `tones` vs `tones_tensions` pitch-mode comparison
 27. Stage B 8-bar approach phrase probe
 28. Stage B swing/motif phrase grammar probe
+29. Stage B real phrase reference statistics
 
 가장 최근 의미 있는 결과:
 
@@ -335,6 +336,8 @@ Stage B에서 명시하는 것:
 - Issue #57 review premise: 이전보다 나아졌지만 아직 jazz solo가 아니라 다이아토닉 코드톤/근음 기반 초급 melodic exercise처럼 들린다.
 - Issue #59 result: `swing_motif_approach`는 strict valid `3/3`을 유지하면서 syncopated onset ratio를 `0.500`에서 `0.750`으로 올렸다.
 - Issue #59 result: unique bar-position pattern ratio는 `0.125`에서 `0.500`으로 올랐고, most-common duration ratio는 `0.552`에서 `0.380`으로 낮아졌다.
+- Issue #61 result: real jazz phrase windows `57`개 기준 syncopation mean은 `0.736`, unique bar-position pattern mean은 `0.996`, duration diversity mean은 `0.379`, IOI diversity mean은 `0.341`이다.
+- Issue #61 result: `swing_motif_approach`는 syncopation은 reference에 가까우나 bar-position variation, duration diversity, IOI diversity가 아직 크게 부족하다.
 
 해석:
 
@@ -343,7 +346,7 @@ Stage B에서 명시하는 것:
 - `tones_tensions`는 no-tension 문제를 줄였지만, 더 좋은 solo phrase라고 바로 판단할 단계는 아니다.
 - `approach_tensions`는 pitch-level resolution을 만들지만, 이 또한 jazz vocabulary 자체는 아니다.
 - `swing_motif_approach`는 기계적인 grid 반복을 줄였지만, 이 또한 jazz vocabulary 자체는 아니다.
-- 다음 비교는 pitch/rhythm rule을 더 늘리는 것보다 real jazz MIDI phrase statistics와 motif/cadence control 쪽이 맞다.
+- real phrase reference stats 기준으로 보면 다음은 hand-written rhythm rule 확장이 아니라 data-derived motif/cadence control 쪽이 맞다.
 
 ### Phase 3.10. Swing/Motif Phrase Grammar
 
@@ -373,6 +376,36 @@ Stage B에서 명시하는 것:
 - generated rhythm profile을 real jazz MIDI window 통계와 비교한다.
 - pitch motif cell, cadence/landing, phrase memory 중 하나를 다음 issue로 분리한다.
 - rule이 아니라 data-derived constraint로 넘어갈지 판단한다.
+
+### Phase 3.11. Real Phrase Reference Statistics
+
+목표:
+
+- generated MIDI가 "이전보다 나음"인지 "실제 jazz phrase 통계에 가까움"인지 분리한다.
+- real Stage B phrase windows에서 rhythm/contour reference metrics를 만든다.
+- generated candidate report와 comparable metric key를 맞춘다.
+
+현재 결과:
+
+- completed: `scripts/run_stage_b_reference_stats.py`를 추가했다.
+- completed: `4`개 MIDI 파일에서 `57`개 8-bar real phrase windows를 분석했다.
+- latest result: real syncopated onset ratio mean은 `0.736`이다.
+- latest result: real unique bar-position pattern ratio mean은 `0.996`이다.
+- latest result: real duration diversity ratio mean은 `0.379`이다.
+- latest result: real IOI diversity ratio mean은 `0.341`이다.
+- latest result: Issue #59 `swing_motif_approach`는 syncopation은 reference와 거의 맞지만 bar-position/duration/IOI diversity는 부족하다.
+
+해석:
+
+- Issue #59는 baseline보다 나아졌지만 아직 real jazz window 통계에는 미달한다.
+- 특히 every-bar pattern variation이 부족하다.
+- 다음 단계는 hand-written swing pattern을 더 추가하기보다 dataset에서 phrase motif templates를 추출하는 것이다.
+
+다음 통과 기준:
+
+- real window에서 rhythm/motif templates를 추출한다.
+- generated candidate가 reference p25-p75 범위 안에 들어오는 metric을 늘린다.
+- phrase ending/cadence도 reference 기반으로 비교한다.
 
 ### Phase 4. Generic Jazz Base 후보 학습
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-59-stage-b-swing-motif-phrase`
+- `issue-61-stage-b-reference-phrase-stats`
 
 현재 범위가 아닌 것:
 
@@ -36,48 +36,39 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 ## Latest Probe Result
 
-Issue #59는 manual listening/piano-roll review에서 나온 "이전보다 나아졌지만 아직 재즈가 아니라 초등학교 음악/다이아토닉 코드톤 나열처럼 들린다"는 피드백을 rhythm/motif grammar 관점에서 검증한다.
+Issue #61은 Issue #59의 swing/motif grammar가 실제 jazz MIDI phrase window 기준선과 얼마나 가까운지 검증한다.
 
-Issue #51에서 이미 adjacent same-note collapse는 아니라는 것을 확인했다. Issue #53에서는 실제 root tone, non-root chord tone, tension 비율을 기록했다. Issue #55는 같은 4-bar 조건에서 `tones_tensions`가 tension을 실제로 늘리고 root bias를 줄이는지 확인했다. Issue #57은 8-bar 길이와 approach/resolution 정책을 추가했다. Issue #59는 같은 8-bar approach setup에서 position/duration rhythm pattern을 swing/motif template으로 바꿔 비교한다.
+Issue #59는 same 8-bar approach setup에서 position/duration rhythm pattern을 swing/motif template으로 바꿔 mechanical rhythm-grid 반복을 줄였다. 하지만 그 rule이 실제 jazz window 통계와 가까운지는 별도로 봐야 한다.
 
 Implemented:
 
-- `scripts/run_stage_b_generation_probe.py` jazz rhythm position/duration constraints
-- `scripts/run_stage_b_generation_probe.py` rhythm profile diagnostics
-- `scripts/run_stage_b_phrase_grammar_compare.py`
-- `scripts/export_stage_b_review_candidates.py` rhythm-aware ranking fields
-- `tests/test_stage_b_generation_probe.py`
-- `tests/test_stage_b_phrase_grammar_compare.py`
-- `scripts/run_stage_b_sampling_sweep.py` rhythm summary fields
-- `scripts/agent_harness.sh stage-b-swing-motif-phrase`
+- `scripts/run_stage_b_reference_stats.py`
+- `tests/test_stage_b_reference_stats.py`
+- `scripts/agent_harness.sh stage-b-reference-stats`
 - output files:
-  - `phrase_grammar_compare_report.json`
-  - `phrase_grammar_compare_report.md`
-  - mode-specific `review_manifest.json`
-  - named comparison MIDI files under `compare_named_midi/`
+  - `reference_stats_report.json`
+  - `reference_stats_report.md`
 
 Result:
 
-- source comparison report: `outputs/stage_b_phrase_grammar_compare/harness_stage_b_swing_motif_phrase/phrase_grammar_compare_report.json`
-- named review output: `outputs/stage_b_review_candidates/harness_stage_b_swing_motif_phrase/compare_named_midi/`
-- setup: `8` bars, `8` note groups per bar, `64` note groups per sample
-- `approach_baseline` strict valid samples: `3/3`
-- `swing_motif_approach` strict valid samples: `3/3`
-- `approach_baseline` average syncopated onset ratio: `0.500`
-- `swing_motif_approach` average syncopated onset ratio: `0.750`
-- `approach_baseline` average unique bar-position pattern ratio: `0.125`
-- `swing_motif_approach` average unique bar-position pattern ratio: `0.500`
-- `approach_baseline` average most-common duration ratio: `0.552`
-- `swing_motif_approach` average most-common duration ratio: `0.380`
-- `approach_baseline` average most-common IOI ratio: `0.508`
-- `swing_motif_approach` average most-common IOI ratio: `0.476`
+- source report: `outputs/stage_b_reference_stats/harness_stage_b_reference_stats/reference_stats_report.json`
+- setup: `./midi_dataset/midi/studio`, max files `4`, `8`-bar windows, stride `4`, min notes `16`
+- analyzed real phrase windows: `57`
+- reference syncopated onset ratio mean: `0.736`
+- reference unique bar-position pattern ratio mean: `0.996`
+- reference duration diversity ratio mean: `0.379`
+- reference most-common duration ratio mean: `0.260`
+- reference IOI diversity ratio mean: `0.341`
+- reference most-common IOI ratio mean: `0.339`
+- Issue #59 `swing_motif_approach` syncopation is close to reference mean: delta `+0.014`
+- Issue #59 `swing_motif_approach` bar-pattern variation is still far below reference: delta `-0.496`
+- Issue #59 `swing_motif_approach` duration and IOI diversity are still far below reference: deltas around `-0.307` and `-0.278`
 
 Decision:
 
-- direct MIDI inspection상 baseline은 bar별 position template과 IOI가 거의 반복된다.
-- `swing_motif_approach`는 syncopation과 bar-to-bar rhythm variation을 올렸다.
-- 이것은 "재즈가 됐다"가 아니라 "mechanical rhythm-grid 문제를 줄였다"는 결과다.
-- 현재 병목은 MIDI validity보다 jazz vocabulary, motif development, phrase ending이다.
+- `swing_motif_approach`는 baseline보다 좋아졌지만, 실제 jazz phrase window의 다양성에는 아직 못 미친다.
+- 특히 bar-to-bar position pattern, duration diversity, IOI diversity가 부족하다.
+- 다음은 hand-written rule을 더 늘리는 것보다 real window에서 motif/rhythm template을 뽑는 방향이 맞다.
 
 Detail:
 
@@ -91,6 +82,7 @@ Detail:
 - `docs/STAGE_B_PITCH_MODE_COMPARE_2026-05-21.md`
 - `docs/STAGE_B_8BAR_APPROACH_PHRASE_2026-05-21.md`
 - `docs/STAGE_B_SWING_MOTIF_PHRASE_2026-05-21.md`
+- `docs/STAGE_B_REFERENCE_PHRASE_STATS_2026-05-21.md`
 
 ## Active Issue #14
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,6 +70,8 @@
   - 8-bar `tones`/`tones_tensions`/`approach_tensions` 비교와 beginner-like melodic exercise 상태 진단.
 - `STAGE_B_SWING_MOTIF_PHRASE_2026-05-21.md`
   - 8-bar `approach_tensions` 위에 swing/motif position-duration grammar를 얹어 기계적인 rhythm-grid 반복을 줄인 결과.
+- `STAGE_B_REFERENCE_PHRASE_STATS_2026-05-21.md`
+  - 실제 Stage B jazz MIDI phrase window 통계를 만들어 generated rhythm/motif 후보와 비교한 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -96,7 +98,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, and swing/motif phrase grammar probe를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, and real phrase reference statistics를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_REFERENCE_PHRASE_STATS_2026-05-21.md
+++ b/docs/STAGE_B_REFERENCE_PHRASE_STATS_2026-05-21.md
@@ -1,0 +1,158 @@
+# Stage B Reference Phrase Statistics
+
+작성일: 2026-05-21
+
+## Context
+
+Issue #59 improved the generated MIDI rhythm grammar:
+
+- baseline approach grammar repeated a mechanical position/IOI template.
+- `swing_motif_approach` increased syncopation and bar-to-bar position variation.
+
+But this was still a hand-written rule.
+
+The next question is:
+
+> Is the generated phrase rhythm actually close to real jazz MIDI phrase windows, or just less bad than the previous baseline?
+
+Issue #61 builds a reference statistics report from real Stage B phrase windows.
+
+## Goal
+
+The goal is not to train a broader model yet.
+
+Goal:
+
+- prepare real jazz MIDI phrase windows with Stage B tokenization
+- compute phrase-level reference statistics
+- compare generated phrase grammar outputs against those reference means
+- use data-derived numbers before adding more hand-written rules
+
+## Implementation
+
+Added:
+
+- `scripts/run_stage_b_reference_stats.py`
+- `tests/test_stage_b_reference_stats.py`
+- `bash scripts/agent_harness.sh stage-b-reference-stats`
+
+The script:
+
+1. runs `prepare_role_dataset.py` with `sequence_format=stage_b_v1`
+2. extracts 8-bar phrase windows
+3. reads tokenized `.npy` records
+4. computes reference metrics from real MIDI windows
+5. optionally compares generated reports against the reference mean
+
+Tracked reference metrics:
+
+- `note_group_count`
+- `unique_pitch_count`
+- `pitch_span`
+- `repeated_pitch_ratio`
+- `syncopated_onset_ratio`
+- `unique_bar_position_pattern_ratio`
+- `duration_diversity_ratio`
+- `most_common_duration_ratio`
+- `ioi_diversity_ratio`
+- `most_common_ioi_ratio`
+- `direction_change_ratio`
+- `stepwise_motion_ratio`
+- `leap_motion_ratio`
+- `onset_coverage_ratio`
+- `sustained_coverage_ratio`
+
+## Local Result
+
+Command:
+
+```bash
+bash scripts/agent_harness.sh stage-b-reference-stats
+```
+
+Report:
+
+```text
+outputs/stage_b_reference_stats/harness_stage_b_reference_stats/reference_stats_report.json
+outputs/stage_b_reference_stats/harness_stage_b_reference_stats/reference_stats_report.md
+```
+
+Setup:
+
+- input dir: `./midi_dataset/midi/studio`
+- max files: `4`
+- window bars: `8`
+- stride bars: `4`
+- min target notes: `16`
+- analyzed records: `57`
+
+Reference summary:
+
+| metric | mean | p50 |
+|---|---:|---:|
+| `note_group_count` | 32.649 | 27.000 |
+| `unique_pitch_count` | 11.000 | 10.000 |
+| `pitch_span` | 19.825 | 14.000 |
+| `repeated_pitch_ratio` | 0.642 | 0.647 |
+| `syncopated_onset_ratio` | 0.736 | 0.750 |
+| `unique_bar_position_pattern_ratio` | 0.996 | 1.000 |
+| `duration_diversity_ratio` | 0.379 | 0.364 |
+| `most_common_duration_ratio` | 0.260 | 0.250 |
+| `ioi_diversity_ratio` | 0.341 | 0.346 |
+| `most_common_ioi_ratio` | 0.339 | 0.333 |
+| `direction_change_ratio` | 0.644 | 0.667 |
+| `stepwise_motion_ratio` | 0.346 | 0.375 |
+| `leap_motion_ratio` | 0.348 | 0.318 |
+| `onset_coverage_ratio` | 0.189 | 0.156 |
+| `sustained_coverage_ratio` | 0.711 | 0.750 |
+
+Generated comparison against Issue #59:
+
+| grammar | sync delta | bar-var delta | dur-var delta | dur-rep delta | ioi-var delta | ioi-rep delta |
+|---|---:|---:|---:|---:|---:|---:|
+| `approach_baseline` | -0.236 | -0.871 | -0.286 | +0.292 | -0.309 | +0.169 |
+| `swing_motif_approach` | +0.014 | -0.496 | -0.307 | +0.120 | -0.278 | +0.137 |
+
+## Interpretation
+
+This gives a clearer answer than manual guesswork.
+
+What improved:
+
+- `swing_motif_approach` syncopation is near the reference mean.
+- `swing_motif_approach` reduced duration repetition compared with baseline.
+- generated MIDI is no longer one-note/two-note/chord-block failure.
+
+What is still weak:
+
+- real MIDI windows almost never repeat the same bar-position pattern.
+- generated bar-position pattern variation is still far below reference.
+- generated duration diversity is far below reference.
+- generated IOI diversity is far below reference.
+- generated most-common duration/IOI ratios are still too high.
+
+Current diagnosis:
+
+> The next problem is not simply "add more swing." The generated phrase needs more data-like rhythmic/motif variation across bars.
+
+## Decision
+
+Do not move to broad training only because Issue #59 sounds better than baseline.
+
+Next useful options:
+
+1. derive rhythm/motif templates from real Stage B windows instead of hand-writing them
+2. add phrase-ending/cadence constraints and compare against reference windows
+3. add motif-level pitch cells with interval movement statistics
+
+Recommended next issue:
+
+> Stage B data-derived phrase motif template extraction.
+
+## Validation
+
+```bash
+./.venv/bin/python -m unittest tests.test_stage_b_reference_stats
+./.venv/bin/python -m compileall scripts/run_stage_b_reference_stats.py tests/test_stage_b_reference_stats.py scripts/agent_harness.sh
+bash scripts/agent_harness.sh stage-b-reference-stats
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -58,6 +58,8 @@ Modes:
                 Compare 8-bar tones/tensions/approach Stage B phrase candidates.
   stage-b-swing-motif-phrase
                 Compare 8-bar baseline approach with swing/motif phrase grammar.
+  stage-b-reference-stats
+                Build real Stage B phrase-window reference statistics.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   all           Run demo and tiny-compare.
@@ -99,6 +101,7 @@ run_quick() {
     scripts/run_stage_b_coverage_ab_sweep.py \
     scripts/run_stage_b_pitch_mode_compare.py \
     scripts/run_stage_b_phrase_grammar_compare.py \
+    scripts/run_stage_b_reference_stats.py \
     scripts/rank_stage_b_candidates.py \
     scripts/audit_brad_mehldau_dataset.py \
     scripts/audit_jazz_piano_dataset.py \
@@ -608,6 +611,20 @@ run_stage_b_swing_motif_phrase() {
     --lora_alpha 8
 }
 
+run_stage_b_reference_stats() {
+  local run_id="${RUN_ID:-harness_stage_b_reference_stats}"
+  print_header "Stage B reference phrase statistics"
+  "$PYTHON_BIN" scripts/run_stage_b_reference_stats.py \
+    --run_id "$run_id" \
+    --input_dir ./midi_dataset/midi/studio \
+    --max_files 4 \
+    --window_bars 8 \
+    --window_stride_bars 4 \
+    --min_window_target_notes 16 \
+    --max_records 64 \
+    --generated_report outputs/stage_b_phrase_grammar_compare/harness_stage_b_swing_motif_phrase/phrase_grammar_compare_report.json
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -682,6 +699,9 @@ case "$MODE" in
     ;;
   stage-b-swing-motif-phrase)
     run_stage_b_swing_motif_phrase
+    ;;
+  stage-b-reference-stats)
+    run_stage_b_reference_stats
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/run_stage_b_reference_stats.py
+++ b/scripts/run_stage_b_reference_stats.py
@@ -1,0 +1,329 @@
+"""Build reference phrase statistics from real Stage B MIDI windows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from statistics import mean
+from typing import Any, Iterable
+
+import numpy as np
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.run_stage_b_generation_probe import (  # noqa: E402
+    analyze_stage_b_collapse,
+    analyze_stage_b_phrase_contour,
+    analyze_stage_b_rhythm_profile,
+    analyze_stage_b_temporal_coverage,
+    extract_stage_b_note_groups,
+)
+
+
+REFERENCE_METRIC_KEYS = [
+    "note_group_count",
+    "unique_pitch_count",
+    "pitch_span",
+    "repeated_pitch_ratio",
+    "syncopated_onset_ratio",
+    "unique_bar_position_pattern_ratio",
+    "duration_diversity_ratio",
+    "most_common_duration_ratio",
+    "ioi_diversity_ratio",
+    "most_common_ioi_ratio",
+    "direction_change_ratio",
+    "stepwise_motion_ratio",
+    "leap_motion_ratio",
+    "onset_coverage_ratio",
+    "sustained_coverage_ratio",
+]
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_command(cmd: list[str]) -> dict[str, Any]:
+    completed = subprocess.run(cmd, cwd=ROOT_DIR, text=True, capture_output=True, check=False)
+    return {
+        "cmd": cmd,
+        "returncode": int(completed.returncode),
+        "stdout_tail": completed.stdout[-4000:],
+        "stderr_tail": completed.stderr[-4000:],
+    }
+
+
+def run_prepare_command(args: argparse.Namespace, output_dir: Path) -> dict[str, Any]:
+    cmd = [
+        sys.executable,
+        "scripts/prepare_role_dataset.py",
+        "--input_dir",
+        str(args.input_dir),
+        "--output_dir",
+        str(output_dir),
+        "--role",
+        str(args.role),
+        "--sequence_format",
+        "stage_b_v1",
+        "--stage_b_window_bars",
+        str(args.window_bars),
+        "--stage_b_window_stride_bars",
+        str(args.window_stride_bars),
+        "--stage_b_min_window_target_notes",
+        str(args.min_window_target_notes),
+        "--overwrite",
+    ]
+    if args.max_files is not None:
+        cmd.extend(["--max_files", str(args.max_files)])
+    return run_command(cmd)
+
+
+def percentile(values: list[float], ratio: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(float(value) for value in values)
+    index = min(len(ordered) - 1, max(0, int(round((len(ordered) - 1) * float(ratio)))))
+    return float(ordered[index])
+
+
+def compact_metric_stats(values: Iterable[float]) -> dict[str, float]:
+    vals = [float(value) for value in values]
+    if not vals:
+        return {"count": 0.0, "mean": 0.0, "min": 0.0, "p25": 0.0, "p50": 0.0, "p75": 0.0, "max": 0.0}
+    return {
+        "count": float(len(vals)),
+        "mean": float(mean(vals)),
+        "min": float(min(vals)),
+        "p25": percentile(vals, 0.25),
+        "p50": percentile(vals, 0.50),
+        "p75": percentile(vals, 0.75),
+        "max": float(max(vals)),
+    }
+
+
+def analyze_token_record(tokens: list[int], bars: int) -> dict[str, Any]:
+    groups = extract_stage_b_note_groups(tokens, primer_size=0)
+    collapse = analyze_stage_b_collapse(tokens, primer_size=0)
+    rhythm = analyze_stage_b_rhythm_profile(tokens, primer_size=0)
+    contour = analyze_stage_b_phrase_contour(tokens, primer_size=0)
+    temporal = analyze_stage_b_temporal_coverage(tokens, primer_size=0, bars=bars)
+    pitches = [int(group["pitch"]) for group in groups]
+
+    metrics = {
+        "note_group_count": float(len(groups)),
+        "unique_pitch_count": float(len(set(pitches))),
+        "pitch_span": float(max(pitches) - min(pitches)) if pitches else 0.0,
+        "repeated_pitch_ratio": float(collapse.get("repeated_pitch_ratio", 0.0) or 0.0),
+        "syncopated_onset_ratio": float(rhythm.get("syncopated_onset_ratio", 0.0) or 0.0),
+        "unique_bar_position_pattern_ratio": float(
+            rhythm.get("unique_bar_position_pattern_ratio", 0.0) or 0.0
+        ),
+        "duration_diversity_ratio": float(rhythm.get("duration_diversity_ratio", 0.0) or 0.0),
+        "most_common_duration_ratio": float(rhythm.get("most_common_duration_ratio", 0.0) or 0.0),
+        "ioi_diversity_ratio": float(rhythm.get("ioi_diversity_ratio", 0.0) or 0.0),
+        "most_common_ioi_ratio": float(rhythm.get("most_common_ioi_ratio", 0.0) or 0.0),
+        "direction_change_ratio": float(contour.get("direction_change_ratio", 0.0) or 0.0),
+        "stepwise_motion_ratio": float(contour.get("stepwise_motion_ratio", 0.0) or 0.0),
+        "leap_motion_ratio": float(contour.get("leap_motion_ratio", 0.0) or 0.0),
+        "onset_coverage_ratio": float(temporal.get("onset_coverage_ratio", 0.0) or 0.0),
+        "sustained_coverage_ratio": float(temporal.get("sustained_coverage_ratio", 0.0) or 0.0),
+    }
+    return {
+        "metrics": metrics,
+        "rhythm_profile": rhythm,
+        "phrase_contour": contour,
+        "temporal_coverage": temporal,
+        "collapse": collapse,
+    }
+
+
+def iter_token_files(tokenized_dir: Path) -> list[Path]:
+    return sorted(tokenized_dir.glob("*/*.npy"))
+
+
+def build_reference_rows(tokenized_dir: Path, bars: int, max_records: int | None = None) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for index, path in enumerate(iter_token_files(tokenized_dir), start=1):
+        if max_records is not None and len(rows) >= int(max_records):
+            break
+        tokens = [int(token) for token in np.load(path).tolist()]
+        if not tokens:
+            continue
+        analysis = analyze_token_record(tokens, bars=bars)
+        rows.append(
+            {
+                "record_index": int(index),
+                "relative_path": str(path.relative_to(tokenized_dir)),
+                **analysis,
+            }
+        )
+    return rows
+
+
+def summarize_reference_rows(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "record_count": int(len(rows)),
+        "metric_keys": REFERENCE_METRIC_KEYS,
+        "metrics": {
+            key: compact_metric_stats(
+                row.get("metrics", {})[key]
+                for row in rows
+                if key in row.get("metrics", {})
+            )
+            for key in REFERENCE_METRIC_KEYS
+        },
+    }
+
+
+def generated_rows_from_report(report: dict[str, Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for row in report.get("rows", []):
+        rows.append(
+            {
+                "label": str(row.get("grammar_mode") or row.get("run_id") or "generated"),
+                "metrics": {
+                    "syncopated_onset_ratio": float(row.get("avg_syncopated_onset_ratio", 0.0) or 0.0),
+                    "unique_bar_position_pattern_ratio": float(
+                        row.get("avg_unique_bar_position_pattern_ratio", 0.0) or 0.0
+                    ),
+                    "duration_diversity_ratio": float(row.get("avg_duration_diversity_ratio", 0.0) or 0.0),
+                    "most_common_duration_ratio": float(row.get("avg_most_common_duration_ratio", 0.0) or 0.0),
+                    "ioi_diversity_ratio": float(row.get("avg_ioi_diversity_ratio", 0.0) or 0.0),
+                    "most_common_ioi_ratio": float(row.get("avg_most_common_ioi_ratio", 0.0) or 0.0),
+                },
+            }
+        )
+    return rows
+
+
+def compare_generated_to_reference(
+    generated_rows: list[dict[str, Any]],
+    reference_summary: dict[str, Any],
+) -> list[dict[str, Any]]:
+    reference_metrics = reference_summary.get("metrics", {})
+    comparisons: list[dict[str, Any]] = []
+    for row in generated_rows:
+        metrics = row.get("metrics", {})
+        deltas: dict[str, float] = {}
+        for key, value in metrics.items():
+            if key not in reference_metrics:
+                continue
+            reference_mean = float(reference_metrics[key].get("mean", 0.0) or 0.0)
+            deltas[key] = float(value) - reference_mean
+        comparisons.append({"label": row.get("label"), "metrics": metrics, "delta_from_reference_mean": deltas})
+    return comparisons
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["reference_summary"]
+    lines = [
+        "# Stage B Reference Phrase Statistics",
+        "",
+        f"- record count: `{summary['record_count']}`",
+        f"- input dir: `{report.get('input_dir')}`",
+        f"- tokenized dir: `{report.get('tokenized_dir')}`",
+        "",
+        "| metric | mean | p25 | p50 | p75 | min | max |",
+        "|---|---:|---:|---:|---:|---:|---:|",
+    ]
+    for key in REFERENCE_METRIC_KEYS:
+        stats = summary["metrics"][key]
+        lines.append(
+            "| {key} | {mean:.3f} | {p25:.3f} | {p50:.3f} | {p75:.3f} | {min:.3f} | {max:.3f} |".format(
+                key=key,
+                **stats,
+            )
+        )
+    if report.get("generated_comparison"):
+        lines.extend(["", "## Generated Comparison", ""])
+        for row in report["generated_comparison"]:
+            lines.append(f"### {row['label']}")
+            for key, delta in row["delta_from_reference_mean"].items():
+                lines.append(f"- `{key}` delta from reference mean: `{delta:.3f}`")
+            lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run Stage B real phrase reference statistics")
+    parser.add_argument("--input_dir", type=str, default="./midi_dataset/midi/studio")
+    parser.add_argument("--output_root", type=str, default=str(ROOT_DIR / "outputs" / "stage_b_reference_stats"))
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--role", type=str, default="lead")
+    parser.add_argument("--max_files", type=int, default=4)
+    parser.add_argument("--window_bars", type=int, default=8)
+    parser.add_argument("--window_stride_bars", type=int, default=4)
+    parser.add_argument("--min_window_target_notes", type=int, default=16)
+    parser.add_argument("--max_records", type=int, default=64)
+    parser.add_argument("--skip_prepare", action="store_true")
+    parser.add_argument("--tokenized_dir", type=str, default=None)
+    parser.add_argument("--generated_report", type=str, default=None)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now().strftime("%Y%m%d_%H%M%S")
+    run_dir = Path(args.output_root) / run_id
+    roles_dir = run_dir / "roles"
+    tokenized_dir = Path(args.tokenized_dir) if args.tokenized_dir else roles_dir / args.role / "tokenized"
+
+    report: dict[str, Any] = {
+        "run_id": run_id,
+        "run_dir": str(run_dir),
+        "input_dir": str(args.input_dir),
+        "tokenized_dir": str(tokenized_dir),
+        "window_bars": int(args.window_bars),
+        "window_stride_bars": int(args.window_stride_bars),
+        "min_window_target_notes": int(args.min_window_target_notes),
+        "max_files": args.max_files,
+        "max_records": args.max_records,
+    }
+
+    if not args.skip_prepare:
+        prepare_result = run_prepare_command(args, roles_dir)
+        report["prepare_result"] = prepare_result
+        if prepare_result["returncode"] != 0:
+            write_json(run_dir / "reference_stats_report.json", report)
+            print(json.dumps(report, ensure_ascii=True, indent=2))
+            return int(prepare_result["returncode"])
+
+    rows = build_reference_rows(tokenized_dir, bars=int(args.window_bars), max_records=args.max_records)
+    report["reference_rows_head"] = rows[:8]
+    report["reference_summary"] = summarize_reference_rows(rows)
+    if not rows:
+        report["failure_reason"] = "No Stage B tokenized records available for reference statistics"
+        write_json(run_dir / "reference_stats_report.json", report)
+        print(json.dumps(report, ensure_ascii=True, indent=2))
+        return 2
+
+    if args.generated_report:
+        generated_report_path = Path(args.generated_report)
+        if generated_report_path.exists():
+            generated_rows = generated_rows_from_report(read_json(generated_report_path))
+            report["generated_report"] = str(generated_report_path)
+            report["generated_comparison"] = compare_generated_to_reference(
+                generated_rows,
+                report["reference_summary"],
+            )
+        else:
+            report["generated_report_warning"] = f"missing generated report: {generated_report_path}"
+
+    write_json(run_dir / "reference_stats_report.json", report)
+    (run_dir / "reference_stats_report.md").write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps(report["reference_summary"], ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_reference_stats.py
+++ b/tests/test_stage_b_reference_stats.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.run_stage_b_reference_stats import (
+    analyze_token_record,
+    compare_generated_to_reference,
+    generated_rows_from_report,
+    summarize_reference_rows,
+)
+from scripts.stage_b_tokens import (
+    TOKEN_END,
+    chord_tokens,
+    note_duration_token,
+    note_pitch_token,
+    note_velocity_token,
+    position_token,
+)
+
+
+def token_phrase() -> list[int]:
+    return [
+        *chord_tokens("Cmaj7"),
+        position_token(0),
+        note_velocity_token(4),
+        note_pitch_token(60),
+        note_duration_token(2),
+        position_token(3),
+        note_velocity_token(4),
+        note_pitch_token(62),
+        note_duration_token(1),
+        position_token(7),
+        note_velocity_token(4),
+        note_pitch_token(65),
+        note_duration_token(3),
+        position_token(11),
+        note_velocity_token(4),
+        note_pitch_token(64),
+        note_duration_token(1),
+        TOKEN_END,
+    ]
+
+
+class StageBReferenceStatsTest(unittest.TestCase):
+    def test_analyze_token_record_reports_phrase_metrics(self) -> None:
+        report = analyze_token_record(token_phrase(), bars=1)
+
+        self.assertEqual(report["metrics"]["note_group_count"], 4.0)
+        self.assertEqual(report["metrics"]["unique_pitch_count"], 4.0)
+        self.assertGreater(report["metrics"]["syncopated_onset_ratio"], 0.5)
+        self.assertGreater(report["metrics"]["direction_change_ratio"], 0.0)
+
+    def test_summarize_reference_rows_builds_distribution(self) -> None:
+        rows = [
+            {"metrics": {"note_group_count": 4.0, "syncopated_onset_ratio": 0.5}},
+            {"metrics": {"note_group_count": 8.0, "syncopated_onset_ratio": 0.75}},
+        ]
+
+        summary = summarize_reference_rows(rows)
+
+        self.assertEqual(summary["record_count"], 2)
+        self.assertAlmostEqual(summary["metrics"]["note_group_count"]["mean"], 6.0)
+        self.assertAlmostEqual(summary["metrics"]["syncopated_onset_ratio"]["mean"], 0.625)
+
+    def test_generated_rows_from_report_maps_comparable_rhythm_fields(self) -> None:
+        generated = generated_rows_from_report(
+            {
+                "rows": [
+                    {
+                        "grammar_mode": "swing_motif_approach",
+                        "avg_syncopated_onset_ratio": 0.75,
+                        "avg_unique_bar_position_pattern_ratio": 0.5,
+                        "avg_most_common_ioi_ratio": 0.47,
+                    }
+                ]
+            }
+        )
+
+        self.assertEqual(generated[0]["label"], "swing_motif_approach")
+        self.assertAlmostEqual(generated[0]["metrics"]["syncopated_onset_ratio"], 0.75)
+
+    def test_compare_generated_to_reference_reports_deltas(self) -> None:
+        comparisons = compare_generated_to_reference(
+            [{"label": "generated", "metrics": {"syncopated_onset_ratio": 0.75}}],
+            {"metrics": {"syncopated_onset_ratio": {"mean": 0.55}}},
+        )
+
+        self.assertAlmostEqual(
+            comparisons[0]["delta_from_reference_mean"]["syncopated_onset_ratio"],
+            0.20,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

- 실제 jazz MIDI Stage B 8-bar phrase window에서 reference statistics를 계산하는 runner를 추가했습니다.
- rhythm, contour, pitch span, coverage 지표를 real window 기준선으로 집계합니다.
- Issue #59 generated phrase grammar report와 comparable rhythm metric을 대조할 수 있게 했습니다.
- 결과와 다음 판단 기준을 docs/STAGE_B_REFERENCE_PHRASE_STATS_2026-05-21.md 및 core plan 문서에 기록했습니다.

## 결과

- real phrase windows: 57개
- reference syncopated onset ratio mean: 0.736
- reference unique bar-position pattern ratio mean: 0.996
- reference duration diversity ratio mean: 0.379
- reference IOI diversity ratio mean: 0.341
- Issue #59 swing_motif_approach는 syncopation은 reference에 가깝지만, bar-position variation과 duration/IOI diversity는 아직 크게 부족합니다.

## 해석

이 결과는 hand-written swing rule을 더 늘리기보다 real window에서 data-derived motif/rhythm template을 추출해야 한다는 근거입니다. 아직 broad training으로 넘어갈 단계는 아닙니다.

## 검증

- ./.venv/bin/python -m unittest tests.test_stage_b_reference_stats
- ./.venv/bin/python -m compileall scripts/run_stage_b_reference_stats.py tests/test_stage_b_reference_stats.py
- bash scripts/agent_harness.sh quick
- bash scripts/agent_harness.sh stage-b-reference-stats
- git diff --check

Closes #61