### PR TITLE
Stage B listening review aggregate 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #87: Stage B listening review notes schema.
+- Issue #89: Stage B filled listening review aggregate.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -218,6 +218,12 @@ For Stage B listening review notes schema changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-listening-review-notes
+```
+
+For Stage B filled listening review aggregate changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-listening-review-aggregate
 ```
 
 For Stage B data-derived motif template extraction changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -146,6 +146,7 @@ Stage B에서 명시하는 것:
 40. Stage B data-guide hybrid generated chord evaluation
 41. Stage B review markdown chord eval summary
 42. Stage B listening review notes schema
+43. Stage B filled listening review aggregate
 
 가장 최근 의미 있는 결과:
 
@@ -168,6 +169,7 @@ Stage B에서 명시하는 것:
 - Issue #83 applies that bridge to actual data-guide hybrid review candidates and shows `data_motif_guide_tones` has higher chord-tone ratio than `data_motif`.
 - Issue #85 writes a combined review markdown so MIDI paths, rhythm metrics, and chord-role metrics can be reviewed together.
 - Issue #87 creates a structured listening review notes schema so subjective review can be recorded consistently instead of as loose comments.
+- Issue #89 aggregates filled listening review notes into next-step signals and refuses to change generation rules when all candidates are still pending.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -381,6 +383,7 @@ Stage B에서 명시하는 것:
 - Issue #83 result: `data_motif` chord-tone ratio는 `0.500`, `data_motif_guide_tones` chord-tone ratio는 `0.812`이다.
 - Issue #85 result: combined review markdown is written to `outputs/stage_b_generated_chord_eval/harness_stage_b_review_markdown_chord_eval/review_candidates_with_chord_eval.md`.
 - Issue #87 result: listening review notes template contains `6` pending candidates and validates phrase quality, timing, chord fit, issue flags, and decision enums.
+- Issue #89 result: listening review aggregate reports `6` pending candidates, `0` reviewed candidates, and only recommends `collect_listening_reviews`.
 
 해석:
 
@@ -390,7 +393,7 @@ Stage B에서 명시하는 것:
 - `approach_tensions`는 pitch-level resolution을 만들지만, 이 또한 jazz vocabulary 자체는 아니다.
 - `swing_motif_approach`는 기계적인 grid 반복을 줄였지만, 이 또한 jazz vocabulary 자체는 아니다.
 - real phrase reference stats와 motif extraction 기준으로 보면 다음은 hand-written rhythm rule 확장이 아니라 data-derived motif/cadence control 쪽이 맞다.
-- 다만 pitch-role 쪽은 real reference chord label이 아직 없으므로, 다음 개선은 filled listening notes를 aggregate하고 이후 수동 reference labels를 넣는 순서가 맞다.
+- 다만 pitch-role 쪽은 real reference chord label이 아직 없으므로, 다음 개선은 실제 청취 결과를 notes에 채운 뒤 issue distribution으로 후속 generation rule을 분기하는 순서가 맞다.
 
 ### Phase 3.10. Swing/Motif Phrase Grammar
 
@@ -660,22 +663,23 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B listening review notes schema 추가
+Stage B filled listening review aggregate 추가
 ```
 
 결과:
 
-- generated chord eval report에서 listening review notes template을 만든다.
-- output: `outputs/stage_b_listening_review_notes/harness_stage_b_listening_review_notes/review_notes_template.json`
+- filled listening review notes를 decision, phrase quality, timing, chord fit, issue flag 기준으로 집계한다.
+- output: `outputs/stage_b_listening_review_aggregate/harness_stage_b_listening_review_aggregate/listening_review_aggregate.json`
 - candidate count: `6`
 - reviewed count: `0`
 - pending count: `6`
-- fields: `phrase_quality`, `timing`, `chord_fit`, `issues`, `decision`, `notes`
+- has reviewed candidates: `false`
+- recommended follow-up: `collect_listening_reviews`
 
 다음 작업:
 
-- filled listening review notes를 aggregate해서 다음 generation rule을 결정한다.
-- `too_safe`, `too_scalar`, `too_mechanical`, `bad_timing`, `bad_chord_fit` 같은 issue flag를 기준으로 후속 issue를 분기한다.
+- 사람이 채운 review notes가 생기면 `too_safe`, `too_scalar`, `too_mechanical`, `bad_timing`, `bad_chord_fit` 같은 issue flag를 기준으로 후속 issue를 분기한다.
+- pending-only artifact에서는 generation rule을 바꾸지 않는다.
 - real Brad/reference chord label은 아직 임의로 넣지 않는다.
 
 ## 10. 한 문장 요약

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-87-stage-b-listening-review-notes`
+- `issue-89-stage-b-listening-review-aggregate`
 
 현재 범위가 아닌 것:
 
@@ -35,6 +35,44 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
 ## Latest Probe Result
+
+Issue #89는 사람이 채운 listening review notes를 다음 generation rule 수정 후보로 집계하는 단계다.
+
+중요한 전제:
+
+- Codex가 subjective listening result를 임의 작성하지 않는다.
+- pending-only notes에서는 generation rule 변경을 추천하지 않는다.
+- 사람이 채운 `issues`와 `decision`만 다음 실험 분기 기준으로 사용한다.
+- real Brad/reference chord label 문제는 아직 해결되지 않았다.
+
+Implemented:
+
+- listening review aggregate script
+- decision / phrase quality / timing / chord fit / issue count aggregation
+- source metric summary by decision
+- pending-only safety follow-up
+- `scripts/summarize_listening_review_notes.py`
+- `scripts/agent_harness.sh stage-b-listening-review-aggregate`
+- docs:
+  - `docs/STAGE_B_LISTENING_REVIEW_AGGREGATE_2026-05-22.md`
+
+Result:
+
+- candidate count: `6`
+- reviewed count: `0`
+- pending count: `6`
+- has reviewed candidates: `false`
+- recommended follow-up:
+  - `collect_listening_reviews`
+- aggregate report:
+  - `outputs/stage_b_listening_review_aggregate/harness_stage_b_listening_review_aggregate/listening_review_aggregate.json`
+
+Decision:
+
+- 지금 artifact만으로 generation rule을 바꾸면 안 된다.
+- 다음 rule change는 사람이 채운 review notes의 issue distribution을 근거로 분기한다.
+
+## Previous Probe Result
 
 Issue #87은 청취 리뷰 결과를 후보별로 구조화해 기록할 notes schema를 만든 단계다.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -98,6 +98,8 @@
   - review candidates markdown과 generated chord eval summary를 결합해 청취 리뷰용 한 파일로 만든 결과.
 - `STAGE_B_LISTENING_REVIEW_NOTES_2026-05-22.md`
   - 청취 리뷰 판단을 후보별 enum/notes schema로 기록하기 위한 template generator 결과.
+- `STAGE_B_LISTENING_REVIEW_AGGREGATE_2026-05-22.md`
+  - 사람이 채운 listening review notes를 다음 generation rule 후보로 집계하는 도구 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -124,7 +126,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, generated chord eval bridge, data-guide generated chord eval, review markdown chord eval summary, and listening review notes schema를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, generated chord eval bridge, data-guide generated chord eval, review markdown chord eval summary, listening review notes schema, and filled listening review aggregate를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_LISTENING_REVIEW_AGGREGATE_2026-05-22.md
+++ b/docs/STAGE_B_LISTENING_REVIEW_AGGREGATE_2026-05-22.md
@@ -1,0 +1,107 @@
+# Stage B Listening Review Aggregate
+
+작성일: 2026-05-22
+
+## 배경
+
+Issue #87에서 generated 후보를 사람이 들었을 때 기록할 `review_notes_template.json` schema를 만들었다.
+
+이번 단계는 그 notes가 채워졌을 때 다음 generation rule 수정 방향을 숫자로 집계하는 도구를 추가한다.
+
+중요한 경계:
+
+- Codex가 subjective listening result를 임의로 채우지 않는다.
+- pending-only notes에서는 generation rule을 바꾸라고 결론 내리지 않는다.
+- 사람이 채운 `issues`와 `decision`을 다음 실험 분기 기준으로만 사용한다.
+
+## 구현
+
+새 스크립트:
+
+```bash
+python scripts/summarize_listening_review_notes.py
+```
+
+새 harness:
+
+```bash
+bash scripts/agent_harness.sh stage-b-listening-review-aggregate
+```
+
+집계 항목:
+
+- `decision_counts`
+- `phrase_quality_counts`
+- `timing_counts`
+- `chord_fit_counts`
+- `issue_counts`
+- `source_metric_by_decision`
+- `recommended_followups`
+
+추천 follow-up code:
+
+- `collect_listening_reviews`
+- `fix_timing_grid`
+- `increase_tension_approach_vocabulary`
+- `improve_phrase_vocabulary`
+- `tighten_chord_fit`
+- `increase_motif_variation`
+- `increase_density_or_coverage`
+
+## 결과
+
+Harness는 현재 pending-only template을 입력으로 검증한다.
+
+| metric | value |
+|---|---:|
+| candidate count | 6 |
+| reviewed | 0 |
+| pending | 6 |
+| has reviewed candidates | false |
+
+Output:
+
+```text
+outputs/stage_b_listening_review_aggregate/harness_stage_b_listening_review_aggregate/listening_review_aggregate.json
+outputs/stage_b_listening_review_aggregate/harness_stage_b_listening_review_aggregate/listening_review_aggregate.md
+```
+
+현재 follow-up:
+
+```json
+[
+  {
+    "code": "collect_listening_reviews",
+    "reason": "No reviewed candidates are present, so generation rules should not be changed from this artifact alone.",
+    "count": 0
+  }
+]
+```
+
+## 판단
+
+이 단계의 의미는 "후보가 좋다"가 아니다.
+
+의미:
+
+- 사람이 채운 listening notes가 들어오면 다음 수정 방향을 자동 집계할 수 있다.
+- `too_safe`, `too_scalar`, `too_mechanical`, `bad_timing`, `bad_chord_fit`를 분리할 수 있다.
+- 아직 reviewed candidate가 없을 때는 rule change를 막는다.
+
+## 다음 작업
+
+실제 청취 결과가 채워진 notes가 생기면 aggregate 결과로 후속 issue를 분기한다.
+
+예:
+
+- `too_safe`가 많으면 tension/approach vocabulary를 늘린다.
+- `too_mechanical` 또는 `too_scalar`가 많으면 phrase vocabulary와 motif variation을 고친다.
+- `bad_timing`이 많으면 swing looseness보다 straight-grid timing을 우선한다.
+- `bad_chord_fit`이 많으면 chord-aware pitch selection을 다시 좁힌다.
+
+## Validation
+
+```bash
+./.venv/bin/python -m unittest tests.test_listening_review_notes tests.test_listening_review_aggregate
+bash scripts/agent_harness.sh stage-b-listening-review-aggregate
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -88,6 +88,8 @@ Modes:
                 Generate data-guide hybrid review package and write a combined chord-eval review markdown.
   stage-b-listening-review-notes
                 Generate pending listening review notes from the combined chord-eval review flow.
+  stage-b-listening-review-aggregate
+                Aggregate pending or filled listening review notes into next-step signals.
   all           Run demo and tiny-compare.
 
 Environment:
@@ -139,6 +141,7 @@ run_quick() {
     scripts/evaluate_chord_labeled_subset.py \
     scripts/evaluate_generated_candidate_chords.py \
     scripts/build_listening_review_notes.py \
+    scripts/summarize_listening_review_notes.py \
     scripts/train_stage_a_full.py \
     scripts/train_stage_a_adapter.py \
     inference/app \
@@ -870,6 +873,16 @@ run_stage_b_listening_review_notes() {
     --source_review_markdown "outputs/stage_b_generated_chord_eval/${run_id}/review_candidates_with_chord_eval.md"
 }
 
+run_stage_b_listening_review_aggregate() {
+  local run_id="${RUN_ID:-harness_stage_b_listening_review_aggregate}"
+  print_header "Stage B listening review notes template"
+  RUN_ID="$run_id" run_stage_b_listening_review_notes
+  print_header "Stage B listening review aggregate"
+  "$PYTHON_BIN" scripts/summarize_listening_review_notes.py \
+    --run_id "$run_id" \
+    --review_notes "outputs/stage_b_listening_review_notes/${run_id}/review_notes_template.json"
+}
+
 case "$MODE" in
   status)
     run_status
@@ -978,6 +991,9 @@ case "$MODE" in
     ;;
   stage-b-listening-review-notes)
     run_stage_b_listening_review_notes
+    ;;
+  stage-b-listening-review-aggregate)
+    run_stage_b_listening_review_aggregate
     ;;
   all)
     run_demo

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -875,12 +875,18 @@ run_stage_b_listening_review_notes() {
 
 run_stage_b_listening_review_aggregate() {
   local run_id="${RUN_ID:-harness_stage_b_listening_review_aggregate}"
-  print_header "Stage B listening review notes template"
-  RUN_ID="$run_id" run_stage_b_listening_review_notes
+  local review_notes_path="outputs/stage_b_listening_review_notes/${run_id}/review_notes_template.json"
+  if [[ ! -f "$review_notes_path" || "${FORCE_REGEN:-0}" == "1" ]]; then
+    print_header "Stage B listening review notes template"
+    RUN_ID="$run_id" run_stage_b_listening_review_notes
+  else
+    print_header "Stage B listening review notes template"
+    printf 'Using existing review notes: %s\n' "$review_notes_path"
+  fi
   print_header "Stage B listening review aggregate"
   "$PYTHON_BIN" scripts/summarize_listening_review_notes.py \
     --run_id "$run_id" \
-    --review_notes "outputs/stage_b_listening_review_notes/${run_id}/review_notes_template.json"
+    --review_notes "$review_notes_path"
 }
 
 case "$MODE" in

--- a/scripts/summarize_listening_review_notes.py
+++ b/scripts/summarize_listening_review_notes.py
@@ -1,0 +1,271 @@
+"""Aggregate filled Stage B listening review notes into follow-up signals."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.build_listening_review_notes import ISSUE_VALUES, read_json, validate_review_notes, write_json
+
+
+AGGREGATE_SCHEMA_VERSION = "stage_b_listening_review_aggregate_v1"
+METRIC_KEYS = (
+    "note_count",
+    "unique_pitch_count",
+    "chord_tone_ratio",
+    "tension_ratio",
+    "approach_ratio",
+    "outside_ratio",
+)
+
+
+def _empty_counter(keys: set[str]) -> dict[str, int]:
+    return {key: 0 for key in sorted(keys)}
+
+
+def _mean(values: list[float]) -> float | None:
+    if not values:
+        return None
+    return float(sum(values) / len(values))
+
+
+def _metric_summary(candidates: list[dict[str, Any]]) -> dict[str, Any]:
+    summary: dict[str, Any] = {"count": len(candidates)}
+    for key in METRIC_KEYS:
+        values: list[float] = []
+        for candidate in candidates:
+            metrics = candidate.get("source_metrics", {})
+            if key in metrics and metrics[key] is not None:
+                values.append(float(metrics[key]))
+        summary[f"avg_{key}"] = _mean(values)
+    return summary
+
+
+def _recommend_followups(
+    reviewed_count: int,
+    issue_counts: Counter[str],
+    timing_counts: Counter[str],
+    chord_fit_counts: Counter[str],
+    phrase_quality_counts: Counter[str],
+) -> list[dict[str, Any]]:
+    if reviewed_count == 0:
+        return [
+            {
+                "code": "collect_listening_reviews",
+                "reason": "No reviewed candidates are present, so generation rules should not be changed from this artifact alone.",
+                "count": 0,
+            }
+        ]
+
+    recommendations: list[dict[str, Any]] = []
+
+    def add(code: str, reason: str, count: int) -> None:
+        if count > 0:
+            recommendations.append({"code": code, "reason": reason, "count": int(count)})
+
+    timing_problem_count = (
+        issue_counts["bad_timing"]
+        + timing_counts["too_stiff"]
+        + timing_counts["too_loose"]
+        + timing_counts["off_grid"]
+    )
+    safety_problem_count = issue_counts["too_safe"] + chord_fit_counts["too_safe"]
+    phrase_problem_count = (
+        issue_counts["too_scalar"]
+        + issue_counts["too_mechanical"]
+        + issue_counts["weak_phrase"]
+        + phrase_quality_counts["exercise"]
+        + phrase_quality_counts["fragment"]
+    )
+    chord_problem_count = issue_counts["bad_chord_fit"] + chord_fit_counts["too_outside"]
+
+    add(
+        "fix_timing_grid",
+        "Reviewed candidates report timing or grid problems; keep straight-grid references before adding more swing looseness.",
+        timing_problem_count,
+    )
+    add(
+        "increase_tension_approach_vocabulary",
+        "Reviewed candidates sound too safe; increase tension and approach-note vocabulary before broad training.",
+        safety_problem_count,
+    )
+    add(
+        "improve_phrase_vocabulary",
+        "Reviewed candidates read as fragments, exercises, scalar motion, or mechanical phrases.",
+        phrase_problem_count,
+    )
+    add(
+        "tighten_chord_fit",
+        "Reviewed candidates have chord-fit problems; revisit chord-aware pitch selection before style adaptation.",
+        chord_problem_count,
+    )
+    add(
+        "increase_motif_variation",
+        "Reviewed candidates are too repetitive; strengthen motif variation and repetition gates.",
+        issue_counts["too_repetitive"],
+    )
+    add(
+        "increase_density_or_coverage",
+        "Reviewed candidates are too sparse; increase phrase density or temporal coverage constraints.",
+        issue_counts["too_sparse"],
+    )
+
+    recommendations.sort(key=lambda item: (-int(item["count"]), str(item["code"])))
+    return recommendations
+
+
+def aggregate_review_notes(payload: dict[str, Any]) -> dict[str, Any]:
+    validation_summary = validate_review_notes(payload)
+    candidates = payload["candidates"]
+
+    phrase_quality_counts: Counter[str] = Counter()
+    timing_counts: Counter[str] = Counter()
+    chord_fit_counts: Counter[str] = Counter()
+    decision_counts: Counter[str] = Counter()
+    issue_counts: Counter[str] = Counter()
+    reviewed_candidates: list[dict[str, Any]] = []
+    by_decision: dict[str, list[dict[str, Any]]] = {}
+
+    for candidate in candidates:
+        listening = candidate["listening"]
+        status = str(listening["status"])
+        phrase_quality = str(listening["phrase_quality"])
+        timing = str(listening["timing"])
+        chord_fit = str(listening["chord_fit"])
+        decision = str(listening["decision"])
+
+        phrase_quality_counts[phrase_quality] += 1
+        timing_counts[timing] += 1
+        chord_fit_counts[chord_fit] += 1
+        decision_counts[decision] += 1
+        by_decision.setdefault(decision, []).append(candidate)
+        for issue in listening.get("issues", []):
+            issue_counts[str(issue)] += 1
+
+        if status == "reviewed":
+            reviewed_candidates.append(
+                {
+                    "candidate_id": candidate["candidate_id"],
+                    "phrase_quality": phrase_quality,
+                    "timing": timing,
+                    "chord_fit": chord_fit,
+                    "issues": list(listening.get("issues", [])),
+                    "decision": decision,
+                    "notes": str(listening.get("notes", "")),
+                    "source_metrics": candidate.get("source_metrics", {}),
+                }
+            )
+
+    reviewed_count = int(validation_summary["reviewed_count"])
+    recommendations = _recommend_followups(
+        reviewed_count=reviewed_count,
+        issue_counts=issue_counts,
+        timing_counts=timing_counts,
+        chord_fit_counts=chord_fit_counts,
+        phrase_quality_counts=phrase_quality_counts,
+    )
+
+    return {
+        "schema_version": AGGREGATE_SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "source_schema_version": payload.get("schema_version"),
+        "source_review_notes": str(payload.get("source_review_notes", "")),
+        "candidate_count": int(validation_summary["candidate_count"]),
+        "reviewed_count": reviewed_count,
+        "pending_count": int(validation_summary["pending_count"]),
+        "has_reviewed_candidates": reviewed_count > 0,
+        "decision_counts": dict(sorted(decision_counts.items())),
+        "phrase_quality_counts": dict(sorted(phrase_quality_counts.items())),
+        "timing_counts": dict(sorted(timing_counts.items())),
+        "chord_fit_counts": dict(sorted(chord_fit_counts.items())),
+        "issue_counts": {**_empty_counter(ISSUE_VALUES), **dict(sorted(issue_counts.items()))},
+        "source_metric_by_decision": {
+            decision: _metric_summary(decision_candidates)
+            for decision, decision_candidates in sorted(by_decision.items())
+        },
+        "reviewed_candidates": reviewed_candidates,
+        "recommended_followups": recommendations,
+    }
+
+
+def markdown_summary(aggregate: dict[str, Any], output_path: Path) -> str:
+    lines = [
+        "# Stage B Listening Review Aggregate",
+        "",
+        f"- output: `{output_path}`",
+        f"- candidates: `{aggregate['candidate_count']}`",
+        f"- reviewed: `{aggregate['reviewed_count']}`",
+        f"- pending: `{aggregate['pending_count']}`",
+        f"- has reviewed candidates: `{aggregate['has_reviewed_candidates']}`",
+        "",
+        "## Decision Counts",
+        "",
+        "| decision | count |",
+        "|---|---:|",
+    ]
+    for decision, count in aggregate["decision_counts"].items():
+        lines.append(f"| {decision} | {count} |")
+
+    lines.extend(["", "## Issue Counts", "", "| issue | count |", "|---|---:|"])
+    for issue, count in aggregate["issue_counts"].items():
+        if count:
+            lines.append(f"| {issue} | {count} |")
+    if len(lines) >= 2 and lines[-1] == "|---|---:|":
+        lines.append("| none | 0 |")
+
+    lines.extend(["", "## Recommended Followups", "", "| code | count | reason |", "|---|---:|---|"])
+    for item in aggregate["recommended_followups"]:
+        lines.append(f"| {item['code']} | {item['count']} | {item['reason']} |")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Aggregate filled Stage B listening review notes")
+    parser.add_argument("--review_notes", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=str(ROOT_DIR / "outputs" / "stage_b_listening_review_aggregate"),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    run_dir = Path(args.output_root) / run_id
+    notes_path = Path(args.review_notes)
+    payload = read_json(notes_path)
+    payload["source_review_notes"] = str(notes_path)
+    aggregate = aggregate_review_notes(payload)
+    output_path = run_dir / "listening_review_aggregate.json"
+    write_json(output_path, aggregate)
+    (run_dir / "listening_review_aggregate.md").write_text(markdown_summary(aggregate, output_path), encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "candidate_count": aggregate["candidate_count"],
+                "reviewed_count": aggregate["reviewed_count"],
+                "pending_count": aggregate["pending_count"],
+                "has_reviewed_candidates": aggregate["has_reviewed_candidates"],
+                "recommended_followups": aggregate["recommended_followups"],
+                "aggregate_path": str(output_path),
+            },
+            ensure_ascii=True,
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/summarize_listening_review_notes.py
+++ b/scripts/summarize_listening_review_notes.py
@@ -197,6 +197,15 @@ def aggregate_review_notes(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def markdown_summary(aggregate: dict[str, Any], output_path: Path) -> str:
+    def append_count_table(title: str, counts: dict[str, int]) -> None:
+        lines.extend(["", f"## {title}", "", "| item | count |", "|---|---:|"])
+        rows = [(key, count) for key, count in counts.items() if count]
+        if not rows:
+            lines.append("| none | 0 |")
+            return
+        for key, count in rows:
+            lines.append(f"| {key} | {count} |")
+
     lines = [
         "# Stage B Listening Review Aggregate",
         "",
@@ -205,21 +214,12 @@ def markdown_summary(aggregate: dict[str, Any], output_path: Path) -> str:
         f"- reviewed: `{aggregate['reviewed_count']}`",
         f"- pending: `{aggregate['pending_count']}`",
         f"- has reviewed candidates: `{aggregate['has_reviewed_candidates']}`",
-        "",
-        "## Decision Counts",
-        "",
-        "| decision | count |",
-        "|---|---:|",
     ]
-    for decision, count in aggregate["decision_counts"].items():
-        lines.append(f"| {decision} | {count} |")
-
-    lines.extend(["", "## Issue Counts", "", "| issue | count |", "|---|---:|"])
-    for issue, count in aggregate["issue_counts"].items():
-        if count:
-            lines.append(f"| {issue} | {count} |")
-    if len(lines) >= 2 and lines[-1] == "|---|---:|":
-        lines.append("| none | 0 |")
+    append_count_table("Decision Counts", aggregate["decision_counts"])
+    append_count_table("Phrase Quality Counts", aggregate["phrase_quality_counts"])
+    append_count_table("Timing Counts", aggregate["timing_counts"])
+    append_count_table("Chord Fit Counts", aggregate["chord_fit_counts"])
+    append_count_table("Issue Counts", aggregate["issue_counts"])
 
     lines.extend(["", "## Recommended Followups", "", "| code | count | reason |", "|---|---:|---|"])
     for item in aggregate["recommended_followups"]:

--- a/tests/test_listening_review_aggregate.py
+++ b/tests/test_listening_review_aggregate.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import unittest
+from pathlib import Path
 
 from scripts.build_listening_review_notes import ReviewNotesError, build_review_notes_template
-from scripts.summarize_listening_review_notes import aggregate_review_notes
+from scripts.summarize_listening_review_notes import aggregate_review_notes, markdown_summary
 
 
 class ListeningReviewAggregateTest(unittest.TestCase):
@@ -103,6 +104,16 @@ class ListeningReviewAggregateTest(unittest.TestCase):
 
         with self.assertRaises(ReviewNotesError):
             aggregate_review_notes(notes)
+
+    def test_markdown_summary_includes_review_dimension_tables(self) -> None:
+        aggregate = aggregate_review_notes(self.sample_notes())
+
+        markdown = markdown_summary(aggregate, Path("aggregate.json"))
+
+        self.assertIn("## Phrase Quality Counts", markdown)
+        self.assertIn("## Timing Counts", markdown)
+        self.assertIn("## Chord Fit Counts", markdown)
+        self.assertIn("| pending | 2 |", markdown)
 
 
 if __name__ == "__main__":

--- a/tests/test_listening_review_aggregate.py
+++ b/tests/test_listening_review_aggregate.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.build_listening_review_notes import ReviewNotesError, build_review_notes_template
+from scripts.summarize_listening_review_notes import aggregate_review_notes
+
+
+class ListeningReviewAggregateTest(unittest.TestCase):
+    def sample_notes(self) -> dict:
+        generated_report = {
+            "samples": [
+                {
+                    "sample_id": "candidate_1",
+                    "note_count": 32,
+                    "unique_pitch_count": 12,
+                    "role_ratios": {
+                        "chord_tone_ratio": 0.75,
+                        "tension_ratio": 0.125,
+                        "approach_ratio": 0.125,
+                        "outside_ratio": 0.0,
+                    },
+                },
+                {
+                    "sample_id": "candidate_2",
+                    "note_count": 24,
+                    "unique_pitch_count": 8,
+                    "role_ratios": {
+                        "chord_tone_ratio": 0.875,
+                        "tension_ratio": 0.0,
+                        "approach_ratio": 0.125,
+                        "outside_ratio": 0.0,
+                    },
+                },
+            ],
+        }
+        return build_review_notes_template(generated_report)
+
+    def test_pending_only_notes_do_not_create_generation_recommendation(self) -> None:
+        aggregate = aggregate_review_notes(self.sample_notes())
+
+        self.assertEqual(aggregate["reviewed_count"], 0)
+        self.assertFalse(aggregate["has_reviewed_candidates"])
+        self.assertEqual(aggregate["recommended_followups"][0]["code"], "collect_listening_reviews")
+
+    def test_filled_notes_aggregate_issue_counts_and_followups(self) -> None:
+        notes = self.sample_notes()
+        notes["candidates"][0]["listening"].update(
+            {
+                "status": "reviewed",
+                "phrase_quality": "exercise",
+                "timing": "acceptable",
+                "chord_fit": "too_safe",
+                "issues": ["too_safe", "too_mechanical"],
+                "decision": "needs_followup",
+                "notes": "Valid but sounds like an exercise.",
+            }
+        )
+        notes["candidates"][1]["listening"].update(
+            {
+                "status": "reviewed",
+                "phrase_quality": "fragment",
+                "timing": "off_grid",
+                "chord_fit": "fits",
+                "issues": ["bad_timing", "weak_phrase"],
+                "decision": "reject",
+                "notes": "Timing does not land cleanly.",
+            }
+        )
+
+        aggregate = aggregate_review_notes(notes)
+        followup_codes = [item["code"] for item in aggregate["recommended_followups"]]
+
+        self.assertEqual(aggregate["reviewed_count"], 2)
+        self.assertEqual(aggregate["issue_counts"]["too_safe"], 1)
+        self.assertEqual(aggregate["issue_counts"]["bad_timing"], 1)
+        self.assertIn("fix_timing_grid", followup_codes)
+        self.assertIn("increase_tension_approach_vocabulary", followup_codes)
+        self.assertIn("improve_phrase_vocabulary", followup_codes)
+
+    def test_metric_summary_groups_by_decision(self) -> None:
+        notes = self.sample_notes()
+        notes["candidates"][0]["listening"].update(
+            {
+                "status": "reviewed",
+                "phrase_quality": "phrase",
+                "timing": "acceptable",
+                "chord_fit": "fits",
+                "decision": "keep",
+            }
+        )
+
+        aggregate = aggregate_review_notes(notes)
+        keep_metrics = aggregate["source_metric_by_decision"]["keep"]
+
+        self.assertEqual(keep_metrics["count"], 1)
+        self.assertEqual(keep_metrics["avg_note_count"], 32.0)
+        self.assertEqual(keep_metrics["avg_chord_tone_ratio"], 0.75)
+
+    def test_invalid_notes_are_rejected_before_aggregation(self) -> None:
+        notes = self.sample_notes()
+        notes["candidates"][0]["listening"]["decision"] = "maybe"
+
+        with self.assertRaises(ReviewNotesError):
+            aggregate_review_notes(notes)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

- 사람이 채운 listening review notes를 decision, phrase quality, timing, chord fit, issue flag 기준으로 집계하는 스크립트를 추가했습니다.
- reviewed candidate가 없으면 generation rule 변경을 추천하지 않고 `collect_listening_reviews`만 반환하도록 했습니다.
- filled notes fixture에서는 `too_safe`, `bad_timing`, `too_mechanical`, `weak_phrase` 같은 issue flag가 follow-up signal로 집계되는지 테스트했습니다.

## 결과

- pending-only harness candidate count: `6`
- reviewed count: `0`
- pending count: `6`
- recommended follow-up: `collect_listening_reviews`
- aggregate artifact: `outputs/stage_b_listening_review_aggregate/harness_stage_b_listening_review_aggregate/listening_review_aggregate.json`

## 검증

- `./.venv/bin/python -m unittest tests.test_listening_review_notes tests.test_listening_review_aggregate`
- `bash scripts/agent_harness.sh stage-b-listening-review-aggregate`
- `bash scripts/agent_harness.sh quick`

Closes #89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added listening review aggregation tool to process and summarize collected feedback data

* **Documentation**
  * Updated project status tracking and milestone documentation
  * Added comprehensive specification for the listening review aggregation stage

* **Tests**
  * Added test suite for listening review aggregation functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohhalim/fine_tuning_art-tatum_midi_solo/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->