### PR TITLE
Stage B data-motif guide-tone hybrid 후보 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #71: Stage B straight-grid guide-tone/cadence candidates.
+- Issue #73: Stage B data-motif rhythm plus guide-tone/cadence pitch hybrid candidates.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -206,6 +206,12 @@ For Stage B straight-grid guide-tone/cadence candidate changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-guide-tone-cadence
+```
+
+For Stage B data-motif rhythm plus guide-tone/cadence pitch hybrid changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-data-guide-hybrid
 ```
 
 For Stage B collapse/sampling-sweep changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -138,6 +138,7 @@ Stage B에서 명시하는 것:
 32. Stage B data motif review export
 33. Stage B chord-context and straight-grid review export
 34. Stage B straight-grid guide-tone/cadence review candidate
+35. Stage B data-motif rhythm plus guide-tone/cadence pitch hybrid
 
 가장 최근 의미 있는 결과:
 
@@ -351,6 +352,8 @@ Stage B에서 명시하는 것:
 - Issue #69 result: chord/bass guide가 들어간 context MIDI와 straight-grid timing reference를 추가했다.
 - Issue #71 result: `straight_guide_tones` 후보를 추가해 swing timing 문제와 chromatic/scale pitch 문제를 분리했다.
 - Issue #71 result: `straight_guide_tones`는 note count `64`, unique pitch count `26-29`, chord-tone ratio `0.656`, tension ratio `0.172`, root-tone ratio `0.000`이지만 straight reference용 dead-air gate 때문에 strict `0/3`이다.
+- Issue #73 result: `data_motif_guide_tones` 후보를 추가해 data-derived rhythm/duration template과 guide-tone/cadence pitch grammar를 결합했다.
+- Issue #73 result: `data_motif_guide_tones`는 strict `3/3`, note count `63`, unique pitch count `23-24`, chord-tone ratio `0.797`, tension ratio `0.062`, root-tone ratio `0.000`, unique bar-position pattern ratio `1.000`이다.
 
 해석:
 
@@ -629,22 +632,22 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B straight-grid guide-tone/cadence review candidate 추가
+Stage B data-motif rhythm plus guide-tone/cadence pitch hybrid 추가
 ```
 
 결과:
 
-- `straight_guide_tones` baseline mode를 추가했다.
-- strong beat은 현재 chord의 guide tone으로 제한한다.
-- weak beat approach tone은 연속 chromatic run이 되지 않게 제한한다.
-- context MIDI review package에 `straight_grid`, `straight_guide_tones`, `hand_written_swing`, `data_motif`를 같이 export한다.
-- `straight_guide_tones`는 root-tone ratio `0.000`, chord-tone ratio `0.656`, tension ratio `0.172`를 기록했다.
-- `straight_guide_tones` strict `0/3`은 current dead-air gate가 straight reference에 맞지 않기 때문이며, 모델 성공 후보가 아니라 timing/pitch reference로 본다.
+- `data_motif_guide_tones` baseline mode를 추가했다.
+- rhythm/duration은 real phrase window에서 추출한 data-derived motif template을 유지한다.
+- contour template은 register 방향 참고로만 사용한다.
+- pitch class는 current chord guide tone, chord tone, tension, limited approach tone으로 제한한다.
+- strong beat은 현재 chord의 3도/7도 guide tone으로 제한한다.
+- 결과는 strict `3/3`, chord-tone ratio `0.797`, root-tone ratio `0.000`, unique bar-position pattern ratio `1.000`이다.
 
 다음 작업:
 
-- `04_straight_guide_tones_*_with_context.mid`를 듣고 scale/chromatic 느낌이 줄었는지 확인한다.
-- 여전히 교과서적이면 data-derived rhythm을 유지하고 strong-beat pitch만 guide-tone cadence로 제한하는 hybrid를 만든다.
+- `data_motif_guide_tones` context MIDI를 `data_motif`, `straight_guide_tones`와 비교해 듣는다.
+- hybrid도 초급 멜로디처럼 들리면 reference-derived guide-tone landing 통계를 뽑는다.
 - in/out 판단이 어렵다면 review markdown에 bar/chord/pitch-role annotation을 추가한다.
 
 ## 10. 한 문장 요약

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-71-stage-b-guide-tone-cadence`
+- `issue-73-stage-b-data-motif-guide-hybrid`
 
 현재 범위가 아닌 것:
 
@@ -35,6 +35,45 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
 ## Latest Probe Result
+
+Issue #73은 Issue #71의 다음 단계다.
+
+수동 리뷰 결론:
+
+- `straight_guide_tones`는 pitch vocabulary 기준선이지만 rhythm이 너무 교과서적일 수 있다.
+- `data_motif`는 rhythm variation이 더 낫지만 pitch가 scale/chromatic exercise처럼 들릴 수 있다.
+- 따라서 이번 후보는 data-derived rhythm과 guide-tone/cadence pitch 문법을 결합한다.
+
+Implemented:
+
+- `data_motif_guide_tones` baseline mode
+- data-derived rhythm/duration template 유지
+- contour template은 register 방향 참고로만 사용
+- strong beat guide-tone constraint
+- `scripts/agent_harness.sh stage-b-data-guide-hybrid`
+- docs:
+  - `docs/STAGE_B_DATA_GUIDE_HYBRID_2026-05-22.md`
+
+Result:
+
+- compare gate: passed
+- `data_motif`: strict `3/3`
+- `data_motif_guide_tones`: strict `3/3`
+- `data_motif_guide_tones` note count: `63`
+- `data_motif_guide_tones` unique pitch count: `23-24`
+- `data_motif_guide_tones` chord-tone ratio: `0.797`
+- `data_motif_guide_tones` tension ratio: `0.062`
+- `data_motif_guide_tones` root-tone ratio: `0.000`
+- `data_motif_guide_tones` unique bar-position pattern ratio: `1.000`
+- review output: `outputs/stage_b_data_motif_review/harness_stage_b_data_guide_hybrid`
+
+Decision:
+
+- 이번 후보의 목적은 "재즈 솔로 완성"이 아니라 `data_motif`와 `straight_guide_tones`의 장단점을 결합한 listening-review candidate를 만드는 것이다.
+- 들어볼 핵심 파일은 `outputs/stage_b_data_motif_review/harness_stage_b_data_guide_hybrid/context_midi/*data_motif_guide_tones*_with_context.mid`다.
+- 이 후보도 초급 멜로디처럼 들리면 다음은 코드 추가가 아니라 reference-derived guide-tone landing 통계 추출이다.
+
+## Previous Probe Result
 
 Issue #71은 Issue #69 review listening에서 나온 피드백을 반영한다.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,6 +82,8 @@
   - solo-only 리뷰의 한계를 반영해 chord/bass context MIDI와 straight-grid timing reference를 추가한 결과.
 - `STAGE_B_GUIDE_TONE_CADENCE_2026-05-22.md`
   - straight-grid timing 위에서 scale/chromatic 나열을 줄이기 위한 guide-tone/cadence 후보를 추가한 결과.
+- `STAGE_B_DATA_GUIDE_HYBRID_2026-05-22.md`
+  - data-derived motif rhythm과 guide-tone/cadence pitch vocabulary를 결합한 hybrid 후보를 추가한 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`

--- a/docs/STAGE_B_DATA_GUIDE_HYBRID_2026-05-22.md
+++ b/docs/STAGE_B_DATA_GUIDE_HYBRID_2026-05-22.md
@@ -1,0 +1,98 @@
+# Stage B Data-Motif Guide-Tone Hybrid
+
+작성일: 2026-05-22
+
+## 배경
+
+Issue #71에서 `straight_guide_tones`를 추가해 timing과 harmonic vocabulary를 분리했다.
+
+수동 리뷰 기준은 다음으로 좁혀졌다.
+
+- swing/humanization은 MIDI 입력 후보에서 박자가 흐트러져 들린다.
+- straight-grid는 박자는 명확하지만 너무 교과서적이다.
+- data-derived motif는 rhythm variation이 낫지만 pitch가 아직 jazz vocabulary처럼 들린다고 보기 어렵다.
+
+따라서 이번 단계는 `data_motif`의 rhythm template을 유지하면서 pitch만 guide-tone/cadence 문법으로 제한하는 hybrid 후보를 만든다.
+
+## 추가된 Mode
+
+```text
+data_motif_guide_tones
+```
+
+구성:
+
+- rhythm: real phrase window에서 추출한 data-derived motif rhythm template
+- duration: data motif duration template
+- register contour: data motif contour를 target pitch 방향 참고로만 사용
+- pitch class: current chord guide tone, chord tone, tension, limited approach tone
+- strong beat: 3도/7도 guide tone으로 제한
+- weak beat: chord/tension/short approach만 허용
+
+## 검증
+
+실행:
+
+```bash
+bash scripts/agent_harness.sh stage-b-data-guide-hybrid
+bash scripts/agent_harness.sh quick
+```
+
+확인하는 것:
+
+- 기존 `data_motif` vs `hand_written_swing` compare gate가 깨지지 않는다.
+- `data_motif_guide_tones`가 context MIDI review package로 export된다.
+- strong beat pitch class가 current chord guide tone에 들어간다.
+- non-chord pitch가 연속 chromatic run으로 이어지지 않는다.
+
+결과:
+
+- compare gate: passed
+- `data_motif`: strict `3/3`
+- `data_motif_guide_tones`: strict `3/3`
+- `hand_written_swing`: strict `3/3`
+- `straight_grid`: strict `0/3`, timing reference
+- `straight_guide_tones`: strict `0/3`, timing/pitch reference
+- `data_motif_guide_tones` note count: `63`
+- `data_motif_guide_tones` unique pitch count: `23-24`
+- `data_motif_guide_tones` chord-tone ratio: `0.797`
+- `data_motif_guide_tones` tension ratio: `0.062`
+- `data_motif_guide_tones` root-tone ratio: `0.000`
+- `data_motif_guide_tones` unique bar-position pattern ratio: `1.000`
+
+## Review Files
+
+생성 위치:
+
+```text
+outputs/stage_b_data_motif_review/harness_stage_b_data_guide_hybrid/
+```
+
+중요 파일:
+
+```text
+review_candidates.md
+chord_guide.mid
+context_midi/02_data_motif_guide_tones_rank_01_sample_01_with_context.mid
+context_midi/02_data_motif_guide_tones_rank_02_sample_02_with_context.mid
+context_midi/02_data_motif_guide_tones_rank_03_sample_03_with_context.mid
+named_midi/02_data_motif_guide_tones_rank_01_sample_01.mid
+named_midi/02_data_motif_guide_tones_rank_02_sample_02.mid
+named_midi/02_data_motif_guide_tones_rank_03_sample_03.mid
+```
+
+## 판단 기준
+
+이번 후보에서 들어볼 것은 세 가지다.
+
+1. `straight_guide_tones`보다 덜 교과서적인가?
+2. `data_motif`보다 scale/chromatic exercise 느낌이 줄었는가?
+3. chord/bass guide 위에서 strong beat이 안정적으로 들리는가?
+
+좋으면 다음 단계는 이 hybrid를 기본 review candidate로 삼는다.
+
+나쁘면 다음 단계는 코드가 아니라 데이터 쪽이다.
+
+- real jazz phrase window에서 bar별 guide-tone landing 통계를 뽑는다.
+- cadence cell을 hand-written이 아니라 reference-derived로 바꾼다.
+- 또는 chord annotation/pitch-role review table을 먼저 추가한다.

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -70,6 +70,8 @@ Modes:
                 Export review MIDI with chord context and straight-grid reference.
   stage-b-guide-tone-cadence
                 Export straight-grid guide-tone/cadence candidates with chord context.
+  stage-b-data-guide-hybrid
+                Export data-motif rhythm plus guide-tone/cadence pitch candidates.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   all           Run demo and tiny-compare.
@@ -737,6 +739,28 @@ run_stage_b_guide_tone_cadence() {
     --copy_review_midi
 }
 
+run_stage_b_data_guide_hybrid() {
+  local run_id="${RUN_ID:-harness_stage_b_data_guide_hybrid}"
+  print_header "Stage B data-motif rhythm plus guide-tone pitch review export"
+  "$PYTHON_BIN" scripts/run_stage_b_data_motif_generation_compare.py \
+    --run_id "$run_id" \
+    --input_dir ./midi_dataset/midi/studio \
+    --baseline_modes straight_grid,straight_guide_tones,hand_written_swing,data_motif,data_motif_guide_tones \
+    --max_files 4 \
+    --window_bars 8 \
+    --window_stride_bars 4 \
+    --min_window_target_notes 16 \
+    --motif_length 4 \
+    --max_bar_span 2 \
+    --max_records 64 \
+    --template_top_n 32 \
+    --num_samples 3 \
+    --bars 8 \
+    --note_groups_per_bar 8 \
+    --review_top_n 3 \
+    --copy_review_midi
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -829,6 +853,9 @@ case "$MODE" in
     ;;
   stage-b-guide-tone-cadence)
     run_stage_b_guide_tone_cadence
+    ;;
+  stage-b-data-guide-hybrid)
+    run_stage_b_data_guide_hybrid
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/run_stage_b_data_motif_generation_compare.py
+++ b/scripts/run_stage_b_data_motif_generation_compare.py
@@ -51,7 +51,13 @@ from scripts.stage_b_tokens import (  # noqa: E402
 )
 
 
-VALID_BASELINE_MODES = {"straight_grid", "straight_guide_tones", "hand_written_swing", "data_motif"}
+VALID_BASELINE_MODES = {
+    "straight_grid",
+    "straight_guide_tones",
+    "hand_written_swing",
+    "data_motif",
+    "data_motif_guide_tones",
+}
 
 
 def write_json(path: Path, payload: dict[str, Any]) -> None:
@@ -333,6 +339,41 @@ def guide_tone_cadence_pitch_classes(
     ]
 
 
+def guide_tone_cell_index_for_position(position: int) -> int:
+    scaled = int(round(max(0, int(position)) * 8 / int(POSITIONS_PER_BAR)))
+    return max(0, min(7, scaled))
+
+
+def is_strong_beat_position(position: int) -> bool:
+    return int(position) % 4 == 0
+
+
+def guide_tone_pitch_for_position(
+    chord: str | None,
+    next_chord: str | None,
+    *,
+    bar_index: int,
+    position: int,
+    target_pitch: int,
+    recent_pitches: Sequence[int],
+) -> int:
+    cells = guide_tone_cadence_pitch_classes(chord, next_chord, bar_index=bar_index)
+    cell_index = guide_tone_cell_index_for_position(position)
+    pitch_class, role = cells[cell_index]
+    if is_strong_beat_position(position):
+        guides = guide_tone_pitch_classes(chord)
+        if guides:
+            guide_index = (int(position) // 4 + int(bar_index)) % len(guides)
+            pitch_class = guides[guide_index]
+    if role.startswith("approach") and recent_pitches:
+        target_pitch = int(recent_pitches[-1])
+    return nearest_pitch_for_pitch_class(
+        pitch_class,
+        target_pitch=target_pitch,
+        recent_pitches=recent_pitches,
+    )
+
+
 def base_pitch_token_for_chord(chord: str | None, rng: random.Random, recent_pitches: Sequence[int]) -> int:
     allowed = chord_aware_pitch_tokens(
         chord,
@@ -577,6 +618,74 @@ def data_motif_tokens(
     return tokens
 
 
+def data_motif_guide_tones_tokens(
+    *,
+    primer_tokens: Sequence[int],
+    chords: Sequence[str],
+    bars: int,
+    note_groups_per_bar: int,
+    template_report: dict[str, Any],
+    seed: int,
+) -> list[int]:
+    rng = random.Random(int(seed))
+    summary = template_report["summary"]
+    rhythm_rows = summary["top_rhythm_templates"]
+    contour_rows = summary["top_contour_templates"]
+    tokens = [int(token) for token in primer_tokens]
+    recent_pitches: list[int] = []
+    motif_length = 4
+    motifs_per_bar = max(1, int(round(max(1, int(note_groups_per_bar)) / motif_length)))
+    slot_size = max(1, int(POSITIONS_PER_BAR) // motifs_per_bar)
+
+    for bar_index in range(max(1, int(bars))):
+        chord = chords[bar_index % len(chords)] if chords else None
+        next_chord = chords[(bar_index + 1) % len(chords)] if chords else chord
+        if bar_index > 0:
+            tokens.append(TOKEN_BAR)
+            tokens.extend(chord_tokens(chord))
+        emitted_in_bar = 0
+        for motif_index in range(motifs_per_bar):
+            row_index = bar_index * motifs_per_bar + motif_index
+            rhythm = weighted_choice(rhythm_rows, rng, row_index)["key"]
+            contour = weighted_choice(contour_rows, rng, row_index + int(seed))["key"]
+            slot_start = min(int(POSITIONS_PER_BAR) - 1, motif_index * slot_size)
+            positions = normalize_position_deltas(
+                rhythm["position_deltas"],
+                slot_start=slot_start,
+                slot_size=slot_size,
+            )
+            durations = fit_duration_tokens_to_positions(positions, rhythm["duration_steps"])
+            contour_steps = [int(step) for step in contour.get("pitch_intervals", [])] or [0]
+            anchor = 64 + ((bar_index % 3) * 3) + rng.choice([-2, 0, 2])
+            for local_index, (position, duration_token) in enumerate(zip(positions, durations)):
+                if emitted_in_bar >= int(note_groups_per_bar):
+                    break
+                contour_offset = contour_steps[local_index % len(contour_steps)]
+                target_pitch = anchor + contour_offset
+                if recent_pitches:
+                    target_pitch = int(round((target_pitch + int(recent_pitches[-1])) / 2))
+                pitch = guide_tone_pitch_for_position(
+                    chord,
+                    next_chord,
+                    bar_index=bar_index,
+                    position=int(position),
+                    target_pitch=target_pitch,
+                    recent_pitches=recent_pitches,
+                )
+                recent_pitches.append(pitch)
+                tokens.extend(
+                    [
+                        position_token(position),
+                        note_velocity_token(4),
+                        note_pitch_token(pitch),
+                        duration_token,
+                    ]
+                )
+                emitted_in_bar += 1
+    tokens.append(TOKEN_END)
+    return tokens
+
+
 def generated_tokens_for_mode(
     mode: str,
     *,
@@ -613,6 +722,15 @@ def generated_tokens_for_mode(
         )
     if mode == "data_motif":
         return data_motif_tokens(
+            primer_tokens=primer_tokens,
+            chords=chords,
+            bars=bars,
+            note_groups_per_bar=note_groups_per_bar,
+            template_report=template_report,
+            seed=seed,
+        )
+    if mode == "data_motif_guide_tones":
+        return data_motif_guide_tones_tokens(
             primer_tokens=primer_tokens,
             chords=chords,
             bars=bars,

--- a/tests/test_stage_b_data_motif_generation_compare.py
+++ b/tests/test_stage_b_data_motif_generation_compare.py
@@ -9,6 +9,7 @@ import pretty_midi
 from scripts.run_stage_b_data_motif_generation_compare import (
     build_review_export,
     chord_tone_pitch_classes,
+    data_motif_guide_tones_tokens,
     data_motif_tokens,
     duration_tokens_from_steps,
     fit_duration_tokens_to_positions,
@@ -76,8 +77,8 @@ class StageBDataMotifGenerationCompareTest(unittest.TestCase):
 
     def test_parse_baseline_modes_accepts_straight_guide_tones(self) -> None:
         self.assertEqual(
-            parse_baseline_modes("straight_grid,straight_guide_tones"),
-            ["straight_grid", "straight_guide_tones"],
+            parse_baseline_modes("straight_grid,straight_guide_tones,data_motif_guide_tones"),
+            ["straight_grid", "straight_guide_tones", "data_motif_guide_tones"],
         )
 
     def test_normalize_position_deltas_scales_into_slot(self) -> None:
@@ -131,6 +132,72 @@ class StageBDataMotifGenerationCompareTest(unittest.TestCase):
         for positions in positions_by_bar.values():
             self.assertEqual(positions, sorted(positions))
             self.assertEqual(len(positions), len(set(positions)))
+
+    def test_data_motif_guide_tones_preserves_data_motif_rhythm_shape(self) -> None:
+        primer = build_stage_b_primer(["Cm7", "F7"], 124)
+        tokens = data_motif_guide_tones_tokens(
+            primer_tokens=primer,
+            chords=["Cm7", "F7"],
+            bars=2,
+            note_groups_per_bar=8,
+            template_report=template_report(),
+            seed=17,
+        )
+
+        grammar = analyze_stage_b_note_grammar(tokens, primer_size=len(primer))
+        groups = extract_stage_b_note_groups(tokens, primer_size=len(primer))
+        positions_by_bar: dict[int, list[int]] = {}
+        for group in groups:
+            positions_by_bar.setdefault(int(group["bar"]), []).append(int(group["position"]))
+
+        self.assertTrue(grammar["grammar_valid"])
+        self.assertEqual(len(groups), 16)
+        self.assertGreater(len({group["position"] for group in groups}), 4)
+        for positions in positions_by_bar.values():
+            self.assertEqual(positions, sorted(positions))
+            self.assertEqual(len(positions), len(set(positions)))
+
+    def test_data_motif_guide_tones_uses_guide_tones_on_strong_beats(self) -> None:
+        chords = ["Cm7", "F7"]
+        primer = build_stage_b_primer(chords, 124)
+        tokens = data_motif_guide_tones_tokens(
+            primer_tokens=primer,
+            chords=chords,
+            bars=2,
+            note_groups_per_bar=8,
+            template_report=template_report(),
+            seed=17,
+        )
+        groups = extract_stage_b_note_groups(tokens, primer_size=len(primer))
+
+        strong_groups = [group for group in groups if int(group["position"]) in {0, 4, 8, 12}]
+        self.assertGreaterEqual(len(strong_groups), 2)
+        for group in strong_groups:
+            chord = chords[int(group["bar"]) % len(chords)]
+            pitch_class = int(group["pitch"]) % 12
+            self.assertIn(pitch_class, set(guide_tone_pitch_classes(chord)))
+
+    def test_data_motif_guide_tones_avoids_chromatic_scale_runs(self) -> None:
+        chords = ["Cm7", "F7"]
+        primer = build_stage_b_primer(chords, 124)
+        tokens = data_motif_guide_tones_tokens(
+            primer_tokens=primer,
+            chords=chords,
+            bars=2,
+            note_groups_per_bar=8,
+            template_report=template_report(),
+            seed=17,
+        )
+        groups = extract_stage_b_note_groups(tokens, primer_size=len(primer))
+        non_chord_run = 0
+
+        for group in groups:
+            chord = chords[int(group["bar"]) % len(chords)]
+            if int(group["pitch"]) % 12 in chord_tone_pitch_classes(chord):
+                non_chord_run = 0
+            else:
+                non_chord_run += 1
+            self.assertLessEqual(non_chord_run, 1)
 
     def test_straight_grid_tokens_stay_on_even_subdivision_grid(self) -> None:
         primer = build_stage_b_primer(["Cm7", "Fm7"], 124)


### PR DESCRIPTION
## 요약

- data_motif의 rhythm/duration template을 유지하면서 pitch class만 guide-tone/cadence 문법으로 제한하는 data_motif_guide_tones baseline mode를 추가했습니다.
- strong beat은 현재 chord의 3도/7도 guide tone으로 제한하고, weak beat은 chord tone, tension, 짧은 approach tone으로 제한했습니다.
- context MIDI review package를 생성하는 stage-b-data-guide-hybrid harness와 결과 문서를 추가했습니다.

## 결과

- compare gate: passed
- data_motif: strict 3/3
- data_motif_guide_tones: strict 3/3
- data_motif_guide_tones note count: 63
- data_motif_guide_tones unique pitch count: 23-24
- data_motif_guide_tones chord-tone ratio: 0.797
- data_motif_guide_tones tension ratio: 0.062
- data_motif_guide_tones root-tone ratio: 0.000
- data_motif_guide_tones unique bar-position pattern ratio: 1.000

## 검증

- ./.venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare
- bash scripts/agent_harness.sh stage-b-data-guide-hybrid
- bash scripts/agent_harness.sh quick

Closes #73