### PR TITLE
Stage B reference pitch-role landing 통계 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #73: Stage B data-motif rhythm plus guide-tone/cadence pitch hybrid candidates.
+- Issue #75: Stage B reference pitch-role landing statistics.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -176,6 +176,12 @@ For Stage B real phrase reference statistics changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-reference-stats
+```
+
+For Stage B reference pitch-role landing statistics changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-reference-pitch-roles
 ```
 
 For Stage B data-derived motif template extraction changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -139,6 +139,7 @@ Stage B에서 명시하는 것:
 33. Stage B chord-context and straight-grid review export
 34. Stage B straight-grid guide-tone/cadence review candidate
 35. Stage B data-motif rhythm plus guide-tone/cadence pitch hybrid
+36. Stage B reference pitch-role landing statistics and chord-coverage gate
 
 가장 최근 의미 있는 결과:
 
@@ -354,6 +355,8 @@ Stage B에서 명시하는 것:
 - Issue #71 result: `straight_guide_tones`는 note count `64`, unique pitch count `26-29`, chord-tone ratio `0.656`, tension ratio `0.172`, root-tone ratio `0.000`이지만 straight reference용 dead-air gate 때문에 strict `0/3`이다.
 - Issue #73 result: `data_motif_guide_tones` 후보를 추가해 data-derived rhythm/duration template과 guide-tone/cadence pitch grammar를 결합했다.
 - Issue #73 result: `data_motif_guide_tones`는 strict `3/3`, note count `63`, unique pitch count `23-24`, chord-tone ratio `0.797`, tension ratio `0.062`, root-tone ratio `0.000`, unique bar-position pattern ratio `1.000`이다.
+- Issue #75 result: reference pitch-role landing 통계를 시도했지만 known chord note ratio가 `0.000`이라 pitch-role reference는 아직 사용할 수 없다.
+- Issue #75 result: 현재 비교 가능한 것은 rhythm reference뿐이며, pitch vocabulary 조정 전에 chord annotation coverage audit이 필요하다.
 
 해석:
 
@@ -632,23 +635,22 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B data-motif rhythm plus guide-tone/cadence pitch hybrid 추가
+Stage B reference pitch-role landing statistics 추가
 ```
 
 결과:
 
-- `data_motif_guide_tones` baseline mode를 추가했다.
-- rhythm/duration은 real phrase window에서 추출한 data-derived motif template을 유지한다.
-- contour template은 register 방향 참고로만 사용한다.
-- pitch class는 current chord guide tone, chord tone, tension, limited approach tone으로 제한한다.
-- strong beat은 현재 chord의 3도/7도 guide tone으로 제한한다.
-- 결과는 strict `3/3`, chord-tone ratio `0.797`, root-tone ratio `0.000`, unique bar-position pattern ratio `1.000`이다.
+- reference rhythm/contour 통계는 정상적으로 산출된다.
+- reference pitch-role landing 통계는 chord annotation coverage 부족으로 사용할 수 없다.
+- known chord note ratio는 `0.000`, unknown chord ratio는 `1.000`이다.
+- generated pitch-role delta는 거짓 기준이 되므로 의도적으로 생략한다.
+- `data_motif_guide_tones`는 rhythm delta만 reference와 비교 가능하다.
 
 다음 작업:
 
-- `data_motif_guide_tones` context MIDI를 `data_motif`, `straight_guide_tones`와 비교해 듣는다.
-- hybrid도 초급 멜로디처럼 들리면 reference-derived guide-tone landing 통계를 뽑는다.
-- in/out 판단이 어렵다면 review markdown에 bar/chord/pitch-role annotation을 추가한다.
+- Stage B source metadata의 chord progression coverage를 audit한다.
+- chord progression이 있는 subset만 reference pitch-role stats에 사용한다.
+- coverage가 없으면 chord inference/lead-sheet alignment를 별도 이슈로 분리한다.
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-73-stage-b-data-motif-guide-hybrid`
+- `issue-75-stage-b-reference-pitch-role-stats`
 
 현재 범위가 아닌 것:
 
@@ -35,6 +35,46 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
 ## Latest Probe Result
+
+Issue #75는 generated 후보를 더 만들기 전에 reference pitch-role 기준을 세우려는 단계다.
+
+Implemented:
+
+- Stage B embedded chord token에서 bar chord 추출
+- note group별 pitch role 분류:
+  - `root`
+  - `guide`
+  - `chord`
+  - `tension`
+  - `approach`
+  - `outside`
+  - `unknown_chord`
+- strong/eighth/offgrid bucket별 landing 분포
+- generated 후보와 reference rhythm/pitch-role delta 비교
+- reference chord coverage가 부족하면 pitch-role delta를 생략하는 guard
+- `scripts/agent_harness.sh stage-b-reference-pitch-roles`
+- docs:
+  - `docs/STAGE_B_REFERENCE_PITCH_ROLE_STATS_2026-05-22.md`
+
+Result:
+
+- reference record count: `57`
+- reference note group mean: `32.649`
+- reference syncopated onset ratio mean: `0.736`
+- reference duration diversity ratio mean: `0.379`
+- reference IOI diversity ratio mean: `0.341`
+- known chord note ratio: `0.000`
+- unknown chord ratio: `1.000`
+- generated pitch-role deltas: intentionally omitted
+- report: `outputs/stage_b_reference_stats/harness_stage_b_reference_pitch_roles/reference_stats_report.md`
+
+Decision:
+
+- 현재 reference tokenized records에는 chord progression annotation이 들어있지 않다.
+- 따라서 `data_motif_guide_tones`가 reference보다 chord-tone/tension/approach 비율이 어떤지는 아직 판단할 수 없다.
+- 다음 논리적 작업은 generator 수정이 아니라 chord progression coverage audit 또는 chord annotation pipeline이다.
+
+## Previous Probe Result
 
 Issue #73은 Issue #71의 다음 단계다.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -84,6 +84,8 @@
   - straight-grid timing 위에서 scale/chromatic 나열을 줄이기 위한 guide-tone/cadence 후보를 추가한 결과.
 - `STAGE_B_DATA_GUIDE_HYBRID_2026-05-22.md`
   - data-derived motif rhythm과 guide-tone/cadence pitch vocabulary를 결합한 hybrid 후보를 추가한 결과.
+- `STAGE_B_REFERENCE_PITCH_ROLE_STATS_2026-05-22.md`
+  - reference phrase window에서 pitch-role landing 통계를 시도했고 chord annotation coverage가 없다는 blocker를 확인한 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`

--- a/docs/STAGE_B_REFERENCE_PITCH_ROLE_STATS_2026-05-22.md
+++ b/docs/STAGE_B_REFERENCE_PITCH_ROLE_STATS_2026-05-22.md
@@ -1,0 +1,115 @@
+# Stage B Reference Pitch-Role Landing Stats
+
+작성일: 2026-05-22
+
+## 배경
+
+Issue #73의 `data_motif_guide_tones`는 strict `3/3`을 통과했고 root-tone ratio는 `0.000`, chord-tone ratio는 `0.797`이었다.
+
+하지만 이 수치만으로는 좋은 jazz solo 후보인지 판단할 수 없다.
+
+- chord-tone ratio가 높으면 안정적일 수 있다.
+- 동시에 너무 안전해서 초급 멜로디처럼 들릴 수 있다.
+- tension/approach가 낮으면 jazz vocabulary가 약할 수 있다.
+
+따라서 실제 Stage B jazz phrase window에서 bar/position별 pitch role landing 분포를 reference로 만들려고 했다.
+
+## 구현
+
+`scripts/run_stage_b_reference_stats.py`에 다음을 추가했다.
+
+- embedded Stage B chord token에서 bar chord 추출
+- note group별 pitch role 분류:
+  - `root`
+  - `guide`
+  - `chord`
+  - `tension`
+  - `approach`
+  - `outside`
+  - `unknown_chord`
+- strong/eighth/offgrid bucket별 role 분포
+- generated report와 reference rhythm/pitch-role delta 비교
+- reference chord coverage가 부족하면 pitch-role delta를 의도적으로 생략하는 guard
+
+새 harness:
+
+```bash
+bash scripts/agent_harness.sh stage-b-reference-pitch-roles
+```
+
+## 결과
+
+Reference rhythm/contour 통계는 정상적으로 생성됐다.
+
+- record count: `57`
+- note group mean: `32.649`
+- unique pitch mean: `11.000`
+- syncopated onset ratio mean: `0.736`
+- unique bar-position pattern ratio mean: `0.996`
+- duration diversity ratio mean: `0.379`
+- IOI diversity ratio mean: `0.341`
+
+하지만 pitch-role reference는 아직 사용할 수 없다.
+
+- known chord note ratio: `0.000`
+- unknown chord ratio: `1.000`
+- known chord note count: `0`
+- unknown chord note count: `1861`
+
+즉 현재 Stage B reference tokenized records에는 chord progression annotation이 들어있지 않다.
+
+## Generated Comparison
+
+Pitch-role delta는 의도적으로 생략했다.
+
+이유:
+
+```text
+Reference tokenized records do not have enough chord annotations for pitch-role comparison
+```
+
+현재 비교 가능한 것은 rhythm 계열뿐이다.
+
+`data_motif_guide_tones` vs reference mean:
+
+- syncopated onset ratio delta: `-0.111`
+- unique bar-position pattern ratio delta: `+0.004`
+- duration diversity ratio delta: `-0.317`
+- most common duration ratio delta: `+0.115`
+- IOI diversity ratio delta: `-0.262`
+- most common IOI ratio delta: `+0.090`
+
+해석:
+
+- bar-position pattern 다양성은 reference에 가깝다.
+- syncopation은 reference보다 낮다.
+- duration/IOI diversity는 reference보다 많이 낮다.
+- pitch-role은 reference chord annotation이 없어서 아직 비교 불가다.
+
+## 판단
+
+다음에 generator를 더 고치는 것은 순서가 아니다.
+
+먼저 reference dataset에 chord annotation을 넣거나, 최소한 audit해서 chord progression이 있는 subset을 찾아야 한다.
+
+다음 작업:
+
+1. Stage B source metadata에서 chord progression coverage를 audit한다.
+2. chord progression이 있는 파일만 reference pitch-role stats에 사용한다.
+3. 없으면 chord inference/lead-sheet alignment는 별도 이슈로 분리한다.
+4. 그 뒤에야 `data_motif_guide_tones`의 tension/approach 비율이 reference보다 낮은지 판단한다.
+
+## Output
+
+```text
+outputs/stage_b_reference_stats/harness_stage_b_reference_pitch_roles/reference_stats_report.json
+outputs/stage_b_reference_stats/harness_stage_b_reference_pitch_roles/reference_stats_report.md
+```
+
+## Validation
+
+```bash
+./.venv/bin/python -m unittest tests.test_stage_b_reference_stats
+bash scripts/agent_harness.sh stage-b-reference-pitch-roles
+bash scripts/agent_harness.sh quick
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -60,6 +60,8 @@ Modes:
                 Compare 8-bar baseline approach with swing/motif phrase grammar.
   stage-b-reference-stats
                 Build real Stage B phrase-window reference statistics.
+  stage-b-reference-pitch-roles
+                Build reference pitch-role landing stats and compare latest hybrid candidates.
   stage-b-motif-templates
                 Extract data-derived Stage B motif/rhythm templates.
   stage-b-data-motif-compare
@@ -639,6 +641,23 @@ run_stage_b_reference_stats() {
     --generated_report outputs/stage_b_phrase_grammar_compare/harness_stage_b_swing_motif_phrase/phrase_grammar_compare_report.json
 }
 
+run_stage_b_reference_pitch_roles() {
+  local run_id="${RUN_ID:-harness_stage_b_reference_pitch_roles}"
+  local generated_run_id="${run_id}_generated"
+  print_header "Stage B generated hybrid candidate report"
+  RUN_ID="$generated_run_id" run_stage_b_data_guide_hybrid
+  print_header "Stage B reference pitch-role landing statistics"
+  "$PYTHON_BIN" scripts/run_stage_b_reference_stats.py \
+    --run_id "$run_id" \
+    --input_dir ./midi_dataset/midi/studio \
+    --max_files 4 \
+    --window_bars 8 \
+    --window_stride_bars 4 \
+    --min_window_target_notes 16 \
+    --max_records 64 \
+    --generated_report "outputs/stage_b_data_motif_compare/${generated_run_id}/data_motif_compare_report.json"
+}
+
 run_stage_b_motif_templates() {
   local run_id="${RUN_ID:-harness_stage_b_motif_templates}"
   print_header "Stage B motif template extraction"
@@ -838,6 +857,9 @@ case "$MODE" in
     ;;
   stage-b-reference-stats)
     run_stage_b_reference_stats
+    ;;
+  stage-b-reference-pitch-roles)
+    run_stage_b_reference_pitch_roles
     ;;
   stage-b-motif-templates)
     run_stage_b_motif_templates

--- a/scripts/run_stage_b_reference_stats.py
+++ b/scripts/run_stage_b_reference_stats.py
@@ -21,7 +21,20 @@ from scripts.run_stage_b_generation_probe import (  # noqa: E402
     analyze_stage_b_phrase_contour,
     analyze_stage_b_rhythm_profile,
     analyze_stage_b_temporal_coverage,
+    chord_approach_pitch_classes,
+    chord_pitch_classes,
+    chord_root_pitch_class,
     extract_stage_b_note_groups,
+)
+from scripts.stage_b_tokens import (  # noqa: E402
+    CHORD_QUALITIES,
+    CHORD_ROOTS,
+    ROOT_TO_PC,
+    TOKEN_BAR,
+    TOKEN_CHORD_QUALITY_START,
+    TOKEN_CHORD_ROOT_START,
+    TOKEN_END,
+    parse_chord_symbol,
 )
 
 
@@ -42,6 +55,30 @@ REFERENCE_METRIC_KEYS = [
     "onset_coverage_ratio",
     "sustained_coverage_ratio",
 ]
+
+PITCH_ROLE_KEYS = ["root", "guide", "chord", "tension", "approach", "outside", "unknown_chord"]
+PITCH_ROLE_RATIO_KEYS = [
+    "root_tone_ratio",
+    "guide_tone_ratio",
+    "chord_tone_ratio",
+    "non_root_chord_tone_ratio",
+    "tension_ratio",
+    "approach_ratio",
+    "outside_ratio",
+    "unknown_chord_ratio",
+]
+
+QUALITY_SUFFIX = {
+    "maj": "",
+    "maj7": "maj7",
+    "min": "m",
+    "min7": "m7",
+    "dom7": "7",
+    "dim": "dim",
+    "halfdim": "m7b5",
+    "sus": "sus",
+    "unknown": "",
+}
 
 
 def write_json(path: Path, payload: dict[str, Any]) -> None:
@@ -111,12 +148,178 @@ def compact_metric_stats(values: Iterable[float]) -> dict[str, float]:
     }
 
 
+def chord_symbol_from_parts(root: str | None, quality: str | None) -> str | None:
+    if not root or root == "N":
+        return None
+    normalized_quality = quality if quality in QUALITY_SUFFIX else "unknown"
+    return f"{root}{QUALITY_SUFFIX[normalized_quality]}"
+
+
+def extract_bar_chords(tokens: list[int]) -> dict[int, str | None]:
+    bar_index = -1
+    pending_root: str | None = None
+    pending_quality: str | None = None
+    bar_chords: dict[int, str | None] = {}
+
+    for raw_token in tokens:
+        token = int(raw_token)
+        if token == TOKEN_END:
+            break
+        if token == TOKEN_BAR:
+            if bar_index >= 0:
+                bar_chords[bar_index] = chord_symbol_from_parts(pending_root, pending_quality)
+            bar_index += 1
+            pending_root = None
+            pending_quality = None
+            continue
+        if TOKEN_CHORD_ROOT_START <= token < TOKEN_CHORD_ROOT_START + len(CHORD_ROOTS):
+            pending_root = CHORD_ROOTS[token - TOKEN_CHORD_ROOT_START]
+            continue
+        if TOKEN_CHORD_QUALITY_START <= token < TOKEN_CHORD_QUALITY_START + len(CHORD_QUALITIES):
+            pending_quality = CHORD_QUALITIES[token - TOKEN_CHORD_QUALITY_START]
+
+    if bar_index >= 0:
+        bar_chords[bar_index] = chord_symbol_from_parts(pending_root, pending_quality)
+    return bar_chords
+
+
+def guide_tone_pitch_classes(chord: str | None) -> set[int]:
+    root, quality = parse_chord_symbol(chord)
+    root_pc = ROOT_TO_PC.get(root)
+    if root_pc is None:
+        return set()
+    guide_intervals_by_quality = {
+        "maj": {4, 7},
+        "maj7": {4, 11},
+        "min": {3, 7},
+        "min7": {3, 10},
+        "dom7": {4, 10},
+        "dim": {3, 6},
+        "halfdim": {3, 10},
+        "sus": {5, 10},
+        "unknown": {4, 7},
+    }
+    intervals = guide_intervals_by_quality.get(quality, guide_intervals_by_quality["unknown"])
+    return {(int(root_pc) + int(interval)) % 12 for interval in intervals}
+
+
+def position_bucket(position: int) -> str:
+    value = int(position)
+    if value % 4 == 0:
+        return "strong"
+    if value % 2 == 0:
+        return "eighth"
+    return "offgrid"
+
+
+def pitch_role_for_group(group: dict[str, int], chord: str | None) -> str:
+    if not chord:
+        return "unknown_chord"
+    pitch_class = int(group["pitch"]) % 12
+    root_pc = chord_root_pitch_class(chord)
+    guide_pcs = guide_tone_pitch_classes(chord)
+    chord_pcs = chord_pitch_classes(chord, pitch_mode="tones")
+    tension_pcs = chord_pitch_classes(chord, pitch_mode="tones_tensions") - chord_pcs
+    approach_pcs = chord_approach_pitch_classes(chord)
+
+    if root_pc is not None and pitch_class == root_pc:
+        return "root"
+    if pitch_class in guide_pcs:
+        return "guide"
+    if pitch_class in chord_pcs:
+        return "chord"
+    if pitch_class in tension_pcs:
+        return "tension"
+    if pitch_class in approach_pcs:
+        return "approach"
+    return "outside"
+
+
+def _empty_role_counts() -> dict[str, int]:
+    return {role: 0 for role in PITCH_ROLE_KEYS}
+
+
+def _role_ratios(counts: dict[str, int]) -> dict[str, float]:
+    total = sum(int(counts.get(role, 0)) for role in PITCH_ROLE_KEYS)
+    if total <= 0:
+        return {role: 0.0 for role in PITCH_ROLE_KEYS}
+    return {role: float(counts.get(role, 0) / total) for role in PITCH_ROLE_KEYS}
+
+
+def pitch_role_ratio_metrics(role_counts: dict[str, int]) -> dict[str, float]:
+    total = sum(int(role_counts.get(role, 0)) for role in PITCH_ROLE_KEYS)
+    if total <= 0:
+        return {key: 0.0 for key in PITCH_ROLE_RATIO_KEYS}
+    root = int(role_counts.get("root", 0))
+    guide = int(role_counts.get("guide", 0))
+    chord = int(role_counts.get("chord", 0))
+    tension = int(role_counts.get("tension", 0))
+    approach = int(role_counts.get("approach", 0))
+    outside = int(role_counts.get("outside", 0))
+    unknown = int(role_counts.get("unknown_chord", 0))
+    chord_total = root + guide + chord
+    return {
+        "root_tone_ratio": float(root / total),
+        "guide_tone_ratio": float(guide / total),
+        "chord_tone_ratio": float(chord_total / total),
+        "non_root_chord_tone_ratio": float((guide + chord) / total),
+        "tension_ratio": float(tension / total),
+        "approach_ratio": float(approach / total),
+        "outside_ratio": float(outside / total),
+        "unknown_chord_ratio": float(unknown / total),
+    }
+
+
+def analyze_stage_b_pitch_role_landings(tokens: list[int]) -> dict[str, Any]:
+    groups = extract_stage_b_note_groups(tokens, primer_size=0)
+    bar_chords = extract_bar_chords(tokens)
+    role_counts = _empty_role_counts()
+    bucket_counts: dict[str, dict[str, int]] = {
+        "strong": _empty_role_counts(),
+        "eighth": _empty_role_counts(),
+        "offgrid": _empty_role_counts(),
+    }
+    position_mod4_counts: dict[str, dict[str, int]] = {str(index): _empty_role_counts() for index in range(4)}
+    known_chord_notes = 0
+
+    for group in groups:
+        group_bar = int(group["bar"])
+        chord = bar_chords.get(group_bar)
+        if chord is None and (group_bar - 1) in bar_chords:
+            chord = bar_chords.get(group_bar - 1)
+        role = pitch_role_for_group(group, chord)
+        role_counts[role] += 1
+        bucket = position_bucket(int(group["position"]))
+        bucket_counts[bucket][role] += 1
+        position_mod4_counts[str(int(group["position"]) % 4)][role] += 1
+        if chord:
+            known_chord_notes += 1
+
+    return {
+        "note_group_count": int(len(groups)),
+        "known_chord_note_count": int(known_chord_notes),
+        "known_chord_note_ratio": float(known_chord_notes / len(groups)) if groups else 0.0,
+        "bar_chords": {str(bar): chord for bar, chord in sorted(bar_chords.items())},
+        "role_counts": role_counts,
+        "role_ratios": _role_ratios(role_counts),
+        "cumulative_ratios": pitch_role_ratio_metrics(role_counts),
+        "bucket_counts": bucket_counts,
+        "bucket_ratios": {bucket: _role_ratios(counts) for bucket, counts in bucket_counts.items()},
+        "position_mod4_counts": position_mod4_counts,
+        "position_mod4_ratios": {
+            bucket: _role_ratios(counts)
+            for bucket, counts in position_mod4_counts.items()
+        },
+    }
+
+
 def analyze_token_record(tokens: list[int], bars: int) -> dict[str, Any]:
     groups = extract_stage_b_note_groups(tokens, primer_size=0)
     collapse = analyze_stage_b_collapse(tokens, primer_size=0)
     rhythm = analyze_stage_b_rhythm_profile(tokens, primer_size=0)
     contour = analyze_stage_b_phrase_contour(tokens, primer_size=0)
     temporal = analyze_stage_b_temporal_coverage(tokens, primer_size=0, bars=bars)
+    pitch_role_landings = analyze_stage_b_pitch_role_landings(tokens)
     pitches = [int(group["pitch"]) for group in groups]
 
     metrics = {
@@ -144,6 +347,7 @@ def analyze_token_record(tokens: list[int], bars: int) -> dict[str, Any]:
         "phrase_contour": contour,
         "temporal_coverage": temporal,
         "collapse": collapse,
+        "pitch_role_landings": pitch_role_landings,
     }
 
 
@@ -182,10 +386,112 @@ def summarize_reference_rows(rows: list[dict[str, Any]]) -> dict[str, Any]:
             )
             for key in REFERENCE_METRIC_KEYS
         },
+        "pitch_role_landing": summarize_pitch_role_landings(rows),
     }
 
 
+def merge_role_counts(rows: list[dict[str, Any]], key_path: tuple[str, ...]) -> dict[str, int]:
+    counts = _empty_role_counts()
+    for row in rows:
+        value: Any = row
+        for key in key_path:
+            value = value.get(key, {}) if isinstance(value, dict) else {}
+        if not isinstance(value, dict):
+            continue
+        for role in PITCH_ROLE_KEYS:
+            counts[role] += int(value.get(role, 0) or 0)
+    return counts
+
+
+def summarize_pitch_role_landings(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    role_counts = merge_role_counts(rows, ("pitch_role_landings", "role_counts"))
+    bucket_counts = {
+        bucket: merge_role_counts(rows, ("pitch_role_landings", "bucket_counts", bucket))
+        for bucket in ("strong", "eighth", "offgrid")
+    }
+    position_mod4_counts = {
+        str(index): merge_role_counts(rows, ("pitch_role_landings", "position_mod4_counts", str(index)))
+        for index in range(4)
+    }
+    note_count = sum(int(role_counts.get(role, 0)) for role in PITCH_ROLE_KEYS)
+    known_count = sum(
+        int(row.get("pitch_role_landings", {}).get("known_chord_note_count", 0) or 0)
+        for row in rows
+    )
+    return {
+        "note_group_count": int(note_count),
+        "known_chord_note_count": int(known_count),
+        "known_chord_note_ratio": float(known_count / note_count) if note_count else 0.0,
+        "role_counts": role_counts,
+        "role_ratios": _role_ratios(role_counts),
+        "cumulative_ratios": pitch_role_ratio_metrics(role_counts),
+        "bucket_counts": bucket_counts,
+        "bucket_ratios": {bucket: _role_ratios(counts) for bucket, counts in bucket_counts.items()},
+        "position_mod4_counts": position_mod4_counts,
+        "position_mod4_ratios": {
+            bucket: _role_ratios(counts)
+            for bucket, counts in position_mod4_counts.items()
+        },
+    }
+
+
+def _mean(values: list[float]) -> float:
+    return float(mean(values)) if values else 0.0
+
+
+def generated_rows_from_samples(report: dict[str, Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for mode, samples in sorted(report.get("samples", {}).items()):
+        if not isinstance(samples, list) or not samples:
+            continue
+        rhythm_rows = [sample.get("rhythm_profile", {}) for sample in samples]
+        pitch_rows = [sample.get("pitch_roles", {}) for sample in samples]
+        rows.append(
+            {
+                "label": str(mode),
+                "metrics": {
+                    "syncopated_onset_ratio": _mean(
+                        [float(row.get("syncopated_onset_ratio", 0.0) or 0.0) for row in rhythm_rows]
+                    ),
+                    "unique_bar_position_pattern_ratio": _mean(
+                        [float(row.get("unique_bar_position_pattern_ratio", 0.0) or 0.0) for row in rhythm_rows]
+                    ),
+                    "duration_diversity_ratio": _mean(
+                        [float(row.get("duration_diversity_ratio", 0.0) or 0.0) for row in rhythm_rows]
+                    ),
+                    "most_common_duration_ratio": _mean(
+                        [float(row.get("most_common_duration_ratio", 0.0) or 0.0) for row in rhythm_rows]
+                    ),
+                    "ioi_diversity_ratio": _mean(
+                        [float(row.get("ioi_diversity_ratio", 0.0) or 0.0) for row in rhythm_rows]
+                    ),
+                    "most_common_ioi_ratio": _mean(
+                        [float(row.get("most_common_ioi_ratio", 0.0) or 0.0) for row in rhythm_rows]
+                    ),
+                    "root_tone_ratio": _mean(
+                        [float(row.get("root_tone_ratio", 0.0) or 0.0) for row in pitch_rows]
+                    ),
+                    "chord_tone_ratio": _mean(
+                        [float(row.get("chord_tone_ratio", 0.0) or 0.0) for row in pitch_rows]
+                    ),
+                    "non_root_chord_tone_ratio": _mean(
+                        [float(row.get("non_root_chord_tone_ratio", 0.0) or 0.0) for row in pitch_rows]
+                    ),
+                    "tension_ratio": _mean(
+                        [float(row.get("tension_ratio", 0.0) or 0.0) for row in pitch_rows]
+                    ),
+                    "non_chord_tone_ratio": _mean(
+                        [float(row.get("non_chord_tone_ratio", 0.0) or 0.0) for row in pitch_rows]
+                    ),
+                },
+            }
+        )
+    return rows
+
+
 def generated_rows_from_report(report: dict[str, Any]) -> list[dict[str, Any]]:
+    if isinstance(report.get("samples"), dict):
+        return generated_rows_from_samples(report)
     rows: list[dict[str, Any]] = []
     for row in report.get("rows", []):
         rows.append(
@@ -209,8 +515,16 @@ def generated_rows_from_report(report: dict[str, Any]) -> list[dict[str, Any]]:
 def compare_generated_to_reference(
     generated_rows: list[dict[str, Any]],
     reference_summary: dict[str, Any],
+    include_pitch_roles: bool | None = None,
 ) -> list[dict[str, Any]]:
-    reference_metrics = reference_summary.get("metrics", {})
+    reference_metrics = dict(reference_summary.get("metrics", {}))
+    pitch_summary = reference_summary.get("pitch_role_landing", {})
+    if include_pitch_roles is None:
+        include_pitch_roles = float(pitch_summary.get("known_chord_note_ratio", 0.0) or 0.0) >= 0.5
+    if include_pitch_roles:
+        pitch_reference_metrics = pitch_summary.get("cumulative_ratios", {})
+        for key, value in pitch_reference_metrics.items():
+            reference_metrics[key] = {"mean": float(value)}
     comparisons: list[dict[str, Any]] = []
     for row in generated_rows:
         metrics = row.get("metrics", {})
@@ -244,6 +558,39 @@ def markdown_report(report: dict[str, Any]) -> str:
                 **stats,
             )
         )
+    pitch_summary = summary.get("pitch_role_landing", {})
+    if pitch_summary:
+        lines.extend(
+            [
+                "",
+                "## Pitch Role Landing",
+                "",
+                f"- known chord note ratio: `{pitch_summary.get('known_chord_note_ratio', 0.0):.3f}`",
+                "",
+                "| role | ratio | count |",
+                "|---|---:|---:|",
+            ]
+        )
+        role_ratios = pitch_summary.get("role_ratios", {})
+        role_counts = pitch_summary.get("role_counts", {})
+        for role in PITCH_ROLE_KEYS:
+            lines.append(f"| {role} | {float(role_ratios.get(role, 0.0)):.3f} | {int(role_counts.get(role, 0))} |")
+        lines.extend(["", "### Strong Beat Role Ratios", "", "| role | ratio |", "|---|---:|"])
+        strong_ratios = pitch_summary.get("bucket_ratios", {}).get("strong", {})
+        for role in PITCH_ROLE_KEYS:
+            lines.append(f"| {role} | {float(strong_ratios.get(role, 0.0)):.3f} |")
+    if report.get("pitch_role_reference_warning"):
+        lines.extend(
+            [
+                "",
+                "## Pitch Role Reference Warning",
+                "",
+                f"- `{report['pitch_role_reference_warning']}`",
+                f"- required known chord note ratio: `{report.get('min_pitch_role_known_chord_ratio', 0.5):.3f}`",
+                f"- actual known chord note ratio: `{pitch_summary.get('known_chord_note_ratio', 0.0):.3f}`",
+                "- generated pitch-role deltas are intentionally omitted until chord annotations exist.",
+            ]
+        )
     if report.get("generated_comparison"):
         lines.extend(["", "## Generated Comparison", ""])
         for row in report["generated_comparison"]:
@@ -268,6 +615,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--skip_prepare", action="store_true")
     parser.add_argument("--tokenized_dir", type=str, default=None)
     parser.add_argument("--generated_report", type=str, default=None)
+    parser.add_argument("--min_pitch_role_known_chord_ratio", type=float, default=0.5)
     return parser
 
 
@@ -312,9 +660,23 @@ def main() -> int:
         if generated_report_path.exists():
             generated_rows = generated_rows_from_report(read_json(generated_report_path))
             report["generated_report"] = str(generated_report_path)
+            known_chord_ratio = float(
+                report["reference_summary"]
+                .get("pitch_role_landing", {})
+                .get("known_chord_note_ratio", 0.0)
+                or 0.0
+            )
+            pitch_role_ready = known_chord_ratio >= float(args.min_pitch_role_known_chord_ratio)
+            report["pitch_role_reference_ready"] = bool(pitch_role_ready)
+            report["min_pitch_role_known_chord_ratio"] = float(args.min_pitch_role_known_chord_ratio)
+            if not pitch_role_ready:
+                report["pitch_role_reference_warning"] = (
+                    "Reference tokenized records do not have enough chord annotations for pitch-role comparison"
+                )
             report["generated_comparison"] = compare_generated_to_reference(
                 generated_rows,
                 report["reference_summary"],
+                include_pitch_roles=pitch_role_ready,
             )
         else:
             report["generated_report_warning"] = f"missing generated report: {generated_report_path}"

--- a/tests/test_stage_b_reference_stats.py
+++ b/tests/test_stage_b_reference_stats.py
@@ -4,11 +4,14 @@ import unittest
 
 from scripts.run_stage_b_reference_stats import (
     analyze_token_record,
+    analyze_stage_b_pitch_role_landings,
     compare_generated_to_reference,
+    extract_bar_chords,
     generated_rows_from_report,
     summarize_reference_rows,
 )
 from scripts.stage_b_tokens import (
+    TOKEN_BAR,
     TOKEN_END,
     chord_tokens,
     note_duration_token,
@@ -20,6 +23,7 @@ from scripts.stage_b_tokens import (
 
 def token_phrase() -> list[int]:
     return [
+        TOKEN_BAR,
         *chord_tokens("Cmaj7"),
         position_token(0),
         note_velocity_token(4),
@@ -42,6 +46,11 @@ def token_phrase() -> list[int]:
 
 
 class StageBReferenceStatsTest(unittest.TestCase):
+    def test_extract_bar_chords_reads_embedded_stage_b_chord_tokens(self) -> None:
+        chords = extract_bar_chords(token_phrase())
+
+        self.assertEqual(chords[0], "Cmaj7")
+
     def test_analyze_token_record_reports_phrase_metrics(self) -> None:
         report = analyze_token_record(token_phrase(), bars=1)
 
@@ -49,18 +58,32 @@ class StageBReferenceStatsTest(unittest.TestCase):
         self.assertEqual(report["metrics"]["unique_pitch_count"], 4.0)
         self.assertGreater(report["metrics"]["syncopated_onset_ratio"], 0.5)
         self.assertGreater(report["metrics"]["direction_change_ratio"], 0.0)
+        self.assertIn("pitch_role_landings", report)
+
+    def test_analyze_stage_b_pitch_role_landings_counts_roles_and_buckets(self) -> None:
+        report = analyze_stage_b_pitch_role_landings(token_phrase())
+
+        self.assertEqual(report["known_chord_note_count"], 4)
+        self.assertGreater(report["role_counts"]["root"], 0)
+        self.assertGreater(report["role_counts"]["guide"], 0)
+        self.assertEqual(report["bucket_counts"]["strong"]["root"], 1)
+        self.assertGreater(report["cumulative_ratios"]["chord_tone_ratio"], 0.0)
 
     def test_summarize_reference_rows_builds_distribution(self) -> None:
-        rows = [
-            {"metrics": {"note_group_count": 4.0, "syncopated_onset_ratio": 0.5}},
-            {"metrics": {"note_group_count": 8.0, "syncopated_onset_ratio": 0.75}},
-        ]
+        first = analyze_token_record(token_phrase(), bars=1)
+        second = analyze_token_record(token_phrase(), bars=1)
+        first["metrics"]["note_group_count"] = 4.0
+        first["metrics"]["syncopated_onset_ratio"] = 0.5
+        second["metrics"]["note_group_count"] = 8.0
+        second["metrics"]["syncopated_onset_ratio"] = 0.75
+        rows = [first, second]
 
         summary = summarize_reference_rows(rows)
 
         self.assertEqual(summary["record_count"], 2)
         self.assertAlmostEqual(summary["metrics"]["note_group_count"]["mean"], 6.0)
         self.assertAlmostEqual(summary["metrics"]["syncopated_onset_ratio"]["mean"], 0.625)
+        self.assertGreater(summary["pitch_role_landing"]["role_counts"]["guide"], 0)
 
     def test_generated_rows_from_report_maps_comparable_rhythm_fields(self) -> None:
         generated = generated_rows_from_report(
@@ -79,16 +102,63 @@ class StageBReferenceStatsTest(unittest.TestCase):
         self.assertEqual(generated[0]["label"], "swing_motif_approach")
         self.assertAlmostEqual(generated[0]["metrics"]["syncopated_onset_ratio"], 0.75)
 
+    def test_generated_rows_from_report_maps_data_motif_compare_samples(self) -> None:
+        generated = generated_rows_from_report(
+            {
+                "samples": {
+                    "data_motif_guide_tones": [
+                        {
+                            "rhythm_profile": {"syncopated_onset_ratio": 0.625},
+                            "pitch_roles": {
+                                "root_tone_ratio": 0.0,
+                                "chord_tone_ratio": 0.8,
+                                "tension_ratio": 0.1,
+                            },
+                        }
+                    ]
+                }
+            }
+        )
+
+        self.assertEqual(generated[0]["label"], "data_motif_guide_tones")
+        self.assertAlmostEqual(generated[0]["metrics"]["chord_tone_ratio"], 0.8)
+
     def test_compare_generated_to_reference_reports_deltas(self) -> None:
         comparisons = compare_generated_to_reference(
-            [{"label": "generated", "metrics": {"syncopated_onset_ratio": 0.75}}],
-            {"metrics": {"syncopated_onset_ratio": {"mean": 0.55}}},
+            [
+                {
+                    "label": "generated",
+                    "metrics": {"syncopated_onset_ratio": 0.75, "chord_tone_ratio": 0.8},
+                }
+            ],
+            {
+                "metrics": {"syncopated_onset_ratio": {"mean": 0.55}},
+                "pitch_role_landing": {
+                    "known_chord_note_ratio": 1.0,
+                    "cumulative_ratios": {"chord_tone_ratio": 0.5},
+                },
+            },
         )
 
         self.assertAlmostEqual(
             comparisons[0]["delta_from_reference_mean"]["syncopated_onset_ratio"],
             0.20,
         )
+        self.assertAlmostEqual(comparisons[0]["delta_from_reference_mean"]["chord_tone_ratio"], 0.30)
+
+    def test_compare_generated_to_reference_omits_pitch_deltas_when_chords_unknown(self) -> None:
+        comparisons = compare_generated_to_reference(
+            [{"label": "generated", "metrics": {"chord_tone_ratio": 0.8}}],
+            {
+                "metrics": {},
+                "pitch_role_landing": {
+                    "known_chord_note_ratio": 0.0,
+                    "cumulative_ratios": {"chord_tone_ratio": 0.5},
+                },
+            },
+        )
+
+        self.assertNotIn("chord_tone_ratio", comparisons[0]["delta_from_reference_mean"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 요약

- 실제 Stage B reference window에서 pitch-role landing 통계를 뽑기 위한 분석을 추가했습니다.
- embedded chord token에서 bar chord를 추출하고 note group별 root, guide, chord, tension, approach, outside, unknown_chord 역할을 집계합니다.
- reference chord coverage가 부족하면 generated pitch-role delta를 의도적으로 생략하는 guard를 추가했습니다.

## 결과

- reference record count: 57
- reference note group mean: 32.649
- reference syncopated onset ratio mean: 0.736
- reference duration diversity ratio mean: 0.379
- reference IOI diversity ratio mean: 0.341
- known chord note ratio: 0.000
- unknown chord ratio: 1.000
- generated pitch-role delta: chord annotation coverage 부족으로 생략

## 판단

현재 reference tokenized records에는 chord progression annotation이 들어있지 않습니다. 따라서 data_motif_guide_tones의 chord-tone/tension/approach 비율이 reference보다 높은지 낮은지는 아직 판단할 수 없습니다. 다음 단계는 generator 수정이 아니라 chord progression coverage audit입니다.

## 검증

- ./.venv/bin/python -m unittest tests.test_stage_b_reference_stats
- bash scripts/agent_harness.sh stage-b-reference-pitch-roles
- bash scripts/agent_harness.sh quick

Closes #75