### PR TITLE
[codex] Stage B focused context register-cadence repair

### DIFF
--- a/docs/CODEX_REMOTE_HANDOFF_2026-05-23.md
+++ b/docs/CODEX_REMOTE_HANDOFF_2026-05-23.md
@@ -200,12 +200,45 @@ Stage B는 REMI/Jazz Transformer 계열 판단을 따른다.
 46. phrase-shape tension repaired MIDI-note proxy review
 47. proxy-keep rhythm candidate focused review package
 48. proxy-keep focused context MIDI-note decision
+49. focused context register-arc cadence repair
 
 자세한 전체 기록은 `docs/CORE_PLAN.md`에 있다.
 
 ## 7. Latest Meaningful Result
 
-최신 의미 있는 결과는 Stage B proxy-keep focused context MIDI-note decision이다.
+최신 의미 있는 결과는 Stage B focused context register-arc cadence repair다.
+
+Issue #142는 Issue #140 focused context decision에서 확인한 C6-to-G3 register/cadence blocker를 generation rule 쪽에서 좁게 고친 작업이다.
+
+결과:
+
+- variation strict samples: `3/3`
+- final landing resolved: `3/3`
+- max interval: `4`
+- duplicate note sequences: `0`
+- objective MIDI flag counts: `{}`
+- selected candidate: `data_motif_rhythm_phrase_variation_rank_1_sample_3`
+- selected candidate note count: `63`
+- selected candidate unique pitch count: `18`
+- selected candidate pitch range: `61-79`
+- selected candidate final landing: `G4`
+- selected candidate final landing role: `guide`
+- selected candidate objective flags: `[]`
+
+해석:
+
+- The previous C6-to-G3 focused context blocker is repaired for the top candidate.
+- The repair preserves objective-clean status and duplicate-free status.
+- broad training is still premature.
+- next work should run a focused proxy review on the repaired candidates and check whether the narrowed register feels boxed-in.
+
+Docs:
+
+```text
+docs/STAGE_B_FOCUSED_CONTEXT_REGISTER_CADENCE_REPAIR_2026-05-25.md
+```
+
+The previous decision was Stage B proxy-keep focused context MIDI-note decision.
 
 Issue #140은 Issue #138 focused package의 단일 proxy `keep` 후보를 solo/context MIDI note 기준으로 다시 판단한 focused context decision이다.
 
@@ -215,21 +248,7 @@ Issue #140은 Issue #138 focused package의 단일 proxy `keep` 후보를 solo/c
 - focused context decision: `needs_followup`
 - keep as diagnostic seed: `yes`
 - ready for broad training: `no`
-- selected candidate: `data_motif_rhythm_phrase_variation_rank_1_sample_3`
-- selected candidate note count: `63`
-- selected candidate unique pitch count: `28`
-- selected candidate timing: `acceptable`
-- selected candidate chord fit: `fits`
-- selected candidate objective flags: `[]`
-- primary blocker: register arc reaches `C6` around bar 4 and drifts to final `G3`
-- secondary blocker: phrase/cadence punctuation is still too grid-cell-like
-
-해석:
-
-- The Issue #138 package remains useful as a focused review artifact.
-- The candidate should not be promoted to a final listening keep.
-- broad training is still premature.
-- next work should preserve the objective-clean rhythm guardrails while adding register-arc control and cadence/phrase punctuation.
+- blocker: register arc reaches `C6` around bar 4 and drifts to final `G3`
 
 Docs:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -180,6 +180,7 @@ Stage B에서 명시하는 것:
 68. Stage B phrase-shape tension repaired MIDI-note proxy review
 69. Stage B proxy-keep rhythm candidate focused review package
 70. Stage B proxy-keep focused context MIDI-note decision
+71. Stage B focused context register-arc cadence repair
 
 가장 최근 의미 있는 결과:
 
@@ -248,6 +249,8 @@ Stage B에서 명시하는 것:
 - Issue #138 result: focused package `candidate_count=1`, selected candidate `data_motif_rhythm_phrase_variation_rank_1_sample_3`, objective flags `[]`.
 - Issue #140 reviews that single package against context MIDI notes and downgrades it from proxy `keep` to focused context `needs_followup`.
 - Issue #140 result: the candidate stays useful as a diagnostic seed, but register arc (`C6` to final `G3`) and cadence/phrase punctuation block a final keep.
+- Issue #142 adds focused-context register bounds to `data_motif_rhythm_phrase_variation` so final cadence stays in a right-hand solo register.
+- Issue #142 result: variation strict `3/3`, final landing `3/3`, max interval `4`, duplicate note sequences `0`, objective flags `{}`; repaired top candidate ends on `G4` instead of `G3`.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest completed: Issue #140, Stage B proxy-keep focused context listening decision
-- 다음 권장 이슈: `Stage B focused context register-arc cadence repair`
+- latest completed: Issue #142, Stage B focused context register-arc cadence repair
+- 다음 권장 이슈: `Stage B register-cadence repaired focused proxy review`
 
 현재 범위가 아닌 것:
 
@@ -41,17 +41,58 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 ## Latest Review Result
 
+Issue #142는 Issue #140 focused context decision에서 확인한 C6-to-G3 register/cadence blocker를 generation rule 쪽에서 좁게 고친 작업이다.
+
+Docs:
+
+- `docs/STAGE_B_FOCUSED_CONTEXT_REGISTER_CADENCE_REPAIR_2026-05-25.md`
+
+중요한 전제:
+
+- 기존 rhythm/position guardrail과 objective-clean 상태를 유지하는 register/cadence repair다.
+- final cadence를 bass-guide register가 아니라 right-hand solo register 안에 남기는 것이 목적이다.
+- 아직 musical pass가 아니며, 다시 focused proxy review가 필요하다.
+
+Result:
+
+- variation strict samples: `3/3`
+- final landing resolved: `3/3`
+- max interval: `4`
+- duplicate note sequences: `0`
+- objective MIDI flag counts: `{}`
+
+Top repaired candidate:
+
+- `data_motif_rhythm_phrase_variation_rank_1_sample_3`
+- note count: `63`
+- unique pitch count: `18`
+- objective pitch range: `61-79`
+- final landing: `G4`
+- final landing role: `guide`
+- final bar notes: `F4, G4, A#4, A4, F4, D4, F#4, G4`
+- source tension ratio: `0.413`
+- objective MIDI tension ratio: `0.540`
+- objective MIDI flags: `[]`
+
+Aggregate tradeoff:
+
+- avg tension ratio moved from the previous `0.437` area to `0.395`
+- top candidate unique pitch count dropped from `28` to `18`
+- this is acceptable for Issue #142 but must be checked for a boxed-in phrase feel
+
+Decision:
+
+- Keep the register/cadence repair.
+- The previous C6-to-G3 focused context blocker is repaired for the top candidate.
+- The next step is a focused proxy review of the repaired candidates.
+
+## Previous Decision Result
+
 Issue #140은 Issue #138 focused package의 단일 proxy `keep` 후보를 solo/context MIDI note 기준으로 다시 판단한 focused context decision이다.
 
 Docs:
 
 - `docs/STAGE_B_PROXY_KEEP_FOCUSED_CONTEXT_DECISION_2026-05-25.md`
-
-중요한 전제:
-
-- 실제 오디오 청취 리뷰가 아니다.
-- MIDI note, context chord guide, bass root guide, objective metrics 기준의 focused proxy decision이다.
-- 이 결과만으로 broad training이나 style adaptation을 시작하지 않는다.
 
 Result:
 
@@ -59,37 +100,7 @@ Result:
 - focused context decision: `needs_followup`
 - keep as diagnostic seed: `yes`
 - ready for broad training: `no`
-
-Focused candidate:
-
-- `data_motif_rhythm_phrase_variation_rank_1_sample_3`
-- note count: `63`
-- unique pitch count: `28`
-- phrase quality: `phrase`
-- timing: `acceptable`
-- chord fit: `fits`
-- source tension ratio: `0.413`
-- objective MIDI tension ratio: `0.540`
-- objective MIDI flags: `[]`
-
-Positive evidence:
-
-- max active notes: `1`
-- off-sixteenth-grid count: `0`
-- repeated pitch interval ratio: `0.000`
-- no duplicated 4-note or 8-note pitch-class chunks
-
-Blocking evidence:
-
-- register/contour: the line reaches `C6` around bar 4, then drifts down to `G3` by the final bar.
-- phrase punctuation: the 8-bar arc still reads like similar eighth/quarter-grid cells rather than a clear cadence.
-- context fit: chord fit is clean, but some outside notes are side-slip artifacts rather than clearly prepared/released color tones.
-
-Decision:
-
-- The Issue #138 package remains useful as a focused review artifact.
-- The candidate should not be promoted to a final listening keep.
-- The next repair should preserve objective-clean rhythm guardrails while adding register-arc control and cadence/phrase punctuation.
+- blocker: register/contour reaches `C6` around bar 4, then drifts down to `G3` by the final bar.
 
 ## Previous Package Result
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -156,6 +156,8 @@
   - 첫 proxy keep 후보만 solo/context MIDI와 objective note summary로 묶은 focused review package 결과.
 - `STAGE_B_PROXY_KEEP_FOCUSED_CONTEXT_DECISION_2026-05-25.md`
   - focused package의 단일 proxy keep 후보를 context MIDI note 기준으로 다시 판단하고 register/cadence blocker를 정리한 결과.
+- `STAGE_B_FOCUSED_CONTEXT_REGISTER_CADENCE_REPAIR_2026-05-25.md`
+  - focused context blocker였던 C6-to-G3 register arc를 줄이고 final cadence를 solo register에 남기는 repair 결과.
 - `REFERENCES.md`
   - 2024-2026 symbolic MIDI 연구까지 포함한 fine-tuning/tokenization reference map과 구현 판단 기준.
 - `INFERENCE_MODEL_SPEC.md`

--- a/docs/STAGE_B_FOCUSED_CONTEXT_REGISTER_CADENCE_REPAIR_2026-05-25.md
+++ b/docs/STAGE_B_FOCUSED_CONTEXT_REGISTER_CADENCE_REPAIR_2026-05-25.md
@@ -1,0 +1,127 @@
+# Stage B Focused Context Register-Cadence Repair
+
+작성일: 2026-05-25
+
+## 목적
+
+Issue #142는 Issue #140 focused context decision에서 확인한 register/cadence blocker를 generation rule 쪽에서 좁게 고친 작업이다.
+
+Blocker:
+
+- 이전 top proxy seed는 bar 4 부근에서 `C6`까지 올라간 뒤 final bar에서 `G3`까지 내려왔다.
+- context MIDI 안에서는 final two bars가 bass/root guide register에 가까워져 solo-line cadence보다 low-register exercise처럼 읽혔다.
+
+목표:
+
+- 기존 rhythm/position guardrail은 유지한다.
+- objective-clean 상태, duplicate-free 상태, max interval guardrail을 유지한다.
+- final cadence를 right-hand solo register 안에 남긴다.
+- broad training이나 style adaptation claim으로 확장하지 않는다.
+
+## 구현
+
+변경 파일:
+
+- `scripts/run_stage_b_data_motif_generation_compare.py`
+- `tests/test_stage_b_data_motif_generation_compare.py`
+
+추가한 helper:
+
+- `focused_context_register_bounds()`
+
+적용:
+
+- `data_motif_rhythm_phrase_variation`의 기본 pitch range를 `55-79`로 좁혔다.
+- 마지막 3 bars는 `58-77` 안으로 제한한다.
+- 마지막 2 bars는 `60-76` 안으로 제한한다.
+- pending recovery, final landing, phrase target shaping, bounded pitch selection 모두 같은 bar-local range를 사용한다.
+
+이 방식은 pitch를 나중에 강제로 transpose하지 않고, 기존 max interval `4` 선택 과정 안에서 register arc를 제한한다.
+
+## Result
+
+실행:
+
+```bash
+bash scripts/agent_harness.sh stage-b-rhythm-phrase-variation
+```
+
+Summary:
+
+| field | result |
+|---|---:|
+| variation valid samples | `3/3` |
+| variation strict samples | `3/3` |
+| final landing resolved | `3/3` |
+| max interval | `4` |
+| duplicate note sequences | `0` |
+| objective MIDI flag counts | `{}` |
+
+Variation aggregate:
+
+| metric | result |
+|---|---:|
+| avg syncopated onset ratio | `0.684` |
+| avg unique bar-position pattern ratio | `0.958` |
+| avg duration diversity ratio | `0.079` |
+| avg most-common duration ratio | `0.384` |
+| avg IOI diversity ratio | `0.091` |
+| avg most-common IOI ratio | `0.385` |
+| avg tension ratio | `0.395` |
+| avg root tone ratio | `0.011` |
+
+Top candidate after repair:
+
+| field | value |
+|---|---|
+| candidate | `data_motif_rhythm_phrase_variation_rank_1_sample_3` |
+| note count | `63` |
+| unique pitch count | `18` |
+| objective pitch range | `61-79` |
+| objective flags | `[]` |
+| final landing | `G4` |
+| final landing role | `guide` |
+| final bar notes | `F4, G4, A#4, A4, F4, D4, F#4, G4` |
+
+Tradeoff:
+
+- unique pitch count fell from the previous top candidate's `28` to `18`.
+- this is acceptable for this issue because the target was register/cadence repair, but the next review must check whether the narrower register now sounds too boxed-in.
+
+## Decision
+
+Issue #142 conclusion:
+
+- Keep the register/cadence repair.
+- The previous C6-to-G3 focused context blocker is repaired for the top candidate.
+- The repair preserves objective-clean status and duplicate-free status.
+- This is not yet a musical pass; it needs a new focused proxy review.
+
+Recommended next issue:
+
+```text
+Stage B register-cadence repaired focused proxy review
+```
+
+Target:
+
+- rebuild focused proxy review evidence from the repaired `harness_stage_b_rhythm_phrase_variation` outputs
+- compare the repaired top candidate against Issue #140 blocker notes
+- decide whether the narrower register range creates a new boxed-in phrase problem
+
+## 검증
+
+실행한 검증:
+
+```bash
+.venv/bin/python -m py_compile scripts/run_stage_b_data_motif_generation_compare.py tests/test_stage_b_data_motif_generation_compare.py
+.venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare
+bash scripts/agent_harness.sh stage-b-rhythm-phrase-variation
+bash scripts/agent_harness.sh quick
+```
+
+Quick harness result:
+
+- unit tests: `236` passed
+- compile checks: passed
+- diff whitespace check: passed

--- a/scripts/run_stage_b_data_motif_generation_compare.py
+++ b/scripts/run_stage_b_data_motif_generation_compare.py
@@ -388,6 +388,26 @@ def phrase_shape_target_pitch(
     return max(int(min_pitch), min(int(max_pitch), shaped))
 
 
+def focused_context_register_bounds(
+    bar_index: int,
+    bars: int,
+    *,
+    min_pitch: int = PIANO_PITCH_MIN,
+    max_pitch: int = PIANO_PITCH_MAX,
+) -> tuple[int, int]:
+    """Keep focused review candidates out of bass-guide and sketch extremes."""
+    total_bars = max(1, int(bars))
+    lower = max(int(min_pitch), 55)
+    upper = min(int(max_pitch), 79)
+    if total_bars >= 4 and int(bar_index) >= total_bars - 3:
+        lower = max(lower, 58)
+        upper = min(upper, 77)
+    if total_bars >= 4 and int(bar_index) >= total_bars - 2:
+        lower = max(lower, 60)
+        upper = min(upper, 76)
+    return lower, max(lower, upper)
+
+
 def phrase_shape_pitch_classes(
     *,
     base_pitch_class: int,
@@ -1603,8 +1623,8 @@ def data_motif_rhythm_phrase_variation_tokens(
     groups_per_bar = max(1, int(note_groups_per_bar))
     motifs_per_bar = max(1, int(round(groups_per_bar / motif_length)))
     pending_recovery_direction = 0
-    min_solo_pitch = 48
-    max_solo_pitch = 84
+    min_solo_pitch = 55
+    max_solo_pitch = 79
     max_variation_interval = 4
     seed_variation = abs(int(seed)) % 17
 
@@ -1612,6 +1632,12 @@ def data_motif_rhythm_phrase_variation_tokens(
         chord = chords[bar_index % len(chords)] if chords else None
         next_chord = chords[(bar_index + 1) % len(chords)] if chords else chord
         final_bar = bar_index == max(1, int(bars)) - 1
+        bar_min_pitch, bar_max_pitch = focused_context_register_bounds(
+            bar_index,
+            bars,
+            min_pitch=min_solo_pitch,
+            max_pitch=max_solo_pitch,
+        )
         if bar_index > 0:
             tokens.append(TOKEN_BAR)
             tokens.extend(chord_tokens(chord))
@@ -1665,15 +1691,15 @@ def data_motif_rhythm_phrase_variation_tokens(
                         leap_direction=pending_recovery_direction,
                         recent_pitches=recent_pitches,
                     )
-                    if pitch < min_solo_pitch or pitch > max_solo_pitch:
+                    if pitch < bar_min_pitch or pitch > bar_max_pitch:
                         pitch = bounded_phrase_pitch_for_pitch_classes(
                             phrase_recovery_pitch_classes(chord, next_chord),
-                            target_pitch=max(min_solo_pitch, min(max_solo_pitch, pitch)),
+                            target_pitch=max(bar_min_pitch, min(bar_max_pitch, pitch)),
                             recent_pitches=recent_pitches,
                             max_interval=max_variation_interval,
                             allow_wider_fallback=False,
-                            min_pitch=min_solo_pitch,
-                            max_pitch=max_solo_pitch,
+                            min_pitch=bar_min_pitch,
+                            max_pitch=bar_max_pitch,
                         )
                     pending_recovery_direction = 0
                 elif last_in_bar:
@@ -1685,8 +1711,8 @@ def data_motif_rhythm_phrase_variation_tokens(
                             recent_pitches=recent_pitches,
                             max_interval=max_variation_interval,
                             allow_wider_fallback=False,
-                            min_pitch=min_solo_pitch,
-                            max_pitch=max_solo_pitch,
+                            min_pitch=bar_min_pitch,
+                            max_pitch=bar_max_pitch,
                         )
                     else:
                         pitch = bounded_phrase_pitch_for_pitch_classes(
@@ -1696,8 +1722,8 @@ def data_motif_rhythm_phrase_variation_tokens(
                             max_interval=max_variation_interval,
                             allow_repeat_fallback=True,
                             allow_wider_fallback=False,
-                            min_pitch=min_solo_pitch,
-                            max_pitch=max_solo_pitch,
+                            min_pitch=bar_min_pitch,
+                            max_pitch=bar_max_pitch,
                         )
                     pending_recovery_direction = 0
                 else:
@@ -1756,8 +1782,8 @@ def data_motif_rhythm_phrase_variation_tokens(
                         bar_index=bar_index,
                         motif_index=motif_index,
                         variation_index=seed_variation,
-                        min_pitch=min_solo_pitch,
-                        max_pitch=max_solo_pitch,
+                        min_pitch=bar_min_pitch,
+                        max_pitch=bar_max_pitch,
                     )
                     pitch = bounded_phrase_pitch_for_pitch_classes(
                         line_pitch_classes,
@@ -1766,8 +1792,8 @@ def data_motif_rhythm_phrase_variation_tokens(
                         max_interval=max_variation_interval,
                         allow_repeat_fallback=True,
                         allow_wider_fallback=False,
-                        min_pitch=min_solo_pitch,
-                        max_pitch=max_solo_pitch,
+                        min_pitch=bar_min_pitch,
+                        max_pitch=bar_max_pitch,
                     )
 
                 if recent_pitches:

--- a/tests/test_stage_b_data_motif_generation_compare.py
+++ b/tests/test_stage_b_data_motif_generation_compare.py
@@ -19,6 +19,7 @@ from scripts.run_stage_b_data_motif_generation_compare import (
     data_motif_tokens,
     duration_tokens_from_steps,
     fit_duration_tokens_to_positions,
+    focused_context_register_bounds,
     guide_tone_pitch_classes,
     nearest_allowed_pitch_token,
     normalize_position_deltas,
@@ -258,6 +259,14 @@ class StageBDataMotifGenerationCompareTest(unittest.TestCase):
 
         self.assertIn(classes[0], tension_pitch_classes("Cm7"))
         self.assertIn(3, classes)
+
+    def test_focused_context_register_bounds_lifts_final_cadence_range(self) -> None:
+        early_min, early_max = focused_context_register_bounds(1, 8, min_pitch=48, max_pitch=84)
+        final_min, final_max = focused_context_register_bounds(7, 8, min_pitch=48, max_pitch=84)
+
+        self.assertEqual((early_min, early_max), (55, 79))
+        self.assertGreaterEqual(final_min, 60)
+        self.assertLessEqual(final_max, 76)
 
     def test_nearest_allowed_pitch_token_avoids_recent_pitch_when_possible(self) -> None:
         allowed = list(range(TOKEN_NOTE_PITCH_START, TOKEN_NOTE_PITCH_END + 1))
@@ -638,6 +647,30 @@ class StageBDataMotifGenerationCompareTest(unittest.TestCase):
             signatures.add(signature)
 
         self.assertEqual(len(signatures), 3)
+
+    def test_data_motif_rhythm_phrase_variation_keeps_final_context_cadence_in_solo_register(self) -> None:
+        chords = ["Cm7", "Fm7", "Bb7", "Ebmaj7"]
+        primer = build_stage_b_primer(chords, 124)
+        tokens = data_motif_rhythm_phrase_variation_tokens(
+            primer_tokens=primer,
+            chords=chords,
+            bars=8,
+            note_groups_per_bar=8,
+            template_report=template_report(),
+            seed=19,
+        )
+        grammar = analyze_stage_b_note_grammar(tokens, primer_size=len(primer))
+        groups = extract_stage_b_note_groups(tokens, primer_size=len(primer))
+        profile = analyze_contour_landing_profile(tokens, chords=chords, primer_size=len(primer))
+        pitches = [int(group["pitch"]) for group in groups]
+        final_bar_pitches = [int(group["pitch"]) for group in groups if int(group["bar"]) == 7]
+
+        self.assertTrue(grammar["grammar_valid"])
+        self.assertGreaterEqual(len(groups), 63)
+        self.assertLessEqual(max(pitches), 79)
+        self.assertGreaterEqual(min(final_bar_pitches), 60)
+        self.assertTrue(profile["final_landing_resolved"])
+        self.assertLessEqual(profile["max_abs_interval"], 4)
 
     def test_contour_landing_summary_counts_resolved_landings(self) -> None:
         summary = contour_landing_summary(


### PR DESCRIPTION
Closes #142

## Summary
- Add focused-context register bounds to `data_motif_rhythm_phrase_variation` so repaired candidates avoid bass-guide and sketch-extreme registers.
- Apply bar-local pitch bounds to recovery, final landing, phrase target shaping, and bounded pitch selection.
- Add tests for the final cadence register constraint and document the Issue #142 result.

## Result
- Variation strict samples: `3/3`
- Final landing resolved: `3/3`
- Max interval: `4`
- Duplicate note sequences: `0`
- Objective MIDI flag counts: `{}`
- Repaired top candidate ends on `G4` instead of the previous focused-context `G3` issue.

## Validation
- `.venv/bin/python -m py_compile scripts/run_stage_b_data_motif_generation_compare.py tests/test_stage_b_data_motif_generation_compare.py`
- `.venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare`
- `bash scripts/agent_harness.sh stage-b-rhythm-phrase-variation`
- `bash scripts/agent_harness.sh quick` (236 tests passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented register-cadence constraints to improve pitch generation in focused contexts, including per-bar pitch bounds refinement.

* **Tests**
  * Added validation tests for register bounds and pitch generation to ensure proper cadence handling and interval constraints.

* **Documentation**
  * Updated progress tracking to reflect completion of register-cadence repair work (Issue `#142`) with updated metrics and next-stage recommendations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohhalim/fine_tuning_art-tatum_midi_solo/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->