### PR TITLE
Stage B data motif review export 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #65: Stage B data-derived motif baseline generation.
+- Issue #67: Stage B data motif review export.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -188,6 +188,12 @@ For Stage B data-derived motif baseline generation changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-data-motif-compare
+```
+
+For Stage B data motif review export changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-data-motif-review-export
 ```
 
 For Stage B collapse/sampling-sweep changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -135,6 +135,7 @@ Stage B에서 명시하는 것:
 29. Stage B real phrase reference statistics
 30. Stage B data-derived motif template extraction
 31. Stage B data-derived motif baseline generation
+32. Stage B data motif review export
 
 가장 최근 의미 있는 결과:
 
@@ -344,6 +345,7 @@ Stage B에서 명시하는 것:
 - Issue #63 result: top rhythm support는 `0.009`, top contour support는 `0.012`, top full motif support는 `0.002`라서 one best motif 복붙이 아니라 distribution sampling이 필요하다.
 - Issue #65 result: data-derived motif baseline도 strict `3/3`을 통과했다.
 - Issue #65 result: hand-written swing 대비 bar-position variation은 `+0.500`, duration diversity는 `+0.016`, IOI diversity는 `+0.016` 개선됐지만 syncopation은 `-0.125` 낮아졌다.
+- Issue #67 result: `data_motif`와 `hand_written_swing` 후보를 mode/sample/rank가 드러나는 named MIDI review package로 export했다.
 
 해석:
 
@@ -474,6 +476,32 @@ Stage B에서 명시하는 것:
 - 실제 piano roll에서 phrase contour가 초급 scale exercise보다 나은지 확인한다.
 - data_motif가 review 가치가 있으면 model constrained generation 쪽에 연결하고, 아니면 contour/cadence extraction을 더 강화한다.
 
+### Phase 3.14. Data Motif Review Export
+
+목표:
+
+- `data_motif`와 `hand_written_swing` 후보를 mode/sample/rank 기준으로 구분한다.
+- piano-roll/listening review가 가능하도록 named MIDI package를 만든다.
+- review markdown에 핵심 metric을 같이 남긴다.
+
+현재 결과:
+
+- completed: `review_manifest.json`과 `review_candidates.md`를 생성한다.
+- completed: `named_midi/` 아래에 mode가 드러나는 MIDI 파일명을 만든다.
+- latest result: review candidates `6`.
+- latest result: `data_motif` strict `3/3`, `hand_written_swing` strict `3/3`.
+
+해석:
+
+- 이제 숫자 비교가 아니라 실제 청취 리뷰가 가능하다.
+- syncopation 하락이 체감상 나쁜지, duration repetition 감소가 실제로 더 나은지 확인해야 한다.
+
+다음 통과 기준:
+
+- named MIDI 후보를 직접 듣고 piano roll로 확인한다.
+- data_motif가 더 자연스러우면 motif sampling을 model constrained generation에 연결한다.
+- 둘 다 초급 scale exercise면 cadence/phrase-ending extraction을 먼저 강화한다.
+
 ### Phase 4. Generic Jazz Base 후보 학습
 
 목표:
@@ -568,7 +596,7 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B data-derived motif baseline generation 추가
+Stage B data motif review export 추가
 ```
 
 결과:
@@ -578,10 +606,10 @@ Stage B data-derived motif baseline generation 추가
 - duration repetition ratio는 `0.750`에서 `0.375`로 낮췄다.
 - duration diversity와 IOI diversity는 소폭 올랐다.
 - syncopation은 `0.750`에서 `0.625`로 낮아졌다.
+- review candidates `6`개와 named MIDI package를 만들었다.
 
 다음 작업:
 
-- generated data_motif MIDI를 review export 대상으로 분리한다.
 - hand_written_swing 후보와 data_motif 후보를 piano roll/listening으로 비교한다.
 - syncopation 하락이 groove 약화로 들리는지 확인한다.
 - contour가 초급 코드톤 나열을 넘어 phrase motion으로 들리는지 본다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-65-stage-b-data-derived-motif-generation`
+- `issue-67-stage-b-data-motif-review-export`
 
 현재 범위가 아닌 것:
 
@@ -36,25 +36,30 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 ## Latest Probe Result
 
-Issue #65는 Issue #63에서 추출한 motif catalog를 generation-side baseline으로 연결하는 단계다.
+Issue #67은 Issue #65에서 만든 `hand_written_swing` vs `data_motif` baseline을 실제 review package로 export하는 단계다.
 
-Issue #63은 실제 Stage B phrase window에서 rhythm/contour/full motif templates를 추출했다. 이번에는 그 catalog를 사용해 hand-written `swing_motif_approach`와 data-derived motif baseline을 같은 8-bar 조건에서 비교한다.
+Issue #65에서 `data_motif`는 strict gate를 통과했고 bar-pattern variation과 duration repetition은 좋아졌지만, syncopation은 낮아졌다. 이제 mode가 명확히 드러나는 MIDI 파일로 piano-roll/listening review를 해야 한다.
 
 Implemented:
 
-- `scripts/run_stage_b_data_motif_generation_compare.py`
-- `tests/test_stage_b_data_motif_generation_compare.py`
-- `scripts/agent_harness.sh stage-b-data-motif-compare`
+- `scripts/run_stage_b_data_motif_generation_compare.py` review export
+- `tests/test_stage_b_data_motif_generation_compare.py` review export test
+- `scripts/agent_harness.sh stage-b-data-motif-review-export`
 - output files:
   - `data_motif_compare_report.json`
   - `data_motif_compare_report.md`
+  - `review_manifest.json`
+  - `review_candidates.md`
+  - `named_midi/*.mid`
 
 Result:
 
-- source report: `outputs/stage_b_data_motif_compare/harness_stage_b_data_motif_compare/data_motif_compare_report.json`
+- source report: `outputs/stage_b_data_motif_compare/harness_stage_b_data_motif_review_export/data_motif_compare_report.json`
 - setup: `./midi_dataset/midi/studio`, max files `4`, `8`-bar windows, stride `4`, min notes `16`
 - `hand_written_swing`: strict `3/3`
 - `data_motif`: strict `3/3`
+- review candidates: `6`
+- review output: `outputs/stage_b_data_motif_review/harness_stage_b_data_motif_review_export`
 - data minus hand duration diversity delta: `+0.016`
 - data minus hand IOI diversity delta: `+0.016`
 - data minus hand bar-pattern delta: `+0.500`
@@ -64,9 +69,9 @@ Result:
 
 Decision:
 
-- data-derived motif baseline은 strict gate를 통과하고, hand-written baseline보다 bar variation과 duration repetition 면에서 낫다.
-- syncopation은 낮아졌으므로 곧바로 더 좋은 jazz phrase라고 말하면 안 된다.
-- 다음은 generated MIDI review export로 실제 piano roll/listening 비교를 해야 한다.
+- review package가 만들어졌으므로 이제 실제 piano roll/listening 비교가 가능하다.
+- 다음 판단은 수치가 아니라 named MIDI 후보를 직접 확인한 결과로 해야 한다.
+- 들어보고 나서 model constrained generation에 연결할지, cadence/ending extraction을 먼저 강화할지 결정한다.
 
 Detail:
 
@@ -83,6 +88,7 @@ Detail:
 - `docs/STAGE_B_REFERENCE_PHRASE_STATS_2026-05-21.md`
 - `docs/STAGE_B_MOTIF_TEMPLATE_EXTRACTION_2026-05-21.md`
 - `docs/STAGE_B_DATA_MOTIF_GENERATION_2026-05-21.md`
+- `docs/STAGE_B_DATA_MOTIF_REVIEW_EXPORT_2026-05-21.md`
 
 ## Active Issue #14
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -76,6 +76,8 @@
   - 실제 Stage B phrase window에서 rhythm/contour/full motif templates를 추출해 다음 data-derived generation constraint로 넘기기 위한 결과.
 - `STAGE_B_DATA_MOTIF_GENERATION_2026-05-21.md`
   - 추출된 motif catalog를 8-bar generation baseline에 연결해 hand-written swing grammar와 비교한 결과.
+- `STAGE_B_DATA_MOTIF_REVIEW_EXPORT_2026-05-21.md`
+  - data-derived motif baseline과 hand-written swing baseline의 MIDI 후보를 named review package로 export한 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -102,7 +104,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, and data-derived motif baseline generation을 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, and data motif review export를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_DATA_MOTIF_REVIEW_EXPORT_2026-05-21.md
+++ b/docs/STAGE_B_DATA_MOTIF_REVIEW_EXPORT_2026-05-21.md
@@ -1,0 +1,85 @@
+# Stage B Data Motif Review Export
+
+작성일: 2026-05-21
+
+## 목적
+
+Issue #65는 `hand_written_swing`과 `data_motif` baseline을 숫자로 비교했다.
+
+이번 작업은 두 baseline의 MIDI 후보를 실제 piano-roll/listening review용으로 분리한다.
+
+숫자상으로는 `data_motif`가 bar-pattern variation과 duration repetition에서 좋아졌지만, syncopation은 낮아졌다. 따라서 다음 판단은 report 수치만으로 하지 않고, mode가 명확히 드러나는 MIDI 파일을 직접 들어보는 것이다.
+
+## 구현
+
+변경 파일:
+
+- `scripts/run_stage_b_data_motif_generation_compare.py`
+- `tests/test_stage_b_data_motif_generation_compare.py`
+- `scripts/agent_harness.sh`
+
+추가 하네스:
+
+```bash
+bash scripts/agent_harness.sh stage-b-data-motif-review-export
+```
+
+생성 산출물:
+
+- `outputs/stage_b_data_motif_compare/<run_id>/data_motif_compare_report.json`
+- `outputs/stage_b_data_motif_compare/<run_id>/data_motif_compare_report.md`
+- `outputs/stage_b_data_motif_review/<run_id>/review_manifest.json`
+- `outputs/stage_b_data_motif_review/<run_id>/review_candidates.md`
+- `outputs/stage_b_data_motif_review/<run_id>/named_midi/*.mid`
+
+Generated artifacts는 커밋하지 않는다.
+
+## Local Result
+
+실행:
+
+```bash
+bash scripts/agent_harness.sh stage-b-data-motif-review-export
+```
+
+결과:
+
+- compare gate: `true`
+- `hand_written_swing`: strict `3/3`
+- `data_motif`: strict `3/3`
+- review candidates: `6`
+- named MIDI files:
+  - `01_data_motif_rank_01_sample_01.mid`
+  - `01_data_motif_rank_02_sample_02.mid`
+  - `01_data_motif_rank_03_sample_03.mid`
+  - `02_hand_written_swing_rank_01_sample_01.mid`
+  - `02_hand_written_swing_rank_02_sample_02.mid`
+  - `02_hand_written_swing_rank_03_sample_03.mid`
+
+## Review 기준
+
+이제 들어봐야 할 것은 "strict gate 통과"가 아니다.
+
+확인할 질문:
+
+- `data_motif`가 hand-written보다 phrase movement가 자연스러운가?
+- syncopation 하락이 groove 약화로 들리는가?
+- duration repetition이 줄어든 것이 실제로 덜 초급스럽게 들리는가?
+- 여전히 코드톤/스케일 나열처럼 들리는가?
+- 8-bar 안에서 call, continuation, landing이 느껴지는가?
+
+## 다음 판단
+
+가능한 분기:
+
+- `data_motif`가 더 낫게 들리면, model constrained generation 쪽에 motif template sampling을 연결한다.
+- 둘 다 초급 scale exercise처럼 들리면, contour보다 cadence/phrase-ending extraction을 먼저 강화한다.
+- syncopation 하락이 크게 들리면, data-derived rhythm sampling에 syncopation floor를 추가한다.
+
+## Validation
+
+```bash
+./.venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare
+bash scripts/agent_harness.sh stage-b-data-motif-review-export
+bash scripts/agent_harness.sh quick
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -64,6 +64,8 @@ Modes:
                 Extract data-derived Stage B motif/rhythm templates.
   stage-b-data-motif-compare
                 Compare hand-written swing against data-derived motif baseline.
+  stage-b-data-motif-review-export
+                Export named MIDI review candidates for data-derived motif compare.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   all           Run demo and tiny-compare.
@@ -666,6 +668,27 @@ run_stage_b_data_motif_compare() {
     --note_groups_per_bar 8
 }
 
+run_stage_b_data_motif_review_export() {
+  local run_id="${RUN_ID:-harness_stage_b_data_motif_review_export}"
+  print_header "Stage B data motif review export"
+  "$PYTHON_BIN" scripts/run_stage_b_data_motif_generation_compare.py \
+    --run_id "$run_id" \
+    --input_dir ./midi_dataset/midi/studio \
+    --max_files 4 \
+    --window_bars 8 \
+    --window_stride_bars 4 \
+    --min_window_target_notes 16 \
+    --motif_length 4 \
+    --max_bar_span 2 \
+    --max_records 64 \
+    --template_top_n 32 \
+    --num_samples 3 \
+    --bars 8 \
+    --note_groups_per_bar 8 \
+    --review_top_n 3 \
+    --copy_review_midi
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -749,6 +772,9 @@ case "$MODE" in
     ;;
   stage-b-data-motif-compare)
     run_stage_b_data_motif_compare
+    ;;
+  stage-b-data-motif-review-export)
+    run_stage_b_data_motif_review_export
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/run_stage_b_data_motif_generation_compare.py
+++ b/scripts/run_stage_b_data_motif_generation_compare.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import random
+import shutil
 import subprocess
 import sys
 from datetime import datetime
@@ -452,6 +453,126 @@ def markdown_report(report: dict[str, Any]) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
+def candidate_sort_key(row: dict[str, Any]) -> tuple[int, int, float, float, float]:
+    rhythm = row.get("rhythm_profile", {})
+    return (
+        int(bool(row.get("strict_valid"))),
+        int(bool(row.get("valid"))),
+        float(rhythm.get("unique_bar_position_pattern_ratio", 0.0) or 0.0),
+        float(rhythm.get("duration_diversity_ratio", 0.0) or 0.0),
+        -float(rhythm.get("most_common_duration_ratio", 0.0) or 0.0),
+    )
+
+
+def compact_review_candidate(
+    mode: str,
+    row: dict[str, Any],
+    *,
+    review_rank: int,
+    review_midi_path: Path | None,
+) -> dict[str, Any]:
+    rhythm = row.get("rhythm_profile", {})
+    pitch_roles = row.get("pitch_roles", {})
+    metrics = row.get("metrics", {})
+    return {
+        "mode": mode,
+        "review_rank": int(review_rank),
+        "sample_index": int(row["sample_index"]),
+        "sample_seed": int(row["sample_seed"]),
+        "valid": bool(row["valid"]),
+        "strict_valid": bool(row["strict_valid"]),
+        "midi_path": row["midi_path"],
+        "review_midi_path": str(review_midi_path) if review_midi_path else None,
+        "note_count": int(metrics.get("note_count", 0) or 0),
+        "unique_pitch_count": int(metrics.get("unique_pitch_count", 0) or 0),
+        "dead_air_ratio": float(metrics.get("dead_air_ratio", 0.0) or 0.0),
+        "syncopated_onset_ratio": float(rhythm.get("syncopated_onset_ratio", 0.0) or 0.0),
+        "unique_bar_position_pattern_ratio": float(
+            rhythm.get("unique_bar_position_pattern_ratio", 0.0) or 0.0
+        ),
+        "duration_diversity_ratio": float(rhythm.get("duration_diversity_ratio", 0.0) or 0.0),
+        "most_common_duration_ratio": float(rhythm.get("most_common_duration_ratio", 0.0) or 0.0),
+        "ioi_diversity_ratio": float(rhythm.get("ioi_diversity_ratio", 0.0) or 0.0),
+        "most_common_ioi_ratio": float(rhythm.get("most_common_ioi_ratio", 0.0) or 0.0),
+        "tension_ratio": float(pitch_roles.get("tension_ratio", 0.0) or 0.0),
+        "root_tone_ratio": float(pitch_roles.get("root_tone_ratio", 0.0) or 0.0),
+        "diagnostic_failure_reason": row.get("diagnostic_failure_reason"),
+    }
+
+
+def review_markdown_report(manifest: dict[str, Any]) -> str:
+    lines = [
+        "# Stage B Data Motif Review Candidates",
+        "",
+        f"- candidate count: `{manifest['candidate_count']}`",
+        f"- copy midi: `{str(manifest['copy_midi']).lower()}`",
+        "",
+        "| mode | rank | sample | strict | notes | pitches | sync | bar-var | dur-var | dur-rep | ioi-var | ioi-rep | tension | midi |",
+        "|---|---:|---:|:---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for row in manifest["candidates"]:
+        midi_path = row.get("review_midi_path") or row.get("midi_path")
+        format_row = dict(row)
+        format_row["display_midi_path"] = midi_path
+        lines.append(
+            "| {mode} | {review_rank} | {sample_index} | {strict_valid} | {note_count} | "
+            "{unique_pitch_count} | {syncopated_onset_ratio:.3f} | "
+            "{unique_bar_position_pattern_ratio:.3f} | {duration_diversity_ratio:.3f} | "
+            "{most_common_duration_ratio:.3f} | {ioi_diversity_ratio:.3f} | "
+            "{most_common_ioi_ratio:.3f} | {tension_ratio:.3f} | `{display_midi_path}` |".format(**format_row)
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_review_export(
+    samples_by_mode: dict[str, list[dict[str, Any]]],
+    *,
+    output_dir: Path,
+    top_n: int,
+    copy_midi: bool,
+) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    named_dir = output_dir / "named_midi"
+    if copy_midi:
+        named_dir.mkdir(parents=True, exist_ok=True)
+
+    candidates: list[dict[str, Any]] = []
+    for mode_index, mode in enumerate(sorted(samples_by_mode), start=1):
+        rows = sorted(samples_by_mode[mode], key=candidate_sort_key, reverse=True)
+        for review_rank, row in enumerate(rows[: int(top_n)], start=1):
+            review_midi_path: Path | None = None
+            if copy_midi:
+                source = Path(str(row["midi_path"]))
+                if not source.is_absolute():
+                    source = ROOT_DIR / source
+                target = named_dir / (
+                    f"{mode_index:02d}_{mode}_rank_{review_rank:02d}_"
+                    f"sample_{int(row['sample_index']):02d}.mid"
+                )
+                if source.exists():
+                    shutil.copy2(source, target)
+                    review_midi_path = target
+            candidates.append(
+                compact_review_candidate(
+                    mode,
+                    row,
+                    review_rank=review_rank,
+                    review_midi_path=review_midi_path,
+                )
+            )
+
+    manifest = {
+        "output_dir": str(output_dir),
+        "copy_midi": bool(copy_midi),
+        "top_n": int(top_n),
+        "candidate_count": int(len(candidates)),
+        "candidates": candidates,
+    }
+    write_json(output_dir / "review_manifest.json", manifest)
+    (output_dir / "review_candidates.md").write_text(review_markdown_report(manifest), encoding="utf-8")
+    return manifest
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run Stage B data-derived motif baseline generation compare")
     parser.add_argument("--output_root", type=str, default=str(ROOT_DIR / "outputs" / "stage_b_data_motif_compare"))
@@ -480,6 +601,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--max_sequence", type=int, default=384)
     parser.add_argument("--max_simultaneous_notes", type=int, default=2)
     parser.add_argument("--min_strict_valid_samples", type=int, default=1)
+    parser.add_argument("--review_top_n", type=int, default=3)
+    parser.add_argument("--review_output_root", type=str, default=str(ROOT_DIR / "outputs" / "stage_b_data_motif_review"))
+    parser.add_argument("--copy_review_midi", action="store_true")
     return parser
 
 
@@ -524,6 +648,7 @@ def main() -> int:
     template_report = read_json(template_report_path)
     primer_tokens = build_stage_b_primer(chords, args.bpm)
     mode_summaries: dict[str, dict[str, Any]] = {}
+    samples_by_mode: dict[str, list[dict[str, Any]]] = {}
     for mode in modes:
         rows: list[dict[str, Any]] = []
         for index in range(1, int(args.num_samples) + 1):
@@ -564,11 +689,18 @@ def main() -> int:
             require_all_grammar_samples=True,
         )
         report["samples"][mode] = rows
+        samples_by_mode[mode] = rows
         mode_summaries[mode] = summary
 
     report["summary"] = build_compare_summary(
         mode_summaries,
         min_strict_valid_samples=int(args.min_strict_valid_samples),
+    )
+    report["review_export"] = build_review_export(
+        samples_by_mode,
+        output_dir=Path(args.review_output_root) / args.run_id,
+        top_n=int(args.review_top_n),
+        copy_midi=bool(args.copy_review_midi),
     )
     write_json(run_dir / "data_motif_compare_report.json", report)
     (run_dir / "data_motif_compare_report.md").write_text(markdown_report(report), encoding="utf-8")

--- a/tests/test_stage_b_data_motif_generation_compare.py
+++ b/tests/test_stage_b_data_motif_generation_compare.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from scripts.run_stage_b_data_motif_generation_compare import (
+    build_review_export,
     data_motif_tokens,
     duration_tokens_from_steps,
     fit_duration_tokens_to_positions,
@@ -116,6 +119,53 @@ class StageBDataMotifGenerationCompareTest(unittest.TestCase):
         for positions in positions_by_bar.values():
             self.assertEqual(positions, sorted(positions))
             self.assertEqual(len(positions), len(set(positions)))
+
+    def test_build_review_export_copies_named_mode_files(self) -> None:
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            source_midi = tmp_path / "source.mid"
+            source_midi.write_bytes(b"MThd")
+            samples = {
+                "data_motif": [
+                    {
+                        "sample_index": 1,
+                        "sample_seed": 17,
+                        "valid": True,
+                        "strict_valid": True,
+                        "midi_path": str(source_midi),
+                        "metrics": {
+                            "note_count": 8,
+                            "unique_pitch_count": 4,
+                            "dead_air_ratio": 0.1,
+                        },
+                        "rhythm_profile": {
+                            "syncopated_onset_ratio": 0.6,
+                            "unique_bar_position_pattern_ratio": 1.0,
+                            "duration_diversity_ratio": 0.2,
+                            "most_common_duration_ratio": 0.4,
+                            "ioi_diversity_ratio": 0.2,
+                            "most_common_ioi_ratio": 0.4,
+                        },
+                        "pitch_roles": {
+                            "tension_ratio": 0.2,
+                            "root_tone_ratio": 0.0,
+                        },
+                    }
+                ]
+            }
+
+            manifest = build_review_export(
+                samples,
+                output_dir=tmp_path / "review",
+                top_n=1,
+                copy_midi=True,
+            )
+
+            copied = Path(manifest["candidates"][0]["review_midi_path"])
+            self.assertTrue(copied.exists())
+            self.assertIn("data_motif", copied.name)
+            self.assertTrue((tmp_path / "review" / "review_manifest.json").exists())
+            self.assertTrue((tmp_path / "review" / "review_candidates.md").exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 요약
- hand_written_swing과 data_motif 후보를 mode/sample/rank가 드러나는 named MIDI review package로 export합니다.
- review_manifest.json과 review_candidates.md를 생성하고, copy 옵션으로 named_midi 디렉터리에 MIDI를 복사합니다.
- 관련 하네스와 문서를 업데이트했습니다.

## 결과
- compare gate: true
- hand_written_swing strict: 3/3
- data_motif strict: 3/3
- review candidates: 6
- named MIDI 파일 생성 확인

## 검증
- bash scripts/agent_harness.sh stage-b-data-motif-review-export
- bash scripts/agent_harness.sh quick

Closes #67