### PR TITLE
Stage B review markdown chord eval summary 첨부

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #83: Stage B data-guide hybrid generated chord eval.
+- Issue #85: Stage B review markdown chord eval summary.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -206,6 +206,12 @@ For Stage B data-guide hybrid generated chord eval changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-data-guide-generated-chord-eval
+```
+
+For Stage B review markdown chord eval summary changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-review-markdown-chord-eval
 ```
 
 For Stage B data-derived motif template extraction changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -144,6 +144,7 @@ Stage B에서 명시하는 것:
 38. Stage B chord-labeled evaluation subset contract
 39. Stage B generated candidate chord-labeled eval bridge
 40. Stage B data-guide hybrid generated chord evaluation
+41. Stage B review markdown chord eval summary
 
 가장 최근 의미 있는 결과:
 
@@ -164,6 +165,7 @@ Stage B에서 명시하는 것:
 - Issue #79 adds a tiny chord-labeled eval contract so known chord labels can produce pitch-role sanity summaries without pretending real Brad/reference labels already exist.
 - Issue #81 connects generated candidate reports with known chord metadata to the chord-labeled evaluator.
 - Issue #83 applies that bridge to actual data-guide hybrid review candidates and shows `data_motif_guide_tones` has higher chord-tone ratio than `data_motif`.
+- Issue #85 writes a combined review markdown so MIDI paths, rhythm metrics, and chord-role metrics can be reviewed together.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -375,6 +377,7 @@ Stage B에서 명시하는 것:
 - Issue #83 result: data-guide hybrid generated chord eval은 `6` candidates, `192` notes를 평가했다.
 - Issue #83 result: aggregate chord-tone ratio는 `0.656`, tension ratio는 `0.120`, outside ratio는 `0.000`이다.
 - Issue #83 result: `data_motif` chord-tone ratio는 `0.500`, `data_motif_guide_tones` chord-tone ratio는 `0.812`이다.
+- Issue #85 result: combined review markdown is written to `outputs/stage_b_generated_chord_eval/harness_stage_b_review_markdown_chord_eval/review_candidates_with_chord_eval.md`.
 
 해석:
 
@@ -384,7 +387,7 @@ Stage B에서 명시하는 것:
 - `approach_tensions`는 pitch-level resolution을 만들지만, 이 또한 jazz vocabulary 자체는 아니다.
 - `swing_motif_approach`는 기계적인 grid 반복을 줄였지만, 이 또한 jazz vocabulary 자체는 아니다.
 - real phrase reference stats와 motif extraction 기준으로 보면 다음은 hand-written rhythm rule 확장이 아니라 data-derived motif/cadence control 쪽이 맞다.
-- 다만 pitch-role 쪽은 real reference chord label이 아직 없으므로, 다음 pitch grammar 개선은 generated review markdown에 chord eval summary를 붙이고 이후 수동 reference labels를 넣는 순서가 맞다.
+- 다만 pitch-role 쪽은 real reference chord label이 아직 없으므로, 다음 개선은 listening review 결과를 구조화하고 이후 수동 reference labels를 넣는 순서가 맞다.
 
 ### Phase 3.10. Swing/Motif Phrase Grammar
 
@@ -654,24 +657,19 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B data-guide hybrid generated chord eval 적용
+Stage B review markdown chord eval summary 첨부
 ```
 
 결과:
 
-- `stage-b-data-guide-hybrid` review package에 generated chord eval bridge를 적용했다.
-- evaluated candidates: `6`
-- note count: `192`
-- aggregate chord-tone ratio: `0.656`
-- aggregate tension ratio: `0.120`
-- outside ratio: `0.000`
-- `data_motif` chord-tone ratio: `0.500`
-- `data_motif_guide_tones` chord-tone ratio: `0.812`
+- 기존 review markdown과 generated chord eval summary를 결합한 artifact를 만들었다.
+- output: `outputs/stage_b_generated_chord_eval/harness_stage_b_review_markdown_chord_eval/review_candidates_with_chord_eval.md`
+- combined markdown에는 MIDI path, context MIDI path, rhythm metrics, strict gate, chord-tone/tension/approach/outside summary가 함께 들어간다.
 
 다음 작업:
 
-- generated review markdown에 chord eval summary를 같이 붙인다.
-- review export가 MIDI 파일명, rhythm metrics, chord-role metrics를 한 화면에서 보여주게 만든다.
+- listening review notes schema를 만든다.
+- 후보별로 phrase/exercise, timing, chord fit, too safe/scalar/mechanical 여부를 기록한다.
 - real Brad/reference chord label은 아직 임의로 넣지 않는다.
 
 ## 10. 한 문장 요약

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-83-stage-b-data-guide-generated-chord-eval`
+- `issue-85-stage-b-review-markdown-chord-eval`
 
 현재 범위가 아닌 것:
 
@@ -35,6 +35,45 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
 ## Latest Probe Result
+
+Issue #85는 generated chord eval summary를 기존 review markdown과 결합한 단계다.
+
+중요한 전제:
+
+- raw generated MIDI는 `outputs/` artifact로만 둔다.
+- 원본 `review_candidates.md`는 수정하지 않는다.
+- combined markdown은 새 artifact로 생성한다.
+- real Brad/reference chord label 문제는 아직 해결되지 않았다.
+
+Implemented:
+
+- `scripts/evaluate_generated_candidate_chords.py --review_markdown`
+- combined review markdown writer
+- chord eval append markdown table
+- `scripts/agent_harness.sh stage-b-review-markdown-chord-eval`
+- docs:
+  - `docs/STAGE_B_REVIEW_MARKDOWN_CHORD_EVAL_2026-05-22.md`
+
+Result:
+
+- evaluated candidate count: `6`
+- note count: `192`
+- aggregate chord-tone ratio: `0.656`
+- aggregate tension ratio: `0.120`
+- aggregate outside ratio: `0.000`
+- `data_motif` chord-tone ratio: `0.500`
+- `data_motif_guide_tones` chord-tone ratio: `0.812`
+- approach ratio: `0.224`
+- outside ratio: `0.000`
+- combined review markdown:
+  - `outputs/stage_b_generated_chord_eval/harness_stage_b_review_markdown_chord_eval/review_candidates_with_chord_eval.md`
+
+Decision:
+
+- 이제 review markdown 한 파일에서 MIDI path, context path, rhythm metrics, chord-role metrics를 같이 볼 수 있다.
+- 다음 작업은 listening review 결과를 구조화해서 "좋다/나쁘다"를 말로 흘리지 않게 만드는 것이다.
+
+## Previous Probe Result
 
 Issue #83은 Issue #81의 bridge를 실제 `stage-b-data-guide-hybrid` review package에 적용한 단계다.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,6 +94,8 @@
   - generated candidate report의 known chord progression metadata를 chord-labeled evaluator에 연결하는 bridge.
 - `STAGE_B_DATA_GUIDE_GENERATED_CHORD_EVAL_2026-05-22.md`
   - data-guide hybrid review package에 generated chord eval bridge를 적용해 `data_motif`와 `data_motif_guide_tones` pitch-role profile을 비교한 결과.
+- `STAGE_B_REVIEW_MARKDOWN_CHORD_EVAL_2026-05-22.md`
+  - review candidates markdown과 generated chord eval summary를 결합해 청취 리뷰용 한 파일로 만든 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -120,7 +122,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, generated chord eval bridge, and data-guide generated chord eval을 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, generated chord eval bridge, data-guide generated chord eval, and review markdown chord eval summary를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_REVIEW_MARKDOWN_CHORD_EVAL_2026-05-22.md
+++ b/docs/STAGE_B_REVIEW_MARKDOWN_CHORD_EVAL_2026-05-22.md
@@ -1,0 +1,117 @@
+# Stage B Review Markdown With Chord Eval Summary
+
+작성일: 2026-05-22
+
+## 배경
+
+Issue #83에서 data-guide hybrid 후보의 generated chord eval report를 만들었다.
+
+이번 단계는 그 chord-role summary를 기존 review markdown과 결합한다.
+
+이유:
+
+- MIDI 파일명과 context MIDI path는 review markdown에 있다.
+- chord-tone/tension/approach/outside summary는 generated chord eval report에 있다.
+- 두 파일을 따로 보면 청취 리뷰 중 판단이 끊긴다.
+
+## 구현
+
+변경:
+
+- `scripts/evaluate_generated_candidate_chords.py`
+  - `--review_markdown`
+  - `--combined_review_markdown_name`
+  - `chord_eval_review_append_markdown()`
+  - `write_combined_review_markdown()`
+- `scripts/agent_harness.sh stage-b-review-markdown-chord-eval`
+
+새 harness:
+
+```bash
+bash scripts/agent_harness.sh stage-b-review-markdown-chord-eval
+```
+
+출력:
+
+```text
+outputs/stage_b_generated_chord_eval/harness_stage_b_review_markdown_chord_eval/review_candidates_with_chord_eval.md
+```
+
+원본 review markdown은 수정하지 않는다.
+
+## 결과
+
+Combined markdown에는 다음이 함께 들어간다.
+
+- 기존 review candidates table
+- solo MIDI path
+- context MIDI path
+- rhythm metrics
+- strict gate result
+- generated chord eval summary
+- candidate별 chord-tone/tension/approach/outside ratio
+
+요약:
+
+| metric | value |
+|---|---:|
+| evaluated candidates | 6 |
+| note count | 192 |
+| chord-tone ratio | 0.656 |
+| tension ratio | 0.120 |
+| approach ratio | 0.224 |
+| outside ratio | 0.000 |
+
+Candidate chord-role summary:
+
+| sample | chord-tone | tension | approach | outside |
+|---|---:|---:|---:|---:|
+| `data_motif_rank_1_sample_1` | 0.500 | 0.219 | 0.281 | 0.000 |
+| `data_motif_rank_2_sample_2` | 0.500 | 0.188 | 0.312 | 0.000 |
+| `data_motif_rank_3_sample_3` | 0.500 | 0.219 | 0.281 | 0.000 |
+| `data_motif_guide_tones_rank_1_sample_1` | 0.812 | 0.031 | 0.156 | 0.000 |
+| `data_motif_guide_tones_rank_2_sample_2` | 0.812 | 0.031 | 0.156 | 0.000 |
+| `data_motif_guide_tones_rank_3_sample_3` | 0.812 | 0.031 | 0.156 | 0.000 |
+
+## 판단
+
+이제 청취 리뷰용 markdown에서 다음을 한 번에 볼 수 있다.
+
+- 어떤 MIDI를 들어야 하는지
+- context MIDI가 어디 있는지
+- rhythm profile이 어떤지
+- chord-role profile이 어떤지
+
+이는 모델 품질 성공 선언이 아니다.
+
+의미는 다음이다.
+
+- generated 후보를 듣기 전에 수치상 이상한 후보를 빠르게 걸러낼 수 있다.
+- `data_motif_guide_tones`가 더 안전한 chord-tone line인지, 너무 안전해서 초급스럽게 들리는지 청취 리뷰로 확인할 수 있다.
+
+## 다음 작업
+
+다음은 listening review 결과를 구조화하는 것이다.
+
+후보:
+
+```text
+Stage B listening review notes schema 추가
+```
+
+필요한 필드:
+
+- candidate id
+- heard as phrase or exercise
+- timing acceptable
+- chord context fit
+- too safe / too scalar / too mechanical
+- keep / reject / needs follow-up
+
+## Validation
+
+```bash
+./.venv/bin/python -m unittest tests.test_generated_candidate_chord_eval
+bash scripts/agent_harness.sh stage-b-review-markdown-chord-eval
+bash scripts/agent_harness.sh quick
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -84,6 +84,8 @@ Modes:
                 Evaluate generated candidate report bridge against known chord metadata.
   stage-b-data-guide-generated-chord-eval
                 Generate data-guide hybrid review package and evaluate its known chord metadata.
+  stage-b-review-markdown-chord-eval
+                Generate data-guide hybrid review package and write a combined chord-eval review markdown.
   all           Run demo and tiny-compare.
 
 Environment:
@@ -842,6 +844,18 @@ run_stage_b_data_guide_generated_chord_eval() {
     --candidate_limit 6
 }
 
+run_stage_b_review_markdown_chord_eval() {
+  local run_id="${RUN_ID:-harness_stage_b_review_markdown_chord_eval}"
+  print_header "Stage B data-guide hybrid review package"
+  RUN_ID="$run_id" run_stage_b_data_guide_hybrid
+  print_header "Stage B combined review markdown with chord eval"
+  "$PYTHON_BIN" scripts/evaluate_generated_candidate_chords.py \
+    --run_id "$run_id" \
+    --candidate_report "outputs/stage_b_data_motif_review/${run_id}/review_manifest.json" \
+    --review_markdown "outputs/stage_b_data_motif_review/${run_id}/review_candidates.md" \
+    --candidate_limit 6
+}
+
 case "$MODE" in
   status)
     run_status
@@ -944,6 +958,9 @@ case "$MODE" in
     ;;
   stage-b-data-guide-generated-chord-eval)
     run_stage_b_data_guide_generated_chord_eval
+    ;;
+  stage-b-review-markdown-chord-eval)
+    run_stage_b_review_markdown_chord_eval
     ;;
   all)
     run_demo

--- a/scripts/evaluate_generated_candidate_chords.py
+++ b/scripts/evaluate_generated_candidate_chords.py
@@ -205,6 +205,53 @@ def markdown_report(report: dict[str, Any]) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
+def chord_eval_review_append_markdown(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    ratios = summary["role_ratios"]
+    lines = [
+        "## Generated Chord Eval Summary",
+        "",
+        f"- source report: `{report['source_report_path']}`",
+        f"- chord progression: `{', '.join(report['chord_progression'])}`",
+        f"- evaluated candidates: `{summary['sample_count']}`",
+        f"- note count: `{summary['note_count']}`",
+        f"- chord-tone ratio: `{ratios['chord_tone_ratio']:.3f}`",
+        f"- tension ratio: `{ratios['tension_ratio']:.3f}`",
+        f"- approach ratio: `{ratios['approach_ratio']:.3f}`",
+        f"- outside ratio: `{ratios['outside_ratio']:.3f}`",
+        "",
+        "| sample | chord-tone | tension | approach | outside |",
+        "|---|---:|---:|---:|---:|",
+    ]
+    for sample in report["samples"]:
+        sample_ratios = sample["role_ratios"]
+        lines.append(
+            "| {sample_id} | {chord:.3f} | {tension:.3f} | {approach:.3f} | {outside:.3f} |".format(
+                sample_id=sample["sample_id"],
+                chord=sample_ratios["chord_tone_ratio"],
+                tension=sample_ratios["tension_ratio"],
+                approach=sample_ratios["approach_ratio"],
+                outside=sample_ratios["outside_ratio"],
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "Boundary: this uses generated candidate chord metadata only; it does not label real reference MIDI.",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_combined_review_markdown(review_markdown_path: Path, report: dict[str, Any], output_path: Path) -> None:
+    if not review_markdown_path.exists():
+        raise ManifestError(f"review markdown does not exist: {review_markdown_path}")
+    original = review_markdown_path.read_text(encoding="utf-8").rstrip()
+    combined = original + "\n\n---\n\n" + chord_eval_review_append_markdown(report)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(combined, encoding="utf-8")
+
+
 def write_tiny_fixture(run_dir: Path) -> Path:
     fixture_dir = run_dir / "fixture_generated_candidates"
     fixture_dir.mkdir(parents=True, exist_ok=True)
@@ -269,6 +316,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--candidate_limit", type=int, default=3)
     parser.add_argument("--default_bpm", type=float, default=124.0)
     parser.add_argument("--write_tiny_fixture", action="store_true")
+    parser.add_argument("--review_markdown", type=str, default=None)
+    parser.add_argument("--combined_review_markdown_name", type=str, default="review_candidates_with_chord_eval.md")
     return parser.parse_args()
 
 
@@ -290,6 +339,10 @@ def main() -> int:
     )
     write_json(run_dir / "generated_chord_eval_report.json", report)
     (run_dir / "generated_chord_eval_report.md").write_text(markdown_report(report), encoding="utf-8")
+    combined_review_path: Path | None = None
+    if args.review_markdown:
+        combined_review_path = run_dir / str(args.combined_review_markdown_name)
+        write_combined_review_markdown(Path(args.review_markdown), report=report, output_path=combined_review_path)
     print(
         json.dumps(
             {
@@ -299,6 +352,7 @@ def main() -> int:
                 "tension_ratio": report["summary"]["role_ratios"]["tension_ratio"],
                 "outside_ratio": report["summary"]["role_ratios"]["outside_ratio"],
                 "report_path": str(run_dir / "generated_chord_eval_report.md"),
+                "combined_review_markdown_path": str(combined_review_path) if combined_review_path else None,
             },
             ensure_ascii=True,
             indent=2,

--- a/tests/test_generated_candidate_chord_eval.py
+++ b/tests/test_generated_candidate_chord_eval.py
@@ -10,7 +10,9 @@ import pretty_midi
 from scripts.evaluate_generated_candidate_chords import (
     ManifestError,
     build_report_from_candidate_report,
+    chord_eval_review_append_markdown,
     expand_chords,
+    write_combined_review_markdown,
     write_tiny_fixture,
 )
 
@@ -102,6 +104,32 @@ class GeneratedCandidateChordEvalTest(unittest.TestCase):
 
             self.assertEqual(report["summary"]["sample_count"], 1)
             self.assertGreater(report["summary"]["note_count"], 0)
+
+    def test_chord_eval_review_append_contains_candidate_table(self) -> None:
+        with TemporaryDirectory() as tmp:
+            report_path = write_tiny_fixture(Path(tmp))
+            report = build_report_from_candidate_report(report_path)
+
+            markdown = chord_eval_review_append_markdown(report)
+
+            self.assertIn("Generated Chord Eval Summary", markdown)
+            self.assertIn("chord-tone", markdown)
+            self.assertIn("fixture_generated_rank_1_sample_1", markdown)
+
+    def test_write_combined_review_markdown_appends_summary(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            report_path = write_tiny_fixture(root)
+            report = build_report_from_candidate_report(report_path)
+            review_path = root / "review_candidates.md"
+            output_path = root / "combined.md"
+            review_path.write_text("# Review Candidates\n\nOriginal content.\n", encoding="utf-8")
+
+            write_combined_review_markdown(review_path, report=report, output_path=output_path)
+
+            combined = output_path.read_text(encoding="utf-8")
+            self.assertIn("Original content.", combined)
+            self.assertIn("Generated Chord Eval Summary", combined)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 요약

- generated chord eval summary를 기존 review markdown 뒤에 붙인 combined markdown 출력 기능을 추가했습니다.
- 원본 review_candidates.md는 수정하지 않고 outputs 아래 review_candidates_with_chord_eval.md를 생성합니다.
- data-guide hybrid review 후보를 볼 때 MIDI path, context MIDI path, rhythm metrics, chord-role metrics를 한 파일에서 확인할 수 있습니다.
- Issue #85 결과를 CURRENT_STATUS, CORE_PLAN, docs index에 기록했습니다.

## 결과

- combined review markdown path: outputs/stage_b_generated_chord_eval/harness_stage_b_review_markdown_chord_eval/review_candidates_with_chord_eval.md
- evaluated candidates: 6
- note count: 192
- chord-tone ratio: 0.656
- tension ratio: 0.120
- approach ratio: 0.224
- outside ratio: 0.000

## 검증

- ./.venv/bin/python -m unittest tests.test_generated_candidate_chord_eval
- bash scripts/agent_harness.sh stage-b-review-markdown-chord-eval
- bash scripts/agent_harness.sh quick

Closes #85