### PR TITLE
Stage B chord-labeled eval contract 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #77: Stage B chord progression coverage audit.
+- Issue #79: Stage B chord-labeled evaluation subset contract.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -188,6 +188,12 @@ For chord progression annotation coverage audit changes, run:
 
 ```bash
 bash scripts/agent_harness.sh chord-coverage-audit
+```
+
+For Stage B chord-labeled evaluation subset changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-chord-labeled-eval
 ```
 
 For Stage B data-derived motif template extraction changes, run:

--- a/data/eval/stage_b_chord_labeled_tiny/manifest.json
+++ b/data/eval/stage_b_chord_labeled_tiny/manifest.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": "stage_b_chord_labeled_eval_v1",
+  "description": "Tiny inline-note fixture for validating the chord-labeled evaluation contract. This is not a real Brad/reference label set.",
+  "samples": [
+    {
+      "sample_id": "tiny_ii_v_i_inline_01",
+      "source_type": "inline_notes",
+      "bar_count": 4,
+      "beats_per_bar": 4,
+      "positions_per_bar": 16,
+      "chords": ["Dm7", "G7", "Cmaj7", "Cmaj7"],
+      "notes": [
+        {"bar": 0, "position": 0, "pitch": 62},
+        {"bar": 0, "position": 3, "pitch": 65},
+        {"bar": 0, "position": 6, "pitch": 69},
+        {"bar": 0, "position": 10, "pitch": 72},
+        {"bar": 1, "position": 0, "pitch": 71},
+        {"bar": 1, "position": 4, "pitch": 67},
+        {"bar": 1, "position": 7, "pitch": 69},
+        {"bar": 1, "position": 12, "pitch": 65},
+        {"bar": 2, "position": 0, "pitch": 72},
+        {"bar": 2, "position": 4, "pitch": 76},
+        {"bar": 2, "position": 8, "pitch": 79},
+        {"bar": 2, "position": 13, "pitch": 74},
+        {"bar": 3, "position": 0, "pitch": 71},
+        {"bar": 3, "position": 5, "pitch": 69},
+        {"bar": 3, "position": 9, "pitch": 67},
+        {"bar": 3, "position": 14, "pitch": 72}
+      ]
+    },
+    {
+      "sample_id": "tiny_minor_turnaround_inline_01",
+      "source_type": "inline_notes",
+      "bar_count": 4,
+      "beats_per_bar": 4,
+      "positions_per_bar": 16,
+      "chords": ["Cm7", "F7", "Bbmaj7", "G7"],
+      "notes": [
+        {"bar": 0, "position": 0, "pitch": 63},
+        {"bar": 0, "position": 2, "pitch": 67},
+        {"bar": 0, "position": 6, "pitch": 70},
+        {"bar": 0, "position": 11, "pitch": 72},
+        {"bar": 1, "position": 0, "pitch": 69},
+        {"bar": 1, "position": 4, "pitch": 75},
+        {"bar": 1, "position": 9, "pitch": 72},
+        {"bar": 1, "position": 13, "pitch": 70},
+        {"bar": 2, "position": 0, "pitch": 70},
+        {"bar": 2, "position": 3, "pitch": 74},
+        {"bar": 2, "position": 8, "pitch": 77},
+        {"bar": 2, "position": 12, "pitch": 81},
+        {"bar": 3, "position": 0, "pitch": 71},
+        {"bar": 3, "position": 5, "pitch": 74},
+        {"bar": 3, "position": 10, "pitch": 77},
+        {"bar": 3, "position": 15, "pitch": 72}
+      ]
+    }
+  ]
+}

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -141,6 +141,7 @@ Stage B에서 명시하는 것:
 35. Stage B data-motif rhythm plus guide-tone/cadence pitch hybrid
 36. Stage B reference pitch-role landing statistics and chord-coverage gate
 37. Stage B chord progression coverage audit
+38. Stage B chord-labeled evaluation subset contract
 
 가장 최근 의미 있는 결과:
 
@@ -158,6 +159,7 @@ Stage B에서 명시하는 것:
 - Issue #53 shows the perceived "root-heavy" line is not pure root collapse: average root tone ratio is around `0.271`, top candidate root ratio is around `0.219`, but tension ratio is `0.000`.
 - Issue #75 shows reference pitch-role stats cannot be trusted yet because known chord note ratio is `0.000`.
 - Issue #77 audits the local dataset for chord progression annotations and finds no usable candidate: role meta `2812` scanned with `0` hits, sidecars `0`, MIDI files scanned for text events `120` with `0` chord-text candidates.
+- Issue #79 adds a tiny chord-labeled eval contract so known chord labels can produce pitch-role sanity summaries without pretending real Brad/reference labels already exist.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -362,6 +364,8 @@ Stage B에서 명시하는 것:
 - Issue #75 result: 현재 비교 가능한 것은 rhythm reference뿐이며, pitch vocabulary 조정 전에 chord annotation coverage audit이 필요하다.
 - Issue #77 result: role metadata `2812`개, raw sidecar `0`개, text event를 검사한 MIDI file `120`개를 scan했지만 chord progression hit는 `0`이다.
 - Issue #77 result: 현재 local dataset에는 바로 쓸 수 있는 chord progression annotation이 없으므로 reference pitch-role comparison은 아직 불가능하다.
+- Issue #79 result: `inline_notes` tiny fixture `2` samples, `32` notes로 chord-labeled eval contract를 검증했다.
+- Issue #79 result: fixture chord-tone ratio는 `0.844`, tension ratio는 `0.156`, outside ratio는 `0.000`이다.
 
 해석:
 
@@ -371,7 +375,7 @@ Stage B에서 명시하는 것:
 - `approach_tensions`는 pitch-level resolution을 만들지만, 이 또한 jazz vocabulary 자체는 아니다.
 - `swing_motif_approach`는 기계적인 grid 반복을 줄였지만, 이 또한 jazz vocabulary 자체는 아니다.
 - real phrase reference stats와 motif extraction 기준으로 보면 다음은 hand-written rhythm rule 확장이 아니라 data-derived motif/cadence control 쪽이 맞다.
-- 다만 pitch-role 쪽은 reference chord label이 없으므로, 다음 pitch grammar 개선은 작은 chord-labeled evaluation subset 또는 chord inference/lead-sheet alignment가 먼저다.
+- 다만 pitch-role 쪽은 real reference chord label이 아직 없으므로, 다음 pitch grammar 개선은 실제 3-5개 phrase의 수동 chord labels 또는 generated metadata bridge가 먼저다.
 
 ### Phase 3.10. Swing/Motif Phrase Grammar
 
@@ -641,22 +645,22 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B chord progression coverage audit 추가
+Stage B chord-labeled evaluation subset contract 추가
 ```
 
 결과:
 
-- role metadata `2812`개를 scan했지만 chord progression hit는 `0`이다.
-- raw sidecar file은 발견되지 않았다.
-- MIDI lyric/text event를 검사한 MIDI file `120`개를 scan했지만 chord-text candidate는 `0`이다.
-- 현재 local dataset에는 바로 쓸 수 있는 chord progression annotation이 없다.
-- 따라서 reference pitch-role comparison은 아직 불가능하다.
+- chord-labeled eval manifest schema를 만들었다.
+- 기본 fixture는 `data/eval/stage_b_chord_labeled_tiny/manifest.json`이다.
+- fixture는 `inline_notes` 기반이며 실제 Brad/reference label이라고 주장하지 않는다.
+- harness result: sample count `2`, note count `32`, chord-tone ratio `0.844`, tension ratio `0.156`, outside ratio `0.000`.
+- `midi_path` sample도 지원하지만 raw MIDI는 커밋하지 않는다.
 
 다음 작업:
 
-- 작은 chord-labeled evaluation subset을 만든다.
-- 우선 3-5개 phrase에 bar-level chord labels를 수동으로 붙여 generated candidate의 pitch-role sanity check를 시작한다.
-- full chord inference/lead-sheet alignment는 그 다음 별도 이슈로 분리한다.
+- 코드가 확실한 3-5개 실제 review phrase를 manifest에 추가한다.
+- 또는 generated candidate report의 known chord progression metadata를 chord-labeled evaluator와 연결한다.
+- 불확실한 Brad/reference chord는 넣지 않는다.
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-77-stage-b-chord-coverage-audit`
+- `issue-79-stage-b-chord-labeled-eval-subset`
 
 현재 범위가 아닌 것:
 
@@ -35,6 +35,45 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
 ## Latest Probe Result
+
+Issue #79는 Issue #77의 결론을 받아, 작은 chord-labeled evaluation subset contract를 만든 단계다.
+
+중요한 전제:
+
+- 실제 Brad/reference 곡에 코드를 임의로 붙이지 않는다.
+- 현재 committed fixture는 `inline_notes` 기반 tiny contract test다.
+- 실제 phrase는 chord label이 확실하거나 수동 검증된 경우에만 manifest에 추가한다.
+
+Implemented:
+
+- chord-labeled eval manifest schema
+- tiny inline-note fixture:
+  - `data/eval/stage_b_chord_labeled_tiny/manifest.json`
+- manifest validator
+- bar-level chord label 기반 pitch-role summary
+- MIDI path sample support without committing raw MIDI
+- `scripts/evaluate_chord_labeled_subset.py`
+- `scripts/agent_harness.sh stage-b-chord-labeled-eval`
+- docs:
+  - `docs/STAGE_B_CHORD_LABELED_EVAL_2026-05-22.md`
+
+Result:
+
+- fixture sample count: `2`
+- fixture note count: `32`
+- chord-tone ratio: `0.844`
+- tension ratio: `0.156`
+- approach ratio: `0.000`
+- outside ratio: `0.000`
+- report: `outputs/stage_b_chord_labeled_eval/harness_stage_b_chord_labeled_eval/chord_labeled_eval_report.md`
+
+Decision:
+
+- pitch-role evaluator는 known chord labels를 받으면 정상 동작한다.
+- 아직 real reference phrase가 라벨링된 것은 아니다.
+- 다음 작업은 코드가 확실한 3-5개 phrase를 manifest에 추가하거나, generated candidate metadata를 이 evaluator와 연결하는 것이다.
+
+## Previous Probe Result
 
 Issue #77은 Issue #75에서 드러난 chord annotation blocker를 실제 dataset 기준으로 확인한 단계다.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -88,6 +88,8 @@
   - reference phrase window에서 pitch-role landing 통계를 시도했고 chord annotation coverage가 없다는 blocker를 확인한 결과.
 - `STAGE_B_CHORD_COVERAGE_AUDIT_2026-05-22.md`
   - role metadata, raw sidecar, MIDI text event를 훑어 현재 dataset에 usable chord progression annotation이 없음을 확인한 결과.
+- `STAGE_B_CHORD_LABELED_EVAL_2026-05-22.md`
+  - known chord labels가 있을 때 pitch-role summary를 계산할 수 있는 tiny evaluation contract와 manifest format.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -114,7 +116,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, and chord coverage audit를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, and chord-labeled eval contract를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_CHORD_LABELED_EVAL_2026-05-22.md
+++ b/docs/STAGE_B_CHORD_LABELED_EVAL_2026-05-22.md
@@ -1,0 +1,132 @@
+# Stage B Chord-Labeled Evaluation Subset Contract
+
+작성일: 2026-05-22
+
+## 배경
+
+Issue #77에서 현재 local dataset에는 바로 사용할 수 있는 chord progression annotation이 없다는 점을 확인했다.
+
+따라서 이번 단계의 목적은 실제 Brad/reference 곡에 코드를 추측해서 붙이는 것이 아니다.
+
+이번 단계는 다음을 먼저 만든다.
+
+- chord-labeled evaluation manifest schema
+- manifest validator
+- inline-note tiny fixture
+- bar-level chord label 기반 pitch-role summary
+- 다음 수동 라벨링이 들어갈 파일 포맷
+
+## 구현
+
+새 스크립트:
+
+```bash
+python scripts/evaluate_chord_labeled_subset.py
+```
+
+기본 manifest:
+
+```text
+data/eval/stage_b_chord_labeled_tiny/manifest.json
+```
+
+새 harness:
+
+```bash
+bash scripts/agent_harness.sh stage-b-chord-labeled-eval
+```
+
+Manifest schema:
+
+- `schema_version`: `stage_b_chord_labeled_eval_v1`
+- `samples[].sample_id`
+- `samples[].bar_count`
+- `samples[].chords`
+- exactly one of:
+  - `samples[].midi_path`
+  - `samples[].notes`
+
+중요한 제약:
+
+- `chords.length == bar_count`
+- unsupported chord symbol은 실패 처리한다.
+- 실제 MIDI는 `midi_path`로 넣을 수 있지만, repo에는 raw MIDI를 커밋하지 않는다.
+- 현재 committed fixture는 `inline_notes`만 사용한다.
+
+## 결과
+
+실행:
+
+```bash
+bash scripts/agent_harness.sh stage-b-chord-labeled-eval
+```
+
+출력:
+
+```text
+outputs/stage_b_chord_labeled_eval/harness_stage_b_chord_labeled_eval/chord_labeled_eval_report.json
+outputs/stage_b_chord_labeled_eval/harness_stage_b_chord_labeled_eval/chord_labeled_eval_report.md
+```
+
+요약:
+
+| metric | value |
+|---|---:|
+| sample count | 2 |
+| note count | 32 |
+| chord-tone ratio | 0.844 |
+| tension ratio | 0.156 |
+| approach ratio | 0.000 |
+| outside ratio | 0.000 |
+
+Sample summary:
+
+| sample | bars | notes | chord-tone | tension | outside |
+|---|---:|---:|---:|---:|---:|
+| `tiny_ii_v_i_inline_01` | 4 | 16 | 0.812 | 0.188 | 0.000 |
+| `tiny_minor_turnaround_inline_01` | 4 | 16 | 0.875 | 0.125 | 0.000 |
+
+## 판단
+
+이 결과는 real jazz reference가 라벨링됐다는 뜻이 아니다.
+
+의미는 다음이다.
+
+- pitch-role evaluator가 known chord labels를 받으면 정상 동작한다.
+- 앞으로 사람이 3-5개 phrase에 chord labels를 붙이면 같은 contract로 sanity check를 돌릴 수 있다.
+- generated MIDI의 chord-tone/tension/outside 비율을 평가할 최소한의 기준 파일 포맷이 생겼다.
+
+## 다음 작업
+
+다음 단계는 두 갈래 중 하나다.
+
+우선순위 1:
+
+```text
+3-5개 실제 review phrase에 수동 chord labels를 붙인다.
+```
+
+조건:
+
+- 코드가 확실한 phrase만 넣는다.
+- 불확실하면 manifest에 넣지 않는다.
+- raw MIDI 파일은 커밋하지 않는다.
+
+우선순위 2:
+
+```text
+generated candidate report를 chord-labeled eval manifest와 비교하는 bridge를 만든다.
+```
+
+조건:
+
+- generated candidate가 어떤 chord progression 위에서 만들어졌는지 metadata가 있어야 한다.
+- solo-only MIDI만으로 in/out 판단하지 않는다.
+
+## Validation
+
+```bash
+./.venv/bin/python -m unittest tests.test_chord_labeled_subset_eval
+bash scripts/agent_harness.sh stage-b-chord-labeled-eval
+bash scripts/agent_harness.sh quick
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -78,6 +78,8 @@ Modes:
                 Run audit -> manifest -> prepare_role_dataset smoke.
   chord-coverage-audit
                 Audit chord annotation coverage in role metadata, sidecars, and MIDI text events.
+  stage-b-chord-labeled-eval
+                Evaluate the tiny chord-labeled subset manifest and pitch-role summary contract.
   all           Run demo and tiny-compare.
 
 Environment:
@@ -126,6 +128,7 @@ run_quick() {
     scripts/build_jazz_training_manifests.py \
     scripts/run_manifest_prepare_smoke.py \
     scripts/audit_chord_progression_coverage.py \
+    scripts/evaluate_chord_labeled_subset.py \
     scripts/train_stage_a_full.py \
     scripts/train_stage_a_adapter.py \
     inference/app \
@@ -804,6 +807,16 @@ run_chord_coverage_audit() {
     --max_midi_files 120
 }
 
+run_stage_b_chord_labeled_eval() {
+  local run_id="${RUN_ID:-harness_stage_b_chord_labeled_eval}"
+  print_header "Stage B chord-labeled evaluation subset"
+  "$PYTHON_BIN" scripts/evaluate_chord_labeled_subset.py \
+    --run_id "$run_id" \
+    --manifest data/eval/stage_b_chord_labeled_tiny/manifest.json \
+    --min_samples 2 \
+    --min_notes 16
+}
+
 case "$MODE" in
   status)
     run_status
@@ -897,6 +910,9 @@ case "$MODE" in
     ;;
   chord-coverage-audit)
     run_chord_coverage_audit
+    ;;
+  stage-b-chord-labeled-eval)
+    run_stage_b_chord_labeled_eval
     ;;
   all)
     run_demo

--- a/scripts/evaluate_chord_labeled_subset.py
+++ b/scripts/evaluate_chord_labeled_subset.py
@@ -1,0 +1,325 @@
+"""Evaluate a small chord-labeled MIDI/inline-note subset for pitch-role sanity."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+import pretty_midi
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.run_stage_b_reference_stats import (  # noqa: E402
+    PITCH_ROLE_KEYS,
+    guide_tone_pitch_classes,
+    pitch_role_for_group,
+    pitch_role_ratio_metrics,
+    position_bucket,
+)
+from scripts.stage_b_tokens import (  # noqa: E402
+    PIANO_PITCH_MAX,
+    PIANO_PITCH_MIN,
+    POSITIONS_PER_BAR,
+    parse_chord_symbol,
+    quantize_note_position,
+)
+
+
+SCHEMA_VERSION = "stage_b_chord_labeled_eval_v1"
+
+
+class ManifestError(ValueError):
+    pass
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validate_chord_symbol(chord: Any, sample_id: str, bar_index: int) -> str:
+    if not isinstance(chord, str) or not chord.strip():
+        raise ManifestError(f"{sample_id}: chord at bar {bar_index} must be a non-empty string")
+    root, quality = parse_chord_symbol(chord)
+    if root == "N" or quality == "unknown":
+        raise ManifestError(f"{sample_id}: unsupported chord symbol at bar {bar_index}: {chord!r}")
+    return chord.strip()
+
+
+def validate_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        raise ManifestError(f"schema_version must be {SCHEMA_VERSION!r}")
+    samples = manifest.get("samples")
+    if not isinstance(samples, list) or not samples:
+        raise ManifestError("manifest.samples must be a non-empty list")
+
+    validated: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for raw in samples:
+        if not isinstance(raw, dict):
+            raise ManifestError("each sample must be an object")
+        sample = dict(raw)
+        sample_id = str(sample.get("sample_id") or "").strip()
+        if not sample_id:
+            raise ManifestError("sample_id is required")
+        if sample_id in seen_ids:
+            raise ManifestError(f"duplicate sample_id: {sample_id}")
+        seen_ids.add(sample_id)
+
+        bar_count = int(sample.get("bar_count", 0) or 0)
+        if bar_count <= 0:
+            raise ManifestError(f"{sample_id}: bar_count must be positive")
+        chords = sample.get("chords")
+        if not isinstance(chords, list) or len(chords) != bar_count:
+            raise ManifestError(f"{sample_id}: chords length must equal bar_count")
+        sample["chords"] = [
+            validate_chord_symbol(chord, sample_id=sample_id, bar_index=index)
+            for index, chord in enumerate(chords)
+        ]
+        sample["bar_count"] = bar_count
+        sample["beats_per_bar"] = int(sample.get("beats_per_bar", 4) or 4)
+        sample["positions_per_bar"] = int(sample.get("positions_per_bar", POSITIONS_PER_BAR) or POSITIONS_PER_BAR)
+        if sample["positions_per_bar"] != POSITIONS_PER_BAR:
+            raise ManifestError(f"{sample_id}: positions_per_bar must be {POSITIONS_PER_BAR}")
+
+        has_midi = bool(sample.get("midi_path"))
+        has_inline = isinstance(sample.get("notes"), list)
+        if has_midi == has_inline:
+            raise ManifestError(f"{sample_id}: provide exactly one of midi_path or notes")
+        if has_midi and float(sample.get("bpm", 0) or 0) <= 0:
+            raise ManifestError(f"{sample_id}: bpm is required for midi_path samples")
+        validated.append(sample)
+    return validated
+
+
+def resolve_midi_path(manifest_path: Path, midi_path: str) -> Path:
+    path = Path(midi_path)
+    if not path.is_absolute():
+        path = manifest_path.parent / path
+    return path
+
+
+def load_groups_from_midi(sample: dict[str, Any], manifest_path: Path) -> list[dict[str, int]]:
+    path = resolve_midi_path(manifest_path, str(sample["midi_path"]))
+    if not path.exists():
+        raise ManifestError(f"{sample['sample_id']}: midi_path does not exist: {path}")
+    midi = pretty_midi.PrettyMIDI(str(path))
+    bpm = float(sample["bpm"])
+    groups: list[dict[str, int]] = []
+    for instrument in midi.instruments:
+        for note in instrument.notes:
+            if int(note.pitch) < PIANO_PITCH_MIN or int(note.pitch) > PIANO_PITCH_MAX:
+                continue
+            bar, position = quantize_note_position(float(note.start), bpm)
+            if 0 <= bar < int(sample["bar_count"]):
+                groups.append({"bar": int(bar), "position": int(position), "pitch": int(note.pitch)})
+    return sorted(groups, key=lambda item: (item["bar"], item["position"], item["pitch"]))
+
+
+def load_groups_from_inline_notes(sample: dict[str, Any]) -> list[dict[str, int]]:
+    groups: list[dict[str, int]] = []
+    sample_id = str(sample["sample_id"])
+    for index, raw_note in enumerate(sample.get("notes", [])):
+        if not isinstance(raw_note, dict):
+            raise ManifestError(f"{sample_id}: note {index} must be an object")
+        bar = int(raw_note.get("bar", -1))
+        position = int(raw_note.get("position", -1))
+        pitch = int(raw_note.get("pitch", -1))
+        if not (0 <= bar < int(sample["bar_count"])):
+            raise ManifestError(f"{sample_id}: note {index} bar out of range: {bar}")
+        if not (0 <= position < POSITIONS_PER_BAR):
+            raise ManifestError(f"{sample_id}: note {index} position out of range: {position}")
+        if not (PIANO_PITCH_MIN <= pitch <= PIANO_PITCH_MAX):
+            raise ManifestError(f"{sample_id}: note {index} pitch out of range: {pitch}")
+        groups.append({"bar": bar, "position": position, "pitch": pitch})
+    return sorted(groups, key=lambda item: (item["bar"], item["position"], item["pitch"]))
+
+
+def load_sample_groups(sample: dict[str, Any], manifest_path: Path) -> list[dict[str, int]]:
+    if sample.get("midi_path"):
+        return load_groups_from_midi(sample, manifest_path=manifest_path)
+    return load_groups_from_inline_notes(sample)
+
+
+def _empty_role_counts() -> dict[str, int]:
+    return {role: 0 for role in PITCH_ROLE_KEYS}
+
+
+def analyze_sample(sample: dict[str, Any], manifest_path: Path) -> dict[str, Any]:
+    groups = load_sample_groups(sample, manifest_path=manifest_path)
+    role_counts: Counter[str] = Counter(_empty_role_counts())
+    bucket_counts: dict[str, Counter[str]] = {
+        "strong": Counter(_empty_role_counts()),
+        "eighth": Counter(_empty_role_counts()),
+        "offgrid": Counter(_empty_role_counts()),
+    }
+    per_bar_counts: dict[str, Counter[str]] = {}
+
+    for group in groups:
+        chord = sample["chords"][int(group["bar"])]
+        role = pitch_role_for_group(group, chord)
+        role_counts[role] += 1
+        bucket_counts[position_bucket(int(group["position"]))][role] += 1
+        bar_key = str(group["bar"])
+        if bar_key not in per_bar_counts:
+            per_bar_counts[bar_key] = Counter(_empty_role_counts())
+        per_bar_counts[bar_key][role] += 1
+
+    note_count = int(len(groups))
+    return {
+        "sample_id": sample["sample_id"],
+        "source_type": "midi" if sample.get("midi_path") else "inline_notes",
+        "bar_count": int(sample["bar_count"]),
+        "chords": sample["chords"],
+        "note_count": note_count,
+        "unique_pitch_count": int(len({int(group["pitch"]) for group in groups})),
+        "role_counts": {role: int(role_counts.get(role, 0)) for role in PITCH_ROLE_KEYS},
+        "role_ratios": pitch_role_ratio_metrics(dict(role_counts)),
+        "bucket_counts": {
+            bucket: {role: int(counter.get(role, 0)) for role in PITCH_ROLE_KEYS}
+            for bucket, counter in bucket_counts.items()
+        },
+        "per_bar_counts": {
+            bar: {role: int(counter.get(role, 0)) for role in PITCH_ROLE_KEYS}
+            for bar, counter in sorted(per_bar_counts.items(), key=lambda item: int(item[0]))
+        },
+        "guide_tone_classes_by_bar": {
+            str(index): sorted(int(pc) for pc in guide_tone_pitch_classes(chord))
+            for index, chord in enumerate(sample["chords"])
+        },
+    }
+
+
+def summarize_samples(samples: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    role_counts: Counter[str] = Counter(_empty_role_counts())
+    note_count = 0
+    for sample in samples:
+        note_count += int(sample.get("note_count", 0) or 0)
+        role_counts.update({role: int(count) for role, count in sample.get("role_counts", {}).items()})
+    return {
+        "sample_count": int(len(samples)),
+        "note_count": int(note_count),
+        "role_counts": {role: int(role_counts.get(role, 0)) for role in PITCH_ROLE_KEYS},
+        "role_ratios": pitch_role_ratio_metrics(dict(role_counts)),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    ratios = summary["role_ratios"]
+    lines = [
+        "# Stage B Chord-Labeled Evaluation Subset",
+        "",
+        f"- manifest: `{report['manifest_path']}`",
+        f"- sample count: `{summary['sample_count']}`",
+        f"- note count: `{summary['note_count']}`",
+        f"- chord-tone ratio: `{ratios['chord_tone_ratio']:.3f}`",
+        f"- tension ratio: `{ratios['tension_ratio']:.3f}`",
+        f"- approach ratio: `{ratios['approach_ratio']:.3f}`",
+        f"- outside ratio: `{ratios['outside_ratio']:.3f}`",
+        "",
+        "## Samples",
+        "",
+        "| sample | bars | notes | unique pitches | chord-tone | tension | approach | outside |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for sample in report["samples"]:
+        sample_ratios = sample["role_ratios"]
+        lines.append(
+            "| {sample_id} | {bar_count} | {note_count} | {unique_pitch_count} | {chord:.3f} | {tension:.3f} | {approach:.3f} | {outside:.3f} |".format(
+                sample_id=sample["sample_id"],
+                bar_count=sample["bar_count"],
+                note_count=sample["note_count"],
+                unique_pitch_count=sample["unique_pitch_count"],
+                chord=sample_ratios["chord_tone_ratio"],
+                tension=sample_ratios["tension_ratio"],
+                approach=sample_ratios["approach_ratio"],
+                outside=sample_ratios["outside_ratio"],
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Decision",
+            "",
+            "- This is an evaluation contract, not a claim that real Brad/reference phrases are labeled.",
+            "- Add real phrases only when their bar-level chord labels are known or manually verified.",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_report(manifest_path: Path) -> dict[str, Any]:
+    manifest = read_json(manifest_path)
+    samples = validate_manifest(manifest)
+    sample_reports = [analyze_sample(sample, manifest_path=manifest_path) for sample in samples]
+    return {
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "schema_version": SCHEMA_VERSION,
+        "manifest_path": str(manifest_path),
+        "samples": sample_reports,
+        "summary": summarize_samples(sample_reports),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Evaluate chord-labeled Stage B subset")
+    parser.add_argument(
+        "--manifest",
+        type=str,
+        default=str(ROOT_DIR / "data" / "eval" / "stage_b_chord_labeled_tiny" / "manifest.json"),
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=str(ROOT_DIR / "outputs" / "stage_b_chord_labeled_eval"),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--min_samples", type=int, default=1)
+    parser.add_argument("--min_notes", type=int, default=1)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    manifest_path = Path(args.manifest)
+    report = build_report(manifest_path)
+    summary = report["summary"]
+    if int(summary["sample_count"]) < int(args.min_samples):
+        raise ManifestError(f"sample_count below minimum: {summary['sample_count']} < {args.min_samples}")
+    if int(summary["note_count"]) < int(args.min_notes):
+        raise ManifestError(f"note_count below minimum: {summary['note_count']} < {args.min_notes}")
+
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    run_dir = Path(args.output_root) / run_id
+    write_json(run_dir / "chord_labeled_eval_report.json", report)
+    (run_dir / "chord_labeled_eval_report.md").write_text(markdown_report(report), encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "sample_count": summary["sample_count"],
+                "note_count": summary["note_count"],
+                "chord_tone_ratio": summary["role_ratios"]["chord_tone_ratio"],
+                "tension_ratio": summary["role_ratios"]["tension_ratio"],
+                "outside_ratio": summary["role_ratios"]["outside_ratio"],
+                "report_path": str(run_dir / "chord_labeled_eval_report.md"),
+            },
+            ensure_ascii=True,
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_chord_labeled_subset_eval.py
+++ b/tests/test_chord_labeled_subset_eval.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pretty_midi
+
+from scripts.evaluate_chord_labeled_subset import (
+    ManifestError,
+    analyze_sample,
+    build_report,
+    load_groups_from_midi,
+    validate_manifest,
+)
+
+
+class ChordLabeledSubsetEvalTest(unittest.TestCase):
+    def test_validate_manifest_accepts_inline_notes(self) -> None:
+        samples = validate_manifest(
+            {
+                "schema_version": "stage_b_chord_labeled_eval_v1",
+                "samples": [
+                    {
+                        "sample_id": "ok",
+                        "bar_count": 1,
+                        "chords": ["Cmaj7"],
+                        "notes": [{"bar": 0, "position": 0, "pitch": 60}],
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(samples[0]["sample_id"], "ok")
+
+    def test_validate_manifest_rejects_chord_count_mismatch(self) -> None:
+        with self.assertRaises(ManifestError):
+            validate_manifest(
+                {
+                    "schema_version": "stage_b_chord_labeled_eval_v1",
+                    "samples": [
+                        {
+                            "sample_id": "bad",
+                            "bar_count": 2,
+                            "chords": ["Cmaj7"],
+                            "notes": [{"bar": 0, "position": 0, "pitch": 60}],
+                        }
+                    ],
+                }
+            )
+
+    def test_analyze_sample_counts_pitch_roles(self) -> None:
+        sample = validate_manifest(
+            {
+                "schema_version": "stage_b_chord_labeled_eval_v1",
+                "samples": [
+                    {
+                        "sample_id": "roles",
+                        "bar_count": 1,
+                        "chords": ["Cmaj7"],
+                        "notes": [
+                            {"bar": 0, "position": 0, "pitch": 60},
+                            {"bar": 0, "position": 4, "pitch": 64},
+                            {"bar": 0, "position": 8, "pitch": 66},
+                        ],
+                    }
+                ],
+            }
+        )[0]
+
+        report = analyze_sample(sample, manifest_path=Path("manifest.json"))
+
+        self.assertEqual(report["note_count"], 3)
+        self.assertEqual(report["role_counts"]["root"], 1)
+        self.assertGreater(report["role_counts"]["guide"], 0)
+        self.assertGreater(report["role_counts"]["tension"], 0)
+
+    def test_load_groups_from_midi_quantizes_notes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            midi_path = root / "phrase.mid"
+            midi = pretty_midi.PrettyMIDI(initial_tempo=120)
+            instrument = pretty_midi.Instrument(program=0)
+            instrument.notes.append(pretty_midi.Note(velocity=80, pitch=60, start=0.0, end=0.25))
+            instrument.notes.append(pretty_midi.Note(velocity=80, pitch=64, start=0.5, end=0.75))
+            midi.instruments.append(instrument)
+            midi.write(str(midi_path))
+
+            sample = {
+                "sample_id": "midi",
+                "bar_count": 1,
+                "bpm": 120,
+                "chords": ["Cmaj7"],
+                "midi_path": "phrase.mid",
+            }
+
+            groups = load_groups_from_midi(sample, manifest_path=root / "manifest.json")
+
+            self.assertEqual(groups[0]["position"], 0)
+            self.assertEqual(groups[1]["position"], 4)
+
+    def test_build_report_reads_fixture_manifest(self) -> None:
+        report = build_report(Path("data/eval/stage_b_chord_labeled_tiny/manifest.json"))
+
+        self.assertEqual(report["summary"]["sample_count"], 2)
+        self.assertGreater(report["summary"]["note_count"], 0)
+        self.assertGreater(report["summary"]["role_ratios"]["chord_tone_ratio"], 0.5)
+
+    def test_build_report_rejects_unknown_chord(self) -> None:
+        with TemporaryDirectory() as tmp:
+            manifest_path = Path(tmp) / "manifest.json"
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "stage_b_chord_labeled_eval_v1",
+                        "samples": [
+                            {
+                                "sample_id": "bad_chord",
+                                "bar_count": 1,
+                                "chords": ["not-a-chord"],
+                                "notes": [{"bar": 0, "position": 0, "pitch": 60}],
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(ManifestError):
+                build_report(manifest_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

- Issue #77에서 chord annotation coverage가 없음을 확인한 뒤, known chord label이 있을 때 pitch-role summary를 계산할 수 있는 evaluation contract를 추가했습니다.
- 실제 Brad/reference 곡에 임의 chord label을 붙이지 않고, inline-note tiny fixture로 schema와 evaluator를 검증했습니다.
- stage-b-chord-labeled-eval harness와 관련 unit test를 추가했습니다.
- Issue #79 결과를 CURRENT_STATUS, CORE_PLAN, docs index에 기록했습니다.

## 결과

- fixture sample count: 2
- fixture note count: 32
- chord-tone ratio: 0.844
- tension ratio: 0.156
- outside ratio: 0.000
- 결론: pitch-role evaluator는 known chord labels를 받으면 정상 동작합니다. 다만 아직 real Brad/reference phrase가 라벨링된 것은 아닙니다.

## 검증

- ./.venv/bin/python -m unittest tests.test_chord_labeled_subset_eval
- bash scripts/agent_harness.sh stage-b-chord-labeled-eval
- bash scripts/agent_harness.sh quick

Closes #79