### PR TITLE
Stage B duration variation 리뷰 baseline 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #97: Stage B overlap-free solo-line review export.
+- Issue #99: Stage B duration variation review baseline.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -242,6 +242,12 @@ For Stage B overlap-free solo-line review export changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-overlap-free-review-export
+```
+
+For Stage B duration variation review changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-duration-variation-review
 ```
 
 For Stage B filled listening review aggregate changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -151,6 +151,7 @@ Stage B에서 명시하는 것:
 45. Stage B objective MIDI note review
 46. Stage B objective flags review flow
 47. Stage B overlap-free solo-line review export
+48. Stage B duration variation review baseline
 
 가장 최근 의미 있는 결과:
 
@@ -178,6 +179,7 @@ Stage B에서 명시하는 것:
 - Issue #93 reads generated MIDI notes directly and reports objective flags for overlap/polyphony, grid alignment, scalar/chromatic motion, duration collapse, and chord-role ratios.
 - Issue #95 connects objective flags to listening review notes and aggregate priority so problem/warning candidates are visible before manual listening.
 - Issue #97 exports overlap-free solo-line review MIDI variants while preserving original sample paths, reducing objective `overlap_polyphonic` from `9` to `0`.
+- Issue #99 adds varied-duration review baselines, reducing objective `duration_pattern_collapse` from `6` to `0` while keeping `overlap_polyphonic=0`.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -396,6 +398,7 @@ Stage B에서 명시하는 것:
 - Issue #93 result: objective MIDI review flags `chromatic_walk=7`, `duration_pattern_collapse=9`, `overlap_polyphonic=9`, and `too_stepwise_or_scalar=4`.
 - Issue #95 result: objective review priority reports `15` candidates, `6` warning/reviewable candidates, and `9` problem candidates before subjective listening.
 - Issue #97 result: overlap-free review export reports `15` reviewable candidates, `5` clean candidates, `10` warning candidates, and `overlap_polyphonic=0`.
+- Issue #99 result: duration variation review reports `15` reviewable candidates, `8` clean candidates, `7` warning candidates, `duration_pattern_collapse=0`, and `overlap_polyphonic=0`.
 
 해석:
 
@@ -675,25 +678,24 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B overlap-free solo-line review export 추가
+Stage B duration variation review baseline 추가
 ```
 
 결과:
 
-- review export 단계에서 overlap-free solo-line MIDI variant를 생성한다.
-- output: `outputs/stage_b_listening_review_aggregate/harness_stage_b_overlap_free_review_export/listening_review_aggregate.md`
+- varied-duration review baseline을 추가해 duration collapse를 줄였다.
+- output: `outputs/stage_b_listening_review_aggregate/harness_stage_b_duration_variation_review/listening_review_aggregate.md`
 - candidate count: `15`
 - objective reviewable: `15`
-- objective clean: `5`
-- objective warning: `10`
+- objective clean: `8`
+- objective warning: `7`
 - chromatic walk: `7`
-- duration pattern collapse: `6`
+- duration pattern collapse: `0`
 - overlap/polyphonic: `0`
-- too stepwise/scalar: `4`
+- too stepwise/scalar: `6`
 
 다음 작업:
 
-- duration collapse가 있는 straight-grid 후보는 rhythm/duration variation을 개선한다.
 - chromatic/scalar exercise처럼 들리는 후보는 phrase vocabulary와 cadence target을 조정한다.
 - subjective listening result는 objective clean/warning priority를 참고해 채운다.
 - real Brad/reference chord label은 아직 임의로 넣지 않는다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-97-stage-b-overlap-free-solo-line-review-export`
+- `issue-99-stage-b-duration-variation-review-baseline`
 
 현재 범위가 아닌 것:
 
@@ -35,6 +35,48 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
 ## Latest Probe Result
+
+Issue #99는 duration collapse를 줄이기 위해 varied-duration review baseline을 추가한 단계다.
+
+중요한 전제:
+
+- 이 단계는 rhythmic 다양성을 조금 추가하는 probe다.
+- "재즈답다"를 자동으로 보장하지 않는다.
+- overlap-free export는 계속 유지한다.
+- subjective listening review는 아직 pending이다.
+
+Implemented:
+
+- `varied_grid` baseline mode
+- `varied_guide_tones` baseline mode
+- 16th-grid onset을 유지하면서 duration pattern 다양화
+- `scripts/agent_harness.sh stage-b-duration-variation-review`
+- docs:
+  - `docs/STAGE_B_DURATION_VARIATION_REVIEW_2026-05-22.md`
+
+Result:
+
+- candidate count: `15`
+- objective reviewable count: `15`
+- objective bucket counts:
+  - clean: `8`
+  - warning: `7`
+- objective flag counts:
+  - chromatic walk: `7`
+  - too stepwise/scalar: `6`
+  - duration pattern collapse: `0`
+  - overlap/polyphonic: `0`
+- previous duration pattern collapse count was `6`
+- aggregate report:
+  - `outputs/stage_b_listening_review_aggregate/harness_stage_b_duration_variation_review/listening_review_aggregate.md`
+
+Decision:
+
+- duration collapse는 objective flag 기준으로 제거됐다.
+- 이제 남은 핵심 문제는 scalar/chromatic exercise 느낌이다.
+- 다음 작업은 pitch contour / phrase vocabulary / cadence target을 개선하는 방향이어야 한다.
+
+## Previous Probe Result
 
 Issue #97은 review export 단계에서 overlap-free solo-line MIDI variant를 만드는 단계다.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -108,6 +108,8 @@
   - objective MIDI flags를 listening review notes와 aggregate priority에 연결한 결과.
 - `STAGE_B_OVERLAP_FREE_REVIEW_EXPORT_2026-05-22.md`
   - overlap-free solo-line review MIDI variant를 export하고 objective overlap/polyphonic flag를 제거한 결과.
+- `STAGE_B_DURATION_VARIATION_REVIEW_2026-05-22.md`
+  - varied-duration baseline을 추가해 review MIDI의 duration collapse flag를 제거한 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -134,7 +136,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, generated chord eval bridge, data-guide generated chord eval, review markdown chord eval summary, listening review notes schema, filled listening review aggregate, full review manifest notes, and objective MIDI note review를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, generated chord eval bridge, data-guide generated chord eval, review markdown chord eval summary, listening review notes schema, filled listening review aggregate, full review manifest notes, objective MIDI note review, objective flags review flow, overlap-free review export, and duration variation review를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_DURATION_VARIATION_REVIEW_2026-05-22.md
+++ b/docs/STAGE_B_DURATION_VARIATION_REVIEW_2026-05-22.md
@@ -1,0 +1,104 @@
+# Stage B Duration Variation Review
+
+작성일: 2026-05-22
+
+## 목적
+
+Issue #99는 overlap-free review export 이후에도 남아 있던 `duration_pattern_collapse` 문제를 줄이기 위한 단계다.
+
+이 작업은 좋은 jazz solo를 만든다는 선언이 아니다. 사람이 들어볼 review MIDI가 같은 길이의 음가만 반복하는지 먼저 제거하고, 남은 문제가 rhythm인지 pitch/phrase vocabulary인지 분리하기 위한 probe다.
+
+## 구현
+
+변경 사항:
+
+- `scripts/run_stage_b_data_motif_generation_compare.py`
+  - `varied_grid_position_duration_steps`
+  - `varied_grid_tokens`
+  - `varied_guide_tones_tokens`
+  - `varied_grid` baseline mode
+  - `varied_guide_tones` baseline mode
+- `scripts/agent_harness.sh`
+  - `stage-b-duration-variation-review`
+- `tests/test_stage_b_data_motif_generation_compare.py`
+  - varied-duration step, token, guide-tone tests
+
+## 동작 방식
+
+기존 overlap-free export는 유지한다.
+
+새 baseline은 다음 원칙을 따른다.
+
+- onset은 16th grid 안에 둔다.
+- duration은 단일 패턴으로 고정하지 않는다.
+- 다음 onset을 침범하지 않도록 duration을 제한한다.
+- `varied_guide_tones`는 guide-tone/cadence pitch vocabulary 위에 varied duration을 얹는다.
+
+## 하네스
+
+실행:
+
+```bash
+bash scripts/agent_harness.sh stage-b-duration-variation-review
+```
+
+이 하네스는 다음 순서로 실행된다.
+
+1. varied-duration baseline 포함 review MIDI export
+2. objective MIDI note review
+3. objective-aware listening review notes 생성
+4. objective-aware aggregate 생성
+
+## 결과
+
+출력:
+
+- review manifest:
+  - `outputs/stage_b_data_motif_review/harness_stage_b_duration_variation_review/review_manifest.json`
+- objective report:
+  - `outputs/stage_b_objective_midi_review/harness_stage_b_duration_variation_review/objective_midi_note_review.md`
+- aggregate:
+  - `outputs/stage_b_listening_review_aggregate/harness_stage_b_duration_variation_review/listening_review_aggregate.md`
+
+요약:
+
+- candidate count: `15`
+- objective reviewable: `15`
+- objective bucket counts:
+  - clean: `8`
+  - warning: `7`
+- objective flag counts:
+  - chromatic walk: `7`
+  - too stepwise/scalar: `6`
+  - duration pattern collapse: `0`
+  - overlap/polyphonic: `0`
+
+비교:
+
+- Issue #97 overlap-free review export의 duration pattern collapse count: `6`
+- Issue #99 duration variation review의 duration pattern collapse count: `0`
+- Issue #97 clean count: `5`
+- Issue #99 clean count: `8`
+
+## 해석
+
+duration collapse는 objective flag 기준으로 제거됐다.
+
+하지만 이것이 jazz vocabulary 문제를 해결했다는 뜻은 아니다. 남아 있는 주요 문제는 다음이다.
+
+- `chromatic_walk`
+- `too_stepwise_or_scalar`
+- 초급 scale exercise처럼 들릴 수 있는 pitch contour
+- cadence target과 phrase vocabulary 부족
+
+따라서 다음 작업은 duration을 더 만지는 것이 아니라, scalar/chromatic exercise 느낌을 줄이는 pitch contour / cadence / motif vocabulary 쪽이어야 한다.
+
+## 검증
+
+실행한 검증:
+
+```bash
+./.venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare
+bash scripts/agent_harness.sh stage-b-duration-variation-review
+bash scripts/agent_harness.sh quick
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -76,6 +76,8 @@ Modes:
                 Export data-motif rhythm plus guide-tone/cadence pitch candidates.
   stage-b-overlap-free-review-export
                 Export overlap-free solo-line review MIDI variants and objective priority.
+  stage-b-duration-variation-review
+                Export varied-duration review candidates and objective priority.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   chord-coverage-audit
@@ -850,6 +852,48 @@ run_stage_b_overlap_free_review_export() {
     --review_notes "$review_notes_path"
 }
 
+run_stage_b_duration_variation_review() {
+  local run_id="${RUN_ID:-harness_stage_b_duration_variation_review}"
+  local review_manifest_path="outputs/stage_b_data_motif_review/${run_id}/review_manifest.json"
+  local review_markdown_path="outputs/stage_b_data_motif_review/${run_id}/review_candidates.md"
+  local objective_report_path="outputs/stage_b_objective_midi_review/${run_id}/objective_midi_note_review.json"
+  local review_notes_path="outputs/stage_b_listening_review_notes/${run_id}/review_notes_template.json"
+  print_header "Stage B duration-variation review export"
+  "$PYTHON_BIN" scripts/run_stage_b_data_motif_generation_compare.py \
+    --run_id "$run_id" \
+    --issue_number 99 \
+    --input_dir ./midi_dataset/midi/studio \
+    --baseline_modes varied_grid,varied_guide_tones,hand_written_swing,data_motif,data_motif_guide_tones \
+    --max_files 4 \
+    --window_bars 8 \
+    --window_stride_bars 4 \
+    --min_window_target_notes 16 \
+    --motif_length 4 \
+    --max_bar_span 2 \
+    --max_records 64 \
+    --template_top_n 32 \
+    --num_samples 3 \
+    --bars 8 \
+    --note_groups_per_bar 8 \
+    --review_top_n 3 \
+    --copy_review_midi \
+    --overlap_free_review_midi
+  print_header "Stage B objective MIDI note review"
+  "$PYTHON_BIN" scripts/review_midi_note_objectives.py \
+    --run_id "$run_id" \
+    --review_manifest "$review_manifest_path"
+  print_header "Stage B objective-aware listening review notes"
+  "$PYTHON_BIN" scripts/build_listening_review_notes.py \
+    --run_id "$run_id" \
+    --review_manifest "$review_manifest_path" \
+    --source_review_markdown "$review_markdown_path" \
+    --objective_midi_review_report "$objective_report_path"
+  print_header "Stage B objective-aware listening review aggregate"
+  "$PYTHON_BIN" scripts/summarize_listening_review_notes.py \
+    --run_id "$run_id" \
+    --review_notes "$review_notes_path"
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -1075,6 +1119,9 @@ case "$MODE" in
     ;;
   stage-b-overlap-free-review-export)
     run_stage_b_overlap_free_review_export
+    ;;
+  stage-b-duration-variation-review)
+    run_stage_b_duration_variation_review
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/run_stage_b_data_motif_generation_compare.py
+++ b/scripts/run_stage_b_data_motif_generation_compare.py
@@ -55,6 +55,8 @@ from scripts.stage_b_tokens import (  # noqa: E402
 VALID_BASELINE_MODES = {
     "straight_grid",
     "straight_guide_tones",
+    "varied_grid",
+    "varied_guide_tones",
     "hand_written_swing",
     "data_motif",
     "data_motif_guide_tones",
@@ -513,6 +515,72 @@ def straight_grid_tokens(
     return tokens
 
 
+def varied_grid_position_duration_steps(note_groups_per_bar: int) -> tuple[list[int], list[int]]:
+    groups_per_bar = max(1, int(note_groups_per_bar))
+    interval_pattern = [1, 3, 2, 2]
+    duration_pattern = [1, 2, 1, 2]
+    positions = [0]
+    while len(positions) < groups_per_bar:
+        next_position = positions[-1] + interval_pattern[(len(positions) - 1) % len(interval_pattern)]
+        if next_position >= int(POSITIONS_PER_BAR):
+            break
+        positions.append(next_position)
+
+    durations: list[int] = []
+    for index, position in enumerate(positions):
+        if index + 1 < len(positions):
+            max_duration = max(1, int(positions[index + 1]) - int(position))
+        else:
+            max_duration = max(1, int(POSITIONS_PER_BAR) - int(position))
+        raw_duration = duration_pattern[index % len(duration_pattern)]
+        durations.append(max(1, min(int(raw_duration), int(max_duration))))
+    return positions, durations
+
+
+def varied_grid_tokens(
+    *,
+    primer_tokens: Sequence[int],
+    chords: Sequence[str],
+    bars: int,
+    note_groups_per_bar: int,
+    seed: int,
+) -> list[int]:
+    rng = random.Random(int(seed))
+    tokens = [int(token) for token in primer_tokens]
+    recent_pitches: list[int] = []
+    contour = [0, 2, 5, 3, 7, 4, 9, 5]
+    positions, durations = varied_grid_position_duration_steps(note_groups_per_bar)
+
+    for bar_index in range(max(1, int(bars))):
+        chord = chords[bar_index % len(chords)] if chords else None
+        if bar_index > 0:
+            tokens.append(TOKEN_BAR)
+            tokens.extend(chord_tokens(chord))
+        base_token = base_pitch_token_for_chord(chord, rng, recent_pitches)
+        base_pitch = pitch_from_token(base_token)
+        for group_index, (position, duration) in enumerate(zip(positions, durations)):
+            target_pitch = base_pitch + contour[group_index % len(contour)]
+            pitch_candidates = chord_aware_pitch_tokens(
+                chord,
+                pitch_mode="approach_tensions",
+                recent_pitches=recent_pitches,
+                repeat_window=2,
+                group_index=group_index,
+            )
+            pitch_token_value = nearest_allowed_pitch_token(target_pitch, pitch_candidates, recent_pitches)
+            recent_pitches.append(pitch_from_token(pitch_token_value))
+            tokens.extend(
+                [
+                    position_token(position),
+                    note_velocity_token(4),
+                    pitch_token_value,
+                    note_duration_token(duration),
+                ]
+            )
+    tokens.append(TOKEN_END)
+    return tokens
+
+
 def straight_guide_tones_tokens(
     *,
     primer_tokens: Sequence[int],
@@ -554,6 +622,51 @@ def straight_guide_tones_tokens(
                     note_velocity_token(4),
                     note_pitch_token(pitch),
                     note_duration_token(duration_steps),
+                ]
+            )
+    tokens.append(TOKEN_END)
+    return tokens
+
+
+def varied_guide_tones_tokens(
+    *,
+    primer_tokens: Sequence[int],
+    chords: Sequence[str],
+    bars: int,
+    note_groups_per_bar: int,
+    seed: int,
+) -> list[int]:
+    rng = random.Random(int(seed))
+    tokens = [int(token) for token in primer_tokens]
+    recent_pitches: list[int] = []
+    positions, durations = varied_grid_position_duration_steps(note_groups_per_bar)
+
+    for bar_index in range(max(1, int(bars))):
+        chord = chords[bar_index % len(chords)] if chords else None
+        next_chord = chords[(bar_index + 1) % len(chords)] if chords else chord
+        if bar_index > 0:
+            tokens.append(TOKEN_BAR)
+            tokens.extend(chord_tokens(chord))
+        anchor = 64 + ((bar_index % 3) * 3) + rng.choice([-2, 0, 2])
+        for group_index, (position, duration) in enumerate(zip(positions, durations)):
+            target_anchor = anchor + (group_index % 4) * 2
+            if recent_pitches and group_index % 3 == 2:
+                target_anchor = int(recent_pitches[-1]) + rng.choice([-3, -1, 1, 3])
+            pitch = guide_tone_pitch_for_position(
+                chord,
+                next_chord,
+                bar_index=bar_index,
+                position=int(position),
+                target_pitch=target_anchor,
+                recent_pitches=recent_pitches,
+            )
+            recent_pitches.append(pitch)
+            tokens.extend(
+                [
+                    position_token(position),
+                    note_velocity_token(4),
+                    note_pitch_token(pitch),
+                    note_duration_token(duration),
                 ]
             )
     tokens.append(TOKEN_END)
@@ -707,6 +820,22 @@ def generated_tokens_for_mode(
         )
     if mode == "straight_guide_tones":
         return straight_guide_tones_tokens(
+            primer_tokens=primer_tokens,
+            chords=chords,
+            bars=bars,
+            note_groups_per_bar=note_groups_per_bar,
+            seed=seed,
+        )
+    if mode == "varied_grid":
+        return varied_grid_tokens(
+            primer_tokens=primer_tokens,
+            chords=chords,
+            bars=bars,
+            note_groups_per_bar=note_groups_per_bar,
+            seed=seed,
+        )
+    if mode == "varied_guide_tones":
+        return varied_guide_tones_tokens(
             primer_tokens=primer_tokens,
             chords=chords,
             bars=bars,

--- a/tests/test_stage_b_data_motif_generation_compare.py
+++ b/tests/test_stage_b_data_motif_generation_compare.py
@@ -20,6 +20,9 @@ from scripts.run_stage_b_data_motif_generation_compare import (
     parse_baseline_modes,
     straight_guide_tones_tokens,
     straight_grid_tokens,
+    varied_grid_position_duration_steps,
+    varied_grid_tokens,
+    varied_guide_tones_tokens,
 )
 from scripts.run_stage_b_generation_probe import (
     analyze_stage_b_note_grammar,
@@ -260,6 +263,53 @@ class StageBDataMotifGenerationCompareTest(unittest.TestCase):
             else:
                 non_chord_run += 1
             self.assertLessEqual(non_chord_run, 1)
+
+    def test_varied_grid_position_duration_steps_do_not_collapse_duration(self) -> None:
+        positions, durations = varied_grid_position_duration_steps(8)
+
+        self.assertEqual(positions, [0, 1, 4, 6, 8, 9, 12, 14])
+        self.assertEqual(len(set(durations)), 2)
+        self.assertLess(max(durations.count(duration) for duration in set(durations)) / len(durations), 0.75)
+        for index, position in enumerate(positions[:-1]):
+            self.assertLessEqual(position + durations[index], positions[index + 1])
+
+    def test_varied_grid_tokens_use_multiple_durations(self) -> None:
+        chords = ["Cm7", "F7"]
+        primer = build_stage_b_primer(chords, 124)
+        tokens = varied_grid_tokens(
+            primer_tokens=primer,
+            chords=chords,
+            bars=2,
+            note_groups_per_bar=8,
+            seed=17,
+        )
+        groups = extract_stage_b_note_groups(tokens, primer_size=len(primer))
+        durations = [int(group["duration_steps"]) for group in groups]
+
+        self.assertGreaterEqual(len(set(durations)), 2)
+
+    def test_varied_guide_tones_tokens_use_guide_tone_pitches_and_multiple_durations(self) -> None:
+        chords = ["Cm7", "F7"]
+        primer = build_stage_b_primer(chords, 124)
+        tokens = varied_guide_tones_tokens(
+            primer_tokens=primer,
+            chords=chords,
+            bars=2,
+            note_groups_per_bar=8,
+            seed=17,
+        )
+        groups = extract_stage_b_note_groups(tokens, primer_size=len(primer))
+        durations = [int(group["duration_steps"]) for group in groups]
+        non_guide_run = 0
+
+        self.assertGreaterEqual(len(set(durations)), 2)
+        for group in groups:
+            chord = chords[int(group["bar"]) % len(chords)]
+            if int(group["pitch"]) % 12 in set(guide_tone_pitch_classes(chord)):
+                non_guide_run = 0
+            else:
+                non_guide_run += 1
+            self.assertLessEqual(non_guide_run, 1)
 
     def test_build_review_export_copies_named_mode_files(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## 요약

- Issue #99: varied-duration review baseline을 추가했습니다.
- `varied_grid`, `varied_guide_tones` baseline mode를 추가했습니다.
- `stage-b-duration-variation-review` 하네스를 추가했습니다.
- Issue #99 결과를 CORE_PLAN, CURRENT_STATUS, docs index, AGENTS에 기록했습니다.

## 결과

- candidate count: `15`
- objective reviewable: `15`
- objective clean: `8`
- objective warning: `7`
- duration_pattern_collapse: `6 -> 0`
- overlap_polyphonic: `0 유지`
- remaining flags: `chromatic_walk=7`, `too_stepwise_or_scalar=6`

## 해석

- duration collapse는 objective flag 기준으로 제거됐습니다.
- 아직 jazz solo quality를 주장하지 않습니다.
- 다음 병목은 scalar/chromatic exercise처럼 들리는 pitch contour와 phrase/cadence vocabulary입니다.

## 검증

```bash
./.venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare
bash scripts/agent_harness.sh stage-b-duration-variation-review
bash scripts/agent_harness.sh quick
```

Closes #99
