### PR TITLE
Stage B 객관 플래그 리뷰 흐름 연결

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #93: Stage B objective MIDI note review.
+- Issue #95: Stage B objective flags review flow.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -230,6 +230,12 @@ For Stage B objective MIDI note review changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-objective-midi-review
+```
+
+For Stage B objective flags review flow changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-objective-flags-review-flow
 ```
 
 For Stage B filled listening review aggregate changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -149,6 +149,7 @@ Stage B에서 명시하는 것:
 43. Stage B filled listening review aggregate
 44. Stage B full review manifest listening notes
 45. Stage B objective MIDI note review
+46. Stage B objective flags review flow
 
 가장 최근 의미 있는 결과:
 
@@ -174,6 +175,7 @@ Stage B에서 명시하는 것:
 - Issue #89 aggregates filled listening review notes into next-step signals and refuses to change generation rules when all candidates are still pending.
 - Issue #91 builds listening review notes from the full review manifest so all 15 review candidates, including timing references, have file paths and pending review fields.
 - Issue #93 reads generated MIDI notes directly and reports objective flags for overlap/polyphony, grid alignment, scalar/chromatic motion, duration collapse, and chord-role ratios.
+- Issue #95 connects objective flags to listening review notes and aggregate priority so problem/warning candidates are visible before manual listening.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -390,6 +392,7 @@ Stage B에서 명시하는 것:
 - Issue #89 result: listening review aggregate reports `6` pending candidates, `0` reviewed candidates, and only recommends `collect_listening_reviews`.
 - Issue #91 result: full review manifest notes contain `15` pending candidates with `review_midi_path`, `context_midi_path`, mode, rank, sample, and rhythm/timing metrics.
 - Issue #93 result: objective MIDI review flags `chromatic_walk=7`, `duration_pattern_collapse=9`, `overlap_polyphonic=9`, and `too_stepwise_or_scalar=4`.
+- Issue #95 result: objective review priority reports `15` candidates, `6` warning/reviewable candidates, and `9` problem candidates before subjective listening.
 
 해석:
 
@@ -669,14 +672,17 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B objective MIDI note review 추가
+Stage B objective flags review flow 연결
 ```
 
 결과:
 
-- generated review MIDI를 직접 읽어 objective note-level diagnostics를 만든다.
-- output: `outputs/stage_b_objective_midi_review/harness_stage_b_objective_midi_review/objective_midi_note_review.md`
+- objective note-level diagnostics를 listening review notes와 aggregate priority에 연결했다.
+- output: `outputs/stage_b_listening_review_aggregate/harness_stage_b_objective_flags_review_flow/listening_review_aggregate.md`
 - candidate count: `15`
+- objective reviewable: `6`
+- objective problem: `9`
+- objective warning: `6`
 - chromatic walk: `7`
 - duration pattern collapse: `9`
 - overlap/polyphonic: `9`
@@ -684,9 +690,9 @@ Stage B objective MIDI note review 추가
 
 다음 작업:
 
-- objective flags를 candidate ranking/listening notes에 연결한다.
-- overlap/polyphonic과 duration collapse를 review priority와 gate에 반영한다.
-- subjective listening result는 objective MIDI review 이후에 채운다.
+- overlap/polyphonic이 생기지 않는 solo-line export를 먼저 고친다.
+- duration collapse가 있는 straight-grid 후보는 rhythm/duration variation을 개선한다.
+- subjective listening result는 objective warning/problem priority를 참고해 채운다.
 - real Brad/reference chord label은 아직 임의로 넣지 않는다.
 
 ## 10. 한 문장 요약

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-93-stage-b-objective-midi-note-review`
+- `issue-95-stage-b-objective-flags-review-flow`
 
 현재 범위가 아닌 것:
 
@@ -35,6 +35,49 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
 ## Latest Probe Result
+
+Issue #95는 objective MIDI note-level diagnostics를 listening review notes와 aggregate priority에 연결하는 단계다.
+
+중요한 전제:
+
+- 이 단계는 subjective listening review를 대체하지 않는다.
+- "재즈답다"를 자동 판정하지 않는다.
+- 사람이 들어야 할 후보를 objective problem/warning priority로 정렬한다.
+- overlap/polyphonic, off-grid, duration collapse, scalar/chromatic flag를 review notes 안에 보존한다.
+
+Implemented:
+
+- objective penalty / bucket / reviewable / priority score
+- listening review notes에 `objective_review` 첨부
+- aggregate report에 objective flag/bucket counts 추가
+- objective review priority table
+- `scripts/build_listening_review_notes.py --objective_midi_review_report`
+- `scripts/agent_harness.sh stage-b-objective-flags-review-flow`
+- docs:
+  - `docs/STAGE_B_OBJECTIVE_FLAGS_REVIEW_FLOW_2026-05-22.md`
+
+Result:
+
+- candidate count: `15`
+- objective reviewable count: `6`
+- objective bucket counts:
+  - problem: `9`
+  - warning: `6`
+- objective flag counts:
+  - chromatic walk: `7`
+  - duration pattern collapse: `9`
+  - overlap/polyphonic: `9`
+  - too stepwise/scalar: `4`
+- aggregate report:
+  - `outputs/stage_b_listening_review_aggregate/harness_stage_b_objective_flags_review_flow/listening_review_aggregate.md`
+
+Decision:
+
+- 지금 후보 중 `problem` 9개는 우선순위 낮은 review target이다.
+- `warning` 6개도 좋은 재즈 솔로라는 뜻은 아니며, duration collapse/chromatic exercise 문제를 갖는다.
+- 다음 generation rule change는 overlap을 만들지 않는 solo-line export와 duration/rhythm variation 개선을 먼저 봐야 한다.
+
+## Previous Probe Result
 
 Issue #93은 generated review MIDI를 직접 읽어 objective note-level diagnostics를 만드는 단계다.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -104,6 +104,8 @@
   - 전체 review manifest 후보 15개를 파일 경로와 함께 listening review notes로 변환한 결과.
 - `STAGE_B_OBJECTIVE_MIDI_NOTE_REVIEW_2026-05-22.md`
   - generated review MIDI를 직접 읽어 overlap, grid, scalar/chromatic, duration collapse를 진단한 결과.
+- `STAGE_B_OBJECTIVE_FLAGS_REVIEW_FLOW_2026-05-22.md`
+  - objective MIDI flags를 listening review notes와 aggregate priority에 연결한 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`

--- a/docs/STAGE_B_OBJECTIVE_FLAGS_REVIEW_FLOW_2026-05-22.md
+++ b/docs/STAGE_B_OBJECTIVE_FLAGS_REVIEW_FLOW_2026-05-22.md
@@ -1,0 +1,99 @@
+# Stage B Objective Flags Review Flow
+
+작성일: 2026-05-22
+
+## 목적
+
+Issue #95는 objective MIDI note review 결과를 listening review notes와 aggregate report에 연결한 단계다.
+
+이 작업은 MIDI가 "재즈답다"를 자동 판정하지 않는다. 목적은 사람이 듣기 전에 명백히 문제가 있는 후보를 `problem`, 상대적으로 들을 가치가 있는 후보를 `warning`으로 분리해 review priority를 만드는 것이다.
+
+## 구현
+
+변경 사항:
+
+- `scripts/review_midi_note_objectives.py`
+  - `objective_penalty`
+  - `objective_priority_score`
+  - `objective_reviewable`
+  - `objective_bucket`
+- `scripts/build_listening_review_notes.py`
+  - `--objective_midi_review_report`
+  - 후보별 `objective_review` 첨부
+- `scripts/summarize_listening_review_notes.py`
+  - objective flag counts
+  - objective bucket counts
+  - objective review priority table
+- `scripts/agent_harness.sh`
+  - `stage-b-objective-flags-review-flow`
+
+## 하네스
+
+실행:
+
+```bash
+bash scripts/agent_harness.sh stage-b-objective-flags-review-flow
+```
+
+이 하네스는 다음 순서로 실행된다.
+
+1. data-guide hybrid review package 생성
+2. objective MIDI note review 생성
+3. objective-aware listening review notes 생성
+4. objective-aware aggregate 생성
+
+## 결과
+
+출력:
+
+- objective report:
+  - `outputs/stage_b_objective_midi_review/harness_stage_b_objective_flags_review_flow/objective_midi_note_review.json`
+  - `outputs/stage_b_objective_midi_review/harness_stage_b_objective_flags_review_flow/objective_midi_note_review.md`
+- review notes:
+  - `outputs/stage_b_listening_review_notes/harness_stage_b_objective_flags_review_flow/review_notes_template.json`
+- aggregate:
+  - `outputs/stage_b_listening_review_aggregate/harness_stage_b_objective_flags_review_flow/listening_review_aggregate.json`
+  - `outputs/stage_b_listening_review_aggregate/harness_stage_b_objective_flags_review_flow/listening_review_aggregate.md`
+
+요약:
+
+- candidate count: `15`
+- objective reviewable count: `6`
+- objective buckets:
+  - problem: `9`
+  - warning: `6`
+- objective flags:
+  - chromatic walk: `7`
+  - duration pattern collapse: `9`
+  - overlap/polyphonic: `9`
+  - too stepwise/scalar: `4`
+
+## 해석
+
+현재 후보는 이전보다 valid MIDI에 가까워졌지만, 좋은 jazz solo라고 볼 수는 없다.
+
+특히:
+
+- `overlap_polyphonic` 후보는 solo-line review 우선순위에서 낮춘다.
+- `duration_pattern_collapse` 후보는 grid는 맞아도 rhythm이 너무 단조롭다.
+- `chromatic_walk` / `too_stepwise_or_scalar` 후보는 scale exercise처럼 들릴 가능성이 높다.
+- `warning` 후보도 최종 성공이 아니라 "문제는 있지만 들어볼 수 있는 후보"다.
+
+## 다음 판단
+
+다음 generation 작업은 broad training이 아니라 다음 두 갈래 중 하나여야 한다.
+
+1. solo-line export에서 overlap/polyphonic이 생기지 않도록 고친다.
+2. straight-grid 후보의 duration collapse를 줄이는 rhythm/duration variation을 추가한다.
+
+subjective listening review는 이 objective priority를 참고해서 채우되, Codex가 임의로 "좋다/나쁘다"를 확정하지 않는다.
+
+## 검증
+
+실행한 검증:
+
+```bash
+./.venv/bin/python -m unittest tests.test_objective_midi_note_review tests.test_listening_review_notes tests.test_listening_review_aggregate
+bash scripts/agent_harness.sh stage-b-objective-flags-review-flow
+bash scripts/agent_harness.sh quick
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -92,6 +92,8 @@ Modes:
                 Generate pending listening review notes from the full data-guide review manifest.
   stage-b-objective-midi-review
                 Run objective note-level MIDI review on the full data-guide review manifest.
+  stage-b-objective-flags-review-flow
+                Attach objective MIDI flags to review notes and aggregate review priority.
   stage-b-listening-review-aggregate
                 Aggregate pending or filled listening review notes into next-step signals.
   all           Run demo and tiny-compare.
@@ -899,6 +901,30 @@ run_stage_b_objective_midi_review() {
     --review_manifest "outputs/stage_b_data_motif_review/${run_id}/review_manifest.json"
 }
 
+run_stage_b_objective_flags_review_flow() {
+  local run_id="${RUN_ID:-harness_stage_b_objective_flags_review_flow}"
+  local review_manifest_path="outputs/stage_b_data_motif_review/${run_id}/review_manifest.json"
+  local review_markdown_path="outputs/stage_b_data_motif_review/${run_id}/review_candidates.md"
+  local objective_report_path="outputs/stage_b_objective_midi_review/${run_id}/objective_midi_note_review.json"
+  local review_notes_path="outputs/stage_b_listening_review_notes/${run_id}/review_notes_template.json"
+  print_header "Stage B data-guide hybrid review package"
+  RUN_ID="$run_id" run_stage_b_data_guide_hybrid
+  print_header "Stage B objective MIDI note review"
+  "$PYTHON_BIN" scripts/review_midi_note_objectives.py \
+    --run_id "$run_id" \
+    --review_manifest "$review_manifest_path"
+  print_header "Stage B objective-aware listening review notes"
+  "$PYTHON_BIN" scripts/build_listening_review_notes.py \
+    --run_id "$run_id" \
+    --review_manifest "$review_manifest_path" \
+    --source_review_markdown "$review_markdown_path" \
+    --objective_midi_review_report "$objective_report_path"
+  print_header "Stage B objective-aware listening review aggregate"
+  "$PYTHON_BIN" scripts/summarize_listening_review_notes.py \
+    --run_id "$run_id" \
+    --review_notes "$review_notes_path"
+}
+
 run_stage_b_listening_review_aggregate() {
   local run_id="${RUN_ID:-harness_stage_b_listening_review_aggregate}"
   local review_notes_path="outputs/stage_b_listening_review_notes/${run_id}/review_notes_template.json"
@@ -1029,6 +1055,9 @@ case "$MODE" in
     ;;
   stage-b-objective-midi-review)
     run_stage_b_objective_midi_review
+    ;;
+  stage-b-objective-flags-review-flow)
+    run_stage_b_objective_flags_review_flow
     ;;
   stage-b-listening-review-aggregate)
     run_stage_b_listening_review_aggregate

--- a/scripts/build_listening_review_notes.py
+++ b/scripts/build_listening_review_notes.py
@@ -19,6 +19,7 @@ PHRASE_QUALITY_VALUES = {"pending", "phrase", "fragment", "exercise", "invalid"}
 TIMING_VALUES = {"pending", "acceptable", "too_stiff", "too_loose", "off_grid"}
 CHORD_FIT_VALUES = {"pending", "fits", "too_safe", "too_outside", "unclear"}
 DECISION_VALUES = {"pending", "keep", "reject", "needs_followup"}
+OBJECTIVE_BUCKET_VALUES = {"clean", "warning", "problem"}
 ISSUE_VALUES = {
     "too_safe",
     "too_scalar",
@@ -124,6 +125,47 @@ def build_candidate_note_from_review_manifest(sample: dict[str, Any]) -> dict[st
     }
 
 
+def objective_review_by_candidate(objective_midi_review_report: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
+    if not objective_midi_review_report:
+        return {}
+    candidates = objective_midi_review_report.get("candidates")
+    if not isinstance(candidates, list):
+        raise ReviewNotesError("objective MIDI review report candidates must be a list")
+    indexed: dict[str, dict[str, Any]] = {}
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            raise ReviewNotesError("objective MIDI review candidate must be an object")
+        candidate_id = str(candidate.get("candidate_id") or "").strip()
+        if not candidate_id:
+            raise ReviewNotesError("objective MIDI review candidate_id is required")
+        indexed[candidate_id] = candidate
+    return indexed
+
+
+def attach_objective_review(candidate_note: dict[str, Any], objective_candidate: dict[str, Any] | None) -> None:
+    if not objective_candidate:
+        return
+    metrics = objective_candidate.get("metrics", {})
+    candidate_note["objective_review"] = {
+        "objective_flags": list(objective_candidate.get("objective_flags", [])),
+        "objective_penalty": int(objective_candidate.get("objective_penalty", 0) or 0),
+        "objective_priority_score": int(objective_candidate.get("objective_priority_score", 0) or 0),
+        "objective_reviewable": bool(objective_candidate.get("objective_reviewable", False)),
+        "objective_bucket": str(objective_candidate.get("objective_bucket", "problem")),
+        "metrics": {
+            "max_active_notes": int(metrics.get("max_active_notes", 0) or 0),
+            "polyphonic_tick_ratio": float(metrics.get("polyphonic_tick_ratio", 0.0) or 0.0),
+            "off_sixteenth_grid_count": int(metrics.get("off_sixteenth_grid_count", 0) or 0),
+            "stepwise_interval_ratio": float(metrics.get("stepwise_interval_ratio", 0.0) or 0.0),
+            "chromatic_interval_ratio": float(metrics.get("chromatic_interval_ratio", 0.0) or 0.0),
+            "chord_tone_ratio": float(metrics.get("chord_tone_ratio", 0.0) or 0.0),
+            "tension_ratio": float(metrics.get("tension_ratio", 0.0) or 0.0),
+            "outside_ratio": float(metrics.get("outside_ratio", 0.0) or 0.0),
+            "most_common_duration_ratio": float(metrics.get("most_common_duration_ratio", 0.0) or 0.0),
+        },
+    }
+
+
 def build_review_notes_template(
     generated_chord_eval_report: dict[str, Any],
     source_review_markdown: str | None = None,
@@ -149,15 +191,23 @@ def build_review_notes_template(
 def build_review_notes_from_review_manifest(
     review_manifest: dict[str, Any],
     source_review_markdown: str | None = None,
+    objective_midi_review_report: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     candidates = review_manifest.get("candidates")
     if not isinstance(candidates, list) or not candidates:
         raise ReviewNotesError("review manifest must contain non-empty candidates")
+    objective_by_candidate = objective_review_by_candidate(objective_midi_review_report)
+    candidate_notes = [build_candidate_note_from_review_manifest(sample) for sample in candidates]
+    for note in candidate_notes:
+        attach_objective_review(note, objective_by_candidate.get(note["candidate_id"]))
     return {
         "schema_version": SCHEMA_VERSION,
         "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
         "source_review_manifest": str(review_manifest.get("source_manifest_path", "")),
         "source_review_markdown": source_review_markdown,
+        "source_objective_midi_review_report": str(
+            objective_midi_review_report.get("source_report_path", "") if objective_midi_review_report else ""
+        ),
         "reviewer": "",
         "review_context": {
             "listen_with_context_midi": True,
@@ -165,7 +215,7 @@ def build_review_notes_from_review_manifest(
             "do_not_infer_real_reference_chords": True,
         },
         "chord_progression": review_manifest.get("chord_progression", []),
-        "candidates": [build_candidate_note_from_review_manifest(sample) for sample in candidates],
+        "candidates": candidate_notes,
     }
 
 
@@ -206,6 +256,19 @@ def validate_review_notes(payload: dict[str, Any]) -> dict[str, Any]:
             raise ReviewNotesError(f"{candidate_id}.listening.issues must be a list")
         for issue in issues:
             _require_enum(issue, ISSUE_VALUES, f"{candidate_id}.listening.issues[]")
+        objective_review = candidate.get("objective_review")
+        if objective_review is not None:
+            if not isinstance(objective_review, dict):
+                raise ReviewNotesError(f"{candidate_id}.objective_review must be an object")
+            _require_enum(
+                objective_review.get("objective_bucket"),
+                OBJECTIVE_BUCKET_VALUES,
+                f"{candidate_id}.objective_review.objective_bucket",
+            )
+            if not isinstance(objective_review.get("objective_flags", []), list):
+                raise ReviewNotesError(f"{candidate_id}.objective_review.objective_flags must be a list")
+            if not isinstance(objective_review.get("objective_reviewable"), bool):
+                raise ReviewNotesError(f"{candidate_id}.objective_review.objective_reviewable must be a boolean")
         if listening.get("status") == "reviewed":
             completed += 1
         decisions[str(listening.get("decision"))] += 1
@@ -239,6 +302,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--generated_chord_eval_report", type=str, default=None)
     parser.add_argument("--review_manifest", type=str, default=None)
     parser.add_argument("--source_review_markdown", type=str, default=None)
+    parser.add_argument("--objective_midi_review_report", type=str, default=None)
     parser.add_argument("--review_notes", type=str, default=None)
     parser.add_argument(
         "--output_root",
@@ -261,9 +325,15 @@ def main() -> int:
             review_manifest_path = Path(args.review_manifest)
             review_manifest = read_json(review_manifest_path)
             review_manifest["source_manifest_path"] = str(review_manifest_path)
+            objective_report = None
+            if args.objective_midi_review_report:
+                objective_report_path = Path(args.objective_midi_review_report)
+                objective_report = read_json(objective_report_path)
+                objective_report["source_report_path"] = str(objective_report_path)
             notes = build_review_notes_from_review_manifest(
                 review_manifest,
                 source_review_markdown=args.source_review_markdown,
+                objective_midi_review_report=objective_report,
             )
         else:
             if not args.generated_chord_eval_report:

--- a/scripts/review_midi_note_objectives.py
+++ b/scripts/review_midi_note_objectives.py
@@ -20,6 +20,16 @@ from scripts.build_listening_review_notes import write_json
 
 SCHEMA_VERSION = "stage_b_objective_midi_note_review_v1"
 NOTE_NAMES = ("C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B")
+OBJECTIVE_FLAG_PENALTIES = {
+    "overlap_polyphonic": 40,
+    "off_sixteenth_grid": 35,
+    "duration_pattern_collapse": 20,
+    "chromatic_walk": 18,
+    "too_stepwise_or_scalar": 16,
+    "repeated_pitch": 14,
+    "too_safe_chord_tones": 12,
+}
+OBJECTIVE_SEVERE_FLAGS = {"overlap_polyphonic", "off_sixteenth_grid"}
 PITCH_CLASSES = {
     "C": 0,
     "C#": 1,
@@ -245,6 +255,37 @@ def objective_flags(metrics: dict[str, Any]) -> list[str]:
     return flags
 
 
+def objective_penalty(flags: list[str]) -> int:
+    return int(sum(OBJECTIVE_FLAG_PENALTIES.get(flag, 10) for flag in flags))
+
+
+def objective_reviewable(metrics: dict[str, Any], flags: list[str]) -> bool:
+    if any(flag in OBJECTIVE_SEVERE_FLAGS for flag in flags):
+        return False
+    if int(metrics.get("note_count", 0) or 0) < 8:
+        return False
+    if int(metrics.get("unique_pitch_count", 0) or 0) < 4:
+        return False
+    return True
+
+
+def objective_bucket(metrics: dict[str, Any], flags: list[str]) -> str:
+    if not objective_reviewable(metrics, flags):
+        return "problem"
+    if flags:
+        return "warning"
+    return "clean"
+
+
+def objective_priority_score(metrics: dict[str, Any], flags: list[str]) -> int:
+    score = 100 - objective_penalty(flags)
+    if int(metrics.get("note_count", 0) or 0) >= 24:
+        score += 3
+    if int(metrics.get("unique_pitch_count", 0) or 0) >= 8:
+        score += 3
+    return int(max(0, min(100, score)))
+
+
 def analyze_candidate(candidate: dict[str, Any], chord_progression: list[str]) -> dict[str, Any]:
     path = Path(str(candidate.get("review_midi_path") or candidate.get("midi_path") or ""))
     if not path.exists():
@@ -273,6 +314,10 @@ def analyze_candidate(candidate: dict[str, Any], chord_progression: list[str]) -
         for note in notes[:16]
     ]
     flags = objective_flags(metrics)
+    penalty = objective_penalty(flags)
+    reviewable = objective_reviewable(metrics, flags)
+    bucket = objective_bucket(metrics, flags)
+    priority_score = objective_priority_score(metrics, flags)
     return {
         "candidate_id": candidate_id(candidate),
         "mode": str(candidate.get("mode", "")),
@@ -282,6 +327,10 @@ def analyze_candidate(candidate: dict[str, Any], chord_progression: list[str]) -
         "context_midi_path": str(candidate.get("context_midi_path") or ""),
         "metrics": metrics,
         "objective_flags": flags,
+        "objective_penalty": penalty,
+        "objective_priority_score": priority_score,
+        "objective_reviewable": reviewable,
+        "objective_bucket": bucket,
         "first_16_notes": first_notes,
     }
 
@@ -293,6 +342,7 @@ def analyze_review_manifest(review_manifest: dict[str, Any]) -> dict[str, Any]:
     chord_progression = list(review_manifest.get("chord_progression") or [])
     analyzed = [analyze_candidate(candidate, chord_progression) for candidate in candidates]
     flag_counts = Counter(flag for candidate in analyzed for flag in candidate["objective_flags"])
+    bucket_counts = Counter(candidate["objective_bucket"] for candidate in analyzed)
     mode_counts: dict[str, Counter[str]] = {}
     for candidate in analyzed:
         counter = mode_counts.setdefault(candidate["mode"], Counter())
@@ -304,6 +354,8 @@ def analyze_review_manifest(review_manifest: dict[str, Any]) -> dict[str, Any]:
         "candidate_count": int(len(analyzed)),
         "chord_progression": chord_progression,
         "flag_counts": dict(sorted(flag_counts.items())),
+        "objective_bucket_counts": dict(sorted(bucket_counts.items())),
+        "objective_reviewable_count": int(sum(1 for candidate in analyzed if candidate["objective_reviewable"])),
         "mode_flag_counts": {mode: dict(sorted(counts.items())) for mode, counts in sorted(mode_counts.items())},
         "candidates": analyzed,
     }
@@ -315,6 +367,7 @@ def markdown_report(report: dict[str, Any], output_path: Path) -> str:
         "",
         f"- output: `{output_path}`",
         f"- candidate count: `{report['candidate_count']}`",
+        f"- objective reviewable: `{report['objective_reviewable_count']}`",
         f"- chord progression: `{' '.join(report['chord_progression'])}`",
         "",
         "## Flag Counts",
@@ -328,13 +381,17 @@ def markdown_report(report: dict[str, Any], output_path: Path) -> str:
     else:
         lines.append("| none | 0 |")
 
+    lines.extend(["", "## Objective Buckets", "", "| bucket | count |", "|---|---:|"])
+    for bucket, count in report["objective_bucket_counts"].items():
+        lines.append(f"| {bucket} | {count} |")
+
     lines.extend(
         [
             "",
             "## Candidates",
             "",
-            "| candidate | notes | unique | max active | poly ratio | stepwise | chromatic | chord tone | tension | outside | flags |",
-            "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+            "| candidate | bucket | reviewable | priority | penalty | notes | unique | max active | poly ratio | stepwise | chromatic | chord tone | tension | outside | flags |",
+            "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
         ]
     )
     for candidate in report["candidates"]:
@@ -345,6 +402,10 @@ def markdown_report(report: dict[str, Any], output_path: Path) -> str:
             + " | ".join(
                 [
                     candidate["candidate_id"],
+                    candidate["objective_bucket"],
+                    str(candidate["objective_reviewable"]).lower(),
+                    str(candidate["objective_priority_score"]),
+                    str(candidate["objective_penalty"]),
                     str(metrics["note_count"]),
                     str(metrics["unique_pitch_count"]),
                     str(metrics["max_active_notes"]),

--- a/scripts/summarize_listening_review_notes.py
+++ b/scripts/summarize_listening_review_notes.py
@@ -131,6 +131,10 @@ def aggregate_review_notes(payload: dict[str, Any]) -> dict[str, Any]:
     chord_fit_counts: Counter[str] = Counter()
     decision_counts: Counter[str] = Counter()
     issue_counts: Counter[str] = Counter()
+    objective_flag_counts: Counter[str] = Counter()
+    objective_bucket_counts: Counter[str] = Counter()
+    objective_reviewable_count = 0
+    objective_candidates: list[dict[str, Any]] = []
     reviewed_candidates: list[dict[str, Any]] = []
     by_decision: dict[str, list[dict[str, Any]]] = {}
 
@@ -150,6 +154,26 @@ def aggregate_review_notes(payload: dict[str, Any]) -> dict[str, Any]:
         for issue in listening.get("issues", []):
             issue_counts[str(issue)] += 1
 
+        objective_review = candidate.get("objective_review")
+        if isinstance(objective_review, dict):
+            objective_bucket = str(objective_review.get("objective_bucket", "problem"))
+            objective_flags = [str(flag) for flag in objective_review.get("objective_flags", [])]
+            objective_reviewable = bool(objective_review.get("objective_reviewable", False))
+            objective_bucket_counts[objective_bucket] += 1
+            objective_reviewable_count += int(objective_reviewable)
+            for flag in objective_flags:
+                objective_flag_counts[flag] += 1
+            objective_candidates.append(
+                {
+                    "candidate_id": candidate["candidate_id"],
+                    "objective_bucket": objective_bucket,
+                    "objective_reviewable": objective_reviewable,
+                    "objective_priority_score": int(objective_review.get("objective_priority_score", 0) or 0),
+                    "objective_penalty": int(objective_review.get("objective_penalty", 0) or 0),
+                    "objective_flags": objective_flags,
+                }
+            )
+
         if status == "reviewed":
             reviewed_candidates.append(
                 {
@@ -161,6 +185,7 @@ def aggregate_review_notes(payload: dict[str, Any]) -> dict[str, Any]:
                     "decision": decision,
                     "notes": str(listening.get("notes", "")),
                     "source_metrics": candidate.get("source_metrics", {}),
+                    "objective_review": candidate.get("objective_review", {}),
                 }
             )
 
@@ -187,6 +212,19 @@ def aggregate_review_notes(payload: dict[str, Any]) -> dict[str, Any]:
         "timing_counts": dict(sorted(timing_counts.items())),
         "chord_fit_counts": dict(sorted(chord_fit_counts.items())),
         "issue_counts": {**_empty_counter(ISSUE_VALUES), **dict(sorted(issue_counts.items()))},
+        "objective_review_candidate_count": int(len(objective_candidates)),
+        "objective_reviewable_count": int(objective_reviewable_count),
+        "objective_flag_counts": dict(sorted(objective_flag_counts.items())),
+        "objective_bucket_counts": dict(sorted(objective_bucket_counts.items())),
+        "objective_candidates_by_priority": sorted(
+            objective_candidates,
+            key=lambda item: (
+                0 if item["objective_reviewable"] else 1,
+                -int(item["objective_priority_score"]),
+                int(item["objective_penalty"]),
+                str(item["candidate_id"]),
+            ),
+        ),
         "source_metric_by_decision": {
             decision: _metric_summary(decision_candidates)
             for decision, decision_candidates in sorted(by_decision.items())
@@ -220,6 +258,30 @@ def markdown_summary(aggregate: dict[str, Any], output_path: Path) -> str:
     append_count_table("Timing Counts", aggregate["timing_counts"])
     append_count_table("Chord Fit Counts", aggregate["chord_fit_counts"])
     append_count_table("Issue Counts", aggregate["issue_counts"])
+    append_count_table("Objective Bucket Counts", aggregate["objective_bucket_counts"])
+    append_count_table("Objective Flag Counts", aggregate["objective_flag_counts"])
+
+    lines.extend(
+        [
+            "",
+            "## Objective Review Priority",
+            "",
+            f"- objective candidates: `{aggregate['objective_review_candidate_count']}`",
+            f"- objective reviewable: `{aggregate['objective_reviewable_count']}`",
+            "",
+            "| candidate | bucket | reviewable | priority | penalty | flags |",
+            "|---|---|---:|---:|---:|---|",
+        ]
+    )
+    for candidate in aggregate["objective_candidates_by_priority"]:
+        flags = ", ".join(candidate["objective_flags"]) or "ok_objective"
+        lines.append(
+            f"| {candidate['candidate_id']} | {candidate['objective_bucket']} | "
+            f"{str(candidate['objective_reviewable']).lower()} | {candidate['objective_priority_score']} | "
+            f"{candidate['objective_penalty']} | {flags} |"
+        )
+    if not aggregate["objective_candidates_by_priority"]:
+        lines.append("| none | none | false | 0 | 0 | none |")
 
     lines.extend(["", "## Recommended Followups", "", "| code | count | reason |", "|---|---:|---|"])
     for item in aggregate["recommended_followups"]:

--- a/tests/test_listening_review_aggregate.py
+++ b/tests/test_listening_review_aggregate.py
@@ -98,6 +98,34 @@ class ListeningReviewAggregateTest(unittest.TestCase):
         self.assertEqual(keep_metrics["avg_note_count"], 32.0)
         self.assertEqual(keep_metrics["avg_chord_tone_ratio"], 0.75)
 
+    def test_objective_review_fields_are_aggregated_for_priority(self) -> None:
+        notes = self.sample_notes()
+        notes["candidates"][0]["objective_review"] = {
+            "objective_flags": ["overlap_polyphonic"],
+            "objective_penalty": 40,
+            "objective_priority_score": 60,
+            "objective_reviewable": False,
+            "objective_bucket": "problem",
+            "metrics": {},
+        }
+        notes["candidates"][1]["objective_review"] = {
+            "objective_flags": ["chromatic_walk"],
+            "objective_penalty": 18,
+            "objective_priority_score": 82,
+            "objective_reviewable": True,
+            "objective_bucket": "warning",
+            "metrics": {},
+        }
+
+        aggregate = aggregate_review_notes(notes)
+        priority_ids = [candidate["candidate_id"] for candidate in aggregate["objective_candidates_by_priority"]]
+
+        self.assertEqual(aggregate["objective_review_candidate_count"], 2)
+        self.assertEqual(aggregate["objective_reviewable_count"], 1)
+        self.assertEqual(aggregate["objective_flag_counts"]["overlap_polyphonic"], 1)
+        self.assertEqual(aggregate["objective_bucket_counts"]["warning"], 1)
+        self.assertEqual(priority_ids[0], "candidate_2")
+
     def test_invalid_notes_are_rejected_before_aggregation(self) -> None:
         notes = self.sample_notes()
         notes["candidates"][0]["listening"]["decision"] = "maybe"

--- a/tests/test_listening_review_notes.py
+++ b/tests/test_listening_review_notes.py
@@ -67,6 +67,51 @@ class ListeningReviewNotesTest(unittest.TestCase):
             ],
         }
 
+    def sample_objective_report(self) -> dict:
+        return {
+            "source_report_path": "outputs/objective/objective_midi_note_review.json",
+            "candidates": [
+                {
+                    "candidate_id": "data_motif_rank_1_sample_1",
+                    "objective_flags": ["overlap_polyphonic"],
+                    "objective_penalty": 40,
+                    "objective_priority_score": 60,
+                    "objective_reviewable": False,
+                    "objective_bucket": "problem",
+                    "metrics": {
+                        "max_active_notes": 2,
+                        "polyphonic_tick_ratio": 0.25,
+                        "off_sixteenth_grid_count": 0,
+                        "stepwise_interval_ratio": 0.4,
+                        "chromatic_interval_ratio": 0.1,
+                        "chord_tone_ratio": 0.7,
+                        "tension_ratio": 0.2,
+                        "outside_ratio": 0.1,
+                        "most_common_duration_ratio": 0.5,
+                    },
+                },
+                {
+                    "candidate_id": "straight_grid_rank_1_sample_1",
+                    "objective_flags": ["chromatic_walk"],
+                    "objective_penalty": 18,
+                    "objective_priority_score": 82,
+                    "objective_reviewable": True,
+                    "objective_bucket": "warning",
+                    "metrics": {
+                        "max_active_notes": 1,
+                        "polyphonic_tick_ratio": 0.0,
+                        "off_sixteenth_grid_count": 0,
+                        "stepwise_interval_ratio": 0.8,
+                        "chromatic_interval_ratio": 0.4,
+                        "chord_tone_ratio": 0.5,
+                        "tension_ratio": 0.3,
+                        "outside_ratio": 0.2,
+                        "most_common_duration_ratio": 0.8,
+                    },
+                },
+            ],
+        }
+
     def test_build_review_notes_template_defaults_to_pending(self) -> None:
         notes = build_review_notes_template(self.sample_generated_report(), source_review_markdown="review.md")
 
@@ -139,6 +184,21 @@ class ListeningReviewNotesTest(unittest.TestCase):
 
         self.assertEqual(summary["candidate_count"], 2)
         self.assertEqual(summary["pending_count"], 2)
+
+    def test_build_review_notes_from_review_manifest_attaches_objective_review(self) -> None:
+        notes = build_review_notes_from_review_manifest(
+            self.sample_review_manifest(),
+            objective_midi_review_report=self.sample_objective_report(),
+        )
+
+        objective_review = notes["candidates"][0]["objective_review"]
+        summary = validate_review_notes(notes)
+
+        self.assertEqual(notes["source_objective_midi_review_report"], "outputs/objective/objective_midi_note_review.json")
+        self.assertEqual(objective_review["objective_bucket"], "problem")
+        self.assertFalse(objective_review["objective_reviewable"])
+        self.assertEqual(objective_review["metrics"]["max_active_notes"], 2)
+        self.assertEqual(summary["candidate_count"], 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_objective_midi_note_review.py
+++ b/tests/test_objective_midi_note_review.py
@@ -6,7 +6,14 @@ from pathlib import Path
 
 import mido
 
-from scripts.review_midi_note_objectives import analyze_review_manifest, chord_pitch_classes, pitch_name
+from scripts.review_midi_note_objectives import (
+    analyze_review_manifest,
+    chord_pitch_classes,
+    objective_bucket,
+    objective_penalty,
+    objective_reviewable,
+    pitch_name,
+)
 
 
 class ObjectiveMidiNoteReviewTest(unittest.TestCase):
@@ -66,6 +73,9 @@ class ObjectiveMidiNoteReviewTest(unittest.TestCase):
         self.assertIn("too_stepwise_or_scalar", candidate["objective_flags"])
         self.assertIn("chromatic_walk", candidate["objective_flags"])
         self.assertEqual(candidate["metrics"]["off_sixteenth_grid_count"], 0)
+        self.assertEqual(candidate["objective_bucket"], "warning")
+        self.assertTrue(candidate["objective_reviewable"])
+        self.assertGreater(candidate["objective_penalty"], 0)
 
     def test_overlap_candidate_is_flagged(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -96,6 +106,15 @@ class ObjectiveMidiNoteReviewTest(unittest.TestCase):
 
         self.assertIn("overlap_polyphonic", candidate["objective_flags"])
         self.assertGreater(candidate["metrics"]["polyphonic_tick_ratio"], 0)
+        self.assertEqual(candidate["objective_bucket"], "problem")
+        self.assertFalse(candidate["objective_reviewable"])
+
+    def test_objective_priority_helpers_penalize_severe_flags(self) -> None:
+        metrics = {"note_count": 16, "unique_pitch_count": 8}
+
+        self.assertEqual(objective_penalty(["overlap_polyphonic", "chromatic_walk"]), 58)
+        self.assertFalse(objective_reviewable(metrics, ["overlap_polyphonic"]))
+        self.assertEqual(objective_bucket(metrics, ["chromatic_walk"]), "warning")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 요약
- objective MIDI note review에 penalty, bucket, reviewable, priority score를 추가했습니다.
- objective MIDI report를 listening review notes에 첨부하고 aggregate에서 flag/bucket counts와 review priority를 출력합니다.
- `stage-b-objective-flags-review-flow` 하네스와 문서를 추가했습니다.

## 결과
- candidate count: `15`
- objective reviewable: `6`
- objective problem: `9`
- objective warning: `6`
- flags: `chromatic_walk=7`, `duration_pattern_collapse=9`, `overlap_polyphonic=9`, `too_stepwise_or_scalar=4`

## 검증
- `./.venv/bin/python -m unittest tests.test_objective_midi_note_review tests.test_listening_review_notes tests.test_listening_review_aggregate`
- `bash scripts/agent_harness.sh stage-b-objective-flags-review-flow`
- `bash scripts/agent_harness.sh quick`

Closes #95