### PR TITLE
[codex] Stage B register-safe focused decision 기록

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -185,6 +185,7 @@ Stage B에서 명시하는 것:
 73. Stage B register-safe phrase vocabulary repair
 74. Stage B register-safe phrase vocabulary repaired proxy review
 75. Stage B register-safe proxy-keep focused context package
+76. Stage B register-safe proxy-keep focused context decision
 
 가장 최근 의미 있는 결과:
 
@@ -264,6 +265,8 @@ Stage B에서 명시하는 것:
 - Issue #148 aggregate result: `improve_phrase_vocabulary=13`, `fix_timing_grid=8`, `increase_motif_variation=3`, so broad training is still premature.
 - Issue #150 isolates that register-safe proxy keep candidate into a focused context review package with copied solo/context MIDI and objective first-note summary.
 - Issue #150 result: focused package `candidate_count=1`, selected candidate `data_motif_rhythm_phrase_variation_rank_1_sample_3`, objective flags `[]`, copied MIDI files `2`.
+- Issue #152 reviews that single focused package against solo/context MIDI notes and keeps it as `keep_for_focused_listening`.
+- Issue #152 result: the prior C6-to-G3 focused-context blocker is gone; remaining risks are repeated pitch-class cells, grid-derived timing, and chromatic color handling that needs real listening review.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -282,7 +285,7 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-이제 다음 단계는 register-safe proxy keep candidate focused context decision이다. Issue #150은 단일 후보 review artifact를 만들었지만, 이것은 focused context review 전까지 broad training 근거가 아니다.
+이제 다음 단계는 register-safe focused listening review notes다. Issue #152는 단일 후보를 focused listening review로 넘길 수 있다고 판단했지만, 이것은 실제 listening note가 채워지기 전까지 broad training 근거가 아니다.
 
 ## 6. 다음 단계 로드맵
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest completed: Issue #150, Stage B register-safe proxy-keep focused context package
-- 다음 권장 이슈: `Stage B register-safe proxy-keep focused context decision`
+- latest completed: Issue #152, Stage B register-safe proxy-keep focused context decision
+- 다음 권장 이슈: `Stage B register-safe focused listening review notes`
 
 현재 범위가 아닌 것:
 
@@ -39,7 +39,53 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
-## Latest Package Result
+## Latest Focused Context Decision
+
+Issue #152는 Issue #150 focused package의 단일 proxy `keep` 후보를 solo/context MIDI note 기준으로 다시 판단한 focused context decision이다.
+
+Docs:
+
+- `docs/STAGE_B_REGISTER_SAFE_FOCUSED_CONTEXT_DECISION_2026-05-27.md`
+
+중요한 전제:
+
+- 실제 오디오 청취 리뷰가 아니다.
+- `keep`은 focused listening review로 넘길 수 있다는 뜻이다.
+- broad training이나 style adaptation claim으로 해석하지 않는다.
+
+Result:
+
+- prior proxy decision: `keep`
+- focused context decision: `keep_for_focused_listening`
+- keep as diagnostic seed: `yes`
+- ready for broad training: `no`
+- ready for style adaptation claim: `no`
+
+Positive evidence:
+
+- candidate: `data_motif_rhythm_phrase_variation_rank_1_sample_3`
+- objective flags: `[]`
+- note count: `63`
+- unique pitch count: `18`
+- pitch range: `G3-G5`
+- final landing: `G4`
+- max interval: `4`
+- max active notes: `1`
+- off-sixteenth-grid count: `0`
+
+Remaining risk:
+
+- repeated 3-note pitch-class cells and one repeated 4-note pitch-class cell remain.
+- timing is still grid-derived.
+- chromatic color handling needs real context listening.
+
+Decision:
+
+- The prior C6-to-G3 focused-context blocker is no longer present.
+- The next boundary should create focused listening review notes for this one candidate.
+- Do not change generation rules again until that focused listening artifact is filled.
+
+## Previous Package Result
 
 Issue #150은 Issue #148에서 복구된 proxy `keep` 후보만 분리해 focused context review용 package로 묶은 작업이다.
 

--- a/docs/STAGE_B_REGISTER_SAFE_FOCUSED_CONTEXT_DECISION_2026-05-27.md
+++ b/docs/STAGE_B_REGISTER_SAFE_FOCUSED_CONTEXT_DECISION_2026-05-27.md
@@ -1,0 +1,121 @@
+# Stage B Register-Safe Proxy-Keep Focused Context Decision
+
+작성일: 2026-05-27
+
+## 목적
+
+Issue #152는 Issue #150 focused package의 단일 proxy `keep` 후보를 solo/context MIDI note 기준으로 다시 판단한 focused context decision이다.
+
+중요한 경계:
+
+- 실제 오디오 청취 리뷰가 아니다.
+- MIDI note, context chord guide, bass root guide, objective metrics 기준의 focused proxy decision이다.
+- `keep`은 focused listening review로 넘길 수 있다는 뜻이지, 최종 음악 품질 승인이나 broad training 준비 완료를 의미하지 않는다.
+
+## 입력
+
+Focused package:
+
+- `outputs/stage_b_focused_review_package/harness_stage_b_register_safe_proxy_keep_focused_package/focused_review_package.json`
+
+후보:
+
+- `data_motif_rhythm_phrase_variation_rank_1_sample_3`
+
+MIDI:
+
+- solo:
+  - `outputs/stage_b_focused_review_package/harness_stage_b_register_safe_proxy_keep_focused_package/midi/02_data_motif_rhythm_phrase_variation_rank_01_sample_03_overlap_free.mid`
+- context:
+  - `outputs/stage_b_focused_review_package/harness_stage_b_register_safe_proxy_keep_focused_package/context_midi/02_data_motif_rhythm_phrase_variation_rank_01_sample_03_overlap_free_with_context.mid`
+
+Context chord cycle:
+
+```text
+Cm7 | Fm7 | Bb7 | Ebmaj7 | Cm7 | Fm7 | Bb7 | Ebmaj7
+```
+
+## Positive Evidence
+
+The prior focused-context register blocker is repaired:
+
+- objective flags: `[]`
+- objective bucket: `clean`
+- max active notes: `1`
+- off-sixteenth-grid count: `0`
+- note count: `63`
+- unique pitch count: `18`
+- pitch range: `G3-G5`
+- final landing: `G4`
+- max interval: `4`
+- outside ratio: `0.000` in objective MIDI review
+- no duplicated 8-note pitch-class chunks in the solo note stream
+
+Bar-level MIDI-note role summary:
+
+| bar | chord | notes | chord tones | tensions | outside/approach colors |
+|---:|---|---:|---:|---:|---:|
+| 1 | `Cm7` | 9 | 6 | 2 | 1 |
+| 2 | `Fm7` | 8 | 5 | 3 | 0 |
+| 3 | `Bb7` | 8 | 4 | 2 | 2 |
+| 4 | `Ebmaj7` | 8 | 5 | 3 | 0 |
+| 5 | `Cm7` | 8 | 4 | 2 | 2 |
+| 6 | `Fm7` | 7 | 3 | 3 | 1 |
+| 7 | `Bb7` | 8 | 3 | 3 | 2 |
+| 8 | `Ebmaj7` | 7 | 5 | 1 | 1 |
+
+Context track check:
+
+- chord guide exists: `32` notes, range `C3-G#4`
+- bass root guide exists: `8` notes, range `C2-A#2`
+- solo track exists: `63` notes, range `G3-G5`
+
+## Remaining Risk
+
+Focused context decision keeps the candidate, but only as a listening-review candidate.
+
+Remaining blockers:
+
+- phrase vocabulary: repeated 3-note pitch-class cells remain, and one 4-note pitch-class cell repeats.
+- motif variation: unique pitch count is `18`, lower than the earlier Issue #136 proxy keep candidate.
+- timing: the line is still grid-derived; `timing=acceptable` means not blocked by proxy review, not that it has natural jazz timing.
+- chromatic color handling: the outside/approach colors are not objective flags, but they still need real context listening to decide whether they sound intentional.
+
+## Decision
+
+Focused context decision:
+
+| field | value |
+|---|---|
+| prior proxy decision | `keep` |
+| focused context decision | `keep_for_focused_listening` |
+| keep as diagnostic seed | `yes` |
+| ready for broad training | `no` |
+| ready for style adaptation claim | `no` |
+
+Issue #152 conclusion:
+
+- The prior C6-to-G3 focused-context blocker is no longer present.
+- The register-safe candidate is now good enough to move into a focused listening review artifact.
+- The candidate is still not proof of jazz quality, because motif/timing naturalness remains unresolved.
+
+Recommended next issue:
+
+```text
+Stage B register-safe focused listening review notes
+```
+
+Target:
+
+- create a one-candidate focused listening review notes artifact
+- include solo/context MIDI paths and focused context decision fields
+- record real-listening fields separately from MIDI-note proxy fields
+- avoid changing generation rules until the focused listening note is filled
+
+## 검증
+
+실행한 검증:
+
+```bash
+bash scripts/agent_harness.sh quick
+```


### PR DESCRIPTION
## Summary

- Document Issue #152 focused context MIDI-note decision for the register-safe proxy keep candidate.
- Keep `data_motif_rhythm_phrase_variation_rank_1_sample_3` only as `keep_for_focused_listening`, not as broad model-quality evidence.
- Update current/core planning docs with the focused listening review notes boundary.

## Validation

- `bash scripts/agent_harness.sh quick`

Closes #152