### PR TITLE
Stage B full review manifest notes 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #89: Stage B filled listening review aggregate.
+- Issue #91: Stage B full review manifest listening notes.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -218,6 +218,12 @@ For Stage B listening review notes schema changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-listening-review-notes
+```
+
+For Stage B full review manifest listening notes changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-full-review-notes
 ```
 
 For Stage B filled listening review aggregate changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -147,6 +147,7 @@ Stage B에서 명시하는 것:
 41. Stage B review markdown chord eval summary
 42. Stage B listening review notes schema
 43. Stage B filled listening review aggregate
+44. Stage B full review manifest listening notes
 
 가장 최근 의미 있는 결과:
 
@@ -170,6 +171,7 @@ Stage B에서 명시하는 것:
 - Issue #85 writes a combined review markdown so MIDI paths, rhythm metrics, and chord-role metrics can be reviewed together.
 - Issue #87 creates a structured listening review notes schema so subjective review can be recorded consistently instead of as loose comments.
 - Issue #89 aggregates filled listening review notes into next-step signals and refuses to change generation rules when all candidates are still pending.
+- Issue #91 builds listening review notes from the full review manifest so all 15 review candidates, including timing references, have file paths and pending review fields.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -384,6 +386,7 @@ Stage B에서 명시하는 것:
 - Issue #85 result: combined review markdown is written to `outputs/stage_b_generated_chord_eval/harness_stage_b_review_markdown_chord_eval/review_candidates_with_chord_eval.md`.
 - Issue #87 result: listening review notes template contains `6` pending candidates and validates phrase quality, timing, chord fit, issue flags, and decision enums.
 - Issue #89 result: listening review aggregate reports `6` pending candidates, `0` reviewed candidates, and only recommends `collect_listening_reviews`.
+- Issue #91 result: full review manifest notes contain `15` pending candidates with `review_midi_path`, `context_midi_path`, mode, rank, sample, and rhythm/timing metrics.
 
 해석:
 
@@ -663,22 +666,21 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B filled listening review aggregate 추가
+Stage B full review manifest listening notes 추가
 ```
 
 결과:
 
-- filled listening review notes를 decision, phrase quality, timing, chord fit, issue flag 기준으로 집계한다.
-- output: `outputs/stage_b_listening_review_aggregate/harness_stage_b_listening_review_aggregate/listening_review_aggregate.json`
-- candidate count: `6`
+- review manifest 전체를 listening review notes template으로 변환한다.
+- output: `outputs/stage_b_listening_review_notes/harness_stage_b_full_review_notes/review_notes_template.json`
+- candidate count: `15`
 - reviewed count: `0`
-- pending count: `6`
-- has reviewed candidates: `false`
-- recommended follow-up: `collect_listening_reviews`
+- pending count: `15`
+- fields: `review_metadata`, `review_files`, `source_metrics`, `listening`
 
 다음 작업:
 
-- 사람이 채운 review notes가 생기면 `too_safe`, `too_scalar`, `too_mechanical`, `bad_timing`, `bad_chord_fit` 같은 issue flag를 기준으로 후속 issue를 분기한다.
+- full review notes가 채워지면 aggregate 결과로 `too_safe`, `too_scalar`, `too_mechanical`, `bad_timing`, `bad_chord_fit` 같은 issue flag를 기준으로 후속 issue를 분기한다.
 - pending-only artifact에서는 generation rule을 바꾸지 않는다.
 - real Brad/reference chord label은 아직 임의로 넣지 않는다.
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-89-stage-b-listening-review-aggregate`
+- `issue-91-stage-b-full-review-manifest-notes`
 
 현재 범위가 아닌 것:
 
@@ -35,6 +35,43 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
 ## Latest Probe Result
+
+Issue #91은 review manifest 전체를 listening review notes template으로 변환하는 단계다.
+
+중요한 전제:
+
+- Codex가 subjective listening result를 임의 작성하지 않는다.
+- 기존 generated chord eval report 기반 6개 후보 notes 경로는 유지한다.
+- 새 경로는 hand-written swing, straight-grid reference까지 포함한 full review package를 notes로 만든다.
+
+Implemented:
+
+- `scripts/build_listening_review_notes.py --review_manifest`
+- full review manifest candidate 변환
+- `review_metadata`와 `review_files` 필드 추가
+- rhythm/timing metrics를 `source_metrics`에 보존
+- `scripts/agent_harness.sh stage-b-full-review-notes`
+- docs:
+  - `docs/STAGE_B_FULL_REVIEW_MANIFEST_NOTES_2026-05-22.md`
+
+Result:
+
+- candidate count: `15`
+- reviewed count: `0`
+- pending count: `15`
+- first candidate:
+  - `data_motif_rank_1_sample_1`
+- last candidate:
+  - `straight_guide_tones_rank_3_sample_3`
+- review notes template:
+  - `outputs/stage_b_listening_review_notes/harness_stage_b_full_review_notes/review_notes_template.json`
+
+Decision:
+
+- 이제 사람이 들어야 할 review MIDI/context MIDI path가 notes 안에 직접 남는다.
+- 다음 rule change는 이 full notes가 실제로 채워진 뒤 aggregate 결과로 결정한다.
+
+## Previous Probe Result
 
 Issue #89는 사람이 채운 listening review notes를 다음 generation rule 수정 후보로 집계하는 단계다.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -100,6 +100,8 @@
   - 청취 리뷰 판단을 후보별 enum/notes schema로 기록하기 위한 template generator 결과.
 - `STAGE_B_LISTENING_REVIEW_AGGREGATE_2026-05-22.md`
   - 사람이 채운 listening review notes를 다음 generation rule 후보로 집계하는 도구 결과.
+- `STAGE_B_FULL_REVIEW_MANIFEST_NOTES_2026-05-22.md`
+  - 전체 review manifest 후보 15개를 파일 경로와 함께 listening review notes로 변환한 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -126,7 +128,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, generated chord eval bridge, data-guide generated chord eval, review markdown chord eval summary, listening review notes schema, and filled listening review aggregate를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, generated chord eval bridge, data-guide generated chord eval, review markdown chord eval summary, listening review notes schema, filled listening review aggregate, and full review manifest notes를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_FULL_REVIEW_MANIFEST_NOTES_2026-05-22.md
+++ b/docs/STAGE_B_FULL_REVIEW_MANIFEST_NOTES_2026-05-22.md
@@ -1,0 +1,124 @@
+# Stage B Full Review Manifest Listening Notes
+
+작성일: 2026-05-22
+
+## 배경
+
+Issue #87의 listening review notes는 generated chord eval report를 기준으로 만들어져서 chord eval이 붙은 상위 6개 후보만 포함했다.
+
+하지만 실제 청취 리뷰에서는 다음 reference 후보도 같이 비교해야 한다.
+
+- `hand_written_swing`
+- `straight_grid`
+- `straight_guide_tones`
+- `data_motif`
+- `data_motif_guide_tones`
+
+이번 단계는 `review_manifest.json` 전체를 notes template으로 변환해서, 사람이 들어야 할 파일명과 context MIDI path가 notes에 직접 남도록 한다.
+
+## 구현
+
+확장된 스크립트:
+
+```bash
+python scripts/build_listening_review_notes.py --review_manifest ...
+```
+
+새 harness:
+
+```bash
+bash scripts/agent_harness.sh stage-b-full-review-notes
+```
+
+기존 경로는 유지된다.
+
+```bash
+python scripts/build_listening_review_notes.py --generated_chord_eval_report ...
+```
+
+## Notes Candidate Fields
+
+`review_manifest` 기반 notes candidate는 다음 필드를 가진다.
+
+- `candidate_id`
+  - 예: `data_motif_rank_1_sample_1`
+- `review_metadata`
+  - `mode`
+  - `review_rank`
+  - `sample_index`
+  - `sample_seed`
+  - `valid`
+  - `strict_valid`
+- `review_files`
+  - `midi_path`
+  - `source_midi_path`
+  - `context_midi_path`
+- `source_metrics`
+  - note/pitch count
+  - dead-air ratio
+  - syncopation ratio
+  - duration/IOI diversity
+  - tension/root ratios
+- `listening`
+  - 사람이 채울 pending review fields
+
+## 결과
+
+Harness result:
+
+| metric | value |
+|---|---:|
+| candidate count | 15 |
+| reviewed | 0 |
+| pending | 15 |
+
+Output:
+
+```text
+outputs/stage_b_listening_review_notes/harness_stage_b_full_review_notes/review_notes_template.json
+```
+
+첫 candidate:
+
+```text
+data_motif_rank_1_sample_1
+```
+
+첫 context MIDI:
+
+```text
+outputs/stage_b_data_motif_review/harness_stage_b_full_review_notes/context_midi/01_data_motif_rank_01_sample_01_with_context.mid
+```
+
+마지막 candidate:
+
+```text
+straight_guide_tones_rank_3_sample_3
+```
+
+## 판단
+
+이 단계의 의미:
+
+- 이제 review notes가 실제 review package 전체와 1:1로 대응된다.
+- 사람이 "어떤 파일을 들어야 하는지"를 notes만 보고 알 수 있다.
+- hand-written swing과 straight-grid reference도 subjective review 대상에 포함된다.
+- Codex는 여전히 subjective listening result를 임의 작성하지 않는다.
+
+## 다음 작업
+
+다음 generation rule 변경은 사람이 채운 full review notes를 aggregate한 뒤 결정한다.
+
+우선순위 예:
+
+- `bad_timing`이 많으면 swing looseness를 줄이고 grid landing을 강화한다.
+- `too_scalar`가 많으면 scale-walk vocabulary를 제한하고 phrase contour/motif를 강화한다.
+- `too_safe`가 많으면 guide-tone만이 아니라 tension/approach resolution을 늘린다.
+
+## Validation
+
+```bash
+./.venv/bin/python -m unittest tests.test_listening_review_notes tests.test_listening_review_aggregate
+bash scripts/agent_harness.sh stage-b-full-review-notes
+bash scripts/agent_harness.sh quick
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -88,6 +88,8 @@ Modes:
                 Generate data-guide hybrid review package and write a combined chord-eval review markdown.
   stage-b-listening-review-notes
                 Generate pending listening review notes from the combined chord-eval review flow.
+  stage-b-full-review-notes
+                Generate pending listening review notes from the full data-guide review manifest.
   stage-b-listening-review-aggregate
                 Aggregate pending or filled listening review notes into next-step signals.
   all           Run demo and tiny-compare.
@@ -873,6 +875,17 @@ run_stage_b_listening_review_notes() {
     --source_review_markdown "outputs/stage_b_generated_chord_eval/${run_id}/review_candidates_with_chord_eval.md"
 }
 
+run_stage_b_full_review_notes() {
+  local run_id="${RUN_ID:-harness_stage_b_full_review_notes}"
+  print_header "Stage B data-guide hybrid review package"
+  RUN_ID="$run_id" run_stage_b_data_guide_hybrid
+  print_header "Stage B full review manifest listening notes"
+  "$PYTHON_BIN" scripts/build_listening_review_notes.py \
+    --run_id "$run_id" \
+    --review_manifest "outputs/stage_b_data_motif_review/${run_id}/review_manifest.json" \
+    --source_review_markdown "outputs/stage_b_data_motif_review/${run_id}/review_candidates.md"
+}
+
 run_stage_b_listening_review_aggregate() {
   local run_id="${RUN_ID:-harness_stage_b_listening_review_aggregate}"
   local review_notes_path="outputs/stage_b_listening_review_notes/${run_id}/review_notes_template.json"
@@ -997,6 +1010,9 @@ case "$MODE" in
     ;;
   stage-b-listening-review-notes)
     run_stage_b_listening_review_notes
+    ;;
+  stage-b-full-review-notes)
+    run_stage_b_full_review_notes
     ;;
   stage-b-listening-review-aggregate)
     run_stage_b_listening_review_aggregate

--- a/scripts/build_listening_review_notes.py
+++ b/scripts/build_listening_review_notes.py
@@ -69,6 +69,61 @@ def build_candidate_note(sample: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _candidate_id_from_review_manifest(sample: dict[str, Any]) -> str:
+    mode = str(sample.get("mode") or "candidate").strip() or "candidate"
+    rank = int(sample.get("review_rank", 0) or 0)
+    sample_index = int(sample.get("sample_index", 0) or 0)
+    if rank and sample_index:
+        return f"{mode}_rank_{rank}_sample_{sample_index}"
+    return str(sample.get("sample_id") or sample.get("review_midi_path") or mode)
+
+
+def build_candidate_note_from_review_manifest(sample: dict[str, Any]) -> dict[str, Any]:
+    ratios = sample.get("role_ratios", {})
+    source_metrics = {
+        "note_count": int(sample.get("note_count", 0) or 0),
+        "unique_pitch_count": int(sample.get("unique_pitch_count", 0) or 0),
+        "chord_tone_ratio": float(sample.get("chord_tone_ratio", ratios.get("chord_tone_ratio", 0.0)) or 0.0),
+        "tension_ratio": float(sample.get("tension_ratio", ratios.get("tension_ratio", 0.0)) or 0.0),
+        "approach_ratio": float(sample.get("approach_ratio", ratios.get("approach_ratio", 0.0)) or 0.0),
+        "outside_ratio": float(sample.get("outside_ratio", ratios.get("outside_ratio", 0.0)) or 0.0),
+        "root_tone_ratio": float(sample.get("root_tone_ratio", 0.0) or 0.0),
+        "dead_air_ratio": float(sample.get("dead_air_ratio", 0.0) or 0.0),
+        "syncopated_onset_ratio": float(sample.get("syncopated_onset_ratio", 0.0) or 0.0),
+        "unique_bar_position_pattern_ratio": float(sample.get("unique_bar_position_pattern_ratio", 0.0) or 0.0),
+        "duration_diversity_ratio": float(sample.get("duration_diversity_ratio", 0.0) or 0.0),
+        "most_common_duration_ratio": float(sample.get("most_common_duration_ratio", 0.0) or 0.0),
+        "ioi_diversity_ratio": float(sample.get("ioi_diversity_ratio", 0.0) or 0.0),
+        "most_common_ioi_ratio": float(sample.get("most_common_ioi_ratio", 0.0) or 0.0),
+    }
+    return {
+        "candidate_id": _candidate_id_from_review_manifest(sample),
+        "review_metadata": {
+            "mode": str(sample.get("mode", "")),
+            "review_rank": int(sample.get("review_rank", 0) or 0),
+            "sample_index": int(sample.get("sample_index", 0) or 0),
+            "sample_seed": sample.get("sample_seed"),
+            "valid": bool(sample.get("valid", False)),
+            "strict_valid": bool(sample.get("strict_valid", False)),
+        },
+        "review_files": {
+            "midi_path": str(sample.get("review_midi_path") or sample.get("midi_path") or ""),
+            "source_midi_path": str(sample.get("midi_path") or ""),
+            "context_midi_path": str(sample.get("context_midi_path") or ""),
+        },
+        "source_metrics": source_metrics,
+        "listening": {
+            "status": "pending",
+            "phrase_quality": "pending",
+            "timing": "pending",
+            "chord_fit": "pending",
+            "issues": [],
+            "decision": "pending",
+            "notes": "",
+        },
+    }
+
+
 def build_review_notes_template(
     generated_chord_eval_report: dict[str, Any],
     source_review_markdown: str | None = None,
@@ -88,6 +143,29 @@ def build_review_notes_template(
             "do_not_infer_real_reference_chords": True,
         },
         "candidates": [build_candidate_note(sample) for sample in samples],
+    }
+
+
+def build_review_notes_from_review_manifest(
+    review_manifest: dict[str, Any],
+    source_review_markdown: str | None = None,
+) -> dict[str, Any]:
+    candidates = review_manifest.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise ReviewNotesError("review manifest must contain non-empty candidates")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "source_review_manifest": str(review_manifest.get("source_manifest_path", "")),
+        "source_review_markdown": source_review_markdown,
+        "reviewer": "",
+        "review_context": {
+            "listen_with_context_midi": True,
+            "compare_solo_and_context": True,
+            "do_not_infer_real_reference_chords": True,
+        },
+        "chord_progression": review_manifest.get("chord_progression", []),
+        "candidates": [build_candidate_note_from_review_manifest(sample) for sample in candidates],
     }
 
 
@@ -159,6 +237,7 @@ def markdown_summary(summary: dict[str, Any], output_path: Path) -> str:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Build or validate Stage B listening review notes")
     parser.add_argument("--generated_chord_eval_report", type=str, default=None)
+    parser.add_argument("--review_manifest", type=str, default=None)
     parser.add_argument("--source_review_markdown", type=str, default=None)
     parser.add_argument("--review_notes", type=str, default=None)
     parser.add_argument(
@@ -178,10 +257,21 @@ def main() -> int:
         notes_path = Path(args.review_notes)
         notes = read_json(notes_path)
     else:
-        if not args.generated_chord_eval_report:
-            raise ReviewNotesError("--generated_chord_eval_report is required when --review_notes is not provided")
-        generated_report = read_json(Path(args.generated_chord_eval_report))
-        notes = build_review_notes_template(generated_report, source_review_markdown=args.source_review_markdown)
+        if args.review_manifest:
+            review_manifest_path = Path(args.review_manifest)
+            review_manifest = read_json(review_manifest_path)
+            review_manifest["source_manifest_path"] = str(review_manifest_path)
+            notes = build_review_notes_from_review_manifest(
+                review_manifest,
+                source_review_markdown=args.source_review_markdown,
+            )
+        else:
+            if not args.generated_chord_eval_report:
+                raise ReviewNotesError(
+                    "--generated_chord_eval_report or --review_manifest is required when --review_notes is not provided"
+                )
+            generated_report = read_json(Path(args.generated_chord_eval_report))
+            notes = build_review_notes_template(generated_report, source_review_markdown=args.source_review_markdown)
         notes_path = run_dir / "review_notes_template.json"
         write_json(notes_path, notes)
     summary = validate_review_notes(notes)

--- a/tests/test_listening_review_notes.py
+++ b/tests/test_listening_review_notes.py
@@ -4,6 +4,7 @@ import unittest
 
 from scripts.build_listening_review_notes import (
     ReviewNotesError,
+    build_review_notes_from_review_manifest,
     build_review_notes_template,
     validate_review_notes,
 )
@@ -25,6 +26,44 @@ class ListeningReviewNotesTest(unittest.TestCase):
                         "outside_ratio": 0.0,
                     },
                 }
+            ],
+        }
+
+    def sample_review_manifest(self) -> dict:
+        return {
+            "chord_progression": ["Cm7", "F7", "Bbmaj7", "Ebmaj7"],
+            "candidates": [
+                {
+                    "mode": "data_motif",
+                    "review_rank": 1,
+                    "sample_index": 1,
+                    "sample_seed": 17,
+                    "valid": True,
+                    "strict_valid": True,
+                    "review_midi_path": "named_midi/01_data_motif_rank_01_sample_01.mid",
+                    "midi_path": "samples/data_motif/data_motif_sample_1.mid",
+                    "context_midi_path": "context_midi/01_data_motif_rank_01_sample_01_with_context.mid",
+                    "note_count": 63,
+                    "unique_pitch_count": 24,
+                    "dead_air_ratio": 0.56,
+                    "syncopated_onset_ratio": 0.625,
+                    "unique_bar_position_pattern_ratio": 1.0,
+                    "duration_diversity_ratio": 0.0625,
+                    "most_common_duration_ratio": 0.375,
+                    "ioi_diversity_ratio": 0.079,
+                    "most_common_ioi_ratio": 0.429,
+                    "tension_ratio": 0.172,
+                    "root_tone_ratio": 0.0,
+                },
+                {
+                    "mode": "straight_grid",
+                    "review_rank": 1,
+                    "sample_index": 1,
+                    "review_midi_path": "named_midi/04_straight_grid_rank_01_sample_01.mid",
+                    "context_midi_path": "context_midi/04_straight_grid_rank_01_sample_01_with_context.mid",
+                    "note_count": 64,
+                    "unique_pitch_count": 26,
+                },
             ],
         }
 
@@ -77,6 +116,29 @@ class ListeningReviewNotesTest(unittest.TestCase):
 
         with self.assertRaises(ReviewNotesError):
             validate_review_notes(notes)
+
+    def test_build_review_notes_from_review_manifest_includes_files_and_modes(self) -> None:
+        notes = build_review_notes_from_review_manifest(
+            self.sample_review_manifest(),
+            source_review_markdown="review_candidates.md",
+        )
+
+        self.assertEqual(len(notes["candidates"]), 2)
+        self.assertEqual(notes["candidates"][0]["candidate_id"], "data_motif_rank_1_sample_1")
+        self.assertEqual(notes["candidates"][0]["review_metadata"]["mode"], "data_motif")
+        self.assertEqual(
+            notes["candidates"][0]["review_files"]["context_midi_path"],
+            "context_midi/01_data_motif_rank_01_sample_01_with_context.mid",
+        )
+        self.assertEqual(notes["candidates"][0]["source_metrics"]["syncopated_onset_ratio"], 0.625)
+
+    def test_build_review_notes_from_review_manifest_validates_pending_candidates(self) -> None:
+        notes = build_review_notes_from_review_manifest(self.sample_review_manifest())
+
+        summary = validate_review_notes(notes)
+
+        self.assertEqual(summary["candidate_count"], 2)
+        self.assertEqual(summary["pending_count"], 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 요약

- `review_manifest.json` 전체 후보를 listening review notes template으로 변환하는 `--review_manifest` 경로를 추가했습니다.
- 기존 generated chord eval report 기반 notes 생성은 유지했습니다.
- 후보별 `mode`, `review_rank`, `sample_index`, `review_midi_path`, `context_midi_path`, rhythm/timing metrics를 notes에 남기도록 했습니다.

## 결과

- full review candidate count: `15`
- reviewed count: `0`
- pending count: `15`
- first candidate: `data_motif_rank_1_sample_1`
- last candidate: `straight_guide_tones_rank_3_sample_3`
- template: `outputs/stage_b_listening_review_notes/harness_stage_b_full_review_notes/review_notes_template.json`

## 검증

- `./.venv/bin/python -m unittest tests.test_listening_review_notes tests.test_listening_review_aggregate`
- `bash scripts/agent_harness.sh stage-b-full-review-notes`
- `bash scripts/agent_harness.sh quick`

Closes #91