### PR TITLE
Stage B 리뷰 MIDI에 코드 컨텍스트 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #67: Stage B data motif review export.
+- Issue #69: Stage B review MIDI chord context and straight-grid candidates.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -194,6 +194,12 @@ For Stage B data motif review export changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-data-motif-review-export
+```
+
+For Stage B review MIDI chord-context/straight-grid changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-review-context-grid
 ```
 
 For Stage B collapse/sampling-sweep changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -136,6 +136,7 @@ Stage B에서 명시하는 것:
 30. Stage B data-derived motif template extraction
 31. Stage B data-derived motif baseline generation
 32. Stage B data motif review export
+33. Stage B chord-context and straight-grid review export
 
 가장 최근 의미 있는 결과:
 
@@ -346,6 +347,7 @@ Stage B에서 명시하는 것:
 - Issue #65 result: data-derived motif baseline도 strict `3/3`을 통과했다.
 - Issue #65 result: hand-written swing 대비 bar-position variation은 `+0.500`, duration diversity는 `+0.016`, IOI diversity는 `+0.016` 개선됐지만 syncopation은 `-0.125` 낮아졌다.
 - Issue #67 result: `data_motif`와 `hand_written_swing` 후보를 mode/sample/rank가 드러나는 named MIDI review package로 export했다.
+- Issue #69 result: chord/bass guide가 들어간 context MIDI와 straight-grid timing reference를 추가했다.
 
 해석:
 
@@ -502,6 +504,34 @@ Stage B에서 명시하는 것:
 - data_motif가 더 자연스러우면 motif sampling을 model constrained generation에 연결한다.
 - 둘 다 초급 scale exercise면 cadence/phrase-ending extraction을 먼저 강화한다.
 
+### Phase 3.15. Chord Context and Straight-Grid Review
+
+목표:
+
+- solo-only MIDI 리뷰의 한계를 줄인다.
+- chord/bass guide가 포함된 context MIDI를 생성한다.
+- swing/motif timing이 문제인지 확인하기 위해 straight-grid reference를 같이 export한다.
+
+현재 결과:
+
+- completed: `chord_guide.mid`를 생성한다.
+- completed: candidate별 `*_with_context.mid`를 생성한다.
+- completed: `straight_grid` baseline mode를 추가했다.
+- latest result: `data_motif` strict `3/3`, `hand_written_swing` strict `3/3`.
+- latest result: `straight_grid`는 timing reference로 export한다.
+
+해석:
+
+- 이제 chord progression 위에서 line이 in인지 out인지 들을 수 있다.
+- swing/motif가 musical swing이 아니라 timing drift처럼 들리는지 비교할 수 있다.
+- straight_grid는 더 좋은 솔로가 아니라 timing 기준점이다.
+
+다음 통과 기준:
+
+- context MIDI를 직접 듣고 `data_motif`, `hand_written_swing`, `straight_grid`를 비교한다.
+- swing이 거슬리면 generated output은 straight quantized grid를 기본으로 둔다.
+- chord context 위에서도 phrase가 초급스럽다면 cadence/phrase-ending extraction을 먼저 강화한다.
+
 ### Phase 4. Generic Jazz Base 후보 학습
 
 목표:
@@ -596,7 +626,7 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B data motif review export 추가
+Stage B chord-context and straight-grid review export 추가
 ```
 
 결과:
@@ -606,13 +636,15 @@ Stage B data motif review export 추가
 - duration repetition ratio는 `0.750`에서 `0.375`로 낮췄다.
 - duration diversity와 IOI diversity는 소폭 올랐다.
 - syncopation은 `0.750`에서 `0.625`로 낮아졌다.
-- review candidates `6`개와 named MIDI package를 만들었다.
+- review candidates `9`개와 named MIDI package를 만들었다.
+- `chord_guide.mid`와 candidate별 `*_with_context.mid`를 만들었다.
+- `straight_grid` timing reference를 추가했다.
 
 다음 작업:
 
-- hand_written_swing 후보와 data_motif 후보를 piano roll/listening으로 비교한다.
-- syncopation 하락이 groove 약화로 들리는지 확인한다.
-- contour가 초급 코드톤 나열을 넘어 phrase motion으로 들리는지 본다.
+- context MIDI에서 chord progression 위에 solo-line을 들어본다.
+- straight_grid와 swing/motif 후보를 비교해 timing 문제가 실제로 들리는지 본다.
+- in/out 판단이 여전히 어렵다면 bar별 chord-tone/tension annotation을 추가한다.
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -1,6 +1,6 @@
 # Current Status and Plan
 
-작성일: 2026-05-21
+작성일: 2026-05-22
 
 ## Current Focus
 
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-67-stage-b-data-motif-review-export`
+- `issue-69-stage-b-review-context-grid`
 
 현재 범위가 아닌 것:
 
@@ -36,30 +36,33 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 ## Latest Probe Result
 
-Issue #67은 Issue #65에서 만든 `hand_written_swing` vs `data_motif` baseline을 실제 review package로 export하는 단계다.
+Issue #69는 solo-only MIDI 리뷰의 한계를 해결하는 단계다.
 
-Issue #65에서 `data_motif`는 strict gate를 통과했고 bar-pattern variation과 duration repetition은 좋아졌지만, syncopation은 낮아졌다. 이제 mode가 명확히 드러나는 MIDI 파일로 piano-roll/listening review를 해야 한다.
+수동 리뷰에서 solo-line만 들으면 chord progression이 들리지 않아 in/out 판단이 어렵고, swing/motif 후보는 박자가 딱 맞지 않는 것처럼 들릴 수 있다는 피드백이 나왔다. 따라서 이번 작업은 chord/bass context와 straight-grid timing reference를 review export에 추가한다.
 
 Implemented:
 
-- `scripts/run_stage_b_data_motif_generation_compare.py` review export
-- `tests/test_stage_b_data_motif_generation_compare.py` review export test
-- `scripts/agent_harness.sh stage-b-data-motif-review-export`
+- `scripts/run_stage_b_data_motif_generation_compare.py` chord/context export
+- `tests/test_stage_b_data_motif_generation_compare.py` context export and straight-grid tests
+- `scripts/agent_harness.sh stage-b-review-context-grid`
 - output files:
   - `data_motif_compare_report.json`
   - `data_motif_compare_report.md`
   - `review_manifest.json`
   - `review_candidates.md`
   - `named_midi/*.mid`
+  - `context_midi/*_with_context.mid`
+  - `chord_guide.mid`
 
 Result:
 
-- source report: `outputs/stage_b_data_motif_compare/harness_stage_b_data_motif_review_export/data_motif_compare_report.json`
+- source report: `outputs/stage_b_data_motif_compare/harness_stage_b_review_context_grid/data_motif_compare_report.json`
 - setup: `./midi_dataset/midi/studio`, max files `4`, `8`-bar windows, stride `4`, min notes `16`
 - `hand_written_swing`: strict `3/3`
 - `data_motif`: strict `3/3`
-- review candidates: `6`
-- review output: `outputs/stage_b_data_motif_review/harness_stage_b_data_motif_review_export`
+- `straight_grid`: exported as timing reference
+- review candidates: `9`
+- review output: `outputs/stage_b_data_motif_review/harness_stage_b_review_context_grid`
 - data minus hand duration diversity delta: `+0.016`
 - data minus hand IOI diversity delta: `+0.016`
 - data minus hand bar-pattern delta: `+0.500`
@@ -69,9 +72,9 @@ Result:
 
 Decision:
 
-- review package가 만들어졌으므로 이제 실제 piano roll/listening 비교가 가능하다.
-- 다음 판단은 수치가 아니라 named MIDI 후보를 직접 확인한 결과로 해야 한다.
-- 들어보고 나서 model constrained generation에 연결할지, cadence/ending extraction을 먼저 강화할지 결정한다.
+- 이제 solo-only가 아니라 chord/bass guide 위에서 in/out을 판단할 수 있다.
+- `straight_grid`는 musical quality candidate가 아니라 timing reference로 본다.
+- 다음 판단은 context MIDI를 들어보고 swing을 유지할지, straight quantized output을 기본으로 둘지 결정하는 것이다.
 
 Detail:
 
@@ -89,6 +92,7 @@ Detail:
 - `docs/STAGE_B_MOTIF_TEMPLATE_EXTRACTION_2026-05-21.md`
 - `docs/STAGE_B_DATA_MOTIF_GENERATION_2026-05-21.md`
 - `docs/STAGE_B_DATA_MOTIF_REVIEW_EXPORT_2026-05-21.md`
+- `docs/STAGE_B_REVIEW_CONTEXT_GRID_2026-05-22.md`
 
 ## Active Issue #14
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -78,6 +78,8 @@
   - 추출된 motif catalog를 8-bar generation baseline에 연결해 hand-written swing grammar와 비교한 결과.
 - `STAGE_B_DATA_MOTIF_REVIEW_EXPORT_2026-05-21.md`
   - data-derived motif baseline과 hand-written swing baseline의 MIDI 후보를 named review package로 export한 결과.
+- `STAGE_B_REVIEW_CONTEXT_GRID_2026-05-22.md`
+  - solo-only 리뷰의 한계를 반영해 chord/bass context MIDI와 straight-grid timing reference를 추가한 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -104,7 +106,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, and data motif review export를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, and review context/grid export를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_REVIEW_CONTEXT_GRID_2026-05-22.md
+++ b/docs/STAGE_B_REVIEW_CONTEXT_GRID_2026-05-22.md
@@ -1,0 +1,124 @@
+# Stage B Review Context and Straight Grid
+
+작성일: 2026-05-22
+
+## 배경
+
+수동 리뷰에서 중요한 문제가 나왔다.
+
+- solo-line만 들으면 chord progression이 들리지 않는다.
+- 그래서 generated line이 in인지 out인지, chord tone인지 아닌지 판단하기 어렵다.
+- swing/motif 후보는 DAW piano-roll에서 박자가 딱 맞지 않는 것처럼 들릴 수 있다.
+- 리뷰용 MIDI는 음악적으로 멋진 후보만이 아니라, 판단 가능한 context를 제공해야 한다.
+
+따라서 이번 작업은 모델 품질 개선이 아니라 review package 보정이다.
+
+## 구현
+
+변경 파일:
+
+- `scripts/run_stage_b_data_motif_generation_compare.py`
+- `tests/test_stage_b_data_motif_generation_compare.py`
+- `scripts/agent_harness.sh`
+
+추가된 것:
+
+- `straight_grid` baseline mode
+- `chord_guide.mid`
+- candidate별 `*_with_context.mid`
+- review markdown의 solo/context MIDI 경로
+
+하네스:
+
+```bash
+bash scripts/agent_harness.sh stage-b-review-context-grid
+```
+
+## 출력 구조
+
+```text
+outputs/stage_b_data_motif_review/harness_stage_b_review_context_grid/
+  chord_guide.mid
+  review_manifest.json
+  review_candidates.md
+  named_midi/
+    01_data_motif_rank_01_sample_01.mid
+    02_hand_written_swing_rank_01_sample_01.mid
+    03_straight_grid_rank_01_sample_01.mid
+  context_midi/
+    01_data_motif_rank_01_sample_01_with_context.mid
+    02_hand_written_swing_rank_01_sample_01_with_context.mid
+    03_straight_grid_rank_01_sample_01_with_context.mid
+```
+
+`named_midi/`는 solo-only 후보다.
+
+`context_midi/`는 다음 track을 같이 넣는다.
+
+- chord guide
+- bass root guide
+- generated solo line
+
+## Straight Grid의 의미
+
+`straight_grid`는 "더 좋은 솔로" 후보가 아니다.
+
+이 모드는 리뷰 기준점이다.
+
+- 16th-position token grid 위에 딱 맞는 straight subdivision을 쓴다.
+- swing/motif 후보가 박자상 이상하게 들리는지 비교하기 위한 reference다.
+- strict gate가 낮게 나올 수 있다. 현재 dead-air metric은 start-to-start IOI를 기준으로 보기 때문에 8th-like straight line을 과하게 불리하게 본다.
+
+따라서 `straight_grid`는 musical quality gate 통과 여부보다 timing reference로 본다.
+
+## Local Result
+
+실행:
+
+```bash
+bash scripts/agent_harness.sh stage-b-review-context-grid
+```
+
+결과:
+
+- `data_motif`: strict `3/3`
+- `hand_written_swing`: strict `3/3`
+- `straight_grid`: exported as timing reference
+- review candidates: `9`
+- chord guide MIDI generated
+- context MIDI generated for every candidate
+
+## 다음 리뷰 방법
+
+이제 solo-only MIDI만 듣지 않는다.
+
+우선순위:
+
+1. `chord_guide.mid`를 먼저 들어 chord progression 감각을 확인한다.
+2. `context_midi/*data_motif*_with_context.mid`를 듣는다.
+3. `context_midi/*hand_written_swing*_with_context.mid`와 비교한다.
+4. `context_midi/*straight_grid*_with_context.mid`로 timing 기준을 확인한다.
+
+판단할 질문:
+
+- chord/bass guide 위에서 line이 in으로 들리는가?
+- out처럼 들리는 음이 의도적인 tension/approach인지, 그냥 틀린 음인지 구별되는가?
+- swing/motif 후보가 groove를 만들기보다 박자 밀림처럼 들리는가?
+- straight-grid 후보는 너무 딱딱하지만 timing reference로는 더 편한가?
+- 다음 생성기는 swing보다 straight quantized output을 먼저 유지해야 하는가?
+
+## 다음 작업
+
+리뷰 결과에 따라 분기한다.
+
+- context 위에서도 line이 초급스럽다면 cadence/phrase-ending extraction을 먼저 한다.
+- timing이 문제라면 generated output은 straight grid를 기본으로 두고 swing은 나중에 humanization 단계로 미룬다.
+- chord context 위에서 out/in 구분이 어렵다면 bar별 chord-tone/tension annotation MIDI 또는 CSV를 추가한다.
+
+## Validation
+
+```bash
+./.venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare
+bash scripts/agent_harness.sh stage-b-review-context-grid
+bash scripts/agent_harness.sh quick
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -66,6 +66,8 @@ Modes:
                 Compare hand-written swing against data-derived motif baseline.
   stage-b-data-motif-review-export
                 Export named MIDI review candidates for data-derived motif compare.
+  stage-b-review-context-grid
+                Export review MIDI with chord context and straight-grid reference.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   all           Run demo and tiny-compare.
@@ -689,6 +691,28 @@ run_stage_b_data_motif_review_export() {
     --copy_review_midi
 }
 
+run_stage_b_review_context_grid() {
+  local run_id="${RUN_ID:-harness_stage_b_review_context_grid}"
+  print_header "Stage B review context and straight-grid export"
+  "$PYTHON_BIN" scripts/run_stage_b_data_motif_generation_compare.py \
+    --run_id "$run_id" \
+    --input_dir ./midi_dataset/midi/studio \
+    --baseline_modes straight_grid,hand_written_swing,data_motif \
+    --max_files 4 \
+    --window_bars 8 \
+    --window_stride_bars 4 \
+    --min_window_target_notes 16 \
+    --motif_length 4 \
+    --max_bar_span 2 \
+    --max_records 64 \
+    --template_top_n 32 \
+    --num_samples 3 \
+    --bars 8 \
+    --note_groups_per_bar 8 \
+    --review_top_n 3 \
+    --copy_review_midi
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -775,6 +799,9 @@ case "$MODE" in
     ;;
   stage-b-data-motif-review-export)
     run_stage_b_data_motif_review_export
+    ;;
+  stage-b-review-context-grid)
+    run_stage_b_review_context_grid
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/run_stage_b_data_motif_generation_compare.py
+++ b/scripts/run_stage_b_data_motif_generation_compare.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import json
 import random
 import shutil
@@ -12,11 +13,14 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Sequence
 
+import pretty_midi
+
 ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
 from inference.app.schemas import GenerationRequest  # noqa: E402
 from scripts.run_stage_b_generation_probe import (  # noqa: E402
+    CHORD_TONE_INTERVALS,
     build_probe_summary,
     build_stage_b_primer,
     chord_aware_pitch_tokens,
@@ -33,18 +37,20 @@ from scripts.stage_b_tokens import (  # noqa: E402
     PIANO_PITCH_MAX,
     PIANO_PITCH_MIN,
     POSITIONS_PER_BAR,
+    ROOT_TO_PC,
     TOKEN_BAR,
     TOKEN_END,
     chord_tokens,
     note_duration_token,
     note_pitch_token,
     note_velocity_token,
+    parse_chord_symbol,
     pitch_from_token as stage_b_pitch_from_token,
     position_token,
 )
 
 
-VALID_BASELINE_MODES = {"hand_written_swing", "data_motif"}
+VALID_BASELINE_MODES = {"straight_grid", "hand_written_swing", "data_motif"}
 
 
 def write_json(path: Path, payload: dict[str, Any]) -> None:
@@ -297,6 +303,52 @@ def hand_written_swing_tokens(
     return tokens
 
 
+def straight_grid_tokens(
+    *,
+    primer_tokens: Sequence[int],
+    chords: Sequence[str],
+    bars: int,
+    note_groups_per_bar: int,
+    seed: int,
+) -> list[int]:
+    rng = random.Random(int(seed))
+    tokens = [int(token) for token in primer_tokens]
+    recent_pitches: list[int] = []
+    contour = [0, 2, 4, 5, 7, 5, 4, 2]
+    groups_per_bar = max(1, int(note_groups_per_bar))
+    duration_steps = max(1, int(POSITIONS_PER_BAR) // groups_per_bar)
+    positions = [min(int(POSITIONS_PER_BAR) - 1, index * duration_steps) for index in range(groups_per_bar)]
+
+    for bar_index in range(max(1, int(bars))):
+        chord = chords[bar_index % len(chords)] if chords else None
+        if bar_index > 0:
+            tokens.append(TOKEN_BAR)
+            tokens.extend(chord_tokens(chord))
+        base_token = base_pitch_token_for_chord(chord, rng, recent_pitches)
+        base_pitch = pitch_from_token(base_token)
+        for group_index, position in enumerate(positions):
+            target_pitch = base_pitch + contour[group_index % len(contour)]
+            pitch_candidates = chord_aware_pitch_tokens(
+                chord,
+                pitch_mode="approach_tensions",
+                recent_pitches=recent_pitches,
+                repeat_window=2,
+                group_index=group_index,
+            )
+            pitch_token_value = nearest_allowed_pitch_token(target_pitch, pitch_candidates, recent_pitches)
+            recent_pitches.append(pitch_from_token(pitch_token_value))
+            tokens.extend(
+                [
+                    position_token(position),
+                    note_velocity_token(4),
+                    pitch_token_value,
+                    note_duration_token(duration_steps),
+                ]
+            )
+    tokens.append(TOKEN_END)
+    return tokens
+
+
 def data_motif_tokens(
     *,
     primer_tokens: Sequence[int],
@@ -366,6 +418,14 @@ def generated_tokens_for_mode(
     template_report: dict[str, Any],
     seed: int,
 ) -> list[int]:
+    if mode == "straight_grid":
+        return straight_grid_tokens(
+            primer_tokens=primer_tokens,
+            chords=chords,
+            bars=bars,
+            note_groups_per_bar=note_groups_per_bar,
+            seed=seed,
+        )
     if mode == "hand_written_swing":
         return hand_written_swing_tokens(
             primer_tokens=primer_tokens,
@@ -401,6 +461,98 @@ def compact_summary(summary: dict[str, Any]) -> dict[str, Any]:
         "avg_root_tone_ratio": float(summary["avg_root_tone_ratio"]),
         "passed_strict_review_gate": bool(summary["passed_strict_review_gate"]),
     }
+
+
+def ordered_chord_pitches(chord: str | None, lower: int = 48, upper: int = 72) -> list[int]:
+    root, quality = parse_chord_symbol(chord)
+    root_pc = ROOT_TO_PC.get(root)
+    if root_pc is None:
+        root_pc = 0
+    intervals = sorted(CHORD_TONE_INTERVALS.get(quality, CHORD_TONE_INTERVALS["unknown"]))
+    base = lower + root_pc
+    while base > lower + 11:
+        base -= 12
+    pitches: list[int] = []
+    for interval in intervals:
+        pitch = base + int(interval)
+        while pitch > int(upper):
+            pitch -= 12
+        while pitch < int(lower):
+            pitch += 12
+        pitches.append(pitch)
+    return sorted(set(pitches))
+
+
+def bass_root_pitch(chord: str | None, lower: int = 36, upper: int = 47) -> int:
+    root, _quality = parse_chord_symbol(chord)
+    root_pc = ROOT_TO_PC.get(root, 0)
+    pitch = lower + root_pc
+    while pitch > upper:
+        pitch -= 12
+    while pitch < lower:
+        pitch += 12
+    return int(pitch)
+
+
+def chord_guide_instruments(
+    chords: Sequence[str],
+    *,
+    bpm: float | int,
+    bars: int,
+) -> list[pretty_midi.Instrument]:
+    bar_duration_sec = 60.0 / max(1e-6, float(bpm)) * 4.0
+    pad = pretty_midi.Instrument(program=4, is_drum=False, name="Chord Guide")
+    bass = pretty_midi.Instrument(program=32, is_drum=False, name="Bass Root Guide")
+    total_bars = max(1, int(bars))
+    for bar_index in range(total_bars):
+        chord = chords[bar_index % len(chords)] if chords else "Cmaj7"
+        start = bar_index * bar_duration_sec
+        end = start + bar_duration_sec
+        for pitch in ordered_chord_pitches(chord):
+            pad.notes.append(pretty_midi.Note(velocity=42, pitch=int(pitch), start=start, end=end))
+        bass.notes.append(
+            pretty_midi.Note(
+                velocity=52,
+                pitch=bass_root_pitch(chord),
+                start=start,
+                end=end,
+            )
+        )
+    return [pad, bass]
+
+
+def write_chord_guide_midi(
+    output_path: Path,
+    chords: Sequence[str],
+    *,
+    bpm: float | int,
+    bars: int,
+) -> Path:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    midi = pretty_midi.PrettyMIDI(initial_tempo=float(bpm))
+    midi.instruments.extend(chord_guide_instruments(chords, bpm=bpm, bars=bars))
+    midi.write(str(output_path))
+    return output_path
+
+
+def write_context_midi(
+    solo_midi_path: Path,
+    output_path: Path,
+    chords: Sequence[str],
+    *,
+    bpm: float | int,
+    bars: int,
+) -> Path:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    context = pretty_midi.PrettyMIDI(initial_tempo=float(bpm))
+    context.instruments.extend(chord_guide_instruments(chords, bpm=bpm, bars=bars))
+    solo = pretty_midi.PrettyMIDI(str(solo_midi_path))
+    for instrument in solo.instruments:
+        copied = copy.deepcopy(instrument)
+        copied.name = f"Solo - {copied.name or 'Stage B'}"
+        context.instruments.append(copied)
+    context.write(str(output_path))
+    return output_path
 
 
 def build_compare_summary(
@@ -470,6 +622,7 @@ def compact_review_candidate(
     *,
     review_rank: int,
     review_midi_path: Path | None,
+    context_midi_path: Path | None,
 ) -> dict[str, Any]:
     rhythm = row.get("rhythm_profile", {})
     pitch_roles = row.get("pitch_roles", {})
@@ -483,6 +636,7 @@ def compact_review_candidate(
         "strict_valid": bool(row["strict_valid"]),
         "midi_path": row["midi_path"],
         "review_midi_path": str(review_midi_path) if review_midi_path else None,
+        "context_midi_path": str(context_midi_path) if context_midi_path else None,
         "note_count": int(metrics.get("note_count", 0) or 0),
         "unique_pitch_count": int(metrics.get("unique_pitch_count", 0) or 0),
         "dead_air_ratio": float(metrics.get("dead_air_ratio", 0.0) or 0.0),
@@ -507,19 +661,26 @@ def review_markdown_report(manifest: dict[str, Any]) -> str:
         f"- candidate count: `{manifest['candidate_count']}`",
         f"- copy midi: `{str(manifest['copy_midi']).lower()}`",
         "",
-        "| mode | rank | sample | strict | notes | pitches | sync | bar-var | dur-var | dur-rep | ioi-var | ioi-rep | tension | midi |",
+        "| mode | rank | sample | strict | notes | pitches | sync | bar-var | dur-var | dur-rep | ioi-var | ioi-rep | tension | solo/context MIDI |",
         "|---|---:|---:|:---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
     ]
+    guide_path = manifest.get("chord_guide_midi_path")
+    if guide_path:
+        lines.insert(4, f"- chord guide midi: `{guide_path}`")
+        lines.insert(5, "")
     for row in manifest["candidates"]:
         midi_path = row.get("review_midi_path") or row.get("midi_path")
+        context_path = row.get("context_midi_path") or ""
         format_row = dict(row)
         format_row["display_midi_path"] = midi_path
+        format_row["display_context_midi_path"] = context_path
         lines.append(
             "| {mode} | {review_rank} | {sample_index} | {strict_valid} | {note_count} | "
             "{unique_pitch_count} | {syncopated_onset_ratio:.3f} | "
             "{unique_bar_position_pattern_ratio:.3f} | {duration_diversity_ratio:.3f} | "
             "{most_common_duration_ratio:.3f} | {ioi_diversity_ratio:.3f} | "
-            "{most_common_ioi_ratio:.3f} | {tension_ratio:.3f} | `{display_midi_path}` |".format(**format_row)
+            "{most_common_ioi_ratio:.3f} | {tension_ratio:.3f} | "
+            "`{display_midi_path}`<br>`{display_context_midi_path}` |".format(**format_row)
         )
     return "\n".join(lines).rstrip() + "\n"
 
@@ -530,17 +691,32 @@ def build_review_export(
     output_dir: Path,
     top_n: int,
     copy_midi: bool,
+    chords: Sequence[str],
+    bpm: float | int,
+    bars: int,
 ) -> dict[str, Any]:
     output_dir.mkdir(parents=True, exist_ok=True)
     named_dir = output_dir / "named_midi"
+    context_dir = output_dir / "context_midi"
     if copy_midi:
         named_dir.mkdir(parents=True, exist_ok=True)
+        context_dir.mkdir(parents=True, exist_ok=True)
+
+    chord_guide_midi_path: Path | None = None
+    if copy_midi:
+        chord_guide_midi_path = write_chord_guide_midi(
+            output_dir / "chord_guide.mid",
+            chords,
+            bpm=bpm,
+            bars=bars,
+        )
 
     candidates: list[dict[str, Any]] = []
     for mode_index, mode in enumerate(sorted(samples_by_mode), start=1):
         rows = sorted(samples_by_mode[mode], key=candidate_sort_key, reverse=True)
         for review_rank, row in enumerate(rows[: int(top_n)], start=1):
             review_midi_path: Path | None = None
+            context_midi_path: Path | None = None
             if copy_midi:
                 source = Path(str(row["midi_path"]))
                 if not source.is_absolute():
@@ -552,12 +728,24 @@ def build_review_export(
                 if source.exists():
                     shutil.copy2(source, target)
                     review_midi_path = target
+                    context_target = context_dir / (
+                        f"{mode_index:02d}_{mode}_rank_{review_rank:02d}_"
+                        f"sample_{int(row['sample_index']):02d}_with_context.mid"
+                    )
+                    context_midi_path = write_context_midi(
+                        target,
+                        context_target,
+                        chords,
+                        bpm=bpm,
+                        bars=bars,
+                    )
             candidates.append(
                 compact_review_candidate(
                     mode,
                     row,
                     review_rank=review_rank,
                     review_midi_path=review_midi_path,
+                    context_midi_path=context_midi_path,
                 )
             )
 
@@ -565,6 +753,8 @@ def build_review_export(
         "output_dir": str(output_dir),
         "copy_midi": bool(copy_midi),
         "top_n": int(top_n),
+        "chord_progression": list(chords),
+        "chord_guide_midi_path": str(chord_guide_midi_path) if chord_guide_midi_path else None,
         "candidate_count": int(len(candidates)),
         "candidates": candidates,
     }
@@ -579,7 +769,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--input_dir", type=str, default="./midi_dataset/midi/studio")
     parser.add_argument("--issue_number", type=int, default=65)
-    parser.add_argument("--baseline_modes", type=str, default="hand_written_swing,data_motif")
+    parser.add_argument("--baseline_modes", type=str, default="straight_grid,hand_written_swing,data_motif")
     parser.add_argument("--max_files", type=int, default=4)
     parser.add_argument("--window_bars", type=int, default=8)
     parser.add_argument("--window_stride_bars", type=int, default=4)
@@ -701,6 +891,9 @@ def main() -> int:
         output_dir=Path(args.review_output_root) / args.run_id,
         top_n=int(args.review_top_n),
         copy_midi=bool(args.copy_review_midi),
+        chords=chords,
+        bpm=args.bpm,
+        bars=args.bars,
     )
     write_json(run_dir / "data_motif_compare_report.json", report)
     (run_dir / "data_motif_compare_report.md").write_text(markdown_report(report), encoding="utf-8")

--- a/tests/test_stage_b_data_motif_generation_compare.py
+++ b/tests/test_stage_b_data_motif_generation_compare.py
@@ -4,6 +4,8 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import pretty_midi
+
 from scripts.run_stage_b_data_motif_generation_compare import (
     build_review_export,
     data_motif_tokens,
@@ -12,6 +14,7 @@ from scripts.run_stage_b_data_motif_generation_compare import (
     nearest_allowed_pitch_token,
     normalize_position_deltas,
     parse_baseline_modes,
+    straight_grid_tokens,
 )
 from scripts.run_stage_b_generation_probe import (
     analyze_stage_b_note_grammar,
@@ -120,11 +123,32 @@ class StageBDataMotifGenerationCompareTest(unittest.TestCase):
             self.assertEqual(positions, sorted(positions))
             self.assertEqual(len(positions), len(set(positions)))
 
+    def test_straight_grid_tokens_stay_on_even_subdivision_grid(self) -> None:
+        primer = build_stage_b_primer(["Cm7", "Fm7"], 124)
+        tokens = straight_grid_tokens(
+            primer_tokens=primer,
+            chords=["Cm7", "Fm7"],
+            bars=2,
+            note_groups_per_bar=8,
+            seed=17,
+        )
+
+        grammar = analyze_stage_b_note_grammar(tokens, primer_size=len(primer))
+        groups = extract_stage_b_note_groups(tokens, primer_size=len(primer))
+
+        self.assertTrue(grammar["grammar_valid"])
+        self.assertEqual(len(groups), 16)
+        self.assertEqual({group["position"] % 2 for group in groups}, {0})
+
     def test_build_review_export_copies_named_mode_files(self) -> None:
         with TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             source_midi = tmp_path / "source.mid"
-            source_midi.write_bytes(b"MThd")
+            midi = pretty_midi.PrettyMIDI(initial_tempo=124)
+            instrument = pretty_midi.Instrument(program=0, name="Solo")
+            instrument.notes.append(pretty_midi.Note(velocity=80, pitch=60, start=0.0, end=0.5))
+            midi.instruments.append(instrument)
+            midi.write(str(source_midi))
             samples = {
                 "data_motif": [
                     {
@@ -159,11 +183,17 @@ class StageBDataMotifGenerationCompareTest(unittest.TestCase):
                 output_dir=tmp_path / "review",
                 top_n=1,
                 copy_midi=True,
+                chords=["Cm7", "Fm7"],
+                bpm=124,
+                bars=2,
             )
 
             copied = Path(manifest["candidates"][0]["review_midi_path"])
+            context = Path(manifest["candidates"][0]["context_midi_path"])
             self.assertTrue(copied.exists())
+            self.assertTrue(context.exists())
             self.assertIn("data_motif", copied.name)
+            self.assertTrue(Path(manifest["chord_guide_midi_path"]).exists())
             self.assertTrue((tmp_path / "review" / "review_manifest.json").exists())
             self.assertTrue((tmp_path / "review" / "review_candidates.md").exists())
 


### PR DESCRIPTION
## 요약
- solo-only 리뷰의 한계를 보완하기 위해 chord guide와 bass root guide가 들어간 context MIDI를 생성합니다.
- straight_grid baseline을 추가해 swing/motif 후보의 timing 문제를 비교할 수 있게 했습니다.
- review markdown에 solo MIDI와 context MIDI 경로를 함께 표시합니다.

## 결과
- chord_guide.mid 생성
- candidate별 *_with_context.mid 생성
- data_motif strict: 3/3
- hand_written_swing strict: 3/3
- straight_grid 후보는 timing reference로 export
- review candidates: 9

## 검증
- bash scripts/agent_harness.sh stage-b-review-context-grid
- bash scripts/agent_harness.sh quick

Closes #69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Stage B review capability with chord/bass context MIDI and straight-grid timing reference to address solo-only review limitations.
  * Expanded review export to include context MIDI files and chord guide reference for improved chord progression and beat alignment assessment.

* **Documentation**
  * Added comprehensive guide for the new Stage B review context and straight-grid process with workflow instructions.
  * Updated active repository status and execution plan references.

* **Tests**
  * Added validation for straight-grid timing alignment and context MIDI generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohhalim/fine_tuning_art-tatum_midi_solo/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->