### PR TITLE
Stage B 실제 phrase motif template 추출 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #61: Stage B real jazz phrase reference statistics.
+- Issue #63: Stage B data-derived phrase motif template extraction.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -176,6 +176,12 @@ For Stage B real phrase reference statistics changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-reference-stats
+```
+
+For Stage B data-derived motif template extraction changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-motif-templates
 ```
 
 For Stage B collapse/sampling-sweep changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -133,6 +133,7 @@ Stage B에서 명시하는 것:
 27. Stage B 8-bar approach phrase probe
 28. Stage B swing/motif phrase grammar probe
 29. Stage B real phrase reference statistics
+30. Stage B data-derived motif template extraction
 
 가장 최근 의미 있는 결과:
 
@@ -166,7 +167,7 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-다음 단계는 manual listening/piano-roll review다. 이제 우선순위 review 대상은 짧은 2-bar package가 아니라 `outputs/stage_b_review_candidates/harness_stage_b_longer_phrase_probe/midi/`의 4-bar candidates다. 이 후보가 귀로도 solo-line phrase sketch라면 generic jazz base 후보 학습 설계로 넘어가고, 아니면 phrase/motif-level constraint 또는 pretrained symbolic base를 먼저 검토한다.
+이제 다음 단계는 data-derived motif catalog를 generation-side constraint로 연결하는 것이다. Manual review에서 8-bar 후보는 이전보다 나아졌지만 아직 초급 다이아토닉 코드톤 나열처럼 들렸고, Issue #61 reference stats에서도 hand-written rhythm diversity가 부족하다고 나왔다. 따라서 generic jazz base 학습 전에 real phrase motif distribution을 사용한 baseline을 먼저 비교한다.
 
 ## 6. 다음 단계 로드맵
 
@@ -338,6 +339,8 @@ Stage B에서 명시하는 것:
 - Issue #59 result: unique bar-position pattern ratio는 `0.125`에서 `0.500`으로 올랐고, most-common duration ratio는 `0.552`에서 `0.380`으로 낮아졌다.
 - Issue #61 result: real jazz phrase windows `57`개 기준 syncopation mean은 `0.736`, unique bar-position pattern mean은 `0.996`, duration diversity mean은 `0.379`, IOI diversity mean은 `0.341`이다.
 - Issue #61 result: `swing_motif_approach`는 syncopation은 reference에 가까우나 bar-position variation, duration diversity, IOI diversity가 아직 크게 부족하다.
+- Issue #63 result: real Stage B windows에서 `803`개 strictly-increasing solo-line motif를 추출했고, rhythm templates `520`, contour templates `328`, full templates `526`개를 만들었다.
+- Issue #63 result: top rhythm support는 `0.009`, top contour support는 `0.012`, top full motif support는 `0.002`라서 one best motif 복붙이 아니라 distribution sampling이 필요하다.
 
 해석:
 
@@ -346,7 +349,7 @@ Stage B에서 명시하는 것:
 - `tones_tensions`는 no-tension 문제를 줄였지만, 더 좋은 solo phrase라고 바로 판단할 단계는 아니다.
 - `approach_tensions`는 pitch-level resolution을 만들지만, 이 또한 jazz vocabulary 자체는 아니다.
 - `swing_motif_approach`는 기계적인 grid 반복을 줄였지만, 이 또한 jazz vocabulary 자체는 아니다.
-- real phrase reference stats 기준으로 보면 다음은 hand-written rhythm rule 확장이 아니라 data-derived motif/cadence control 쪽이 맞다.
+- real phrase reference stats와 motif extraction 기준으로 보면 다음은 hand-written rhythm rule 확장이 아니라 data-derived motif/cadence control 쪽이 맞다.
 
 ### Phase 3.10. Swing/Motif Phrase Grammar
 
@@ -406,6 +409,36 @@ Stage B에서 명시하는 것:
 - real window에서 rhythm/motif templates를 추출한다.
 - generated candidate가 reference p25-p75 범위 안에 들어오는 metric을 늘린다.
 - phrase ending/cadence도 reference 기반으로 비교한다.
+
+### Phase 3.12. Data-Derived Motif Template Extraction
+
+목표:
+
+- hand-written swing/motif rule을 더 늘리지 않는다.
+- real Stage B phrase windows에서 rhythm, contour, full motif templates를 추출한다.
+- chord-block 또는 same-onset voicing이 solo-line motif catalog를 오염시키지 않도록 기본 필터를 둔다.
+- 다음 generation probe가 data-derived rhythm/contour distribution을 사용할 수 있게 만든다.
+
+현재 결과:
+
+- completed: `scripts/run_stage_b_motif_template_extraction.py`를 추가했다.
+- completed: same-onset/non-increasing onset motif를 기본적으로 제외한다.
+- completed: `4`개 MIDI 파일에서 만든 Stage B 8-bar windows 기준 `803`개 motif를 추출했다.
+- latest result: source records `56`, rhythm templates `520`, contour templates `328`, full templates `526`.
+- latest result: top full motif support가 `0.002`라서 full motif를 그대로 복사하는 방식은 맞지 않다.
+
+해석:
+
+- 실제 jazz phrase material은 매우 분산되어 있다.
+- 다음 단계는 top motif 하나를 쓰는 것이 아니라 rhythm template과 contour template을 분리해서 sampling하는 것이다.
+- 이 단계는 생성 품질을 바로 올리는 작업이 아니라, beginner-like hand-written line에서 data-derived phrase material로 넘어가는 준비다.
+
+다음 통과 기준:
+
+- data-derived motif catalog를 constrained generation의 position/duration/contour 후보로 연결한다.
+- generated candidate의 duration diversity와 IOI diversity가 Issue #59보다 좋아지는지 본다.
+- reference p25-p75 범위에 가까워지는 metric을 늘린다.
+- piano roll에서 chord-tone 나열이 아니라 phrase contour로 들리는지 review export로 확인한다.
 
 ### Phase 4. Generic Jazz Base 후보 학습
 
@@ -500,35 +533,24 @@ Stage B에서 명시하는 것:
 
 완료된 바로 전 작업:
 
-- `Stage B temporal coverage diagnostics 추가`
-- 결과: 2-file Brad Stage B window dataset은 `137` samples, train `123`, val `14`로 정상 생성됐다.
-- 결과: generated samples는 grammar gate `3/3`, collapse warning `0/3`이었다.
-- 결과: basic valid `0/3`, strict valid `0/3`이었다.
-- 결과: avg onset coverage `0.167`, avg sustained coverage `0.417`, max longest sustained empty run `11` steps였다.
-- 결론: Stage B grammar와 collapse는 2-file probe에서 즉시 병목이 아니며, 현재 병목은 sparse onset과 long empty span으로 인한 dead-air/temporal coverage다.
-
-완료된 바로 전 작업:
-
 ```text
-Stage B chord-aware pitch constrained generation 추가
+Stage B data-derived motif template extraction 추가
 ```
 
-작업 범위:
+결과:
 
-- constrained generation에서 pitch 후보군을 현재 bar chord에 맞게 제한하거나 가중한다.
-- chord tones와 허용 tension을 구분한다.
-- dominant pitch repetition과 low pitch variety를 동시에 줄인다.
-- temporal coverage는 유지하면서 bar-level chord-tone ratio가 개선되는지 비교한다.
-- 과한 postprocess로 모델 성공처럼 보이게 만들지 않는다.
+- real Stage B phrase windows에서 `803`개 solo-line motif를 추출했다.
+- rhythm templates `520`, contour templates `328`, full templates `526`개를 만들었다.
+- top full motif support가 `0.002`라서 하나의 motif를 복사하는 방식은 맞지 않다.
+- same-onset chord/block motif는 기본 필터로 제외했다.
 
-이 작업이 끝난 뒤 판단:
+다음 작업:
 
-- chord-aware pitch probe에서 viable unflagged candidate가 `9`개 나왔다.
-- 바로 broad training으로 가지 않고 top `coverage_chord` MIDI를 귀와 piano roll로 리뷰했다.
-- 2-bar 후보는 melodic fragment일 수는 있어도 너무 짧고 미완성처럼 느껴졌다.
-- 그래서 다음 작업은 4-bar longer phrase probe로 잡았다.
-- 리뷰가 괜찮으면 generic jazz base 후보 학습 설계로 넘어간다.
-- 리뷰가 여전히 기계적이면 rhythm/motif-level constraint 또는 pretrained symbolic base를 먼저 검토한다.
+- extracted rhythm templates를 position/duration 후보로 연결한다.
+- extracted contour templates를 pitch interval 후보로 연결한다.
+- current chord/tension pitch set 위에 contour를 transpose한다.
+- `swing_motif_approach`와 data-derived motif baseline을 같은 8-bar 조건에서 비교한다.
+- duration diversity, IOI diversity, bar-position variation이 reference range에 가까워지는지 본다.
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-61-stage-b-reference-phrase-stats`
+- `issue-63-stage-b-motif-template-extraction`
 
 현재 범위가 아닌 것:
 
@@ -36,39 +36,38 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 ## Latest Probe Result
 
-Issue #61은 Issue #59의 swing/motif grammar가 실제 jazz MIDI phrase window 기준선과 얼마나 가까운지 검증한다.
+Issue #63은 Issue #61의 reference statistics 이후 단계다.
 
-Issue #59는 same 8-bar approach setup에서 position/duration rhythm pattern을 swing/motif template으로 바꿔 mechanical rhythm-grid 반복을 줄였다. 하지만 그 rule이 실제 jazz window 통계와 가까운지는 별도로 봐야 한다.
+Issue #61에서 hand-written `swing_motif_approach`는 syncopation은 실제 jazz window와 가까웠지만, bar-position variation, duration diversity, IOI diversity가 부족했다. 그래서 이번에는 rule을 더 쓰는 대신 실제 Stage B phrase window에서 motif templates를 추출한다.
 
 Implemented:
 
-- `scripts/run_stage_b_reference_stats.py`
-- `tests/test_stage_b_reference_stats.py`
-- `scripts/agent_harness.sh stage-b-reference-stats`
+- `scripts/run_stage_b_motif_template_extraction.py`
+- `tests/test_stage_b_motif_template_extraction.py`
+- `scripts/agent_harness.sh stage-b-motif-templates`
 - output files:
-  - `reference_stats_report.json`
-  - `reference_stats_report.md`
+  - `motif_template_report.json`
+  - `motif_template_report.md`
 
 Result:
 
-- source report: `outputs/stage_b_reference_stats/harness_stage_b_reference_stats/reference_stats_report.json`
+- source report: `outputs/stage_b_motif_templates/harness_stage_b_motif_templates/motif_template_report.json`
 - setup: `./midi_dataset/midi/studio`, max files `4`, `8`-bar windows, stride `4`, min notes `16`
-- analyzed real phrase windows: `57`
-- reference syncopated onset ratio mean: `0.736`
-- reference unique bar-position pattern ratio mean: `0.996`
-- reference duration diversity ratio mean: `0.379`
-- reference most-common duration ratio mean: `0.260`
-- reference IOI diversity ratio mean: `0.341`
-- reference most-common IOI ratio mean: `0.339`
-- Issue #59 `swing_motif_approach` syncopation is close to reference mean: delta `+0.014`
-- Issue #59 `swing_motif_approach` bar-pattern variation is still far below reference: delta `-0.496`
-- Issue #59 `swing_motif_approach` duration and IOI diversity are still far below reference: deltas around `-0.307` and `-0.278`
+- source records: `56`
+- motif count: `803`
+- unique rhythm templates: `520`
+- unique contour templates: `328`
+- unique full templates: `526`
+- top rhythm support: `0.009`
+- top contour support: `0.012`
+- top full support: `0.002`
+- default extraction filters same-onset motifs so chord blocks do not dominate solo-line material
 
 Decision:
 
-- `swing_motif_approach`는 baseline보다 좋아졌지만, 실제 jazz phrase window의 다양성에는 아직 못 미친다.
-- 특히 bar-to-bar position pattern, duration diversity, IOI diversity가 부족하다.
-- 다음은 hand-written rule을 더 늘리는 것보다 real window에서 motif/rhythm template을 뽑는 방향이 맞다.
+- 실제 phrase material은 매우 다양해서 top template 하나를 hardcode하면 안 된다.
+- 다음 generator는 data-derived rhythm/contour templates를 distribution으로 sampling해야 한다.
+- 이것은 생성기 자체가 아니라 다음 data-derived generation constraint를 만들기 위한 reference catalog다.
 
 Detail:
 
@@ -83,6 +82,7 @@ Detail:
 - `docs/STAGE_B_8BAR_APPROACH_PHRASE_2026-05-21.md`
 - `docs/STAGE_B_SWING_MOTIF_PHRASE_2026-05-21.md`
 - `docs/STAGE_B_REFERENCE_PHRASE_STATS_2026-05-21.md`
+- `docs/STAGE_B_MOTIF_TEMPLATE_EXTRACTION_2026-05-21.md`
 
 ## Active Issue #14
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,6 +72,8 @@
   - 8-bar `approach_tensions` 위에 swing/motif position-duration grammar를 얹어 기계적인 rhythm-grid 반복을 줄인 결과.
 - `STAGE_B_REFERENCE_PHRASE_STATS_2026-05-21.md`
   - 실제 Stage B jazz MIDI phrase window 통계를 만들어 generated rhythm/motif 후보와 비교한 결과.
+- `STAGE_B_MOTIF_TEMPLATE_EXTRACTION_2026-05-21.md`
+  - 실제 Stage B phrase window에서 rhythm/contour/full motif templates를 추출해 다음 data-derived generation constraint로 넘기기 위한 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -98,7 +100,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, and real phrase reference statistics를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, and motif template extraction을 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_MOTIF_TEMPLATE_EXTRACTION_2026-05-21.md
+++ b/docs/STAGE_B_MOTIF_TEMPLATE_EXTRACTION_2026-05-21.md
@@ -1,0 +1,136 @@
+# Stage B Motif Template Extraction
+
+작성일: 2026-05-21
+
+## 목적
+
+Issue #61에서 실제 jazz MIDI phrase window 통계를 만든 결과, hand-written `swing_motif_approach`는 syncopation은 reference에 가까워졌지만 bar-position variation, duration diversity, IOI diversity가 여전히 부족했다.
+
+이번 작업의 목적은 hand-written rhythm rule을 더 늘리는 것이 아니다.
+
+목표:
+
+- 실제 Stage B phrase window에서 짧은 note-group motif를 추출한다.
+- rhythm template, contour template, full motif template을 분리해서 집계한다.
+- 다음 generation probe가 data-derived phrase material을 사용할 수 있게 만든다.
+- chord-block 또는 same-onset voicing이 solo-line motif로 섞이지 않도록 기본 필터를 둔다.
+
+## 구현
+
+추가 파일:
+
+- `scripts/run_stage_b_motif_template_extraction.py`
+- `tests/test_stage_b_motif_template_extraction.py`
+
+하네스:
+
+```bash
+bash scripts/agent_harness.sh stage-b-motif-templates
+```
+
+출력:
+
+- `outputs/stage_b_motif_templates/<run_id>/motif_template_report.json`
+- `outputs/stage_b_motif_templates/<run_id>/motif_template_report.md`
+
+추출 단위:
+
+- Stage B tokenized record의 decoded note groups
+- 기본 motif length: `4`
+- 기본 max bar span: `2`
+- 기본 same-onset filter: enabled
+
+## Same-Onset Filter
+
+초기 extraction에서는 같은 position에 찍힌 note들이 top motif로 올라올 수 있었다.
+
+이것은 piano voicing 또는 chord block일 수 있고, 지금 목표인 solo-line phrase material과 다르다.
+
+따라서 기본 동작은 onset이 strictly increasing인 motif만 남긴다.
+
+진단 목적으로 chord/block motif까지 보고 싶을 때만 다음 옵션을 쓴다.
+
+```bash
+python scripts/run_stage_b_motif_template_extraction.py --allow_same_onset_motifs
+```
+
+## Local Result
+
+실행 조건:
+
+```bash
+bash scripts/agent_harness.sh stage-b-motif-templates
+```
+
+결과:
+
+- source records: `56`
+- motif count: `803`
+- unique rhythm templates: `520`
+- unique contour templates: `328`
+- unique full templates: `526`
+- top rhythm support: `0.009`
+- top contour support: `0.012`
+- top full support: `0.002`
+
+Top rhythm templates:
+
+| rank | count | support | template |
+|---:|---:|---:|---|
+| 1 | 7 | 0.009 | duration `[2, 2, 2, 2]`, position deltas `[0, 1, 2, 3]` |
+| 2 | 6 | 0.007 | duration `[1, 1, 1, 1]`, position deltas `[0, 1, 2, 3]` |
+| 3 | 2 | 0.002 | duration `[5, 6, 8, 3]`, position deltas `[0, 2, 3, 5]` |
+
+Top contour templates:
+
+| rank | count | support | template |
+|---:|---:|---:|---|
+| 1 | 10 | 0.012 | pitch intervals `[0, 0, -2, 0]`, melodic intervals `[0, -2, 2]` |
+| 2 | 9 | 0.011 | pitch intervals `[0, 0, 0, -9]`, melodic intervals `[0, 0, -9]` |
+| 3 | 9 | 0.011 | pitch intervals `[0, -2, 1, 0]`, melodic intervals `[-2, 3, -1]` |
+
+## 해석
+
+이 결과는 "가장 많이 나온 motif 하나를 가져다 쓰면 된다"는 뜻이 아니다.
+
+오히려 반대다.
+
+- top rhythm template support가 `0.009`라서 dominant rhythm template이 없다.
+- top full motif support가 `0.002`라서 full motif 단위 복붙은 위험하다.
+- rhythm, contour, pitch interval을 분리해서 sampling하거나 clustering해야 한다.
+- next generator는 one best motif가 아니라 reference distribution에서 후보를 뽑아야 한다.
+
+따라서 이번 작업의 가치는 생성 품질을 바로 올리는 데 있지 않다.
+
+가치는 다음과 같다.
+
+- "재즈스럽게 만들어라"를 수치화 가능한 motif catalog로 바꿨다.
+- hand-written beginner-like pattern에서 data-derived phrase material로 넘어갈 준비가 됐다.
+- chord-block/same-onset motif가 solo-line 후보를 오염시키는 문제를 기본 필터로 막았다.
+
+## 다음 작업
+
+다음 issue는 data-derived motif catalog를 generation-side constraint로 연결하는 것이다.
+
+구체적으로:
+
+- extracted rhythm template에서 position/duration 후보를 sampling한다.
+- extracted contour template에서 interval movement 후보를 sampling한다.
+- current chord/tension pitch set 위에 contour를 transpose한다.
+- generated candidate의 rhythm/duration/IOI diversity가 real reference p25-p75 범위에 가까워지는지 본다.
+- MIDI review export에서 hand-written `swing_motif_approach`와 data-derived motif baseline을 비교한다.
+
+성공 기준:
+
+- one-note/two-note/chord-block/long-sustain output이 아니다.
+- 8-bar phrase가 너무 짧거나 단어처럼 끊기지 않는다.
+- `swing_motif_approach`보다 duration diversity와 IOI diversity가 오른다.
+- piano roll에서 "코드톤 나열"보다 phrase contour가 더 분명하다.
+
+## Validation
+
+```bash
+./.venv/bin/python -m unittest tests.test_stage_b_motif_template_extraction
+./.venv/bin/python -m compileall scripts/run_stage_b_motif_template_extraction.py tests/test_stage_b_motif_template_extraction.py
+bash scripts/agent_harness.sh stage-b-motif-templates
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -60,6 +60,8 @@ Modes:
                 Compare 8-bar baseline approach with swing/motif phrase grammar.
   stage-b-reference-stats
                 Build real Stage B phrase-window reference statistics.
+  stage-b-motif-templates
+                Extract data-derived Stage B motif/rhythm templates.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   all           Run demo and tiny-compare.
@@ -102,6 +104,7 @@ run_quick() {
     scripts/run_stage_b_pitch_mode_compare.py \
     scripts/run_stage_b_phrase_grammar_compare.py \
     scripts/run_stage_b_reference_stats.py \
+    scripts/run_stage_b_motif_template_extraction.py \
     scripts/rank_stage_b_candidates.py \
     scripts/audit_brad_mehldau_dataset.py \
     scripts/audit_jazz_piano_dataset.py \
@@ -625,6 +628,22 @@ run_stage_b_reference_stats() {
     --generated_report outputs/stage_b_phrase_grammar_compare/harness_stage_b_swing_motif_phrase/phrase_grammar_compare_report.json
 }
 
+run_stage_b_motif_templates() {
+  local run_id="${RUN_ID:-harness_stage_b_motif_templates}"
+  print_header "Stage B motif template extraction"
+  "$PYTHON_BIN" scripts/run_stage_b_motif_template_extraction.py \
+    --run_id "$run_id" \
+    --input_dir ./midi_dataset/midi/studio \
+    --max_files 4 \
+    --window_bars 8 \
+    --window_stride_bars 4 \
+    --min_window_target_notes 16 \
+    --motif_length 4 \
+    --max_bar_span 2 \
+    --max_records 64 \
+    --top_n 20
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -702,6 +721,9 @@ case "$MODE" in
     ;;
   stage-b-reference-stats)
     run_stage_b_reference_stats
+    ;;
+  stage-b-motif-templates)
+    run_stage_b_motif_templates
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/run_stage_b_motif_template_extraction.py
+++ b/scripts/run_stage_b_motif_template_extraction.py
@@ -1,0 +1,406 @@
+"""Extract data-derived motif templates from real Stage B phrase windows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+import numpy as np
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.run_stage_b_generation_probe import extract_stage_b_note_groups  # noqa: E402
+from scripts.stage_b_tokens import POSITIONS_PER_BAR  # noqa: E402
+
+STRONG_POSITIONS = {0, 4, 8, 12}
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def run_command(cmd: list[str]) -> dict[str, Any]:
+    completed = subprocess.run(cmd, cwd=ROOT_DIR, text=True, capture_output=True, check=False)
+    return {
+        "cmd": cmd,
+        "returncode": int(completed.returncode),
+        "stdout_tail": completed.stdout[-4000:],
+        "stderr_tail": completed.stderr[-4000:],
+    }
+
+
+def run_prepare_command(args: argparse.Namespace, output_dir: Path) -> dict[str, Any]:
+    cmd = [
+        sys.executable,
+        "scripts/prepare_role_dataset.py",
+        "--input_dir",
+        str(args.input_dir),
+        "--output_dir",
+        str(output_dir),
+        "--role",
+        str(args.role),
+        "--sequence_format",
+        "stage_b_v1",
+        "--stage_b_window_bars",
+        str(args.window_bars),
+        "--stage_b_window_stride_bars",
+        str(args.window_stride_bars),
+        "--stage_b_min_window_target_notes",
+        str(args.min_window_target_notes),
+        "--overwrite",
+    ]
+    if args.max_files is not None:
+        cmd.extend(["--max_files", str(args.max_files)])
+    return run_command(cmd)
+
+
+def absolute_position(group: dict[str, int]) -> int:
+    return int(group["bar"]) * int(POSITIONS_PER_BAR) + int(group["position"])
+
+
+def _sign(value: int) -> int:
+    if value > 0:
+        return 1
+    if value < 0:
+        return -1
+    return 0
+
+
+def motif_from_groups(
+    groups: Sequence[dict[str, int]],
+    *,
+    source_record: str,
+    start_index: int,
+) -> dict[str, Any]:
+    abs_positions = [absolute_position(group) for group in groups]
+    pitches = [int(group["pitch"]) for group in groups]
+    durations = [int(group["duration_steps"]) for group in groups]
+    first_abs = abs_positions[0]
+    first_pitch = pitches[0]
+    position_deltas = [int(position - first_abs) for position in abs_positions]
+    ioi_steps = [int(abs_positions[index + 1] - abs_positions[index]) for index in range(len(abs_positions) - 1)]
+    pitch_intervals = [int(pitch - first_pitch) for pitch in pitches]
+    melodic_intervals = [int(pitches[index + 1] - pitches[index]) for index in range(len(pitches) - 1)]
+    interval_signs = [_sign(interval) for interval in melodic_intervals if interval != 0]
+    direction_changes = sum(1 for index in range(1, len(interval_signs)) if interval_signs[index] != interval_signs[index - 1])
+    start_bar = int(groups[0]["bar"])
+    end_bar = int(groups[-1]["bar"])
+    positions = [int(group["position"]) for group in groups]
+    syncopated_count = sum(1 for position in positions if position not in STRONG_POSITIONS)
+
+    return {
+        "source_record": source_record,
+        "start_index": int(start_index),
+        "length": int(len(groups)),
+        "start_bar": start_bar,
+        "start_position": int(groups[0]["position"]),
+        "bar_span": int(end_bar - start_bar + 1),
+        "position_deltas": position_deltas,
+        "ioi_steps": ioi_steps,
+        "duration_steps": durations,
+        "pitch_intervals": pitch_intervals,
+        "melodic_intervals": melodic_intervals,
+        "interval_signs": interval_signs,
+        "pitch_span": int(max(pitches) - min(pitches)) if pitches else 0,
+        "syncopated_onset_ratio": float(syncopated_count / len(groups)) if groups else 0.0,
+        "direction_change_ratio": float(direction_changes / max(1, len(interval_signs) - 1)) if interval_signs else 0.0,
+        "rhythm_key": {
+            "position_deltas": position_deltas,
+            "duration_steps": durations,
+        },
+        "contour_key": {
+            "pitch_intervals": pitch_intervals,
+            "melodic_intervals": melodic_intervals,
+        },
+        "full_key": {
+            "position_deltas": position_deltas,
+            "duration_steps": durations,
+            "pitch_intervals": pitch_intervals,
+        },
+    }
+
+
+def stable_key(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def extract_motif_templates_from_tokens(
+    tokens: Sequence[int],
+    *,
+    source_record: str,
+    motif_length: int,
+    max_bar_span: int,
+    require_strictly_increasing_onsets: bool = True,
+) -> list[dict[str, Any]]:
+    groups = sorted(
+        extract_stage_b_note_groups(tokens, primer_size=0),
+        key=lambda group: (int(group["bar"]), int(group["position"]), int(group["pitch"])),
+    )
+    length = max(2, int(motif_length))
+    motifs: list[dict[str, Any]] = []
+    if len(groups) < length:
+        return motifs
+    for start_index in range(0, len(groups) - length + 1):
+        segment = groups[start_index : start_index + length]
+        bar_span = int(segment[-1]["bar"]) - int(segment[0]["bar"]) + 1
+        if bar_span > int(max_bar_span):
+            continue
+        if require_strictly_increasing_onsets:
+            abs_positions = [absolute_position(group) for group in segment]
+            if any(abs_positions[index + 1] <= abs_positions[index] for index in range(len(abs_positions) - 1)):
+                continue
+        motifs.append(motif_from_groups(segment, source_record=source_record, start_index=start_index))
+    return motifs
+
+
+def iter_token_files(tokenized_dir: Path) -> list[Path]:
+    return sorted(tokenized_dir.glob("*/*.npy"))
+
+
+def load_motif_rows(
+    tokenized_dir: Path,
+    *,
+    motif_length: int,
+    max_bar_span: int,
+    max_records: int | None,
+    require_strictly_increasing_onsets: bool = True,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for path in iter_token_files(tokenized_dir):
+        if max_records is not None and len({row["source_record"] for row in rows}) >= int(max_records):
+            break
+        tokens = [int(token) for token in np.load(path).tolist()]
+        if not tokens:
+            continue
+        rows.extend(
+            extract_motif_templates_from_tokens(
+                tokens,
+                source_record=str(path.relative_to(tokenized_dir)),
+                motif_length=motif_length,
+                max_bar_span=max_bar_span,
+                require_strictly_increasing_onsets=require_strictly_increasing_onsets,
+            )
+        )
+    return rows
+
+
+def compact_counter(
+    counter: Counter[str],
+    *,
+    examples_by_key: dict[str, list[dict[str, Any]]],
+    total_count: int,
+    top_n: int,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for rank, (key, count) in enumerate(counter.most_common(int(top_n)), start=1):
+        examples = examples_by_key.get(key, [])
+        decoded_key = json.loads(key)
+        rows.append(
+            {
+                "rank": int(rank),
+                "count": int(count),
+                "support_ratio": float(count / total_count) if total_count else 0.0,
+                "key": decoded_key,
+                "examples": [
+                    {
+                        "source_record": example["source_record"],
+                        "start_index": int(example["start_index"]),
+                        "start_bar": int(example["start_bar"]),
+                        "start_position": int(example["start_position"]),
+                    }
+                    for example in examples[:3]
+                ],
+            }
+        )
+    return rows
+
+
+def summarize_motif_templates(motif_rows: list[dict[str, Any]], top_n: int = 20) -> dict[str, Any]:
+    rhythm_counter: Counter[str] = Counter()
+    contour_counter: Counter[str] = Counter()
+    full_counter: Counter[str] = Counter()
+    examples_by_rhythm: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    examples_by_contour: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    examples_by_full: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    source_records = {str(row["source_record"]) for row in motif_rows}
+
+    for row in motif_rows:
+        rhythm_key = stable_key(row["rhythm_key"])
+        contour_key = stable_key(row["contour_key"])
+        full_key = stable_key(row["full_key"])
+        rhythm_counter[rhythm_key] += 1
+        contour_counter[contour_key] += 1
+        full_counter[full_key] += 1
+        examples_by_rhythm[rhythm_key].append(row)
+        examples_by_contour[contour_key].append(row)
+        examples_by_full[full_key].append(row)
+
+    total = int(len(motif_rows))
+    return {
+        "source_record_count": int(len(source_records)),
+        "motif_count": total,
+        "unique_rhythm_template_count": int(len(rhythm_counter)),
+        "unique_contour_template_count": int(len(contour_counter)),
+        "unique_full_template_count": int(len(full_counter)),
+        "top_rhythm_template_support_ratio": (
+            float(rhythm_counter.most_common(1)[0][1] / total) if total and rhythm_counter else 0.0
+        ),
+        "top_contour_template_support_ratio": (
+            float(contour_counter.most_common(1)[0][1] / total) if total and contour_counter else 0.0
+        ),
+        "top_full_template_support_ratio": (
+            float(full_counter.most_common(1)[0][1] / total) if total and full_counter else 0.0
+        ),
+        "top_rhythm_templates": compact_counter(
+            rhythm_counter,
+            examples_by_key=examples_by_rhythm,
+            total_count=total,
+            top_n=top_n,
+        ),
+        "top_contour_templates": compact_counter(
+            contour_counter,
+            examples_by_key=examples_by_contour,
+            total_count=total,
+            top_n=top_n,
+        ),
+        "top_full_templates": compact_counter(
+            full_counter,
+            examples_by_key=examples_by_full,
+            total_count=total,
+            top_n=top_n,
+        ),
+    }
+
+
+def format_key_value(value: Any) -> str:
+    if isinstance(value, dict):
+        return "; ".join(f"{key}={val}" for key, val in value.items())
+    return str(value)
+
+
+def markdown_template_table(title: str, rows: list[dict[str, Any]]) -> list[str]:
+    lines = [
+        f"## {title}",
+        "",
+        "| rank | count | support | key | example |",
+        "|---:|---:|---:|---|---|",
+    ]
+    for row in rows:
+        example = row["examples"][0] if row["examples"] else {}
+        example_text = (
+            f"{example.get('source_record')}@{example.get('start_index')}"
+            if example
+            else ""
+        )
+        lines.append(
+            f"| {row['rank']} | {row['count']} | {row['support_ratio']:.3f} | "
+            f"`{format_key_value(row['key'])}` | `{example_text}` |"
+        )
+    return lines
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    lines = [
+        "# Stage B Motif Template Extraction",
+        "",
+        f"- source records: `{summary['source_record_count']}`",
+        f"- motif count: `{summary['motif_count']}`",
+        f"- unique rhythm templates: `{summary['unique_rhythm_template_count']}`",
+        f"- unique contour templates: `{summary['unique_contour_template_count']}`",
+        f"- unique full templates: `{summary['unique_full_template_count']}`",
+        f"- top rhythm support: `{summary['top_rhythm_template_support_ratio']:.3f}`",
+        f"- top contour support: `{summary['top_contour_template_support_ratio']:.3f}`",
+        f"- top full support: `{summary['top_full_template_support_ratio']:.3f}`",
+        "",
+    ]
+    lines.extend(markdown_template_table("Top Rhythm Templates", summary["top_rhythm_templates"]))
+    lines.append("")
+    lines.extend(markdown_template_table("Top Contour Templates", summary["top_contour_templates"]))
+    lines.append("")
+    lines.extend(markdown_template_table("Top Full Motif Templates", summary["top_full_templates"]))
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Extract Stage B data-derived phrase motif templates")
+    parser.add_argument("--input_dir", type=str, default="./midi_dataset/midi/studio")
+    parser.add_argument("--output_root", type=str, default=str(ROOT_DIR / "outputs" / "stage_b_motif_templates"))
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--role", type=str, default="lead")
+    parser.add_argument("--max_files", type=int, default=4)
+    parser.add_argument("--window_bars", type=int, default=8)
+    parser.add_argument("--window_stride_bars", type=int, default=4)
+    parser.add_argument("--min_window_target_notes", type=int, default=16)
+    parser.add_argument("--motif_length", type=int, default=4)
+    parser.add_argument("--max_bar_span", type=int, default=2)
+    parser.add_argument("--max_records", type=int, default=64)
+    parser.add_argument("--top_n", type=int, default=20)
+    parser.add_argument("--allow_same_onset_motifs", action="store_true")
+    parser.add_argument("--skip_prepare", action="store_true")
+    parser.add_argument("--tokenized_dir", type=str, default=None)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now().strftime("%Y%m%d_%H%M%S")
+    run_dir = Path(args.output_root) / run_id
+    roles_dir = run_dir / "roles"
+    tokenized_dir = Path(args.tokenized_dir) if args.tokenized_dir else roles_dir / args.role / "tokenized"
+
+    report: dict[str, Any] = {
+        "run_id": run_id,
+        "run_dir": str(run_dir),
+        "input_dir": str(args.input_dir),
+        "tokenized_dir": str(tokenized_dir),
+        "window_bars": int(args.window_bars),
+        "window_stride_bars": int(args.window_stride_bars),
+        "min_window_target_notes": int(args.min_window_target_notes),
+        "motif_length": int(args.motif_length),
+        "max_bar_span": int(args.max_bar_span),
+        "max_files": args.max_files,
+        "max_records": args.max_records,
+        "top_n": int(args.top_n),
+        "require_strictly_increasing_onsets": not bool(args.allow_same_onset_motifs),
+    }
+
+    if not args.skip_prepare:
+        prepare_result = run_prepare_command(args, roles_dir)
+        report["prepare_result"] = prepare_result
+        if prepare_result["returncode"] != 0:
+            write_json(run_dir / "motif_template_report.json", report)
+            print(json.dumps(report, ensure_ascii=True, indent=2))
+            return int(prepare_result["returncode"])
+
+    motif_rows = load_motif_rows(
+        tokenized_dir,
+        motif_length=int(args.motif_length),
+        max_bar_span=int(args.max_bar_span),
+        max_records=args.max_records,
+        require_strictly_increasing_onsets=not bool(args.allow_same_onset_motifs),
+    )
+    report["motif_rows_head"] = motif_rows[:8]
+    report["summary"] = summarize_motif_templates(motif_rows, top_n=int(args.top_n))
+    if not motif_rows:
+        report["failure_reason"] = "No motif templates extracted from Stage B tokenized records"
+        write_json(run_dir / "motif_template_report.json", report)
+        print(json.dumps(report, ensure_ascii=True, indent=2))
+        return 2
+
+    write_json(run_dir / "motif_template_report.json", report)
+    (run_dir / "motif_template_report.md").write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps(report["summary"], ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_motif_template_extraction.py
+++ b/tests/test_stage_b_motif_template_extraction.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.run_stage_b_motif_template_extraction import (
+    extract_motif_templates_from_tokens,
+    motif_from_groups,
+    summarize_motif_templates,
+)
+from scripts.stage_b_tokens import (
+    TOKEN_BAR,
+    TOKEN_END,
+    chord_tokens,
+    note_duration_token,
+    note_pitch_token,
+    note_velocity_token,
+    position_token,
+)
+
+
+def phrase_tokens(pitch_shift: int = 0) -> list[int]:
+    return [
+        *chord_tokens("Cmaj7"),
+        position_token(0),
+        note_velocity_token(4),
+        note_pitch_token(60 + pitch_shift),
+        note_duration_token(2),
+        position_token(3),
+        note_velocity_token(4),
+        note_pitch_token(62 + pitch_shift),
+        note_duration_token(1),
+        position_token(7),
+        note_velocity_token(4),
+        note_pitch_token(65 + pitch_shift),
+        note_duration_token(3),
+        TOKEN_BAR,
+        *chord_tokens("F7"),
+        position_token(1),
+        note_velocity_token(4),
+        note_pitch_token(64 + pitch_shift),
+        note_duration_token(2),
+        position_token(5),
+        note_velocity_token(4),
+        note_pitch_token(67 + pitch_shift),
+        note_duration_token(1),
+        TOKEN_END,
+    ]
+
+
+def same_onset_phrase_tokens() -> list[int]:
+    return [
+        *chord_tokens("Cmaj7"),
+        position_token(0),
+        note_velocity_token(4),
+        note_pitch_token(60),
+        note_duration_token(2),
+        position_token(0),
+        note_velocity_token(4),
+        note_pitch_token(64),
+        note_duration_token(2),
+        position_token(3),
+        note_velocity_token(4),
+        note_pitch_token(67),
+        note_duration_token(2),
+        position_token(5),
+        note_velocity_token(4),
+        note_pitch_token(69),
+        note_duration_token(2),
+        TOKEN_END,
+    ]
+
+
+class StageBMotifTemplateExtractionTest(unittest.TestCase):
+    def test_extract_motif_templates_from_tokens_slides_note_groups(self) -> None:
+        motifs = extract_motif_templates_from_tokens(
+            phrase_tokens(),
+            source_record="sample.npy",
+            motif_length=3,
+            max_bar_span=2,
+        )
+
+        self.assertEqual(len(motifs), 3)
+        self.assertEqual(motifs[0]["position_deltas"], [0, 3, 7])
+        self.assertEqual(motifs[0]["duration_steps"], [2, 1, 3])
+        self.assertEqual(motifs[0]["pitch_intervals"], [0, 2, 5])
+
+    def test_extract_motif_templates_filters_same_onset_blocks_by_default(self) -> None:
+        motifs = extract_motif_templates_from_tokens(
+            same_onset_phrase_tokens(),
+            source_record="same_onset.npy",
+            motif_length=4,
+            max_bar_span=1,
+        )
+
+        self.assertEqual(motifs, [])
+
+    def test_extract_motif_templates_can_allow_same_onset_for_diagnostics(self) -> None:
+        motifs = extract_motif_templates_from_tokens(
+            same_onset_phrase_tokens(),
+            source_record="same_onset.npy",
+            motif_length=4,
+            max_bar_span=1,
+            require_strictly_increasing_onsets=False,
+        )
+
+        self.assertEqual(len(motifs), 1)
+        self.assertEqual(motifs[0]["position_deltas"], [0, 0, 3, 5])
+
+    def test_pitch_intervals_are_transposition_invariant(self) -> None:
+        base = extract_motif_templates_from_tokens(
+            phrase_tokens(0),
+            source_record="base.npy",
+            motif_length=4,
+            max_bar_span=2,
+        )[0]
+        shifted = extract_motif_templates_from_tokens(
+            phrase_tokens(5),
+            source_record="shifted.npy",
+            motif_length=4,
+            max_bar_span=2,
+        )[0]
+
+        self.assertEqual(base["pitch_intervals"], shifted["pitch_intervals"])
+        self.assertEqual(base["melodic_intervals"], shifted["melodic_intervals"])
+
+    def test_motif_from_groups_reports_syncopation_and_direction(self) -> None:
+        motifs = extract_motif_templates_from_tokens(
+            phrase_tokens(),
+            source_record="sample.npy",
+            motif_length=4,
+            max_bar_span=2,
+        )
+
+        motif = motifs[0]
+
+        self.assertGreater(motif["syncopated_onset_ratio"], 0.5)
+        self.assertGreaterEqual(motif["direction_change_ratio"], 0.0)
+        self.assertEqual(motif["bar_span"], 2)
+
+    def test_summarize_motif_templates_ranks_repeated_templates(self) -> None:
+        motifs = extract_motif_templates_from_tokens(
+            phrase_tokens(),
+            source_record="a.npy",
+            motif_length=3,
+            max_bar_span=2,
+        )
+        motifs.extend(
+            extract_motif_templates_from_tokens(
+                phrase_tokens(2),
+                source_record="b.npy",
+                motif_length=3,
+                max_bar_span=2,
+            )
+        )
+
+        summary = summarize_motif_templates(motifs, top_n=2)
+
+        self.assertEqual(summary["source_record_count"], 2)
+        self.assertGreater(summary["motif_count"], 0)
+        self.assertEqual(summary["top_rhythm_templates"][0]["count"], 2)
+        self.assertEqual(summary["top_contour_templates"][0]["count"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약
- 실제 Stage B phrase window에서 rhythm/contour/full motif template을 추출하는 스크립트를 추가했습니다.
- same-onset chord/block motif가 solo-line material로 섞이지 않도록 기본 필터를 추가했습니다.
- motif extraction 하네스와 문서/CORE_PLAN 상태를 업데이트했습니다.

## 결과
- source records: 56
- motif count: 803
- rhythm templates: 520
- contour templates: 328
- full templates: 526
- top full motif support: 0.002

## 검증
- bash scripts/agent_harness.sh quick
- bash scripts/agent_harness.sh stage-b-motif-templates

Closes #63