### PR TITLE
Stage B listening review notes schema 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #85: Stage B review markdown chord eval summary.
+- Issue #87: Stage B listening review notes schema.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -212,6 +212,12 @@ For Stage B review markdown chord eval summary changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-review-markdown-chord-eval
+```
+
+For Stage B listening review notes schema changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-listening-review-notes
 ```
 
 For Stage B data-derived motif template extraction changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -145,6 +145,7 @@ Stage B에서 명시하는 것:
 39. Stage B generated candidate chord-labeled eval bridge
 40. Stage B data-guide hybrid generated chord evaluation
 41. Stage B review markdown chord eval summary
+42. Stage B listening review notes schema
 
 가장 최근 의미 있는 결과:
 
@@ -166,6 +167,7 @@ Stage B에서 명시하는 것:
 - Issue #81 connects generated candidate reports with known chord metadata to the chord-labeled evaluator.
 - Issue #83 applies that bridge to actual data-guide hybrid review candidates and shows `data_motif_guide_tones` has higher chord-tone ratio than `data_motif`.
 - Issue #85 writes a combined review markdown so MIDI paths, rhythm metrics, and chord-role metrics can be reviewed together.
+- Issue #87 creates a structured listening review notes schema so subjective review can be recorded consistently instead of as loose comments.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -378,6 +380,7 @@ Stage B에서 명시하는 것:
 - Issue #83 result: aggregate chord-tone ratio는 `0.656`, tension ratio는 `0.120`, outside ratio는 `0.000`이다.
 - Issue #83 result: `data_motif` chord-tone ratio는 `0.500`, `data_motif_guide_tones` chord-tone ratio는 `0.812`이다.
 - Issue #85 result: combined review markdown is written to `outputs/stage_b_generated_chord_eval/harness_stage_b_review_markdown_chord_eval/review_candidates_with_chord_eval.md`.
+- Issue #87 result: listening review notes template contains `6` pending candidates and validates phrase quality, timing, chord fit, issue flags, and decision enums.
 
 해석:
 
@@ -387,7 +390,7 @@ Stage B에서 명시하는 것:
 - `approach_tensions`는 pitch-level resolution을 만들지만, 이 또한 jazz vocabulary 자체는 아니다.
 - `swing_motif_approach`는 기계적인 grid 반복을 줄였지만, 이 또한 jazz vocabulary 자체는 아니다.
 - real phrase reference stats와 motif extraction 기준으로 보면 다음은 hand-written rhythm rule 확장이 아니라 data-derived motif/cadence control 쪽이 맞다.
-- 다만 pitch-role 쪽은 real reference chord label이 아직 없으므로, 다음 개선은 listening review 결과를 구조화하고 이후 수동 reference labels를 넣는 순서가 맞다.
+- 다만 pitch-role 쪽은 real reference chord label이 아직 없으므로, 다음 개선은 filled listening notes를 aggregate하고 이후 수동 reference labels를 넣는 순서가 맞다.
 
 ### Phase 3.10. Swing/Motif Phrase Grammar
 
@@ -657,19 +660,22 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B review markdown chord eval summary 첨부
+Stage B listening review notes schema 추가
 ```
 
 결과:
 
-- 기존 review markdown과 generated chord eval summary를 결합한 artifact를 만들었다.
-- output: `outputs/stage_b_generated_chord_eval/harness_stage_b_review_markdown_chord_eval/review_candidates_with_chord_eval.md`
-- combined markdown에는 MIDI path, context MIDI path, rhythm metrics, strict gate, chord-tone/tension/approach/outside summary가 함께 들어간다.
+- generated chord eval report에서 listening review notes template을 만든다.
+- output: `outputs/stage_b_listening_review_notes/harness_stage_b_listening_review_notes/review_notes_template.json`
+- candidate count: `6`
+- reviewed count: `0`
+- pending count: `6`
+- fields: `phrase_quality`, `timing`, `chord_fit`, `issues`, `decision`, `notes`
 
 다음 작업:
 
-- listening review notes schema를 만든다.
-- 후보별로 phrase/exercise, timing, chord fit, too safe/scalar/mechanical 여부를 기록한다.
+- filled listening review notes를 aggregate해서 다음 generation rule을 결정한다.
+- `too_safe`, `too_scalar`, `too_mechanical`, `bad_timing`, `bad_chord_fit` 같은 issue flag를 기준으로 후속 issue를 분기한다.
 - real Brad/reference chord label은 아직 임의로 넣지 않는다.
 
 ## 10. 한 문장 요약

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-85-stage-b-review-markdown-chord-eval`
+- `issue-87-stage-b-listening-review-notes`
 
 현재 범위가 아닌 것:
 
@@ -35,6 +35,45 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
 ## Latest Probe Result
+
+Issue #87은 청취 리뷰 결과를 후보별로 구조화해 기록할 notes schema를 만든 단계다.
+
+중요한 전제:
+
+- raw generated MIDI는 `outputs/` artifact로만 둔다.
+- Codex가 subjective listening result를 임의 작성하지 않는다.
+- 사람이 들은 결과를 같은 enum/field로 기록하기 위한 양식이다.
+- real Brad/reference chord label 문제는 아직 해결되지 않았다.
+
+Implemented:
+
+- listening review notes schema
+- review notes template generator
+- enum/status validator
+- `scripts/build_listening_review_notes.py`
+- `scripts/agent_harness.sh stage-b-listening-review-notes`
+- docs:
+  - `docs/STAGE_B_LISTENING_REVIEW_NOTES_2026-05-22.md`
+
+Result:
+
+- candidate count: `6`
+- reviewed count: `0`
+- pending count: `6`
+- decisions:
+  - keep: `0`
+  - needs_followup: `0`
+  - reject: `0`
+  - pending: `6`
+- review notes template:
+  - `outputs/stage_b_listening_review_notes/harness_stage_b_listening_review_notes/review_notes_template.json`
+
+Decision:
+
+- 이제 실제 청취 리뷰 결과를 `phrase_quality`, `timing`, `chord_fit`, `issues`, `decision`으로 분리해서 기록할 수 있다.
+- 다음 작업은 filled review notes를 aggregate해 다음 generation rule을 결정하는 것이다.
+
+## Previous Probe Result
 
 Issue #85는 generated chord eval summary를 기존 review markdown과 결합한 단계다.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,6 +96,8 @@
   - data-guide hybrid review package에 generated chord eval bridge를 적용해 `data_motif`와 `data_motif_guide_tones` pitch-role profile을 비교한 결과.
 - `STAGE_B_REVIEW_MARKDOWN_CHORD_EVAL_2026-05-22.md`
   - review candidates markdown과 generated chord eval summary를 결합해 청취 리뷰용 한 파일로 만든 결과.
+- `STAGE_B_LISTENING_REVIEW_NOTES_2026-05-22.md`
+  - 청취 리뷰 판단을 후보별 enum/notes schema로 기록하기 위한 template generator 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -122,7 +124,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, generated chord eval bridge, data-guide generated chord eval, and review markdown chord eval summary를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, generated chord eval bridge, data-guide generated chord eval, review markdown chord eval summary, and listening review notes schema를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_LISTENING_REVIEW_NOTES_2026-05-22.md
+++ b/docs/STAGE_B_LISTENING_REVIEW_NOTES_2026-05-22.md
@@ -1,0 +1,169 @@
+# Stage B Listening Review Notes Schema
+
+작성일: 2026-05-22
+
+## 배경
+
+Issue #85에서 review markdown과 chord eval summary를 한 파일로 결합했다.
+
+이번 단계는 실제 청취 리뷰 결과를 후보별로 구조화해서 기록할 schema와 template generator를 만든다.
+
+중요한 경계:
+
+- Codex가 청취 판단을 임의로 작성하지 않는다.
+- 이 schema는 사람이 들은 결과를 일관되게 기록하기 위한 양식이다.
+- raw MIDI/generated output은 계속 `outputs/` artifact로만 둔다.
+
+## 구현
+
+새 스크립트:
+
+```bash
+python scripts/build_listening_review_notes.py
+```
+
+새 harness:
+
+```bash
+bash scripts/agent_harness.sh stage-b-listening-review-notes
+```
+
+실행 순서:
+
+1. combined review markdown with chord eval을 생성한다.
+2. generated chord eval report에서 candidate list를 읽는다.
+3. `review_notes_template.json`을 만든다.
+4. enum/status validation을 수행한다.
+
+출력:
+
+```text
+outputs/stage_b_listening_review_notes/harness_stage_b_listening_review_notes/review_notes_template.json
+outputs/stage_b_listening_review_notes/harness_stage_b_listening_review_notes/review_notes_summary.json
+outputs/stage_b_listening_review_notes/harness_stage_b_listening_review_notes/review_notes_summary.md
+```
+
+## Schema
+
+각 candidate는 다음 정보를 가진다.
+
+Source metrics:
+
+- `note_count`
+- `unique_pitch_count`
+- `chord_tone_ratio`
+- `tension_ratio`
+- `approach_ratio`
+- `outside_ratio`
+
+Listening fields:
+
+- `status`
+  - `pending`
+  - `reviewed`
+- `phrase_quality`
+  - `pending`
+  - `phrase`
+  - `fragment`
+  - `exercise`
+  - `invalid`
+- `timing`
+  - `pending`
+  - `acceptable`
+  - `too_stiff`
+  - `too_loose`
+  - `off_grid`
+- `chord_fit`
+  - `pending`
+  - `fits`
+  - `too_safe`
+  - `too_outside`
+  - `unclear`
+- `issues`
+  - `too_safe`
+  - `too_scalar`
+  - `too_mechanical`
+  - `weak_phrase`
+  - `bad_timing`
+  - `bad_chord_fit`
+  - `too_repetitive`
+  - `too_sparse`
+  - `other`
+- `decision`
+  - `pending`
+  - `keep`
+  - `reject`
+  - `needs_followup`
+- `notes`
+
+## 결과
+
+Harness result:
+
+| metric | value |
+|---|---:|
+| candidate count | 6 |
+| reviewed | 0 |
+| pending | 6 |
+| keep | 0 |
+| needs_followup | 0 |
+| reject | 0 |
+
+첫 candidate template 예:
+
+```json
+{
+  "candidate_id": "data_motif_rank_1_sample_1",
+  "source_metrics": {
+    "note_count": 32,
+    "unique_pitch_count": 18,
+    "chord_tone_ratio": 0.5,
+    "tension_ratio": 0.21875,
+    "approach_ratio": 0.28125,
+    "outside_ratio": 0.0
+  },
+  "listening": {
+    "status": "pending",
+    "phrase_quality": "pending",
+    "timing": "pending",
+    "chord_fit": "pending",
+    "issues": [],
+    "decision": "pending",
+    "notes": ""
+  }
+}
+```
+
+## 판단
+
+이제 다음 청취 리뷰는 자유서술이 아니라 structured note로 남길 수 있다.
+
+의미:
+
+- "좋다/별로다"가 아니라 왜 별로인지 분리할 수 있다.
+- timing 문제인지, chord fit 문제인지, phrase vocabulary 문제인지 구분할 수 있다.
+- 다음 generation rule 수정의 근거가 생긴다.
+
+## 다음 작업
+
+다음은 사람이 실제로 combined review markdown을 보면서 `review_notes_template.json`을 채우는 단계다.
+
+그 후 자동화할 수 있는 작업:
+
+```text
+filled listening review notes를 aggregate해서 다음 generation rule을 결정한다.
+```
+
+예:
+
+- `too_safe`가 많으면 tension/approach vocabulary를 늘린다.
+- `too_mechanical`이 많으면 motif/rhythm variation을 강화한다.
+- `bad_timing`이 많으면 straight-grid 기본값을 유지한다.
+
+## Validation
+
+```bash
+./.venv/bin/python -m unittest tests.test_listening_review_notes
+bash scripts/agent_harness.sh stage-b-listening-review-notes
+bash scripts/agent_harness.sh quick
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -86,6 +86,8 @@ Modes:
                 Generate data-guide hybrid review package and evaluate its known chord metadata.
   stage-b-review-markdown-chord-eval
                 Generate data-guide hybrid review package and write a combined chord-eval review markdown.
+  stage-b-listening-review-notes
+                Generate pending listening review notes from the combined chord-eval review flow.
   all           Run demo and tiny-compare.
 
 Environment:
@@ -136,6 +138,7 @@ run_quick() {
     scripts/audit_chord_progression_coverage.py \
     scripts/evaluate_chord_labeled_subset.py \
     scripts/evaluate_generated_candidate_chords.py \
+    scripts/build_listening_review_notes.py \
     scripts/train_stage_a_full.py \
     scripts/train_stage_a_adapter.py \
     inference/app \
@@ -856,6 +859,17 @@ run_stage_b_review_markdown_chord_eval() {
     --candidate_limit 6
 }
 
+run_stage_b_listening_review_notes() {
+  local run_id="${RUN_ID:-harness_stage_b_listening_review_notes}"
+  print_header "Stage B combined review markdown with chord eval"
+  RUN_ID="$run_id" run_stage_b_review_markdown_chord_eval
+  print_header "Stage B listening review notes template"
+  "$PYTHON_BIN" scripts/build_listening_review_notes.py \
+    --run_id "$run_id" \
+    --generated_chord_eval_report "outputs/stage_b_generated_chord_eval/${run_id}/generated_chord_eval_report.json" \
+    --source_review_markdown "outputs/stage_b_generated_chord_eval/${run_id}/review_candidates_with_chord_eval.md"
+}
+
 case "$MODE" in
   status)
     run_status
@@ -961,6 +975,9 @@ case "$MODE" in
     ;;
   stage-b-review-markdown-chord-eval)
     run_stage_b_review_markdown_chord_eval
+    ;;
+  stage-b-listening-review-notes)
+    run_stage_b_listening_review_notes
     ;;
   all)
     run_demo

--- a/scripts/build_listening_review_notes.py
+++ b/scripts/build_listening_review_notes.py
@@ -1,0 +1,195 @@
+"""Build and validate structured listening review notes for Stage B candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+
+SCHEMA_VERSION = "stage_b_listening_review_notes_v1"
+
+PHRASE_QUALITY_VALUES = {"pending", "phrase", "fragment", "exercise", "invalid"}
+TIMING_VALUES = {"pending", "acceptable", "too_stiff", "too_loose", "off_grid"}
+CHORD_FIT_VALUES = {"pending", "fits", "too_safe", "too_outside", "unclear"}
+DECISION_VALUES = {"pending", "keep", "reject", "needs_followup"}
+ISSUE_VALUES = {
+    "too_safe",
+    "too_scalar",
+    "too_mechanical",
+    "weak_phrase",
+    "bad_timing",
+    "bad_chord_fit",
+    "too_repetitive",
+    "too_sparse",
+    "other",
+}
+
+
+class ReviewNotesError(ValueError):
+    pass
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def build_candidate_note(sample: dict[str, Any]) -> dict[str, Any]:
+    ratios = sample.get("role_ratios", {})
+    return {
+        "candidate_id": str(sample["sample_id"]),
+        "source_metrics": {
+            "note_count": int(sample.get("note_count", 0) or 0),
+            "unique_pitch_count": int(sample.get("unique_pitch_count", 0) or 0),
+            "chord_tone_ratio": float(ratios.get("chord_tone_ratio", 0.0) or 0.0),
+            "tension_ratio": float(ratios.get("tension_ratio", 0.0) or 0.0),
+            "approach_ratio": float(ratios.get("approach_ratio", 0.0) or 0.0),
+            "outside_ratio": float(ratios.get("outside_ratio", 0.0) or 0.0),
+        },
+        "listening": {
+            "status": "pending",
+            "phrase_quality": "pending",
+            "timing": "pending",
+            "chord_fit": "pending",
+            "issues": [],
+            "decision": "pending",
+            "notes": "",
+        },
+    }
+
+
+def build_review_notes_template(
+    generated_chord_eval_report: dict[str, Any],
+    source_review_markdown: str | None = None,
+) -> dict[str, Any]:
+    samples = generated_chord_eval_report.get("samples")
+    if not isinstance(samples, list) or not samples:
+        raise ReviewNotesError("generated chord eval report must contain non-empty samples")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "source_generated_chord_eval_report": str(generated_chord_eval_report.get("source_report_path", "")),
+        "source_review_markdown": source_review_markdown,
+        "reviewer": "",
+        "review_context": {
+            "listen_with_context_midi": True,
+            "compare_solo_and_context": True,
+            "do_not_infer_real_reference_chords": True,
+        },
+        "candidates": [build_candidate_note(sample) for sample in samples],
+    }
+
+
+def _require_enum(value: Any, allowed: set[str], path: str) -> None:
+    if value not in allowed:
+        raise ReviewNotesError(f"{path} must be one of {sorted(allowed)}")
+
+
+def validate_review_notes(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise ReviewNotesError(f"schema_version must be {SCHEMA_VERSION!r}")
+    candidates = payload.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise ReviewNotesError("candidates must be a non-empty list")
+    seen: set[str] = set()
+    completed = 0
+    decisions: dict[str, int] = {decision: 0 for decision in DECISION_VALUES}
+    for index, candidate in enumerate(candidates):
+        if not isinstance(candidate, dict):
+            raise ReviewNotesError(f"candidate {index} must be an object")
+        candidate_id = str(candidate.get("candidate_id") or "").strip()
+        if not candidate_id:
+            raise ReviewNotesError(f"candidate {index} candidate_id is required")
+        if candidate_id in seen:
+            raise ReviewNotesError(f"duplicate candidate_id: {candidate_id}")
+        seen.add(candidate_id)
+
+        listening = candidate.get("listening")
+        if not isinstance(listening, dict):
+            raise ReviewNotesError(f"{candidate_id}: listening object is required")
+        _require_enum(listening.get("status"), {"pending", "reviewed"}, f"{candidate_id}.listening.status")
+        _require_enum(listening.get("phrase_quality"), PHRASE_QUALITY_VALUES, f"{candidate_id}.listening.phrase_quality")
+        _require_enum(listening.get("timing"), TIMING_VALUES, f"{candidate_id}.listening.timing")
+        _require_enum(listening.get("chord_fit"), CHORD_FIT_VALUES, f"{candidate_id}.listening.chord_fit")
+        _require_enum(listening.get("decision"), DECISION_VALUES, f"{candidate_id}.listening.decision")
+        issues = listening.get("issues", [])
+        if not isinstance(issues, list):
+            raise ReviewNotesError(f"{candidate_id}.listening.issues must be a list")
+        for issue in issues:
+            _require_enum(issue, ISSUE_VALUES, f"{candidate_id}.listening.issues[]")
+        if listening.get("status") == "reviewed":
+            completed += 1
+        decisions[str(listening.get("decision"))] += 1
+    return {
+        "candidate_count": int(len(candidates)),
+        "reviewed_count": int(completed),
+        "pending_count": int(len(candidates) - completed),
+        "decision_counts": decisions,
+    }
+
+
+def markdown_summary(summary: dict[str, Any], output_path: Path) -> str:
+    lines = [
+        "# Stage B Listening Review Notes",
+        "",
+        f"- output: `{output_path}`",
+        f"- candidate count: `{summary['candidate_count']}`",
+        f"- reviewed: `{summary['reviewed_count']}`",
+        f"- pending: `{summary['pending_count']}`",
+        "",
+        "Decision counts:",
+        "",
+    ]
+    for decision, count in sorted(summary["decision_counts"].items()):
+        lines.append(f"- {decision}: `{count}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build or validate Stage B listening review notes")
+    parser.add_argument("--generated_chord_eval_report", type=str, default=None)
+    parser.add_argument("--source_review_markdown", type=str, default=None)
+    parser.add_argument("--review_notes", type=str, default=None)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=str(ROOT_DIR / "outputs" / "stage_b_listening_review_notes"),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    run_dir = Path(args.output_root) / run_id
+    if args.review_notes:
+        notes_path = Path(args.review_notes)
+        notes = read_json(notes_path)
+    else:
+        if not args.generated_chord_eval_report:
+            raise ReviewNotesError("--generated_chord_eval_report is required when --review_notes is not provided")
+        generated_report = read_json(Path(args.generated_chord_eval_report))
+        notes = build_review_notes_template(generated_report, source_review_markdown=args.source_review_markdown)
+        notes_path = run_dir / "review_notes_template.json"
+        write_json(notes_path, notes)
+    summary = validate_review_notes(notes)
+    write_json(run_dir / "review_notes_summary.json", summary)
+    (run_dir / "review_notes_summary.md").write_text(markdown_summary(summary, notes_path), encoding="utf-8")
+    print(json.dumps({**summary, "review_notes_path": str(notes_path)}, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_listening_review_notes.py
+++ b/tests/test_listening_review_notes.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.build_listening_review_notes import (
+    ReviewNotesError,
+    build_review_notes_template,
+    validate_review_notes,
+)
+
+
+class ListeningReviewNotesTest(unittest.TestCase):
+    def sample_generated_report(self) -> dict:
+        return {
+            "source_report_path": "outputs/example/review_manifest.json",
+            "samples": [
+                {
+                    "sample_id": "candidate_1",
+                    "note_count": 32,
+                    "unique_pitch_count": 12,
+                    "role_ratios": {
+                        "chord_tone_ratio": 0.75,
+                        "tension_ratio": 0.125,
+                        "approach_ratio": 0.125,
+                        "outside_ratio": 0.0,
+                    },
+                }
+            ],
+        }
+
+    def test_build_review_notes_template_defaults_to_pending(self) -> None:
+        notes = build_review_notes_template(self.sample_generated_report(), source_review_markdown="review.md")
+
+        self.assertEqual(notes["schema_version"], "stage_b_listening_review_notes_v1")
+        self.assertEqual(notes["candidates"][0]["candidate_id"], "candidate_1")
+        self.assertEqual(notes["candidates"][0]["listening"]["status"], "pending")
+        self.assertEqual(notes["candidates"][0]["source_metrics"]["chord_tone_ratio"], 0.75)
+
+    def test_validate_review_notes_counts_pending_candidates(self) -> None:
+        notes = build_review_notes_template(self.sample_generated_report())
+
+        summary = validate_review_notes(notes)
+
+        self.assertEqual(summary["candidate_count"], 1)
+        self.assertEqual(summary["pending_count"], 1)
+        self.assertEqual(summary["decision_counts"]["pending"], 1)
+
+    def test_validate_review_notes_accepts_reviewed_candidate(self) -> None:
+        notes = build_review_notes_template(self.sample_generated_report())
+        notes["candidates"][0]["listening"].update(
+            {
+                "status": "reviewed",
+                "phrase_quality": "exercise",
+                "timing": "acceptable",
+                "chord_fit": "too_safe",
+                "issues": ["too_safe", "too_mechanical"],
+                "decision": "needs_followup",
+                "notes": "Sounds valid but too safe.",
+            }
+        )
+
+        summary = validate_review_notes(notes)
+
+        self.assertEqual(summary["reviewed_count"], 1)
+        self.assertEqual(summary["decision_counts"]["needs_followup"], 1)
+
+    def test_validate_review_notes_rejects_invalid_enum(self) -> None:
+        notes = build_review_notes_template(self.sample_generated_report())
+        notes["candidates"][0]["listening"]["timing"] = "swingy"
+
+        with self.assertRaises(ReviewNotesError):
+            validate_review_notes(notes)
+
+    def test_validate_review_notes_rejects_duplicate_candidate_id(self) -> None:
+        notes = build_review_notes_template(self.sample_generated_report())
+        notes["candidates"].append(dict(notes["candidates"][0]))
+
+        with self.assertRaises(ReviewNotesError):
+            validate_review_notes(notes)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

- generated chord eval report에서 listening review notes template을 생성하는 스크립트와 validator를 추가했습니다.
- 후보별 subjective review를 `phrase_quality`, `timing`, `chord_fit`, `issues`, `decision`, `notes`로 구조화했습니다.
- Codex가 청취 결과를 임의 작성하지 않고, 모든 후보를 `pending`으로 둔 template만 생성하도록 경계를 명시했습니다.

## 결과

- candidate count: `6`
- reviewed count: `0`
- pending count: `6`
- template: `outputs/stage_b_listening_review_notes/harness_stage_b_listening_review_notes/review_notes_template.json`

## 검증

- `./.venv/bin/python -m unittest tests.test_listening_review_notes`
- `bash scripts/agent_harness.sh stage-b-listening-review-notes`
- `bash scripts/agent_harness.sh quick`

Closes #87