### PR TITLE
Stage B straight-grid guide-tone cadence 후보 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #69: Stage B review MIDI chord context and straight-grid candidates.
+- Issue #71: Stage B straight-grid guide-tone/cadence candidates.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -200,6 +200,12 @@ For Stage B review MIDI chord-context/straight-grid changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-review-context-grid
+```
+
+For Stage B straight-grid guide-tone/cadence candidate changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-guide-tone-cadence
 ```
 
 For Stage B collapse/sampling-sweep changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -137,6 +137,7 @@ Stage B에서 명시하는 것:
 31. Stage B data-derived motif baseline generation
 32. Stage B data motif review export
 33. Stage B chord-context and straight-grid review export
+34. Stage B straight-grid guide-tone/cadence review candidate
 
 가장 최근 의미 있는 결과:
 
@@ -348,6 +349,8 @@ Stage B에서 명시하는 것:
 - Issue #65 result: hand-written swing 대비 bar-position variation은 `+0.500`, duration diversity는 `+0.016`, IOI diversity는 `+0.016` 개선됐지만 syncopation은 `-0.125` 낮아졌다.
 - Issue #67 result: `data_motif`와 `hand_written_swing` 후보를 mode/sample/rank가 드러나는 named MIDI review package로 export했다.
 - Issue #69 result: chord/bass guide가 들어간 context MIDI와 straight-grid timing reference를 추가했다.
+- Issue #71 result: `straight_guide_tones` 후보를 추가해 swing timing 문제와 chromatic/scale pitch 문제를 분리했다.
+- Issue #71 result: `straight_guide_tones`는 note count `64`, unique pitch count `26-29`, chord-tone ratio `0.656`, tension ratio `0.172`, root-tone ratio `0.000`이지만 straight reference용 dead-air gate 때문에 strict `0/3`이다.
 
 해석:
 
@@ -626,25 +629,23 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B chord-context and straight-grid review export 추가
+Stage B straight-grid guide-tone/cadence review candidate 추가
 ```
 
 결과:
 
-- `hand_written_swing`과 `data_motif` 모두 strict `3/3`을 통과했다.
-- data-derived baseline은 bar-pattern variation을 `0.500`에서 `1.000`으로 올렸다.
-- duration repetition ratio는 `0.750`에서 `0.375`로 낮췄다.
-- duration diversity와 IOI diversity는 소폭 올랐다.
-- syncopation은 `0.750`에서 `0.625`로 낮아졌다.
-- review candidates `9`개와 named MIDI package를 만들었다.
-- `chord_guide.mid`와 candidate별 `*_with_context.mid`를 만들었다.
-- `straight_grid` timing reference를 추가했다.
+- `straight_guide_tones` baseline mode를 추가했다.
+- strong beat은 현재 chord의 guide tone으로 제한한다.
+- weak beat approach tone은 연속 chromatic run이 되지 않게 제한한다.
+- context MIDI review package에 `straight_grid`, `straight_guide_tones`, `hand_written_swing`, `data_motif`를 같이 export한다.
+- `straight_guide_tones`는 root-tone ratio `0.000`, chord-tone ratio `0.656`, tension ratio `0.172`를 기록했다.
+- `straight_guide_tones` strict `0/3`은 current dead-air gate가 straight reference에 맞지 않기 때문이며, 모델 성공 후보가 아니라 timing/pitch reference로 본다.
 
 다음 작업:
 
-- context MIDI에서 chord progression 위에 solo-line을 들어본다.
-- straight_grid와 swing/motif 후보를 비교해 timing 문제가 실제로 들리는지 본다.
-- in/out 판단이 여전히 어렵다면 bar별 chord-tone/tension annotation을 추가한다.
+- `04_straight_guide_tones_*_with_context.mid`를 듣고 scale/chromatic 느낌이 줄었는지 확인한다.
+- 여전히 교과서적이면 data-derived rhythm을 유지하고 strong-beat pitch만 guide-tone cadence로 제한하는 hybrid를 만든다.
+- in/out 판단이 어렵다면 review markdown에 bar/chord/pitch-role annotation을 추가한다.
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-69-stage-b-review-context-grid`
+- `issue-71-stage-b-guide-tone-cadence`
 
 현재 범위가 아닌 것:
 
@@ -35,6 +35,46 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
 ## Latest Probe Result
+
+Issue #71은 Issue #69 review listening에서 나온 피드백을 반영한다.
+
+수동 리뷰 결론:
+
+- `hand_written_swing`과 `data_motif`의 swing timing은 MIDI 입력 관점에서 박자가 어긋나게 들릴 수 있다.
+- `straight_grid`는 박자는 맞지만 scale/chromatic exercise처럼 들린다.
+- 따라서 다음 후보는 swing/humanization보다 straight quantized timing과 guide-tone/cadence pitch grammar를 먼저 검증해야 한다.
+
+Implemented:
+
+- `straight_guide_tones` baseline mode
+- strong beat guide-tone constraint
+- limited approach-tone cadence cell
+- `scripts/agent_harness.sh stage-b-guide-tone-cadence`
+- docs:
+  - `docs/STAGE_B_GUIDE_TONE_CADENCE_2026-05-22.md`
+
+Result:
+
+- compare gate: passed
+- `data_motif`: strict `3/3`
+- `hand_written_swing`: strict `3/3`
+- `straight_grid`: strict `0/3`, timing reference
+- `straight_guide_tones`: strict `0/3`, timing/pitch reference
+- `straight_guide_tones` note count: `64`
+- `straight_guide_tones` unique pitch count: `26-29`
+- `straight_guide_tones` chord-tone ratio: `0.656`
+- `straight_guide_tones` tension ratio: `0.172`
+- `straight_guide_tones` root-tone ratio: `0.000`
+- review output: `outputs/stage_b_data_motif_review/harness_stage_b_guide_tone_cadence`
+
+Decision:
+
+- swing 후보는 현재 MVP default로 밀지 않는다.
+- straight timing 후보와 data-derived motif 후보를 chord context 위에서 비교한다.
+- `straight_guide_tones`는 모델 성공 후보가 아니라, 박자와 harmonic vocabulary를 분리해 듣기 위한 reference다.
+- 다음 단계는 chord/pitch-role annotation 또는 data-motif rhythm + guide-tone strong-beat hybrid다.
+
+## Previous Probe Result
 
 Issue #69는 solo-only MIDI 리뷰의 한계를 해결하는 단계다.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -80,6 +80,8 @@
   - data-derived motif baseline과 hand-written swing baseline의 MIDI 후보를 named review package로 export한 결과.
 - `STAGE_B_REVIEW_CONTEXT_GRID_2026-05-22.md`
   - solo-only 리뷰의 한계를 반영해 chord/bass context MIDI와 straight-grid timing reference를 추가한 결과.
+- `STAGE_B_GUIDE_TONE_CADENCE_2026-05-22.md`
+  - straight-grid timing 위에서 scale/chromatic 나열을 줄이기 위한 guide-tone/cadence 후보를 추가한 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`

--- a/docs/STAGE_B_GUIDE_TONE_CADENCE_2026-05-22.md
+++ b/docs/STAGE_B_GUIDE_TONE_CADENCE_2026-05-22.md
@@ -1,0 +1,88 @@
+# Stage B Guide-Tone Cadence Candidate
+
+작성일: 2026-05-22
+
+## 배경
+
+Issue #69 review package를 듣고 다음 문제가 확인됐다.
+
+- `hand_written_swing`과 `data_motif` 후보는 "swing"이라고 부르기에는 MIDI grid가 흔들려 들린다.
+- `straight_grid`는 박자는 맞지만 scale/chromatic exercise처럼 들린다.
+- solo-only MIDI보다 chord/bass context MIDI가 리뷰에는 더 낫다.
+
+따라서 이번 단계는 swing을 더 고치는 것이 아니라, straight quantized timing을 유지한 채 pitch vocabulary를 guide-tone/cadence 중심으로 제한하는 것이다.
+
+## 구현
+
+추가된 baseline mode:
+
+```text
+straight_guide_tones
+```
+
+핵심 규칙:
+
+- position은 straight 8th grid를 유지한다.
+- strong beat position `0`, `4`, `8`, `12`는 현재 chord의 guide tone으로 제한한다.
+- guide tone은 주로 3도와 7도다.
+- root는 가능한 피하고 non-root chord tone, tension, 짧은 approach tone을 사용한다.
+- approach tone은 연속으로 나오지 않게 제한한다.
+- bar 마지막 note는 다음 chord guide tone으로 가는 짧은 approach로 둔다.
+
+## 검증
+
+실행:
+
+```bash
+bash scripts/agent_harness.sh stage-b-guide-tone-cadence
+bash scripts/agent_harness.sh quick
+```
+
+결과:
+
+- compare gate: passed
+- `hand_written_swing`: strict `3/3`
+- `data_motif`: strict `3/3`
+- `straight_grid`: exported as timing reference, strict `0/3`
+- `straight_guide_tones`: exported as timing/pitch reference, strict `0/3`
+- `straight_guide_tones` note count: `64`
+- `straight_guide_tones` unique pitch count: `26-29`
+- `straight_guide_tones` chord-tone ratio: `0.656`
+- `straight_guide_tones` tension ratio: `0.172`
+- `straight_guide_tones` root-tone ratio: `0.000`
+
+`straight_grid`와 `straight_guide_tones`가 strict false인 주된 이유는 current metric의 dead-air 판단이 straight 8th grid reference에 맞지 않기 때문이다. 이 후보들은 "모델 성공 후보"가 아니라 timing/pitch review reference로 본다.
+
+## Review Files
+
+생성 위치:
+
+```text
+outputs/stage_b_data_motif_review/harness_stage_b_guide_tone_cadence/
+```
+
+중요 파일:
+
+```text
+review_candidates.md
+chord_guide.mid
+context_midi/04_straight_guide_tones_rank_01_sample_01_with_context.mid
+context_midi/04_straight_guide_tones_rank_02_sample_02_with_context.mid
+context_midi/04_straight_guide_tones_rank_03_sample_03_with_context.mid
+```
+
+## 판단
+
+이번 결과는 jazz solo 완성이 아니다.
+
+의미는 다음이다.
+
+- swing/humanization을 억지로 넣기 전에 quantized MIDI review 후보를 분리했다.
+- scale/chromatic 나열 문제를 pitch grammar로 줄이는 첫 기준선을 만들었다.
+- 앞으로의 musical review는 `data_motif`와 `straight_guide_tones`를 chord context 위에서 비교해야 한다.
+
+다음 단계:
+
+- `straight_guide_tones`를 들어보고 너무 교과서적이면 motif rhythm은 data-derived로 유지하고 strong-beat pitch만 guide-tone cadence로 제한한다.
+- strict gate는 generated swing 후보용과 straight reference용을 분리한다.
+- chord별 in/out annotation이 아직 부족하면 review markdown에 bar/chord/pitch-role table을 추가한다.

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -68,6 +68,8 @@ Modes:
                 Export named MIDI review candidates for data-derived motif compare.
   stage-b-review-context-grid
                 Export review MIDI with chord context and straight-grid reference.
+  stage-b-guide-tone-cadence
+                Export straight-grid guide-tone/cadence candidates with chord context.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   all           Run demo and tiny-compare.
@@ -713,6 +715,28 @@ run_stage_b_review_context_grid() {
     --copy_review_midi
 }
 
+run_stage_b_guide_tone_cadence() {
+  local run_id="${RUN_ID:-harness_stage_b_guide_tone_cadence}"
+  print_header "Stage B straight-grid guide-tone/cadence review export"
+  "$PYTHON_BIN" scripts/run_stage_b_data_motif_generation_compare.py \
+    --run_id "$run_id" \
+    --input_dir ./midi_dataset/midi/studio \
+    --baseline_modes straight_grid,straight_guide_tones,hand_written_swing,data_motif \
+    --max_files 4 \
+    --window_bars 8 \
+    --window_stride_bars 4 \
+    --min_window_target_notes 16 \
+    --motif_length 4 \
+    --max_bar_span 2 \
+    --max_records 64 \
+    --template_top_n 32 \
+    --num_samples 3 \
+    --bars 8 \
+    --note_groups_per_bar 8 \
+    --review_top_n 3 \
+    --copy_review_midi
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -802,6 +826,9 @@ case "$MODE" in
     ;;
   stage-b-review-context-grid)
     run_stage_b_review_context_grid
+    ;;
+  stage-b-guide-tone-cadence)
+    run_stage_b_guide_tone_cadence
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/run_stage_b_data_motif_generation_compare.py
+++ b/scripts/run_stage_b_data_motif_generation_compare.py
@@ -21,6 +21,7 @@ sys.path.insert(0, str(ROOT_DIR))
 from inference.app.schemas import GenerationRequest  # noqa: E402
 from scripts.run_stage_b_generation_probe import (  # noqa: E402
     CHORD_TONE_INTERVALS,
+    TENSION_INTERVALS,
     build_probe_summary,
     build_stage_b_primer,
     chord_aware_pitch_tokens,
@@ -50,7 +51,7 @@ from scripts.stage_b_tokens import (  # noqa: E402
 )
 
 
-VALID_BASELINE_MODES = {"straight_grid", "hand_written_swing", "data_motif"}
+VALID_BASELINE_MODES = {"straight_grid", "straight_guide_tones", "hand_written_swing", "data_motif"}
 
 
 def write_json(path: Path, payload: dict[str, Any]) -> None:
@@ -211,6 +212,127 @@ def nearest_allowed_pitch_token(
     )
 
 
+def pitch_class_set(chord: str | None, intervals_by_quality: dict[str, set[int]]) -> set[int]:
+    root, quality = parse_chord_symbol(chord)
+    root_pc = ROOT_TO_PC.get(root)
+    if root_pc is None:
+        return set()
+    intervals = intervals_by_quality.get(quality, intervals_by_quality["unknown"])
+    return {(int(root_pc) + int(interval)) % 12 for interval in intervals}
+
+
+def chord_tone_pitch_classes(chord: str | None, *, include_root: bool = True) -> set[int]:
+    tones = pitch_class_set(chord, CHORD_TONE_INTERVALS)
+    if include_root:
+        return tones
+    root, _quality = parse_chord_symbol(chord)
+    root_pc = ROOT_TO_PC.get(root)
+    if root_pc is not None and len(tones) > 1:
+        tones.discard(int(root_pc))
+    return tones
+
+
+def guide_tone_pitch_classes(chord: str | None) -> list[int]:
+    root, quality = parse_chord_symbol(chord)
+    root_pc = ROOT_TO_PC.get(root)
+    if root_pc is None:
+        return sorted(chord_tone_pitch_classes(chord, include_root=False))
+    guide_intervals_by_quality = {
+        "maj": [4, 7],
+        "maj7": [4, 11],
+        "min": [3, 7],
+        "min7": [3, 10],
+        "dom7": [4, 10],
+        "dim": [3, 6],
+        "halfdim": [3, 10],
+        "sus": [5, 10],
+        "unknown": [4, 7],
+    }
+    return [
+        (int(root_pc) + int(interval)) % 12
+        for interval in guide_intervals_by_quality.get(quality, guide_intervals_by_quality["unknown"])
+    ]
+
+
+def tension_pitch_classes(chord: str | None) -> set[int]:
+    return pitch_class_set(chord, TENSION_INTERVALS)
+
+
+def approach_pitch_class(target_pitch_class: int, recent_pitch_classes: Sequence[int]) -> int:
+    for offset in (-1, 1, -2, 2):
+        candidate = (int(target_pitch_class) + offset) % 12
+        if candidate not in recent_pitch_classes[-1:]:
+            return candidate
+    return (int(target_pitch_class) - 1) % 12
+
+
+def nearest_pitch_for_pitch_class(
+    pitch_class: int,
+    *,
+    target_pitch: int,
+    recent_pitches: Sequence[int] | None = None,
+) -> int:
+    recent = list(recent_pitches or [])
+    candidates = [
+        pitch
+        for pitch in range(int(PIANO_PITCH_MIN), int(PIANO_PITCH_MAX) + 1)
+        if pitch % 12 == int(pitch_class) % 12
+    ]
+    blocked = set(recent[-2:])
+    filtered = [pitch for pitch in candidates if pitch not in blocked]
+    if filtered:
+        candidates = filtered
+    if recent:
+        previous = int(recent[-1])
+        preferred = [pitch for pitch in candidates if 1 <= abs(pitch - previous) <= 7]
+        if preferred:
+            candidates = preferred
+    return int(
+        min(
+            candidates,
+            key=lambda pitch: (
+                abs(int(pitch) - int(target_pitch)),
+                abs(int(pitch) - 67),
+                int(pitch),
+            ),
+        )
+    )
+
+
+def guide_tone_cadence_pitch_classes(
+    chord: str | None,
+    next_chord: str | None,
+    *,
+    bar_index: int,
+) -> list[tuple[int, str]]:
+    guides = guide_tone_pitch_classes(chord)
+    non_root_tones = sorted(chord_tone_pitch_classes(chord, include_root=False))
+    tensions = sorted(tension_pitch_classes(chord))
+    next_guides = guide_tone_pitch_classes(next_chord)
+
+    if not guides:
+        guides = non_root_tones or sorted(chord_tone_pitch_classes(chord))
+    if not non_root_tones:
+        non_root_tones = guides or sorted(chord_tone_pitch_classes(chord))
+
+    guide_a = guides[int(bar_index) % len(guides)]
+    guide_b = guides[(int(bar_index) + 1) % len(guides)]
+    color = tensions[int(bar_index) % len(tensions)] if tensions else non_root_tones[0]
+    chord_color = non_root_tones[(int(bar_index) + 1) % len(non_root_tones)]
+    next_target = next_guides[0] if next_guides else guide_a
+
+    return [
+        (guide_a, "guide"),
+        (color, "color"),
+        (guide_b, "guide"),
+        (approach_pitch_class(guide_b, [guide_a, color]), "approach"),
+        (guide_b, "guide"),
+        (chord_color, "chord"),
+        (guide_a, "guide"),
+        (approach_pitch_class(next_target, [guide_b, chord_color, guide_a]), "approach_next"),
+    ]
+
+
 def base_pitch_token_for_chord(chord: str | None, rng: random.Random, recent_pitches: Sequence[int]) -> int:
     allowed = chord_aware_pitch_tokens(
         chord,
@@ -349,6 +471,53 @@ def straight_grid_tokens(
     return tokens
 
 
+def straight_guide_tones_tokens(
+    *,
+    primer_tokens: Sequence[int],
+    chords: Sequence[str],
+    bars: int,
+    note_groups_per_bar: int,
+    seed: int,
+) -> list[int]:
+    rng = random.Random(int(seed))
+    tokens = [int(token) for token in primer_tokens]
+    recent_pitches: list[int] = []
+    groups_per_bar = max(1, int(note_groups_per_bar))
+    duration_steps = max(1, int(POSITIONS_PER_BAR) // groups_per_bar)
+    positions = [min(int(POSITIONS_PER_BAR) - 1, index * duration_steps) for index in range(groups_per_bar)]
+
+    for bar_index in range(max(1, int(bars))):
+        chord = chords[bar_index % len(chords)] if chords else None
+        next_chord = chords[(bar_index + 1) % len(chords)] if chords else chord
+        if bar_index > 0:
+            tokens.append(TOKEN_BAR)
+            tokens.extend(chord_tokens(chord))
+        pitch_cells = guide_tone_cadence_pitch_classes(chord, next_chord, bar_index=bar_index)
+        anchor = 64 + ((bar_index % 3) * 3) + rng.choice([-2, 0, 2])
+        for group_index, position in enumerate(positions):
+            pitch_class, role = pitch_cells[group_index % len(pitch_cells)]
+            if role.startswith("approach") and group_index > 0:
+                target_anchor = recent_pitches[-1] + rng.choice([-2, -1, 1, 2])
+            else:
+                target_anchor = anchor + (group_index % 4) * 2
+            pitch = nearest_pitch_for_pitch_class(
+                pitch_class,
+                target_pitch=target_anchor,
+                recent_pitches=recent_pitches,
+            )
+            recent_pitches.append(pitch)
+            tokens.extend(
+                [
+                    position_token(position),
+                    note_velocity_token(4),
+                    note_pitch_token(pitch),
+                    note_duration_token(duration_steps),
+                ]
+            )
+    tokens.append(TOKEN_END)
+    return tokens
+
+
 def data_motif_tokens(
     *,
     primer_tokens: Sequence[int],
@@ -420,6 +589,14 @@ def generated_tokens_for_mode(
 ) -> list[int]:
     if mode == "straight_grid":
         return straight_grid_tokens(
+            primer_tokens=primer_tokens,
+            chords=chords,
+            bars=bars,
+            note_groups_per_bar=note_groups_per_bar,
+            seed=seed,
+        )
+    if mode == "straight_guide_tones":
+        return straight_guide_tones_tokens(
             primer_tokens=primer_tokens,
             chords=chords,
             bars=bars,

--- a/tests/test_stage_b_data_motif_generation_compare.py
+++ b/tests/test_stage_b_data_motif_generation_compare.py
@@ -8,12 +8,15 @@ import pretty_midi
 
 from scripts.run_stage_b_data_motif_generation_compare import (
     build_review_export,
+    chord_tone_pitch_classes,
     data_motif_tokens,
     duration_tokens_from_steps,
     fit_duration_tokens_to_positions,
+    guide_tone_pitch_classes,
     nearest_allowed_pitch_token,
     normalize_position_deltas,
     parse_baseline_modes,
+    straight_guide_tones_tokens,
     straight_grid_tokens,
 )
 from scripts.run_stage_b_generation_probe import (
@@ -70,6 +73,12 @@ class StageBDataMotifGenerationCompareTest(unittest.TestCase):
     def test_parse_baseline_modes_rejects_unknown_mode(self) -> None:
         with self.assertRaises(ValueError):
             parse_baseline_modes("hand_written_swing,random")
+
+    def test_parse_baseline_modes_accepts_straight_guide_tones(self) -> None:
+        self.assertEqual(
+            parse_baseline_modes("straight_grid,straight_guide_tones"),
+            ["straight_grid", "straight_guide_tones"],
+        )
 
     def test_normalize_position_deltas_scales_into_slot(self) -> None:
         positions = normalize_position_deltas([0, 3, 9, 12], slot_start=8, slot_size=8)
@@ -139,6 +148,50 @@ class StageBDataMotifGenerationCompareTest(unittest.TestCase):
         self.assertTrue(grammar["grammar_valid"])
         self.assertEqual(len(groups), 16)
         self.assertEqual({group["position"] % 2 for group in groups}, {0})
+
+    def test_straight_guide_tones_tokens_use_guide_tones_on_strong_beats(self) -> None:
+        chords = ["Cm7", "F7"]
+        primer = build_stage_b_primer(chords, 124)
+        tokens = straight_guide_tones_tokens(
+            primer_tokens=primer,
+            chords=chords,
+            bars=2,
+            note_groups_per_bar=8,
+            seed=17,
+        )
+
+        grammar = analyze_stage_b_note_grammar(tokens, primer_size=len(primer))
+        groups = extract_stage_b_note_groups(tokens, primer_size=len(primer))
+
+        self.assertTrue(grammar["grammar_valid"])
+        self.assertEqual(len(groups), 16)
+        self.assertEqual({group["position"] % 2 for group in groups}, {0})
+        for group in groups:
+            if int(group["position"]) in {0, 4, 8, 12}:
+                chord = chords[int(group["bar"]) % len(chords)]
+                pitch_class = int(group["pitch"]) % 12
+                self.assertIn(pitch_class, set(guide_tone_pitch_classes(chord)))
+
+    def test_straight_guide_tones_tokens_avoid_chromatic_scale_runs(self) -> None:
+        chords = ["Cm7", "F7"]
+        primer = build_stage_b_primer(chords, 124)
+        tokens = straight_guide_tones_tokens(
+            primer_tokens=primer,
+            chords=chords,
+            bars=2,
+            note_groups_per_bar=8,
+            seed=17,
+        )
+        groups = extract_stage_b_note_groups(tokens, primer_size=len(primer))
+        non_chord_run = 0
+
+        for group in groups:
+            chord = chords[int(group["bar"]) % len(chords)]
+            if int(group["pitch"]) % 12 in chord_tone_pitch_classes(chord):
+                non_chord_run = 0
+            else:
+                non_chord_run += 1
+            self.assertLessEqual(non_chord_run, 1)
 
     def test_build_review_export_copies_named_mode_files(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## 요약

- swing 후보의 grid 흔들림과 straight_grid의 scale/chromatic 느낌을 분리하기 위해 straight_guide_tones baseline mode를 추가했습니다.
- strong beat은 현재 chord의 3도/7도 guide tone으로 제한하고, weak beat approach tone은 연속 chromatic run이 되지 않게 제한했습니다.
- chord context review package를 뽑는 stage-b-guide-tone-cadence harness와 결과 문서를 추가했습니다.

## 결과

- compare gate: passed
- data_motif: strict 3/3
- hand_written_swing: strict 3/3
- straight_guide_tones: note count 64, unique pitch count 26-29, chord-tone ratio 0.656, tension ratio 0.172, root-tone ratio 0.000
- straight_guide_tones strict 0/3은 current dead-air gate가 straight reference MIDI를 과벌점하는 것으로 기록했습니다.

## 검증

- ./.venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare
- bash scripts/agent_harness.sh stage-b-guide-tone-cadence
- bash scripts/agent_harness.sh quick

Closes #71