### PR TITLE
Stage B generated chord eval bridge 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #79: Stage B chord-labeled evaluation subset contract.
+- Issue #81: Stage B generated candidate chord-labeled eval bridge.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -194,6 +194,12 @@ For Stage B chord-labeled evaluation subset changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-chord-labeled-eval
+```
+
+For Stage B generated candidate chord-labeled eval bridge changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-generated-chord-eval
 ```
 
 For Stage B data-derived motif template extraction changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -142,6 +142,7 @@ Stage B에서 명시하는 것:
 36. Stage B reference pitch-role landing statistics and chord-coverage gate
 37. Stage B chord progression coverage audit
 38. Stage B chord-labeled evaluation subset contract
+39. Stage B generated candidate chord-labeled eval bridge
 
 가장 최근 의미 있는 결과:
 
@@ -160,6 +161,7 @@ Stage B에서 명시하는 것:
 - Issue #75 shows reference pitch-role stats cannot be trusted yet because known chord note ratio is `0.000`.
 - Issue #77 audits the local dataset for chord progression annotations and finds no usable candidate: role meta `2812` scanned with `0` hits, sidecars `0`, MIDI files scanned for text events `120` with `0` chord-text candidates.
 - Issue #79 adds a tiny chord-labeled eval contract so known chord labels can produce pitch-role sanity summaries without pretending real Brad/reference labels already exist.
+- Issue #81 connects generated candidate reports with known chord metadata to the chord-labeled evaluator.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -366,6 +368,8 @@ Stage B에서 명시하는 것:
 - Issue #77 result: 현재 local dataset에는 바로 쓸 수 있는 chord progression annotation이 없으므로 reference pitch-role comparison은 아직 불가능하다.
 - Issue #79 result: `inline_notes` tiny fixture `2` samples, `32` notes로 chord-labeled eval contract를 검증했다.
 - Issue #79 result: fixture chord-tone ratio는 `0.844`, tension ratio는 `0.156`, outside ratio는 `0.000`이다.
+- Issue #81 result: generated candidate bridge fixture `1` sample, `16` notes로 report-to-evaluator 연결을 검증했다.
+- Issue #81 result: fixture chord-tone ratio는 `1.000`, tension ratio는 `0.000`, outside ratio는 `0.000`이다.
 
 해석:
 
@@ -375,7 +379,7 @@ Stage B에서 명시하는 것:
 - `approach_tensions`는 pitch-level resolution을 만들지만, 이 또한 jazz vocabulary 자체는 아니다.
 - `swing_motif_approach`는 기계적인 grid 반복을 줄였지만, 이 또한 jazz vocabulary 자체는 아니다.
 - real phrase reference stats와 motif extraction 기준으로 보면 다음은 hand-written rhythm rule 확장이 아니라 data-derived motif/cadence control 쪽이 맞다.
-- 다만 pitch-role 쪽은 real reference chord label이 아직 없으므로, 다음 pitch grammar 개선은 실제 3-5개 phrase의 수동 chord labels 또는 generated metadata bridge가 먼저다.
+- 다만 pitch-role 쪽은 real reference chord label이 아직 없으므로, 다음 pitch grammar 개선은 실제 generated review package에 bridge를 적용하고 이후 수동 reference labels를 넣는 순서가 맞다.
 
 ### Phase 3.10. Swing/Motif Phrase Grammar
 
@@ -645,22 +649,21 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B chord-labeled evaluation subset contract 추가
+Stage B generated candidate chord-labeled eval bridge 추가
 ```
 
 결과:
 
-- chord-labeled eval manifest schema를 만들었다.
-- 기본 fixture는 `data/eval/stage_b_chord_labeled_tiny/manifest.json`이다.
-- fixture는 `inline_notes` 기반이며 실제 Brad/reference label이라고 주장하지 않는다.
-- harness result: sample count `2`, note count `32`, chord-tone ratio `0.844`, tension ratio `0.156`, outside ratio `0.000`.
-- `midi_path` sample도 지원하지만 raw MIDI는 커밋하지 않는다.
+- generated candidate/review report의 known chord progression metadata를 chord-labeled evaluator에 연결했다.
+- supported metadata source: `chord_progression`, `chords`, `request.chord_progression`, `source_report.request.chord_progression`.
+- harness는 raw MIDI를 커밋하지 않고 outputs 아래 tiny fixture를 생성한다.
+- harness result: sample count `1`, note count `16`, chord-tone ratio `1.000`, tension ratio `0.000`, outside ratio `0.000`.
 
 다음 작업:
 
-- 코드가 확실한 3-5개 실제 review phrase를 manifest에 추가한다.
-- 또는 generated candidate report의 known chord progression metadata를 chord-labeled evaluator와 연결한다.
-- 불확실한 Brad/reference chord는 넣지 않는다.
+- 실제 `stage-b-data-guide-hybrid` review manifest에 generated chord eval bridge를 적용한다.
+- generated review markdown에 bridge report 요약을 같이 붙인다.
+- real Brad/reference chord label은 아직 임의로 넣지 않는다.
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-79-stage-b-chord-labeled-eval-subset`
+- `issue-81-stage-b-generated-chord-eval-bridge`
 
 현재 범위가 아닌 것:
 
@@ -35,6 +35,43 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
 ## Latest Probe Result
+
+Issue #81은 Issue #79의 chord-labeled evaluator를 generated candidate report와 연결한 단계다.
+
+중요한 전제:
+
+- generated candidate report가 chord progression metadata를 알고 있을 때만 평가한다.
+- solo-only MIDI에서 chord를 추측하지 않는다.
+- real Brad/reference chord label 문제는 아직 해결되지 않았다.
+
+Implemented:
+
+- generated review/candidate report bridge
+- `chord_progression`, `chords`, `request.chord_progression`, `source_report.request.chord_progression` fallback
+- generated MIDI candidate `review_midi_path` / `midi_path` support
+- harness-local tiny generated-candidate fixture
+- `scripts/evaluate_generated_candidate_chords.py`
+- `scripts/agent_harness.sh stage-b-generated-chord-eval`
+- docs:
+  - `docs/STAGE_B_GENERATED_CHORD_EVAL_2026-05-22.md`
+
+Result:
+
+- fixture sample count: `1`
+- fixture note count: `16`
+- chord-tone ratio: `1.000`
+- tension ratio: `0.000`
+- approach ratio: `0.000`
+- outside ratio: `0.000`
+- report: `outputs/stage_b_generated_chord_eval/harness_stage_b_generated_chord_eval/generated_chord_eval_report.md`
+
+Decision:
+
+- generated candidate report에 known chord progression metadata가 있으면 pitch-role evaluator로 연결할 수 있다.
+- fixture score는 model quality가 아니라 bridge smoke result다.
+- 다음 작업은 실제 `stage-b-data-guide-hybrid` review manifest 같은 generated review package에 이 bridge를 적용하는 것이다.
+
+## Previous Probe Result
 
 Issue #79는 Issue #77의 결론을 받아, 작은 chord-labeled evaluation subset contract를 만든 단계다.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -90,6 +90,8 @@
   - role metadata, raw sidecar, MIDI text event를 훑어 현재 dataset에 usable chord progression annotation이 없음을 확인한 결과.
 - `STAGE_B_CHORD_LABELED_EVAL_2026-05-22.md`
   - known chord labels가 있을 때 pitch-role summary를 계산할 수 있는 tiny evaluation contract와 manifest format.
+- `STAGE_B_GENERATED_CHORD_EVAL_2026-05-22.md`
+  - generated candidate report의 known chord progression metadata를 chord-labeled evaluator에 연결하는 bridge.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -116,7 +118,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, and chord-labeled eval contract를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, and generated chord eval bridge를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_GENERATED_CHORD_EVAL_2026-05-22.md
+++ b/docs/STAGE_B_GENERATED_CHORD_EVAL_2026-05-22.md
@@ -1,0 +1,120 @@
+# Stage B Generated Candidate Chord Evaluation Bridge
+
+작성일: 2026-05-22
+
+## 배경
+
+Issue #79에서 chord-labeled evaluation contract를 만들었다.
+
+이번 단계는 generated candidate report가 이미 알고 있는 chord progression metadata를 그 evaluator에 연결한다.
+
+이 작업은 real reference chord labels 문제를 해결하지 않는다.
+
+목적은 다음이다.
+
+- generated MIDI candidate가 어떤 chord progression 위에서 만들어졌는지 metadata가 있을 때만 평가한다.
+- solo-only MIDI를 억지로 in/out 판단하지 않는다.
+- generated candidate의 chord-tone/tension/outside ratio를 같은 evaluator contract로 산출한다.
+
+## 구현
+
+새 스크립트:
+
+```bash
+python scripts/evaluate_generated_candidate_chords.py
+```
+
+새 harness:
+
+```bash
+bash scripts/agent_harness.sh stage-b-generated-chord-eval
+```
+
+지원 입력:
+
+- review manifest with:
+  - `chord_progression`
+  - `candidates[].review_midi_path`
+  - `candidates[].midi_path`
+- generation report with:
+  - `request.chord_progression`
+  - `request.bars`
+  - `samples[].midi_path`
+- review manifest that points to `source_report`
+
+Harness는 raw MIDI를 커밋하지 않고, `outputs/` 아래 tiny generated-candidate fixture를 만들어 bridge를 검증한다.
+
+## 결과
+
+실행:
+
+```bash
+bash scripts/agent_harness.sh stage-b-generated-chord-eval
+```
+
+출력:
+
+```text
+outputs/stage_b_generated_chord_eval/harness_stage_b_generated_chord_eval/generated_chord_eval_report.json
+outputs/stage_b_generated_chord_eval/harness_stage_b_generated_chord_eval/generated_chord_eval_report.md
+```
+
+요약:
+
+| metric | value |
+|---|---:|
+| sample count | 1 |
+| note count | 16 |
+| chord-tone ratio | 1.000 |
+| tension ratio | 0.000 |
+| outside ratio | 0.000 |
+
+Fixture chord progression:
+
+```text
+Cm7, F7, Bbmaj7, G7
+```
+
+## 판단
+
+이 결과는 다음을 의미한다.
+
+- generated candidate report에 chord metadata가 있으면 pitch-role evaluator로 연결할 수 있다.
+- 기존 candidate ranking의 chord-tone proxy와 별도로, manifest/evaluator 기반 report를 만들 수 있다.
+- 앞으로 generated review package마다 같은 bridge를 붙이면 청취 전 수치 sanity check가 쉬워진다.
+
+이 결과가 의미하지 않는 것:
+
+- real Brad/reference phrase chord labels가 생긴 것은 아니다.
+- generated sample이 jazz solo quality를 만족한다는 뜻도 아니다.
+- fixture chord-tone ratio `1.000`은 bridge smoke result일 뿐 model score가 아니다.
+
+## 다음 작업
+
+다음 단계는 실제 generated review package에 bridge를 적용하는 것이다.
+
+우선순위:
+
+```text
+stage-b-data-guide-hybrid review_manifest를 generated chord eval bridge에 연결한다.
+```
+
+조건:
+
+- `review_manifest.json`에 chord progression metadata가 있어야 한다.
+- raw generated MIDI는 계속 `outputs/` artifact로만 둔다.
+- PR에는 script/docs/test만 커밋한다.
+
+그 다음:
+
+```text
+generated chord eval report를 review markdown에 같이 붙인다.
+```
+
+## Validation
+
+```bash
+./.venv/bin/python -m unittest tests.test_generated_candidate_chord_eval
+bash scripts/agent_harness.sh stage-b-generated-chord-eval
+bash scripts/agent_harness.sh quick
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -80,6 +80,8 @@ Modes:
                 Audit chord annotation coverage in role metadata, sidecars, and MIDI text events.
   stage-b-chord-labeled-eval
                 Evaluate the tiny chord-labeled subset manifest and pitch-role summary contract.
+  stage-b-generated-chord-eval
+                Evaluate generated candidate report bridge against known chord metadata.
   all           Run demo and tiny-compare.
 
 Environment:
@@ -129,6 +131,7 @@ run_quick() {
     scripts/run_manifest_prepare_smoke.py \
     scripts/audit_chord_progression_coverage.py \
     scripts/evaluate_chord_labeled_subset.py \
+    scripts/evaluate_generated_candidate_chords.py \
     scripts/train_stage_a_full.py \
     scripts/train_stage_a_adapter.py \
     inference/app \
@@ -817,6 +820,15 @@ run_stage_b_chord_labeled_eval() {
     --min_notes 16
 }
 
+run_stage_b_generated_chord_eval() {
+  local run_id="${RUN_ID:-harness_stage_b_generated_chord_eval}"
+  print_header "Stage B generated candidate chord-labeled eval bridge"
+  "$PYTHON_BIN" scripts/evaluate_generated_candidate_chords.py \
+    --run_id "$run_id" \
+    --write_tiny_fixture \
+    --candidate_limit 1
+}
+
 case "$MODE" in
   status)
     run_status
@@ -913,6 +925,9 @@ case "$MODE" in
     ;;
   stage-b-chord-labeled-eval)
     run_stage_b_chord_labeled_eval
+    ;;
+  stage-b-generated-chord-eval)
+    run_stage_b_generated_chord_eval
     ;;
   all)
     run_demo

--- a/scripts/evaluate_generated_candidate_chords.py
+++ b/scripts/evaluate_generated_candidate_chords.py
@@ -1,0 +1,311 @@
+"""Bridge generated candidate reports into the chord-labeled evaluator."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+import pretty_midi
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.evaluate_chord_labeled_subset import (  # noqa: E402
+    ManifestError,
+    analyze_sample,
+    summarize_samples,
+    write_json,
+)
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def resolve_path(base_path: Path, raw_path: str | None) -> Path | None:
+    if not raw_path:
+        return None
+    path = Path(str(raw_path))
+    if not path.is_absolute():
+        path = base_path.parent / path
+    return path
+
+
+def sanitize_sample_id(value: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "_", value.strip())
+    return cleaned.strip("_") or "candidate"
+
+
+def expand_chords(chords: Sequence[str], bars: int) -> list[str]:
+    if not chords:
+        raise ManifestError("chord progression is required")
+    return [str(chords[index % len(chords)]) for index in range(int(bars))]
+
+
+def load_source_report(report_path: Path, report: dict[str, Any]) -> dict[str, Any] | None:
+    source_path = resolve_path(report_path, report.get("source_report") or report.get("source_ranking_report"))
+    if source_path and source_path.exists():
+        return read_json(source_path)
+    return None
+
+
+def extract_request_context(report_path: Path, report: dict[str, Any], default_bpm: float) -> dict[str, Any]:
+    source_report = load_source_report(report_path, report)
+    source_request = source_report.get("request", {}) if source_report else {}
+    request = report.get("request", {}) if isinstance(report.get("request"), dict) else {}
+
+    chords = (
+        report.get("chord_progression")
+        or report.get("chords")
+        or request.get("chord_progression")
+        or source_request.get("chord_progression")
+        or (source_report or {}).get("chords", [])
+    )
+    if not isinstance(chords, list) or not chords:
+        raise ManifestError("candidate report does not include chord_progression/chords metadata")
+
+    bars = report.get("bars") or request.get("bars") or source_request.get("bars") or len(chords)
+    bpm = report.get("bpm") or request.get("bpm") or source_request.get("bpm") or default_bpm
+    return {
+        "chord_progression": [str(chord) for chord in chords],
+        "bars": int(bars),
+        "bpm": float(bpm),
+    }
+
+
+def collect_candidate_rows(report: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = report.get("candidates")
+    if isinstance(rows, list):
+        return [row for row in rows if isinstance(row, dict)]
+    rows = report.get("samples")
+    if isinstance(rows, list):
+        return [row for row in rows if isinstance(row, dict)]
+    raise ManifestError("candidate report must contain candidates or samples")
+
+
+def candidate_midi_path(row: dict[str, Any]) -> str | None:
+    for key in ("review_midi_path", "midi_path", "source_path"):
+        value = row.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+def candidate_sample_id(index: int, row: dict[str, Any]) -> str:
+    parts = [
+        str(row.get("mode") or row.get("generation_mode") or "candidate"),
+        f"rank_{row.get('review_rank') or row.get('rank') or index}",
+        f"sample_{row.get('sample_index') or index}",
+    ]
+    return sanitize_sample_id("_".join(parts))
+
+
+def build_eval_samples(
+    report_path: Path,
+    candidate_report: dict[str, Any],
+    candidate_limit: int,
+    default_bpm: float,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    context = extract_request_context(report_path, candidate_report, default_bpm=default_bpm)
+    rows = collect_candidate_rows(candidate_report)[: max(1, int(candidate_limit))]
+    samples: list[dict[str, Any]] = []
+    for index, row in enumerate(rows, start=1):
+        midi_path = candidate_midi_path(row)
+        if not midi_path:
+            continue
+        resolved = resolve_path(report_path, midi_path)
+        if not resolved or not resolved.exists():
+            continue
+        samples.append(
+            {
+                "sample_id": candidate_sample_id(index, row),
+                "bar_count": context["bars"],
+                "bpm": context["bpm"],
+                "chords": expand_chords(context["chord_progression"], context["bars"]),
+                "midi_path": str(resolved),
+            }
+        )
+    if not samples:
+        raise ManifestError("no generated candidates with readable MIDI paths")
+    return samples, context
+
+
+def build_report_from_candidate_report(
+    report_path: Path,
+    candidate_limit: int = 3,
+    default_bpm: float = 124.0,
+) -> dict[str, Any]:
+    candidate_report = read_json(report_path)
+    samples, context = build_eval_samples(
+        report_path,
+        candidate_report,
+        candidate_limit=candidate_limit,
+        default_bpm=default_bpm,
+    )
+    sample_reports = [analyze_sample(sample, manifest_path=report_path) for sample in samples]
+    return {
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "source_report_path": str(report_path),
+        "chord_progression": context["chord_progression"],
+        "expanded_chords": expand_chords(context["chord_progression"], context["bars"]),
+        "bars": int(context["bars"]),
+        "bpm": float(context["bpm"]),
+        "samples": sample_reports,
+        "summary": summarize_samples(sample_reports),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    ratios = summary["role_ratios"]
+    lines = [
+        "# Generated Candidate Chord-Labeled Evaluation",
+        "",
+        f"- source report: `{report['source_report_path']}`",
+        f"- chord progression: `{', '.join(report['chord_progression'])}`",
+        f"- bars: `{report['bars']}`",
+        f"- sample count: `{summary['sample_count']}`",
+        f"- note count: `{summary['note_count']}`",
+        f"- chord-tone ratio: `{ratios['chord_tone_ratio']:.3f}`",
+        f"- tension ratio: `{ratios['tension_ratio']:.3f}`",
+        f"- outside ratio: `{ratios['outside_ratio']:.3f}`",
+        "",
+        "## Candidates",
+        "",
+        "| sample | notes | unique pitches | chord-tone | tension | approach | outside |",
+        "|---|---:|---:|---:|---:|---:|---:|",
+    ]
+    for sample in report["samples"]:
+        ratios = sample["role_ratios"]
+        lines.append(
+            "| {sample_id} | {note_count} | {unique_pitch_count} | {chord:.3f} | {tension:.3f} | {approach:.3f} | {outside:.3f} |".format(
+                sample_id=sample["sample_id"],
+                note_count=sample["note_count"],
+                unique_pitch_count=sample["unique_pitch_count"],
+                chord=ratios["chord_tone_ratio"],
+                tension=ratios["tension_ratio"],
+                approach=ratios["approach_ratio"],
+                outside=ratios["outside_ratio"],
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Boundary",
+            "",
+            "- This evaluates generated candidates only when chord metadata is known.",
+            "- It does not solve missing chord labels for real reference MIDI.",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_tiny_fixture(run_dir: Path) -> Path:
+    fixture_dir = run_dir / "fixture_generated_candidates"
+    fixture_dir.mkdir(parents=True, exist_ok=True)
+    midi_path = fixture_dir / "tiny_generated_candidate.mid"
+
+    midi = pretty_midi.PrettyMIDI(initial_tempo=124)
+    instrument = pretty_midi.Instrument(program=0)
+    step = 60.0 / 124.0 / 4.0
+    notes = [
+        (60, 0),
+        (63, 4),
+        (67, 8),
+        (70, 12),
+        (65, 16),
+        (69, 20),
+        (72, 24),
+        (75, 28),
+        (70, 32),
+        (74, 36),
+        (77, 40),
+        (81, 44),
+        (67, 48),
+        (71, 52),
+        (74, 56),
+        (77, 60),
+    ]
+    for pitch, step_index in notes:
+        start = step * step_index
+        instrument.notes.append(pretty_midi.Note(velocity=84, pitch=pitch, start=start, end=start + step * 2))
+    midi.instruments.append(instrument)
+    midi.write(str(midi_path))
+
+    report_path = run_dir / "fixture_review_manifest.json"
+    write_json(
+        report_path,
+        {
+            "chord_progression": ["Cm7", "F7", "Bbmaj7", "G7"],
+            "bars": 4,
+            "bpm": 124,
+            "candidates": [
+                {
+                    "mode": "fixture_generated",
+                    "review_rank": 1,
+                    "sample_index": 1,
+                    "review_midi_path": str(midi_path),
+                }
+            ],
+        },
+    )
+    return report_path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Evaluate generated candidates against known chord metadata")
+    parser.add_argument("--candidate_report", type=str, default=None)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=str(ROOT_DIR / "outputs" / "stage_b_generated_chord_eval"),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--candidate_limit", type=int, default=3)
+    parser.add_argument("--default_bpm", type=float, default=124.0)
+    parser.add_argument("--write_tiny_fixture", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    run_dir = Path(args.output_root) / run_id
+    if args.write_tiny_fixture:
+        candidate_report = write_tiny_fixture(run_dir)
+    elif args.candidate_report:
+        candidate_report = Path(args.candidate_report)
+    else:
+        raise ManifestError("--candidate_report is required unless --write_tiny_fixture is set")
+
+    report = build_report_from_candidate_report(
+        Path(candidate_report),
+        candidate_limit=args.candidate_limit,
+        default_bpm=args.default_bpm,
+    )
+    write_json(run_dir / "generated_chord_eval_report.json", report)
+    (run_dir / "generated_chord_eval_report.md").write_text(markdown_report(report), encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "sample_count": report["summary"]["sample_count"],
+                "note_count": report["summary"]["note_count"],
+                "chord_tone_ratio": report["summary"]["role_ratios"]["chord_tone_ratio"],
+                "tension_ratio": report["summary"]["role_ratios"]["tension_ratio"],
+                "outside_ratio": report["summary"]["role_ratios"]["outside_ratio"],
+                "report_path": str(run_dir / "generated_chord_eval_report.md"),
+            },
+            ensure_ascii=True,
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_generated_candidate_chord_eval.py
+++ b/tests/test_generated_candidate_chord_eval.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pretty_midi
+
+from scripts.evaluate_generated_candidate_chords import (
+    ManifestError,
+    build_report_from_candidate_report,
+    expand_chords,
+    write_tiny_fixture,
+)
+
+
+def write_tiny_midi(path: Path) -> None:
+    midi = pretty_midi.PrettyMIDI(initial_tempo=120)
+    instrument = pretty_midi.Instrument(program=0)
+    instrument.notes.append(pretty_midi.Note(velocity=80, pitch=60, start=0.0, end=0.25))
+    instrument.notes.append(pretty_midi.Note(velocity=80, pitch=64, start=0.5, end=0.75))
+    instrument.notes.append(pretty_midi.Note(velocity=80, pitch=67, start=1.0, end=1.25))
+    instrument.notes.append(pretty_midi.Note(velocity=80, pitch=71, start=1.5, end=1.75))
+    midi.instruments.append(instrument)
+    midi.write(str(path))
+
+
+class GeneratedCandidateChordEvalTest(unittest.TestCase):
+    def test_expand_chords_cycles_progression_to_bar_count(self) -> None:
+        self.assertEqual(expand_chords(["Cm7", "F7"], 5), ["Cm7", "F7", "Cm7", "F7", "Cm7"])
+
+    def test_build_report_reads_review_manifest_chords(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            midi_path = root / "candidate.mid"
+            write_tiny_midi(midi_path)
+            manifest_path = root / "review_manifest.json"
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "chord_progression": ["Cmaj7"],
+                        "bars": 1,
+                        "bpm": 120,
+                        "candidates": [{"mode": "fixture", "review_rank": 1, "review_midi_path": str(midi_path)}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            report = build_report_from_candidate_report(manifest_path)
+
+            self.assertEqual(report["summary"]["sample_count"], 1)
+            self.assertEqual(report["summary"]["note_count"], 4)
+            self.assertGreater(report["summary"]["role_ratios"]["chord_tone_ratio"], 0.0)
+
+    def test_build_report_falls_back_to_source_request(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            midi_path = root / "candidate.mid"
+            write_tiny_midi(midi_path)
+            source_path = root / "source_report.json"
+            source_path.write_text(
+                json.dumps({"request": {"chord_progression": ["Cmaj7"], "bars": 1, "bpm": 120}}),
+                encoding="utf-8",
+            )
+            manifest_path = root / "review_manifest.json"
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "source_report": str(source_path),
+                        "candidates": [{"mode": "fixture", "review_rank": 1, "midi_path": str(midi_path)}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            report = build_report_from_candidate_report(manifest_path)
+
+            self.assertEqual(report["chord_progression"], ["Cmaj7"])
+            self.assertEqual(report["bars"], 1)
+
+    def test_build_report_rejects_missing_chords(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            midi_path = root / "candidate.mid"
+            write_tiny_midi(midi_path)
+            manifest_path = root / "review_manifest.json"
+            manifest_path.write_text(
+                json.dumps({"candidates": [{"review_midi_path": str(midi_path)}]}),
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(ManifestError):
+                build_report_from_candidate_report(manifest_path)
+
+    def test_write_tiny_fixture_builds_evaluable_report(self) -> None:
+        with TemporaryDirectory() as tmp:
+            report_path = write_tiny_fixture(Path(tmp))
+
+            report = build_report_from_candidate_report(report_path)
+
+            self.assertEqual(report["summary"]["sample_count"], 1)
+            self.assertGreater(report["summary"]["note_count"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

- generated candidate/review report의 known chord progression metadata를 chord-labeled evaluator에 연결하는 bridge를 추가했습니다.
- chord_progression, chords, request.chord_progression, source_report.request.chord_progression fallback을 지원합니다.
- raw MIDI를 커밋하지 않고 harness에서 outputs 아래 tiny generated-candidate fixture를 만들어 검증합니다.
- Issue #81 결과를 CURRENT_STATUS, CORE_PLAN, docs index에 기록했습니다.

## 결과

- fixture sample count: 1
- fixture note count: 16
- chord-tone ratio: 1.000
- tension ratio: 0.000
- outside ratio: 0.000
- 결론: generated candidate report에 chord metadata가 있으면 pitch-role evaluator로 연결할 수 있습니다. real reference chord label 문제는 아직 해결하지 않습니다.

## 검증

- ./.venv/bin/python -m unittest tests.test_generated_candidate_chord_eval
- bash scripts/agent_harness.sh stage-b-generated-chord-eval
- bash scripts/agent_harness.sh quick

Closes #81