### PR TITLE
Stage B data-derived motif baseline 생성 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #63: Stage B data-derived phrase motif template extraction.
+- Issue #65: Stage B data-derived motif baseline generation.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -182,6 +182,12 @@ For Stage B data-derived motif template extraction changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-motif-templates
+```
+
+For Stage B data-derived motif baseline generation changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-data-motif-compare
 ```
 
 For Stage B collapse/sampling-sweep changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -134,6 +134,7 @@ Stage B에서 명시하는 것:
 28. Stage B swing/motif phrase grammar probe
 29. Stage B real phrase reference statistics
 30. Stage B data-derived motif template extraction
+31. Stage B data-derived motif baseline generation
 
 가장 최근 의미 있는 결과:
 
@@ -167,7 +168,7 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-이제 다음 단계는 data-derived motif catalog를 generation-side constraint로 연결하는 것이다. Manual review에서 8-bar 후보는 이전보다 나아졌지만 아직 초급 다이아토닉 코드톤 나열처럼 들렸고, Issue #61 reference stats에서도 hand-written rhythm diversity가 부족하다고 나왔다. 따라서 generic jazz base 학습 전에 real phrase motif distribution을 사용한 baseline을 먼저 비교한다.
+이제 다음 단계는 data-derived motif baseline을 실제 MIDI review 대상으로 내보내는 것이다. Issue #65에서 motif baseline은 strict gate를 통과했고 hand-written rhythm보다 pattern variation은 좋아졌지만, syncopation은 낮아졌다. 따라서 generic jazz base 학습 전에 piano-roll/listening review로 musical value를 확인한다.
 
 ## 6. 다음 단계 로드맵
 
@@ -341,6 +342,8 @@ Stage B에서 명시하는 것:
 - Issue #61 result: `swing_motif_approach`는 syncopation은 reference에 가까우나 bar-position variation, duration diversity, IOI diversity가 아직 크게 부족하다.
 - Issue #63 result: real Stage B windows에서 `803`개 strictly-increasing solo-line motif를 추출했고, rhythm templates `520`, contour templates `328`, full templates `526`개를 만들었다.
 - Issue #63 result: top rhythm support는 `0.009`, top contour support는 `0.012`, top full motif support는 `0.002`라서 one best motif 복붙이 아니라 distribution sampling이 필요하다.
+- Issue #65 result: data-derived motif baseline도 strict `3/3`을 통과했다.
+- Issue #65 result: hand-written swing 대비 bar-position variation은 `+0.500`, duration diversity는 `+0.016`, IOI diversity는 `+0.016` 개선됐지만 syncopation은 `-0.125` 낮아졌다.
 
 해석:
 
@@ -440,6 +443,37 @@ Stage B에서 명시하는 것:
 - reference p25-p75 범위에 가까워지는 metric을 늘린다.
 - piano roll에서 chord-tone 나열이 아니라 phrase contour로 들리는지 review export로 확인한다.
 
+### Phase 3.13. Data-Derived Motif Baseline Generation
+
+목표:
+
+- Issue #63 motif catalog를 실제 8-bar generation baseline에 연결한다.
+- hand-written `swing_motif_approach`와 data-derived motif baseline을 같은 조건에서 비교한다.
+- 생성이 strict gate를 통과하는지, rhythm diversity가 나아지는지 본다.
+
+현재 결과:
+
+- completed: `scripts/run_stage_b_data_motif_generation_compare.py`를 추가했다.
+- completed: extracted rhythm template을 position/duration 후보로 사용한다.
+- completed: extracted contour template을 pitch interval 후보로 사용한다.
+- completed: duration을 다음 onset 전까지 제한해 overlap/postprocess removal을 막는다.
+- latest result: `hand_written_swing` strict `3/3`, `data_motif` strict `3/3`.
+- latest result: data-derived baseline은 bar-position variation을 `0.500`에서 `1.000`으로 올렸다.
+- latest result: duration repetition ratio를 `0.750`에서 `0.375`로 낮췄다.
+- latest result: syncopation은 `0.750`에서 `0.625`로 낮아졌다.
+
+해석:
+
+- data-derived motif baseline은 hand-written baseline보다 pattern variation 면에서 낫다.
+- 하지만 syncopation 하락과 낮은 diversity 상승폭 때문에 바로 더 좋은 jazz solo라고 말할 수 없다.
+- 다음은 MIDI review export와 listening/piano-roll 비교가 필요하다.
+
+다음 통과 기준:
+
+- data_motif 후보를 hand_written_swing 후보와 파일명으로 구분해 review export한다.
+- 실제 piano roll에서 phrase contour가 초급 scale exercise보다 나은지 확인한다.
+- data_motif가 review 가치가 있으면 model constrained generation 쪽에 연결하고, 아니면 contour/cadence extraction을 더 강화한다.
+
 ### Phase 4. Generic Jazz Base 후보 학습
 
 목표:
@@ -534,23 +568,23 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B data-derived motif template extraction 추가
+Stage B data-derived motif baseline generation 추가
 ```
 
 결과:
 
-- real Stage B phrase windows에서 `803`개 solo-line motif를 추출했다.
-- rhythm templates `520`, contour templates `328`, full templates `526`개를 만들었다.
-- top full motif support가 `0.002`라서 하나의 motif를 복사하는 방식은 맞지 않다.
-- same-onset chord/block motif는 기본 필터로 제외했다.
+- `hand_written_swing`과 `data_motif` 모두 strict `3/3`을 통과했다.
+- data-derived baseline은 bar-pattern variation을 `0.500`에서 `1.000`으로 올렸다.
+- duration repetition ratio는 `0.750`에서 `0.375`로 낮췄다.
+- duration diversity와 IOI diversity는 소폭 올랐다.
+- syncopation은 `0.750`에서 `0.625`로 낮아졌다.
 
 다음 작업:
 
-- extracted rhythm templates를 position/duration 후보로 연결한다.
-- extracted contour templates를 pitch interval 후보로 연결한다.
-- current chord/tension pitch set 위에 contour를 transpose한다.
-- `swing_motif_approach`와 data-derived motif baseline을 같은 8-bar 조건에서 비교한다.
-- duration diversity, IOI diversity, bar-position variation이 reference range에 가까워지는지 본다.
+- generated data_motif MIDI를 review export 대상으로 분리한다.
+- hand_written_swing 후보와 data_motif 후보를 piano roll/listening으로 비교한다.
+- syncopation 하락이 groove 약화로 들리는지 확인한다.
+- contour가 초급 코드톤 나열을 넘어 phrase motion으로 들리는지 본다.
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-63-stage-b-motif-template-extraction`
+- `issue-65-stage-b-data-derived-motif-generation`
 
 현재 범위가 아닌 것:
 
@@ -36,38 +36,37 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 ## Latest Probe Result
 
-Issue #63은 Issue #61의 reference statistics 이후 단계다.
+Issue #65는 Issue #63에서 추출한 motif catalog를 generation-side baseline으로 연결하는 단계다.
 
-Issue #61에서 hand-written `swing_motif_approach`는 syncopation은 실제 jazz window와 가까웠지만, bar-position variation, duration diversity, IOI diversity가 부족했다. 그래서 이번에는 rule을 더 쓰는 대신 실제 Stage B phrase window에서 motif templates를 추출한다.
+Issue #63은 실제 Stage B phrase window에서 rhythm/contour/full motif templates를 추출했다. 이번에는 그 catalog를 사용해 hand-written `swing_motif_approach`와 data-derived motif baseline을 같은 8-bar 조건에서 비교한다.
 
 Implemented:
 
-- `scripts/run_stage_b_motif_template_extraction.py`
-- `tests/test_stage_b_motif_template_extraction.py`
-- `scripts/agent_harness.sh stage-b-motif-templates`
+- `scripts/run_stage_b_data_motif_generation_compare.py`
+- `tests/test_stage_b_data_motif_generation_compare.py`
+- `scripts/agent_harness.sh stage-b-data-motif-compare`
 - output files:
-  - `motif_template_report.json`
-  - `motif_template_report.md`
+  - `data_motif_compare_report.json`
+  - `data_motif_compare_report.md`
 
 Result:
 
-- source report: `outputs/stage_b_motif_templates/harness_stage_b_motif_templates/motif_template_report.json`
+- source report: `outputs/stage_b_data_motif_compare/harness_stage_b_data_motif_compare/data_motif_compare_report.json`
 - setup: `./midi_dataset/midi/studio`, max files `4`, `8`-bar windows, stride `4`, min notes `16`
-- source records: `56`
-- motif count: `803`
-- unique rhythm templates: `520`
-- unique contour templates: `328`
-- unique full templates: `526`
-- top rhythm support: `0.009`
-- top contour support: `0.012`
-- top full support: `0.002`
-- default extraction filters same-onset motifs so chord blocks do not dominate solo-line material
+- `hand_written_swing`: strict `3/3`
+- `data_motif`: strict `3/3`
+- data minus hand duration diversity delta: `+0.016`
+- data minus hand IOI diversity delta: `+0.016`
+- data minus hand bar-pattern delta: `+0.500`
+- data minus hand syncopation delta: `-0.125`
+- `data_motif` duration repetition ratio: `0.375`
+- `hand_written_swing` duration repetition ratio: `0.750`
 
 Decision:
 
-- 실제 phrase material은 매우 다양해서 top template 하나를 hardcode하면 안 된다.
-- 다음 generator는 data-derived rhythm/contour templates를 distribution으로 sampling해야 한다.
-- 이것은 생성기 자체가 아니라 다음 data-derived generation constraint를 만들기 위한 reference catalog다.
+- data-derived motif baseline은 strict gate를 통과하고, hand-written baseline보다 bar variation과 duration repetition 면에서 낫다.
+- syncopation은 낮아졌으므로 곧바로 더 좋은 jazz phrase라고 말하면 안 된다.
+- 다음은 generated MIDI review export로 실제 piano roll/listening 비교를 해야 한다.
 
 Detail:
 
@@ -83,6 +82,7 @@ Detail:
 - `docs/STAGE_B_SWING_MOTIF_PHRASE_2026-05-21.md`
 - `docs/STAGE_B_REFERENCE_PHRASE_STATS_2026-05-21.md`
 - `docs/STAGE_B_MOTIF_TEMPLATE_EXTRACTION_2026-05-21.md`
+- `docs/STAGE_B_DATA_MOTIF_GENERATION_2026-05-21.md`
 
 ## Active Issue #14
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,8 @@
   - 실제 Stage B jazz MIDI phrase window 통계를 만들어 generated rhythm/motif 후보와 비교한 결과.
 - `STAGE_B_MOTIF_TEMPLATE_EXTRACTION_2026-05-21.md`
   - 실제 Stage B phrase window에서 rhythm/contour/full motif templates를 추출해 다음 data-derived generation constraint로 넘기기 위한 결과.
+- `STAGE_B_DATA_MOTIF_GENERATION_2026-05-21.md`
+  - 추출된 motif catalog를 8-bar generation baseline에 연결해 hand-written swing grammar와 비교한 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -100,7 +102,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, and motif template extraction을 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, and data-derived motif baseline generation을 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_DATA_MOTIF_GENERATION_2026-05-21.md
+++ b/docs/STAGE_B_DATA_MOTIF_GENERATION_2026-05-21.md
@@ -1,0 +1,117 @@
+# Stage B Data Motif Generation
+
+작성일: 2026-05-21
+
+## 목적
+
+Issue #63은 실제 Stage B phrase window에서 rhythm/contour/full motif templates를 추출했다.
+
+이번 작업은 그 catalog를 실제 8-bar generation baseline으로 연결한다.
+
+핵심은 hand-written `swing_motif_approach`를 더 늘리는 것이 아니라, 실제 MIDI에서 뽑은 motif material을 사용해 다음을 비교하는 것이다.
+
+- hand-written swing rhythm baseline
+- data-derived motif baseline
+
+이 작업은 아직 broad training이 아니다.
+또한 "재즈 솔로 모델 완성"도 아니다.
+
+## 구현
+
+추가 파일:
+
+- `scripts/run_stage_b_data_motif_generation_compare.py`
+- `tests/test_stage_b_data_motif_generation_compare.py`
+
+하네스:
+
+```bash
+bash scripts/agent_harness.sh stage-b-data-motif-compare
+```
+
+비교 방식:
+
+- 먼저 `scripts/run_stage_b_motif_template_extraction.py`로 motif catalog를 만든다.
+- `hand_written_swing`은 기존 static swing/motif position-duration grammar를 사용한다.
+- `data_motif`은 extracted rhythm template을 position/duration 후보로 사용한다.
+- `data_motif`은 extracted contour template을 pitch interval 후보로 사용한다.
+- pitch는 current chord/tension/approach 후보군 위에 가장 가까운 pitch로 투영한다.
+
+## Duration Fit
+
+초기 실행에서 data-derived motif는 grammar/collapse gate는 통과했지만, duration을 그대로 쓰면서 note overlap이 생겼고 postprocess가 많은 note를 제거했다.
+
+그 결과 dead-air ratio가 `0.821`로 gate를 실패했다.
+
+따라서 data-derived baseline은 motif duration을 다음 onset 전까지로 제한한다.
+
+이것은 음악적 성공을 꾸미는 postprocess가 아니라, solo-line baseline에서 동시에 겹치는 sustain을 만들지 않기 위한 constraint다.
+
+## Local Result
+
+실행:
+
+```bash
+bash scripts/agent_harness.sh stage-b-data-motif-compare
+```
+
+결과:
+
+- compare gate: `true`
+- `hand_written_swing`: strict `3/3`
+- `data_motif`: strict `3/3`
+- data minus hand duration diversity delta: `+0.016`
+- data minus hand IOI diversity delta: `+0.016`
+- data minus hand bar-pattern delta: `+0.500`
+- data minus hand syncopation delta: `-0.125`
+
+요약 표:
+
+| mode | strict | sync | bar-var | dur-var | dur-rep | ioi-var | ioi-rep | tension | root |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| data_motif | 3/3 | 0.625 | 1.000 | 0.062 | 0.375 | 0.079 | 0.429 | 0.177 | 0.000 |
+| hand_written_swing | 3/3 | 0.750 | 0.500 | 0.047 | 0.750 | 0.063 | 0.476 | 0.198 | 0.000 |
+
+## 해석
+
+좋아진 점:
+
+- `data_motif`도 strict review gate를 통과한다.
+- bar-position pattern variation이 `0.500`에서 `1.000`으로 오른다.
+- most-common duration ratio가 `0.750`에서 `0.375`로 낮아진다.
+- IOI repetition도 약간 낮아진다.
+
+나빠졌거나 아직 부족한 점:
+
+- syncopation은 `0.750`에서 `0.625`로 낮아졌다.
+- duration diversity와 IOI diversity 상승폭은 아직 작다.
+- 이것만으로 jazz vocabulary가 생겼다고 말할 수 없다.
+- 실제 piano-roll/listening review가 필요하다.
+
+판단:
+
+> data-derived motif baseline은 hand-written baseline보다 bar-to-bar variation과 duration repetition 측면에서 낫지만, 아직 "재즈 솔로" 품질을 증명하지는 않는다.
+
+## 다음 작업
+
+다음 단계는 생성된 `data_motif` MIDI를 review export 대상으로 분리하고, hand-written swing 후보와 실제 piano roll에서 비교하는 것이다.
+
+확인할 것:
+
+- data_motif가 "패턴 변화"만 늘린 것인지, 실제 phrase처럼 들리는지
+- syncopation 하락이 체감상 groove 약화로 들리는지
+- contour가 chord-tone 나열을 넘어선 phrase motion으로 들리는지
+- extracted contour를 더 길게 연결해야 하는지
+
+통과 기준:
+
+- data_motif MIDI가 초급 scale exercise처럼만 들리지 않는다.
+- 8-bar phrase 안에 call/continuation/landing 느낌이 일부라도 있다.
+- 다음 broad generic training 전에 사용할 constraint candidate로 남길 가치가 있다.
+
+## Validation
+
+```bash
+./.venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare
+bash scripts/agent_harness.sh stage-b-data-motif-compare
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -62,6 +62,8 @@ Modes:
                 Build real Stage B phrase-window reference statistics.
   stage-b-motif-templates
                 Extract data-derived Stage B motif/rhythm templates.
+  stage-b-data-motif-compare
+                Compare hand-written swing against data-derived motif baseline.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   all           Run demo and tiny-compare.
@@ -105,6 +107,7 @@ run_quick() {
     scripts/run_stage_b_phrase_grammar_compare.py \
     scripts/run_stage_b_reference_stats.py \
     scripts/run_stage_b_motif_template_extraction.py \
+    scripts/run_stage_b_data_motif_generation_compare.py \
     scripts/rank_stage_b_candidates.py \
     scripts/audit_brad_mehldau_dataset.py \
     scripts/audit_jazz_piano_dataset.py \
@@ -644,6 +647,25 @@ run_stage_b_motif_templates() {
     --top_n 20
 }
 
+run_stage_b_data_motif_compare() {
+  local run_id="${RUN_ID:-harness_stage_b_data_motif_compare}"
+  print_header "Stage B data-derived motif generation compare"
+  "$PYTHON_BIN" scripts/run_stage_b_data_motif_generation_compare.py \
+    --run_id "$run_id" \
+    --input_dir ./midi_dataset/midi/studio \
+    --max_files 4 \
+    --window_bars 8 \
+    --window_stride_bars 4 \
+    --min_window_target_notes 16 \
+    --motif_length 4 \
+    --max_bar_span 2 \
+    --max_records 64 \
+    --template_top_n 32 \
+    --num_samples 3 \
+    --bars 8 \
+    --note_groups_per_bar 8
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -724,6 +746,9 @@ case "$MODE" in
     ;;
   stage-b-motif-templates)
     run_stage_b_motif_templates
+    ;;
+  stage-b-data-motif-compare)
+    run_stage_b_data_motif_compare
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/run_stage_b_data_motif_generation_compare.py
+++ b/scripts/run_stage_b_data_motif_generation_compare.py
@@ -1,0 +1,580 @@
+"""Compare hand-written swing grammar with data-derived motif baseline generation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from inference.app.schemas import GenerationRequest  # noqa: E402
+from scripts.run_stage_b_generation_probe import (  # noqa: E402
+    build_probe_summary,
+    build_stage_b_primer,
+    chord_aware_pitch_tokens,
+    decode_stage_b_midi,
+    jazz_rhythm_duration_tokens,
+    jazz_rhythm_position_tokens,
+    parse_chords,
+    pitch_from_token,
+    postprocess_stage_b_midi,
+    sample_report,
+)
+from scripts.stage_b_tokens import (  # noqa: E402
+    MAX_DURATION_STEPS,
+    PIANO_PITCH_MAX,
+    PIANO_PITCH_MIN,
+    POSITIONS_PER_BAR,
+    TOKEN_BAR,
+    TOKEN_END,
+    chord_tokens,
+    note_duration_token,
+    note_pitch_token,
+    note_velocity_token,
+    pitch_from_token as stage_b_pitch_from_token,
+    position_token,
+)
+
+
+VALID_BASELINE_MODES = {"hand_written_swing", "data_motif"}
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def run_command(cmd: list[str]) -> dict[str, Any]:
+    completed = subprocess.run(cmd, cwd=ROOT_DIR, text=True, capture_output=True, check=False)
+    return {
+        "cmd": cmd,
+        "returncode": int(completed.returncode),
+        "stdout_tail": completed.stdout[-4000:],
+        "stderr_tail": completed.stderr[-4000:],
+    }
+
+
+def run_template_extraction(args: argparse.Namespace, run_dir: Path) -> tuple[Path, dict[str, Any]]:
+    template_run_id = f"{args.run_id}_templates"
+    output_root = run_dir / "templates"
+    cmd = [
+        sys.executable,
+        "scripts/run_stage_b_motif_template_extraction.py",
+        "--run_id",
+        template_run_id,
+        "--output_root",
+        str(output_root),
+        "--input_dir",
+        str(args.input_dir),
+        "--max_files",
+        str(args.max_files),
+        "--window_bars",
+        str(args.window_bars),
+        "--window_stride_bars",
+        str(args.window_stride_bars),
+        "--min_window_target_notes",
+        str(args.min_window_target_notes),
+        "--motif_length",
+        str(args.motif_length),
+        "--max_bar_span",
+        str(args.max_bar_span),
+        "--max_records",
+        str(args.max_records),
+        "--top_n",
+        str(args.template_top_n),
+    ]
+    result = run_command(cmd)
+    report_path = output_root / template_run_id / "motif_template_report.json"
+    return report_path, result
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def parse_baseline_modes(raw: str) -> list[str]:
+    modes = [mode.strip().lower() for mode in raw.split(",") if mode.strip()]
+    invalid = [mode for mode in modes if mode not in VALID_BASELINE_MODES]
+    if invalid:
+        raise ValueError(f"Unknown baseline modes: {invalid}")
+    return modes
+
+
+def weighted_choice(rows: Sequence[dict[str, Any]], rng: random.Random, index: int) -> dict[str, Any]:
+    if not rows:
+        raise ValueError("template rows must not be empty")
+    weights = [max(1, int(row.get("count", 1))) for row in rows]
+    if index < len(rows):
+        # Cycle through the highest-ranked rows first so tiny harness runs cover more than one template.
+        return rows[index]
+    return rng.choices(list(rows), weights=weights, k=1)[0]
+
+
+def strictly_increasing_positions(raw_positions: Sequence[int], minimum: int, maximum: int) -> list[int]:
+    result: list[int] = []
+    previous = int(minimum) - 1
+    for raw in raw_positions:
+        value = max(int(minimum), min(int(maximum), int(raw)))
+        if value <= previous:
+            value = previous + 1
+        if value > int(maximum):
+            break
+        result.append(value)
+        previous = value
+    return result
+
+
+def normalize_position_deltas(
+    position_deltas: Sequence[int],
+    *,
+    slot_start: int,
+    slot_size: int,
+) -> list[int]:
+    deltas = [max(0, int(delta)) for delta in position_deltas]
+    if not deltas:
+        return []
+    local_max = max(deltas)
+    slot_size = max(1, int(slot_size))
+    slot_end = min(int(POSITIONS_PER_BAR) - 1, int(slot_start) + slot_size - 1)
+    if local_max <= 0:
+        raw_positions = [int(slot_start) + index for index in range(len(deltas))]
+    else:
+        raw_positions = [
+            int(slot_start) + int(round(delta * (slot_size - 1) / local_max))
+            for delta in deltas
+        ]
+    return strictly_increasing_positions(raw_positions, int(slot_start), slot_end)
+
+
+def duration_tokens_from_steps(duration_steps: Sequence[int], target_count: int) -> list[int]:
+    steps = [max(1, min(int(MAX_DURATION_STEPS), int(step))) for step in duration_steps]
+    if not steps:
+        steps = [2]
+    while len(steps) < int(target_count):
+        steps.append(steps[-1])
+    return [note_duration_token(step) for step in steps[: int(target_count)]]
+
+
+def fit_duration_tokens_to_positions(
+    positions: Sequence[int],
+    duration_steps: Sequence[int],
+    max_tail_duration: int = 4,
+) -> list[int]:
+    raw_steps = [max(1, min(int(MAX_DURATION_STEPS), int(step))) for step in duration_steps]
+    if not raw_steps:
+        raw_steps = [2]
+    while len(raw_steps) < len(positions):
+        raw_steps.append(raw_steps[-1])
+
+    fitted: list[int] = []
+    for index, position in enumerate(positions):
+        if index + 1 < len(positions):
+            max_duration = max(1, int(positions[index + 1]) - int(position))
+        else:
+            max_duration = max(1, min(int(max_tail_duration), int(POSITIONS_PER_BAR) - int(position)))
+        fitted.append(max(1, min(raw_steps[index], max_duration)))
+    return [note_duration_token(step) for step in fitted]
+
+
+def nearest_allowed_pitch_token(
+    target_pitch: int,
+    allowed_tokens: Sequence[int],
+    recent_pitches: Sequence[int] | None = None,
+) -> int:
+    if not allowed_tokens:
+        return note_pitch_token(max(int(PIANO_PITCH_MIN), min(int(PIANO_PITCH_MAX), int(target_pitch))))
+    blocked = set(int(pitch) for pitch in (recent_pitches or [])[-2:])
+    candidates = [int(token) for token in allowed_tokens if stage_b_pitch_from_token(token) not in blocked]
+    if not candidates:
+        candidates = [int(token) for token in allowed_tokens]
+    return min(
+        candidates,
+        key=lambda token: (
+            abs(stage_b_pitch_from_token(token) - int(target_pitch)),
+            abs(stage_b_pitch_from_token(token) - 67),
+            stage_b_pitch_from_token(token),
+        ),
+    )
+
+
+def base_pitch_token_for_chord(chord: str | None, rng: random.Random, recent_pitches: Sequence[int]) -> int:
+    allowed = chord_aware_pitch_tokens(
+        chord,
+        pitch_mode="tones_tensions",
+        recent_pitches=recent_pitches,
+        repeat_window=2,
+    )
+    target = 64 + rng.choice([-5, -2, 0, 2, 5])
+    return nearest_allowed_pitch_token(target, allowed, recent_pitches)
+
+
+def pitch_tokens_from_contour(
+    chord: str | None,
+    pitch_intervals: Sequence[int],
+    *,
+    rng: random.Random,
+    recent_pitches: list[int],
+    group_offset: int,
+) -> list[int]:
+    start_token = base_pitch_token_for_chord(chord, rng, recent_pitches)
+    start_pitch = pitch_from_token(start_token)
+    tokens: list[int] = []
+    intervals = [int(interval) for interval in pitch_intervals] or [0]
+    for index, interval in enumerate(intervals):
+        target_pitch = start_pitch + int(interval)
+        allowed = chord_aware_pitch_tokens(
+            chord,
+            pitch_mode="approach_tensions",
+            recent_pitches=recent_pitches,
+            repeat_window=2,
+            group_index=group_offset + index,
+        )
+        token = nearest_allowed_pitch_token(target_pitch, allowed, recent_pitches)
+        tokens.append(token)
+        recent_pitches.append(pitch_from_token(token))
+    return tokens
+
+
+def hand_written_swing_tokens(
+    *,
+    primer_tokens: Sequence[int],
+    chords: Sequence[str],
+    bars: int,
+    note_groups_per_bar: int,
+    seed: int,
+) -> list[int]:
+    rng = random.Random(int(seed))
+    tokens = [int(token) for token in primer_tokens]
+    recent_pitches: list[int] = []
+    contour = [0, 2, 5, 3, 7, 5, 9, 7]
+    for bar_index in range(max(1, int(bars))):
+        chord = chords[bar_index % len(chords)] if chords else None
+        if bar_index > 0:
+            tokens.append(TOKEN_BAR)
+            tokens.extend(chord_tokens(chord))
+        base_token = base_pitch_token_for_chord(chord, rng, recent_pitches)
+        base_pitch = pitch_from_token(base_token)
+        for group_index in range(max(1, int(note_groups_per_bar))):
+            position_candidates = jazz_rhythm_position_tokens(
+                bar_index=bar_index,
+                group_index=group_index,
+                note_groups_per_bar=note_groups_per_bar,
+                profile="swing_motif",
+            )
+            duration_candidates = jazz_rhythm_duration_tokens(
+                bar_index=bar_index,
+                group_index=group_index,
+                note_groups_per_bar=note_groups_per_bar,
+                profile="swing_motif",
+            )
+            target_pitch = base_pitch + contour[group_index % len(contour)]
+            pitch_candidates = chord_aware_pitch_tokens(
+                chord,
+                pitch_mode="approach_tensions",
+                recent_pitches=recent_pitches,
+                repeat_window=2,
+                group_index=group_index,
+            )
+            pitch_token_value = nearest_allowed_pitch_token(target_pitch, pitch_candidates, recent_pitches)
+            recent_pitches.append(pitch_from_token(pitch_token_value))
+            tokens.extend(
+                [
+                    position_candidates[len(position_candidates) // 2],
+                    note_velocity_token(4),
+                    pitch_token_value,
+                    duration_candidates[len(duration_candidates) // 2],
+                ]
+            )
+    tokens.append(TOKEN_END)
+    return tokens
+
+
+def data_motif_tokens(
+    *,
+    primer_tokens: Sequence[int],
+    chords: Sequence[str],
+    bars: int,
+    note_groups_per_bar: int,
+    template_report: dict[str, Any],
+    seed: int,
+) -> list[int]:
+    rng = random.Random(int(seed))
+    summary = template_report["summary"]
+    rhythm_rows = summary["top_rhythm_templates"]
+    contour_rows = summary["top_contour_templates"]
+    tokens = [int(token) for token in primer_tokens]
+    recent_pitches: list[int] = []
+    motif_length = 4
+    motifs_per_bar = max(1, int(round(max(1, int(note_groups_per_bar)) / motif_length)))
+    slot_size = max(1, int(POSITIONS_PER_BAR) // motifs_per_bar)
+
+    for bar_index in range(max(1, int(bars))):
+        chord = chords[bar_index % len(chords)] if chords else None
+        if bar_index > 0:
+            tokens.append(TOKEN_BAR)
+            tokens.extend(chord_tokens(chord))
+        emitted_in_bar = 0
+        for motif_index in range(motifs_per_bar):
+            row_index = bar_index * motifs_per_bar + motif_index
+            rhythm = weighted_choice(rhythm_rows, rng, row_index)["key"]
+            contour = weighted_choice(contour_rows, rng, row_index + int(seed))["key"]
+            slot_start = min(int(POSITIONS_PER_BAR) - 1, motif_index * slot_size)
+            positions = normalize_position_deltas(
+                rhythm["position_deltas"],
+                slot_start=slot_start,
+                slot_size=slot_size,
+            )
+            durations = fit_duration_tokens_to_positions(positions, rhythm["duration_steps"])
+            pitch_tokens = pitch_tokens_from_contour(
+                chord,
+                contour["pitch_intervals"],
+                rng=rng,
+                recent_pitches=recent_pitches,
+                group_offset=emitted_in_bar,
+            )
+            for position, duration_token, pitch_token_value in zip(positions, durations, pitch_tokens):
+                if emitted_in_bar >= int(note_groups_per_bar):
+                    break
+                tokens.extend(
+                    [
+                        position_token(position),
+                        note_velocity_token(4),
+                        pitch_token_value,
+                        duration_token,
+                    ]
+                )
+                emitted_in_bar += 1
+    tokens.append(TOKEN_END)
+    return tokens
+
+
+def generated_tokens_for_mode(
+    mode: str,
+    *,
+    primer_tokens: Sequence[int],
+    chords: Sequence[str],
+    bars: int,
+    note_groups_per_bar: int,
+    template_report: dict[str, Any],
+    seed: int,
+) -> list[int]:
+    if mode == "hand_written_swing":
+        return hand_written_swing_tokens(
+            primer_tokens=primer_tokens,
+            chords=chords,
+            bars=bars,
+            note_groups_per_bar=note_groups_per_bar,
+            seed=seed,
+        )
+    if mode == "data_motif":
+        return data_motif_tokens(
+            primer_tokens=primer_tokens,
+            chords=chords,
+            bars=bars,
+            note_groups_per_bar=note_groups_per_bar,
+            template_report=template_report,
+            seed=seed,
+        )
+    raise ValueError(f"unknown baseline mode: {mode}")
+
+
+def compact_summary(summary: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "sample_count": int(summary["sample_count"]),
+        "valid_sample_count": int(summary["valid_sample_count"]),
+        "strict_valid_sample_count": int(summary["strict_valid_sample_count"]),
+        "avg_syncopated_onset_ratio": float(summary["avg_syncopated_onset_ratio"]),
+        "avg_unique_bar_position_pattern_ratio": float(summary["avg_unique_bar_position_pattern_ratio"]),
+        "avg_duration_diversity_ratio": float(summary["avg_duration_diversity_ratio"]),
+        "avg_most_common_duration_ratio": float(summary["avg_most_common_duration_ratio"]),
+        "avg_ioi_diversity_ratio": float(summary["avg_ioi_diversity_ratio"]),
+        "avg_most_common_ioi_ratio": float(summary["avg_most_common_ioi_ratio"]),
+        "avg_tension_ratio": float(summary["avg_tension_ratio"]),
+        "avg_root_tone_ratio": float(summary["avg_root_tone_ratio"]),
+        "passed_strict_review_gate": bool(summary["passed_strict_review_gate"]),
+    }
+
+
+def build_compare_summary(
+    mode_summaries: dict[str, dict[str, Any]],
+    min_strict_valid_samples: int,
+) -> dict[str, Any]:
+    hand = mode_summaries.get("hand_written_swing")
+    data = mode_summaries.get("data_motif")
+    ready = bool(hand and data)
+    data_passed = bool(data and int(data["strict_valid_sample_count"]) >= int(min_strict_valid_samples))
+    hand_passed = bool(hand and int(hand["strict_valid_sample_count"]) >= int(min_strict_valid_samples))
+    def delta(metric: str) -> float:
+        return float(data.get(metric, 0.0) - hand.get(metric, 0.0)) if ready and data and hand else 0.0
+
+    return {
+        "comparison_ready": ready,
+        "passed_hand_written_swing_gate": hand_passed,
+        "passed_data_motif_gate": data_passed,
+        "passed_compare_gate": bool(ready and hand_passed and data_passed),
+        "duration_diversity_delta_data_minus_hand": delta("avg_duration_diversity_ratio"),
+        "ioi_diversity_delta_data_minus_hand": delta("avg_ioi_diversity_ratio"),
+        "bar_pattern_delta_data_minus_hand": delta("avg_unique_bar_position_pattern_ratio"),
+        "syncopation_delta_data_minus_hand": delta("avg_syncopated_onset_ratio"),
+        "mode_summaries": {mode: compact_summary(summary) for mode, summary in sorted(mode_summaries.items())},
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    lines = [
+        "# Stage B Data Motif Generation Compare",
+        "",
+        f"- passed compare gate: `{str(summary['passed_compare_gate']).lower()}`",
+        f"- duration diversity delta, data minus hand: `{summary['duration_diversity_delta_data_minus_hand']:.3f}`",
+        f"- IOI diversity delta, data minus hand: `{summary['ioi_diversity_delta_data_minus_hand']:.3f}`",
+        f"- bar-pattern delta, data minus hand: `{summary['bar_pattern_delta_data_minus_hand']:.3f}`",
+        f"- syncopation delta, data minus hand: `{summary['syncopation_delta_data_minus_hand']:.3f}`",
+        "",
+        "| mode | samples | strict | sync | bar-var | dur-var | dur-rep | ioi-var | ioi-rep | tension | root |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for mode, row in sorted(summary["mode_summaries"].items()):
+        lines.append(
+            "| {mode} | {sample_count} | {strict_valid_sample_count} | "
+            "{avg_syncopated_onset_ratio:.3f} | {avg_unique_bar_position_pattern_ratio:.3f} | "
+            "{avg_duration_diversity_ratio:.3f} | {avg_most_common_duration_ratio:.3f} | "
+            "{avg_ioi_diversity_ratio:.3f} | {avg_most_common_ioi_ratio:.3f} | "
+            "{avg_tension_ratio:.3f} | {avg_root_tone_ratio:.3f} |".format(mode=mode, **row)
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run Stage B data-derived motif baseline generation compare")
+    parser.add_argument("--output_root", type=str, default=str(ROOT_DIR / "outputs" / "stage_b_data_motif_compare"))
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--input_dir", type=str, default="./midi_dataset/midi/studio")
+    parser.add_argument("--issue_number", type=int, default=65)
+    parser.add_argument("--baseline_modes", type=str, default="hand_written_swing,data_motif")
+    parser.add_argument("--max_files", type=int, default=4)
+    parser.add_argument("--window_bars", type=int, default=8)
+    parser.add_argument("--window_stride_bars", type=int, default=4)
+    parser.add_argument("--min_window_target_notes", type=int, default=16)
+    parser.add_argument("--motif_length", type=int, default=4)
+    parser.add_argument("--max_bar_span", type=int, default=2)
+    parser.add_argument("--max_records", type=int, default=64)
+    parser.add_argument("--template_top_n", type=int, default=32)
+    parser.add_argument("--bpm", type=int, default=124)
+    parser.add_argument("--bars", type=int, default=8)
+    parser.add_argument("--chords", type=str, default="Cm7,Fm7,Bb7,Ebmaj7")
+    parser.add_argument("--density", type=str, default="medium")
+    parser.add_argument("--energy", type=str, default="mid")
+    parser.add_argument("--temperature", type=float, default=0.9)
+    parser.add_argument("--top_k", type=int, default=2)
+    parser.add_argument("--seed", type=int, default=17)
+    parser.add_argument("--num_samples", type=int, default=3)
+    parser.add_argument("--note_groups_per_bar", type=int, default=8)
+    parser.add_argument("--max_sequence", type=int, default=384)
+    parser.add_argument("--max_simultaneous_notes", type=int, default=2)
+    parser.add_argument("--min_strict_valid_samples", type=int, default=1)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    args.run_id = args.run_id or datetime.now().strftime("%Y%m%d_%H%M%S")
+    run_dir = Path(args.output_root) / args.run_id
+    samples_dir = run_dir / "samples"
+    modes = parse_baseline_modes(args.baseline_modes)
+    chords = parse_chords(args.chords)
+    request = GenerationRequest(
+        bpm=int(args.bpm),
+        chord_progression=chords,
+        bars=int(args.bars),
+        density=args.density,
+        energy=args.energy,
+        temperature=float(args.temperature),
+        top_k=int(args.top_k),
+        seed=int(args.seed),
+    )
+    request.validate()
+
+    template_report_path, template_command = run_template_extraction(args, run_dir)
+    report: dict[str, Any] = {
+        "run_id": args.run_id,
+        "run_dir": str(run_dir),
+        "issue": int(args.issue_number),
+        "baseline_modes": modes,
+        "template_report_path": str(template_report_path),
+        "template_command": template_command,
+        "chords": chords,
+        "bars": int(args.bars),
+        "note_groups_per_bar": int(args.note_groups_per_bar),
+        "samples": {},
+    }
+    if template_command["returncode"] != 0:
+        report["failure_reason"] = "motif template extraction failed"
+        write_json(run_dir / "data_motif_compare_report.json", report)
+        print(json.dumps(report, ensure_ascii=True, indent=2))
+        return int(template_command["returncode"])
+
+    template_report = read_json(template_report_path)
+    primer_tokens = build_stage_b_primer(chords, args.bpm)
+    mode_summaries: dict[str, dict[str, Any]] = {}
+    for mode in modes:
+        rows: list[dict[str, Any]] = []
+        for index in range(1, int(args.num_samples) + 1):
+            sample_seed = int(args.seed) + index - 1
+            tokens = generated_tokens_for_mode(
+                mode,
+                primer_tokens=primer_tokens,
+                chords=chords,
+                bars=int(args.bars),
+                note_groups_per_bar=int(args.note_groups_per_bar),
+                template_report=template_report,
+                seed=sample_seed,
+            )[: int(args.max_sequence)]
+            midi_path = samples_dir / mode / f"{mode}_sample_{index}.mid"
+            midi_path.parent.mkdir(parents=True, exist_ok=True)
+            midi = decode_stage_b_midi(tokens, tempo_bpm=args.bpm)
+            postprocess_report = postprocess_stage_b_midi(
+                midi,
+                simultaneous_limit=int(args.max_simultaneous_notes),
+            )
+            midi.write(str(midi_path))
+            rows.append(
+                sample_report(
+                    sample_index=index,
+                    sample_seed=sample_seed,
+                    tokens=tokens,
+                    primer_size=len(primer_tokens),
+                    target_length=int(args.max_sequence),
+                    midi_path=midi_path,
+                    request=request,
+                    postprocess_report=postprocess_report,
+                )
+            )
+        summary = build_probe_summary(
+            rows,
+            min_valid_samples=1,
+            min_strict_valid_samples=int(args.min_strict_valid_samples),
+            require_all_grammar_samples=True,
+        )
+        report["samples"][mode] = rows
+        mode_summaries[mode] = summary
+
+    report["summary"] = build_compare_summary(
+        mode_summaries,
+        min_strict_valid_samples=int(args.min_strict_valid_samples),
+    )
+    write_json(run_dir / "data_motif_compare_report.json", report)
+    (run_dir / "data_motif_compare_report.md").write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps(report["summary"], ensure_ascii=True, indent=2))
+    return 0 if report["summary"]["passed_compare_gate"] else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_data_motif_generation_compare.py
+++ b/tests/test_stage_b_data_motif_generation_compare.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.run_stage_b_data_motif_generation_compare import (
+    data_motif_tokens,
+    duration_tokens_from_steps,
+    fit_duration_tokens_to_positions,
+    nearest_allowed_pitch_token,
+    normalize_position_deltas,
+    parse_baseline_modes,
+)
+from scripts.run_stage_b_generation_probe import (
+    analyze_stage_b_note_grammar,
+    build_stage_b_primer,
+    extract_stage_b_note_groups,
+)
+from scripts.stage_b_tokens import (
+    TOKEN_NOTE_PITCH_END,
+    TOKEN_NOTE_PITCH_START,
+    duration_steps_from_token,
+    pitch_from_token,
+)
+
+
+def template_report() -> dict:
+    return {
+        "summary": {
+            "top_rhythm_templates": [
+                {
+                    "count": 3,
+                    "key": {
+                        "position_deltas": [0, 2, 5, 7],
+                        "duration_steps": [2, 1, 3, 2],
+                    },
+                },
+                {
+                    "count": 1,
+                    "key": {
+                        "position_deltas": [0, 3, 4, 9],
+                        "duration_steps": [1, 4, 2, 1],
+                    },
+                },
+            ],
+            "top_contour_templates": [
+                {
+                    "count": 2,
+                    "key": {
+                        "pitch_intervals": [0, 2, 5, 3],
+                    },
+                },
+                {
+                    "count": 1,
+                    "key": {
+                        "pitch_intervals": [0, -2, 1, 0],
+                    },
+                },
+            ],
+        }
+    }
+
+
+class StageBDataMotifGenerationCompareTest(unittest.TestCase):
+    def test_parse_baseline_modes_rejects_unknown_mode(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_baseline_modes("hand_written_swing,random")
+
+    def test_normalize_position_deltas_scales_into_slot(self) -> None:
+        positions = normalize_position_deltas([0, 3, 9, 12], slot_start=8, slot_size=8)
+
+        self.assertEqual(positions[0], 8)
+        self.assertLessEqual(positions[-1], 15)
+        self.assertEqual(positions, sorted(set(positions)))
+
+    def test_duration_tokens_from_steps_clamps_count(self) -> None:
+        tokens = duration_tokens_from_steps([0, 2, 99], target_count=4)
+        steps = [duration_steps_from_token(token) for token in tokens]
+
+        self.assertEqual(len(steps), 4)
+        self.assertEqual(steps[0], 1)
+        self.assertGreaterEqual(steps[-1], 1)
+
+    def test_fit_duration_tokens_to_positions_prevents_overlap(self) -> None:
+        tokens = fit_duration_tokens_to_positions([0, 1, 3, 7], [8, 8, 8, 8])
+        steps = [duration_steps_from_token(token) for token in tokens]
+
+        self.assertEqual(steps, [1, 2, 4, 4])
+
+    def test_nearest_allowed_pitch_token_avoids_recent_pitch_when_possible(self) -> None:
+        allowed = list(range(TOKEN_NOTE_PITCH_START, TOKEN_NOTE_PITCH_END + 1))
+        recent_pitch = pitch_from_token(allowed[0])
+
+        token = nearest_allowed_pitch_token(recent_pitch, allowed[:3], recent_pitches=[recent_pitch])
+
+        self.assertNotEqual(pitch_from_token(token), recent_pitch)
+
+    def test_data_motif_tokens_builds_strictly_increasing_solo_line_groups(self) -> None:
+        primer = build_stage_b_primer(["Cm7", "Fm7"], 124)
+        tokens = data_motif_tokens(
+            primer_tokens=primer,
+            chords=["Cm7", "Fm7"],
+            bars=2,
+            note_groups_per_bar=8,
+            template_report=template_report(),
+            seed=17,
+        )
+
+        grammar = analyze_stage_b_note_grammar(tokens, primer_size=len(primer))
+        groups = extract_stage_b_note_groups(tokens, primer_size=len(primer))
+        positions_by_bar: dict[int, list[int]] = {}
+        for group in groups:
+            positions_by_bar.setdefault(int(group["bar"]), []).append(int(group["position"]))
+
+        self.assertTrue(grammar["grammar_valid"])
+        self.assertEqual(len(groups), 16)
+        for positions in positions_by_bar.values():
+            self.assertEqual(positions, sorted(positions))
+            self.assertEqual(len(positions), len(set(positions)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약
- Issue #63에서 추출한 real phrase motif catalog를 8-bar generation baseline에 연결했습니다.
- hand_written_swing과 data_motif baseline을 같은 조건에서 비교하는 스크립트와 하네스를 추가했습니다.
- data-derived duration을 다음 onset 전까지 제한해 overlap/postprocess 제거로 인한 dead-air 실패를 막았습니다.

## 결과
- hand_written_swing strict: 3/3
- data_motif strict: 3/3
- data minus hand duration diversity delta: +0.016
- data minus hand IOI diversity delta: +0.016
- data minus hand bar-pattern delta: +0.500
- data minus hand syncopation delta: -0.125

## 해석
- data_motif는 pattern variation과 duration repetition 측면에서 나아졌습니다.
- syncopation은 낮아졌으므로 더 좋은 jazz solo라고 바로 말하지 않고, 다음 단계에서 MIDI review export/listening 비교가 필요합니다.

## 검증
- bash scripts/agent_harness.sh stage-b-data-motif-compare
- bash scripts/agent_harness.sh quick

Closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added baseline comparison capability for Stage B data-derived motif generation, enabling comparison between hand-written swing rhythm and data-derived motif approaches.
  * Introduced new validation harness command for Stage B motif comparison workflows.

* **Documentation**
  * Updated Stage B progress documentation with latest Issue `#65` results and comparison metrics.
  * Added comprehensive guide for data-derived motif baseline generation process and validation steps.

* **Tests**
  * Added test suite for motif generation utilities, covering position normalization, duration fitting, and pitch selection logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohhalim/fine_tuning_art-tatum_midi_solo/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->