### PR TITLE
Stage B data motif phrase recovery baseline 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #105: Stage B phrase recovery review baseline.
+- Issue #107: Stage B data motif phrase recovery baseline.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -267,6 +267,12 @@ For Stage B phrase recovery review changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-phrase-recovery-review
+```
+
+For Stage B data motif phrase recovery review changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-data-motif-phrase-recovery-review
 ```
 
 For Stage B filled listening review aggregate changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -155,6 +155,7 @@ Stage B에서 명시하는 것:
 49. Stage B phrase/cadence review baseline
 50. Stage B phrase naturalness objective metrics
 51. Stage B phrase recovery review baseline
+52. Stage B data motif phrase recovery baseline
 
 가장 최근 의미 있는 결과:
 
@@ -186,6 +187,7 @@ Stage B에서 명시하는 것:
 - Issue #101 adds a phrase/cadence review baseline, reducing `chromatic_walk` from `7` to `1` and `too_stepwise_or_scalar` from `6` to `0` in the next review set.
 - Issue #103 adds phrase naturalness metrics and reveals that all `12` Issue #101 review candidates have `unresolved_large_leaps`.
 - Issue #105 adds a phrase recovery baseline, reducing `phrase_recovery` unresolved large leap ratio to `0.000-0.048`.
+- Issue #107 combines data-derived motif rhythm with phrase recovery pitch grammar and keeps `data_motif_phrase_recovery` objective-clean.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -408,6 +410,7 @@ Stage B에서 명시하는 것:
 - Issue #101 result: phrase/cadence review reports `12` reviewable candidates, `11` clean candidates, `1` warning candidate, `chromatic_walk=1`, and `too_stepwise_or_scalar=0`.
 - Issue #103 result: phrase naturalness review reclassifies the same `12` candidates as warnings because `unresolved_large_leaps=12`.
 - Issue #105 result: phrase recovery review reports `phrase_cadence` candidates as `3` warnings and `phrase_recovery` candidates as `3` clean candidates.
+- Issue #107 result: data motif phrase recovery review reports `data_motif_guide_tones` as `3` warnings and `data_motif_phrase_recovery` as `3` clean candidates.
 
 해석:
 
@@ -687,28 +690,29 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B phrase recovery review baseline 추가
+Stage B data motif phrase recovery baseline 추가
 ```
 
 결과:
 
-- phrase recovery baseline을 추가해 unresolved large leap risk를 줄였다.
-- output: `outputs/stage_b_listening_review_aggregate/harness_stage_b_phrase_recovery_review/listening_review_aggregate.md`
-- candidate count: `6`
-- objective clean: `3`
+- data-derived motif rhythm과 phrase recovery pitch grammar를 결합했다.
+- output: `outputs/stage_b_listening_review_aggregate/harness_stage_b_data_motif_phrase_recovery_review/listening_review_aggregate.md`
+- candidate count: `9`
+- objective clean: `6`
 - objective warning: `3`
 - duration pattern collapse: `0`
 - overlap/polyphonic: `0`
 - too stepwise/scalar: `0`
 - unresolved large leaps: `3`
-- `phrase_cadence`: unresolved large leaps `3`
+- `data_motif_guide_tones`: unresolved large leaps `3`
+- `data_motif_phrase_recovery`: objective flags 없음
 - `phrase_recovery`: objective flags 없음
 
 다음 작업:
 
-- `phrase_recovery`를 data-derived motif rhythm과 결합한다.
 - 새 후보의 context MIDI를 기준으로 subjective listening review를 채운다.
-- broad training으로 넘어가기 전 reference contour template과 비교한다.
+- objective clean 후보라도 broad training으로 넘어가기 전 실제 piano-roll/listening review를 먼저 한다.
+- data-derived contour template에서 recovery pattern을 더 직접 추출할지 결정한다.
 - real Brad/reference chord label은 아직 임의로 넣지 않는다.
 
 ## 10. 한 문장 요약

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-105-stage-b-phrase-recovery-review`
+- `issue-107-stage-b-data-motif-phrase-recovery`
 
 현재 범위가 아닌 것:
 
@@ -35,6 +35,46 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
 ## Latest Probe Result
+
+Issue #107은 `phrase_recovery` pitch grammar를 data-derived motif rhythm template과 결합한 단계다.
+
+중요한 전제:
+
+- hand-written grid가 아니라 실제 데이터에서 추출한 rhythm shape를 사용한다.
+- objective clean은 subjective jazz quality를 뜻하지 않는다.
+- 다음 단계는 듣기 리뷰가 필요하다.
+
+Implemented:
+
+- `data_motif_phrase_recovery` baseline mode
+- data-derived rhythm position/duration 유지
+- phrase recovery pitch grammar 결합
+- `scripts/agent_harness.sh stage-b-data-motif-phrase-recovery-review`
+- docs:
+  - `docs/STAGE_B_DATA_MOTIF_PHRASE_RECOVERY_2026-05-22.md`
+
+Result:
+
+- candidate count: `9`
+- objective bucket counts:
+  - clean: `6`
+  - warning: `3`
+- objective flag counts:
+  - unresolved large leaps: `3`
+- mode flag counts:
+  - `data_motif_guide_tones`: unresolved large leaps `3`
+  - `data_motif_phrase_recovery`: no objective flags
+  - `phrase_recovery`: no objective flags
+- `data_motif_guide_tones` unresolved large leap ratio: `0.583-0.652`
+- `data_motif_phrase_recovery` unresolved large leap ratio: `0.000-0.045`
+- `data_motif_phrase_recovery` tension ratio: `0.476-0.524`
+
+Decision:
+
+- `data_motif_phrase_recovery`는 data rhythm shape와 phrase recovery를 동시에 만족한다.
+- 다음 작업은 review MIDI/context MIDI를 listening review 대상으로 정리하거나, subjective review notes를 채우는 것이다.
+
+## Previous Probe Result
 
 Issue #105는 Issue #103에서 드러난 `unresolved_large_leaps` 문제를 줄이기 위해 phrase recovery baseline을 추가한 단계다.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -116,6 +116,8 @@
   - 큰 도약 뒤 회복 움직임이 없는 phrase naturalness risk를 objective flag로 추가한 결과.
 - `STAGE_B_PHRASE_RECOVERY_REVIEW_2026-05-22.md`
   - 큰 도약 뒤 반대 방향 small recovery를 넣는 phrase recovery baseline 결과.
+- `STAGE_B_DATA_MOTIF_PHRASE_RECOVERY_2026-05-22.md`
+  - data-derived motif rhythm과 phrase recovery pitch grammar를 결합한 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -142,7 +144,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, generated chord eval bridge, data-guide generated chord eval, review markdown chord eval summary, listening review notes schema, filled listening review aggregate, full review manifest notes, objective MIDI note review, objective flags review flow, overlap-free review export, duration variation review, phrase/cadence review, phrase naturalness objective review, and phrase recovery review를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, generated chord eval bridge, data-guide generated chord eval, review markdown chord eval summary, listening review notes schema, filled listening review aggregate, full review manifest notes, objective MIDI note review, objective flags review flow, overlap-free review export, duration variation review, phrase/cadence review, phrase naturalness objective review, phrase recovery review, and data motif phrase recovery review를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_DATA_MOTIF_PHRASE_RECOVERY_2026-05-22.md
+++ b/docs/STAGE_B_DATA_MOTIF_PHRASE_RECOVERY_2026-05-22.md
@@ -1,0 +1,101 @@
+# Stage B Data Motif Phrase Recovery
+
+작성일: 2026-05-22
+
+## 목적
+
+Issue #107은 Issue #105의 `phrase_recovery` pitch grammar를 data-derived motif rhythm template과 결합한 단계다.
+
+목표는 hand-written grid가 아니라 실제 MIDI phrase window에서 추출한 rhythm shape 위에서도 unresolved large leap 문제가 줄어드는지 확인하는 것이다.
+
+## 구현
+
+변경 사항:
+
+- `scripts/run_stage_b_data_motif_generation_compare.py`
+  - `data_motif_phrase_recovery` baseline mode
+  - `data_motif_phrase_recovery_tokens`
+- `scripts/agent_harness.sh`
+  - `stage-b-data-motif-phrase-recovery-review`
+- `tests/test_stage_b_data_motif_generation_compare.py`
+  - mode parsing test
+  - data rhythm preservation and leap recovery test
+
+## 동작 방식
+
+`data_motif_phrase_recovery`는 다음을 결합한다.
+
+- rhythm:
+  - extracted motif template의 position/duration
+  - data-derived bar-position variation 유지
+- pitch:
+  - phrase/cadence pitch-class cells
+  - large leap 뒤 반대 방향 small recovery
+  - current/next chord의 guide tone, non-root chord tone, tension tone 후보
+
+## 하네스
+
+실행:
+
+```bash
+bash scripts/agent_harness.sh stage-b-data-motif-phrase-recovery-review
+```
+
+비교 mode:
+
+- `data_motif_guide_tones`
+- `data_motif_phrase_recovery`
+- `phrase_recovery`
+
+## 결과
+
+출력:
+
+- review manifest:
+  - `outputs/stage_b_data_motif_review/harness_stage_b_data_motif_phrase_recovery_review/review_manifest.json`
+- objective report:
+  - `outputs/stage_b_objective_midi_review/harness_stage_b_data_motif_phrase_recovery_review/objective_midi_note_review.md`
+- aggregate:
+  - `outputs/stage_b_listening_review_aggregate/harness_stage_b_data_motif_phrase_recovery_review/listening_review_aggregate.md`
+
+요약:
+
+- candidate count: `9`
+- objective bucket counts:
+  - clean: `6`
+  - warning: `3`
+- objective flag counts:
+  - unresolved large leaps: `3`
+- mode flag counts:
+  - `data_motif_guide_tones`: unresolved large leaps `3`
+  - `data_motif_phrase_recovery`: no objective flags
+  - `phrase_recovery`: no objective flags
+
+비교:
+
+- `data_motif_guide_tones` unresolved large leap ratio:
+  - `0.583-0.652`
+- `data_motif_phrase_recovery` unresolved large leap ratio:
+  - `0.000-0.045`
+- `data_motif_phrase_recovery` tension ratio:
+  - `0.476-0.524`
+
+## 해석
+
+`data_motif_phrase_recovery`는 data-derived rhythm shape를 유지하면서 phrase recovery objective risk를 줄였다.
+
+이제 다음 판단은 pure objective gate가 아니라 listening review에 가깝다. 특히 다음을 들어봐야 한다.
+
+- recovery motion이 음악적으로 자연스러운지
+- data-derived rhythm이 실제로 덜 기계적으로 느껴지는지
+- tension ratio가 높아져도 random color tone처럼 들리지 않는지
+
+## 검증
+
+실행한 검증:
+
+```bash
+./.venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare
+bash scripts/agent_harness.sh stage-b-data-motif-phrase-recovery-review
+bash scripts/agent_harness.sh quick
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -82,6 +82,8 @@ Modes:
                 Export phrase/cadence review candidates and objective priority.
   stage-b-phrase-recovery-review
                 Compare phrase/cadence against leap-recovery phrase candidates.
+  stage-b-data-motif-phrase-recovery-review
+                Compare data-motif guide tones against data-motif phrase recovery.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   chord-coverage-audit
@@ -982,6 +984,48 @@ run_stage_b_phrase_recovery_review() {
     --review_notes "$review_notes_path"
 }
 
+run_stage_b_data_motif_phrase_recovery_review() {
+  local run_id="${RUN_ID:-harness_stage_b_data_motif_phrase_recovery_review}"
+  local review_manifest_path="outputs/stage_b_data_motif_review/${run_id}/review_manifest.json"
+  local review_markdown_path="outputs/stage_b_data_motif_review/${run_id}/review_candidates.md"
+  local objective_report_path="outputs/stage_b_objective_midi_review/${run_id}/objective_midi_note_review.json"
+  local review_notes_path="outputs/stage_b_listening_review_notes/${run_id}/review_notes_template.json"
+  print_header "Stage B data-motif phrase recovery review export"
+  "$PYTHON_BIN" scripts/run_stage_b_data_motif_generation_compare.py \
+    --run_id "$run_id" \
+    --issue_number 107 \
+    --input_dir ./midi_dataset/midi/studio \
+    --baseline_modes data_motif_guide_tones,data_motif_phrase_recovery,phrase_recovery \
+    --max_files 4 \
+    --window_bars 8 \
+    --window_stride_bars 4 \
+    --min_window_target_notes 16 \
+    --motif_length 4 \
+    --max_bar_span 2 \
+    --max_records 64 \
+    --template_top_n 32 \
+    --num_samples 3 \
+    --bars 8 \
+    --note_groups_per_bar 8 \
+    --review_top_n 3 \
+    --copy_review_midi \
+    --overlap_free_review_midi
+  print_header "Stage B objective MIDI note review"
+  "$PYTHON_BIN" scripts/review_midi_note_objectives.py \
+    --run_id "$run_id" \
+    --review_manifest "$review_manifest_path"
+  print_header "Stage B objective-aware listening review notes"
+  "$PYTHON_BIN" scripts/build_listening_review_notes.py \
+    --run_id "$run_id" \
+    --review_manifest "$review_manifest_path" \
+    --source_review_markdown "$review_markdown_path" \
+    --objective_midi_review_report "$objective_report_path"
+  print_header "Stage B objective-aware listening review aggregate"
+  "$PYTHON_BIN" scripts/summarize_listening_review_notes.py \
+    --run_id "$run_id" \
+    --review_notes "$review_notes_path"
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -1216,6 +1260,9 @@ case "$MODE" in
     ;;
   stage-b-phrase-recovery-review)
     run_stage_b_phrase_recovery_review
+    ;;
+  stage-b-data-motif-phrase-recovery-review)
+    run_stage_b_data_motif_phrase_recovery_review
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/run_stage_b_data_motif_generation_compare.py
+++ b/scripts/run_stage_b_data_motif_generation_compare.py
@@ -62,6 +62,7 @@ VALID_BASELINE_MODES = {
     "hand_written_swing",
     "data_motif",
     "data_motif_guide_tones",
+    "data_motif_phrase_recovery",
 }
 
 
@@ -1046,6 +1047,90 @@ def data_motif_guide_tones_tokens(
     return tokens
 
 
+def data_motif_phrase_recovery_tokens(
+    *,
+    primer_tokens: Sequence[int],
+    chords: Sequence[str],
+    bars: int,
+    note_groups_per_bar: int,
+    template_report: dict[str, Any],
+    seed: int,
+) -> list[int]:
+    rng = random.Random(int(seed))
+    summary = template_report["summary"]
+    rhythm_rows = summary["top_rhythm_templates"]
+    contour_rows = summary["top_contour_templates"]
+    tokens = [int(token) for token in primer_tokens]
+    recent_pitches: list[int] = []
+    motif_length = 4
+    motifs_per_bar = max(1, int(round(max(1, int(note_groups_per_bar)) / motif_length)))
+    slot_size = max(1, int(POSITIONS_PER_BAR) // motifs_per_bar)
+    pending_recovery_direction = 0
+
+    for bar_index in range(max(1, int(bars))):
+        chord = chords[bar_index % len(chords)] if chords else None
+        next_chord = chords[(bar_index + 1) % len(chords)] if chords else chord
+        if bar_index > 0:
+            tokens.append(TOKEN_BAR)
+            tokens.extend(chord_tokens(chord))
+        emitted_in_bar = 0
+        pitch_cells = phrase_cadence_pitch_class_cells(chord, next_chord, bar_index=bar_index)
+        for motif_index in range(motifs_per_bar):
+            row_index = bar_index * motifs_per_bar + motif_index
+            rhythm = weighted_choice(rhythm_rows, rng, row_index)["key"]
+            contour = weighted_choice(contour_rows, rng, row_index + int(seed))["key"]
+            slot_start = min(int(POSITIONS_PER_BAR) - 1, motif_index * slot_size)
+            positions = normalize_position_deltas(
+                rhythm["position_deltas"],
+                slot_start=slot_start,
+                slot_size=slot_size,
+            )
+            durations = fit_duration_tokens_to_positions(positions, rhythm["duration_steps"])
+            contour_steps = [int(step) for step in contour.get("pitch_intervals", [])] or [0]
+            anchor = 64 + ((bar_index % 3) * 3) + rng.choice([-2, 0, 2])
+            for local_index, (position, duration_token) in enumerate(zip(positions, durations)):
+                if emitted_in_bar >= int(note_groups_per_bar):
+                    break
+                if pending_recovery_direction and recent_pitches:
+                    pitch = recovery_pitch_after_large_leap(
+                        chord=chord,
+                        next_chord=next_chord,
+                        previous_pitch=recent_pitches[-1],
+                        leap_direction=pending_recovery_direction,
+                        recent_pitches=recent_pitches,
+                    )
+                    pending_recovery_direction = 0
+                else:
+                    cell_index = guide_tone_cell_index_for_position(int(position))
+                    pitch_class = pitch_cells[cell_index % len(pitch_cells)]
+                    contour_offset = contour_steps[local_index % len(contour_steps)]
+                    target_pitch = anchor + contour_offset
+                    if recent_pitches:
+                        target_pitch = int(round((target_pitch + int(recent_pitches[-1])) / 2))
+                    pitch = nearest_phrase_pitch_for_pitch_class(
+                        pitch_class,
+                        target_pitch=target_pitch,
+                        recent_pitches=recent_pitches,
+                    )
+
+                if recent_pitches:
+                    interval = int(pitch) - int(recent_pitches[-1])
+                    if abs(interval) >= 7:
+                        pending_recovery_direction = 1 if interval > 0 else -1
+                recent_pitches.append(pitch)
+                tokens.extend(
+                    [
+                        position_token(position),
+                        note_velocity_token(4),
+                        note_pitch_token(pitch),
+                        duration_token,
+                    ]
+                )
+                emitted_in_bar += 1
+    tokens.append(TOKEN_END)
+    return tokens
+
+
 def generated_tokens_for_mode(
     mode: str,
     *,
@@ -1123,6 +1208,15 @@ def generated_tokens_for_mode(
         )
     if mode == "data_motif_guide_tones":
         return data_motif_guide_tones_tokens(
+            primer_tokens=primer_tokens,
+            chords=chords,
+            bars=bars,
+            note_groups_per_bar=note_groups_per_bar,
+            template_report=template_report,
+            seed=seed,
+        )
+    if mode == "data_motif_phrase_recovery":
+        return data_motif_phrase_recovery_tokens(
             primer_tokens=primer_tokens,
             chords=chords,
             bars=bars,

--- a/tests/test_stage_b_data_motif_generation_compare.py
+++ b/tests/test_stage_b_data_motif_generation_compare.py
@@ -11,6 +11,7 @@ from scripts.run_stage_b_data_motif_generation_compare import (
     build_review_export,
     chord_tone_pitch_classes,
     data_motif_guide_tones_tokens,
+    data_motif_phrase_recovery_tokens,
     data_motif_tokens,
     duration_tokens_from_steps,
     fit_duration_tokens_to_positions,
@@ -93,6 +94,9 @@ class StageBDataMotifGenerationCompareTest(unittest.TestCase):
 
     def test_parse_baseline_modes_accepts_phrase_recovery(self) -> None:
         self.assertEqual(parse_baseline_modes("phrase_recovery"), ["phrase_recovery"])
+
+    def test_parse_baseline_modes_accepts_data_motif_phrase_recovery(self) -> None:
+        self.assertEqual(parse_baseline_modes("data_motif_phrase_recovery"), ["data_motif_phrase_recovery"])
 
     def test_build_compare_summary_allows_selected_modes_without_hand_written_reference(self) -> None:
         def valid_summary() -> dict:
@@ -401,6 +405,38 @@ class StageBDataMotifGenerationCompareTest(unittest.TestCase):
 
         self.assertTrue(grammar["grammar_valid"])
         self.assertEqual(len(groups), 32)
+        self.assertLess(unresolved_ratio, 0.45)
+
+    def test_data_motif_phrase_recovery_preserves_data_rhythm_and_resolves_leaps(self) -> None:
+        chords = ["Cm7", "F7", "Bbmaj7", "Ebmaj7"]
+        primer = build_stage_b_primer(chords, 124)
+        tokens = data_motif_phrase_recovery_tokens(
+            primer_tokens=primer,
+            chords=chords,
+            bars=4,
+            note_groups_per_bar=8,
+            template_report=template_report(),
+            seed=17,
+        )
+        grammar = analyze_stage_b_note_grammar(tokens, primer_size=len(primer))
+        groups = extract_stage_b_note_groups(tokens, primer_size=len(primer))
+        pitches = [int(group["pitch"]) for group in groups]
+        intervals = [right - left for left, right in zip(pitches, pitches[1:])]
+        large_leap_indexes = [index for index, interval in enumerate(intervals) if abs(interval) >= 7]
+        unresolved = 0
+        for index in large_leap_indexes:
+            if index + 1 >= len(intervals):
+                unresolved += 1
+                continue
+            direction = 1 if intervals[index] > 0 else -1
+            next_direction = 1 if intervals[index + 1] > 0 else -1 if intervals[index + 1] < 0 else 0
+            if next_direction != -direction or not 1 <= abs(intervals[index + 1]) <= 5:
+                unresolved += 1
+        unresolved_ratio = unresolved / len(large_leap_indexes)
+
+        self.assertTrue(grammar["grammar_valid"])
+        self.assertEqual(len(groups), 32)
+        self.assertGreater(len({group["position"] for group in groups}), 4)
         self.assertLess(unresolved_ratio, 0.45)
 
     def test_build_review_export_copies_named_mode_files(self) -> None:


### PR DESCRIPTION
## 요약

- Issue #107: `data_motif_phrase_recovery` baseline을 추가했습니다.
- data-derived motif rhythm position/duration은 유지하고, pitch는 phrase recovery grammar를 적용했습니다.
- `stage-b-data-motif-phrase-recovery-review` 하네스를 추가했습니다.
- 결과를 CORE_PLAN, CURRENT_STATUS, docs index, AGENTS에 기록했습니다.

## 결과

- candidate count: `9`
- objective bucket counts: `clean=6`, `warning=3`
- `data_motif_guide_tones`: unresolved_large_leaps `3`
- `data_motif_phrase_recovery`: objective flags 없음
- `phrase_recovery`: objective flags 없음
- `data_motif_guide_tones` unresolved large leap ratio: `0.583-0.652`
- `data_motif_phrase_recovery` unresolved large leap ratio: `0.000-0.045`
- `data_motif_phrase_recovery` tension ratio: `0.476-0.524`

## 해석

- data-derived rhythm shape와 phrase recovery pitch grammar를 동시에 만족합니다.
- 아직 subjective jazz quality를 주장하지 않습니다.
- 다음 작업은 context MIDI 기준 listening review package를 정리하거나 notes를 채우는 것입니다.

## 검증

```bash
./.venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare
bash scripts/agent_harness.sh stage-b-data-motif-phrase-recovery-review
bash scripts/agent_harness.sh quick
```

Closes #107
