### PR TITLE
[codex] Stage B focused context decision

### DIFF
--- a/docs/CODEX_REMOTE_HANDOFF_2026-05-23.md
+++ b/docs/CODEX_REMOTE_HANDOFF_2026-05-23.md
@@ -199,12 +199,45 @@ Stage B는 REMI/Jazz Transformer 계열 판단을 따른다.
 45. rhythm variation phrase-shape tension repair
 46. phrase-shape tension repaired MIDI-note proxy review
 47. proxy-keep rhythm candidate focused review package
+48. proxy-keep focused context MIDI-note decision
 
 자세한 전체 기록은 `docs/CORE_PLAN.md`에 있다.
 
 ## 7. Latest Meaningful Result
 
-최신 의미 있는 결과는 Stage B proxy-keep rhythm candidate focused review package다.
+최신 의미 있는 결과는 Stage B proxy-keep focused context MIDI-note decision이다.
+
+Issue #140은 Issue #138 focused package의 단일 proxy `keep` 후보를 solo/context MIDI note 기준으로 다시 판단한 focused context decision이다.
+
+결과:
+
+- prior proxy decision: `keep`
+- focused context decision: `needs_followup`
+- keep as diagnostic seed: `yes`
+- ready for broad training: `no`
+- selected candidate: `data_motif_rhythm_phrase_variation_rank_1_sample_3`
+- selected candidate note count: `63`
+- selected candidate unique pitch count: `28`
+- selected candidate timing: `acceptable`
+- selected candidate chord fit: `fits`
+- selected candidate objective flags: `[]`
+- primary blocker: register arc reaches `C6` around bar 4 and drifts to final `G3`
+- secondary blocker: phrase/cadence punctuation is still too grid-cell-like
+
+해석:
+
+- The Issue #138 package remains useful as a focused review artifact.
+- The candidate should not be promoted to a final listening keep.
+- broad training is still premature.
+- next work should preserve the objective-clean rhythm guardrails while adding register-arc control and cadence/phrase punctuation.
+
+Docs:
+
+```text
+docs/STAGE_B_PROXY_KEEP_FOCUSED_CONTEXT_DECISION_2026-05-25.md
+```
+
+The previous package was Stage B proxy-keep rhythm candidate focused review package.
 
 Issue #138은 Issue #136에서 처음 나온 proxy `keep` 후보만 solo/context MIDI와 objective note summary로 묶은 focused review package다.
 
@@ -214,19 +247,6 @@ Issue #138은 Issue #136에서 처음 나온 proxy `keep` 후보만 solo/context
 - package candidate count: `1`
 - copied solo MIDI files: `1`
 - copied context MIDI files: `1`
-- selected candidate: `data_motif_rhythm_phrase_variation_rank_1_sample_3`
-- selected candidate note count: `63`
-- selected candidate unique pitch count: `28`
-- selected candidate timing: `acceptable`
-- selected candidate chord fit: `fits`
-- selected candidate objective flags: `[]`
-
-해석:
-
-- This isolates the first proxy keep candidate in the current Stage B review chain.
-- `keep` still means focused context listening candidate, not real audio proof or training readiness.
-- broad training is still premature.
-- next work should make a focused context listening decision on the single copied solo/context MIDI pair.
 
 Docs:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -179,6 +179,7 @@ Stage B에서 명시하는 것:
 67. Stage B rhythm variation phrase-shape tension repair
 68. Stage B phrase-shape tension repaired MIDI-note proxy review
 69. Stage B proxy-keep rhythm candidate focused review package
+70. Stage B proxy-keep focused context MIDI-note decision
 
 가장 최근 의미 있는 결과:
 
@@ -245,6 +246,8 @@ Stage B에서 명시하는 것:
 - Issue #136 marks `data_motif_rhythm_phrase_variation_rank_1_sample_3` as the first proxy keep candidate for focused context listening.
 - Issue #138 isolates that proxy keep candidate into a focused review package with copied solo/context MIDI and objective first-note summary.
 - Issue #138 result: focused package `candidate_count=1`, selected candidate `data_motif_rhythm_phrase_variation_rank_1_sample_3`, objective flags `[]`.
+- Issue #140 reviews that single package against context MIDI notes and downgrades it from proxy `keep` to focused context `needs_followup`.
+- Issue #140 result: the candidate stays useful as a diagnostic seed, but register arc (`C6` to final `G3`) and cadence/phrase punctuation block a final keep.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest completed: Issue #138, Stage B proxy-keep rhythm candidate focused review package
-- 다음 권장 이슈: `Stage B proxy-keep focused context listening decision`
+- latest completed: Issue #140, Stage B proxy-keep focused context listening decision
+- 다음 권장 이슈: `Stage B focused context register-arc cadence repair`
 
 현재 범위가 아닌 것:
 
@@ -41,24 +41,24 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 ## Latest Review Result
 
-Issue #138은 Issue #136에서 처음 나온 proxy `keep` 후보만 solo/context MIDI와 objective note summary로 묶은 focused review package다.
+Issue #140은 Issue #138 focused package의 단일 proxy `keep` 후보를 solo/context MIDI note 기준으로 다시 판단한 focused context decision이다.
 
 Docs:
 
-- `docs/STAGE_B_PROXY_KEEP_FOCUSED_REVIEW_PACKAGE_2026-05-25.md`
+- `docs/STAGE_B_PROXY_KEEP_FOCUSED_CONTEXT_DECISION_2026-05-25.md`
 
 중요한 전제:
 
-- 이 package는 실제 오디오 청취 승인이 아니다.
-- `keep` 후보를 focused context listening으로 넘기기 위한 재현 가능한 artifact다.
-- `outputs/` 아래 copied MIDI/package 파일은 생성 artifact라 커밋하지 않는다.
+- 실제 오디오 청취 리뷰가 아니다.
+- MIDI note, context chord guide, bass root guide, objective metrics 기준의 focused proxy decision이다.
+- 이 결과만으로 broad training이나 style adaptation을 시작하지 않는다.
 
 Result:
 
-- decision filter: `keep`
-- package candidate count: `1`
-- copied solo MIDI files: `1`
-- copied context MIDI files: `1`
+- prior proxy decision: `keep`
+- focused context decision: `needs_followup`
+- keep as diagnostic seed: `yes`
+- ready for broad training: `no`
 
 Focused candidate:
 
@@ -72,18 +72,41 @@ Focused candidate:
 - objective MIDI tension ratio: `0.540`
 - objective MIDI flags: `[]`
 
-Generated package:
+Positive evidence:
 
-- `outputs/stage_b_focused_review_package/harness_stage_b_proxy_keep_focused_package/focused_review_package.json`
-- `outputs/stage_b_focused_review_package/harness_stage_b_proxy_keep_focused_package/focused_review_package.md`
+- max active notes: `1`
+- off-sixteenth-grid count: `0`
+- repeated pitch interval ratio: `0.000`
+- no duplicated 4-note or 8-note pitch-class chunks
+
+Blocking evidence:
+
+- register/contour: the line reaches `C6` around bar 4, then drifts down to `G3` by the final bar.
+- phrase punctuation: the 8-bar arc still reads like similar eighth/quarter-grid cells rather than a clear cadence.
+- context fit: chord fit is clean, but some outside notes are side-slip artifacts rather than clearly prepared/released color tones.
 
 Decision:
 
-- The proxy keep candidate is isolated and reproducible.
-- The next decision should be a focused context listening decision on this single solo/context pair.
-- broad training is still premature until this candidate survives real listening.
+- The Issue #138 package remains useful as a focused review artifact.
+- The candidate should not be promoted to a final listening keep.
+- The next repair should preserve objective-clean rhythm guardrails while adding register-arc control and cadence/phrase punctuation.
 
-## Previous Review Result
+## Previous Package Result
+
+Issue #138은 Issue #136에서 처음 나온 proxy `keep` 후보만 solo/context MIDI와 objective note summary로 묶은 focused review package다.
+
+Docs:
+
+- `docs/STAGE_B_PROXY_KEEP_FOCUSED_REVIEW_PACKAGE_2026-05-25.md`
+
+Result:
+
+- decision filter: `keep`
+- package candidate count: `1`
+- copied solo MIDI files: `1`
+- copied context MIDI files: `1`
+
+## Previous Proxy Review Result
 
 Issue #136은 Issue #134 phrase-shape/tension repaired rhythm 후보를 MIDI-note/context 기준으로 다시 채운 proxy review다.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -154,6 +154,8 @@
   - phrase-shape/tension repaired rhythm 후보를 MIDI-note/context 기준으로 proxy review하고 첫 proxy keep 후보를 정리한 결과.
 - `STAGE_B_PROXY_KEEP_FOCUSED_REVIEW_PACKAGE_2026-05-25.md`
   - 첫 proxy keep 후보만 solo/context MIDI와 objective note summary로 묶은 focused review package 결과.
+- `STAGE_B_PROXY_KEEP_FOCUSED_CONTEXT_DECISION_2026-05-25.md`
+  - focused package의 단일 proxy keep 후보를 context MIDI note 기준으로 다시 판단하고 register/cadence blocker를 정리한 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`

--- a/docs/STAGE_B_PROXY_KEEP_FOCUSED_CONTEXT_DECISION_2026-05-25.md
+++ b/docs/STAGE_B_PROXY_KEEP_FOCUSED_CONTEXT_DECISION_2026-05-25.md
@@ -1,0 +1,123 @@
+# Stage B Proxy-Keep Focused Context Decision
+
+작성일: 2026-05-25
+
+## 목적
+
+Issue #140은 Issue #138 focused package의 단일 proxy `keep` 후보를 solo/context MIDI note 기준으로 다시 판단한 focused context decision이다.
+
+중요한 경계:
+
+- 실제 오디오 청취 리뷰가 아니다.
+- MIDI note, context chord guide, bass root guide, objective metrics 기준의 focused proxy decision이다.
+- 이 결과만으로 broad training이나 style adaptation을 시작하지 않는다.
+
+## 입력
+
+Focused package:
+
+- `outputs/stage_b_focused_review_package/harness_stage_b_proxy_keep_focused_package/focused_review_package.json`
+
+후보:
+
+- `data_motif_rhythm_phrase_variation_rank_1_sample_3`
+
+MIDI:
+
+- solo:
+  - `outputs/stage_b_focused_review_package/harness_stage_b_proxy_keep_focused_package/midi/02_data_motif_rhythm_phrase_variation_rank_01_sample_03_overlap_free.mid`
+- context:
+  - `outputs/stage_b_focused_review_package/harness_stage_b_proxy_keep_focused_package/context_midi/02_data_motif_rhythm_phrase_variation_rank_01_sample_03_overlap_free_with_context.mid`
+
+Context chord cycle:
+
+```text
+Cm7 | Fm7 | Bb7 | Ebmaj7 | Cm7 | Fm7 | Bb7 | Ebmaj7
+```
+
+## Positive Evidence
+
+The candidate remains the strongest current Stage B rhythm-variation seed:
+
+- objective flags: `[]`
+- objective bucket: `clean`
+- max active notes: `1`
+- off-sixteenth-grid count: `0`
+- note count: `63`
+- unique pitch count: `28`
+- max interval: `4`
+- chord-tone ratio: `0.444`
+- tension ratio: `0.540`
+- outside ratio: `0.016`
+- repeated pitch interval ratio: `0.000`
+- no duplicated 4-note or 8-note pitch-class chunks in the solo note stream
+
+Bar-level role summary after sixteenth-grid quantization:
+
+| bar | chord | notes | chord tones | tensions | outside |
+|---:|---|---:|---:|---:|---:|
+| 1 | `Cm7` | 8 | 4 | 2 | 2 |
+| 2 | `Fm7` | 8 | 3 | 3 | 2 |
+| 3 | `Bb7` | 8 | 3 | 4 | 1 |
+| 4 | `Ebmaj7` | 8 | 3 | 5 | 0 |
+| 5 | `Cm7` | 8 | 4 | 3 | 1 |
+| 6 | `Fm7` | 7 | 4 | 2 | 1 |
+| 7 | `Bb7` | 8 | 3 | 4 | 1 |
+| 8 | `Ebmaj7` | 8 | 4 | 3 | 1 |
+
+## Blocking Evidence
+
+Focused context decision downgrades this from proxy `keep` to `needs_followup`.
+
+Primary blockers:
+
+- register/contour: the line reaches `C6` around bar 4, then drifts down to `G3` by the final bar. The final two bars sit close to the bass/root guide register and read more like a low-register exercise ending than a confident solo-line cadence.
+- phrase punctuation: the candidate fills most bars with similar eighth/quarter-grid cells. It has valid note counts, but the 8-bar arc still lacks clear phrase-level breathing and cadence punctuation.
+- context fit: chord fit is objectively clean, but some outside notes are side-slip artifacts rather than clearly prepared/released color tones, especially early `G#4/E4` over `Cm7` and `D4/C#4` over `Fm7`.
+
+This is a useful diagnostic seed, but it should not be promoted to a real listening pass yet.
+
+## Decision
+
+Focused context decision:
+
+| field | value |
+|---|---|
+| prior proxy decision | `keep` |
+| focused context decision | `needs_followup` |
+| keep as diagnostic seed | `yes` |
+| ready for broad training | `no` |
+| ready for style adaptation claim | `no` |
+
+Issue #140 conclusion:
+
+- The Issue #138 package is useful and should stay as the focused review artifact.
+- The candidate does not survive focused context MIDI-note review as a final keep.
+- The next repair should preserve the objective-clean rhythm guardrails while adding register-arc control and cadence/phrase punctuation.
+
+Recommended next issue:
+
+```text
+Stage B focused context register-arc cadence repair
+```
+
+Target:
+
+- avoid ending the solo line in the bass-guide register
+- keep final cadence in a right-hand solo register unless explicitly requested otherwise
+- add phrase punctuation without reintroducing dead-air or overlap/polyphony flags
+- preserve objective-clean status, duplicate-free status, and max interval guardrails
+
+## 검증
+
+실행한 검증:
+
+```bash
+bash scripts/agent_harness.sh quick
+```
+
+Quick harness result:
+
+- unit tests: `234` passed
+- compile checks: passed
+- diff whitespace check: passed


### PR DESCRIPTION
Closes #140

## Summary
- Record the focused context MIDI-note decision for the Issue #138 proxy-keep candidate.
- Downgrade the candidate from proxy `keep` to focused context `needs_followup` based on register/cadence and phrase-punctuation blockers.
- Update status, handoff, core plan, and docs index with the next repair boundary.

## Validation
- `bash scripts/agent_harness.sh quick` (234 tests passed)