### PR TITLE
feat: Stage B clean listening review notes 추가

### DIFF
--- a/docs/STAGE_B_CLEAN_LISTENING_REVIEW_NOTES_2026-05-23.md
+++ b/docs/STAGE_B_CLEAN_LISTENING_REVIEW_NOTES_2026-05-23.md
@@ -1,0 +1,44 @@
+# Stage B Clean Listening Review Notes (Issue #113)
+
+작성일: 2026-05-23
+
+## 목표
+
+Issue #109 clean review package와 Issue #111 clean context diagnostics 결과를 바탕으로,
+objective-clean 후보 3개를 같은 schema에서 subjective listening review 할 수 있는 템플릿을 만든다.
+
+리뷰 기준은 다음 5개다.
+
+- timing
+- chord_fit
+- phrase_continuation
+- landing
+- jazz_vocabulary
+
+## 구현
+
+- `scripts/build_clean_listening_review_notes.py`
+  - clean package + clean context diagnostics를 입력으로 review notes 템플릿 생성
+  - 후보별 context/chord guide 경로와 핵심 objective metric 연결
+  - enum 검증 및 summary 출력
+- `tests/test_clean_listening_review_notes.py`
+  - 템플릿 기본값/검증/enum 실패 케이스 테스트
+- `scripts/agent_harness.sh stage-b-clean-listening-review-notes`
+  - clean package, diagnostics가 없으면 선행 harness 자동 실행 후 notes 생성
+
+## 실행
+
+```bash
+bash scripts/agent_harness.sh stage-b-clean-listening-review-notes
+```
+
+## 출력
+
+- `outputs/stage_b_clean_listening_review_notes/harness_stage_b_clean_listening_review_notes/clean_listening_review_notes_template.json`
+- `outputs/stage_b_clean_listening_review_notes/harness_stage_b_clean_listening_review_notes/clean_listening_review_notes_summary.json`
+
+## 해석
+
+이 단계는 generation rule을 바꾸지 않는다.
+
+목적은 objective-clean 3개를 실제 청취 관점으로 같은 기준에서 비교할 수 있게 만드는 것이다.

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -88,6 +88,8 @@ Modes:
                 Extract objective-clean data-motif phrase recovery candidates for listening review.
   stage-b-clean-context-diagnostics
                 Diagnose objective-clean context MIDI candidates before subjective review.
+  stage-b-clean-listening-review-notes
+                Build clean listening review notes template for 3 context candidates.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   chord-coverage-audit
@@ -1064,6 +1066,23 @@ run_stage_b_clean_context_diagnostics() {
     --min_candidates 3
 }
 
+
+run_stage_b_clean_listening_review_notes() {
+  local clean_run_id="${CLEAN_RUN_ID:-harness_stage_b_clean_review_package}"
+  local diagnostics_run_id="${DIAGNOSTICS_RUN_ID:-harness_stage_b_clean_context_diagnostics}"
+  local run_id="${RUN_ID:-harness_stage_b_clean_listening_review_notes}"
+  local clean_package_path="outputs/stage_b_clean_review_package/${clean_run_id}/clean_review_package.json"
+  local diagnostics_path="outputs/stage_b_clean_context_diagnostics/${diagnostics_run_id}/clean_context_diagnostics.json"
+  if [[ ! -f "$clean_package_path" ]]; then
+    RUN_ID="$clean_run_id" run_stage_b_clean_review_package
+  fi
+  if [[ ! -f "$diagnostics_path" ]]; then
+    SOURCE_RUN_ID="$clean_run_id" RUN_ID="$diagnostics_run_id" run_stage_b_clean_context_diagnostics
+  fi
+  print_header "Stage B clean listening review notes"
+  "$PYTHON_BIN" scripts/build_clean_listening_review_notes.py     --run_id "$run_id"     --clean_package "$clean_package_path"     --clean_context_diagnostics "$diagnostics_path"
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -1307,6 +1326,9 @@ case "$MODE" in
     ;;
   stage-b-clean-context-diagnostics)
     run_stage_b_clean_context_diagnostics
+    ;;
+  stage-b-clean-listening-review-notes)
+    run_stage_b_clean_listening_review_notes
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/build_clean_listening_review_notes.py
+++ b/scripts/build_clean_listening_review_notes.py
@@ -1,0 +1,184 @@
+"""Build and validate Stage B clean context listening review notes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SCHEMA_VERSION = "stage_b_clean_listening_review_notes_v1"
+
+TIMING_VALUES = {"pending", "strong", "acceptable", "stiff", "rushed", "dragging"}
+CHORD_FIT_VALUES = {"pending", "strong", "acceptable", "too_safe", "too_outside", "unclear"}
+PHRASE_CONTINUATION_VALUES = {"pending", "strong", "acceptable", "weak", "broken"}
+LANDING_VALUES = {"pending", "strong", "acceptable", "weak", "unresolved"}
+JAZZ_VOCABULARY_VALUES = {"pending", "strong", "acceptable", "thin", "exercise_like"}
+DECISION_VALUES = {"pending", "keep", "needs_followup", "reject"}
+
+
+class CleanListeningReviewNotesError(ValueError):
+    pass
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def build_candidate_note(candidate: dict[str, Any], diagnostics_by_id: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    candidate_id = str(candidate.get("candidate_id") or "").strip()
+    if not candidate_id:
+        raise CleanListeningReviewNotesError("clean package candidate_id is required")
+    diagnostics = diagnostics_by_id.get(candidate_id, {})
+    phrase_metrics = diagnostics.get("phrase_metrics", {})
+    return {
+        "candidate_id": candidate_id,
+        "review_files": {
+            "midi_path": str(candidate.get("midi_path") or ""),
+            "context_midi_path": str(candidate.get("context_midi_path") or ""),
+            "chord_guide_path": str(candidate.get("chord_guide_path") or ""),
+            "bass_root_guide_path": str(candidate.get("bass_root_guide_path") or ""),
+        },
+        "source_metrics": {
+            "note_count": int(candidate.get("note_count", 0) or 0),
+            "unique_pitch_count": int(candidate.get("unique_pitch_count", 0) or 0),
+            "chord_tone_ratio": float(candidate.get("chord_tone_ratio", 0.0) or 0.0),
+            "tension_ratio": float(candidate.get("tension_ratio", 0.0) or 0.0),
+            "unresolved_large_leap_ratio": float(candidate.get("unresolved_large_leap_ratio", 0.0) or 0.0),
+            "bar_coverage_ratio": float(phrase_metrics.get("bar_coverage_ratio", 0.0) or 0.0),
+            "off_grid_ratio": float(phrase_metrics.get("off_grid_ratio", 0.0) or 0.0),
+            "max_duration_beats": float(phrase_metrics.get("max_duration_beats", 0.0) or 0.0),
+            "max_simultaneous_notes": int(phrase_metrics.get("max_simultaneous_notes", 0) or 0),
+        },
+        "listening": {
+            "status": "pending",
+            "timing": "pending",
+            "chord_fit": "pending",
+            "phrase_continuation": "pending",
+            "landing": "pending",
+            "jazz_vocabulary": "pending",
+            "decision": "pending",
+            "notes": "",
+        },
+    }
+
+
+def _require_enum(value: Any, allowed: set[str], path: str) -> None:
+    if value not in allowed:
+        raise CleanListeningReviewNotesError(f"{path} must be one of {sorted(allowed)}")
+
+
+def build_clean_listening_review_notes(clean_package: dict[str, Any], clean_context_diagnostics: dict[str, Any]) -> dict[str, Any]:
+    candidates = clean_package.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise CleanListeningReviewNotesError("clean package must contain non-empty candidates")
+    diagnostic_candidates = clean_context_diagnostics.get("candidates", [])
+    diagnostics_by_id = {
+        str(item.get("candidate_id") or ""): item
+        for item in diagnostic_candidates
+        if isinstance(item, dict) and str(item.get("candidate_id") or "").strip()
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "source_clean_review_package": str(clean_package.get("output_dir") or ""),
+        "source_clean_context_diagnostics": str(clean_context_diagnostics.get("output_dir") or ""),
+        "reviewer": "",
+        "review_context": {
+            "listen_with_context_midi": True,
+            "compare_solo_and_context": True,
+            "focus": ["timing", "chord_fit", "phrase_continuation", "landing", "jazz_vocabulary"],
+        },
+        "candidates": [build_candidate_note(candidate, diagnostics_by_id) for candidate in candidates],
+    }
+
+
+def validate_clean_listening_review_notes(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise CleanListeningReviewNotesError(f"schema_version must be {SCHEMA_VERSION!r}")
+    candidates = payload.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise CleanListeningReviewNotesError("candidates must be a non-empty list")
+    seen: set[str] = set()
+    reviewed_count = 0
+    decision_counts = {key: 0 for key in DECISION_VALUES}
+    for index, candidate in enumerate(candidates):
+        if not isinstance(candidate, dict):
+            raise CleanListeningReviewNotesError(f"candidate {index} must be an object")
+        candidate_id = str(candidate.get("candidate_id") or "").strip()
+        if not candidate_id:
+            raise CleanListeningReviewNotesError(f"candidate {index} candidate_id is required")
+        if candidate_id in seen:
+            raise CleanListeningReviewNotesError(f"duplicate candidate_id: {candidate_id}")
+        seen.add(candidate_id)
+        listening = candidate.get("listening")
+        if not isinstance(listening, dict):
+            raise CleanListeningReviewNotesError(f"{candidate_id}.listening must be an object")
+        _require_enum(listening.get("status"), {"pending", "reviewed"}, f"{candidate_id}.listening.status")
+        _require_enum(listening.get("timing"), TIMING_VALUES, f"{candidate_id}.listening.timing")
+        _require_enum(listening.get("chord_fit"), CHORD_FIT_VALUES, f"{candidate_id}.listening.chord_fit")
+        _require_enum(
+            listening.get("phrase_continuation"),
+            PHRASE_CONTINUATION_VALUES,
+            f"{candidate_id}.listening.phrase_continuation",
+        )
+        _require_enum(listening.get("landing"), LANDING_VALUES, f"{candidate_id}.listening.landing")
+        _require_enum(
+            listening.get("jazz_vocabulary"),
+            JAZZ_VOCABULARY_VALUES,
+            f"{candidate_id}.listening.jazz_vocabulary",
+        )
+        _require_enum(listening.get("decision"), DECISION_VALUES, f"{candidate_id}.listening.decision")
+        if listening.get("status") == "reviewed":
+            reviewed_count += 1
+        decision_counts[str(listening.get("decision"))] += 1
+    return {
+        "candidate_count": len(candidates),
+        "reviewed_count": reviewed_count,
+        "pending_count": len(candidates) - reviewed_count,
+        "decision_counts": decision_counts,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build Stage B clean listening review notes")
+    parser.add_argument("--clean_package", type=str, required=True)
+    parser.add_argument("--clean_context_diagnostics", type=str, required=True)
+    parser.add_argument("--review_notes", type=str, default=None)
+    parser.add_argument("--output_root", type=str, default=str(ROOT_DIR / "outputs" / "stage_b_clean_listening_review_notes"))
+    parser.add_argument("--run_id", type=str, default=None)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    run_dir = Path(args.output_root) / run_id
+    if args.review_notes:
+        notes_path = Path(args.review_notes)
+        notes = read_json(notes_path)
+    else:
+        clean_package_path = Path(args.clean_package)
+        diagnostics_path = Path(args.clean_context_diagnostics)
+        clean_package = read_json(clean_package_path)
+        clean_package["output_dir"] = str(clean_package_path.parent)
+        diagnostics = read_json(diagnostics_path)
+        diagnostics["output_dir"] = str(diagnostics_path.parent)
+        notes = build_clean_listening_review_notes(clean_package, diagnostics)
+        notes_path = run_dir / "clean_listening_review_notes_template.json"
+        write_json(notes_path, notes)
+    summary = validate_clean_listening_review_notes(notes)
+    write_json(run_dir / "clean_listening_review_notes_summary.json", summary)
+    print(json.dumps({**summary, "review_notes_path": str(notes_path)}, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_clean_listening_review_notes.py
+++ b/tests/test_clean_listening_review_notes.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.build_clean_listening_review_notes import (
+    CleanListeningReviewNotesError,
+    build_clean_listening_review_notes,
+    validate_clean_listening_review_notes,
+)
+
+
+class CleanListeningReviewNotesTest(unittest.TestCase):
+    def sample_clean_package(self) -> dict:
+        return {
+            "output_dir": "outputs/stage_b_clean_review_package/harness_stage_b_clean_review_package",
+            "candidates": [
+                {
+                    "candidate_id": "data_motif_phrase_recovery_rank_1_sample_1",
+                    "midi_path": "outputs/a.mid",
+                    "context_midi_path": "outputs/a_ctx.mid",
+                    "chord_guide_path": "outputs/a_chord.mid",
+                    "bass_root_guide_path": "outputs/a_bass.mid",
+                    "note_count": 63,
+                    "unique_pitch_count": 19,
+                    "chord_tone_ratio": 0.508,
+                    "tension_ratio": 0.492,
+                    "unresolved_large_leap_ratio": 0.0,
+                }
+            ],
+        }
+
+    def sample_diagnostics(self) -> dict:
+        return {
+            "output_dir": "outputs/stage_b_clean_context_diagnostics/harness_stage_b_clean_context_diagnostics",
+            "candidates": [
+                {
+                    "candidate_id": "data_motif_phrase_recovery_rank_1_sample_1",
+                    "phrase_metrics": {
+                        "bar_coverage_ratio": 1.0,
+                        "off_grid_ratio": 0.0,
+                        "max_duration_beats": 1.0,
+                        "max_simultaneous_notes": 1,
+                    },
+                }
+            ],
+        }
+
+    def test_build_template_has_pending_fields(self) -> None:
+        notes = build_clean_listening_review_notes(self.sample_clean_package(), self.sample_diagnostics())
+        listening = notes["candidates"][0]["listening"]
+
+        self.assertEqual(notes["schema_version"], "stage_b_clean_listening_review_notes_v1")
+        self.assertEqual(listening["timing"], "pending")
+        self.assertEqual(listening["phrase_continuation"], "pending")
+        self.assertEqual(listening["landing"], "pending")
+        self.assertEqual(listening["jazz_vocabulary"], "pending")
+
+    def test_validate_counts_pending(self) -> None:
+        notes = build_clean_listening_review_notes(self.sample_clean_package(), self.sample_diagnostics())
+
+        summary = validate_clean_listening_review_notes(notes)
+
+        self.assertEqual(summary["candidate_count"], 1)
+        self.assertEqual(summary["pending_count"], 1)
+        self.assertEqual(summary["decision_counts"]["pending"], 1)
+
+    def test_validate_accepts_reviewed(self) -> None:
+        notes = build_clean_listening_review_notes(self.sample_clean_package(), self.sample_diagnostics())
+        notes["candidates"][0]["listening"].update(
+            {
+                "status": "reviewed",
+                "timing": "acceptable",
+                "chord_fit": "strong",
+                "phrase_continuation": "acceptable",
+                "landing": "strong",
+                "jazz_vocabulary": "acceptable",
+                "decision": "keep",
+            }
+        )
+
+        summary = validate_clean_listening_review_notes(notes)
+
+        self.assertEqual(summary["reviewed_count"], 1)
+        self.assertEqual(summary["decision_counts"]["keep"], 1)
+
+    def test_validate_rejects_invalid_enum(self) -> None:
+        notes = build_clean_listening_review_notes(self.sample_clean_package(), self.sample_diagnostics())
+        notes["candidates"][0]["listening"]["landing"] = "great"
+
+        with self.assertRaises(CleanListeningReviewNotesError):
+            validate_clean_listening_review_notes(notes)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a structured subjective listening review template for the 3 objective-clean Stage B context candidates so reviewers can compare timing/chord-fit/phrase-continuation/landing/jazz-vocabulary consistently.
- Chain the new listening-review step into the existing harness so clean package and diagnostics are produced automatically when missing. 

### Description
- Add `scripts/build_clean_listening_review_notes.py` which builds and validates a `stage_b_clean_listening_review_notes_v1` template that includes review files, source metrics, and enums for `timing`, `chord_fit`, `phrase_continuation`, `landing`, and `jazz_vocabulary`.
- Add unit tests `tests/test_clean_listening_review_notes.py` covering template generation, validation, and enum error cases.
- Add documentation `docs/STAGE_B_CLEAN_LISTENING_REVIEW_NOTES_2026-05-23.md` describing intent, execution, and outputs.
- Extend `scripts/agent_harness.sh` with a `stage-b-clean-listening-review-notes` mode that runs the clean package and diagnostics steps if needed and then produces the clean listening review notes template. 

### Testing
- Ran `bash scripts/agent_harness.sh stage-b-clean-review-package` and it completed and produced the expected clean review package successfully. 
- Ran `bash scripts/agent_harness.sh stage-b-clean-context-diagnostics` and it completed and produced the expected diagnostics successfully. 
- Ran `bash scripts/agent_harness.sh stage-b-clean-listening-review-notes` (via the harness chain) and it completed and produced `outputs/stage_b_clean_listening_review_notes/.../clean_listening_review_notes_template.json` successfully. 
- Ran unit tests `python -m unittest tests/test_clean_listening_review_notes.py` and the new tests passed; a full `quick` harness run failed a pre-existing baseline test (`tests/test_request_conditioning.py`) which is unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a119e4a6af88320a7ae185b30a162fe)