### PR TITLE
Stage B overlap-free solo-line 리뷰 export 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #95: Stage B objective flags review flow.
+- Issue #97: Stage B overlap-free solo-line review export.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -236,6 +236,12 @@ For Stage B objective flags review flow changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-objective-flags-review-flow
+```
+
+For Stage B overlap-free solo-line review export changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-overlap-free-review-export
 ```
 
 For Stage B filled listening review aggregate changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -150,6 +150,7 @@ Stage B에서 명시하는 것:
 44. Stage B full review manifest listening notes
 45. Stage B objective MIDI note review
 46. Stage B objective flags review flow
+47. Stage B overlap-free solo-line review export
 
 가장 최근 의미 있는 결과:
 
@@ -176,6 +177,7 @@ Stage B에서 명시하는 것:
 - Issue #91 builds listening review notes from the full review manifest so all 15 review candidates, including timing references, have file paths and pending review fields.
 - Issue #93 reads generated MIDI notes directly and reports objective flags for overlap/polyphony, grid alignment, scalar/chromatic motion, duration collapse, and chord-role ratios.
 - Issue #95 connects objective flags to listening review notes and aggregate priority so problem/warning candidates are visible before manual listening.
+- Issue #97 exports overlap-free solo-line review MIDI variants while preserving original sample paths, reducing objective `overlap_polyphonic` from `9` to `0`.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -393,6 +395,7 @@ Stage B에서 명시하는 것:
 - Issue #91 result: full review manifest notes contain `15` pending candidates with `review_midi_path`, `context_midi_path`, mode, rank, sample, and rhythm/timing metrics.
 - Issue #93 result: objective MIDI review flags `chromatic_walk=7`, `duration_pattern_collapse=9`, `overlap_polyphonic=9`, and `too_stepwise_or_scalar=4`.
 - Issue #95 result: objective review priority reports `15` candidates, `6` warning/reviewable candidates, and `9` problem candidates before subjective listening.
+- Issue #97 result: overlap-free review export reports `15` reviewable candidates, `5` clean candidates, `10` warning candidates, and `overlap_polyphonic=0`.
 
 해석:
 
@@ -672,27 +675,27 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B objective flags review flow 연결
+Stage B overlap-free solo-line review export 추가
 ```
 
 결과:
 
-- objective note-level diagnostics를 listening review notes와 aggregate priority에 연결했다.
-- output: `outputs/stage_b_listening_review_aggregate/harness_stage_b_objective_flags_review_flow/listening_review_aggregate.md`
+- review export 단계에서 overlap-free solo-line MIDI variant를 생성한다.
+- output: `outputs/stage_b_listening_review_aggregate/harness_stage_b_overlap_free_review_export/listening_review_aggregate.md`
 - candidate count: `15`
-- objective reviewable: `6`
-- objective problem: `9`
-- objective warning: `6`
+- objective reviewable: `15`
+- objective clean: `5`
+- objective warning: `10`
 - chromatic walk: `7`
-- duration pattern collapse: `9`
-- overlap/polyphonic: `9`
+- duration pattern collapse: `6`
+- overlap/polyphonic: `0`
 - too stepwise/scalar: `4`
 
 다음 작업:
 
-- overlap/polyphonic이 생기지 않는 solo-line export를 먼저 고친다.
 - duration collapse가 있는 straight-grid 후보는 rhythm/duration variation을 개선한다.
-- subjective listening result는 objective warning/problem priority를 참고해 채운다.
+- chromatic/scalar exercise처럼 들리는 후보는 phrase vocabulary와 cadence target을 조정한다.
+- subjective listening result는 objective clean/warning priority를 참고해 채운다.
 - real Brad/reference chord label은 아직 임의로 넣지 않는다.
 
 ## 10. 한 문장 요약

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-95-stage-b-objective-flags-review-flow`
+- `issue-97-stage-b-overlap-free-solo-line-review-export`
 
 현재 범위가 아닌 것:
 
@@ -35,6 +35,50 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
 ## Latest Probe Result
+
+Issue #97은 review export 단계에서 overlap-free solo-line MIDI variant를 만드는 단계다.
+
+중요한 전제:
+
+- 원본 generated sample MIDI는 `midi_path`에 보존한다.
+- 사람이 듣는 `review_midi_path`에는 `*_overlap_free.mid` variant를 넣는다.
+- 이것은 음악성을 높이는 학습이 아니라, chord block처럼 보이는 overlap artifact를 review 전에 제거하는 export step이다.
+- subjective jazz quality를 성공으로 주장하지 않는다.
+
+Implemented:
+
+- `--overlap_free_review_midi`
+- overlap-free solo-line MIDI writer
+- review manifest `review_variant`
+- review manifest `review_postprocess_report`
+- listening review notes `review_metadata.review_variant`
+- `scripts/agent_harness.sh stage-b-overlap-free-review-export`
+- docs:
+  - `docs/STAGE_B_OVERLAP_FREE_REVIEW_EXPORT_2026-05-22.md`
+
+Result:
+
+- candidate count: `15`
+- objective reviewable count: `15`
+- objective bucket counts:
+  - clean: `5`
+  - warning: `10`
+- objective flag counts:
+  - chromatic walk: `7`
+  - duration pattern collapse: `6`
+  - too stepwise/scalar: `4`
+  - overlap/polyphonic: `0`
+- previous overlap/polyphonic count was `9`
+- aggregate report:
+  - `outputs/stage_b_listening_review_aggregate/harness_stage_b_overlap_free_review_export/listening_review_aggregate.md`
+
+Decision:
+
+- overlap/polyphonic 문제는 review export에서 제거됐다.
+- 지금 남은 문제는 jazz vocabulary보다 duration collapse, scalar/chromatic motion, phrase quality 쪽이다.
+- 다음 generation rule change는 duration/rhythm variation 또는 candidate vocabulary 개선이어야 한다.
+
+## Previous Probe Result
 
 Issue #95는 objective MIDI note-level diagnostics를 listening review notes와 aggregate priority에 연결하는 단계다.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,6 +106,8 @@
   - generated review MIDI를 직접 읽어 overlap, grid, scalar/chromatic, duration collapse를 진단한 결과.
 - `STAGE_B_OBJECTIVE_FLAGS_REVIEW_FLOW_2026-05-22.md`
   - objective MIDI flags를 listening review notes와 aggregate priority에 연결한 결과.
+- `STAGE_B_OVERLAP_FREE_REVIEW_EXPORT_2026-05-22.md`
+  - overlap-free solo-line review MIDI variant를 export하고 objective overlap/polyphonic flag를 제거한 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`

--- a/docs/STAGE_B_OVERLAP_FREE_REVIEW_EXPORT_2026-05-22.md
+++ b/docs/STAGE_B_OVERLAP_FREE_REVIEW_EXPORT_2026-05-22.md
@@ -1,0 +1,107 @@
+# Stage B Overlap-Free Review Export
+
+작성일: 2026-05-22
+
+## 목적
+
+Issue #97은 generated review MIDI 후보가 solo-line이 아니라 chord block처럼 보이는 문제를 줄이기 위해, review export 단계에서 overlap-free solo-line variant를 생성한 단계다.
+
+이 작업은 모델 품질 향상이 아니다. 원본 generated sample은 보존하고, 사람이 듣는 review MIDI만 겹침 없는 solo-line으로 정리해서 objective review가 제대로 비교할 수 있게 한다.
+
+## 구현
+
+변경 사항:
+
+- `scripts/run_stage_b_data_motif_generation_compare.py`
+  - `--overlap_free_review_midi`
+  - `overlap_free_solo_notes`
+  - `write_overlap_free_solo_midi`
+  - review manifest `review_variant`
+  - review manifest `review_postprocess_report`
+- `scripts/build_listening_review_notes.py`
+  - `review_metadata.review_variant`
+  - `review_metadata.review_postprocess_report`
+- `scripts/agent_harness.sh`
+  - `stage-b-overlap-free-review-export`
+
+## 동작 방식
+
+원본 MIDI:
+
+- `midi_path`에 보존한다.
+
+청취 리뷰 MIDI:
+
+- `review_midi_path`에 `*_overlap_free.mid`를 기록한다.
+- 같은 onset의 중복 음은 대표 note만 남긴다.
+- 다음 onset을 침범하는 duration은 다음 onset 직전까지 자른다.
+- export report에 before/after max simultaneous notes와 trimmed note count를 남긴다.
+
+## 하네스
+
+실행:
+
+```bash
+bash scripts/agent_harness.sh stage-b-overlap-free-review-export
+```
+
+이 하네스는 다음 순서로 실행된다.
+
+1. overlap-free review MIDI export
+2. objective MIDI note review
+3. objective-aware listening review notes 생성
+4. objective-aware aggregate 생성
+
+## 결과
+
+출력:
+
+- review manifest:
+  - `outputs/stage_b_data_motif_review/harness_stage_b_overlap_free_review_export/review_manifest.json`
+- objective report:
+  - `outputs/stage_b_objective_midi_review/harness_stage_b_overlap_free_review_export/objective_midi_note_review.md`
+- aggregate:
+  - `outputs/stage_b_listening_review_aggregate/harness_stage_b_overlap_free_review_export/listening_review_aggregate.md`
+
+요약:
+
+- candidate count: `15`
+- objective reviewable: `15`
+- objective bucket counts:
+  - clean: `5`
+  - warning: `10`
+- objective flag counts:
+  - chromatic walk: `7`
+  - duration pattern collapse: `6`
+  - too stepwise/scalar: `4`
+  - overlap/polyphonic: `0`
+
+비교:
+
+- 이전 objective flags review flow의 overlap/polyphonic count: `9`
+- 이번 overlap-free review export의 overlap/polyphonic count: `0`
+
+## 해석
+
+overlap-free export는 명백한 piano-roll artifact를 제거했다.
+
+하지만 이것이 좋은 jazz solo를 의미하지는 않는다.
+
+남은 문제:
+
+- `duration_pattern_collapse`
+- `chromatic_walk`
+- `too_stepwise_or_scalar`
+- subjective phrase quality 미확정
+
+따라서 다음 작업은 broad training이 아니라 duration/rhythm variation 또는 phrase/cadence vocabulary 개선이어야 한다.
+
+## 검증
+
+실행한 검증:
+
+```bash
+./.venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare tests.test_listening_review_notes
+bash scripts/agent_harness.sh stage-b-overlap-free-review-export
+bash scripts/agent_harness.sh quick
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -74,6 +74,8 @@ Modes:
                 Export straight-grid guide-tone/cadence candidates with chord context.
   stage-b-data-guide-hybrid
                 Export data-motif rhythm plus guide-tone/cadence pitch candidates.
+  stage-b-overlap-free-review-export
+                Export overlap-free solo-line review MIDI variants and objective priority.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   chord-coverage-audit
@@ -806,6 +808,48 @@ run_stage_b_data_guide_hybrid() {
     --copy_review_midi
 }
 
+run_stage_b_overlap_free_review_export() {
+  local run_id="${RUN_ID:-harness_stage_b_overlap_free_review_export}"
+  local review_manifest_path="outputs/stage_b_data_motif_review/${run_id}/review_manifest.json"
+  local review_markdown_path="outputs/stage_b_data_motif_review/${run_id}/review_candidates.md"
+  local objective_report_path="outputs/stage_b_objective_midi_review/${run_id}/objective_midi_note_review.json"
+  local review_notes_path="outputs/stage_b_listening_review_notes/${run_id}/review_notes_template.json"
+  print_header "Stage B overlap-free solo-line review export"
+  "$PYTHON_BIN" scripts/run_stage_b_data_motif_generation_compare.py \
+    --run_id "$run_id" \
+    --issue_number 97 \
+    --input_dir ./midi_dataset/midi/studio \
+    --baseline_modes straight_grid,straight_guide_tones,hand_written_swing,data_motif,data_motif_guide_tones \
+    --max_files 4 \
+    --window_bars 8 \
+    --window_stride_bars 4 \
+    --min_window_target_notes 16 \
+    --motif_length 4 \
+    --max_bar_span 2 \
+    --max_records 64 \
+    --template_top_n 32 \
+    --num_samples 3 \
+    --bars 8 \
+    --note_groups_per_bar 8 \
+    --review_top_n 3 \
+    --copy_review_midi \
+    --overlap_free_review_midi
+  print_header "Stage B objective MIDI note review"
+  "$PYTHON_BIN" scripts/review_midi_note_objectives.py \
+    --run_id "$run_id" \
+    --review_manifest "$review_manifest_path"
+  print_header "Stage B objective-aware listening review notes"
+  "$PYTHON_BIN" scripts/build_listening_review_notes.py \
+    --run_id "$run_id" \
+    --review_manifest "$review_manifest_path" \
+    --source_review_markdown "$review_markdown_path" \
+    --objective_midi_review_report "$objective_report_path"
+  print_header "Stage B objective-aware listening review aggregate"
+  "$PYTHON_BIN" scripts/summarize_listening_review_notes.py \
+    --run_id "$run_id" \
+    --review_notes "$review_notes_path"
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -1028,6 +1072,9 @@ case "$MODE" in
     ;;
   stage-b-data-guide-hybrid)
     run_stage_b_data_guide_hybrid
+    ;;
+  stage-b-overlap-free-review-export)
+    run_stage_b_overlap_free_review_export
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/build_listening_review_notes.py
+++ b/scripts/build_listening_review_notes.py
@@ -106,6 +106,8 @@ def build_candidate_note_from_review_manifest(sample: dict[str, Any]) -> dict[st
             "sample_seed": sample.get("sample_seed"),
             "valid": bool(sample.get("valid", False)),
             "strict_valid": bool(sample.get("strict_valid", False)),
+            "review_variant": str(sample.get("review_variant", "original") or "original"),
+            "review_postprocess_report": sample.get("review_postprocess_report", {}),
         },
         "review_files": {
             "midi_path": str(sample.get("review_midi_path") or sample.get("midi_path") or ""),

--- a/scripts/run_stage_b_data_motif_generation_compare.py
+++ b/scripts/run_stage_b_data_motif_generation_compare.py
@@ -18,6 +18,7 @@ import pretty_midi
 ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
+from inference.app.metrics import max_simultaneous_notes  # noqa: E402
 from inference.app.schemas import GenerationRequest  # noqa: E402
 from scripts.run_stage_b_generation_probe import (  # noqa: E402
     CHORD_TONE_INTERVALS,
@@ -850,6 +851,109 @@ def write_context_midi(
     return output_path
 
 
+def _best_note_for_onset(notes: Sequence[pretty_midi.Note]) -> pretty_midi.Note:
+    return max(
+        notes,
+        key=lambda note: (
+            int(note.velocity),
+            float(note.end) - float(note.start),
+            -abs(int(note.pitch) - 67),
+            -int(note.pitch),
+        ),
+    )
+
+
+def overlap_free_solo_notes(
+    notes: Sequence[pretty_midi.Note],
+    *,
+    time_precision: int = 6,
+    min_duration_sec: float = 0.001,
+) -> tuple[list[pretty_midi.Note], dict[str, Any]]:
+    valid_notes = [note for note in notes if float(note.end) > float(note.start)]
+    by_onset: dict[float, list[pretty_midi.Note]] = {}
+    for note in valid_notes:
+        onset = round(float(note.start), int(time_precision))
+        by_onset.setdefault(onset, []).append(note)
+
+    selected = [
+        _best_note_for_onset(onset_notes)
+        for _onset, onset_notes in sorted(by_onset.items(), key=lambda item: item[0])
+    ]
+
+    solo_notes: list[pretty_midi.Note] = []
+    trimmed_note_count = 0
+    for index, note in enumerate(selected):
+        start = float(note.start)
+        original_end = float(note.end)
+        next_start = float(selected[index + 1].start) if index + 1 < len(selected) else None
+        end = original_end
+        if next_start is not None and end > next_start:
+            end = next_start
+            trimmed_note_count += 1
+        if end <= start:
+            continue
+        if end - start < float(min_duration_sec):
+            end = start + float(min_duration_sec)
+            if next_start is not None and end > next_start:
+                continue
+        solo_notes.append(
+            pretty_midi.Note(
+                velocity=int(note.velocity),
+                pitch=int(note.pitch),
+                start=start,
+                end=end,
+            )
+        )
+
+    report = {
+        "before_note_count": int(len(valid_notes)),
+        "after_note_count": int(len(solo_notes)),
+        "same_onset_dropped_note_count": int(max(0, len(valid_notes) - len(selected))),
+        "trimmed_note_count": int(trimmed_note_count),
+        "before_max_simultaneous_notes": int(max_simultaneous_notes(list(valid_notes))) if valid_notes else 0,
+        "after_max_simultaneous_notes": int(max_simultaneous_notes(list(solo_notes))) if solo_notes else 0,
+    }
+    return solo_notes, report
+
+
+def write_overlap_free_solo_midi(
+    source_path: Path,
+    output_path: Path,
+    *,
+    bpm: float | int | None = None,
+) -> dict[str, Any]:
+    source = pretty_midi.PrettyMIDI(str(source_path))
+    tempo = float(bpm) if bpm is not None else float(source.estimate_tempo() or 120.0)
+    result = pretty_midi.PrettyMIDI(initial_tempo=tempo)
+    source_instruments = [instrument for instrument in source.instruments if not instrument.is_drum]
+    source_notes = [note for instrument in source_instruments for note in instrument.notes]
+    solo_notes, report = overlap_free_solo_notes(source_notes)
+    program = int(source_instruments[0].program) if source_instruments else 0
+    name = source_instruments[0].name if source_instruments else "Solo"
+    copied = pretty_midi.Instrument(
+        program=program,
+        is_drum=False,
+        name=f"Overlap-free {name or 'Solo'}",
+    )
+    copied.notes = solo_notes
+    result.instruments.append(copied)
+    total_report = {
+        "enabled": True,
+        "source_midi_path": str(source_path),
+        "output_midi_path": str(output_path),
+        "bpm": tempo,
+        "before_note_count": int(report["before_note_count"]),
+        "after_note_count": int(report["after_note_count"]),
+        "same_onset_dropped_note_count": int(report["same_onset_dropped_note_count"]),
+        "trimmed_note_count": int(report["trimmed_note_count"]),
+        "before_max_simultaneous_notes": int(report["before_max_simultaneous_notes"]),
+        "after_max_simultaneous_notes": int(report["after_max_simultaneous_notes"]),
+    }
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    result.write(str(output_path))
+    return total_report
+
+
 def build_compare_summary(
     mode_summaries: dict[str, dict[str, Any]],
     min_strict_valid_samples: int,
@@ -918,6 +1022,8 @@ def compact_review_candidate(
     review_rank: int,
     review_midi_path: Path | None,
     context_midi_path: Path | None,
+    review_variant: str = "original",
+    review_postprocess_report: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     rhythm = row.get("rhythm_profile", {})
     pitch_roles = row.get("pitch_roles", {})
@@ -932,6 +1038,8 @@ def compact_review_candidate(
         "midi_path": row["midi_path"],
         "review_midi_path": str(review_midi_path) if review_midi_path else None,
         "context_midi_path": str(context_midi_path) if context_midi_path else None,
+        "review_variant": review_variant,
+        "review_postprocess_report": review_postprocess_report or {},
         "note_count": int(metrics.get("note_count", 0) or 0),
         "unique_pitch_count": int(metrics.get("unique_pitch_count", 0) or 0),
         "dead_air_ratio": float(metrics.get("dead_air_ratio", 0.0) or 0.0),
@@ -956,8 +1064,8 @@ def review_markdown_report(manifest: dict[str, Any]) -> str:
         f"- candidate count: `{manifest['candidate_count']}`",
         f"- copy midi: `{str(manifest['copy_midi']).lower()}`",
         "",
-        "| mode | rank | sample | strict | notes | pitches | sync | bar-var | dur-var | dur-rep | ioi-var | ioi-rep | tension | solo/context MIDI |",
-        "|---|---:|---:|:---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+        "| mode | rank | sample | variant | strict | notes | pitches | sync | bar-var | dur-var | dur-rep | ioi-var | ioi-rep | tension | solo/context MIDI |",
+        "|---|---:|---:|---|:---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
     ]
     guide_path = manifest.get("chord_guide_midi_path")
     if guide_path:
@@ -970,7 +1078,7 @@ def review_markdown_report(manifest: dict[str, Any]) -> str:
         format_row["display_midi_path"] = midi_path
         format_row["display_context_midi_path"] = context_path
         lines.append(
-            "| {mode} | {review_rank} | {sample_index} | {strict_valid} | {note_count} | "
+            "| {mode} | {review_rank} | {sample_index} | {review_variant} | {strict_valid} | {note_count} | "
             "{unique_pitch_count} | {syncopated_onset_ratio:.3f} | "
             "{unique_bar_position_pattern_ratio:.3f} | {duration_diversity_ratio:.3f} | "
             "{most_common_duration_ratio:.3f} | {ioi_diversity_ratio:.3f} | "
@@ -989,6 +1097,7 @@ def build_review_export(
     chords: Sequence[str],
     bpm: float | int,
     bars: int,
+    overlap_free_review_midi: bool = False,
 ) -> dict[str, Any]:
     output_dir.mkdir(parents=True, exist_ok=True)
     named_dir = output_dir / "named_midi"
@@ -1012,21 +1121,24 @@ def build_review_export(
         for review_rank, row in enumerate(rows[: int(top_n)], start=1):
             review_midi_path: Path | None = None
             context_midi_path: Path | None = None
+            review_variant = "original"
+            review_postprocess_report: dict[str, Any] | None = None
             if copy_midi:
                 source = Path(str(row["midi_path"]))
                 if not source.is_absolute():
                     source = ROOT_DIR / source
-                target = named_dir / (
-                    f"{mode_index:02d}_{mode}_rank_{review_rank:02d}_"
-                    f"sample_{int(row['sample_index']):02d}.mid"
-                )
+                base_name = f"{mode_index:02d}_{mode}_rank_{review_rank:02d}_sample_{int(row['sample_index']):02d}"
+                suffix = "_overlap_free.mid" if overlap_free_review_midi else ".mid"
+                target = named_dir / f"{base_name}{suffix}"
                 if source.exists():
-                    shutil.copy2(source, target)
+                    if overlap_free_review_midi:
+                        review_postprocess_report = write_overlap_free_solo_midi(source, target, bpm=bpm)
+                        review_variant = "overlap_free_solo_line"
+                    else:
+                        shutil.copy2(source, target)
                     review_midi_path = target
-                    context_target = context_dir / (
-                        f"{mode_index:02d}_{mode}_rank_{review_rank:02d}_"
-                        f"sample_{int(row['sample_index']):02d}_with_context.mid"
-                    )
+                    context_suffix = "_overlap_free_with_context.mid" if overlap_free_review_midi else "_with_context.mid"
+                    context_target = context_dir / f"{base_name}{context_suffix}"
                     context_midi_path = write_context_midi(
                         target,
                         context_target,
@@ -1041,12 +1153,15 @@ def build_review_export(
                     review_rank=review_rank,
                     review_midi_path=review_midi_path,
                     context_midi_path=context_midi_path,
+                    review_variant=review_variant,
+                    review_postprocess_report=review_postprocess_report,
                 )
             )
 
     manifest = {
         "output_dir": str(output_dir),
         "copy_midi": bool(copy_midi),
+        "overlap_free_review_midi": bool(overlap_free_review_midi),
         "top_n": int(top_n),
         "chord_progression": list(chords),
         "chord_guide_midi_path": str(chord_guide_midi_path) if chord_guide_midi_path else None,
@@ -1089,6 +1204,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--review_top_n", type=int, default=3)
     parser.add_argument("--review_output_root", type=str, default=str(ROOT_DIR / "outputs" / "stage_b_data_motif_review"))
     parser.add_argument("--copy_review_midi", action="store_true")
+    parser.add_argument("--overlap_free_review_midi", action="store_true")
     return parser
 
 
@@ -1186,6 +1302,7 @@ def main() -> int:
         output_dir=Path(args.review_output_root) / args.run_id,
         top_n=int(args.review_top_n),
         copy_midi=bool(args.copy_review_midi),
+        overlap_free_review_midi=bool(args.overlap_free_review_midi),
         chords=chords,
         bpm=args.bpm,
         bars=args.bars,

--- a/tests/test_listening_review_notes.py
+++ b/tests/test_listening_review_notes.py
@@ -43,6 +43,11 @@ class ListeningReviewNotesTest(unittest.TestCase):
                     "review_midi_path": "named_midi/01_data_motif_rank_01_sample_01.mid",
                     "midi_path": "samples/data_motif/data_motif_sample_1.mid",
                     "context_midi_path": "context_midi/01_data_motif_rank_01_sample_01_with_context.mid",
+                    "review_variant": "overlap_free_solo_line",
+                    "review_postprocess_report": {
+                        "before_max_simultaneous_notes": 2,
+                        "after_max_simultaneous_notes": 1,
+                    },
                     "note_count": 63,
                     "unique_pitch_count": 24,
                     "dead_air_ratio": 0.56,
@@ -171,6 +176,11 @@ class ListeningReviewNotesTest(unittest.TestCase):
         self.assertEqual(len(notes["candidates"]), 2)
         self.assertEqual(notes["candidates"][0]["candidate_id"], "data_motif_rank_1_sample_1")
         self.assertEqual(notes["candidates"][0]["review_metadata"]["mode"], "data_motif")
+        self.assertEqual(notes["candidates"][0]["review_metadata"]["review_variant"], "overlap_free_solo_line")
+        self.assertEqual(
+            notes["candidates"][0]["review_metadata"]["review_postprocess_report"]["after_max_simultaneous_notes"],
+            1,
+        )
         self.assertEqual(
             notes["candidates"][0]["review_files"]["context_midi_path"],
             "context_midi/01_data_motif_rank_01_sample_01_with_context.mid",

--- a/tests/test_stage_b_data_motif_generation_compare.py
+++ b/tests/test_stage_b_data_motif_generation_compare.py
@@ -16,6 +16,7 @@ from scripts.run_stage_b_data_motif_generation_compare import (
     guide_tone_pitch_classes,
     nearest_allowed_pitch_token,
     normalize_position_deltas,
+    overlap_free_solo_notes,
     parse_baseline_modes,
     straight_guide_tones_tokens,
     straight_grid_tokens,
@@ -316,6 +317,73 @@ class StageBDataMotifGenerationCompareTest(unittest.TestCase):
             self.assertTrue(Path(manifest["chord_guide_midi_path"]).exists())
             self.assertTrue((tmp_path / "review" / "review_manifest.json").exists())
             self.assertTrue((tmp_path / "review" / "review_candidates.md").exists())
+
+    def test_overlap_free_solo_notes_trims_to_next_onset(self) -> None:
+        notes = [
+            pretty_midi.Note(velocity=80, pitch=60, start=0.0, end=1.0),
+            pretty_midi.Note(velocity=82, pitch=62, start=0.5, end=1.5),
+            pretty_midi.Note(velocity=70, pitch=64, start=1.0, end=1.25),
+        ]
+
+        solo_notes, report = overlap_free_solo_notes(notes)
+
+        self.assertEqual(len(solo_notes), 3)
+        self.assertLessEqual(solo_notes[0].end, solo_notes[1].start)
+        self.assertLessEqual(solo_notes[1].end, solo_notes[2].start)
+        self.assertEqual(report["trimmed_note_count"], 2)
+        self.assertEqual(report["after_max_simultaneous_notes"], 1)
+
+    def test_build_review_export_can_write_overlap_free_variant(self) -> None:
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            source_midi = tmp_path / "source.mid"
+            midi = pretty_midi.PrettyMIDI(initial_tempo=124)
+            instrument = pretty_midi.Instrument(program=0, name="Solo")
+            instrument.notes.append(pretty_midi.Note(velocity=80, pitch=60, start=0.0, end=1.0))
+            instrument.notes.append(pretty_midi.Note(velocity=80, pitch=62, start=0.5, end=1.5))
+            midi.instruments.append(instrument)
+            midi.write(str(source_midi))
+            samples = {
+                "data_motif": [
+                    {
+                        "sample_index": 1,
+                        "sample_seed": 17,
+                        "valid": True,
+                        "strict_valid": True,
+                        "midi_path": str(source_midi),
+                        "metrics": {"note_count": 2, "unique_pitch_count": 2, "dead_air_ratio": 0.0},
+                        "rhythm_profile": {
+                            "syncopated_onset_ratio": 0.0,
+                            "unique_bar_position_pattern_ratio": 1.0,
+                            "duration_diversity_ratio": 0.5,
+                            "most_common_duration_ratio": 0.5,
+                            "ioi_diversity_ratio": 0.5,
+                            "most_common_ioi_ratio": 0.5,
+                        },
+                        "pitch_roles": {"tension_ratio": 0.0, "root_tone_ratio": 0.0},
+                    }
+                ]
+            }
+
+            manifest = build_review_export(
+                samples,
+                output_dir=tmp_path / "review",
+                top_n=1,
+                copy_midi=True,
+                chords=["Cm7"],
+                bpm=124,
+                bars=1,
+                overlap_free_review_midi=True,
+            )
+
+            candidate = manifest["candidates"][0]
+            exported = pretty_midi.PrettyMIDI(candidate["review_midi_path"])
+            exported_notes = exported.instruments[0].notes
+
+            self.assertEqual(candidate["review_variant"], "overlap_free_solo_line")
+            self.assertTrue(candidate["review_midi_path"].endswith("_overlap_free.mid"))
+            self.assertEqual(candidate["review_postprocess_report"]["after_max_simultaneous_notes"], 1)
+            self.assertLessEqual(exported_notes[0].end, exported_notes[1].start)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 요약
- overlap-free solo-line review MIDI export 옵션을 추가했습니다.
- 원본 sample MIDI는 `midi_path`에 보존하고, 청취용 `review_midi_path`에는 `*_overlap_free.mid` variant를 기록합니다.
- objective review, listening notes, aggregate까지 이어지는 `stage-b-overlap-free-review-export` 하네스를 추가했습니다.

## 결과
- candidate count: `15`
- objective reviewable: `15`
- objective clean: `5`
- objective warning: `10`
- `overlap_polyphonic`: `9 -> 0`
- 남은 flags: `chromatic_walk=7`, `duration_pattern_collapse=6`, `too_stepwise_or_scalar=4`

## 검증
- `./.venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare tests.test_listening_review_notes`
- `bash scripts/agent_harness.sh stage-b-overlap-free-review-export`
- `bash scripts/agent_harness.sh quick`

Closes #97


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added overlap-free solo-line review export capability that removes simultaneous notes and trims durations for cleaner MIDI review.

* **Documentation**
  * Added comprehensive documentation for the overlap-free review export process.
  * Updated project status and planning docs to reflect new review milestone.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohhalim/fine_tuning_art-tatum_midi_solo/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->