### PR TITLE
[codex] Stage B register-safe focused package 기록

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -184,6 +184,7 @@ Stage B에서 명시하는 것:
 72. Stage B register-cadence repaired focused proxy review
 73. Stage B register-safe phrase vocabulary repair
 74. Stage B register-safe phrase vocabulary repaired proxy review
+75. Stage B register-safe proxy-keep focused context package
 
 가장 최근 의미 있는 결과:
 
@@ -261,6 +262,8 @@ Stage B에서 명시하는 것:
 - Issue #148 fills MIDI-note/context proxy review notes for the register-safe phrase vocabulary repaired candidates.
 - Issue #148 result: `reviewed=6`, `keep=1`, `needs_followup=4`, `reject=1`, objective flags `{}`; `data_motif_rhythm_phrase_variation_rank_1_sample_3` is restored as a proxy keep candidate for focused context review only.
 - Issue #148 aggregate result: `improve_phrase_vocabulary=13`, `fix_timing_grid=8`, `increase_motif_variation=3`, so broad training is still premature.
+- Issue #150 isolates that register-safe proxy keep candidate into a focused context review package with copied solo/context MIDI and objective first-note summary.
+- Issue #150 result: focused package `candidate_count=1`, selected candidate `data_motif_rhythm_phrase_variation_rank_1_sample_3`, objective flags `[]`, copied MIDI files `2`.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -279,7 +282,7 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-이제 다음 단계는 register-safe proxy keep candidate focused context package다. Issue #148은 proxy 기준 `keep` 후보를 되살렸지만, 이것은 focused context review 전까지 broad training 근거가 아니다.
+이제 다음 단계는 register-safe proxy keep candidate focused context decision이다. Issue #150은 단일 후보 review artifact를 만들었지만, 이것은 focused context review 전까지 broad training 근거가 아니다.
 
 ## 6. 다음 단계 로드맵
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest completed: Issue #148, Stage B register-safe phrase vocabulary repaired proxy review
-- 다음 권장 이슈: `Stage B register-safe proxy-keep focused context package`
+- latest completed: Issue #150, Stage B register-safe proxy-keep focused context package
+- 다음 권장 이슈: `Stage B register-safe proxy-keep focused context decision`
 
 현재 범위가 아닌 것:
 
@@ -39,7 +39,45 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
-## Latest Proxy Review Result
+## Latest Package Result
+
+Issue #150은 Issue #148에서 복구된 proxy `keep` 후보만 분리해 focused context review용 package로 묶은 작업이다.
+
+Docs:
+
+- `docs/STAGE_B_REGISTER_SAFE_PROXY_KEEP_FOCUSED_PACKAGE_2026-05-27.md`
+
+중요한 전제:
+
+- `keep`은 MIDI-note proxy 기준이다.
+- 실제 오디오 청취 승인이나 최종 musical-quality claim이 아니다.
+- broad training이나 Brad style adaptation으로 바로 확장하지 않는다.
+
+Result:
+
+- decision filter: `keep`
+- package candidate count: `1`
+- copied solo MIDI files: `1`
+- copied context MIDI files: `1`
+
+Selected candidate:
+
+- `data_motif_rhythm_phrase_variation_rank_1_sample_3`
+- phrase: `phrase`
+- timing: `acceptable`
+- chord fit: `fits`
+- notes: `63`
+- unique pitch count: `18`
+- source tension ratio: `0.349`
+- objective flags: `[]`
+
+Decision:
+
+- Issue #148 proxy keep candidate is now isolated as a single focused context review artifact.
+- The next decision should come from reviewing this one solo/context MIDI pair.
+- This still does not prove broad model quality.
+
+## Previous Proxy Review Result
 
 Issue #148은 Issue #146 register-safe phrase vocabulary repair 이후의 후보를 MIDI-note/context 기준으로 다시 채운 proxy review다.
 

--- a/docs/STAGE_B_REGISTER_SAFE_PROXY_KEEP_FOCUSED_PACKAGE_2026-05-27.md
+++ b/docs/STAGE_B_REGISTER_SAFE_PROXY_KEEP_FOCUSED_PACKAGE_2026-05-27.md
@@ -1,0 +1,108 @@
+# Stage B Register-Safe Proxy-Keep Focused Context Package
+
+작성일: 2026-05-27
+
+## 목적
+
+Issue #150은 Issue #148에서 복구된 proxy `keep` 후보만 분리해 focused context review용 package로 묶은 작업이다.
+
+중요한 경계:
+
+- `keep`은 MIDI-note proxy 기준이다.
+- 실제 오디오 청취 승인이나 최종 musical-quality claim이 아니다.
+- broad training이나 Brad style adaptation으로 바로 확장하지 않는다.
+- `outputs/` 아래 생성 artifact는 커밋하지 않는다.
+
+## 구현
+
+기존 도구:
+
+- `scripts/build_focused_review_package.py`
+
+Harness 보강:
+
+- `scripts/agent_harness.sh`
+  - `stage-b-proxy-keep-focused-package`가 `REVIEW_NOTES_FILE` 또는 `REVIEW_NOTES_PATH` 환경 변수를 받을 수 있게 했다.
+  - 기존 Issue #138 기본 경로는 그대로 유지했다.
+  - 이번 Issue #150의 register-safe proxy notes도 같은 harness로 재현할 수 있다.
+
+## 입력
+
+Review notes:
+
+- `outputs/stage_b_listening_review_notes/harness_stage_b_register_safe_phrase_vocab_codex_proxy/register_safe_phrase_vocab_repaired_review_notes_codex_midi_proxy.json`
+
+Objective MIDI review:
+
+- `outputs/stage_b_objective_midi_review/harness_stage_b_rhythm_phrase_variation/objective_midi_note_review.json`
+
+## Package Result
+
+생성 package:
+
+- JSON:
+  - `outputs/stage_b_focused_review_package/harness_stage_b_register_safe_proxy_keep_focused_package/focused_review_package.json`
+- Markdown:
+  - `outputs/stage_b_focused_review_package/harness_stage_b_register_safe_proxy_keep_focused_package/focused_review_package.md`
+- copied solo MIDI:
+  - `outputs/stage_b_focused_review_package/harness_stage_b_register_safe_proxy_keep_focused_package/midi/02_data_motif_rhythm_phrase_variation_rank_01_sample_03_overlap_free.mid`
+- copied context MIDI:
+  - `outputs/stage_b_focused_review_package/harness_stage_b_register_safe_proxy_keep_focused_package/context_midi/02_data_motif_rhythm_phrase_variation_rank_01_sample_03_overlap_free_with_context.mid`
+
+Result:
+
+| field | value |
+|---|---:|
+| decision filter | `keep` |
+| candidate count | `1` |
+| copied MIDI files | `2` |
+
+Selected candidate:
+
+| candidate | phrase | timing | chord fit | notes | unique pitches | source tension | objective flags |
+|---|---|---|---|---:|---:|---:|---|
+| `data_motif_rhythm_phrase_variation_rank_1_sample_3` | `phrase` | `acceptable` | `fits` | `63` | `18` | `0.349` | `[]` |
+
+Objective first-phrase note summary starts:
+
+| start beats | duration beats | pitch |
+|---:|---:|---|
+| `0.00` | `0.25` | `A#4` |
+| `0.25` | `0.50` | `G4` |
+| `0.75` | `1.25` | `F4` |
+| `2.00` | `0.25` | `G#4` |
+| `2.25` | `0.50` | `A#4` |
+| `2.75` | `0.50` | `D5` |
+| `3.25` | `0.50` | `D#5` |
+| `3.75` | `0.25` | `G5` |
+
+## Decision
+
+Issue #150 conclusion:
+
+- The focused review package is reproducible from the Issue #148 structured review notes.
+- Only the register-safe proxy `keep` candidate is included.
+- This is now the correct single-candidate artifact for focused context review.
+- The next decision should come from reviewing this one solo/context MIDI pair, not from another broad generation repair.
+
+Recommended next issue:
+
+```text
+Stage B register-safe proxy-keep focused context decision
+```
+
+Target:
+
+- review the copied solo/context MIDI pair
+- record whether the proxy keep survives focused context review
+- if it fails, classify the failure as timing, phrase vocabulary, register/contour, chord fit, or motif repetition
+- if it passes, define the next narrow generation/evaluation boundary without claiming production readiness
+
+## 검증
+
+실행한 검증:
+
+```bash
+SOURCE_RUN_ID=harness_stage_b_register_safe_phrase_vocab_codex_proxy REVIEW_NOTES_FILE=register_safe_phrase_vocab_repaired_review_notes_codex_midi_proxy.json RUN_ID=harness_stage_b_register_safe_proxy_keep_focused_package bash scripts/agent_harness.sh stage-b-proxy-keep-focused-package
+bash scripts/agent_harness.sh quick
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -1146,7 +1146,8 @@ run_stage_b_proxy_keep_focused_package() {
   local source_run_id="${SOURCE_RUN_ID:-harness_stage_b_phrase_shape_tension_codex_proxy}"
   local objective_run_id="${OBJECTIVE_RUN_ID:-harness_stage_b_rhythm_phrase_variation}"
   local run_id="${RUN_ID:-harness_stage_b_proxy_keep_focused_package}"
-  local review_notes_path="outputs/stage_b_listening_review_notes/${source_run_id}/phrase_shape_tension_repaired_review_notes_codex_midi_proxy.json"
+  local review_notes_file="${REVIEW_NOTES_FILE:-phrase_shape_tension_repaired_review_notes_codex_midi_proxy.json}"
+  local review_notes_path="${REVIEW_NOTES_PATH:-outputs/stage_b_listening_review_notes/${source_run_id}/${review_notes_file}}"
   local objective_report_path="outputs/stage_b_objective_midi_review/${objective_run_id}/objective_midi_note_review.json"
   if [[ ! -f "$review_notes_path" ]]; then
     printf 'Missing proxy-filled review notes: %s\n' "$review_notes_path" >&2


### PR DESCRIPTION
## Summary

- Add Issue #150 focused context package documentation for the register-safe proxy keep candidate.
- Extend `stage-b-proxy-keep-focused-package` harness input handling with `REVIEW_NOTES_FILE` / `REVIEW_NOTES_PATH` while preserving the existing default.
- Update current/core planning docs with the next focused context decision boundary.

## Validation

- `SOURCE_RUN_ID=harness_stage_b_register_safe_phrase_vocab_codex_proxy REVIEW_NOTES_FILE=register_safe_phrase_vocab_repaired_review_notes_codex_midi_proxy.json RUN_ID=harness_stage_b_register_safe_proxy_keep_focused_package bash scripts/agent_harness.sh stage-b-proxy-keep-focused-package`
- `bash scripts/agent_harness.sh quick`

Closes #150