### PR TITLE
Stage B phrase cadence 리뷰 baseline 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #99: Stage B duration variation review baseline.
+- Issue #101: Stage B phrase/cadence review baseline.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -248,6 +248,12 @@ For Stage B duration variation review changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-duration-variation-review
+```
+
+For Stage B phrase/cadence review changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-phrase-cadence-review
 ```
 
 For Stage B filled listening review aggregate changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -152,6 +152,7 @@ Stage B에서 명시하는 것:
 46. Stage B objective flags review flow
 47. Stage B overlap-free solo-line review export
 48. Stage B duration variation review baseline
+49. Stage B phrase/cadence review baseline
 
 가장 최근 의미 있는 결과:
 
@@ -180,6 +181,7 @@ Stage B에서 명시하는 것:
 - Issue #95 connects objective flags to listening review notes and aggregate priority so problem/warning candidates are visible before manual listening.
 - Issue #97 exports overlap-free solo-line review MIDI variants while preserving original sample paths, reducing objective `overlap_polyphonic` from `9` to `0`.
 - Issue #99 adds varied-duration review baselines, reducing objective `duration_pattern_collapse` from `6` to `0` while keeping `overlap_polyphonic=0`.
+- Issue #101 adds a phrase/cadence review baseline, reducing `chromatic_walk` from `7` to `1` and `too_stepwise_or_scalar` from `6` to `0` in the next review set.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -399,6 +401,7 @@ Stage B에서 명시하는 것:
 - Issue #95 result: objective review priority reports `15` candidates, `6` warning/reviewable candidates, and `9` problem candidates before subjective listening.
 - Issue #97 result: overlap-free review export reports `15` reviewable candidates, `5` clean candidates, `10` warning candidates, and `overlap_polyphonic=0`.
 - Issue #99 result: duration variation review reports `15` reviewable candidates, `8` clean candidates, `7` warning candidates, `duration_pattern_collapse=0`, and `overlap_polyphonic=0`.
+- Issue #101 result: phrase/cadence review reports `12` reviewable candidates, `11` clean candidates, `1` warning candidate, `chromatic_walk=1`, and `too_stepwise_or_scalar=0`.
 
 해석:
 
@@ -678,26 +681,26 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B duration variation review baseline 추가
+Stage B phrase/cadence review baseline 추가
 ```
 
 결과:
 
-- varied-duration review baseline을 추가해 duration collapse를 줄였다.
-- output: `outputs/stage_b_listening_review_aggregate/harness_stage_b_duration_variation_review/listening_review_aggregate.md`
-- candidate count: `15`
-- objective reviewable: `15`
-- objective clean: `8`
-- objective warning: `7`
-- chromatic walk: `7`
+- phrase/cadence review baseline을 추가해 scalar/chromatic objective flags를 줄였다.
+- output: `outputs/stage_b_listening_review_aggregate/harness_stage_b_phrase_cadence_review/listening_review_aggregate.md`
+- candidate count: `12`
+- objective reviewable: `12`
+- objective clean: `11`
+- objective warning: `1`
+- chromatic walk: `1`
 - duration pattern collapse: `0`
 - overlap/polyphonic: `0`
-- too stepwise/scalar: `6`
+- too stepwise/scalar: `0`
 
 다음 작업:
 
-- chromatic/scalar exercise처럼 들리는 후보는 phrase vocabulary와 cadence target을 조정한다.
-- subjective listening result는 objective clean/warning priority를 참고해 채운다.
+- subjective listening result는 phrase/cadence review 후보를 기준으로 채운다.
+- subjective review 없이 다음 rule을 바꿔야 한다면 phrase naturalness를 objective metric으로 먼저 추가한다.
 - real Brad/reference chord label은 아직 임의로 넣지 않는다.
 
 ## 10. 한 문장 요약

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-99-stage-b-duration-variation-review-baseline`
+- `issue-101-stage-b-phrase-cadence-review`
 
 현재 범위가 아닌 것:
 
@@ -35,6 +35,50 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
 ## Latest Probe Result
+
+Issue #101은 duration collapse 이후 남은 scalar/chromatic exercise 문제를 줄이기 위해 phrase/cadence review baseline을 추가한 단계다.
+
+중요한 전제:
+
+- 이 단계는 objective pitch-contour flag를 줄이는 probe다.
+- "재즈답다"를 자동으로 보장하지 않는다.
+- overlap-free export와 varied-duration grid는 유지한다.
+- subjective listening review는 아직 pending이다.
+
+Implemented:
+
+- `phrase_cadence` baseline mode
+- phrase interval을 선호하는 pitch-class/register target
+- selected-mode strict gate
+- `scripts/agent_harness.sh stage-b-phrase-cadence-review`
+- docs:
+  - `docs/STAGE_B_PHRASE_CADENCE_REVIEW_2026-05-22.md`
+
+Result:
+
+- candidate count: `12`
+- objective reviewable count: `12`
+- objective bucket counts:
+  - clean: `11`
+  - warning: `1`
+- objective flag counts:
+  - chromatic walk: `1`
+  - too stepwise/scalar: `0`
+  - duration pattern collapse: `0`
+  - overlap/polyphonic: `0`
+- previous issue had:
+  - chromatic walk: `7`
+  - too stepwise/scalar: `6`
+- aggregate report:
+  - `outputs/stage_b_listening_review_aggregate/harness_stage_b_phrase_cadence_review/listening_review_aggregate.md`
+
+Decision:
+
+- scalar/chromatic objective flag는 크게 줄었다.
+- 이제 남은 핵심 문제는 objective metric보다 subjective phrase quality다.
+- 다음 작업은 새 review set을 기준으로 listening notes를 채우거나, subjective review 없이 바꿀 경우에는 phrase naturalness를 측정하는 objective metric을 추가해야 한다.
+
+## Previous Probe Result
 
 Issue #99는 duration collapse를 줄이기 위해 varied-duration review baseline을 추가한 단계다.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -110,6 +110,8 @@
   - overlap-free solo-line review MIDI variant를 export하고 objective overlap/polyphonic flag를 제거한 결과.
 - `STAGE_B_DURATION_VARIATION_REVIEW_2026-05-22.md`
   - varied-duration baseline을 추가해 review MIDI의 duration collapse flag를 제거한 결과.
+- `STAGE_B_PHRASE_CADENCE_REVIEW_2026-05-22.md`
+  - phrase/cadence baseline을 추가해 scalar/chromatic objective flags를 줄인 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -136,7 +138,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, generated chord eval bridge, data-guide generated chord eval, review markdown chord eval summary, listening review notes schema, filled listening review aggregate, full review manifest notes, objective MIDI note review, objective flags review flow, overlap-free review export, and duration variation review를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, generated chord eval bridge, data-guide generated chord eval, review markdown chord eval summary, listening review notes schema, filled listening review aggregate, full review manifest notes, objective MIDI note review, objective flags review flow, overlap-free review export, duration variation review, and phrase/cadence review를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_PHRASE_CADENCE_REVIEW_2026-05-22.md
+++ b/docs/STAGE_B_PHRASE_CADENCE_REVIEW_2026-05-22.md
@@ -1,0 +1,112 @@
+# Stage B Phrase/Cadence Review
+
+작성일: 2026-05-22
+
+## 목적
+
+Issue #101은 Issue #99 이후 남은 `chromatic_walk`와 `too_stepwise_or_scalar` 문제를 줄이기 위한 단계다.
+
+이 작업은 review set을 더 좋은 jazz solo라고 주장하는 단계가 아니다. duration collapse와 overlap artifact를 줄인 다음, MIDI가 scale/chromatic exercise처럼 들리는 문제를 objective flag 기준으로 줄일 수 있는지 확인하는 probe다.
+
+## 구현
+
+변경 사항:
+
+- `scripts/run_stage_b_data_motif_generation_compare.py`
+  - `phrase_cadence` baseline mode
+  - `phrase_cadence_pitch_class_cells`
+  - `nearest_phrase_pitch_for_pitch_class`
+  - selected-mode strict gate
+- `scripts/agent_harness.sh`
+  - `stage-b-phrase-cadence-review`
+- `tests/test_stage_b_data_motif_generation_compare.py`
+  - `phrase_cadence` mode parsing
+  - selected-mode gate test
+  - scalar/chromatic interval ratio test
+
+## 동작 방식
+
+`phrase_cadence`는 Issue #99의 varied-duration grid를 유지한다.
+
+pitch는 다음 원칙을 따른다.
+
+- strong target은 guide tone과 non-root chord tone을 우선한다.
+- color/tension tone을 포함해 너무 안전한 chord-tone 나열을 피한다.
+- register target을 번갈아 사용해 stepwise scale run을 줄인다.
+- 이전 2개 pitch 반복을 피하고, 가능하면 3-10 semitone 범위의 phrase interval을 선호한다.
+
+## 하네스
+
+실행:
+
+```bash
+bash scripts/agent_harness.sh stage-b-phrase-cadence-review
+```
+
+이 하네스는 다음 순서로 실행된다.
+
+1. `phrase_cadence`, `varied_guide_tones`, `data_motif`, `data_motif_guide_tones` review MIDI export
+2. overlap-free review MIDI 생성
+3. objective MIDI note review
+4. objective-aware listening review notes 생성
+5. objective-aware aggregate 생성
+
+## 결과
+
+출력:
+
+- review manifest:
+  - `outputs/stage_b_data_motif_review/harness_stage_b_phrase_cadence_review/review_manifest.json`
+- objective report:
+  - `outputs/stage_b_objective_midi_review/harness_stage_b_phrase_cadence_review/objective_midi_note_review.md`
+- aggregate:
+  - `outputs/stage_b_listening_review_aggregate/harness_stage_b_phrase_cadence_review/listening_review_aggregate.md`
+
+요약:
+
+- candidate count: `12`
+- objective reviewable: `12`
+- objective bucket counts:
+  - clean: `11`
+  - warning: `1`
+- objective flag counts:
+  - chromatic walk: `1`
+  - too stepwise/scalar: `0`
+  - duration pattern collapse: `0`
+  - overlap/polyphonic: `0`
+
+비교:
+
+- Issue #99 duration variation review:
+  - candidate count: `15`
+  - clean: `8`
+  - warning: `7`
+  - chromatic walk: `7`
+  - too stepwise/scalar: `6`
+- Issue #101 phrase/cadence review:
+  - candidate count: `12`
+  - clean: `11`
+  - warning: `1`
+  - chromatic walk: `1`
+  - too stepwise/scalar: `0`
+
+## 해석
+
+objective MIDI flag 기준으로 scalar/chromatic exercise 문제는 크게 줄었다.
+
+하지만 이 결과는 아직 subjective jazz quality를 증명하지 않는다. 특히 `phrase_cadence`는 register leap을 의도적으로 넣었기 때문에 실제 청취에서는 다음을 확인해야 한다.
+
+- leap이 자연스러운 phrase로 들리는지
+- chord context 위에서 cadence가 분명한지
+- 너무 건조한 guide-tone exercise처럼 들리지 않는지
+- data-derived motif rhythm과 충분히 결합할 가치가 있는지
+
+## 검증
+
+실행한 검증:
+
+```bash
+./.venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare
+bash scripts/agent_harness.sh stage-b-phrase-cadence-review
+bash scripts/agent_harness.sh quick
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -78,6 +78,8 @@ Modes:
                 Export overlap-free solo-line review MIDI variants and objective priority.
   stage-b-duration-variation-review
                 Export varied-duration review candidates and objective priority.
+  stage-b-phrase-cadence-review
+                Export phrase/cadence review candidates and objective priority.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   chord-coverage-audit
@@ -894,6 +896,48 @@ run_stage_b_duration_variation_review() {
     --review_notes "$review_notes_path"
 }
 
+run_stage_b_phrase_cadence_review() {
+  local run_id="${RUN_ID:-harness_stage_b_phrase_cadence_review}"
+  local review_manifest_path="outputs/stage_b_data_motif_review/${run_id}/review_manifest.json"
+  local review_markdown_path="outputs/stage_b_data_motif_review/${run_id}/review_candidates.md"
+  local objective_report_path="outputs/stage_b_objective_midi_review/${run_id}/objective_midi_note_review.json"
+  local review_notes_path="outputs/stage_b_listening_review_notes/${run_id}/review_notes_template.json"
+  print_header "Stage B phrase/cadence review export"
+  "$PYTHON_BIN" scripts/run_stage_b_data_motif_generation_compare.py \
+    --run_id "$run_id" \
+    --issue_number 101 \
+    --input_dir ./midi_dataset/midi/studio \
+    --baseline_modes phrase_cadence,varied_guide_tones,data_motif,data_motif_guide_tones \
+    --max_files 4 \
+    --window_bars 8 \
+    --window_stride_bars 4 \
+    --min_window_target_notes 16 \
+    --motif_length 4 \
+    --max_bar_span 2 \
+    --max_records 64 \
+    --template_top_n 32 \
+    --num_samples 3 \
+    --bars 8 \
+    --note_groups_per_bar 8 \
+    --review_top_n 3 \
+    --copy_review_midi \
+    --overlap_free_review_midi
+  print_header "Stage B objective MIDI note review"
+  "$PYTHON_BIN" scripts/review_midi_note_objectives.py \
+    --run_id "$run_id" \
+    --review_manifest "$review_manifest_path"
+  print_header "Stage B objective-aware listening review notes"
+  "$PYTHON_BIN" scripts/build_listening_review_notes.py \
+    --run_id "$run_id" \
+    --review_manifest "$review_manifest_path" \
+    --source_review_markdown "$review_markdown_path" \
+    --objective_midi_review_report "$objective_report_path"
+  print_header "Stage B objective-aware listening review aggregate"
+  "$PYTHON_BIN" scripts/summarize_listening_review_notes.py \
+    --run_id "$run_id" \
+    --review_notes "$review_notes_path"
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -1122,6 +1166,9 @@ case "$MODE" in
     ;;
   stage-b-duration-variation-review)
     run_stage_b_duration_variation_review
+    ;;
+  stage-b-phrase-cadence-review)
+    run_stage_b_phrase_cadence_review
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/run_stage_b_data_motif_generation_compare.py
+++ b/scripts/run_stage_b_data_motif_generation_compare.py
@@ -57,6 +57,7 @@ VALID_BASELINE_MODES = {
     "straight_guide_tones",
     "varied_grid",
     "varied_guide_tones",
+    "phrase_cadence",
     "hand_written_swing",
     "data_motif",
     "data_motif_guide_tones",
@@ -296,6 +297,45 @@ def nearest_pitch_for_pitch_class(
         preferred = [pitch for pitch in candidates if 1 <= abs(pitch - previous) <= 7]
         if preferred:
             candidates = preferred
+    return int(
+        min(
+            candidates,
+            key=lambda pitch: (
+                abs(int(pitch) - int(target_pitch)),
+                abs(int(pitch) - 67),
+                int(pitch),
+            ),
+        )
+    )
+
+
+def nearest_phrase_pitch_for_pitch_class(
+    pitch_class: int,
+    *,
+    target_pitch: int,
+    recent_pitches: Sequence[int] | None = None,
+    min_interval: int = 3,
+    max_interval: int = 10,
+) -> int:
+    recent = list(recent_pitches or [])
+    candidates = [
+        pitch
+        for pitch in range(int(PIANO_PITCH_MIN), int(PIANO_PITCH_MAX) + 1)
+        if pitch % 12 == int(pitch_class) % 12
+    ]
+    blocked = set(recent[-2:])
+    filtered = [pitch for pitch in candidates if pitch not in blocked]
+    if filtered:
+        candidates = filtered
+    if recent:
+        previous = int(recent[-1])
+        phrase_candidates = [
+            pitch
+            for pitch in candidates
+            if int(min_interval) <= abs(int(pitch) - previous) <= int(max_interval)
+        ]
+        if phrase_candidates:
+            candidates = phrase_candidates
     return int(
         min(
             candidates,
@@ -673,6 +713,93 @@ def varied_guide_tones_tokens(
     return tokens
 
 
+def phrase_cadence_pitch_class_cells(
+    chord: str | None,
+    next_chord: str | None,
+    *,
+    bar_index: int,
+) -> list[int]:
+    guides = guide_tone_pitch_classes(chord)
+    non_root_tones = sorted(chord_tone_pitch_classes(chord, include_root=False))
+    tensions = sorted(tension_pitch_classes(chord))
+    next_guides = guide_tone_pitch_classes(next_chord)
+    fallback_tones = sorted(chord_tone_pitch_classes(chord)) or [0]
+
+    if not guides:
+        guides = non_root_tones or fallback_tones
+    if not non_root_tones:
+        non_root_tones = guides or fallback_tones
+    if not tensions:
+        tensions = non_root_tones
+    if not next_guides:
+        next_guides = guides
+
+    guide_a = guides[int(bar_index) % len(guides)]
+    guide_b = guides[(int(bar_index) + 1) % len(guides)]
+    color_a = tensions[int(bar_index) % len(tensions)]
+    color_b = tensions[(int(bar_index) + 1) % len(tensions)]
+    chord_color = non_root_tones[(int(bar_index) + 1) % len(non_root_tones)]
+    next_target = next_guides[int(bar_index) % len(next_guides)]
+
+    return [
+        guide_a,
+        color_a,
+        guide_b,
+        chord_color,
+        color_b,
+        guide_a,
+        approach_pitch_class(next_target, [guide_a, color_a, guide_b]),
+        next_target,
+    ]
+
+
+def phrase_cadence_tokens(
+    *,
+    primer_tokens: Sequence[int],
+    chords: Sequence[str],
+    bars: int,
+    note_groups_per_bar: int,
+    seed: int,
+) -> list[int]:
+    rng = random.Random(int(seed))
+    tokens = [int(token) for token in primer_tokens]
+    recent_pitches: list[int] = []
+    positions, durations = varied_grid_position_duration_steps(note_groups_per_bar)
+    target_register_patterns = [
+        [64, 72, 60, 69, 74, 65, 71, 67],
+        [69, 61, 73, 64, 70, 76, 63, 72],
+    ]
+
+    for bar_index in range(max(1, int(bars))):
+        chord = chords[bar_index % len(chords)] if chords else None
+        next_chord = chords[(bar_index + 1) % len(chords)] if chords else chord
+        if bar_index > 0:
+            tokens.append(TOKEN_BAR)
+            tokens.extend(chord_tokens(chord))
+        pitch_cells = phrase_cadence_pitch_class_cells(chord, next_chord, bar_index=bar_index)
+        register_pattern = target_register_patterns[bar_index % len(target_register_patterns)]
+        register_shift = rng.choice([-2, 0, 2])
+        for group_index, (position, duration) in enumerate(zip(positions, durations)):
+            pitch_class = pitch_cells[group_index % len(pitch_cells)]
+            target_pitch = register_pattern[group_index % len(register_pattern)] + register_shift
+            pitch = nearest_phrase_pitch_for_pitch_class(
+                pitch_class,
+                target_pitch=target_pitch,
+                recent_pitches=recent_pitches,
+            )
+            recent_pitches.append(pitch)
+            tokens.extend(
+                [
+                    position_token(position),
+                    note_velocity_token(4),
+                    note_pitch_token(pitch),
+                    note_duration_token(duration),
+                ]
+            )
+    tokens.append(TOKEN_END)
+    return tokens
+
+
 def data_motif_tokens(
     *,
     primer_tokens: Sequence[int],
@@ -836,6 +963,14 @@ def generated_tokens_for_mode(
         )
     if mode == "varied_guide_tones":
         return varied_guide_tones_tokens(
+            primer_tokens=primer_tokens,
+            chords=chords,
+            bars=bars,
+            note_groups_per_bar=note_groups_per_bar,
+            seed=seed,
+        )
+    if mode == "phrase_cadence":
+        return phrase_cadence_tokens(
             primer_tokens=primer_tokens,
             chords=chords,
             bars=bars,
@@ -1090,6 +1225,10 @@ def build_compare_summary(
     hand = mode_summaries.get("hand_written_swing")
     data = mode_summaries.get("data_motif")
     ready = bool(hand and data)
+    selected_modes_passed = bool(mode_summaries) and all(
+        int(summary["strict_valid_sample_count"]) >= int(min_strict_valid_samples)
+        for summary in mode_summaries.values()
+    )
     data_passed = bool(data and int(data["strict_valid_sample_count"]) >= int(min_strict_valid_samples))
     hand_passed = bool(hand and int(hand["strict_valid_sample_count"]) >= int(min_strict_valid_samples))
     def delta(metric: str) -> float:
@@ -1099,7 +1238,8 @@ def build_compare_summary(
         "comparison_ready": ready,
         "passed_hand_written_swing_gate": hand_passed,
         "passed_data_motif_gate": data_passed,
-        "passed_compare_gate": bool(ready and hand_passed and data_passed),
+        "passed_selected_modes_gate": selected_modes_passed,
+        "passed_compare_gate": bool((ready and hand_passed and data_passed) or selected_modes_passed),
         "duration_diversity_delta_data_minus_hand": delta("avg_duration_diversity_ratio"),
         "ioi_diversity_delta_data_minus_hand": delta("avg_ioi_diversity_ratio"),
         "bar_pattern_delta_data_minus_hand": delta("avg_unique_bar_position_pattern_ratio"),

--- a/tests/test_stage_b_data_motif_generation_compare.py
+++ b/tests/test_stage_b_data_motif_generation_compare.py
@@ -7,6 +7,7 @@ from tempfile import TemporaryDirectory
 import pretty_midi
 
 from scripts.run_stage_b_data_motif_generation_compare import (
+    build_compare_summary,
     build_review_export,
     chord_tone_pitch_classes,
     data_motif_guide_tones_tokens,
@@ -18,6 +19,7 @@ from scripts.run_stage_b_data_motif_generation_compare import (
     normalize_position_deltas,
     overlap_free_solo_notes,
     parse_baseline_modes,
+    phrase_cadence_tokens,
     straight_guide_tones_tokens,
     straight_grid_tokens,
     varied_grid_position_duration_steps,
@@ -84,6 +86,38 @@ class StageBDataMotifGenerationCompareTest(unittest.TestCase):
             parse_baseline_modes("straight_grid,straight_guide_tones,data_motif_guide_tones"),
             ["straight_grid", "straight_guide_tones", "data_motif_guide_tones"],
         )
+
+    def test_parse_baseline_modes_accepts_phrase_cadence(self) -> None:
+        self.assertEqual(parse_baseline_modes("phrase_cadence"), ["phrase_cadence"])
+
+    def test_build_compare_summary_allows_selected_modes_without_hand_written_reference(self) -> None:
+        def valid_summary() -> dict:
+            return {
+                "sample_count": 3,
+                "valid_sample_count": 3,
+                "strict_valid_sample_count": 3,
+                "avg_syncopated_onset_ratio": 0.5,
+                "avg_unique_bar_position_pattern_ratio": 0.5,
+                "avg_duration_diversity_ratio": 0.25,
+                "avg_most_common_duration_ratio": 0.5,
+                "avg_ioi_diversity_ratio": 0.25,
+                "avg_most_common_ioi_ratio": 0.5,
+                "avg_tension_ratio": 0.2,
+                "avg_root_tone_ratio": 0.0,
+                "passed_strict_review_gate": True,
+            }
+
+        summary = build_compare_summary(
+            {
+                "phrase_cadence": valid_summary(),
+                "varied_guide_tones": valid_summary(),
+            },
+            min_strict_valid_samples=1,
+        )
+
+        self.assertFalse(summary["comparison_ready"])
+        self.assertTrue(summary["passed_selected_modes_gate"])
+        self.assertTrue(summary["passed_compare_gate"])
 
     def test_normalize_position_deltas_scales_into_slot(self) -> None:
         positions = normalize_position_deltas([0, 3, 9, 12], slot_start=8, slot_size=8)
@@ -310,6 +344,30 @@ class StageBDataMotifGenerationCompareTest(unittest.TestCase):
             else:
                 non_guide_run += 1
             self.assertLessEqual(non_guide_run, 1)
+
+    def test_phrase_cadence_tokens_reduce_scalar_and_chromatic_motion(self) -> None:
+        chords = ["Cm7", "F7", "Bbmaj7", "Ebmaj7"]
+        primer = build_stage_b_primer(chords, 124)
+        tokens = phrase_cadence_tokens(
+            primer_tokens=primer,
+            chords=chords,
+            bars=4,
+            note_groups_per_bar=8,
+            seed=17,
+        )
+        grammar = analyze_stage_b_note_grammar(tokens, primer_size=len(primer))
+        groups = extract_stage_b_note_groups(tokens, primer_size=len(primer))
+        pitches = [int(group["pitch"]) for group in groups]
+        intervals = [abs(right - left) for left, right in zip(pitches, pitches[1:])]
+        stepwise_ratio = sum(1 for interval in intervals if interval in {1, 2}) / len(intervals)
+        chromatic_ratio = sum(1 for interval in intervals if interval == 1) / len(intervals)
+        durations = [int(group["duration_steps"]) for group in groups]
+
+        self.assertTrue(grammar["grammar_valid"])
+        self.assertEqual(len(groups), 32)
+        self.assertGreaterEqual(len(set(durations)), 2)
+        self.assertLess(stepwise_ratio, 0.70)
+        self.assertLess(chromatic_ratio, 0.35)
 
     def test_build_review_export_copies_named_mode_files(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## 요약

- Issue #101: scalar/chromatic exercise 느낌을 줄이기 위한 `phrase_cadence` review baseline을 추가했습니다.
- `stage-b-phrase-cadence-review` 하네스를 추가했습니다.
- hand-written reference가 없는 review set도 선택된 mode가 strict valid이면 통과하도록 compare gate를 일반화했습니다.
- 결과를 CORE_PLAN, CURRENT_STATUS, docs index, AGENTS에 기록했습니다.

## 결과

- candidate count: `12`
- objective reviewable: `12`
- objective clean: `11`
- objective warning: `1`
- chromatic_walk: `7 -> 1`
- too_stepwise_or_scalar: `6 -> 0`
- duration_pattern_collapse: `0 유지`
- overlap_polyphonic: `0 유지`

## 해석

- objective MIDI flag 기준으로 scalar/chromatic 문제는 크게 줄었습니다.
- 아직 subjective jazz quality를 주장하지 않습니다.
- 다음 병목은 실제 청취 기준 phrase naturalness입니다.

## 검증

```bash
./.venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare
bash scripts/agent_harness.sh stage-b-phrase-cadence-review
bash scripts/agent_harness.sh quick
```

Closes #101
