### PR TITLE
Stage B chord progression coverage audit 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #75: Stage B reference pitch-role landing statistics.
+- Issue #77: Stage B chord progression coverage audit.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -182,6 +182,12 @@ For Stage B reference pitch-role landing statistics changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-reference-pitch-roles
+```
+
+For chord progression annotation coverage audit changes, run:
+
+```bash
+bash scripts/agent_harness.sh chord-coverage-audit
 ```
 
 For Stage B data-derived motif template extraction changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -140,6 +140,7 @@ Stage B에서 명시하는 것:
 34. Stage B straight-grid guide-tone/cadence review candidate
 35. Stage B data-motif rhythm plus guide-tone/cadence pitch hybrid
 36. Stage B reference pitch-role landing statistics and chord-coverage gate
+37. Stage B chord progression coverage audit
 
 가장 최근 의미 있는 결과:
 
@@ -155,6 +156,8 @@ Stage B에서 명시하는 것:
 - Issue #49 fixes the length problem structurally, but repeated-pitch dependence remains a listening-review risk.
 - Issue #51 shows this is not adjacent same-note collapse: adjacent repeated pitch ratio is `0.000`, average direction change ratio is around `0.689`, and max longest same pitch run is `1`.
 - Issue #53 shows the perceived "root-heavy" line is not pure root collapse: average root tone ratio is around `0.271`, top candidate root ratio is around `0.219`, but tension ratio is `0.000`.
+- Issue #75 shows reference pitch-role stats cannot be trusted yet because known chord note ratio is `0.000`.
+- Issue #77 audits the local dataset for chord progression annotations and finds no usable candidate: role meta `2812` scanned with `0` hits, sidecars `0`, MIDI text events `120` scanned with `0` chord hits.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -357,6 +360,8 @@ Stage B에서 명시하는 것:
 - Issue #73 result: `data_motif_guide_tones`는 strict `3/3`, note count `63`, unique pitch count `23-24`, chord-tone ratio `0.797`, tension ratio `0.062`, root-tone ratio `0.000`, unique bar-position pattern ratio `1.000`이다.
 - Issue #75 result: reference pitch-role landing 통계를 시도했지만 known chord note ratio가 `0.000`이라 pitch-role reference는 아직 사용할 수 없다.
 - Issue #75 result: 현재 비교 가능한 것은 rhythm reference뿐이며, pitch vocabulary 조정 전에 chord annotation coverage audit이 필요하다.
+- Issue #77 result: role metadata `2812`개, raw sidecar `0`개, MIDI text event `120`개를 scan했지만 chord progression hit는 `0`이다.
+- Issue #77 result: 현재 local dataset에는 바로 쓸 수 있는 chord progression annotation이 없으므로 reference pitch-role comparison은 아직 불가능하다.
 
 해석:
 
@@ -366,6 +371,7 @@ Stage B에서 명시하는 것:
 - `approach_tensions`는 pitch-level resolution을 만들지만, 이 또한 jazz vocabulary 자체는 아니다.
 - `swing_motif_approach`는 기계적인 grid 반복을 줄였지만, 이 또한 jazz vocabulary 자체는 아니다.
 - real phrase reference stats와 motif extraction 기준으로 보면 다음은 hand-written rhythm rule 확장이 아니라 data-derived motif/cadence control 쪽이 맞다.
+- 다만 pitch-role 쪽은 reference chord label이 없으므로, 다음 pitch grammar 개선은 작은 chord-labeled evaluation subset 또는 chord inference/lead-sheet alignment가 먼저다.
 
 ### Phase 3.10. Swing/Motif Phrase Grammar
 
@@ -635,22 +641,22 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B reference pitch-role landing statistics 추가
+Stage B chord progression coverage audit 추가
 ```
 
 결과:
 
-- reference rhythm/contour 통계는 정상적으로 산출된다.
-- reference pitch-role landing 통계는 chord annotation coverage 부족으로 사용할 수 없다.
-- known chord note ratio는 `0.000`, unknown chord ratio는 `1.000`이다.
-- generated pitch-role delta는 거짓 기준이 되므로 의도적으로 생략한다.
-- `data_motif_guide_tones`는 rhythm delta만 reference와 비교 가능하다.
+- role metadata `2812`개를 scan했지만 chord progression hit는 `0`이다.
+- raw sidecar file은 발견되지 않았다.
+- MIDI lyric/text event `120`개를 scan했지만 chord symbol hit는 `0`이다.
+- 현재 local dataset에는 바로 쓸 수 있는 chord progression annotation이 없다.
+- 따라서 reference pitch-role comparison은 아직 불가능하다.
 
 다음 작업:
 
-- Stage B source metadata의 chord progression coverage를 audit한다.
-- chord progression이 있는 subset만 reference pitch-role stats에 사용한다.
-- coverage가 없으면 chord inference/lead-sheet alignment를 별도 이슈로 분리한다.
+- 작은 chord-labeled evaluation subset을 만든다.
+- 우선 3-5개 phrase에 bar-level chord labels를 수동으로 붙여 generated candidate의 pitch-role sanity check를 시작한다.
+- full chord inference/lead-sheet alignment는 그 다음 별도 이슈로 분리한다.
 
 ## 10. 한 문장 요약
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -157,7 +157,7 @@ Stage B에서 명시하는 것:
 - Issue #51 shows this is not adjacent same-note collapse: adjacent repeated pitch ratio is `0.000`, average direction change ratio is around `0.689`, and max longest same pitch run is `1`.
 - Issue #53 shows the perceived "root-heavy" line is not pure root collapse: average root tone ratio is around `0.271`, top candidate root ratio is around `0.219`, but tension ratio is `0.000`.
 - Issue #75 shows reference pitch-role stats cannot be trusted yet because known chord note ratio is `0.000`.
-- Issue #77 audits the local dataset for chord progression annotations and finds no usable candidate: role meta `2812` scanned with `0` hits, sidecars `0`, MIDI text events `120` scanned with `0` chord hits.
+- Issue #77 audits the local dataset for chord progression annotations and finds no usable candidate: role meta `2812` scanned with `0` hits, sidecars `0`, MIDI files scanned for text events `120` with `0` chord-text candidates.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -360,7 +360,7 @@ Stage B에서 명시하는 것:
 - Issue #73 result: `data_motif_guide_tones`는 strict `3/3`, note count `63`, unique pitch count `23-24`, chord-tone ratio `0.797`, tension ratio `0.062`, root-tone ratio `0.000`, unique bar-position pattern ratio `1.000`이다.
 - Issue #75 result: reference pitch-role landing 통계를 시도했지만 known chord note ratio가 `0.000`이라 pitch-role reference는 아직 사용할 수 없다.
 - Issue #75 result: 현재 비교 가능한 것은 rhythm reference뿐이며, pitch vocabulary 조정 전에 chord annotation coverage audit이 필요하다.
-- Issue #77 result: role metadata `2812`개, raw sidecar `0`개, MIDI text event `120`개를 scan했지만 chord progression hit는 `0`이다.
+- Issue #77 result: role metadata `2812`개, raw sidecar `0`개, text event를 검사한 MIDI file `120`개를 scan했지만 chord progression hit는 `0`이다.
 - Issue #77 result: 현재 local dataset에는 바로 쓸 수 있는 chord progression annotation이 없으므로 reference pitch-role comparison은 아직 불가능하다.
 
 해석:
@@ -648,7 +648,7 @@ Stage B chord progression coverage audit 추가
 
 - role metadata `2812`개를 scan했지만 chord progression hit는 `0`이다.
 - raw sidecar file은 발견되지 않았다.
-- MIDI lyric/text event `120`개를 scan했지만 chord symbol hit는 `0`이다.
+- MIDI lyric/text event를 검사한 MIDI file `120`개를 scan했지만 chord-text candidate는 `0`이다.
 - 현재 local dataset에는 바로 쓸 수 있는 chord progression annotation이 없다.
 - 따라서 reference pitch-role comparison은 아직 불가능하다.
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -63,8 +63,9 @@ Result:
 - role meta chord hits: `0`
 - role meta unique source MIDI count: `28`
 - sidecar files found: `0`
-- MIDI text events scanned: `120`
-- MIDI chord text hits: `0`
+- MIDI files scanned for text events: `120`
+- MIDI files with any text event: `0`
+- MIDI chord-text candidate files: `0`
 - usable chord annotation candidate: `false`
 - report: `outputs/chord_coverage_audit/harness_chord_coverage_audit/chord_coverage_audit.md`
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-75-stage-b-reference-pitch-role-stats`
+- `issue-77-stage-b-chord-coverage-audit`
 
 현재 범위가 아닌 것:
 
@@ -36,7 +36,48 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 ## Latest Probe Result
 
-Issue #75는 generated 후보를 더 만들기 전에 reference pitch-role 기준을 세우려는 단계다.
+Issue #77은 Issue #75에서 드러난 chord annotation blocker를 실제 dataset 기준으로 확인한 단계다.
+
+Implemented:
+
+- role dataset `meta.json` chord field/string scan
+- raw dataset sidecar scan:
+  - `.json`
+  - `.csv`
+  - `.tsv`
+  - `.txt`
+  - `.lab`
+  - `.jams`
+  - `.xml`
+  - `.musicxml`
+  - `.mxl`
+- MIDI lyric/text event chord-symbol scan
+- `scripts/audit_chord_progression_coverage.py`
+- `scripts/agent_harness.sh chord-coverage-audit`
+- docs:
+  - `docs/STAGE_B_CHORD_COVERAGE_AUDIT_2026-05-22.md`
+
+Result:
+
+- role meta scanned: `2812`
+- role meta chord hits: `0`
+- role meta unique source MIDI count: `28`
+- sidecar files found: `0`
+- MIDI text events scanned: `120`
+- MIDI chord text hits: `0`
+- usable chord annotation candidate: `false`
+- report: `outputs/chord_coverage_audit/harness_chord_coverage_audit/chord_coverage_audit.md`
+
+Decision:
+
+- 현재 로컬 dataset에는 바로 사용할 수 있는 chord progression annotation이 없다.
+- 따라서 generated 후보의 pitch-role 비율을 reference와 비교할 수 없다.
+- 다음 논리적 작업은 generator 튜닝이 아니라 작은 chord-labeled evaluation subset 또는 chord inference/lead-sheet alignment다.
+- 한 달 MVP 관점에서는 full chord inference보다 3-5개 phrase의 수동 chord-labeled evaluation subset이 더 작고 검증 가능하다.
+
+## Previous Probe Result
+
+Issue #75는 generated 후보를 더 만들기 전에 reference pitch-role 기준을 세우려는 단계였다.
 
 Implemented:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,6 +86,8 @@
   - data-derived motif rhythm과 guide-tone/cadence pitch vocabulary를 결합한 hybrid 후보를 추가한 결과.
 - `STAGE_B_REFERENCE_PITCH_ROLE_STATS_2026-05-22.md`
   - reference phrase window에서 pitch-role landing 통계를 시도했고 chord annotation coverage가 없다는 blocker를 확인한 결과.
+- `STAGE_B_CHORD_COVERAGE_AUDIT_2026-05-22.md`
+  - role metadata, raw sidecar, MIDI text event를 훑어 현재 dataset에 usable chord progression annotation이 없음을 확인한 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -112,7 +114,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, and review context/grid export를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, and chord coverage audit를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_CHORD_COVERAGE_AUDIT_2026-05-22.md
+++ b/docs/STAGE_B_CHORD_COVERAGE_AUDIT_2026-05-22.md
@@ -76,14 +76,16 @@ outputs/chord_coverage_audit/harness_chord_coverage_audit/chord_coverage_audit.m
 |---|---:|---:|---:|
 | role meta | 2812 | 0 | 0.000 |
 | sidecars | 0 | 0 | 0.000 |
-| MIDI text events | 120 | 0 | 0.000 |
+| MIDI files scanned for text events | 120 | 0 | 0.000 |
 
 추가 정보:
 
 - role meta unique source MIDI count: `28`
 - role meta chord fields: `0`
 - sidecar files found: `0`
+- MIDI files scanned for text events: `120`
 - MIDI files with any text event: `0`
+- MIDI chord-text candidate files: `0`
 - usable chord annotation candidate: `false`
 
 ## 판단

--- a/docs/STAGE_B_CHORD_COVERAGE_AUDIT_2026-05-22.md
+++ b/docs/STAGE_B_CHORD_COVERAGE_AUDIT_2026-05-22.md
@@ -1,0 +1,139 @@
+# Stage B Chord Progression Coverage Audit
+
+작성일: 2026-05-22
+
+## 배경
+
+Issue #75에서 reference pitch-role landing stats를 만들려고 했지만, known chord note ratio가 `0.000`이었다.
+
+이 문제는 generator 문제가 아니다.
+
+실제 reference tokenized records에 chord progression annotation이 없으면 다음을 판단할 수 없다.
+
+- 어떤 음이 chord tone인지
+- 어떤 음이 guide tone인지
+- 어떤 음이 tension인지
+- 어떤 음이 approach/outside인지
+
+따라서 이번 단계는 현재 로컬 데이터 안에 chord progression annotation이 실제로 있는지 audit하는 것이다.
+
+## 구현
+
+새 스크립트:
+
+```bash
+python scripts/audit_chord_progression_coverage.py
+```
+
+새 harness:
+
+```bash
+bash scripts/agent_harness.sh chord-coverage-audit
+```
+
+Audit 대상:
+
+- role dataset `meta.json`
+- raw dataset sidecar files:
+  - `.json`
+  - `.csv`
+  - `.tsv`
+  - `.txt`
+  - `.lab`
+  - `.jams`
+  - `.xml`
+  - `.musicxml`
+  - `.mxl`
+- MIDI lyric/text events
+
+탐지 기준:
+
+- `chord_progression`
+- `chords`
+- `harmony`
+- `changes`
+- `lead_sheet`
+- chord-like symbols such as `Cm7`, `F7`, `Bbmaj7`
+
+## 결과
+
+실행:
+
+```bash
+bash scripts/agent_harness.sh chord-coverage-audit
+```
+
+출력:
+
+```text
+outputs/chord_coverage_audit/harness_chord_coverage_audit/chord_coverage_audit.json
+outputs/chord_coverage_audit/harness_chord_coverage_audit/chord_coverage_audit.md
+```
+
+요약:
+
+| source | scanned | hits | ratio |
+|---|---:|---:|---:|
+| role meta | 2812 | 0 | 0.000 |
+| sidecars | 0 | 0 | 0.000 |
+| MIDI text events | 120 | 0 | 0.000 |
+
+추가 정보:
+
+- role meta unique source MIDI count: `28`
+- role meta chord fields: `0`
+- sidecar files found: `0`
+- MIDI files with any text event: `0`
+- usable chord annotation candidate: `false`
+
+## 판단
+
+현재 로컬 데이터셋에는 바로 사용할 수 있는 chord progression annotation이 없다.
+
+따라서 다음 중 하나가 필요하다.
+
+1. chord inference pipeline
+2. lead-sheet / changes source alignment
+3. 외부 chord-annotated jazz dataset 확보
+4. 수동으로 작은 chord-labeled evaluation subset 작성
+
+지금 generator를 더 조정하면 안 된다.
+
+이유:
+
+- generated 후보의 chord-tone/tension/approach 비율을 reference와 비교할 수 없다.
+- reference 없는 상태에서 pitch grammar를 조정하면 "재즈스러움"이 아니라 임의의 hand-written rule을 최적화하게 된다.
+
+## 다음 작업
+
+다음 이슈는 다음 중 하나로 잡는다.
+
+우선순위 1:
+
+```text
+작은 chord-labeled evaluation subset 만들기
+```
+
+이유:
+
+- full automatic chord inference보다 작고 검증 가능하다.
+- 3-5개 phrase만 chord-labeled로 만들어도 generated candidate의 pitch-role sanity check를 시작할 수 있다.
+
+우선순위 2:
+
+```text
+chord inference / lead-sheet alignment 조사
+```
+
+이유:
+
+- 전체 dataset에 chord labels가 없으므로 long-term에는 필요하다.
+- 하지만 MVP 한 달 계획에서는 작게 잘라야 한다.
+
+## Validation
+
+```bash
+./.venv/bin/python -m unittest tests.test_chord_progression_coverage_audit
+bash scripts/agent_harness.sh chord-coverage-audit
+bash scripts/agent_harness.sh quick
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -76,6 +76,8 @@ Modes:
                 Export data-motif rhythm plus guide-tone/cadence pitch candidates.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
+  chord-coverage-audit
+                Audit chord annotation coverage in role metadata, sidecars, and MIDI text events.
   all           Run demo and tiny-compare.
 
 Environment:
@@ -123,6 +125,7 @@ run_quick() {
     scripts/audit_jazz_piano_dataset.py \
     scripts/build_jazz_training_manifests.py \
     scripts/run_manifest_prepare_smoke.py \
+    scripts/audit_chord_progression_coverage.py \
     scripts/train_stage_a_full.py \
     scripts/train_stage_a_adapter.py \
     inference/app \
@@ -791,6 +794,16 @@ run_manifest_dry_run() {
     --overwrite
 }
 
+run_chord_coverage_audit() {
+  local run_id="${RUN_ID:-harness_chord_coverage_audit}"
+  print_header "Chord progression coverage audit"
+  "$PYTHON_BIN" scripts/audit_chord_progression_coverage.py \
+    --run_id "$run_id" \
+    --input_dir ./midi_dataset \
+    --role_meta_roots ./data,./outputs \
+    --max_midi_files 120
+}
+
 case "$MODE" in
   status)
     run_status
@@ -881,6 +894,9 @@ case "$MODE" in
     ;;
   manifest-dry-run)
     run_manifest_dry_run
+    ;;
+  chord-coverage-audit)
+    run_chord_coverage_audit
     ;;
   all)
     run_demo

--- a/scripts/audit_chord_progression_coverage.py
+++ b/scripts/audit_chord_progression_coverage.py
@@ -1,0 +1,384 @@
+"""Audit chord-progression annotation coverage before pitch-role reference work."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+import pretty_midi
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+
+CHORD_FIELD_KEYWORDS = (
+    "chord",
+    "chords",
+    "chord_progression",
+    "harmony",
+    "harmonic",
+    "changes",
+    "lead_sheet",
+    "leadsheet",
+)
+
+SIDECAR_SUFFIXES = {
+    ".json",
+    ".csv",
+    ".tsv",
+    ".txt",
+    ".lab",
+    ".jams",
+    ".xml",
+    ".musicxml",
+    ".mxl",
+}
+
+CHORD_SYMBOL_RE = re.compile(
+    r"(?<![A-Za-z0-9#b])"
+    r"([A-G](?:#|b)?(?:maj7|maj9|maj13|maj|min7|min9|min13|min|m7b5|m7|m9|m13|m|"
+    r"dim7|dim|aug|sus4|sus2|sus|add9|6|7|9|11|13|ø|°|Δ)"
+    r"(?:/[A-G](?:#|b)?)?)"
+    r"(?![A-Za-z0-9#b])"
+)
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def count_chord_symbols(text: str) -> int:
+    return len(CHORD_SYMBOL_RE.findall(text))
+
+
+def normalize_key(key: str) -> str:
+    return str(key).strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def is_chord_key(key: str) -> bool:
+    normalized = normalize_key(key)
+    return any(keyword in normalized for keyword in CHORD_FIELD_KEYWORDS)
+
+
+def value_has_chord_like_content(value: Any) -> bool:
+    if isinstance(value, str):
+        return count_chord_symbols(value) > 0
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return any(value_has_chord_like_content(item) for item in value)
+    if isinstance(value, dict):
+        return any(value_has_chord_like_content(item) for item in value.values())
+    return False
+
+
+def find_chord_fields(payload: Any, prefix: str = "") -> list[dict[str, Any]]:
+    matches: list[dict[str, Any]] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            path = f"{prefix}.{key}" if prefix else str(key)
+            if is_chord_key(str(key)) or value_has_chord_like_content(value):
+                matches.append(
+                    {
+                        "path": path,
+                        "key": str(key),
+                        "is_chord_key": bool(is_chord_key(str(key))),
+                        "value_type": type(value).__name__,
+                        "chord_symbol_hits": int(count_chord_symbols(json.dumps(value, ensure_ascii=True))),
+                        "preview": compact_preview(value),
+                    }
+                )
+            matches.extend(find_chord_fields(value, path))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload[:50]):
+            matches.extend(find_chord_fields(value, f"{prefix}[{index}]"))
+    return matches
+
+
+def compact_preview(value: Any, max_len: int = 160) -> str:
+    if isinstance(value, (dict, list)):
+        text = json.dumps(value, ensure_ascii=True)
+    else:
+        text = str(value)
+    text = " ".join(text.split())
+    return text[:max_len]
+
+
+def iter_limited(paths: Iterable[Path], limit: int | None) -> list[Path]:
+    result: list[Path] = []
+    for path in paths:
+        if limit is not None and len(result) >= int(limit):
+            break
+        result.append(path)
+    return result
+
+
+def iter_role_meta_files(roots: Sequence[Path], limit: int | None = None) -> list[Path]:
+    files: list[Path] = []
+    for root in roots:
+        if not root.exists():
+            continue
+        files.extend(sorted(root.rglob("meta.json")))
+    return iter_limited(sorted(set(files)), limit)
+
+
+def audit_role_meta_files(paths: Sequence[Path]) -> dict[str, Any]:
+    rows: list[dict[str, Any]] = []
+    source_midi_counter: Counter[str] = Counter()
+    for path in paths:
+        row: dict[str, Any] = {"path": str(path), "readable": False, "chord_field_count": 0}
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            row["error"] = str(exc)
+            rows.append(row)
+            continue
+        matches = find_chord_fields(payload)
+        source_midi = str(payload.get("source_midi") or "")
+        if source_midi:
+            source_midi_counter[source_midi] += 1
+        row.update(
+            {
+                "readable": True,
+                "source_midi": source_midi or None,
+                "sequence_format": payload.get("sequence_format"),
+                "sample_id": payload.get("sample_id"),
+                "chord_field_count": len(matches),
+                "chord_fields": matches[:8],
+            }
+        )
+        rows.append(row)
+    with_chords = [row for row in rows if int(row.get("chord_field_count", 0) or 0) > 0]
+    return {
+        "scanned_file_count": int(len(rows)),
+        "readable_file_count": int(sum(1 for row in rows if row.get("readable"))),
+        "with_chord_field_count": int(len(with_chords)),
+        "with_chord_field_ratio": float(len(with_chords) / len(rows)) if rows else 0.0,
+        "unique_source_midi_count": int(len(source_midi_counter)),
+        "top_source_midi": dict(source_midi_counter.most_common(20)),
+        "matches_head": with_chords[:20],
+    }
+
+
+def iter_sidecar_files(input_dir: Path, limit: int | None = None) -> list[Path]:
+    if not input_dir.exists():
+        return []
+    files = [
+        path
+        for path in sorted(input_dir.rglob("*"))
+        if path.is_file() and path.suffix.lower() in SIDECAR_SUFFIXES
+    ]
+    return iter_limited(files, limit)
+
+
+def read_text_lossy(path: Path, max_chars: int = 200_000) -> str:
+    data = path.read_bytes()[:max_chars]
+    return data.decode("utf-8", errors="ignore")
+
+
+def audit_sidecar_files(paths: Sequence[Path]) -> dict[str, Any]:
+    rows: list[dict[str, Any]] = []
+    suffix_counts: Counter[str] = Counter()
+    for path in paths:
+        suffix_counts[path.suffix.lower()] += 1
+        row: dict[str, Any] = {"path": str(path), "suffix": path.suffix.lower(), "readable": False}
+        try:
+            text = read_text_lossy(path)
+        except Exception as exc:
+            row["error"] = str(exc)
+            rows.append(row)
+            continue
+        chord_hits = count_chord_symbols(text)
+        keyword_hits = sum(text.lower().count(keyword) for keyword in CHORD_FIELD_KEYWORDS)
+        row.update(
+            {
+                "readable": True,
+                "size_bytes": int(path.stat().st_size),
+                "chord_symbol_hits": int(chord_hits),
+                "chord_keyword_hits": int(keyword_hits),
+                "candidate": bool(chord_hits >= 4 or keyword_hits > 0),
+                "preview": compact_preview(text[:240]),
+            }
+        )
+        rows.append(row)
+    candidates = [row for row in rows if row.get("candidate")]
+    return {
+        "scanned_file_count": int(len(rows)),
+        "readable_file_count": int(sum(1 for row in rows if row.get("readable"))),
+        "candidate_file_count": int(len(candidates)),
+        "candidate_file_ratio": float(len(candidates) / len(rows)) if rows else 0.0,
+        "suffix_counts": {str(key): int(value) for key, value in suffix_counts.most_common()},
+        "matches_head": candidates[:30],
+    }
+
+
+def iter_midi_files(input_dir: Path, limit: int | None = None) -> list[Path]:
+    if not input_dir.exists():
+        return []
+    files = sorted([*input_dir.rglob("*.mid"), *input_dir.rglob("*.midi")])
+    return iter_limited(files, limit)
+
+
+def midi_text_events(path: Path) -> list[str]:
+    midi = pretty_midi.PrettyMIDI(str(path))
+    texts: list[str] = []
+    texts.extend(str(lyric.text) for lyric in getattr(midi, "lyrics", []))
+    texts.extend(str(text.text) for text in getattr(midi, "text_events", []))
+    return [text for text in texts if text.strip()]
+
+
+def audit_midi_text_events(paths: Sequence[Path]) -> dict[str, Any]:
+    rows: list[dict[str, Any]] = []
+    for path in paths:
+        row: dict[str, Any] = {"path": str(path), "readable": False}
+        try:
+            texts = midi_text_events(path)
+        except Exception as exc:
+            row["error"] = str(exc)
+            rows.append(row)
+            continue
+        joined = " ".join(texts)
+        chord_hits = count_chord_symbols(joined)
+        row.update(
+            {
+                "readable": True,
+                "text_event_count": int(len(texts)),
+                "chord_symbol_hits": int(chord_hits),
+                "candidate": bool(chord_hits >= 4),
+                "texts_head": texts[:12],
+            }
+        )
+        rows.append(row)
+    with_text = [row for row in rows if int(row.get("text_event_count", 0) or 0) > 0]
+    candidates = [row for row in rows if row.get("candidate")]
+    return {
+        "scanned_file_count": int(len(rows)),
+        "readable_file_count": int(sum(1 for row in rows if row.get("readable"))),
+        "with_text_event_count": int(len(with_text)),
+        "with_text_event_ratio": float(len(with_text) / len(rows)) if rows else 0.0,
+        "candidate_file_count": int(len(candidates)),
+        "candidate_file_ratio": float(len(candidates) / len(rows)) if rows else 0.0,
+        "matches_head": candidates[:30],
+        "text_events_head": with_text[:20],
+    }
+
+
+def build_decision(summary: dict[str, Any]) -> dict[str, Any]:
+    role_meta_hits = int(summary["role_meta"]["with_chord_field_count"])
+    sidecar_hits = int(summary["sidecars"]["candidate_file_count"])
+    midi_text_hits = int(summary["midi_text_events"]["candidate_file_count"])
+    has_usable_annotation = role_meta_hits > 0 or sidecar_hits > 0 or midi_text_hits > 0
+    if role_meta_hits > 0:
+        next_step = "build_chord_annotated_role_subset_from_meta"
+    elif sidecar_hits > 0 or midi_text_hits > 0:
+        next_step = "inspect_chord_sidecars_or_midi_text_events"
+    else:
+        next_step = "create_chord_inference_or_lead_sheet_alignment_issue"
+    return {
+        "has_usable_chord_annotation_candidate": bool(has_usable_annotation),
+        "role_meta_chord_hits": int(role_meta_hits),
+        "sidecar_chord_candidate_hits": int(sidecar_hits),
+        "midi_text_chord_candidate_hits": int(midi_text_hits),
+        "next_step": next_step,
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    decision = report["decision"]
+    lines = [
+        "# Chord Progression Coverage Audit",
+        "",
+        f"- input dir: `{report['input_dir']}`",
+        f"- role meta roots: `{', '.join(report['role_meta_roots'])}`",
+        f"- usable chord annotation candidate: `{str(decision['has_usable_chord_annotation_candidate']).lower()}`",
+        f"- next step: `{decision['next_step']}`",
+        "",
+        "## Summary",
+        "",
+        "| source | scanned | hits | ratio |",
+        "|---|---:|---:|---:|",
+        "| role meta | {scanned_file_count} | {with_chord_field_count} | {with_chord_field_ratio:.3f} |".format(
+            **report["role_meta"]
+        ),
+        "| sidecars | {scanned_file_count} | {candidate_file_count} | {candidate_file_ratio:.3f} |".format(
+            **report["sidecars"]
+        ),
+        "| MIDI text events | {scanned_file_count} | {candidate_file_count} | {candidate_file_ratio:.3f} |".format(
+            **report["midi_text_events"]
+        ),
+        "",
+        "## Role Meta",
+        "",
+        f"- unique source MIDI count: `{report['role_meta']['unique_source_midi_count']}`",
+        f"- with chord fields: `{report['role_meta']['with_chord_field_count']}`",
+        "",
+        "## Sidecars",
+        "",
+        f"- suffix counts: `{report['sidecars']['suffix_counts']}`",
+        f"- chord candidates: `{report['sidecars']['candidate_file_count']}`",
+        "",
+        "## MIDI Text Events",
+        "",
+        f"- files with any text event: `{report['midi_text_events']['with_text_event_count']}`",
+        f"- chord candidates: `{report['midi_text_events']['candidate_file_count']}`",
+        "",
+        "## Decision",
+        "",
+        f"`{decision['next_step']}`",
+    ]
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def parse_csv_paths(raw: str) -> list[Path]:
+    return [Path(item.strip()) for item in raw.split(",") if item.strip()]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Audit chord progression annotation coverage")
+    parser.add_argument("--input_dir", type=str, default="./midi_dataset")
+    parser.add_argument("--role_meta_roots", type=str, default="./data,./outputs")
+    parser.add_argument("--output_root", type=str, default=str(ROOT_DIR / "outputs" / "chord_coverage_audit"))
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--max_role_meta_files", type=int, default=None)
+    parser.add_argument("--max_sidecar_files", type=int, default=None)
+    parser.add_argument("--max_midi_files", type=int, default=200)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now().strftime("%Y%m%d_%H%M%S")
+    run_dir = Path(args.output_root) / run_id
+    input_dir = Path(args.input_dir)
+    role_meta_roots = parse_csv_paths(args.role_meta_roots)
+
+    role_meta = audit_role_meta_files(iter_role_meta_files(role_meta_roots, args.max_role_meta_files))
+    sidecars = audit_sidecar_files(iter_sidecar_files(input_dir, args.max_sidecar_files))
+    midi_text_events = audit_midi_text_events(iter_midi_files(input_dir, args.max_midi_files))
+    report = {
+        "run_id": run_id,
+        "run_dir": str(run_dir),
+        "input_dir": str(input_dir),
+        "role_meta_roots": [str(path) for path in role_meta_roots],
+        "max_role_meta_files": args.max_role_meta_files,
+        "max_sidecar_files": args.max_sidecar_files,
+        "max_midi_files": args.max_midi_files,
+        "role_meta": role_meta,
+        "sidecars": sidecars,
+        "midi_text_events": midi_text_events,
+    }
+    report["decision"] = build_decision(report)
+    write_json(run_dir / "chord_coverage_audit.json", report)
+    (run_dir / "chord_coverage_audit.md").write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps(report["decision"], ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_chord_progression_coverage.py
+++ b/scripts/audit_chord_progression_coverage.py
@@ -7,6 +7,7 @@ import csv
 import json
 import re
 import sys
+import zipfile
 from collections import Counter
 from datetime import datetime
 from pathlib import Path
@@ -177,7 +178,24 @@ def iter_sidecar_files(input_dir: Path, limit: int | None = None) -> list[Path]:
     return iter_limited(files, limit)
 
 
+def read_mxl_text(path: Path, max_chars: int = 200_000) -> str:
+    with zipfile.ZipFile(path) as archive:
+        names = [
+            name
+            for name in archive.namelist()
+            if name.lower().endswith((".xml", ".musicxml")) and "meta-inf/" not in name.lower()
+        ]
+        if not names:
+            names = [name for name in archive.namelist() if name.lower().endswith((".xml", ".musicxml"))]
+        if not names:
+            return ""
+        data = archive.read(sorted(names)[0])[:max_chars]
+    return data.decode("utf-8", errors="ignore")
+
+
 def read_text_lossy(path: Path, max_chars: int = 200_000) -> str:
+    if path.suffix.lower() == ".mxl":
+        return read_mxl_text(path, max_chars=max_chars)
     data = path.read_bytes()[:max_chars]
     return data.decode("utf-8", errors="ignore")
 
@@ -260,6 +278,7 @@ def audit_midi_text_events(paths: Sequence[Path]) -> dict[str, Any]:
     return {
         "scanned_file_count": int(len(rows)),
         "readable_file_count": int(sum(1 for row in rows if row.get("readable"))),
+        "total_text_event_count": int(sum(int(row.get("text_event_count", 0) or 0) for row in rows)),
         "with_text_event_count": int(len(with_text)),
         "with_text_event_ratio": float(len(with_text) / len(rows)) if rows else 0.0,
         "candidate_file_count": int(len(candidates)),
@@ -309,7 +328,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         "| sidecars | {scanned_file_count} | {candidate_file_count} | {candidate_file_ratio:.3f} |".format(
             **report["sidecars"]
         ),
-        "| MIDI text events | {scanned_file_count} | {candidate_file_count} | {candidate_file_ratio:.3f} |".format(
+        "| MIDI files scanned for text events | {scanned_file_count} | {candidate_file_count} | {candidate_file_ratio:.3f} |".format(
             **report["midi_text_events"]
         ),
         "",
@@ -325,6 +344,8 @@ def markdown_report(report: dict[str, Any]) -> str:
         "",
         "## MIDI Text Events",
         "",
+        f"- scanned MIDI files: `{report['midi_text_events']['scanned_file_count']}`",
+        f"- total text event occurrences: `{report['midi_text_events']['total_text_event_count']}`",
         f"- files with any text event: `{report['midi_text_events']['with_text_event_count']}`",
         f"- chord candidates: `{report['midi_text_events']['candidate_file_count']}`",
         "",

--- a/tests/test_chord_progression_coverage_audit.py
+++ b/tests/test_chord_progression_coverage_audit.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import unittest
+import zipfile
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -49,6 +50,17 @@ class ChordProgressionCoverageAuditTest(unittest.TestCase):
         with TemporaryDirectory() as tmp:
             sidecar = Path(tmp) / "changes.txt"
             sidecar.write_text("Cm7 F7 Bbmaj7 Ebmaj7\n", encoding="utf-8")
+
+            report = audit_sidecar_files([sidecar])
+
+            self.assertEqual(report["candidate_file_count"], 1)
+
+    def test_audit_sidecar_files_reads_mxl_container(self) -> None:
+        with TemporaryDirectory() as tmp:
+            sidecar = Path(tmp) / "changes.mxl"
+            with zipfile.ZipFile(sidecar, mode="w") as archive:
+                archive.writestr("META-INF/container.xml", "<container />")
+                archive.writestr("score.musicxml", "<credit-words>Cm7 F7 Bbmaj7 Ebmaj7</credit-words>")
 
             report = audit_sidecar_files([sidecar])
 

--- a/tests/test_chord_progression_coverage_audit.py
+++ b/tests/test_chord_progression_coverage_audit.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pretty_midi
+
+from scripts.audit_chord_progression_coverage import (
+    audit_midi_text_events,
+    audit_role_meta_files,
+    audit_sidecar_files,
+    build_decision,
+    count_chord_symbols,
+    find_chord_fields,
+)
+
+
+class ChordProgressionCoverageAuditTest(unittest.TestCase):
+    def test_count_chord_symbols_detects_quality_suffixes(self) -> None:
+        self.assertGreaterEqual(count_chord_symbols("Cm7 F7 Bbmaj7 Ebmaj7"), 4)
+        self.assertEqual(count_chord_symbols("This sentence has capital letters but no changes"), 0)
+
+    def test_find_chord_fields_detects_explicit_chord_progression(self) -> None:
+        matches = find_chord_fields({"meta": {"chord_progression": ["Cm7", "F7"]}})
+
+        self.assertTrue(any(match["key"] == "chord_progression" for match in matches))
+
+    def test_audit_role_meta_files_counts_chord_fields(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with_chords = root / "with" / "meta.json"
+            without_chords = root / "without" / "meta.json"
+            with_chords.parent.mkdir(parents=True)
+            without_chords.parent.mkdir(parents=True)
+            with_chords.write_text(
+                json.dumps({"sample_id": "1", "source_midi": "a.mid", "chord_progression": ["Cm7", "F7"]}),
+                encoding="utf-8",
+            )
+            without_chords.write_text(json.dumps({"sample_id": "2", "source_midi": "b.mid"}), encoding="utf-8")
+
+            report = audit_role_meta_files([with_chords, without_chords])
+
+            self.assertEqual(report["scanned_file_count"], 2)
+            self.assertEqual(report["with_chord_field_count"], 1)
+
+    def test_audit_sidecar_files_marks_chord_like_text_candidate(self) -> None:
+        with TemporaryDirectory() as tmp:
+            sidecar = Path(tmp) / "changes.txt"
+            sidecar.write_text("Cm7 F7 Bbmaj7 Ebmaj7\n", encoding="utf-8")
+
+            report = audit_sidecar_files([sidecar])
+
+            self.assertEqual(report["candidate_file_count"], 1)
+
+    def test_audit_midi_text_events_marks_chord_like_lyric_candidate(self) -> None:
+        with TemporaryDirectory() as tmp:
+            midi_path = Path(tmp) / "text_chords.mid"
+            midi = pretty_midi.PrettyMIDI(initial_tempo=120)
+            instrument = pretty_midi.Instrument(program=0)
+            instrument.notes.append(pretty_midi.Note(velocity=80, pitch=60, start=0.0, end=0.5))
+            midi.instruments.append(instrument)
+            for index, text in enumerate(["Cm7", "F7", "Bbmaj7", "Ebmaj7"]):
+                midi.lyrics.append(pretty_midi.Lyric(text=text, time=float(index)))
+            midi.write(str(midi_path))
+
+            report = audit_midi_text_events([midi_path])
+
+            self.assertEqual(report["candidate_file_count"], 1)
+            self.assertEqual(report["with_text_event_count"], 1)
+
+    def test_build_decision_routes_to_chord_inference_when_no_hits(self) -> None:
+        decision = build_decision(
+            {
+                "role_meta": {"with_chord_field_count": 0},
+                "sidecars": {"candidate_file_count": 0},
+                "midi_text_events": {"candidate_file_count": 0},
+            }
+        )
+
+        self.assertEqual(decision["next_step"], "create_chord_inference_or_lead_sheet_alignment_issue")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

- role metadata, raw sidecar, MIDI text event에서 chord progression annotation 후보를 찾는 audit script를 추가했습니다.
- chord coverage audit harness를 추가했고, AGENTS 규칙에도 해당 harness를 연결했습니다.
- Issue #77 결과를 CURRENT_STATUS, CORE_PLAN, docs index에 기록했습니다.

## 결과

- role metadata: 2812개 scan, chord hit 0개
- raw sidecar: 0개 발견
- MIDI text event: 120개 scan, chord hit 0개
- 결론: 현재 local dataset에는 바로 쓸 수 있는 chord progression annotation이 없습니다.
- 다음 판단: generator tuning이 아니라 작은 chord-labeled evaluation subset 또는 chord inference/lead-sheet alignment로 넘어가야 합니다.

## 검증

- ./.venv/bin/python -m unittest tests.test_chord_progression_coverage_audit
- bash scripts/agent_harness.sh chord-coverage-audit
- bash scripts/agent_harness.sh quick

Closes #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chord progression coverage audit to identify annotation gaps in the dataset
  * New `chord-coverage-audit` mode available in the agent harness

* **Documentation**
  * Updated project status and core plan documentation to reflect focus shift toward chord coverage audit
  * Added audit results showing zero usable chord annotations in current dataset and documented next steps

* **Tests**
  * Added comprehensive test coverage for chord progression audit functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohhalim/fine_tuning_art-tatum_midi_solo/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->