### PR TITLE
[codex] Stage B clean listening review 지표/문서 보정

### DIFF
--- a/docs/CODEX_REMOTE_HANDOFF_2026-05-23.md
+++ b/docs/CODEX_REMOTE_HANDOFF_2026-05-23.md
@@ -184,12 +184,14 @@ Stage B는 REMI/Jazz Transformer 계열 판단을 따른다.
 30. data motif phrase recovery baseline
 31. objective clean review package
 32. clean context diagnostics
+33. clean listening review notes template
+34. clean MIDI-note proxy review
 
 자세한 전체 기록은 `docs/CORE_PLAN.md`에 있다.
 
 ## 7. Latest Meaningful Result
 
-최신 의미 있는 결과는 Issue #111이다.
+최신 의미 있는 결과는 Issue #113 이후의 clean MIDI-note proxy review다.
 
 Issue #109에서 objective-clean 후보 3개를 골랐다.
 
@@ -199,34 +201,54 @@ Issue #109에서 objective-clean 후보 3개를 골랐다.
 - `data_motif_phrase_recovery_rank_2_sample_2`
 - `data_motif_phrase_recovery_rank_3_sample_3`
 
-Issue #111에서 이 후보들을 MIDI note-level로 다시 진단했다.
+Issue #111에서 이 후보들을 MIDI note-level로 다시 진단했고, Issue #113에서 같은 schema로 review할 수 있는 clean listening review notes template을 만들었다.
+
+2026-05-24 로컬 follow-up에서는 Codex가 MIDI note timing, pitch contour, context chord guide track을 읽어 proxy review를 작성했다.
+
+중요한 경계:
+
+```text
+이것은 실제 오디오 청취 리뷰가 아니다.
+MIDI-note / piano-roll proxy review이며, 최종 subjective jazz quality proof가 아니다.
+```
 
 결과:
 
 - candidate count: `3`
-- diagnostic flags: none
-- decision hint:
-  - `listen_with_context`: `3`
+- reviewed count: `3`
+- pending count: `0`
+- decision counts:
+  - `needs_followup`: `2`
+  - `reject`: `1`
+  - `keep`: `0`
 - all candidates:
   - note count: `63`
   - bar coverage: `8/8`
   - off-grid ratio: `0.000`
   - max duration: `1.000` beat
+  - max simultaneous solo notes: `1`
   - context MIDI exists
   - chord guide exists
   - bass root guide exists
 
+Candidate decisions:
+
+| candidate | timing | chord_fit | phrase | landing | vocabulary | decision |
+|---|---|---|---|---|---|---|
+| `data_motif_phrase_recovery_rank_1_sample_1` | `stiff` | `acceptable` | `acceptable` | `acceptable` | `thin` | `needs_followup` |
+| `data_motif_phrase_recovery_rank_2_sample_2` | `stiff` | `acceptable` | `weak` | `unresolved` | `thin` | `needs_followup` |
+| `data_motif_phrase_recovery_rank_3_sample_3` | `stiff` | `acceptable` | `broken` | `unresolved` | `exercise_like` | `reject` |
+
 해석:
 
 ```text
-객관 진단상 지금 후보 3개는 더 자동으로 거르기보다 들어볼 단계다.
+객관 진단상 clean이지만, proxy review 기준으로는 keep 후보가 없다.
 ```
 
 중요:
 
 ```text
-이것은 jazz quality 성공이 아니다.
-이제 병목은 subjective listening review다.
+다음 병목은 basic MIDI validity가 아니라 rhythm stiffness, contour continuity, landing, thin vocabulary다.
 ```
 
 ## 8. Generated Outputs Are Not Committed
@@ -238,6 +260,7 @@ Issue #111에서 이 후보들을 MIDI note-level로 다시 진단했다.
 ```bash
 bash scripts/agent_harness.sh stage-b-clean-review-package
 bash scripts/agent_harness.sh stage-b-clean-context-diagnostics
+bash scripts/agent_harness.sh stage-b-clean-listening-review-notes
 ```
 
 생성될 주요 파일:
@@ -245,6 +268,7 @@ bash scripts/agent_harness.sh stage-b-clean-context-diagnostics
 ```text
 outputs/stage_b_clean_review_package/harness_stage_b_clean_review_package/clean_review_package.md
 outputs/stage_b_clean_context_diagnostics/harness_stage_b_clean_context_diagnostics/clean_context_diagnostics.md
+outputs/stage_b_clean_listening_review_notes/harness_stage_b_clean_listening_review_notes/clean_listening_review_notes_template.json
 ```
 
 로컬에서 마지막으로 사용한 context MIDI 파일:
@@ -271,9 +295,11 @@ Latest implementation files:
 ```text
 scripts/build_clean_review_package.py
 scripts/build_clean_context_diagnostics.py
+scripts/build_clean_listening_review_notes.py
 scripts/agent_harness.sh
 tests/test_clean_review_package.py
 tests/test_clean_context_diagnostics.py
+tests/test_clean_listening_review_notes.py
 ```
 
 Latest result docs:
@@ -281,6 +307,8 @@ Latest result docs:
 ```text
 docs/STAGE_B_CLEAN_REVIEW_PACKAGE_2026-05-23.md
 docs/STAGE_B_CLEAN_CONTEXT_DIAGNOSTICS_2026-05-23.md
+docs/STAGE_B_CLEAN_LISTENING_REVIEW_NOTES_2026-05-23.md
+docs/STAGE_B_CLEAN_MIDI_PROXY_REVIEW_2026-05-24.md
 ```
 
 Core historical docs:
@@ -314,6 +342,12 @@ For the latest clean context diagnostics:
 bash scripts/agent_harness.sh stage-b-clean-context-diagnostics
 ```
 
+For the latest clean listening review notes template:
+
+```bash
+bash scripts/agent_harness.sh stage-b-clean-listening-review-notes
+```
+
 Expected quick result:
 
 ```text
@@ -345,70 +379,31 @@ Minimum checks:
 - grid/timing is explainable
 - context MIDI exists when listening review needs chord context
 
-Current latest candidates pass the objective gate, but still need listening review.
+Current latest candidates pass the objective gate, but the MIDI-note proxy review did not produce a `keep` candidate.
 
 ## 12. What To Do Next
 
-The next correct task is **not** to add another generation rule immediately.
+The next correct task is **not** broad training, audio diffusion, or backend work.
 
-Next step:
-
-```text
-Create or fill a clean listening review notes package for the 3 context MIDI candidates.
-```
-
-The review should classify each candidate:
-
-- timing:
-  - `good`
-  - `too_loose`
-  - `too_straight`
-  - `unclear`
-- chord fit:
-  - `fits`
-  - `too_safe`
-  - `too_outside`
-  - `unclear`
-- phrase continuation:
-  - `phrase_like`
-  - `fragmented`
-  - `exercise_like`
-  - `unclear`
-- landing:
-  - `clear`
-  - `weak`
-  - `missing`
-  - `unclear`
-- jazz vocabulary:
-  - `present`
-  - `weak`
-  - `absent`
-  - `unclear`
-
-If the 3 candidates sound acceptable:
+Next step after documenting the proxy review:
 
 ```text
-Move toward model-side phrase continuation / generic jazz base probe.
+Stage B data-derived contour/cadence landing repair probe
 ```
 
-If they still sound beginner-like:
+The next probe should target:
 
-```text
-Do not pivot to audio.
-Do not add backend.
-Strengthen data-derived phrase/cadence vocabulary.
-```
+- final-note landing repair
+- large-leap/register contour smoothing
+- data-derived contour or cadence cells
+- rhythm/duration diversity without reintroducing duration collapse
+- candidate 1 as the best follow-up baseline
+- candidate 3 as the negative example
 
 Recommended next issue title:
 
 ```text
-Stage B clean listening review notes 추가
-```
-
-Alternative next issue if listening feedback says "still beginner-like":
-
-```text
-Stage B data-derived cadence vocabulary 추가
+Stage B data-derived contour/cadence landing repair probe
 ```
 
 ## 13. Do Not Do Next
@@ -442,13 +437,14 @@ Short explanation:
 We are building a symbolic MIDI jazz piano solo generation pipeline.
 Stage A failed musically, so the project moved to Stage B with explicit bar/position/chord/duration tokens.
 The latest work narrowed generated candidates down to 3 objective-clean, 8-bar, context-aware MIDI candidates.
-Objective note-level diagnostics show no current blocker, so the next step is listening review for phrase quality.
+Objective note-level diagnostics show no basic MIDI blocker, but MIDI-note proxy review found no keep candidate.
+The next step is a data-derived contour/cadence landing repair probe, not broad training.
 ```
 
 Very short explanation:
 
 ```text
-The pipeline can now produce objective-clean context MIDI candidates, but it has not yet proven real jazz phrase quality.
+The pipeline can now produce objective-clean context MIDI candidates, but proxy review points to rhythm stiffness, contour, and landing repair before broad training.
 ```
 
 ## 15. Remote Codex Working Rules
@@ -473,8 +469,8 @@ issue-<number>-stage-b-<short-scope>
 Recommended commit style:
 
 ```text
-feat: Stage B clean listening review notes 추가
-docs: Stage B listening review 결과 기록
+feat: Stage B contour/cadence landing repair 추가
+docs: Stage B MIDI-note proxy review 결과 기록
 ```
 
 ## 16. Critical Handoff Warning

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -424,6 +424,8 @@ Stage B에서 명시하는 것:
 - Issue #107 result: data motif phrase recovery review reports `data_motif_guide_tones` as `3` warnings and `data_motif_phrase_recovery` as `3` clean candidates.
 - Issue #109 result: objective clean review package keeps only the `3` `data_motif_phrase_recovery` candidates and writes `outputs/stage_b_clean_review_package/harness_stage_b_clean_review_package/clean_review_package.md`.
 - Issue #111 result: clean context diagnostics reports `3` candidates, diagnostic flags `{}`, bar coverage `8/8`, off-grid ratio `0.000`, max duration `1.000` beat, and decision hint `listen_with_context`.
+- Issue #113 result: clean listening review notes template covers the `3` objective-clean context candidates and validates review enums/summary output.
+- 2026-05-24 Codex MIDI-note proxy review result: `needs_followup=2`, `reject=1`, `keep=0`; the strongest candidate is still `timing=stiff`, `jazz_vocabulary=thin`.
 
 해석:
 
@@ -434,8 +436,10 @@ Stage B에서 명시하는 것:
 - `swing_motif_approach`는 기계적인 grid 반복을 줄였지만, 이 또한 jazz vocabulary 자체는 아니다.
 - real phrase reference stats와 motif extraction 기준으로 보면 다음은 hand-written rhythm rule 확장이 아니라 data-derived motif/cadence control 쪽이 맞다.
 - 다만 pitch-role 쪽은 real reference chord label이 아직 없으므로, 다음 개선은 실제 청취 결과를 notes에 채운 뒤 issue distribution으로 후속 generation rule을 분기하는 순서가 맞다.
-- 현재 다음 판단은 새 rule 추가가 아니라 clean package의 context MIDI를 듣고 phrase/timing/chord-fit review를 채우는 것이다.
-- Issue #111 기준으로도 자동 objective blocker는 남지 않았으므로, 다음 병목은 실제 subjective phrase quality review다.
+- clean package의 context MIDI review boundary는 proxy review까지 진행됐다.
+- proxy review는 실제 오디오 청취가 아니므로 최종 subjective quality proof가 아니다.
+- 그러나 다음 generation 방향은 분명해졌다: broad training이 아니라 data-derived contour/cadence landing repair가 먼저다.
+- Issue #111/#113 기준으로도 자동 objective blocker는 남지 않았으므로, 다음 병목은 rhythm stiffness, contour continuity, landing, thin vocabulary다.
 
 ### Phase 3.10. Swing/Motif Phrase Grammar
 
@@ -705,29 +709,36 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B clean context phrase diagnostics 추가
+Stage B clean MIDI-note proxy review 결과 기록
 ```
 
 결과:
 
-- Issue #109 clean package 후보 3개를 MIDI note-level로 다시 진단했다.
-- output: `outputs/stage_b_clean_context_diagnostics/harness_stage_b_clean_context_diagnostics/clean_context_diagnostics.md`
+- Issue #109 clean package 후보 3개를 MIDI note-level로 다시 진단했고, Issue #113에서 clean listening review notes template을 만들었다.
+- Codex MIDI-note proxy review는 실제 오디오 청취가 아니라 note timing, pitch contour, context chord guide 기준의 piano-roll proxy review다.
+- output: `outputs/stage_b_clean_listening_review_notes/harness_stage_b_clean_listening_review_notes_codex_proxy/clean_listening_review_notes_codex_midi_proxy.json`
+- docs: `docs/STAGE_B_CLEAN_MIDI_PROXY_REVIEW_2026-05-24.md`
 - candidate count: `3`
-- selected mode: `data_motif_phrase_recovery`
-- note count: `63`, `63`, `63`
-- unique pitch count: `19-23`
-- bar coverage: `8/8`
-- off-grid ratio: `0.000`
-- max duration: `1.000` beat
-- diagnostic flags: none
-- decision hint: `listen_with_context`
-- context MIDI includes chord guide, bass root guide, and solo track.
+- reviewed count: `3`
+- pending count: `0`
+- decisions:
+  - `needs_followup`: `2`
+  - `reject`: `1`
+  - `keep`: `0`
+- 공통 문제:
+  - timing stiff
+  - repeated duration/rest template
+  - 큰 register jump 뒤 contour continuity 부족
+  - weak/unresolved landing
+  - jazz vocabulary thin 또는 exercise-like
 
 다음 작업:
 
-- clean context MIDI를 기준으로 subjective listening review를 채운다.
-- objective clean 후보라도 broad training으로 넘어가기 전 실제 piano-roll/listening review를 먼저 한다.
-- 문제가 계속 "초급 멜로디/코드톤 나열"이면 data-derived contour/cadence pattern을 더 직접 추출할지 결정한다.
+- 다음 issue는 `Stage B data-derived contour/cadence landing repair probe`로 잡는다.
+- 후보 1은 best follow-up baseline으로 유지한다.
+- 후보 3은 negative example로 둔다.
+- final-note landing repair, large-leap 이후 contour smoothing, data-derived cadence/contour cells를 검증한다.
+- objective clean 후보라도 broad training으로 넘어가지 않는다.
 - real Brad/reference chord label은 아직 임의로 넣지 않는다.
 - LMDM/audio diffusion은 장기 live instrument reference로만 남기고, 현재 MVP를 audio로 pivot하지 않는다.
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -1,6 +1,6 @@
 # Current Status and Plan
 
-작성일: 2026-05-23
+작성일: 2026-05-24
 
 ## Current Focus
 
@@ -8,12 +8,12 @@
 
 현재 브랜치:
 
-- `main`
+- 기준 브랜치: `main`
 
 현재 active issue:
 
-- 없음. Issue #111은 PR #112로 main에 merge 완료.
-- 다음 권장 이슈: `Stage B clean listening review notes 추가`
+- Stage B clean MIDI-note proxy review 결과 기록
+- 다음 권장 이슈: `Stage B data-derived contour/cadence landing repair probe`
 
 현재 범위가 아닌 것:
 
@@ -39,7 +39,51 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
-## Latest Probe Result
+## Latest Review Result
+
+Issue #113은 Issue #109 clean review package와 Issue #111 clean context diagnostics 결과를 바탕으로,
+objective-clean context MIDI 후보 3개를 같은 schema에서 review할 수 있는 notes template을 추가한 단계다.
+
+그 다음 로컬 follow-up으로 Codex MIDI-note proxy review를 작성했다.
+
+중요한 전제:
+
+- 실제 오디오 청취 리뷰가 아니다.
+- MIDI note timing, pitch contour, context chord guide track을 읽은 piano-roll proxy review다.
+- `keep` 후보는 아직 없다.
+- 이 결과는 다음 generation probe 방향을 정하기 위한 보조 근거다.
+
+Docs:
+
+- `docs/STAGE_B_CLEAN_LISTENING_REVIEW_NOTES_2026-05-23.md`
+- `docs/STAGE_B_CLEAN_MIDI_PROXY_REVIEW_2026-05-24.md`
+
+Result:
+
+- reviewed candidates: `3`
+- pending candidates: `0`
+- decisions:
+  - `needs_followup`: `2`
+  - `reject`: `1`
+  - `keep`: `0`
+
+Candidate decisions:
+
+| candidate | timing | chord_fit | phrase | landing | vocabulary | decision |
+|---|---|---|---|---|---|---|
+| `data_motif_phrase_recovery_rank_1_sample_1` | `stiff` | `acceptable` | `acceptable` | `acceptable` | `thin` | `needs_followup` |
+| `data_motif_phrase_recovery_rank_2_sample_2` | `stiff` | `acceptable` | `weak` | `unresolved` | `thin` | `needs_followup` |
+| `data_motif_phrase_recovery_rank_3_sample_3` | `stiff` | `acceptable` | `broken` | `unresolved` | `exercise_like` | `reject` |
+
+Decision:
+
+- 후보 1은 현재 best follow-up baseline으로 남긴다.
+- 후보 2는 landing repair와 contour smoothing 테스트용으로만 의미가 있다.
+- 후보 3은 negative example로 둔다.
+- 다음 probe는 broad training이나 audio pivot이 아니라 contour/cadence/landing repair여야 한다.
+- rhythm stiffness와 repeated duration/rest template도 같이 추적해야 한다.
+
+## Previous Probe Result
 
 Issue #111은 Issue #109 clean review package 후보 3개를 context listening review 전에 MIDI note-level로 다시 진단한 단계다.
 
@@ -77,8 +121,9 @@ Result:
 Decision:
 
 - 객관 진단상 지금 후보 3개는 더 자동으로 거르기보다 들어볼 단계다.
-- 다음은 listening notes를 채워 phrase/timing/chord-fit/jazz-vocabulary 문제를 분류해야 한다.
-- 계속 초급 멜로디처럼 들리면 data-derived phrase/cadence vocabulary를 강화한다.
+- Issue #113과 2026-05-24 proxy review에서 notes는 채워졌다.
+- proxy review 결과, 후보들은 objective-clean이지만 여전히 timing stiff, contour/landing weakness, thin vocabulary 문제가 있다.
+- 다음은 data-derived contour/cadence landing repair probe다.
 - LMDM/audio diffusion 구현으로 pivot하지 않는다.
 
 ## Previous Probe Result

--- a/docs/README.md
+++ b/docs/README.md
@@ -124,6 +124,10 @@
   - objective-clean `data_motif_phrase_recovery` 후보만 골라 context MIDI와 함께 listening review package로 묶은 결과.
 - `STAGE_B_CLEAN_CONTEXT_DIAGNOSTICS_2026-05-23.md`
   - clean context MIDI 후보 3개를 note-level로 다시 읽어 coverage/timing/pitch-reuse 진단을 남긴 결과.
+- `STAGE_B_CLEAN_LISTENING_REVIEW_NOTES_2026-05-23.md`
+  - objective-clean context 후보 3개를 같은 schema로 review할 수 있는 notes template 결과.
+- `STAGE_B_CLEAN_MIDI_PROXY_REVIEW_2026-05-24.md`
+  - clean 후보 3개를 MIDI note/context track 기준으로 proxy review하고 다음 contour/cadence landing repair 방향을 정리한 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`
@@ -150,7 +154,7 @@
 2. Brad Mehldau subset은 style adaptation과 holdout evaluation 용도로 분리한다.
 3. `max_files=2` Brad `control_v1` probe 결과를 기준으로 Stage A 한계를 문서화한다.
 4. broad training 전에 duration-explicit Stage B tokenization과 phrase/window dataset을 설계한다.
-5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, generated chord eval bridge, data-guide generated chord eval, review markdown chord eval summary, listening review notes schema, filled listening review aggregate, full review manifest notes, objective MIDI note review, objective flags review flow, overlap-free review export, duration variation review, phrase/cadence review, phrase naturalness objective review, phrase recovery review, data motif phrase recovery review, objective clean review package, and clean context diagnostics를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
+5. Stage B phrase/window tiny-overfit, constrained grammar probe, overlap gate, multi-sample probe, collapse sweep, strict collapse gate, 2-file generation probe, temporal coverage probe, coverage-aware constrained probe, coverage-aware A/B sweep, candidate ranking, harmonic/repetition gate, chord-aware pitch probe, candidate review export, longer 4-bar phrase probe, phrase contour diagnostics, root-bias diagnostics, pitch-mode comparison, 8-bar approach phrase probe, swing/motif phrase grammar probe, real phrase reference statistics, motif template extraction, data-derived motif baseline generation, data motif review export, review context/grid export, reference pitch-role stats, chord coverage audit, chord-labeled eval contract, generated chord eval bridge, data-guide generated chord eval, review markdown chord eval summary, listening review notes schema, filled listening review aggregate, full review manifest notes, objective MIDI note review, objective flags review flow, overlap-free review export, duration variation review, phrase/cadence review, phrase naturalness objective review, phrase recovery review, data motif phrase recovery review, objective clean review package, clean context diagnostics, clean listening review notes, and clean MIDI-note proxy review를 통과한 뒤 generic jazz base 학습 여부를 다시 결정한다.
 
 핵심 원칙:
 

--- a/docs/STAGE_B_CLEAN_LISTENING_REVIEW_NOTES_2026-05-23.md
+++ b/docs/STAGE_B_CLEAN_LISTENING_REVIEW_NOTES_2026-05-23.md
@@ -42,3 +42,22 @@ bash scripts/agent_harness.sh stage-b-clean-listening-review-notes
 이 단계는 generation rule을 바꾸지 않는다.
 
 목적은 objective-clean 3개를 실제 청취 관점으로 같은 기준에서 비교할 수 있게 만드는 것이다.
+
+## 후속 기록
+
+2026-05-24에 Codex MIDI-note proxy review를 별도 문서로 기록했다.
+
+```text
+docs/STAGE_B_CLEAN_MIDI_PROXY_REVIEW_2026-05-24.md
+```
+
+이 후속 기록은 실제 오디오 청취 리뷰가 아니라 MIDI note timing, pitch contour, context chord guide track을 읽은 piano-roll proxy review다.
+
+요약:
+
+- reviewed candidates: `3`
+- `needs_followup`: `2`
+- `reject`: `1`
+- `keep`: `0`
+
+다음 generation 방향은 broad training이 아니라 data-derived contour/cadence landing repair probe다.

--- a/docs/STAGE_B_CLEAN_MIDI_PROXY_REVIEW_2026-05-24.md
+++ b/docs/STAGE_B_CLEAN_MIDI_PROXY_REVIEW_2026-05-24.md
@@ -1,0 +1,229 @@
+# Stage B Clean MIDI-Note Proxy Review
+
+작성일: 2026-05-24
+
+## 목적
+
+Issue #109 clean review package, Issue #111 clean context diagnostics, Issue #113 clean listening review notes template 이후,
+objective-clean context MIDI 후보 3개를 MIDI note-level로 다시 보고 follow-up 방향을 정리한다.
+
+중요한 경계:
+
+- 이 문서는 실제 오디오 청취 리뷰가 아니다.
+- Codex가 MIDI note timing, pitch contour, context chord guide track을 읽어 작성한 piano-roll proxy review다.
+- 따라서 `keep` 판단을 내리지 않고, 다음 generation probe 방향을 정하기 위한 보조 근거로만 사용한다.
+
+## 입력
+
+Review notes template:
+
+```text
+outputs/stage_b_clean_listening_review_notes/harness_stage_b_clean_listening_review_notes/clean_listening_review_notes_template.json
+```
+
+Proxy-filled notes:
+
+```text
+outputs/stage_b_clean_listening_review_notes/harness_stage_b_clean_listening_review_notes_codex_proxy/clean_listening_review_notes_codex_midi_proxy.json
+```
+
+대상 후보:
+
+- `data_motif_phrase_recovery_rank_1_sample_1`
+- `data_motif_phrase_recovery_rank_2_sample_2`
+- `data_motif_phrase_recovery_rank_3_sample_3`
+
+## Objective Context
+
+세 후보 모두 objective gate 기준으로는 들을 수 있는 상태다.
+
+| candidate | notes | unique | bars | off-grid | max duration | max simultaneous |
+|---|---:|---:|---:|---:|---:|---:|
+| `data_motif_phrase_recovery_rank_1_sample_1` | 63 | 19 | 8/8 | 0.000 | 1.000 | 1 |
+| `data_motif_phrase_recovery_rank_2_sample_2` | 63 | 23 | 8/8 | 0.000 | 1.000 | 1 |
+| `data_motif_phrase_recovery_rank_3_sample_3` | 63 | 22 | 8/8 | 0.000 | 1.000 | 1 |
+
+이것은 성공 판정이 아니다.
+
+의미는 다음과 같다.
+
+- one-note/two-note collapse가 아니다.
+- chord-block/polyphonic artifact가 아니다.
+- long sustain block이 아니다.
+- 8-bar coverage가 있다.
+- context MIDI에 chord guide, bass root guide, solo track이 있다.
+
+## Proxy Review Result
+
+| candidate | timing | chord_fit | phrase_continuation | landing | jazz_vocabulary | decision |
+|---|---|---|---|---|---|---|
+| `data_motif_phrase_recovery_rank_1_sample_1` | `stiff` | `acceptable` | `acceptable` | `acceptable` | `thin` | `needs_followup` |
+| `data_motif_phrase_recovery_rank_2_sample_2` | `stiff` | `acceptable` | `weak` | `unresolved` | `thin` | `needs_followup` |
+| `data_motif_phrase_recovery_rank_3_sample_3` | `stiff` | `acceptable` | `broken` | `unresolved` | `exercise_like` | `reject` |
+
+Aggregate:
+
+- candidate count: `3`
+- reviewed count: `3`
+- pending count: `0`
+- decisions:
+  - `needs_followup`: `2`
+  - `reject`: `1`
+  - `keep`: `0`
+
+## Candidate Notes
+
+### Candidate 1
+
+`data_motif_phrase_recovery_rank_1_sample_1`
+
+Best of the three by MIDI-note proxy review.
+
+Strengths:
+
+- 8-bar coverage is complete.
+- no simultaneous solo-note overlap.
+- chord-tone and tension balance is close to even.
+- final note lands on a chord tone over the last context chord.
+
+Weaknesses:
+
+- rhythm is fully grid-stiff.
+- duration/rest template is nearly the same as the other candidates.
+- contour still uses many large octave-like jumps instead of connected phrase resolution.
+- jazz vocabulary reads as thin, not strong.
+
+Decision:
+
+```text
+needs_followup
+```
+
+This is the candidate to preserve as the best current comparison point.
+
+### Candidate 2
+
+`data_motif_phrase_recovery_rank_2_sample_2`
+
+Technically clean, but weaker phrase continuity than candidate 1.
+
+Strengths:
+
+- 8-bar coverage is complete.
+- no simultaneous solo-note overlap.
+- chord-tone ratio is slightly higher than candidate 1.
+
+Weaknesses:
+
+- bar 4 jumps into a high D6/F6 register area and then drops back sharply.
+- the final note is C against the final context chord pitch classes `D`, `D#`, `G`, `A#`.
+- the landing is unresolved by this proxy.
+- phrase continuation feels more like register displacement than shaped melodic development.
+
+Decision:
+
+```text
+needs_followup
+```
+
+Useful mainly for testing landing repair and contour smoothing.
+
+### Candidate 3
+
+`data_motif_phrase_recovery_rank_3_sample_3`
+
+Reject by MIDI-note proxy review.
+
+Strengths:
+
+- objective MIDI gate is clean.
+- 8-bar coverage is complete.
+- no simultaneous solo-note overlap.
+
+Weaknesses:
+
+- bar 3 jumps up to the G#6/F6/C6 area.
+- bar 4 collapses back toward F3/A3/A4.
+- the register reset makes the phrase feel broken.
+- final C does not resolve against the final context chord.
+- grid-stiff rhythm plus extreme register movement reads as exercise-like.
+
+Decision:
+
+```text
+reject
+```
+
+## Interpretation
+
+The current best candidates are structurally valid, but not yet convincing jazz phrase candidates.
+
+The problem is no longer basic MIDI validity.
+
+Current blockers:
+
+- rhythm stiffness
+- repeated duration/rest template
+- large register jumps without enough phrase-level contour control
+- weak or unresolved final landing
+- thin jazz vocabulary despite acceptable chord fit
+
+This supports the direction already suggested by earlier docs:
+
+- do not pivot to audio diffusion
+- do not expand backend/UI scope
+- do not move to broad training from these candidates
+- do not add another hand-written rhythm patch without reference-driven justification
+
+## Next Probe Direction
+
+Recommended next issue:
+
+```text
+Stage B data-derived contour/cadence landing repair probe
+```
+
+The next probe should test:
+
+- final-note landing repair against current or next chord guide tones
+- register-contour smoothing after large leaps
+- data-derived contour templates or cadence cells instead of one fixed grid pattern
+- candidate 1 as the follow-up baseline
+- candidate 3 as a negative example to avoid
+
+Minimum success criteria:
+
+- still no overlap/polyphonic solo-line artifact
+- 8-bar coverage remains complete
+- max simultaneous solo notes remains `1`
+- final landing is not unresolved for top candidates
+- contour avoids isolated high-register spikes followed by abrupt low-register reset
+- rhythm/duration diversity improves without reintroducing duration collapse
+
+## Validation
+
+Proxy notes validation:
+
+```bash
+.venv/bin/python scripts/build_clean_listening_review_notes.py \
+  --run_id harness_stage_b_clean_listening_review_notes_codex_proxy \
+  --clean_package outputs/stage_b_clean_review_package/harness_stage_b_clean_review_package/clean_review_package.json \
+  --clean_context_diagnostics outputs/stage_b_clean_context_diagnostics/harness_stage_b_clean_context_diagnostics/clean_context_diagnostics.json \
+  --review_notes outputs/stage_b_clean_listening_review_notes/harness_stage_b_clean_listening_review_notes_codex_proxy/clean_listening_review_notes_codex_midi_proxy.json
+```
+
+Result:
+
+```json
+{
+  "candidate_count": 3,
+  "reviewed_count": 3,
+  "pending_count": 0,
+  "decision_counts": {
+    "reject": 1,
+    "pending": 0,
+    "keep": 0,
+    "needs_followup": 2
+  }
+}
+```

--- a/scripts/build_clean_context_diagnostics.py
+++ b/scripts/build_clean_context_diagnostics.py
@@ -83,6 +83,19 @@ def run_lengths(values: list[int]) -> list[int]:
     return lengths
 
 
+def max_simultaneous_notes(notes: list[pretty_midi.Note]) -> int:
+    events: list[tuple[float, int]] = []
+    for note in notes:
+        events.append((float(note.start), 1))
+        events.append((float(note.end), -1))
+    current = 0
+    peak = 0
+    for _, delta in sorted(events, key=lambda event: (event[0], 0 if event[1] < 0 else 1)):
+        current += delta
+        peak = max(peak, current)
+    return int(peak)
+
+
 def analyze_solo_path(path: Path) -> dict[str, Any]:
     if not path.exists():
         raise CleanContextDiagnosticsError(f"solo MIDI does not exist: {path}")
@@ -137,6 +150,7 @@ def analyze_solo_path(path: Path) -> dict[str, Any]:
         "max_duration_beats": float(max(durations_beats)),
         "max_duration_bar_ratio": ratio(max(durations_beats), 4.0),
         "long_note_ratio": ratio(sum(1 for duration in durations_beats if duration >= 1.0), len(notes)),
+        "max_simultaneous_notes": max_simultaneous_notes(notes),
         "most_common_pitch_ratio": ratio(most_common_pitch_count, len(notes)),
         "repeated_pitch_interval_ratio": ratio(repeated_interval_count, len(intervals)),
         "longest_same_pitch_run": int(max(same_pitch_runs)),
@@ -184,6 +198,8 @@ def diagnostic_flags(metrics: dict[str, Any]) -> list[str]:
         flags.append("timing_needs_review")
     if float(metrics.get("max_duration_bar_ratio", 0.0) or 0.0) > 0.50:
         flags.append("long_sustain_risk")
+    if int(metrics.get("max_simultaneous_notes", 0) or 0) > 1:
+        flags.append("polyphonic_solo_overlap")
     if float(metrics.get("most_common_pitch_ratio", 0.0) or 0.0) > 0.20:
         flags.append("dominant_pitch_reuse")
     if int(metrics.get("longest_same_pitch_run", 0) or 0) >= 3:
@@ -257,8 +273,8 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- diagnostic flags: `{report['diagnostic_flag_counts']}`",
         f"- decision hints: `{report['decision_hint_counts']}`",
         "",
-        "| candidate | notes | unique | bars | grid off | max dur | pitch reuse | flags | hint | context |",
-        "|---|---:|---:|---:|---:|---:|---:|---|---|---|",
+        "| candidate | notes | unique | bars | grid off | max dur | max simultaneous | pitch reuse | flags | hint | context |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---|---|---|",
     ]
     for candidate in report["candidates"]:
         solo = candidate["solo_metrics"]
@@ -273,6 +289,7 @@ def markdown_report(report: dict[str, Any]) -> str:
                     f"{solo.get('covered_bar_count', 0)}/{solo.get('bar_count', 0)}",
                     f"{float(solo.get('off_sixteenth_grid_ratio', 0.0)):.3f}",
                     f"{float(solo.get('max_duration_beats', 0.0)):.3f}",
+                    str(solo.get("max_simultaneous_notes", 0)),
                     f"{float(solo.get('most_common_pitch_ratio', 0.0)):.3f}",
                     ", ".join(solo.get("diagnostic_flags", [])) or "none",
                     str(solo.get("decision_hint", "")),
@@ -288,11 +305,12 @@ def markdown_report(report: dict[str, Any]) -> str:
             "",
             "For each candidate, listen to the context MIDI and fill:",
             "",
-            "- timing: `good`, `too_loose`, `too_straight`, `unclear`",
-            "- chord_fit: `fits`, `too_safe`, `too_outside`, `unclear`",
-            "- phrase_continuation: `phrase_like`, `fragmented`, `exercise_like`, `unclear`",
-            "- landing: `clear`, `weak`, `missing`, `unclear`",
-            "- jazz_vocabulary: `present`, `weak`, `absent`, `unclear`",
+            "- timing: `strong`, `acceptable`, `stiff`, `rushed`, `dragging`, `pending`",
+            "- chord_fit: `strong`, `acceptable`, `too_safe`, `too_outside`, `unclear`, `pending`",
+            "- phrase_continuation: `strong`, `acceptable`, `weak`, `broken`, `pending`",
+            "- landing: `strong`, `acceptable`, `weak`, `unresolved`, `pending`",
+            "- jazz_vocabulary: `strong`, `acceptable`, `thin`, `exercise_like`, `pending`",
+            "- decision: `keep`, `needs_followup`, `reject`, `pending`",
         ]
     )
     return "\n".join(lines).rstrip() + "\n"

--- a/scripts/build_clean_listening_review_notes.py
+++ b/scripts/build_clean_listening_review_notes.py
@@ -32,28 +32,52 @@ def write_json(path: Path, payload: dict[str, Any]) -> None:
     path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
 
 
+def _as_mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def _first_present(*values: Any, default: Any = "") -> Any:
+    for value in values:
+        if value not in (None, ""):
+            return value
+    return default
+
+
 def build_candidate_note(candidate: dict[str, Any], diagnostics_by_id: dict[str, dict[str, Any]]) -> dict[str, Any]:
     candidate_id = str(candidate.get("candidate_id") or "").strip()
     if not candidate_id:
         raise CleanListeningReviewNotesError("clean package candidate_id is required")
     diagnostics = diagnostics_by_id.get(candidate_id, {})
-    phrase_metrics = diagnostics.get("phrase_metrics", {})
+    package_metrics = _as_mapping(candidate.get("metrics"))
+    if not package_metrics:
+        package_metrics = candidate
+    phrase_metrics = _as_mapping(diagnostics.get("solo_metrics"))
+    if not phrase_metrics:
+        phrase_metrics = _as_mapping(diagnostics.get("phrase_metrics"))
     return {
         "candidate_id": candidate_id,
         "review_files": {
-            "midi_path": str(candidate.get("midi_path") or ""),
+            "midi_path": str(_first_present(candidate.get("review_midi_path"), candidate.get("midi_path"))),
             "context_midi_path": str(candidate.get("context_midi_path") or ""),
             "chord_guide_path": str(candidate.get("chord_guide_path") or ""),
             "bass_root_guide_path": str(candidate.get("bass_root_guide_path") or ""),
         },
         "source_metrics": {
-            "note_count": int(candidate.get("note_count", 0) or 0),
-            "unique_pitch_count": int(candidate.get("unique_pitch_count", 0) or 0),
-            "chord_tone_ratio": float(candidate.get("chord_tone_ratio", 0.0) or 0.0),
-            "tension_ratio": float(candidate.get("tension_ratio", 0.0) or 0.0),
-            "unresolved_large_leap_ratio": float(candidate.get("unresolved_large_leap_ratio", 0.0) or 0.0),
+            "note_count": int(_first_present(package_metrics.get("note_count"), phrase_metrics.get("note_count"), default=0) or 0),
+            "unique_pitch_count": int(
+                _first_present(package_metrics.get("unique_pitch_count"), phrase_metrics.get("unique_pitch_count"), default=0)
+                or 0
+            ),
+            "chord_tone_ratio": float(package_metrics.get("chord_tone_ratio", 0.0) or 0.0),
+            "tension_ratio": float(package_metrics.get("tension_ratio", 0.0) or 0.0),
+            "unresolved_large_leap_ratio": float(package_metrics.get("unresolved_large_leap_ratio", 0.0) or 0.0),
             "bar_coverage_ratio": float(phrase_metrics.get("bar_coverage_ratio", 0.0) or 0.0),
-            "off_grid_ratio": float(phrase_metrics.get("off_grid_ratio", 0.0) or 0.0),
+            "off_grid_ratio": float(
+                _first_present(phrase_metrics.get("off_sixteenth_grid_ratio"), phrase_metrics.get("off_grid_ratio"), default=0.0)
+                or 0.0
+            ),
             "max_duration_beats": float(phrase_metrics.get("max_duration_beats", 0.0) or 0.0),
             "max_simultaneous_notes": int(phrase_metrics.get("max_simultaneous_notes", 0) or 0),
         },

--- a/tests/test_clean_context_diagnostics.py
+++ b/tests/test_clean_context_diagnostics.py
@@ -66,9 +66,35 @@ class CleanContextDiagnosticsTest(unittest.TestCase):
             candidate = report["candidates"][0]
             self.assertEqual(candidate["solo_metrics"]["note_count"], 32)
             self.assertEqual(candidate["solo_metrics"]["covered_bar_count"], 4)
+            self.assertEqual(candidate["solo_metrics"]["max_simultaneous_notes"], 1)
             self.assertEqual(candidate["context_summary"]["has_chord_guide"], True)
             self.assertEqual(candidate["context_summary"]["has_bass_guide"], True)
             self.assertIn("timing", candidate["review_checklist"])
+
+    def test_build_clean_context_diagnostics_reports_overlap_peak(self) -> None:
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            solo_path = tmp_path / "solo.mid"
+            context_path = tmp_path / "context.mid"
+            write_midi(solo_path, [(60, 0.0, 1.0), (64, 0.5, 1.5)])
+            write_context(context_path)
+
+            report = build_clean_context_diagnostics(
+                {
+                    "candidates": [
+                        {
+                            "candidate_id": "overlap_candidate",
+                            "review_midi_path": str(solo_path),
+                            "context_midi_path": str(context_path),
+                        }
+                    ],
+                },
+                output_dir=tmp_path / "diagnostics",
+            )
+
+        candidate = report["candidates"][0]
+        self.assertEqual(candidate["solo_metrics"]["max_simultaneous_notes"], 2)
+        self.assertIn("polyphonic_solo_overlap", candidate["solo_metrics"]["diagnostic_flags"])
 
     def test_context_summary_handles_missing_context(self) -> None:
         summary = context_summary(Path("missing_context.mid"))
@@ -101,6 +127,9 @@ class CleanContextDiagnosticsTest(unittest.TestCase):
         self.assertIn("short_candidate", markdown)
         self.assertIn("too_sparse_for_phrase_review", markdown)
         self.assertIn("Review Checklist", markdown)
+        self.assertIn("max simultaneous", markdown)
+        self.assertIn("needs_followup", markdown)
+        self.assertNotIn("too_straight", markdown)
 
 
 if __name__ == "__main__":

--- a/tests/test_clean_listening_review_notes.py
+++ b/tests/test_clean_listening_review_notes.py
@@ -16,15 +16,17 @@ class CleanListeningReviewNotesTest(unittest.TestCase):
             "candidates": [
                 {
                     "candidate_id": "data_motif_phrase_recovery_rank_1_sample_1",
-                    "midi_path": "outputs/a.mid",
+                    "review_midi_path": "outputs/a.mid",
                     "context_midi_path": "outputs/a_ctx.mid",
                     "chord_guide_path": "outputs/a_chord.mid",
                     "bass_root_guide_path": "outputs/a_bass.mid",
-                    "note_count": 63,
-                    "unique_pitch_count": 19,
-                    "chord_tone_ratio": 0.508,
-                    "tension_ratio": 0.492,
-                    "unresolved_large_leap_ratio": 0.0,
+                    "metrics": {
+                        "note_count": 63,
+                        "unique_pitch_count": 19,
+                        "chord_tone_ratio": 0.508,
+                        "tension_ratio": 0.492,
+                        "unresolved_large_leap_ratio": 0.0,
+                    },
                 }
             ],
         }
@@ -35,9 +37,11 @@ class CleanListeningReviewNotesTest(unittest.TestCase):
             "candidates": [
                 {
                     "candidate_id": "data_motif_phrase_recovery_rank_1_sample_1",
-                    "phrase_metrics": {
+                    "solo_metrics": {
+                        "note_count": 63,
+                        "unique_pitch_count": 19,
                         "bar_coverage_ratio": 1.0,
-                        "off_grid_ratio": 0.0,
+                        "off_sixteenth_grid_ratio": 0.0,
                         "max_duration_beats": 1.0,
                         "max_simultaneous_notes": 1,
                     },
@@ -54,6 +58,18 @@ class CleanListeningReviewNotesTest(unittest.TestCase):
         self.assertEqual(listening["phrase_continuation"], "pending")
         self.assertEqual(listening["landing"], "pending")
         self.assertEqual(listening["jazz_vocabulary"], "pending")
+
+    def test_build_template_carries_review_paths_and_metrics(self) -> None:
+        notes = build_clean_listening_review_notes(self.sample_clean_package(), self.sample_diagnostics())
+        candidate = notes["candidates"][0]
+
+        self.assertEqual(candidate["review_files"]["midi_path"], "outputs/a.mid")
+        self.assertEqual(candidate["review_files"]["context_midi_path"], "outputs/a_ctx.mid")
+        self.assertEqual(candidate["source_metrics"]["note_count"], 63)
+        self.assertEqual(candidate["source_metrics"]["unique_pitch_count"], 19)
+        self.assertEqual(candidate["source_metrics"]["chord_tone_ratio"], 0.508)
+        self.assertEqual(candidate["source_metrics"]["bar_coverage_ratio"], 1.0)
+        self.assertEqual(candidate["source_metrics"]["off_grid_ratio"], 0.0)
 
     def test_validate_counts_pending(self) -> None:
         notes = build_clean_listening_review_notes(self.sample_clean_package(), self.sample_diagnostics())


### PR DESCRIPTION
## Summary

- Fix clean listening review notes so the template reads the actual clean package fields (`review_midi_path`, nested `metrics`) and clean diagnostics `solo_metrics`.
- Add `max_simultaneous_notes` to clean context diagnostics and show it in the diagnostics markdown.
- Record the Codex MIDI-note proxy review for the three objective-clean context candidates.
- Update current/core/handoff docs so the next recommended work is a data-derived contour/cadence landing repair probe, not broad training.

## Review Result

- `needs_followup`: 2
- `reject`: 1
- `keep`: 0

This is documented as a MIDI-note / piano-roll proxy review, not final subjective audio listening proof.

## Validation

- `.venv/bin/python -m unittest tests.test_clean_context_diagnostics tests.test_clean_listening_review_notes`
- `bash scripts/agent_harness.sh stage-b-clean-context-diagnostics`
- `bash scripts/agent_harness.sh stage-b-clean-listening-review-notes`
- proxy review notes validation via `scripts/build_clean_listening_review_notes.py --review_notes ...`
- `bash scripts/agent_harness.sh quick`