### PR TITLE
Stage B objective clean 리뷰 패키지 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #107: Stage B data motif phrase recovery baseline.
+- Issue #109: Stage B objective clean review package.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -273,6 +273,12 @@ For Stage B data motif phrase recovery review changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-data-motif-phrase-recovery-review
+```
+
+For Stage B objective-clean review package changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-clean-review-package
 ```
 
 For Stage B filled listening review aggregate changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -21,6 +21,12 @@
 이 프로젝트는 raw audio generation이 아니다.
 지금 단계에서는 DAW plugin, Spring Boot backend, SaaS, UI가 핵심이 아니다.
 
+Long-term reference:
+
+- Live Music Diffusion Models, LMDM, is relevant to the final live-AI-instrument direction.
+- The useful ideas are block-wise generation, sliding context, live input/output scheduling, and long-horizon drift control.
+- It does not change the current MVP: the present work remains symbolic MIDI jazz solo grammar, reviewability, and phrase quality.
+
 ## 2. 현재 MVP 목표
 
 현재 MVP는 제품 MVP가 아니라 model-core MVP다.
@@ -156,6 +162,7 @@ Stage B에서 명시하는 것:
 50. Stage B phrase naturalness objective metrics
 51. Stage B phrase recovery review baseline
 52. Stage B data motif phrase recovery baseline
+53. Stage B objective clean review package
 
 가장 최근 의미 있는 결과:
 
@@ -188,6 +195,8 @@ Stage B에서 명시하는 것:
 - Issue #103 adds phrase naturalness metrics and reveals that all `12` Issue #101 review candidates have `unresolved_large_leaps`.
 - Issue #105 adds a phrase recovery baseline, reducing `phrase_recovery` unresolved large leap ratio to `0.000-0.048`.
 - Issue #107 combines data-derived motif rhythm with phrase recovery pitch grammar and keeps `data_motif_phrase_recovery` objective-clean.
+- Issue #109 extracts only the objective-clean `data_motif_phrase_recovery` candidates into a focused listening review package.
+- Issue #109 result: `3` clean candidates, all with context MIDI paths, note count `63`, unique pitch count `19-23`, unresolved large leap ratio `0.000-0.045`, and tension ratio `0.476-0.524`.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -411,6 +420,7 @@ Stage B에서 명시하는 것:
 - Issue #103 result: phrase naturalness review reclassifies the same `12` candidates as warnings because `unresolved_large_leaps=12`.
 - Issue #105 result: phrase recovery review reports `phrase_cadence` candidates as `3` warnings and `phrase_recovery` candidates as `3` clean candidates.
 - Issue #107 result: data motif phrase recovery review reports `data_motif_guide_tones` as `3` warnings and `data_motif_phrase_recovery` as `3` clean candidates.
+- Issue #109 result: objective clean review package keeps only the `3` `data_motif_phrase_recovery` candidates and writes `outputs/stage_b_clean_review_package/harness_stage_b_clean_review_package/clean_review_package.md`.
 
 해석:
 
@@ -421,6 +431,7 @@ Stage B에서 명시하는 것:
 - `swing_motif_approach`는 기계적인 grid 반복을 줄였지만, 이 또한 jazz vocabulary 자체는 아니다.
 - real phrase reference stats와 motif extraction 기준으로 보면 다음은 hand-written rhythm rule 확장이 아니라 data-derived motif/cadence control 쪽이 맞다.
 - 다만 pitch-role 쪽은 real reference chord label이 아직 없으므로, 다음 개선은 실제 청취 결과를 notes에 채운 뒤 issue distribution으로 후속 generation rule을 분기하는 순서가 맞다.
+- 현재 다음 판단은 새 rule 추가가 아니라 clean package의 context MIDI를 듣고 phrase/timing/chord-fit review를 채우는 것이다.
 
 ### Phase 3.10. Swing/Motif Phrase Grammar
 
@@ -690,30 +701,29 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B data motif phrase recovery baseline 추가
+Stage B objective clean review package 추가
 ```
 
 결과:
 
-- data-derived motif rhythm과 phrase recovery pitch grammar를 결합했다.
-- output: `outputs/stage_b_listening_review_aggregate/harness_stage_b_data_motif_phrase_recovery_review/listening_review_aggregate.md`
-- candidate count: `9`
-- objective clean: `6`
-- objective warning: `3`
-- duration pattern collapse: `0`
-- overlap/polyphonic: `0`
-- too stepwise/scalar: `0`
-- unresolved large leaps: `3`
-- `data_motif_guide_tones`: unresolved large leaps `3`
-- `data_motif_phrase_recovery`: objective flags 없음
-- `phrase_recovery`: objective flags 없음
+- Issue #107 후보 중 objective-clean `data_motif_phrase_recovery`만 추출했다.
+- output: `outputs/stage_b_clean_review_package/harness_stage_b_clean_review_package/clean_review_package.md`
+- candidate count: `3`
+- selected mode: `data_motif_phrase_recovery`
+- note count: `63`
+- unique pitch count: `19-23`
+- unresolved large leap ratio: `0.000-0.045`
+- chord-tone ratio: `0.476-0.524`
+- tension ratio: `0.476-0.524`
+- solo MIDI와 context MIDI를 함께 제공한다.
 
 다음 작업:
 
-- 새 후보의 context MIDI를 기준으로 subjective listening review를 채운다.
+- clean package의 context MIDI를 기준으로 subjective listening review를 채운다.
 - objective clean 후보라도 broad training으로 넘어가기 전 실제 piano-roll/listening review를 먼저 한다.
-- data-derived contour template에서 recovery pattern을 더 직접 추출할지 결정한다.
+- 문제가 계속 "초급 멜로디/코드톤 나열"이면 data-derived contour/cadence pattern을 더 직접 추출할지 결정한다.
 - real Brad/reference chord label은 아직 임의로 넣지 않는다.
+- LMDM/audio diffusion은 장기 live instrument reference로만 남기고, 현재 MVP를 audio로 pivot하지 않는다.
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -1,6 +1,6 @@
 # Current Status and Plan
 
-작성일: 2026-05-22
+작성일: 2026-05-23
 
 ## Current Focus
 
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-107-stage-b-data-motif-phrase-recovery`
+- `issue-109-stage-b-clean-review-package`
 
 현재 범위가 아닌 것:
 
@@ -35,6 +35,51 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
 ## Latest Probe Result
+
+Issue #109는 Issue #107의 Stage B data-motif phrase recovery 결과에서 objective-clean 후보만 추출해 listening review package로 묶는 단계다.
+
+중요한 전제:
+
+- 새 generation rule을 추가한 것이 아니다.
+- objective clean은 subjective jazz quality를 뜻하지 않는다.
+- 목적은 "들을 가치가 있는 후보"만 줄여서 review loop를 좁히는 것이다.
+
+Implemented:
+
+- `scripts/build_clean_review_package.py`
+- clean 후보 필터:
+  - `objective_bucket == clean`
+  - `objective_flags == []`
+  - `mode == data_motif_phrase_recovery`
+- copied solo MIDI/context MIDI review package
+- `scripts/agent_harness.sh stage-b-clean-review-package`
+- docs:
+  - `docs/STAGE_B_CLEAN_REVIEW_PACKAGE_2026-05-23.md`
+
+Result:
+
+- output:
+  - `outputs/stage_b_clean_review_package/harness_stage_b_clean_review_package/clean_review_package.md`
+- candidate count: `3`
+- selected mode:
+  - `data_motif_phrase_recovery`
+- selected candidates:
+  - `data_motif_phrase_recovery_rank_1_sample_1`
+  - `data_motif_phrase_recovery_rank_2_sample_2`
+  - `data_motif_phrase_recovery_rank_3_sample_3`
+- note count: `63`, `63`, `63`
+- unique pitch count: `19`, `23`, `22`
+- unresolved large leap ratio: `0.000`, `0.000`, `0.045`
+- chord-tone ratio: `0.508`, `0.524`, `0.476`
+- tension ratio: `0.492`, `0.476`, `0.524`
+
+Decision:
+
+- 이제 "무작위 후보 전체"가 아니라 objective-clean 후보 3개를 context MIDI로 들으면 된다.
+- 이 결과는 아직 jazz solo quality 성공이 아니다.
+- 다음 판단은 chord context 위에서 phrase continuation, landing, timing, jazz vocabulary가 실제로 들리는지 확인하는 것이다.
+
+## Previous Probe Result
 
 Issue #107은 `phrase_recovery` pitch grammar를 data-derived motif rhythm template과 결합한 단계다.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -118,6 +118,8 @@
   - 큰 도약 뒤 반대 방향 small recovery를 넣는 phrase recovery baseline 결과.
 - `STAGE_B_DATA_MOTIF_PHRASE_RECOVERY_2026-05-22.md`
   - data-derived motif rhythm과 phrase recovery pitch grammar를 결합한 결과.
+- `STAGE_B_CLEAN_REVIEW_PACKAGE_2026-05-23.md`
+  - objective-clean `data_motif_phrase_recovery` 후보만 골라 context MIDI와 함께 listening review package로 묶은 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -144,7 +146,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, generated chord eval bridge, data-guide generated chord eval, review markdown chord eval summary, listening review notes schema, filled listening review aggregate, full review manifest notes, objective MIDI note review, objective flags review flow, overlap-free review export, duration variation review, phrase/cadence review, phrase naturalness objective review, phrase recovery review, and data motif phrase recovery review를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, generated chord eval bridge, data-guide generated chord eval, review markdown chord eval summary, listening review notes schema, filled listening review aggregate, full review manifest notes, objective MIDI note review, objective flags review flow, overlap-free review export, duration variation review, phrase/cadence review, phrase naturalness objective review, phrase recovery review, data motif phrase recovery review, and objective clean review package를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_CLEAN_REVIEW_PACKAGE_2026-05-23.md
+++ b/docs/STAGE_B_CLEAN_REVIEW_PACKAGE_2026-05-23.md
@@ -1,0 +1,90 @@
+# Stage B Objective Clean Review Package
+
+작성일: 2026-05-23
+
+## Purpose
+
+Issue #109는 Stage B data-motif phrase recovery review 결과에서 objective metric 기준으로 clean 후보만 따로 묶는 단계다.
+
+이 단계의 목적은 새 generation rule을 추가하는 것이 아니다. 이전 probe에서 이미 만들어진 후보 중, 최소한 다음 조건을 만족하는 후보만 listening review 대상으로 줄인다.
+
+- objective bucket: `clean`
+- objective flags: none
+- mode: `data_motif_phrase_recovery`
+- review MIDI와 context MIDI 경로를 같이 제공
+
+이렇게 해야 사람이 이상한 MIDI까지 모두 듣지 않고, 지금 가장 리뷰 가치가 높은 후보만 확인할 수 있다.
+
+## Implementation
+
+Added:
+
+- `scripts/build_clean_review_package.py`
+- `tests/test_clean_review_package.py`
+- `bash scripts/agent_harness.sh stage-b-clean-review-package`
+
+The package builder reads:
+
+- review manifest
+- objective MIDI note review report
+
+Then it writes:
+
+- `clean_review_package.json`
+- `clean_review_package.md`
+- optional copied solo MIDI files
+- optional copied context MIDI files
+
+## Harness Result
+
+Command:
+
+```bash
+bash scripts/agent_harness.sh stage-b-clean-review-package
+```
+
+Output package:
+
+```text
+outputs/stage_b_clean_review_package/harness_stage_b_clean_review_package/clean_review_package.md
+```
+
+Result:
+
+- candidate count: `3`
+- allowed mode: `data_motif_phrase_recovery`
+- all selected candidates have no objective flags
+
+Selected candidates:
+
+| candidate | notes | unique pitches | unresolved large leap | chord tone | tension |
+|---|---:|---:|---:|---:|---:|
+| `data_motif_phrase_recovery_rank_1_sample_1` | 63 | 19 | 0.000 | 0.508 | 0.492 |
+| `data_motif_phrase_recovery_rank_2_sample_2` | 63 | 23 | 0.000 | 0.524 | 0.476 |
+| `data_motif_phrase_recovery_rank_3_sample_3` | 63 | 22 | 0.045 | 0.476 | 0.524 |
+
+## Interpretation
+
+This is not proof of jazz quality.
+
+It only means the candidates no longer show the objective failures that previously blocked review:
+
+- one-note/two-note failure
+- chord-block review artifact
+- overlap/polyphonic review artifact
+- duration collapse
+- scalar/chromatic objective flag
+- unresolved large-leap objective flag
+
+The next decision must come from listening/piano-roll review with chord context.
+
+## Next Step
+
+Use the context MIDI files from the clean package to answer:
+
+- does the solo line fit the chord context?
+- does the rhythm feel intentionally quantized, not timing-drifted?
+- does the phrase have continuation and landing, not just isolated notes?
+- does it sound like jazz vocabulary or only chord-tone/tension enumeration?
+
+If these three clean candidates still sound beginner-like, the next generation work should not be another hand-written rule. It should move toward stronger data-derived phrase/cadence material or a model-side phrase continuation objective.

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -84,6 +84,8 @@ Modes:
                 Compare phrase/cadence against leap-recovery phrase candidates.
   stage-b-data-motif-phrase-recovery-review
                 Compare data-motif guide tones against data-motif phrase recovery.
+  stage-b-clean-review-package
+                Extract objective-clean data-motif phrase recovery candidates for listening review.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   chord-coverage-audit
@@ -1026,6 +1028,25 @@ run_stage_b_data_motif_phrase_recovery_review() {
     --review_notes "$review_notes_path"
 }
 
+run_stage_b_clean_review_package() {
+  local source_run_id="${SOURCE_RUN_ID:-harness_stage_b_data_motif_phrase_recovery_review}"
+  local run_id="${RUN_ID:-harness_stage_b_clean_review_package}"
+  local review_manifest_path="outputs/stage_b_data_motif_review/${source_run_id}/review_manifest.json"
+  local objective_report_path="outputs/stage_b_objective_midi_review/${source_run_id}/objective_midi_note_review.json"
+  if [[ ! -f "$review_manifest_path" || ! -f "$objective_report_path" ]]; then
+    print_header "Stage B data-motif phrase recovery review export"
+    SOURCE_RUN_ID="$source_run_id" RUN_ID="$source_run_id" run_stage_b_data_motif_phrase_recovery_review
+  fi
+  print_header "Stage B objective-clean review package"
+  "$PYTHON_BIN" scripts/build_clean_review_package.py \
+    --run_id "$run_id" \
+    --review_manifest "$review_manifest_path" \
+    --objective_report "$objective_report_path" \
+    --allowed_modes data_motif_phrase_recovery \
+    --copy_files \
+    --min_candidates 3
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -1263,6 +1284,9 @@ case "$MODE" in
     ;;
   stage-b-data-motif-phrase-recovery-review)
     run_stage_b_data_motif_phrase_recovery_review
+    ;;
+  stage-b-clean-review-package)
+    run_stage_b_clean_review_package
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/build_clean_review_package.py
+++ b/scripts/build_clean_review_package.py
@@ -1,0 +1,239 @@
+"""Extract objective-clean Stage B review candidates into a compact package."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.build_listening_review_notes import write_json  # noqa: E402
+
+
+SCHEMA_VERSION = "stage_b_clean_review_package_v1"
+
+
+class CleanReviewPackageError(ValueError):
+    pass
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def candidate_id_from_review_row(row: dict[str, Any]) -> str:
+    mode = str(row.get("mode") or "candidate").strip() or "candidate"
+    rank = int(row.get("review_rank", 0) or 0)
+    sample_index = int(row.get("sample_index", 0) or 0)
+    if rank and sample_index:
+        return f"{mode}_rank_{rank}_sample_{sample_index}"
+    return str(row.get("sample_id") or row.get("review_midi_path") or mode)
+
+
+def objective_candidates_by_id(objective_report: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    candidates = objective_report.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise CleanReviewPackageError("objective report must contain non-empty candidates")
+    indexed: dict[str, dict[str, Any]] = {}
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            raise CleanReviewPackageError("objective candidate must be an object")
+        candidate_id = str(candidate.get("candidate_id") or "").strip()
+        if not candidate_id:
+            raise CleanReviewPackageError("objective candidate_id is required")
+        indexed[candidate_id] = candidate
+    return indexed
+
+
+def selected_clean_candidates(
+    review_manifest: dict[str, Any],
+    objective_report: dict[str, Any],
+    *,
+    allowed_modes: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    rows = review_manifest.get("candidates")
+    if not isinstance(rows, list) or not rows:
+        raise CleanReviewPackageError("review manifest must contain non-empty candidates")
+    objective_by_id = objective_candidates_by_id(objective_report)
+    selected: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            raise CleanReviewPackageError("review manifest candidate must be an object")
+        mode = str(row.get("mode") or "")
+        if allowed_modes and mode not in allowed_modes:
+            continue
+        candidate_id = candidate_id_from_review_row(row)
+        objective = objective_by_id.get(candidate_id)
+        if not objective:
+            continue
+        if objective.get("objective_bucket") != "clean":
+            continue
+        if objective.get("objective_flags"):
+            continue
+        selected.append({"candidate_id": candidate_id, "review": row, "objective": objective})
+    selected.sort(
+        key=lambda item: (
+            -int(item["objective"].get("objective_priority_score", 0) or 0),
+            str(item["review"].get("mode") or ""),
+            int(item["review"].get("review_rank", 0) or 0),
+        )
+    )
+    return selected
+
+
+def maybe_copy(source: str, target_dir: Path, *, enabled: bool) -> str:
+    if not source:
+        return ""
+    source_path = Path(source)
+    if not enabled:
+        return str(source_path)
+    if not source_path.exists():
+        return str(source_path)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_path = target_dir / source_path.name
+    shutil.copy2(source_path, target_path)
+    return str(target_path)
+
+
+def compact_candidate(item: dict[str, Any], output_dir: Path, *, copy_files: bool) -> dict[str, Any]:
+    review = item["review"]
+    objective = item["objective"]
+    metrics = objective.get("metrics", {})
+    midi_path = maybe_copy(str(review.get("review_midi_path") or ""), output_dir / "midi", enabled=copy_files)
+    context_path = maybe_copy(
+        str(review.get("context_midi_path") or ""),
+        output_dir / "context_midi",
+        enabled=copy_files,
+    )
+    return {
+        "candidate_id": item["candidate_id"],
+        "mode": str(review.get("mode") or ""),
+        "review_rank": int(review.get("review_rank", 0) or 0),
+        "sample_index": int(review.get("sample_index", 0) or 0),
+        "review_midi_path": midi_path,
+        "context_midi_path": context_path,
+        "objective_priority_score": int(objective.get("objective_priority_score", 0) or 0),
+        "objective_bucket": str(objective.get("objective_bucket") or ""),
+        "objective_flags": list(objective.get("objective_flags") or []),
+        "metrics": {
+            "note_count": int(metrics.get("note_count", 0) or 0),
+            "unique_pitch_count": int(metrics.get("unique_pitch_count", 0) or 0),
+            "stepwise_interval_ratio": float(metrics.get("stepwise_interval_ratio", 0.0) or 0.0),
+            "chromatic_interval_ratio": float(metrics.get("chromatic_interval_ratio", 0.0) or 0.0),
+            "large_leap_interval_ratio": float(metrics.get("large_leap_interval_ratio", 0.0) or 0.0),
+            "unresolved_large_leap_ratio": float(metrics.get("unresolved_large_leap_ratio", 0.0) or 0.0),
+            "chord_tone_ratio": float(metrics.get("chord_tone_ratio", 0.0) or 0.0),
+            "tension_ratio": float(metrics.get("tension_ratio", 0.0) or 0.0),
+            "outside_ratio": float(metrics.get("outside_ratio", 0.0) or 0.0),
+            "root_tone_ratio": float(metrics.get("root_tone_ratio", 0.0) or 0.0),
+        },
+    }
+
+
+def build_clean_review_package(
+    review_manifest: dict[str, Any],
+    objective_report: dict[str, Any],
+    *,
+    output_dir: Path,
+    allowed_modes: set[str] | None = None,
+    copy_files: bool = False,
+) -> dict[str, Any]:
+    selected = selected_clean_candidates(review_manifest, objective_report, allowed_modes=allowed_modes)
+    candidates = [compact_candidate(item, output_dir, copy_files=copy_files) for item in selected]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_review_manifest": str(review_manifest.get("output_dir") or ""),
+        "source_objective_report": str(objective_report.get("report_path") or ""),
+        "allowed_modes": sorted(allowed_modes) if allowed_modes else [],
+        "copy_files": bool(copy_files),
+        "candidate_count": int(len(candidates)),
+        "candidates": candidates,
+    }
+
+
+def markdown_report(package: dict[str, Any]) -> str:
+    lines = [
+        "# Stage B Objective Clean Review Package",
+        "",
+        f"- candidate count: `{package['candidate_count']}`",
+        f"- allowed modes: `{', '.join(package['allowed_modes']) if package['allowed_modes'] else 'all'}`",
+        "",
+        "| candidate | mode | score | notes | unique | unresolved leap | chord tone | tension | MIDI | context |",
+        "|---|---|---:|---:|---:|---:|---:|---:|---|---|",
+    ]
+    if not package["candidates"]:
+        lines.append("| none | - | 0 | 0 | 0 | 0.000 | 0.000 | 0.000 | - | - |")
+    for candidate in package["candidates"]:
+        metrics = candidate["metrics"]
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    candidate["candidate_id"],
+                    candidate["mode"],
+                    str(candidate["objective_priority_score"]),
+                    str(metrics["note_count"]),
+                    str(metrics["unique_pitch_count"]),
+                    f"{metrics['unresolved_large_leap_ratio']:.3f}",
+                    f"{metrics['chord_tone_ratio']:.3f}",
+                    f"{metrics['tension_ratio']:.3f}",
+                    f"`{candidate['review_midi_path']}`",
+                    f"`{candidate['context_midi_path']}`",
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build objective-clean Stage B review package")
+    parser.add_argument("--review_manifest", type=str, required=True)
+    parser.add_argument("--objective_report", type=str, required=True)
+    parser.add_argument("--output_root", type=str, default=str(ROOT_DIR / "outputs" / "stage_b_clean_review_package"))
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--allowed_modes", type=str, default="")
+    parser.add_argument("--copy_files", action="store_true")
+    parser.add_argument("--min_candidates", type=int, default=1)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    allowed_modes = {mode.strip() for mode in args.allowed_modes.split(",") if mode.strip()} or None
+    package = build_clean_review_package(
+        read_json(Path(args.review_manifest)),
+        read_json(Path(args.objective_report)),
+        output_dir=output_dir,
+        allowed_modes=allowed_modes,
+        copy_files=bool(args.copy_files),
+    )
+    write_json(output_dir / "clean_review_package.json", package)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "clean_review_package.md").write_text(markdown_report(package), encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "candidate_count": package["candidate_count"],
+                "package_path": str(output_dir / "clean_review_package.json"),
+                "markdown_path": str(output_dir / "clean_review_package.md"),
+            },
+            ensure_ascii=True,
+            indent=2,
+        )
+    )
+    return 0 if int(package["candidate_count"]) >= int(args.min_candidates) else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_clean_review_package.py
+++ b/tests/test_clean_review_package.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from scripts.build_clean_review_package import build_clean_review_package, markdown_report
+
+
+class CleanReviewPackageTest(unittest.TestCase):
+    def sample_review_manifest(self, midi_path: str, context_path: str) -> dict:
+        return {
+            "output_dir": "outputs/review",
+            "candidates": [
+                {
+                    "mode": "data_motif_phrase_recovery",
+                    "review_rank": 1,
+                    "sample_index": 1,
+                    "review_midi_path": midi_path,
+                    "context_midi_path": context_path,
+                },
+                {
+                    "mode": "data_motif_guide_tones",
+                    "review_rank": 1,
+                    "sample_index": 1,
+                    "review_midi_path": "warning.mid",
+                    "context_midi_path": "warning_context.mid",
+                },
+            ],
+        }
+
+    def sample_objective_report(self) -> dict:
+        return {
+            "report_path": "outputs/objective/objective_midi_note_review.json",
+            "candidates": [
+                {
+                    "candidate_id": "data_motif_phrase_recovery_rank_1_sample_1",
+                    "objective_bucket": "clean",
+                    "objective_flags": [],
+                    "objective_priority_score": 100,
+                    "metrics": {
+                        "note_count": 63,
+                        "unique_pitch_count": 24,
+                        "stepwise_interval_ratio": 0.1,
+                        "chromatic_interval_ratio": 0.05,
+                        "large_leap_interval_ratio": 0.3,
+                        "unresolved_large_leap_ratio": 0.0,
+                        "chord_tone_ratio": 0.5,
+                        "tension_ratio": 0.48,
+                        "outside_ratio": 0.0,
+                        "root_tone_ratio": 0.0,
+                    },
+                },
+                {
+                    "candidate_id": "data_motif_guide_tones_rank_1_sample_1",
+                    "objective_bucket": "warning",
+                    "objective_flags": ["unresolved_large_leaps"],
+                    "objective_priority_score": 84,
+                    "metrics": {"note_count": 63},
+                },
+            ],
+        }
+
+    def test_build_clean_review_package_filters_clean_allowed_modes(self) -> None:
+        package = build_clean_review_package(
+            self.sample_review_manifest("clean.mid", "clean_context.mid"),
+            self.sample_objective_report(),
+            output_dir=Path("outputs/clean"),
+            allowed_modes={"data_motif_phrase_recovery"},
+            copy_files=False,
+        )
+
+        self.assertEqual(package["candidate_count"], 1)
+        candidate = package["candidates"][0]
+        self.assertEqual(candidate["candidate_id"], "data_motif_phrase_recovery_rank_1_sample_1")
+        self.assertEqual(candidate["objective_flags"], [])
+        self.assertEqual(candidate["metrics"]["unresolved_large_leap_ratio"], 0.0)
+
+    def test_build_clean_review_package_can_copy_files(self) -> None:
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            midi_path = tmp_path / "clean.mid"
+            context_path = tmp_path / "clean_context.mid"
+            midi_path.write_bytes(b"midi")
+            context_path.write_bytes(b"context")
+
+            package = build_clean_review_package(
+                self.sample_review_manifest(str(midi_path), str(context_path)),
+                self.sample_objective_report(),
+                output_dir=tmp_path / "package",
+                allowed_modes={"data_motif_phrase_recovery"},
+                copy_files=True,
+            )
+
+            candidate = package["candidates"][0]
+            self.assertTrue(Path(candidate["review_midi_path"]).exists())
+            self.assertTrue(Path(candidate["context_midi_path"]).exists())
+            self.assertIn("package/midi", candidate["review_midi_path"])
+            self.assertIn("package/context_midi", candidate["context_midi_path"])
+
+    def test_markdown_report_lists_review_paths(self) -> None:
+        package = build_clean_review_package(
+            self.sample_review_manifest("clean.mid", "clean_context.mid"),
+            self.sample_objective_report(),
+            output_dir=Path("outputs/clean"),
+            allowed_modes={"data_motif_phrase_recovery"},
+            copy_files=False,
+        )
+        markdown = markdown_report(package)
+
+        self.assertIn("data_motif_phrase_recovery_rank_1_sample_1", markdown)
+        self.assertIn("clean_context.mid", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

- Issue #107의 review manifest/objective report에서 objective-clean 후보만 추출하는 패키지 빌더를 추가했습니다.
- `data_motif_phrase_recovery` 후보만 골라 solo MIDI와 context MIDI를 함께 묶습니다.
- LMDM은 장기 live instrument reference로만 기록하고, 현재 MVP는 symbolic MIDI phrase quality에 집중한다는 판단을 문서화했습니다.

## 결과

- clean 후보: 3개
- mode: `data_motif_phrase_recovery`
- output: `outputs/stage_b_clean_review_package/harness_stage_b_clean_review_package/clean_review_package.md`
- note count: 63, 63, 63
- unique pitch count: 19, 23, 22
- unresolved large leap ratio: 0.000, 0.000, 0.045
- tension ratio: 0.492, 0.476, 0.524

## 검증

- `bash scripts/agent_harness.sh stage-b-clean-review-package`
- `bash scripts/agent_harness.sh quick`

Closes #109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Stage B objective clean review package generation to filter and select candidates for focused listening review validation.

* **Documentation**
  * Updated workflow documentation to include the new clean review package step in the Stage B validation sequence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohhalim/fine_tuning_art-tatum_midi_solo/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->