### PR TITLE
[codex] Stage B proxy-keep focused review package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,6 +283,12 @@ For Stage B objective-clean review package changes, run:
 bash scripts/agent_harness.sh stage-b-clean-review-package
 ```
 
+For Stage B proxy-keep focused review package changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-proxy-keep-focused-package
+```
+
 For Stage B clean context diagnostics changes, run:
 
 ```bash

--- a/docs/CODEX_REMOTE_HANDOFF_2026-05-23.md
+++ b/docs/CODEX_REMOTE_HANDOFF_2026-05-23.md
@@ -198,12 +198,43 @@ Stage B는 REMI/Jazz Transformer 계열 판단을 따른다.
 44. phrase-vocabulary repaired rhythm MIDI-note proxy review
 45. rhythm variation phrase-shape tension repair
 46. phrase-shape tension repaired MIDI-note proxy review
+47. proxy-keep rhythm candidate focused review package
 
 자세한 전체 기록은 `docs/CORE_PLAN.md`에 있다.
 
 ## 7. Latest Meaningful Result
 
-최신 의미 있는 결과는 Stage B phrase-shape tension repaired MIDI-note proxy review다.
+최신 의미 있는 결과는 Stage B proxy-keep rhythm candidate focused review package다.
+
+Issue #138은 Issue #136에서 처음 나온 proxy `keep` 후보만 solo/context MIDI와 objective note summary로 묶은 focused review package다.
+
+결과:
+
+- decision filter: `keep`
+- package candidate count: `1`
+- copied solo MIDI files: `1`
+- copied context MIDI files: `1`
+- selected candidate: `data_motif_rhythm_phrase_variation_rank_1_sample_3`
+- selected candidate note count: `63`
+- selected candidate unique pitch count: `28`
+- selected candidate timing: `acceptable`
+- selected candidate chord fit: `fits`
+- selected candidate objective flags: `[]`
+
+해석:
+
+- This isolates the first proxy keep candidate in the current Stage B review chain.
+- `keep` still means focused context listening candidate, not real audio proof or training readiness.
+- broad training is still premature.
+- next work should make a focused context listening decision on the single copied solo/context MIDI pair.
+
+Docs:
+
+```text
+docs/STAGE_B_PROXY_KEEP_FOCUSED_REVIEW_PACKAGE_2026-05-25.md
+```
+
+The previous review was Stage B phrase-shape tension repaired MIDI-note proxy review.
 
 Issue #136은 Issue #134 phrase-shape/tension repaired rhythm 후보를 MIDI-note/context 기준으로 다시 채운 proxy review다.
 
@@ -211,7 +242,6 @@ Issue #136은 Issue #134 phrase-shape/tension repaired rhythm 후보를 MIDI-not
 
 - candidate count: `6`
 - reviewed count: `6`
-- pending count: `0`
 - decisions:
   - `keep`: `1`
   - `needs_followup`: `5`
@@ -223,18 +253,10 @@ Issue #136은 Issue #134 phrase-shape/tension repaired rhythm 후보를 MIDI-not
   - `fits`: `6`
 - duplicate note sequences: `0`
 - objective MIDI flag counts: `{}`
-- proxy keep candidate: `data_motif_rhythm_phrase_variation_rank_1_sample_3`
 - aggregate follow-ups:
   - `improve_phrase_vocabulary`: `10`
   - `fix_timing_grid`: `8`
   - `increase_motif_variation`: `5`
-
-해석:
-
-- This is the first proxy keep candidate in the current Stage B review chain.
-- `keep` means focused context listening candidate, not real audio proof or training readiness.
-- broad training is still premature.
-- next work should isolate the proxy keep candidate into a focused context review package.
 
 Docs:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -178,6 +178,7 @@ Stage B에서 명시하는 것:
 66. Stage B phrase-vocabulary repaired rhythm MIDI-note proxy review
 67. Stage B rhythm variation phrase-shape tension repair
 68. Stage B phrase-shape tension repaired MIDI-note proxy review
+69. Stage B proxy-keep rhythm candidate focused review package
 
 가장 최근 의미 있는 결과:
 
@@ -242,6 +243,8 @@ Stage B에서 명시하는 것:
 - Issue #136 fills MIDI-note proxy review notes for the phrase-shape/tension repaired candidates.
 - Issue #136 result: `reviewed=6`, `keep=1`, `needs_followup=5`, `reject=0`, objective flags `{}`.
 - Issue #136 marks `data_motif_rhythm_phrase_variation_rank_1_sample_3` as the first proxy keep candidate for focused context listening.
+- Issue #138 isolates that proxy keep candidate into a focused review package with copied solo/context MIDI and objective first-note summary.
+- Issue #138 result: focused package `candidate_count=1`, selected candidate `data_motif_rhythm_phrase_variation_rank_1_sample_3`, objective flags `[]`.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- Stage B phrase-shape tension repaired MIDI-note proxy review
-- 다음 권장 이슈: `Stage B proxy-keep rhythm candidate focused review package`
+- latest completed: Issue #138, Stage B proxy-keep rhythm candidate focused review package
+- 다음 권장 이슈: `Stage B proxy-keep focused context listening decision`
 
 현재 범위가 아닌 것:
 
@@ -41,22 +41,59 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 ## Latest Review Result
 
+Issue #138은 Issue #136에서 처음 나온 proxy `keep` 후보만 solo/context MIDI와 objective note summary로 묶은 focused review package다.
+
+Docs:
+
+- `docs/STAGE_B_PROXY_KEEP_FOCUSED_REVIEW_PACKAGE_2026-05-25.md`
+
+중요한 전제:
+
+- 이 package는 실제 오디오 청취 승인이 아니다.
+- `keep` 후보를 focused context listening으로 넘기기 위한 재현 가능한 artifact다.
+- `outputs/` 아래 copied MIDI/package 파일은 생성 artifact라 커밋하지 않는다.
+
+Result:
+
+- decision filter: `keep`
+- package candidate count: `1`
+- copied solo MIDI files: `1`
+- copied context MIDI files: `1`
+
+Focused candidate:
+
+- `data_motif_rhythm_phrase_variation_rank_1_sample_3`
+- note count: `63`
+- unique pitch count: `28`
+- phrase quality: `phrase`
+- timing: `acceptable`
+- chord fit: `fits`
+- source tension ratio: `0.413`
+- objective MIDI tension ratio: `0.540`
+- objective MIDI flags: `[]`
+
+Generated package:
+
+- `outputs/stage_b_focused_review_package/harness_stage_b_proxy_keep_focused_package/focused_review_package.json`
+- `outputs/stage_b_focused_review_package/harness_stage_b_proxy_keep_focused_package/focused_review_package.md`
+
+Decision:
+
+- The proxy keep candidate is isolated and reproducible.
+- The next decision should be a focused context listening decision on this single solo/context pair.
+- broad training is still premature until this candidate survives real listening.
+
+## Previous Review Result
+
 Issue #136은 Issue #134 phrase-shape/tension repaired rhythm 후보를 MIDI-note/context 기준으로 다시 채운 proxy review다.
 
 Docs:
 
 - `docs/STAGE_B_PHRASE_SHAPE_TENSION_PROXY_REVIEW_2026-05-25.md`
 
-중요한 전제:
-
-- 실제 오디오 청취 리뷰가 아니다.
-- `keep`은 proxy 기준 focused context listening 후보라는 뜻이다.
-- broad training이나 musical success claim으로 해석하지 않는다.
-
 Result:
 
 - reviewed candidates: `6`
-- pending candidates: `0`
 - decisions:
   - `keep`: `1`
   - `needs_followup`: `5`
@@ -68,29 +105,11 @@ Result:
   - `fits`: `6`
 - duplicate note sequences: `0`
 - objective MIDI flags: `{}`
-
-Proxy keep candidate:
-
-- `data_motif_rhythm_phrase_variation_rank_1_sample_3`
-- note count: `63`
-- unique pitch count: `28`
-- max interval: `4`
-- IOI repetition: `0.371`
-- objective MIDI tension ratio: `0.540`
-
-Aggregate follow-ups:
-
-- `improve_phrase_vocabulary`: `10`
-- `fix_timing_grid`: `8`
-- `increase_motif_variation`: `5`
-- `increase_tension_approach_vocabulary`: `0`
-
-Decision:
-
-- Issue #134 phrase-shape/tension repair should be kept.
-- `data_motif_rhythm_phrase_variation_rank_1_sample_3` becomes a proxy keep candidate.
-- broad training is still premature.
-- next work should isolate the proxy keep candidate into a focused context review package.
+- aggregate follow-ups:
+  - `improve_phrase_vocabulary`: `10`
+  - `fix_timing_grid`: `8`
+  - `increase_motif_variation`: `5`
+  - `increase_tension_approach_vocabulary`: `0`
 
 ## Previous Probe Result
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -152,6 +152,8 @@
   - rhythm/position guardrail을 유지하면서 phrase target register와 tension pitch-class 우선순위를 보강한 결과.
 - `STAGE_B_PHRASE_SHAPE_TENSION_PROXY_REVIEW_2026-05-25.md`
   - phrase-shape/tension repaired rhythm 후보를 MIDI-note/context 기준으로 proxy review하고 첫 proxy keep 후보를 정리한 결과.
+- `STAGE_B_PROXY_KEEP_FOCUSED_REVIEW_PACKAGE_2026-05-25.md`
+  - 첫 proxy keep 후보만 solo/context MIDI와 objective note summary로 묶은 focused review package 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`

--- a/docs/STAGE_B_PROXY_KEEP_FOCUSED_REVIEW_PACKAGE_2026-05-25.md
+++ b/docs/STAGE_B_PROXY_KEEP_FOCUSED_REVIEW_PACKAGE_2026-05-25.md
@@ -1,0 +1,121 @@
+# Stage B Proxy-Keep Focused Review Package
+
+작성일: 2026-05-25
+
+## 목적
+
+Issue #138은 Issue #136에서 처음 나온 proxy `keep` 후보만 분리해 focused context listening용 package로 묶은 작업이다.
+
+중요한 경계:
+
+- `keep`은 MIDI-note proxy 기준이다.
+- 실제 오디오 청취 승인이나 최종 musical-quality claim이 아니다.
+- broad training이나 Brad style adaptation으로 바로 확장하지 않는다.
+- `outputs/` 아래 생성 artifact는 커밋하지 않는다.
+
+## 구현
+
+새 도구:
+
+- `scripts/build_focused_review_package.py`
+
+이 도구는 filled listening review notes에서 `listening.decision == keep` 후보만 선택한다.
+
+패키지에 보존하는 정보:
+
+- candidate id와 review metadata
+- solo MIDI, context MIDI, source MIDI path
+- note count, unique pitch count, timing/rhythm source metrics
+- listening review decision/notes
+- objective MIDI review flags/metrics
+- objective first 16 notes summary
+
+새 harness:
+
+```bash
+bash scripts/agent_harness.sh stage-b-proxy-keep-focused-package
+```
+
+기본 입력:
+
+- review notes:
+  - `outputs/stage_b_listening_review_notes/harness_stage_b_phrase_shape_tension_codex_proxy/phrase_shape_tension_repaired_review_notes_codex_midi_proxy.json`
+- objective MIDI review:
+  - `outputs/stage_b_objective_midi_review/harness_stage_b_rhythm_phrase_variation/objective_midi_note_review.json`
+
+## Package Result
+
+생성 package:
+
+- JSON:
+  - `outputs/stage_b_focused_review_package/harness_stage_b_proxy_keep_focused_package/focused_review_package.json`
+- Markdown:
+  - `outputs/stage_b_focused_review_package/harness_stage_b_proxy_keep_focused_package/focused_review_package.md`
+- copied solo MIDI:
+  - `outputs/stage_b_focused_review_package/harness_stage_b_proxy_keep_focused_package/midi/02_data_motif_rhythm_phrase_variation_rank_01_sample_03_overlap_free.mid`
+- copied context MIDI:
+  - `outputs/stage_b_focused_review_package/harness_stage_b_proxy_keep_focused_package/context_midi/02_data_motif_rhythm_phrase_variation_rank_01_sample_03_overlap_free_with_context.mid`
+
+Result:
+
+| field | value |
+|---|---:|
+| decision filter | `keep` |
+| candidate count | `1` |
+| copied MIDI files | `2` |
+
+Selected candidate:
+
+| candidate | phrase | timing | chord fit | notes | unique pitches | source tension | objective flags |
+|---|---|---|---|---:|---:|---:|---|
+| `data_motif_rhythm_phrase_variation_rank_1_sample_3` | `phrase` | `acceptable` | `fits` | `63` | `28` | `0.413` | `[]` |
+
+Objective first-phrase note summary starts:
+
+| start beats | duration beats | pitch |
+|---:|---:|---|
+| `0.00` | `0.25` | `A#4` |
+| `0.25` | `0.50` | `G#4` |
+| `0.75` | `1.25` | `F4` |
+| `2.00` | `0.25` | `G4` |
+| `2.25` | `0.50` | `D#4` |
+| `2.75` | `0.50` | `D4` |
+
+## Decision
+
+Issue #138 conclusion:
+
+- The focused review package is now reproducible from structured review notes.
+- Only the proxy `keep` candidate is included.
+- This is the correct next artifact for focused context listening.
+- The next decision should come from listening to this one candidate with its context MIDI, not from another broad generation repair.
+
+Recommended next issue:
+
+```text
+Stage B proxy-keep focused context listening decision
+```
+
+Target:
+
+- listen to the copied solo/context MIDI pair
+- record whether the proxy keep survives real context listening
+- if it fails, classify the failure as timing, phrase vocabulary, register/contour, chord fit, or motif repetition
+- if it passes, define the next narrow generation/evaluation boundary without claiming production readiness
+
+## 검증
+
+실행한 검증:
+
+```bash
+.venv/bin/python -m py_compile scripts/build_focused_review_package.py tests/test_focused_review_package.py
+.venv/bin/python -m unittest tests.test_focused_review_package
+bash scripts/agent_harness.sh stage-b-proxy-keep-focused-package
+bash scripts/agent_harness.sh quick
+```
+
+Quick harness result:
+
+- unit tests: `234` passed
+- compile checks: passed
+- diff whitespace check: passed

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -90,6 +90,8 @@ Modes:
                 Compare contour landing repair against rhythm/phrase vocabulary variation.
   stage-b-clean-review-package
                 Extract objective-clean data-motif phrase recovery candidates for listening review.
+  stage-b-proxy-keep-focused-package
+                Extract proxy-keep reviewed candidates into a focused context listening package.
   stage-b-clean-context-diagnostics
                 Diagnose objective-clean context MIDI candidates before subjective review.
   stage-b-clean-listening-review-notes
@@ -168,6 +170,7 @@ run_quick() {
     scripts/evaluate_generated_candidate_chords.py \
     scripts/build_listening_review_notes.py \
     scripts/summarize_listening_review_notes.py \
+    scripts/build_focused_review_package.py \
     scripts/review_midi_note_objectives.py \
     scripts/train_stage_a_full.py \
     scripts/train_stage_a_adapter.py \
@@ -1139,6 +1142,29 @@ run_stage_b_clean_review_package() {
     --min_candidates 3
 }
 
+run_stage_b_proxy_keep_focused_package() {
+  local source_run_id="${SOURCE_RUN_ID:-harness_stage_b_phrase_shape_tension_codex_proxy}"
+  local objective_run_id="${OBJECTIVE_RUN_ID:-harness_stage_b_rhythm_phrase_variation}"
+  local run_id="${RUN_ID:-harness_stage_b_proxy_keep_focused_package}"
+  local review_notes_path="outputs/stage_b_listening_review_notes/${source_run_id}/phrase_shape_tension_repaired_review_notes_codex_midi_proxy.json"
+  local objective_report_path="outputs/stage_b_objective_midi_review/${objective_run_id}/objective_midi_note_review.json"
+  if [[ ! -f "$review_notes_path" ]]; then
+    printf 'Missing proxy-filled review notes: %s\n' "$review_notes_path" >&2
+    return 2
+  fi
+  if [[ ! -f "$objective_report_path" ]]; then
+    printf 'Missing objective MIDI review report: %s\n' "$objective_report_path" >&2
+    return 2
+  fi
+  print_header "Stage B proxy-keep focused review package"
+  "$PYTHON_BIN" scripts/build_focused_review_package.py \
+    --run_id "$run_id" \
+    --review_notes "$review_notes_path" \
+    --objective_report "$objective_report_path" \
+    --copy_files \
+    --min_candidates 1
+}
+
 run_stage_b_clean_context_diagnostics() {
   local source_run_id="${SOURCE_RUN_ID:-harness_stage_b_clean_review_package}"
   local run_id="${RUN_ID:-harness_stage_b_clean_context_diagnostics}"
@@ -1417,6 +1443,9 @@ case "$MODE" in
     ;;
   stage-b-clean-review-package)
     run_stage_b_clean_review_package
+    ;;
+  stage-b-proxy-keep-focused-package)
+    run_stage_b_proxy_keep_focused_package
     ;;
   stage-b-clean-context-diagnostics)
     run_stage_b_clean_context_diagnostics

--- a/scripts/build_focused_review_package.py
+++ b/scripts/build_focused_review_package.py
@@ -1,0 +1,227 @@
+"""Build a focused Stage B review package from structured review notes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.build_listening_review_notes import write_json  # noqa: E402
+
+
+SCHEMA_VERSION = "stage_b_focused_review_package_v1"
+
+
+class FocusedReviewPackageError(ValueError):
+    pass
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def objective_candidates_by_id(objective_report: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
+    if not objective_report:
+        return {}
+    candidates = objective_report.get("candidates")
+    if not isinstance(candidates, list):
+        return {}
+    indexed: dict[str, dict[str, Any]] = {}
+    for candidate in candidates:
+        if isinstance(candidate, dict) and candidate.get("candidate_id"):
+            indexed[str(candidate["candidate_id"])] = candidate
+    return indexed
+
+
+def maybe_copy(source: str, target_dir: Path, *, enabled: bool) -> str:
+    if not source:
+        return ""
+    source_path = Path(source)
+    if not enabled or not source_path.exists():
+        return str(source_path)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_path = target_dir / source_path.name
+    shutil.copy2(source_path, target_path)
+    return str(target_path)
+
+
+def selected_review_candidates(review_notes: dict[str, Any], *, decision: str) -> list[dict[str, Any]]:
+    candidates = review_notes.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise FocusedReviewPackageError("review notes must contain non-empty candidates")
+    selected = []
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            raise FocusedReviewPackageError("review note candidate must be an object")
+        listening = candidate.get("listening")
+        if not isinstance(listening, dict):
+            raise FocusedReviewPackageError("candidate listening review must be an object")
+        if str(listening.get("decision") or "") == decision:
+            selected.append(candidate)
+    selected.sort(
+        key=lambda item: (
+            str(item.get("review_metadata", {}).get("mode") or ""),
+            int(item.get("review_metadata", {}).get("review_rank", 0) or 0),
+            str(item.get("candidate_id") or ""),
+        )
+    )
+    return selected
+
+
+def compact_candidate(
+    candidate: dict[str, Any],
+    *,
+    output_dir: Path,
+    copy_files: bool,
+    objective_by_id: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    candidate_id = str(candidate.get("candidate_id") or "")
+    files = candidate.get("review_files") if isinstance(candidate.get("review_files"), dict) else {}
+    objective = objective_by_id.get(candidate_id, {})
+    return {
+        "candidate_id": candidate_id,
+        "review_metadata": dict(candidate.get("review_metadata") or {}),
+        "review_files": {
+            "midi_path": maybe_copy(str(files.get("midi_path") or ""), output_dir / "midi", enabled=copy_files),
+            "context_midi_path": maybe_copy(
+                str(files.get("context_midi_path") or ""),
+                output_dir / "context_midi",
+                enabled=copy_files,
+            ),
+            "source_midi_path": str(files.get("source_midi_path") or ""),
+        },
+        "source_metrics": dict(candidate.get("source_metrics") or {}),
+        "listening": dict(candidate.get("listening") or {}),
+        "objective_review": dict(candidate.get("objective_review") or {}),
+        "objective_first_16_notes": list(objective.get("first_16_notes") or []),
+    }
+
+
+def build_focused_review_package(
+    review_notes: dict[str, Any],
+    *,
+    output_dir: Path,
+    decision: str = "keep",
+    copy_files: bool = False,
+    objective_report: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    selected = selected_review_candidates(review_notes, decision=decision)
+    objective_by_id = objective_candidates_by_id(objective_report)
+    candidates = [
+        compact_candidate(
+            candidate,
+            output_dir=output_dir,
+            copy_files=copy_files,
+            objective_by_id=objective_by_id,
+        )
+        for candidate in selected
+    ]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_review_notes": str(review_notes.get("review_notes_path") or ""),
+        "source_review_manifest": str(review_notes.get("source_review_manifest") or ""),
+        "source_objective_midi_review_report": str(review_notes.get("source_objective_midi_review_report") or ""),
+        "decision_filter": str(decision),
+        "copy_files": bool(copy_files),
+        "candidate_count": int(len(candidates)),
+        "candidates": candidates,
+    }
+
+
+def markdown_report(package: dict[str, Any]) -> str:
+    lines = [
+        "# Stage B Focused Review Package",
+        "",
+        f"- decision filter: `{package['decision_filter']}`",
+        f"- candidate count: `{package['candidate_count']}`",
+        f"- copy files: `{package['copy_files']}`",
+        "",
+        "This package is for focused context review. It is not a final musical-quality claim.",
+        "",
+        "| candidate | decision | phrase | timing | chord fit | notes | unique | tension | flags | MIDI | context |",
+        "|---|---|---|---|---|---:|---:|---:|---|---|---|",
+    ]
+    if not package["candidates"]:
+        lines.append("| none | - | - | - | - | 0 | 0 | 0.000 | - | - | - |")
+    for candidate in package["candidates"]:
+        listening = candidate["listening"]
+        source_metrics = candidate["source_metrics"]
+        objective_flags = candidate.get("objective_review", {}).get("objective_flags", [])
+        files = candidate["review_files"]
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    candidate["candidate_id"],
+                    str(listening.get("decision") or ""),
+                    str(listening.get("phrase_quality") or ""),
+                    str(listening.get("timing") or ""),
+                    str(listening.get("chord_fit") or ""),
+                    str(int(source_metrics.get("note_count", 0) or 0)),
+                    str(int(source_metrics.get("unique_pitch_count", 0) or 0)),
+                    f"{float(source_metrics.get('tension_ratio', 0.0) or 0.0):.3f}",
+                    ",".join(objective_flags) if objective_flags else "ok",
+                    f"`{files.get('midi_path', '')}`",
+                    f"`{files.get('context_midi_path', '')}`",
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build focused Stage B review package")
+    parser.add_argument("--review_notes", type=str, required=True)
+    parser.add_argument("--objective_report", type=str, default="")
+    parser.add_argument("--output_root", type=str, default=str(ROOT_DIR / "outputs" / "stage_b_focused_review_package"))
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--decision", type=str, default="keep")
+    parser.add_argument("--copy_files", action="store_true")
+    parser.add_argument("--min_candidates", type=int, default=1)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    review_notes_path = Path(args.review_notes)
+    review_notes = read_json(review_notes_path)
+    review_notes["review_notes_path"] = str(review_notes_path)
+    objective_report = read_json(Path(args.objective_report)) if args.objective_report else None
+    package = build_focused_review_package(
+        review_notes,
+        output_dir=output_dir,
+        decision=args.decision,
+        copy_files=bool(args.copy_files),
+        objective_report=objective_report,
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "focused_review_package.json", package)
+    (output_dir / "focused_review_package.md").write_text(markdown_report(package), encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "candidate_count": package["candidate_count"],
+                "package_path": str(output_dir / "focused_review_package.json"),
+                "markdown_path": str(output_dir / "focused_review_package.md"),
+            },
+            ensure_ascii=True,
+            indent=2,
+        )
+    )
+    return 0 if int(package["candidate_count"]) >= int(args.min_candidates) else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_focused_review_package.py
+++ b/tests/test_focused_review_package.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from scripts.build_focused_review_package import (
+    FocusedReviewPackageError,
+    build_focused_review_package,
+    selected_review_candidates,
+)
+
+
+def sample_candidate(candidate_id: str, decision: str, midi_path: Path, context_path: Path) -> dict:
+    return {
+        "candidate_id": candidate_id,
+        "review_metadata": {
+            "mode": "data_motif_rhythm_phrase_variation",
+            "review_rank": 1,
+            "sample_index": 3,
+        },
+        "review_files": {
+            "midi_path": str(midi_path),
+            "context_midi_path": str(context_path),
+            "source_midi_path": "outputs/source.mid",
+        },
+        "source_metrics": {
+            "note_count": 63,
+            "unique_pitch_count": 28,
+            "tension_ratio": 0.413,
+        },
+        "listening": {
+            "status": "reviewed",
+            "phrase_quality": "phrase",
+            "timing": "acceptable",
+            "chord_fit": "fits",
+            "issues": [],
+            "decision": decision,
+            "notes": "proxy note",
+        },
+        "objective_review": {
+            "objective_bucket": "clean",
+            "objective_flags": [],
+            "objective_reviewable": True,
+        },
+    }
+
+
+class FocusedReviewPackageTest(unittest.TestCase):
+    def test_selected_review_candidates_filters_decision(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            keep = sample_candidate("keep_candidate", "keep", root / "keep.mid", root / "keep_context.mid")
+            followup = sample_candidate(
+                "followup_candidate",
+                "needs_followup",
+                root / "followup.mid",
+                root / "followup_context.mid",
+            )
+
+            selected = selected_review_candidates({"candidates": [followup, keep]}, decision="keep")
+
+        self.assertEqual([candidate["candidate_id"] for candidate in selected], ["keep_candidate"])
+
+    def test_selected_review_candidates_requires_listening_object(self) -> None:
+        with self.assertRaises(FocusedReviewPackageError):
+            selected_review_candidates({"candidates": [{"candidate_id": "bad"}]}, decision="keep")
+
+    def test_build_focused_review_package_copies_keep_files_and_preserves_objective_notes(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            midi_path = root / "candidate.mid"
+            context_path = root / "candidate_context.mid"
+            midi_path.write_bytes(b"midi")
+            context_path.write_bytes(b"context")
+            review_notes = {
+                "review_notes_path": "outputs/review_notes.json",
+                "source_review_manifest": "outputs/review_manifest.json",
+                "source_objective_midi_review_report": "outputs/objective.json",
+                "candidates": [
+                    sample_candidate("keep_candidate", "keep", midi_path, context_path),
+                    sample_candidate("followup_candidate", "needs_followup", midi_path, context_path),
+                ],
+            }
+            objective_report = {
+                "candidates": [
+                    {
+                        "candidate_id": "keep_candidate",
+                        "first_16_notes": [{"pitch": 70, "start_beats": 0.0}],
+                    }
+                ]
+            }
+
+            package = build_focused_review_package(
+                review_notes,
+                output_dir=root / "focused",
+                copy_files=True,
+                objective_report=objective_report,
+            )
+
+            self.assertEqual(package["schema_version"], "stage_b_focused_review_package_v1")
+            self.assertEqual(package["source_review_notes"], "outputs/review_notes.json")
+            self.assertEqual(package["candidate_count"], 1)
+            candidate = package["candidates"][0]
+            self.assertEqual(candidate["candidate_id"], "keep_candidate")
+            self.assertEqual(candidate["objective_first_16_notes"], [{"pitch": 70, "start_beats": 0.0}])
+            self.assertTrue(Path(candidate["review_files"]["midi_path"]).exists())
+            self.assertTrue(Path(candidate["review_files"]["context_midi_path"]).exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #138

## Summary
- Add `scripts/build_focused_review_package.py` to extract filled listening review notes with `decision=keep` into a focused review package.
- Add a harness mode, unit tests, and docs for the proxy-keep package flow.
- Document the generated Issue #138 package result without committing `outputs/` artifacts.

## Validation
- `.venv/bin/python -m py_compile scripts/build_focused_review_package.py tests/test_focused_review_package.py`
- `.venv/bin/python -m unittest tests.test_focused_review_package`
- `bash scripts/agent_harness.sh stage-b-proxy-keep-focused-package`
- `bash scripts/agent_harness.sh quick` (234 tests passed)