### PR TITLE
Stage B clean context 진단 리포트 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Primary goal:
 
 Current active branch scope:
 
-- Issue #109: Stage B objective clean review package.
+- Issue #111: Stage B clean context phrase diagnostics.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -279,6 +279,12 @@ For Stage B objective-clean review package changes, run:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-clean-review-package
+```
+
+For Stage B clean context diagnostics changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-clean-context-diagnostics
 ```
 
 For Stage B filled listening review aggregate changes, run:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -163,6 +163,7 @@ Stage B에서 명시하는 것:
 51. Stage B phrase recovery review baseline
 52. Stage B data motif phrase recovery baseline
 53. Stage B objective clean review package
+54. Stage B clean context phrase diagnostics
 
 가장 최근 의미 있는 결과:
 
@@ -197,6 +198,7 @@ Stage B에서 명시하는 것:
 - Issue #107 combines data-derived motif rhythm with phrase recovery pitch grammar and keeps `data_motif_phrase_recovery` objective-clean.
 - Issue #109 extracts only the objective-clean `data_motif_phrase_recovery` candidates into a focused listening review package.
 - Issue #109 result: `3` clean candidates, all with context MIDI paths, note count `63`, unique pitch count `19-23`, unresolved large leap ratio `0.000-0.045`, and tension ratio `0.476-0.524`.
+- Issue #111 reads those clean context candidates back at MIDI note-level and reports `3/3` as `listen_with_context`, with no diagnostic flags.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -421,6 +423,7 @@ Stage B에서 명시하는 것:
 - Issue #105 result: phrase recovery review reports `phrase_cadence` candidates as `3` warnings and `phrase_recovery` candidates as `3` clean candidates.
 - Issue #107 result: data motif phrase recovery review reports `data_motif_guide_tones` as `3` warnings and `data_motif_phrase_recovery` as `3` clean candidates.
 - Issue #109 result: objective clean review package keeps only the `3` `data_motif_phrase_recovery` candidates and writes `outputs/stage_b_clean_review_package/harness_stage_b_clean_review_package/clean_review_package.md`.
+- Issue #111 result: clean context diagnostics reports `3` candidates, diagnostic flags `{}`, bar coverage `8/8`, off-grid ratio `0.000`, max duration `1.000` beat, and decision hint `listen_with_context`.
 
 해석:
 
@@ -432,6 +435,7 @@ Stage B에서 명시하는 것:
 - real phrase reference stats와 motif extraction 기준으로 보면 다음은 hand-written rhythm rule 확장이 아니라 data-derived motif/cadence control 쪽이 맞다.
 - 다만 pitch-role 쪽은 real reference chord label이 아직 없으므로, 다음 개선은 실제 청취 결과를 notes에 채운 뒤 issue distribution으로 후속 generation rule을 분기하는 순서가 맞다.
 - 현재 다음 판단은 새 rule 추가가 아니라 clean package의 context MIDI를 듣고 phrase/timing/chord-fit review를 채우는 것이다.
+- Issue #111 기준으로도 자동 objective blocker는 남지 않았으므로, 다음 병목은 실제 subjective phrase quality review다.
 
 ### Phase 3.10. Swing/Motif Phrase Grammar
 
@@ -701,25 +705,27 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B objective clean review package 추가
+Stage B clean context phrase diagnostics 추가
 ```
 
 결과:
 
-- Issue #107 후보 중 objective-clean `data_motif_phrase_recovery`만 추출했다.
-- output: `outputs/stage_b_clean_review_package/harness_stage_b_clean_review_package/clean_review_package.md`
+- Issue #109 clean package 후보 3개를 MIDI note-level로 다시 진단했다.
+- output: `outputs/stage_b_clean_context_diagnostics/harness_stage_b_clean_context_diagnostics/clean_context_diagnostics.md`
 - candidate count: `3`
 - selected mode: `data_motif_phrase_recovery`
-- note count: `63`
+- note count: `63`, `63`, `63`
 - unique pitch count: `19-23`
-- unresolved large leap ratio: `0.000-0.045`
-- chord-tone ratio: `0.476-0.524`
-- tension ratio: `0.476-0.524`
-- solo MIDI와 context MIDI를 함께 제공한다.
+- bar coverage: `8/8`
+- off-grid ratio: `0.000`
+- max duration: `1.000` beat
+- diagnostic flags: none
+- decision hint: `listen_with_context`
+- context MIDI includes chord guide, bass root guide, and solo track.
 
 다음 작업:
 
-- clean package의 context MIDI를 기준으로 subjective listening review를 채운다.
+- clean context MIDI를 기준으로 subjective listening review를 채운다.
 - objective clean 후보라도 broad training으로 넘어가기 전 실제 piano-roll/listening review를 먼저 한다.
 - 문제가 계속 "초급 멜로디/코드톤 나열"이면 data-derived contour/cadence pattern을 더 직접 추출할지 결정한다.
 - real Brad/reference chord label은 아직 임의로 넣지 않는다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -8,7 +8,7 @@
 
 현재 브랜치:
 
-- `issue-109-stage-b-clean-review-package`
+- `issue-111-stage-b-clean-context-diagnostics`
 
 현재 범위가 아닌 것:
 
@@ -35,6 +35,48 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
 ## Latest Probe Result
+
+Issue #111은 Issue #109 clean review package 후보 3개를 context listening review 전에 MIDI note-level로 다시 진단한 단계다.
+
+중요한 전제:
+
+- 새 generation rule을 추가한 것이 아니다.
+- objective-clean 후보가 실제 jazz quality를 보장하지 않는다.
+- 목적은 "이제 들어볼 후보인지"와 "자동 rule을 더 고칠 문제인지"를 분리하는 것이다.
+
+Implemented:
+
+- `scripts/build_clean_context_diagnostics.py`
+- `tests/test_clean_context_diagnostics.py`
+- `scripts/agent_harness.sh stage-b-clean-context-diagnostics`
+- docs:
+  - `docs/STAGE_B_CLEAN_CONTEXT_DIAGNOSTICS_2026-05-23.md`
+
+Result:
+
+- output:
+  - `outputs/stage_b_clean_context_diagnostics/harness_stage_b_clean_context_diagnostics/clean_context_diagnostics.md`
+- candidate count: `3`
+- diagnostic flags: none
+- decision hint:
+  - `listen_with_context`: `3`
+- all candidates:
+  - note count: `63`
+  - bar coverage: `8/8`
+  - off-grid ratio: `0.000`
+  - max duration: `1.000` beat
+  - context MIDI: exists
+  - chord guide: exists
+  - bass root guide: exists
+
+Decision:
+
+- 객관 진단상 지금 후보 3개는 더 자동으로 거르기보다 들어볼 단계다.
+- 다음은 listening notes를 채워 phrase/timing/chord-fit/jazz-vocabulary 문제를 분류해야 한다.
+- 계속 초급 멜로디처럼 들리면 data-derived phrase/cadence vocabulary를 강화한다.
+- LMDM/audio diffusion 구현으로 pivot하지 않는다.
+
+## Previous Probe Result
 
 Issue #109는 Issue #107의 Stage B data-motif phrase recovery 결과에서 objective-clean 후보만 추출해 listening review package로 묶는 단계다.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -120,6 +120,8 @@
   - data-derived motif rhythm과 phrase recovery pitch grammar를 결합한 결과.
 - `STAGE_B_CLEAN_REVIEW_PACKAGE_2026-05-23.md`
   - objective-clean `data_motif_phrase_recovery` 후보만 골라 context MIDI와 함께 listening review package로 묶은 결과.
+- `STAGE_B_CLEAN_CONTEXT_DIAGNOSTICS_2026-05-23.md`
+  - clean context MIDI 후보 3개를 note-level로 다시 읽어 coverage/timing/pitch-reuse 진단을 남긴 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -146,7 +148,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, generated chord eval bridge, data-guide generated chord eval, review markdown chord eval summary, listening review notes schema, filled listening review aggregate, full review manifest notes, objective MIDI note review, objective flags review flow, overlap-free review export, duration variation review, phrase/cadence review, phrase naturalness objective review, phrase recovery review, data motif phrase recovery review, and objective clean review package를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, generated chord eval bridge, data-guide generated chord eval, review markdown chord eval summary, listening review notes schema, filled listening review aggregate, full review manifest notes, objective MIDI note review, objective flags review flow, overlap-free review export, duration variation review, phrase/cadence review, phrase naturalness objective review, phrase recovery review, data motif phrase recovery review, objective clean review package, and clean context diagnostics를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_CLEAN_CONTEXT_DIAGNOSTICS_2026-05-23.md
+++ b/docs/STAGE_B_CLEAN_CONTEXT_DIAGNOSTICS_2026-05-23.md
@@ -1,0 +1,91 @@
+# Stage B Clean Context Diagnostics
+
+작성일: 2026-05-23
+
+## Purpose
+
+Issue #111은 Issue #109에서 추출한 objective-clean 후보 3개를 다시 MIDI note-level로 읽어, context listening review 전에 확인해야 할 구조적 위험을 정리하는 단계다.
+
+이 단계는 새 generation rule을 추가하지 않는다. 목적은 다음 질문에 답하는 것이다.
+
+- 후보가 실제로 8-bar phrase coverage를 갖는가?
+- 박자가 grid에서 벗어난 timing drift인가?
+- 긴 sustain이나 dominant pitch reuse가 다시 나타나는가?
+- chord/bass/solo context MIDI가 함께 들어 있는가?
+- 객관적으로는 들을 수 있는 후보인지, 아니면 다시 generation rule을 고쳐야 하는 후보인지?
+
+## Implementation
+
+Added:
+
+- `scripts/build_clean_context_diagnostics.py`
+- `tests/test_clean_context_diagnostics.py`
+- `bash scripts/agent_harness.sh stage-b-clean-context-diagnostics`
+
+Input:
+
+- `outputs/stage_b_clean_review_package/harness_stage_b_clean_review_package/clean_review_package.json`
+
+Output:
+
+- `outputs/stage_b_clean_context_diagnostics/harness_stage_b_clean_context_diagnostics/clean_context_diagnostics.json`
+- `outputs/stage_b_clean_context_diagnostics/harness_stage_b_clean_context_diagnostics/clean_context_diagnostics.md`
+
+## Result
+
+Command:
+
+```bash
+bash scripts/agent_harness.sh stage-b-clean-context-diagnostics
+```
+
+Summary:
+
+- candidate count: `3`
+- diagnostic flags: `{}`
+- decision hints:
+  - `listen_with_context`: `3`
+
+Candidate metrics:
+
+| candidate | notes | unique | bars | off-grid ratio | max duration beats | most-common pitch ratio | flags | hint |
+|---|---:|---:|---:|---:|---:|---:|---|---|
+| `data_motif_phrase_recovery_rank_1_sample_1` | 63 | 19 | 8/8 | 0.000 | 1.000 | 0.159 | none | `listen_with_context` |
+| `data_motif_phrase_recovery_rank_2_sample_2` | 63 | 23 | 8/8 | 0.000 | 1.000 | 0.111 | none | `listen_with_context` |
+| `data_motif_phrase_recovery_rank_3_sample_3` | 63 | 22 | 8/8 | 0.000 | 1.000 | 0.095 | none | `listen_with_context` |
+
+Context summary:
+
+- all candidates have context MIDI
+- context MIDI contains chord guide
+- context MIDI contains bass root guide
+- context MIDI contains solo track
+
+## Interpretation
+
+The three candidates are not blocked by the objective failures that previously made review misleading.
+
+They are:
+
+- not sparse one-note/two-note outputs
+- not low-coverage fragments
+- not off-grid timing drift
+- not long-sustain blocks
+- not dominant-pitch collapse by the current thresholds
+- packaged with chord/bass context
+
+This still does not prove jazz quality.
+
+It means the next correct step is listening review, not another automatic generation tweak.
+
+## Next Decision
+
+Listen to the context MIDI files and classify each candidate:
+
+- timing: `good`, `too_loose`, `too_straight`, `unclear`
+- chord fit: `fits`, `too_safe`, `too_outside`, `unclear`
+- phrase continuation: `phrase_like`, `fragmented`, `exercise_like`, `unclear`
+- landing: `clear`, `weak`, `missing`, `unclear`
+- jazz vocabulary: `present`, `weak`, `absent`, `unclear`
+
+If the candidates still sound like beginner chord-tone/tension enumeration, the next issue should target data-derived phrase/cadence vocabulary, not audio diffusion or backend expansion.

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -86,6 +86,8 @@ Modes:
                 Compare data-motif guide tones against data-motif phrase recovery.
   stage-b-clean-review-package
                 Extract objective-clean data-motif phrase recovery candidates for listening review.
+  stage-b-clean-context-diagnostics
+                Diagnose objective-clean context MIDI candidates before subjective review.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   chord-coverage-audit
@@ -1047,6 +1049,21 @@ run_stage_b_clean_review_package() {
     --min_candidates 3
 }
 
+run_stage_b_clean_context_diagnostics() {
+  local source_run_id="${SOURCE_RUN_ID:-harness_stage_b_clean_review_package}"
+  local run_id="${RUN_ID:-harness_stage_b_clean_context_diagnostics}"
+  local clean_package_path="outputs/stage_b_clean_review_package/${source_run_id}/clean_review_package.json"
+  if [[ ! -f "$clean_package_path" ]]; then
+    print_header "Stage B objective-clean review package"
+    RUN_ID="$source_run_id" run_stage_b_clean_review_package
+  fi
+  print_header "Stage B clean context diagnostics"
+  "$PYTHON_BIN" scripts/build_clean_context_diagnostics.py \
+    --run_id "$run_id" \
+    --clean_package "$clean_package_path" \
+    --min_candidates 3
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -1287,6 +1304,9 @@ case "$MODE" in
     ;;
   stage-b-clean-review-package)
     run_stage_b_clean_review_package
+    ;;
+  stage-b-clean-context-diagnostics)
+    run_stage_b_clean_context_diagnostics
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/build_clean_context_diagnostics.py
+++ b/scripts/build_clean_context_diagnostics.py
@@ -1,0 +1,333 @@
+"""Build phrase diagnostics for objective-clean Stage B context review candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pretty_midi
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.build_listening_review_notes import write_json  # noqa: E402
+
+
+SCHEMA_VERSION = "stage_b_clean_context_diagnostics_v1"
+
+
+class CleanContextDiagnosticsError(ValueError):
+    pass
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def non_drum_notes(midi: pretty_midi.PrettyMIDI) -> list[pretty_midi.Note]:
+    notes: list[pretty_midi.Note] = []
+    for instrument in midi.instruments:
+        if instrument.is_drum:
+            continue
+        notes.extend(instrument.notes)
+    return sorted(notes, key=lambda note: (note.start, note.pitch, note.end))
+
+
+def infer_bpm(midi: pretty_midi.PrettyMIDI, fallback_bpm: float = 120.0) -> float:
+    _, tempi = midi.get_tempo_changes()
+    if len(tempi) == 0:
+        return float(fallback_bpm)
+    return float(tempi[0])
+
+
+def seconds_to_beats(seconds: float, bpm: float) -> float:
+    return float(seconds * bpm / 60.0)
+
+
+def nearest_grid_distance(beats: float, grid_beats: float = 0.25) -> float:
+    remainder = beats % grid_beats
+    return float(min(remainder, grid_beats - remainder))
+
+
+def ratio(part: int | float, total: int | float) -> float:
+    if total <= 0:
+        return 0.0
+    return float(part / total)
+
+
+def pitch_name(pitch: int) -> str:
+    names = ("C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B")
+    return f"{names[pitch % 12]}{pitch // 12 - 1}"
+
+
+def run_lengths(values: list[int]) -> list[int]:
+    if not values:
+        return []
+    lengths: list[int] = []
+    current = values[0]
+    count = 1
+    for value in values[1:]:
+        if value == current:
+            count += 1
+        else:
+            lengths.append(count)
+            current = value
+            count = 1
+    lengths.append(count)
+    return lengths
+
+
+def analyze_solo_path(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise CleanContextDiagnosticsError(f"solo MIDI does not exist: {path}")
+    midi = pretty_midi.PrettyMIDI(str(path))
+    bpm = infer_bpm(midi)
+    notes = non_drum_notes(midi)
+    if not notes:
+        return {
+            "bpm": bpm,
+            "note_count": 0,
+            "unique_pitch_count": 0,
+            "bar_count": 0,
+            "bar_coverage_ratio": 0.0,
+            "diagnostic_flags": ["empty_solo_midi"],
+        }
+
+    starts_beats = [seconds_to_beats(note.start, bpm) for note in notes]
+    ends_beats = [seconds_to_beats(note.end, bpm) for note in notes]
+    durations_beats = [max(0.0, end - start) for start, end in zip(starts_beats, ends_beats)]
+    pitches = [int(note.pitch) for note in notes]
+    bar_indexes = [int(start // 4.0) for start in starts_beats]
+    bar_count = max(1, int(math.ceil(max(ends_beats) / 4.0)))
+    bar_note_counts = Counter(bar_indexes)
+    off_grid_count = sum(1 for start in starts_beats if nearest_grid_distance(start) > 0.035)
+    pitch_counts = Counter(pitches)
+    most_common_pitch_count = pitch_counts.most_common(1)[0][1]
+    intervals = [pitches[index + 1] - pitches[index] for index in range(len(pitches) - 1)]
+    repeated_interval_count = sum(1 for interval in intervals if interval == 0)
+    same_pitch_runs = run_lengths(pitches)
+    first_notes = [
+        {
+            "start_beats": round(starts_beats[index], 3),
+            "duration_beats": round(durations_beats[index], 3),
+            "pitch": pitches[index],
+            "pitch_name": pitch_name(pitches[index]),
+        }
+        for index in range(min(16, len(notes)))
+    ]
+    metrics = {
+        "bpm": bpm,
+        "note_count": int(len(notes)),
+        "unique_pitch_count": int(len(set(pitches))),
+        "pitch_min": int(min(pitches)),
+        "pitch_max": int(max(pitches)),
+        "pitch_range_semitones": int(max(pitches) - min(pitches)),
+        "bar_count": int(bar_count),
+        "covered_bar_count": int(len(bar_note_counts)),
+        "bar_coverage_ratio": ratio(len(bar_note_counts), bar_count),
+        "bar_note_counts": {str(key + 1): int(value) for key, value in sorted(bar_note_counts.items())},
+        "off_sixteenth_grid_count": int(off_grid_count),
+        "off_sixteenth_grid_ratio": ratio(off_grid_count, len(notes)),
+        "max_duration_beats": float(max(durations_beats)),
+        "max_duration_bar_ratio": ratio(max(durations_beats), 4.0),
+        "long_note_ratio": ratio(sum(1 for duration in durations_beats if duration >= 1.0), len(notes)),
+        "most_common_pitch_ratio": ratio(most_common_pitch_count, len(notes)),
+        "repeated_pitch_interval_ratio": ratio(repeated_interval_count, len(intervals)),
+        "longest_same_pitch_run": int(max(same_pitch_runs)),
+        "first_16_notes": first_notes,
+    }
+    flags = diagnostic_flags(metrics)
+    metrics["diagnostic_flags"] = flags
+    metrics["decision_hint"] = decision_hint(flags)
+    return metrics
+
+
+def context_summary(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"context_exists": False, "instrument_count": 0, "instruments": []}
+    midi = pretty_midi.PrettyMIDI(str(path))
+    instruments = [
+        {
+            "name": instrument.name,
+            "program": int(instrument.program),
+            "is_drum": bool(instrument.is_drum),
+            "note_count": int(len(instrument.notes)),
+        }
+        for instrument in midi.instruments
+    ]
+    names = [item["name"].lower() for item in instruments]
+    return {
+        "context_exists": True,
+        "instrument_count": int(len(instruments)),
+        "instruments": instruments,
+        "has_chord_guide": any("chord" in name for name in names),
+        "has_bass_guide": any("bass" in name for name in names),
+        "has_solo_track": any("solo" in name for name in names),
+    }
+
+
+def diagnostic_flags(metrics: dict[str, Any]) -> list[str]:
+    flags: list[str] = []
+    if int(metrics.get("note_count", 0) or 0) < 32:
+        flags.append("too_sparse_for_phrase_review")
+    if int(metrics.get("unique_pitch_count", 0) or 0) < 12:
+        flags.append("low_pitch_variety")
+    if float(metrics.get("bar_coverage_ratio", 0.0) or 0.0) < 0.75:
+        flags.append("low_bar_coverage")
+    if float(metrics.get("off_sixteenth_grid_ratio", 0.0) or 0.0) > 0.10:
+        flags.append("timing_needs_review")
+    if float(metrics.get("max_duration_bar_ratio", 0.0) or 0.0) > 0.50:
+        flags.append("long_sustain_risk")
+    if float(metrics.get("most_common_pitch_ratio", 0.0) or 0.0) > 0.20:
+        flags.append("dominant_pitch_reuse")
+    if int(metrics.get("longest_same_pitch_run", 0) or 0) >= 3:
+        flags.append("same_pitch_run")
+    return flags
+
+
+def decision_hint(flags: list[str]) -> str:
+    if not flags:
+        return "listen_with_context"
+    if "timing_needs_review" in flags:
+        return "review_timing_before_generation_changes"
+    if "dominant_pitch_reuse" in flags or "low_pitch_variety" in flags:
+        return "review_phrase_vocabulary_and_pitch_reuse"
+    if "low_bar_coverage" in flags or "too_sparse_for_phrase_review" in flags:
+        return "increase_phrase_coverage_before_quality_claim"
+    return "listen_with_context_and_record_issue_flags"
+
+
+def analyze_candidate(candidate: dict[str, Any]) -> dict[str, Any]:
+    solo_path = Path(str(candidate.get("review_midi_path") or ""))
+    context_path = Path(str(candidate.get("context_midi_path") or ""))
+    solo_metrics = analyze_solo_path(solo_path)
+    context = context_summary(context_path)
+    package_metrics = dict(candidate.get("metrics") or {})
+    return {
+        "candidate_id": str(candidate.get("candidate_id") or solo_path.stem),
+        "mode": str(candidate.get("mode") or ""),
+        "review_rank": int(candidate.get("review_rank", 0) or 0),
+        "sample_index": int(candidate.get("sample_index", 0) or 0),
+        "review_midi_path": str(solo_path),
+        "context_midi_path": str(context_path),
+        "package_metrics": package_metrics,
+        "solo_metrics": solo_metrics,
+        "context_summary": context,
+        "review_checklist": {
+            "timing": "pending",
+            "chord_fit": "pending",
+            "phrase_continuation": "pending",
+            "landing": "pending",
+            "jazz_vocabulary": "pending",
+            "notes": "",
+        },
+    }
+
+
+def build_clean_context_diagnostics(clean_package: dict[str, Any], *, output_dir: Path) -> dict[str, Any]:
+    candidates = clean_package.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise CleanContextDiagnosticsError("clean package must contain non-empty candidates")
+    analyzed = [analyze_candidate(candidate) for candidate in candidates]
+    flag_counts = Counter(flag for item in analyzed for flag in item["solo_metrics"].get("diagnostic_flags", []))
+    decision_counts = Counter(item["solo_metrics"].get("decision_hint", "") for item in analyzed)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_clean_package": str(clean_package.get("output_dir") or ""),
+        "candidate_count": int(len(analyzed)),
+        "diagnostic_flag_counts": dict(sorted(flag_counts.items())),
+        "decision_hint_counts": dict(sorted(decision_counts.items())),
+        "candidates": analyzed,
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    lines = [
+        "# Stage B Clean Context Diagnostics",
+        "",
+        f"- candidate count: `{report['candidate_count']}`",
+        f"- diagnostic flags: `{report['diagnostic_flag_counts']}`",
+        f"- decision hints: `{report['decision_hint_counts']}`",
+        "",
+        "| candidate | notes | unique | bars | grid off | max dur | pitch reuse | flags | hint | context |",
+        "|---|---:|---:|---:|---:|---:|---:|---|---|---|",
+    ]
+    for candidate in report["candidates"]:
+        solo = candidate["solo_metrics"]
+        context = candidate["context_summary"]
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    candidate["candidate_id"],
+                    str(solo.get("note_count", 0)),
+                    str(solo.get("unique_pitch_count", 0)),
+                    f"{solo.get('covered_bar_count', 0)}/{solo.get('bar_count', 0)}",
+                    f"{float(solo.get('off_sixteenth_grid_ratio', 0.0)):.3f}",
+                    f"{float(solo.get('max_duration_beats', 0.0)):.3f}",
+                    f"{float(solo.get('most_common_pitch_ratio', 0.0)):.3f}",
+                    ", ".join(solo.get("diagnostic_flags", [])) or "none",
+                    str(solo.get("decision_hint", "")),
+                    "yes" if context.get("context_exists") else "no",
+                ]
+            )
+            + " |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Review Checklist",
+            "",
+            "For each candidate, listen to the context MIDI and fill:",
+            "",
+            "- timing: `good`, `too_loose`, `too_straight`, `unclear`",
+            "- chord_fit: `fits`, `too_safe`, `too_outside`, `unclear`",
+            "- phrase_continuation: `phrase_like`, `fragmented`, `exercise_like`, `unclear`",
+            "- landing: `clear`, `weak`, `missing`, `unclear`",
+            "- jazz_vocabulary: `present`, `weak`, `absent`, `unclear`",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build clean context phrase diagnostics")
+    parser.add_argument("--clean_package", type=str, required=True)
+    parser.add_argument("--output_root", type=str, default=str(ROOT_DIR / "outputs" / "stage_b_clean_context_diagnostics"))
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--min_candidates", type=int, default=1)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_clean_context_diagnostics(read_json(Path(args.clean_package)), output_dir=output_dir)
+    write_json(output_dir / "clean_context_diagnostics.json", report)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "clean_context_diagnostics.md").write_text(markdown_report(report), encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "candidate_count": report["candidate_count"],
+                "diagnostic_path": str(output_dir / "clean_context_diagnostics.json"),
+                "markdown_path": str(output_dir / "clean_context_diagnostics.md"),
+            },
+            ensure_ascii=True,
+            indent=2,
+        )
+    )
+    return 0 if int(report["candidate_count"]) >= int(args.min_candidates) else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_clean_context_diagnostics.py
+++ b/tests/test_clean_context_diagnostics.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pretty_midi
+
+from scripts.build_clean_context_diagnostics import (
+    build_clean_context_diagnostics,
+    context_summary,
+    markdown_report,
+)
+
+
+def write_midi(path: Path, notes: list[tuple[int, float, float]], *, name: str = "Solo") -> None:
+    midi = pretty_midi.PrettyMIDI(initial_tempo=120)
+    instrument = pretty_midi.Instrument(program=0, is_drum=False, name=name)
+    for pitch, start, end in notes:
+        instrument.notes.append(pretty_midi.Note(velocity=80, pitch=pitch, start=start, end=end))
+    midi.instruments.append(instrument)
+    midi.write(str(path))
+
+
+def write_context(path: Path) -> None:
+    midi = pretty_midi.PrettyMIDI(initial_tempo=120)
+    chord = pretty_midi.Instrument(program=4, is_drum=False, name="Chord Guide")
+    bass = pretty_midi.Instrument(program=32, is_drum=False, name="Bass Root Guide")
+    solo = pretty_midi.Instrument(program=0, is_drum=False, name="Solo - Test")
+    chord.notes.append(pretty_midi.Note(velocity=50, pitch=60, start=0.0, end=2.0))
+    bass.notes.append(pretty_midi.Note(velocity=50, pitch=36, start=0.0, end=2.0))
+    solo.notes.append(pretty_midi.Note(velocity=80, pitch=72, start=0.0, end=0.25))
+    midi.instruments.extend([chord, bass, solo])
+    midi.write(str(path))
+
+
+class CleanContextDiagnosticsTest(unittest.TestCase):
+    def test_build_clean_context_diagnostics_reports_phrase_metrics(self) -> None:
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            solo_path = tmp_path / "solo.mid"
+            context_path = tmp_path / "context.mid"
+            notes = [(60 + (index % 7), index * 0.25, index * 0.25 + 0.2) for index in range(32)]
+            write_midi(solo_path, notes)
+            write_context(context_path)
+
+            report = build_clean_context_diagnostics(
+                {
+                    "output_dir": "outputs/clean",
+                    "candidates": [
+                        {
+                            "candidate_id": "clean_rank_1",
+                            "mode": "data_motif_phrase_recovery",
+                            "review_rank": 1,
+                            "sample_index": 1,
+                            "review_midi_path": str(solo_path),
+                            "context_midi_path": str(context_path),
+                            "metrics": {"chord_tone_ratio": 0.5, "tension_ratio": 0.5},
+                        }
+                    ],
+                },
+                output_dir=tmp_path / "diagnostics",
+            )
+
+            self.assertEqual(report["candidate_count"], 1)
+            candidate = report["candidates"][0]
+            self.assertEqual(candidate["solo_metrics"]["note_count"], 32)
+            self.assertEqual(candidate["solo_metrics"]["covered_bar_count"], 4)
+            self.assertEqual(candidate["context_summary"]["has_chord_guide"], True)
+            self.assertEqual(candidate["context_summary"]["has_bass_guide"], True)
+            self.assertIn("timing", candidate["review_checklist"])
+
+    def test_context_summary_handles_missing_context(self) -> None:
+        summary = context_summary(Path("missing_context.mid"))
+
+        self.assertFalse(summary["context_exists"])
+        self.assertEqual(summary["instrument_count"], 0)
+
+    def test_markdown_report_lists_decision_hints(self) -> None:
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            solo_path = tmp_path / "solo.mid"
+            context_path = tmp_path / "context.mid"
+            write_midi(solo_path, [(60, 0.0, 0.25), (62, 0.5, 0.75), (64, 1.0, 1.25)])
+            write_context(context_path)
+            report = build_clean_context_diagnostics(
+                {
+                    "candidates": [
+                        {
+                            "candidate_id": "short_candidate",
+                            "review_midi_path": str(solo_path),
+                            "context_midi_path": str(context_path),
+                        }
+                    ],
+                },
+                output_dir=tmp_path / "diagnostics",
+            )
+
+        markdown = markdown_report(report)
+
+        self.assertIn("short_candidate", markdown)
+        self.assertIn("too_sparse_for_phrase_review", markdown)
+        self.assertIn("Review Checklist", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

- Issue #109 clean review package 후보 3개를 다시 MIDI note-level로 읽는 context diagnostics를 추가했습니다.
- solo MIDI와 context MIDI를 함께 보고 bar coverage, grid alignment, duration, pitch reuse, context guide 존재 여부를 markdown/json으로 기록합니다.
- 결과상 세 후보 모두 자동 objective blocker 없이 `listen_with_context` 단계로 분류됩니다.

## 결과

- candidate count: 3
- diagnostic flags: 없음
- decision hint: `listen_with_context` 3개
- bar coverage: 8/8, 8/8, 8/8
- off-grid ratio: 0.000, 0.000, 0.000
- max duration: 1.000 beat
- context MIDI: chord guide / bass root guide / solo track 포함

## 검증

- `./.venv/bin/python -m unittest tests.test_clean_context_diagnostics`
- `bash scripts/agent_harness.sh stage-b-clean-context-diagnostics`
- `bash scripts/agent_harness.sh quick`

Closes #111