### PR TITLE
Stage B data-guide generated chord eval 적용

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #81: Stage B generated candidate chord-labeled eval bridge.
+- Issue #83: Stage B data-guide hybrid generated chord eval.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -200,6 +200,12 @@ For Stage B generated candidate chord-labeled eval bridge changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-generated-chord-eval
+```
+
+For Stage B data-guide hybrid generated chord eval changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-data-guide-generated-chord-eval
 ```
 
 For Stage B data-derived motif template extraction changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -143,6 +143,7 @@ Stage B에서 명시하는 것:
 37. Stage B chord progression coverage audit
 38. Stage B chord-labeled evaluation subset contract
 39. Stage B generated candidate chord-labeled eval bridge
+40. Stage B data-guide hybrid generated chord evaluation
 
 가장 최근 의미 있는 결과:
 
@@ -162,6 +163,7 @@ Stage B에서 명시하는 것:
 - Issue #77 audits the local dataset for chord progression annotations and finds no usable candidate: role meta `2812` scanned with `0` hits, sidecars `0`, MIDI files scanned for text events `120` with `0` chord-text candidates.
 - Issue #79 adds a tiny chord-labeled eval contract so known chord labels can produce pitch-role sanity summaries without pretending real Brad/reference labels already exist.
 - Issue #81 connects generated candidate reports with known chord metadata to the chord-labeled evaluator.
+- Issue #83 applies that bridge to actual data-guide hybrid review candidates and shows `data_motif_guide_tones` has higher chord-tone ratio than `data_motif`.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -370,6 +372,9 @@ Stage B에서 명시하는 것:
 - Issue #79 result: fixture chord-tone ratio는 `0.844`, tension ratio는 `0.156`, outside ratio는 `0.000`이다.
 - Issue #81 result: generated candidate bridge fixture `1` sample, `16` notes로 report-to-evaluator 연결을 검증했다.
 - Issue #81 result: fixture chord-tone ratio는 `1.000`, tension ratio는 `0.000`, outside ratio는 `0.000`이다.
+- Issue #83 result: data-guide hybrid generated chord eval은 `6` candidates, `192` notes를 평가했다.
+- Issue #83 result: aggregate chord-tone ratio는 `0.656`, tension ratio는 `0.120`, outside ratio는 `0.000`이다.
+- Issue #83 result: `data_motif` chord-tone ratio는 `0.500`, `data_motif_guide_tones` chord-tone ratio는 `0.812`이다.
 
 해석:
 
@@ -379,7 +384,7 @@ Stage B에서 명시하는 것:
 - `approach_tensions`는 pitch-level resolution을 만들지만, 이 또한 jazz vocabulary 자체는 아니다.
 - `swing_motif_approach`는 기계적인 grid 반복을 줄였지만, 이 또한 jazz vocabulary 자체는 아니다.
 - real phrase reference stats와 motif extraction 기준으로 보면 다음은 hand-written rhythm rule 확장이 아니라 data-derived motif/cadence control 쪽이 맞다.
-- 다만 pitch-role 쪽은 real reference chord label이 아직 없으므로, 다음 pitch grammar 개선은 실제 generated review package에 bridge를 적용하고 이후 수동 reference labels를 넣는 순서가 맞다.
+- 다만 pitch-role 쪽은 real reference chord label이 아직 없으므로, 다음 pitch grammar 개선은 generated review markdown에 chord eval summary를 붙이고 이후 수동 reference labels를 넣는 순서가 맞다.
 
 ### Phase 3.10. Swing/Motif Phrase Grammar
 
@@ -649,20 +654,24 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B generated candidate chord-labeled eval bridge 추가
+Stage B data-guide hybrid generated chord eval 적용
 ```
 
 결과:
 
-- generated candidate/review report의 known chord progression metadata를 chord-labeled evaluator에 연결했다.
-- supported metadata source: `chord_progression`, `chords`, `request.chord_progression`, `source_report.request.chord_progression`.
-- harness는 raw MIDI를 커밋하지 않고 outputs 아래 tiny fixture를 생성한다.
-- harness result: sample count `1`, note count `16`, chord-tone ratio `1.000`, tension ratio `0.000`, outside ratio `0.000`.
+- `stage-b-data-guide-hybrid` review package에 generated chord eval bridge를 적용했다.
+- evaluated candidates: `6`
+- note count: `192`
+- aggregate chord-tone ratio: `0.656`
+- aggregate tension ratio: `0.120`
+- outside ratio: `0.000`
+- `data_motif` chord-tone ratio: `0.500`
+- `data_motif_guide_tones` chord-tone ratio: `0.812`
 
 다음 작업:
 
-- 실제 `stage-b-data-guide-hybrid` review manifest에 generated chord eval bridge를 적용한다.
-- generated review markdown에 bridge report 요약을 같이 붙인다.
+- generated review markdown에 chord eval summary를 같이 붙인다.
+- review export가 MIDI 파일명, rhythm metrics, chord-role metrics를 한 화면에서 보여주게 만든다.
 - real Brad/reference chord label은 아직 임의로 넣지 않는다.
 
 ## 10. 한 문장 요약

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-81-stage-b-generated-chord-eval-bridge`
+- `issue-83-stage-b-data-guide-generated-chord-eval`
 
 현재 범위가 아닌 것:
 
@@ -35,6 +35,44 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
 ## Latest Probe Result
+
+Issue #83은 Issue #81의 bridge를 실제 `stage-b-data-guide-hybrid` review package에 적용한 단계다.
+
+중요한 전제:
+
+- raw generated MIDI는 `outputs/` artifact로만 둔다.
+- `review_manifest.json`의 known chord progression metadata만 사용한다.
+- real Brad/reference chord label 문제는 아직 해결되지 않았다.
+
+Implemented:
+
+- `stage-b-data-guide-hybrid` review package 생성
+- generated chord eval bridge 적용
+- `data_motif` vs `data_motif_guide_tones` chord-role profile 비교
+- `scripts/agent_harness.sh stage-b-data-guide-generated-chord-eval`
+- docs:
+  - `docs/STAGE_B_DATA_GUIDE_GENERATED_CHORD_EVAL_2026-05-22.md`
+
+Result:
+
+- evaluated candidate count: `6`
+- note count: `192`
+- aggregate chord-tone ratio: `0.656`
+- aggregate tension ratio: `0.120`
+- aggregate outside ratio: `0.000`
+- `data_motif` chord-tone ratio: `0.500`
+- `data_motif_guide_tones` chord-tone ratio: `0.812`
+- `data_motif` approach ratio: `0.281-0.312`
+- `data_motif_guide_tones` approach ratio: `0.156`
+- report: `outputs/stage_b_generated_chord_eval/harness_stage_b_data_guide_generated_chord_eval/generated_chord_eval_report.md`
+
+Decision:
+
+- `data_motif_guide_tones`는 실제로 chord-tone 쪽으로 더 안전하게 기울어져 있다.
+- 현재 문제가 outside note 폭주는 아니다.
+- 더 정확한 문제 후보는 chord-tone safety 과다, 낮은 tension 비율, phrase vocabulary 부족이다.
+
+## Previous Probe Result
 
 Issue #81은 Issue #79의 chord-labeled evaluator를 generated candidate report와 연결한 단계다.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,6 +92,8 @@
   - known chord labels가 있을 때 pitch-role summary를 계산할 수 있는 tiny evaluation contract와 manifest format.
 - `STAGE_B_GENERATED_CHORD_EVAL_2026-05-22.md`
   - generated candidate report의 known chord progression metadata를 chord-labeled evaluator에 연결하는 bridge.
+- `STAGE_B_DATA_GUIDE_GENERATED_CHORD_EVAL_2026-05-22.md`
+  - data-guide hybrid review package에 generated chord eval bridge를 적용해 `data_motif`와 `data_motif_guide_tones` pitch-role profile을 비교한 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -118,7 +120,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, and generated chord eval bridge를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, generated chord eval bridge, and data-guide generated chord eval을 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_DATA_GUIDE_GENERATED_CHORD_EVAL_2026-05-22.md
+++ b/docs/STAGE_B_DATA_GUIDE_GENERATED_CHORD_EVAL_2026-05-22.md
@@ -1,0 +1,100 @@
+# Stage B Data-Guide Hybrid Generated Chord Evaluation
+
+작성일: 2026-05-22
+
+## 배경
+
+Issue #81에서 generated candidate report를 chord-labeled evaluator에 연결하는 bridge를 만들었다.
+
+이번 단계는 그 bridge를 실제 Stage B data-guide hybrid review package에 적용한다.
+
+목적은 다음이다.
+
+- `data_motif`와 `data_motif_guide_tones` 후보의 chord-role profile을 같은 evaluator로 비교한다.
+- review MIDI를 듣기 전에 chord-tone/tension/approach/outside 비율을 확인한다.
+- raw generated MIDI는 계속 `outputs/` artifact로만 둔다.
+
+## 구현
+
+새 harness:
+
+```bash
+bash scripts/agent_harness.sh stage-b-data-guide-generated-chord-eval
+```
+
+실행 순서:
+
+1. `stage-b-data-guide-hybrid` review package를 생성한다.
+2. 생성된 `review_manifest.json`을 `evaluate_generated_candidate_chords.py`에 넣는다.
+3. top generated review MIDI 후보를 chord-labeled evaluator로 분석한다.
+
+입력:
+
+```text
+outputs/stage_b_data_motif_review/harness_stage_b_data_guide_generated_chord_eval/review_manifest.json
+```
+
+출력:
+
+```text
+outputs/stage_b_generated_chord_eval/harness_stage_b_data_guide_generated_chord_eval/generated_chord_eval_report.json
+outputs/stage_b_generated_chord_eval/harness_stage_b_data_guide_generated_chord_eval/generated_chord_eval_report.md
+```
+
+## 결과
+
+요약:
+
+| metric | value |
+|---|---:|
+| sample count | 6 |
+| note count | 192 |
+| chord-tone ratio | 0.656 |
+| tension ratio | 0.120 |
+| outside ratio | 0.000 |
+
+Candidate summary:
+
+| sample | notes | chord-tone | tension | approach | outside |
+|---|---:|---:|---:|---:|---:|
+| `data_motif_rank_1_sample_1` | 32 | 0.500 | 0.219 | 0.281 | 0.000 |
+| `data_motif_rank_2_sample_2` | 32 | 0.500 | 0.188 | 0.312 | 0.000 |
+| `data_motif_rank_3_sample_3` | 32 | 0.500 | 0.219 | 0.281 | 0.000 |
+| `data_motif_guide_tones_rank_1_sample_1` | 32 | 0.812 | 0.031 | 0.156 | 0.000 |
+| `data_motif_guide_tones_rank_2_sample_2` | 32 | 0.812 | 0.031 | 0.156 | 0.000 |
+| `data_motif_guide_tones_rank_3_sample_3` | 32 | 0.812 | 0.031 | 0.156 | 0.000 |
+
+## 판단
+
+이번 결과는 `data_motif_guide_tones`의 pitch grammar가 실제로 chord-tone 쪽으로 더 강하게 기울어져 있음을 보여준다.
+
+구체적으로:
+
+- `data_motif`는 chord-tone `0.500`이고 approach `0.281-0.312`가 많다.
+- `data_motif_guide_tones`는 chord-tone `0.812`이고 approach `0.156`으로 낮다.
+- outside ratio는 둘 다 `0.000`이다.
+
+따라서 현재 "초급 멜로디처럼 들린다"는 문제는 outside note 폭주가 아니다.
+
+더 정확한 문제 후보는 다음이다.
+
+- chord-tone safety가 너무 강함
+- tension 비율이 낮음
+- phrase vocabulary와 motif development가 아직 부족함
+
+## 다음 작업
+
+다음은 generated review markdown에 이 chord eval summary를 자동 첨부하는 것이다.
+
+그 다음 판단:
+
+- chord-tone이 너무 낮은 후보는 review 우선순위에서 내린다.
+- chord-tone이 높아도 초급스럽게 들리면 tension/approach/cadence vocabulary를 조정한다.
+- real reference chord labels는 계속 임의로 만들지 않는다.
+
+## Validation
+
+```bash
+bash scripts/agent_harness.sh stage-b-data-guide-generated-chord-eval
+bash scripts/agent_harness.sh quick
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -82,6 +82,8 @@ Modes:
                 Evaluate the tiny chord-labeled subset manifest and pitch-role summary contract.
   stage-b-generated-chord-eval
                 Evaluate generated candidate report bridge against known chord metadata.
+  stage-b-data-guide-generated-chord-eval
+                Generate data-guide hybrid review package and evaluate its known chord metadata.
   all           Run demo and tiny-compare.
 
 Environment:
@@ -829,6 +831,17 @@ run_stage_b_generated_chord_eval() {
     --candidate_limit 1
 }
 
+run_stage_b_data_guide_generated_chord_eval() {
+  local run_id="${RUN_ID:-harness_stage_b_data_guide_generated_chord_eval}"
+  print_header "Stage B data-guide hybrid review package"
+  RUN_ID="$run_id" run_stage_b_data_guide_hybrid
+  print_header "Stage B data-guide hybrid generated chord eval"
+  "$PYTHON_BIN" scripts/evaluate_generated_candidate_chords.py \
+    --run_id "$run_id" \
+    --candidate_report "outputs/stage_b_data_motif_review/${run_id}/review_manifest.json" \
+    --candidate_limit 6
+}
+
 case "$MODE" in
   status)
     run_status
@@ -928,6 +941,9 @@ case "$MODE" in
     ;;
   stage-b-generated-chord-eval)
     run_stage_b_generated_chord_eval
+    ;;
+  stage-b-data-guide-generated-chord-eval)
+    run_stage_b_data_guide_generated_chord_eval
     ;;
   all)
     run_demo


### PR DESCRIPTION
## 요약

- stage-b-data-guide-hybrid review package를 생성한 뒤 generated chord eval bridge를 적용하는 통합 harness를 추가했습니다.
- data_motif와 data_motif_guide_tones 후보의 chord-tone, tension, approach, outside profile을 같은 evaluator로 비교했습니다.
- raw generated MIDI와 report는 outputs artifact로만 유지하고 커밋하지 않았습니다.
- Issue #83 결과를 CURRENT_STATUS, CORE_PLAN, docs index에 기록했습니다.

## 결과

- evaluated candidates: 6
- note count: 192
- aggregate chord-tone ratio: 0.656
- aggregate tension ratio: 0.120
- aggregate outside ratio: 0.000
- data_motif chord-tone ratio: 0.500
- data_motif_guide_tones chord-tone ratio: 0.812
- 결론: 현재 문제는 outside note 폭주라기보다 chord-tone safety 과다, 낮은 tension 비율, phrase vocabulary 부족 쪽입니다.

## 검증

- bash scripts/agent_harness.sh stage-b-data-guide-generated-chord-eval
- bash scripts/agent_harness.sh quick

Closes #83