### PR TITLE
[codex] Stage B register-safe proxy review 기록

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -258,6 +258,9 @@ Stage B에서 명시하는 것:
 - Issue #144 result: `reviewed=6`, `keep=0`, `needs_followup=5`, `reject=1`, objective flags `{}`; repaired top candidate fixes the register blocker but remains boxed-in/cell-like with unique pitch count `18`.
 - Issue #146 adds register-safe phrase vocabulary repair to reduce repeated cells without reopening the focused-context register/cadence blocker.
 - Issue #146 result: variation strict `3/3`, final landing `3/3`, max interval `4`, duplicate note sequences `0`, objective flags `{}`; top repaired candidate keeps unique pitch count `18` and has `0` exact repeated 4-note cells in the solo review MIDI.
+- Issue #148 fills MIDI-note/context proxy review notes for the register-safe phrase vocabulary repaired candidates.
+- Issue #148 result: `reviewed=6`, `keep=1`, `needs_followup=4`, `reject=1`, objective flags `{}`; `data_motif_rhythm_phrase_variation_rank_1_sample_3` is restored as a proxy keep candidate for focused context review only.
+- Issue #148 aggregate result: `improve_phrase_vocabulary=13`, `fix_timing_grid=8`, `increase_motif_variation=3`, so broad training is still premature.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -276,7 +279,7 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-이제 다음 단계는 register-safe phrase vocabulary repaired proxy review다. Issue #146은 objective-clean/register-safe 후보를 만들었지만, 이것은 fresh proxy/listening review 전까지 broad training 근거가 아니다.
+이제 다음 단계는 register-safe proxy keep candidate focused context package다. Issue #148은 proxy 기준 `keep` 후보를 되살렸지만, 이것은 focused context review 전까지 broad training 근거가 아니다.
 
 ## 6. 다음 단계 로드맵
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -1,6 +1,6 @@
 # Current Status and Plan
 
-작성일: 2026-05-26
+작성일: 2026-05-27
 
 ## Current Focus
 
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest completed: Issue #146, Stage B register-safe phrase vocabulary repair
-- 다음 권장 이슈: `Stage B register-safe phrase vocabulary repaired proxy review`
+- latest completed: Issue #148, Stage B register-safe phrase vocabulary repaired proxy review
+- 다음 권장 이슈: `Stage B register-safe proxy-keep focused context package`
 
 현재 범위가 아닌 것:
 
@@ -39,7 +39,61 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
-## Latest Probe Result
+## Latest Proxy Review Result
+
+Issue #148은 Issue #146 register-safe phrase vocabulary repair 이후의 후보를 MIDI-note/context 기준으로 다시 채운 proxy review다.
+
+Docs:
+
+- `docs/STAGE_B_REGISTER_SAFE_PHRASE_VOCAB_PROXY_REVIEW_2026-05-27.md`
+
+중요한 전제:
+
+- 실제 오디오 청취 리뷰가 아니다.
+- `keep`은 focused context review로 넘길 proxy 후보라는 뜻이다.
+- broad training이나 style adaptation claim으로 해석하지 않는다.
+
+Result:
+
+- reviewed candidates: `6`
+- pending candidates: `0`
+- decisions:
+  - `keep`: `1`
+  - `needs_followup`: `4`
+  - `reject`: `1`
+- timing:
+  - `acceptable`: `2`
+  - `too_stiff`: `4`
+- chord fit:
+  - `fits`: `6`
+- objective MIDI flags: `{}`
+
+Proxy keep candidate:
+
+- `data_motif_rhythm_phrase_variation_rank_1_sample_3`
+- note count: `63`
+- unique pitch count: `18`
+- pitch range: `G3-G5`
+- final landing: `G4`
+- max interval: `4`
+- outside ratio: `0.000`
+- max active notes: `1`
+- off-sixteenth-grid count: `0`
+
+Aggregate follow-ups:
+
+- `improve_phrase_vocabulary`: `13`
+- `fix_timing_grid`: `8`
+- `increase_motif_variation`: `3`
+
+Decision:
+
+- Issue #146 register-safe phrase vocabulary repair should be kept.
+- The top repaired variation candidate is strong enough to isolate as a focused context review candidate.
+- This still does not prove final musical quality.
+- The next boundary should package the proxy keep candidate for focused context review.
+
+## Previous Probe Result
 
 Issue #146는 Issue #144 proxy review에서 남은 boxed-in/cell-like phrase blocker를 generation rule 쪽에서 좁게 고친 작업이다.
 

--- a/docs/STAGE_B_REGISTER_SAFE_PHRASE_VOCAB_PROXY_REVIEW_2026-05-27.md
+++ b/docs/STAGE_B_REGISTER_SAFE_PHRASE_VOCAB_PROXY_REVIEW_2026-05-27.md
@@ -1,0 +1,130 @@
+# Stage B Register-Safe Phrase Vocabulary Repaired Proxy Review
+
+작성일: 2026-05-27
+
+## 목적
+
+Issue #148은 Issue #146 register-safe phrase vocabulary repair 이후의 후보를 MIDI-note/context 기준으로 다시 채운 proxy review다.
+
+중요한 경계:
+
+- 실제 오디오 청취 리뷰가 아니다.
+- MIDI note, context chord guide, bass root guide, objective metrics 기준의 proxy review다.
+- `keep`은 focused context review로 넘길 proxy 후보라는 뜻이며, 최종 음악 품질이나 broad training 준비 완료를 의미하지 않는다.
+- `outputs/` 아래 filled review notes와 aggregate는 생성 artifact라 커밋하지 않는다.
+
+## 입력
+
+Review 대상:
+
+- `data_motif_contour_landing_repair` 후보 3개
+- `data_motif_rhythm_phrase_variation` register-safe phrase vocabulary repaired 후보 3개
+
+Generated artifacts:
+
+- review manifest:
+  - `outputs/stage_b_data_motif_review/harness_stage_b_rhythm_phrase_variation/review_manifest.json`
+- objective MIDI review:
+  - `outputs/stage_b_objective_midi_review/harness_stage_b_rhythm_phrase_variation/objective_midi_note_review.json`
+- proxy-filled notes:
+  - `outputs/stage_b_listening_review_notes/harness_stage_b_register_safe_phrase_vocab_codex_proxy/register_safe_phrase_vocab_repaired_review_notes_codex_midi_proxy.json`
+- aggregate:
+  - `outputs/stage_b_listening_review_aggregate/harness_stage_b_register_safe_phrase_vocab_codex_proxy/listening_review_aggregate.md`
+
+## Review Result
+
+Decision counts:
+
+| decision | count |
+|---|---:|
+| `keep` | 1 |
+| `needs_followup` | 4 |
+| `reject` | 1 |
+
+Quality counts:
+
+| field | result |
+|---|---|
+| phrase quality | `phrase=2`, `fragment=3`, `exercise=1` |
+| timing | `acceptable=2`, `too_stiff=4` |
+| chord fit | `fits=6` |
+| objective bucket | `clean=6` |
+| objective flags | `{}` |
+
+Candidate decisions:
+
+| candidate | phrase | timing | chord fit | decision | reason |
+|---|---|---|---|---|---|
+| `data_motif_contour_landing_repair_rank_1_sample_1` | `fragment` | `too_stiff` | `fits` | `reject` | C1-G2 bass-register artifact remains and final landing is G2 |
+| `data_motif_contour_landing_repair_rank_2_sample_2` | `fragment` | `too_stiff` | `fits` | `needs_followup` | final G4 is usable, but bars 3-6 still drop through low-register cells |
+| `data_motif_contour_landing_repair_rank_3_sample_3` | `fragment` | `too_stiff` | `fits` | `needs_followup` | low-register contour movement and one unresolved large leap remain |
+| `data_motif_rhythm_phrase_variation_rank_1_sample_3` | `phrase` | `acceptable` | `fits` | `keep` | proxy keep for focused context review only |
+| `data_motif_rhythm_phrase_variation_rank_2_sample_1` | `phrase` | `too_stiff` | `fits` | `needs_followup` | safe final G4, but high stepwise/chromatic ratios still read as bounded scalar cells |
+| `data_motif_rhythm_phrase_variation_rank_3_sample_2` | `exercise` | `acceptable` | `fits` | `needs_followup` | objective-clean, but low direction change and repeated pitch-class cells read like an exercise |
+
+Aggregate follow-up signals:
+
+| code | count | interpretation |
+|---|---:|---|
+| `improve_phrase_vocabulary` | 13 | still the strongest remaining blocker |
+| `fix_timing_grid` | 8 | baseline and rank 2 still read too stiff |
+| `increase_motif_variation` | 3 | repeated pitch-class cells remain in variation candidates |
+
+## Proxy Keep Candidate
+
+`data_motif_rhythm_phrase_variation_rank_1_sample_3` is promoted back to proxy `keep` for focused context review.
+
+Positive evidence:
+
+- objective flags: `[]`
+- objective bucket: `clean`
+- note count: `63`
+- unique pitch count: `18`
+- pitch range: `G3-G5`
+- final landing: `G4`
+- max interval: `4`
+- max active notes: `1`
+- off-sixteenth-grid count: `0`
+- outside ratio: `0.000`
+- duplicate note sequence: `false`
+
+Important limitations:
+
+- repeated pitch-class cells still exist.
+- timing is still grid-derived.
+- unique pitch count remains lower than the earlier Issue #136 proxy keep candidate.
+- this is not a real audio listening keep and not a broad-training claim.
+
+## Decision
+
+Issue #148 conclusion:
+
+- Issue #146 register-safe phrase vocabulary repair should be kept.
+- The top repaired variation candidate is strong enough to isolate as a focused context review candidate.
+- Broad training and Brad style adaptation are still premature.
+- The next issue should package the register-safe proxy keep candidate with context MIDI and objective summaries for a focused context decision.
+
+Recommended next issue:
+
+```text
+Stage B register-safe proxy-keep focused context package
+```
+
+Target:
+
+- copy only the proxy keep candidate and context MIDI into a focused package
+- preserve objective metrics and MIDI-note summary
+- keep comparison links back to the full review manifest
+- do not claim final musical quality before focused context review
+
+## 검증
+
+실행한 검증:
+
+```bash
+bash scripts/agent_harness.sh stage-b-rhythm-phrase-variation
+.venv/bin/python scripts/build_listening_review_notes.py --run_id harness_stage_b_register_safe_phrase_vocab_codex_proxy --review_notes outputs/stage_b_listening_review_notes/harness_stage_b_register_safe_phrase_vocab_codex_proxy/register_safe_phrase_vocab_repaired_review_notes_codex_midi_proxy.json
+.venv/bin/python scripts/summarize_listening_review_notes.py --run_id harness_stage_b_register_safe_phrase_vocab_codex_proxy --review_notes outputs/stage_b_listening_review_notes/harness_stage_b_register_safe_phrase_vocab_codex_proxy/register_safe_phrase_vocab_repaired_review_notes_codex_midi_proxy.json
+```
+
+Commit 전 필수 quick harness도 실행한다.


### PR DESCRIPTION
## Summary

- Document Issue #148 MIDI-note/context proxy review for the register-safe phrase vocabulary repaired candidates.
- Promote `data_motif_rhythm_phrase_variation_rank_1_sample_3` back to proxy `keep` for focused context review only.
- Update `CURRENT_STATUS_AND_PLAN.md` and `CORE_PLAN.md` with the next focused package boundary.

## Validation

- `bash scripts/agent_harness.sh stage-b-rhythm-phrase-variation`
- `.venv/bin/python scripts/build_listening_review_notes.py --run_id harness_stage_b_register_safe_phrase_vocab_codex_proxy --review_notes outputs/stage_b_listening_review_notes/harness_stage_b_register_safe_phrase_vocab_codex_proxy/register_safe_phrase_vocab_repaired_review_notes_codex_midi_proxy.json`
- `.venv/bin/python scripts/summarize_listening_review_notes.py --run_id harness_stage_b_register_safe_phrase_vocab_codex_proxy --review_notes outputs/stage_b_listening_review_notes/harness_stage_b_register_safe_phrase_vocab_codex_proxy/register_safe_phrase_vocab_repaired_review_notes_codex_midi_proxy.json`
- `bash scripts/agent_harness.sh quick`

Closes #148