### PR TITLE
Stage B phrase recovery 리뷰 baseline 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #103: Stage B phrase naturalness objective metrics.
+- Issue #105: Stage B phrase recovery review baseline.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -261,6 +261,12 @@ For Stage B phrase naturalness objective metric changes, run:
 ```bash
 bash scripts/agent_harness.sh stage-b-objective-midi-review
 bash scripts/agent_harness.sh stage-b-phrase-cadence-review
+```
+
+For Stage B phrase recovery review changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-phrase-recovery-review
 ```
 
 For Stage B filled listening review aggregate changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -154,6 +154,7 @@ Stage B에서 명시하는 것:
 48. Stage B duration variation review baseline
 49. Stage B phrase/cadence review baseline
 50. Stage B phrase naturalness objective metrics
+51. Stage B phrase recovery review baseline
 
 가장 최근 의미 있는 결과:
 
@@ -184,6 +185,7 @@ Stage B에서 명시하는 것:
 - Issue #99 adds varied-duration review baselines, reducing objective `duration_pattern_collapse` from `6` to `0` while keeping `overlap_polyphonic=0`.
 - Issue #101 adds a phrase/cadence review baseline, reducing `chromatic_walk` from `7` to `1` and `too_stepwise_or_scalar` from `6` to `0` in the next review set.
 - Issue #103 adds phrase naturalness metrics and reveals that all `12` Issue #101 review candidates have `unresolved_large_leaps`.
+- Issue #105 adds a phrase recovery baseline, reducing `phrase_recovery` unresolved large leap ratio to `0.000-0.048`.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -405,6 +407,7 @@ Stage B에서 명시하는 것:
 - Issue #99 result: duration variation review reports `15` reviewable candidates, `8` clean candidates, `7` warning candidates, `duration_pattern_collapse=0`, and `overlap_polyphonic=0`.
 - Issue #101 result: phrase/cadence review reports `12` reviewable candidates, `11` clean candidates, `1` warning candidate, `chromatic_walk=1`, and `too_stepwise_or_scalar=0`.
 - Issue #103 result: phrase naturalness review reclassifies the same `12` candidates as warnings because `unresolved_large_leaps=12`.
+- Issue #105 result: phrase recovery review reports `phrase_cadence` candidates as `3` warnings and `phrase_recovery` candidates as `3` clean candidates.
 
 해석:
 
@@ -684,28 +687,28 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B phrase naturalness objective metrics 추가
+Stage B phrase recovery review baseline 추가
 ```
 
 결과:
 
-- phrase naturalness objective metric을 추가해 unresolved large leap risk를 드러냈다.
-- output: `outputs/stage_b_listening_review_aggregate/harness_stage_b_phrase_cadence_review/listening_review_aggregate.md`
-- candidate count: `12`
-- objective reviewable: `12`
-- objective clean: `0`
-- objective warning: `12`
-- chromatic walk: `1`
+- phrase recovery baseline을 추가해 unresolved large leap risk를 줄였다.
+- output: `outputs/stage_b_listening_review_aggregate/harness_stage_b_phrase_recovery_review/listening_review_aggregate.md`
+- candidate count: `6`
+- objective clean: `3`
+- objective warning: `3`
 - duration pattern collapse: `0`
 - overlap/polyphonic: `0`
 - too stepwise/scalar: `0`
-- unresolved large leaps: `12`
+- unresolved large leaps: `3`
+- `phrase_cadence`: unresolved large leaps `3`
+- `phrase_recovery`: objective flags 없음
 
 다음 작업:
 
-- leap 뒤에 반대 방향 small recovery를 넣는 phrase-shape grammar를 추가한다.
-- 또는 data-derived contour template에서 leap-resolution pattern을 추출한다.
-- subjective listening result는 새 objective warning을 참고해 채운다.
+- `phrase_recovery`를 data-derived motif rhythm과 결합한다.
+- 새 후보의 context MIDI를 기준으로 subjective listening review를 채운다.
+- broad training으로 넘어가기 전 reference contour template과 비교한다.
 - real Brad/reference chord label은 아직 임의로 넣지 않는다.
 
 ## 10. 한 문장 요약

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-103-stage-b-phrase-naturalness-objectives`
+- `issue-105-stage-b-phrase-recovery-review`
 
 현재 범위가 아닌 것:
 
@@ -35,6 +35,43 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
 ## Latest Probe Result
+
+Issue #105는 Issue #103에서 드러난 `unresolved_large_leaps` 문제를 줄이기 위해 phrase recovery baseline을 추가한 단계다.
+
+중요한 전제:
+
+- 큰 도약을 금지하지 않는다.
+- 큰 도약 뒤 반대 방향 small recovery를 넣는다.
+- objective clean은 subjective jazz quality를 뜻하지 않는다.
+
+Implemented:
+
+- `phrase_recovery` baseline mode
+- `recovery_pitch_after_large_leap`
+- `scripts/agent_harness.sh stage-b-phrase-recovery-review`
+- docs:
+  - `docs/STAGE_B_PHRASE_RECOVERY_REVIEW_2026-05-22.md`
+
+Result:
+
+- candidate count: `6`
+- objective bucket counts:
+  - clean: `3`
+  - warning: `3`
+- objective flag counts:
+  - unresolved large leaps: `3`
+- mode flag counts:
+  - `phrase_cadence`: unresolved large leaps `3`
+  - `phrase_recovery`: no objective flags
+- `phrase_cadence` unresolved large leap ratio: `0.750-0.757`
+- `phrase_recovery` unresolved large leap ratio: `0.000-0.048`
+
+Decision:
+
+- `phrase_recovery`는 objective phrase naturalness risk를 줄인다.
+- 다음 작업은 `phrase_recovery`를 data-derived motif rhythm과 결합하거나, review MIDI/context MIDI 기준으로 listening review package를 만드는 것이다.
+
+## Previous Probe Result
 
 Issue #103은 Issue #101의 phrase/cadence 후보가 scalar/chromatic flag를 줄인 대신 leap-heavy exercise가 되었는지 확인하기 위해 phrase naturalness objective metric을 추가한 단계다.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -114,6 +114,8 @@
   - phrase/cadence baseline을 추가해 scalar/chromatic objective flags를 줄인 결과.
 - `STAGE_B_PHRASE_NATURALNESS_OBJECTIVES_2026-05-22.md`
   - 큰 도약 뒤 회복 움직임이 없는 phrase naturalness risk를 objective flag로 추가한 결과.
+- `STAGE_B_PHRASE_RECOVERY_REVIEW_2026-05-22.md`
+  - 큰 도약 뒤 반대 방향 small recovery를 넣는 phrase recovery baseline 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -140,7 +142,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, generated chord eval bridge, data-guide generated chord eval, review markdown chord eval summary, listening review notes schema, filled listening review aggregate, full review manifest notes, objective MIDI note review, objective flags review flow, overlap-free review export, duration variation review, phrase/cadence review, and phrase naturalness objective review를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, generated chord eval bridge, data-guide generated chord eval, review markdown chord eval summary, listening review notes schema, filled listening review aggregate, full review manifest notes, objective MIDI note review, objective flags review flow, overlap-free review export, duration variation review, phrase/cadence review, phrase naturalness objective review, and phrase recovery review를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_PHRASE_RECOVERY_REVIEW_2026-05-22.md
+++ b/docs/STAGE_B_PHRASE_RECOVERY_REVIEW_2026-05-22.md
@@ -1,0 +1,95 @@
+# Stage B Phrase Recovery Review
+
+작성일: 2026-05-22
+
+## 목적
+
+Issue #105는 Issue #103에서 드러난 `unresolved_large_leaps` 문제를 줄이기 위해 `phrase_recovery` baseline을 추가한 단계다.
+
+이 작업은 큰 도약을 금지하지 않는다. 큰 도약 뒤에 반대 방향의 작은 회복 움직임을 넣어, 도약 나열 exercise가 아니라 phrase motion에 가까워지는지 objective metric으로 확인한다.
+
+## 구현
+
+변경 사항:
+
+- `scripts/run_stage_b_data_motif_generation_compare.py`
+  - `phrase_recovery` baseline mode
+  - `phrase_recovery_pitch_classes`
+  - `recovery_pitch_after_large_leap`
+  - `phrase_recovery_tokens`
+- `scripts/agent_harness.sh`
+  - `stage-b-phrase-recovery-review`
+- `tests/test_stage_b_data_motif_generation_compare.py`
+  - `phrase_recovery` mode parsing
+  - unresolved large leap ratio regression test
+
+## 동작 방식
+
+`phrase_recovery`는 `phrase_cadence`와 같은 varied-duration grid와 guide/tension/cadence pitch-class vocabulary를 사용한다.
+
+추가 규칙:
+
+- 이전 interval이 `7` semitone 이상이면 large leap로 본다.
+- 다음 note는 가능한 경우 반대 방향으로 움직인다.
+- recovery interval은 `1-5` semitone 범위를 선호한다.
+- recovery pitch는 current/next chord의 guide tone, non-root chord tone, tension tone 후보 안에서 고른다.
+
+## 하네스
+
+실행:
+
+```bash
+bash scripts/agent_harness.sh stage-b-phrase-recovery-review
+```
+
+이 하네스는 `phrase_cadence`와 `phrase_recovery`를 같은 조건에서 비교한다.
+
+## 결과
+
+출력:
+
+- review manifest:
+  - `outputs/stage_b_data_motif_review/harness_stage_b_phrase_recovery_review/review_manifest.json`
+- objective report:
+  - `outputs/stage_b_objective_midi_review/harness_stage_b_phrase_recovery_review/objective_midi_note_review.md`
+- aggregate:
+  - `outputs/stage_b_listening_review_aggregate/harness_stage_b_phrase_recovery_review/listening_review_aggregate.md`
+
+요약:
+
+- candidate count: `6`
+- objective bucket counts:
+  - clean: `3`
+  - warning: `3`
+- objective flag counts:
+  - unresolved large leaps: `3`
+- mode flag counts:
+  - `phrase_cadence`: unresolved large leaps `3`
+  - `phrase_recovery`: no objective flags
+
+비교:
+
+- `phrase_cadence` unresolved large leap ratio:
+  - `0.750-0.757`
+- `phrase_recovery` unresolved large leap ratio:
+  - `0.000-0.048`
+
+## 해석
+
+`phrase_recovery`는 Issue #103에서 드러난 large-leap recovery 문제를 objective 기준으로 해결한다.
+
+하지만 이것은 아직 subjective jazz quality를 의미하지 않는다. 다음 확인 지점은 다음이다.
+
+- recovery motion이 실제로 자연스럽게 들리는지
+- guide-tone exercise처럼 건조하지 않은지
+- data-derived motif rhythm과 결합했을 때도 clean 상태를 유지하는지
+
+## 검증
+
+실행한 검증:
+
+```bash
+./.venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare
+bash scripts/agent_harness.sh stage-b-phrase-recovery-review
+bash scripts/agent_harness.sh quick
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -80,6 +80,8 @@ Modes:
                 Export varied-duration review candidates and objective priority.
   stage-b-phrase-cadence-review
                 Export phrase/cadence review candidates and objective priority.
+  stage-b-phrase-recovery-review
+                Compare phrase/cadence against leap-recovery phrase candidates.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   chord-coverage-audit
@@ -938,6 +940,48 @@ run_stage_b_phrase_cadence_review() {
     --review_notes "$review_notes_path"
 }
 
+run_stage_b_phrase_recovery_review() {
+  local run_id="${RUN_ID:-harness_stage_b_phrase_recovery_review}"
+  local review_manifest_path="outputs/stage_b_data_motif_review/${run_id}/review_manifest.json"
+  local review_markdown_path="outputs/stage_b_data_motif_review/${run_id}/review_candidates.md"
+  local objective_report_path="outputs/stage_b_objective_midi_review/${run_id}/objective_midi_note_review.json"
+  local review_notes_path="outputs/stage_b_listening_review_notes/${run_id}/review_notes_template.json"
+  print_header "Stage B phrase recovery review export"
+  "$PYTHON_BIN" scripts/run_stage_b_data_motif_generation_compare.py \
+    --run_id "$run_id" \
+    --issue_number 105 \
+    --input_dir ./midi_dataset/midi/studio \
+    --baseline_modes phrase_cadence,phrase_recovery \
+    --max_files 4 \
+    --window_bars 8 \
+    --window_stride_bars 4 \
+    --min_window_target_notes 16 \
+    --motif_length 4 \
+    --max_bar_span 2 \
+    --max_records 64 \
+    --template_top_n 32 \
+    --num_samples 3 \
+    --bars 8 \
+    --note_groups_per_bar 8 \
+    --review_top_n 3 \
+    --copy_review_midi \
+    --overlap_free_review_midi
+  print_header "Stage B objective MIDI note review"
+  "$PYTHON_BIN" scripts/review_midi_note_objectives.py \
+    --run_id "$run_id" \
+    --review_manifest "$review_manifest_path"
+  print_header "Stage B objective-aware listening review notes"
+  "$PYTHON_BIN" scripts/build_listening_review_notes.py \
+    --run_id "$run_id" \
+    --review_manifest "$review_manifest_path" \
+    --source_review_markdown "$review_markdown_path" \
+    --objective_midi_review_report "$objective_report_path"
+  print_header "Stage B objective-aware listening review aggregate"
+  "$PYTHON_BIN" scripts/summarize_listening_review_notes.py \
+    --run_id "$run_id" \
+    --review_notes "$review_notes_path"
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -1169,6 +1213,9 @@ case "$MODE" in
     ;;
   stage-b-phrase-cadence-review)
     run_stage_b_phrase_cadence_review
+    ;;
+  stage-b-phrase-recovery-review)
+    run_stage_b_phrase_recovery_review
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/run_stage_b_data_motif_generation_compare.py
+++ b/scripts/run_stage_b_data_motif_generation_compare.py
@@ -58,6 +58,7 @@ VALID_BASELINE_MODES = {
     "varied_grid",
     "varied_guide_tones",
     "phrase_cadence",
+    "phrase_recovery",
     "hand_written_swing",
     "data_motif",
     "data_motif_guide_tones",
@@ -753,6 +754,61 @@ def phrase_cadence_pitch_class_cells(
     ]
 
 
+def phrase_recovery_pitch_classes(chord: str | None, next_chord: str | None) -> list[int]:
+    classes: list[int] = []
+    for pitch_class in (
+        guide_tone_pitch_classes(chord)
+        + sorted(chord_tone_pitch_classes(chord, include_root=False))
+        + sorted(tension_pitch_classes(chord))
+        + guide_tone_pitch_classes(next_chord)
+    ):
+        if pitch_class not in classes:
+            classes.append(int(pitch_class))
+    if not classes:
+        classes = sorted(chord_tone_pitch_classes(chord)) or [0]
+    return classes
+
+
+def recovery_pitch_after_large_leap(
+    *,
+    chord: str | None,
+    next_chord: str | None,
+    previous_pitch: int,
+    leap_direction: int,
+    recent_pitches: Sequence[int],
+) -> int:
+    pitch_classes = phrase_recovery_pitch_classes(chord, next_chord)
+    target_pitch = int(previous_pitch) - int(leap_direction) * 3
+    candidates = [
+        pitch
+        for pitch in range(int(PIANO_PITCH_MIN), int(PIANO_PITCH_MAX) + 1)
+        if pitch % 12 in pitch_classes
+    ]
+    blocked = set(int(pitch) for pitch in recent_pitches[-2:])
+    filtered = [pitch for pitch in candidates if pitch not in blocked]
+    if filtered:
+        candidates = filtered
+    recovery_candidates = [
+        pitch
+        for pitch in candidates
+        if 1 <= abs(int(pitch) - int(previous_pitch)) <= 5
+        and (1 if int(pitch) > int(previous_pitch) else -1 if int(pitch) < int(previous_pitch) else 0)
+        == -int(leap_direction)
+    ]
+    if recovery_candidates:
+        candidates = recovery_candidates
+    return int(
+        min(
+            candidates,
+            key=lambda pitch: (
+                abs(int(pitch) - int(target_pitch)),
+                abs(int(pitch) - 67),
+                int(pitch),
+            ),
+        )
+    )
+
+
 def phrase_cadence_tokens(
     *,
     primer_tokens: Sequence[int],
@@ -787,6 +843,69 @@ def phrase_cadence_tokens(
                 target_pitch=target_pitch,
                 recent_pitches=recent_pitches,
             )
+            recent_pitches.append(pitch)
+            tokens.extend(
+                [
+                    position_token(position),
+                    note_velocity_token(4),
+                    note_pitch_token(pitch),
+                    note_duration_token(duration),
+                ]
+            )
+    tokens.append(TOKEN_END)
+    return tokens
+
+
+def phrase_recovery_tokens(
+    *,
+    primer_tokens: Sequence[int],
+    chords: Sequence[str],
+    bars: int,
+    note_groups_per_bar: int,
+    seed: int,
+) -> list[int]:
+    rng = random.Random(int(seed))
+    tokens = [int(token) for token in primer_tokens]
+    recent_pitches: list[int] = []
+    positions, durations = varied_grid_position_duration_steps(note_groups_per_bar)
+    target_register_patterns = [
+        [64, 72, 60, 69, 74, 65, 71, 67],
+        [69, 61, 73, 64, 70, 76, 63, 72],
+    ]
+    pending_recovery_direction = 0
+
+    for bar_index in range(max(1, int(bars))):
+        chord = chords[bar_index % len(chords)] if chords else None
+        next_chord = chords[(bar_index + 1) % len(chords)] if chords else chord
+        if bar_index > 0:
+            tokens.append(TOKEN_BAR)
+            tokens.extend(chord_tokens(chord))
+        pitch_cells = phrase_cadence_pitch_class_cells(chord, next_chord, bar_index=bar_index)
+        register_pattern = target_register_patterns[bar_index % len(target_register_patterns)]
+        register_shift = rng.choice([-2, 0, 2])
+        for group_index, (position, duration) in enumerate(zip(positions, durations)):
+            if pending_recovery_direction and recent_pitches:
+                pitch = recovery_pitch_after_large_leap(
+                    chord=chord,
+                    next_chord=next_chord,
+                    previous_pitch=recent_pitches[-1],
+                    leap_direction=pending_recovery_direction,
+                    recent_pitches=recent_pitches,
+                )
+                pending_recovery_direction = 0
+            else:
+                pitch_class = pitch_cells[group_index % len(pitch_cells)]
+                target_pitch = register_pattern[group_index % len(register_pattern)] + register_shift
+                pitch = nearest_phrase_pitch_for_pitch_class(
+                    pitch_class,
+                    target_pitch=target_pitch,
+                    recent_pitches=recent_pitches,
+                )
+
+            if recent_pitches:
+                interval = int(pitch) - int(recent_pitches[-1])
+                if abs(interval) >= 7:
+                    pending_recovery_direction = 1 if interval > 0 else -1
             recent_pitches.append(pitch)
             tokens.extend(
                 [
@@ -971,6 +1090,14 @@ def generated_tokens_for_mode(
         )
     if mode == "phrase_cadence":
         return phrase_cadence_tokens(
+            primer_tokens=primer_tokens,
+            chords=chords,
+            bars=bars,
+            note_groups_per_bar=note_groups_per_bar,
+            seed=seed,
+        )
+    if mode == "phrase_recovery":
+        return phrase_recovery_tokens(
             primer_tokens=primer_tokens,
             chords=chords,
             bars=bars,

--- a/tests/test_stage_b_data_motif_generation_compare.py
+++ b/tests/test_stage_b_data_motif_generation_compare.py
@@ -20,6 +20,7 @@ from scripts.run_stage_b_data_motif_generation_compare import (
     overlap_free_solo_notes,
     parse_baseline_modes,
     phrase_cadence_tokens,
+    phrase_recovery_tokens,
     straight_guide_tones_tokens,
     straight_grid_tokens,
     varied_grid_position_duration_steps,
@@ -89,6 +90,9 @@ class StageBDataMotifGenerationCompareTest(unittest.TestCase):
 
     def test_parse_baseline_modes_accepts_phrase_cadence(self) -> None:
         self.assertEqual(parse_baseline_modes("phrase_cadence"), ["phrase_cadence"])
+
+    def test_parse_baseline_modes_accepts_phrase_recovery(self) -> None:
+        self.assertEqual(parse_baseline_modes("phrase_recovery"), ["phrase_recovery"])
 
     def test_build_compare_summary_allows_selected_modes_without_hand_written_reference(self) -> None:
         def valid_summary() -> dict:
@@ -368,6 +372,36 @@ class StageBDataMotifGenerationCompareTest(unittest.TestCase):
         self.assertGreaterEqual(len(set(durations)), 2)
         self.assertLess(stepwise_ratio, 0.70)
         self.assertLess(chromatic_ratio, 0.35)
+
+    def test_phrase_recovery_tokens_resolve_large_leaps(self) -> None:
+        chords = ["Cm7", "F7", "Bbmaj7", "Ebmaj7"]
+        primer = build_stage_b_primer(chords, 124)
+        tokens = phrase_recovery_tokens(
+            primer_tokens=primer,
+            chords=chords,
+            bars=4,
+            note_groups_per_bar=8,
+            seed=17,
+        )
+        grammar = analyze_stage_b_note_grammar(tokens, primer_size=len(primer))
+        groups = extract_stage_b_note_groups(tokens, primer_size=len(primer))
+        pitches = [int(group["pitch"]) for group in groups]
+        intervals = [right - left for left, right in zip(pitches, pitches[1:])]
+        large_leap_indexes = [index for index, interval in enumerate(intervals) if abs(interval) >= 7]
+        unresolved = 0
+        for index in large_leap_indexes:
+            if index + 1 >= len(intervals):
+                unresolved += 1
+                continue
+            direction = 1 if intervals[index] > 0 else -1
+            next_direction = 1 if intervals[index + 1] > 0 else -1 if intervals[index + 1] < 0 else 0
+            if next_direction != -direction or not 1 <= abs(intervals[index + 1]) <= 5:
+                unresolved += 1
+        unresolved_ratio = unresolved / len(large_leap_indexes)
+
+        self.assertTrue(grammar["grammar_valid"])
+        self.assertEqual(len(groups), 32)
+        self.assertLess(unresolved_ratio, 0.45)
 
     def test_build_review_export_copies_named_mode_files(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## 요약

- Issue #105: `phrase_recovery` review baseline을 추가했습니다.
- 큰 도약 뒤 반대 방향 1-5 semitone small recovery를 선호합니다.
- `stage-b-phrase-recovery-review` 하네스를 추가했습니다.
- 결과를 CORE_PLAN, CURRENT_STATUS, docs index, AGENTS에 기록했습니다.

## 결과

- candidate count: `6`
- objective bucket counts: `clean=3`, `warning=3`
- `phrase_cadence`: unresolved_large_leaps `3`
- `phrase_recovery`: objective flags 없음
- `phrase_cadence` unresolved large leap ratio: `0.750-0.757`
- `phrase_recovery` unresolved large leap ratio: `0.000-0.048`

## 해석

- Issue #103에서 드러난 unresolved large leap risk를 `phrase_recovery` baseline에서는 objective 기준으로 해결했습니다.
- 아직 subjective jazz quality를 주장하지 않습니다.
- 다음 작업은 `phrase_recovery`를 data-derived motif rhythm과 결합하거나 listening review package로 검토하는 것입니다.

## 검증

```bash
./.venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare
bash scripts/agent_harness.sh stage-b-phrase-recovery-review
bash scripts/agent_harness.sh quick
```

Closes #105


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added phrase recovery review capability for Stage B, enabling recovery pitch selection after large pitch leaps.

* **Documentation**
  * Updated baseline reference and added comprehensive review documentation describing phrase recovery behavior, execution commands, and results.

* **Tests**
  * Added unit tests validating phrase recovery mode parsing and large-leap resolution behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohhalim/fine_tuning_art-tatum_midi_solo/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->