### PR TITLE
[codex] Stage B focused listening notes 추가

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -186,6 +186,7 @@ Stage B에서 명시하는 것:
 74. Stage B register-safe phrase vocabulary repaired proxy review
 75. Stage B register-safe proxy-keep focused context package
 76. Stage B register-safe proxy-keep focused context decision
+77. Stage B register-safe focused listening review notes
 
 가장 최근 의미 있는 결과:
 
@@ -267,6 +268,8 @@ Stage B에서 명시하는 것:
 - Issue #150 result: focused package `candidate_count=1`, selected candidate `data_motif_rhythm_phrase_variation_rank_1_sample_3`, objective flags `[]`, copied MIDI files `2`.
 - Issue #152 reviews that single focused package against solo/context MIDI notes and keeps it as `keep_for_focused_listening`.
 - Issue #152 result: the prior C6-to-G3 focused-context blocker is gone; remaining risks are repeated pitch-class cells, grid-derived timing, and chromatic color handling that needs real listening review.
+- Issue #154 creates a one-candidate focused listening review notes template from the focused package.
+- Issue #154 result: candidate count `1`, pending count `1`, proxy decision `keep`; real-listening fields remain pending and must be filled before another generation repair.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -285,7 +288,7 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-이제 다음 단계는 register-safe focused listening review notes다. Issue #152는 단일 후보를 focused listening review로 넘길 수 있다고 판단했지만, 이것은 실제 listening note가 채워지기 전까지 broad training 근거가 아니다.
+이제 다음 단계는 register-safe focused listening review fill이다. Issue #154는 notes template만 만들었고, 실제 listening note가 채워지기 전까지 broad training 또는 추가 generation repair 근거가 아니다.
 
 ## 6. 다음 단계 로드맵
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest completed: Issue #152, Stage B register-safe proxy-keep focused context decision
-- 다음 권장 이슈: `Stage B register-safe focused listening review notes`
+- latest completed: Issue #154, Stage B register-safe focused listening review notes
+- 다음 권장 이슈: `Stage B register-safe focused listening review fill`
 
 현재 범위가 아닌 것:
 
@@ -39,7 +39,39 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
-## Latest Focused Context Decision
+## Latest Focused Listening Notes Result
+
+Issue #154는 Issue #152에서 `keep_for_focused_listening`으로 판단한 단일 후보를 실제 청취용 review notes template으로 만든 작업이다.
+
+Docs:
+
+- `docs/STAGE_B_REGISTER_SAFE_FOCUSED_LISTENING_REVIEW_NOTES_2026-05-27.md`
+
+Result:
+
+- candidate count: `1`
+- reviewed count: `0`
+- pending count: `1`
+- generated template:
+  - `outputs/stage_b_focused_listening_review_notes/harness_stage_b_focused_listening_review_notes/focused_listening_review_notes_template.json`
+
+Candidate:
+
+- `data_motif_rhythm_phrase_variation_rank_1_sample_3`
+- proxy decision: `keep`
+- proxy timing: `acceptable`
+- note count: `63`
+- unique pitch count: `18`
+- source tension ratio: `0.349`
+- objective flags: `[]`
+
+Decision:
+
+- The one-candidate focused listening review template is ready.
+- The candidate remains pending until a real listening pass is filled.
+- No generation repair should start from this artifact alone.
+
+## Previous Focused Context Decision
 
 Issue #152는 Issue #150 focused package의 단일 proxy `keep` 후보를 solo/context MIDI note 기준으로 다시 판단한 focused context decision이다.
 

--- a/docs/STAGE_B_REGISTER_SAFE_FOCUSED_LISTENING_REVIEW_NOTES_2026-05-27.md
+++ b/docs/STAGE_B_REGISTER_SAFE_FOCUSED_LISTENING_REVIEW_NOTES_2026-05-27.md
@@ -1,0 +1,99 @@
+# Stage B Register-Safe Focused Listening Review Notes
+
+작성일: 2026-05-27
+
+## 목적
+
+Issue #154는 Issue #152에서 `keep_for_focused_listening`으로 판단한 단일 후보를 실제 청취용 review notes template으로 만든 작업이다.
+
+중요한 경계:
+
+- 이 단계는 generation rule을 바꾸지 않는다.
+- MIDI-note proxy decision과 실제 listening decision을 분리한다.
+- 다음 generation 수정은 focused listening note가 채워진 뒤에만 판단한다.
+
+## 구현
+
+추가:
+
+- `scripts/build_focused_listening_review_notes.py`
+- `tests/test_focused_listening_review_notes.py`
+- `bash scripts/agent_harness.sh stage-b-focused-listening-review-notes`
+
+입력:
+
+- `outputs/stage_b_focused_review_package/harness_stage_b_register_safe_proxy_keep_focused_package/focused_review_package.json`
+
+출력:
+
+- `outputs/stage_b_focused_listening_review_notes/harness_stage_b_focused_listening_review_notes/focused_listening_review_notes_template.json`
+- `outputs/stage_b_focused_listening_review_notes/harness_stage_b_focused_listening_review_notes/focused_listening_review_notes_summary.json`
+
+## Template Result
+
+Summary:
+
+| field | value |
+|---|---:|
+| candidate count | `1` |
+| reviewed count | `0` |
+| pending count | `1` |
+
+Candidate:
+
+| candidate | proxy decision | proxy timing | notes | unique | tension | objective flags |
+|---|---|---|---:|---:|---:|---|
+| `data_motif_rhythm_phrase_variation_rank_1_sample_3` | `keep` | `acceptable` | `63` | `18` | `0.349` | `[]` |
+
+The template preserves:
+
+- solo MIDI path
+- context MIDI path
+- source MIDI path
+- source metrics
+- proxy review decision and notes
+- objective flags and objective bucket
+- objective first 16 note summary
+- pending real-listening fields
+
+Real-listening fields:
+
+- `timing`
+- `chord_fit`
+- `phrase_continuation`
+- `landing`
+- `jazz_vocabulary`
+- `decision`
+- free-form `notes`
+
+## Decision
+
+Issue #154 conclusion:
+
+- The one-candidate focused listening review template is ready.
+- The candidate remains pending until a real listening pass is filled.
+- No generation repair should start from this artifact alone.
+
+Recommended next issue:
+
+```text
+Stage B register-safe focused listening review fill
+```
+
+Target:
+
+- listen to the solo/context MIDI pair
+- fill the real-listening fields in the generated notes template
+- decide whether the candidate remains `keep`, becomes `needs_followup`, or should be rejected
+- only then choose the next generation or evaluation boundary
+
+## 검증
+
+실행한 검증:
+
+```bash
+.venv/bin/python -m unittest tests.test_focused_listening_review_notes
+.venv/bin/python -m py_compile scripts/build_focused_listening_review_notes.py tests/test_focused_listening_review_notes.py
+bash scripts/agent_harness.sh stage-b-focused-listening-review-notes
+bash scripts/agent_harness.sh quick
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -96,6 +96,8 @@ Modes:
                 Diagnose objective-clean context MIDI candidates before subjective review.
   stage-b-clean-listening-review-notes
                 Build clean listening review notes template for 3 context candidates.
+  stage-b-focused-listening-review-notes
+                Build focused listening review notes template for a proxy-keep package.
   manifest-dry-run
                 Run audit -> manifest -> prepare_role_dataset smoke.
   chord-coverage-audit
@@ -169,6 +171,7 @@ run_quick() {
     scripts/evaluate_chord_labeled_subset.py \
     scripts/evaluate_generated_candidate_chords.py \
     scripts/build_listening_review_notes.py \
+    scripts/build_focused_listening_review_notes.py \
     scripts/summarize_listening_review_notes.py \
     scripts/build_focused_review_package.py \
     scripts/review_midi_note_objectives.py \
@@ -1198,6 +1201,20 @@ run_stage_b_clean_listening_review_notes() {
   "$PYTHON_BIN" scripts/build_clean_listening_review_notes.py     --run_id "$run_id"     --clean_package "$clean_package_path"     --clean_context_diagnostics "$diagnostics_path"
 }
 
+run_stage_b_focused_listening_review_notes() {
+  local focused_run_id="${FOCUSED_RUN_ID:-harness_stage_b_register_safe_proxy_keep_focused_package}"
+  local run_id="${RUN_ID:-harness_stage_b_focused_listening_review_notes}"
+  local focused_package_path="${FOCUSED_PACKAGE_PATH:-outputs/stage_b_focused_review_package/${focused_run_id}/focused_review_package.json}"
+  if [[ ! -f "$focused_package_path" ]]; then
+    printf 'Missing focused review package: %s\n' "$focused_package_path" >&2
+    return 2
+  fi
+  print_header "Stage B focused listening review notes"
+  "$PYTHON_BIN" scripts/build_focused_listening_review_notes.py \
+    --run_id "$run_id" \
+    --focused_package "$focused_package_path"
+}
+
 run_manifest_dry_run() {
   local run_id="${RUN_ID:-harness_manifest_prepare}"
   print_header "Manifest prepare dry-run"
@@ -1453,6 +1470,9 @@ case "$MODE" in
     ;;
   stage-b-clean-listening-review-notes)
     run_stage_b_clean_listening_review_notes
+    ;;
+  stage-b-focused-listening-review-notes)
+    run_stage_b_focused_listening_review_notes
     ;;
   manifest-dry-run)
     run_manifest_dry_run

--- a/scripts/build_focused_listening_review_notes.py
+++ b/scripts/build_focused_listening_review_notes.py
@@ -1,0 +1,206 @@
+"""Build focused listening review notes from a focused Stage B package."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SCHEMA_VERSION = "stage_b_focused_listening_review_notes_v1"
+
+TIMING_VALUES = {"pending", "strong", "acceptable", "stiff", "rushed", "dragging"}
+CHORD_FIT_VALUES = {"pending", "strong", "acceptable", "too_safe", "too_outside", "unclear"}
+PHRASE_CONTINUATION_VALUES = {"pending", "strong", "acceptable", "weak", "broken"}
+LANDING_VALUES = {"pending", "strong", "acceptable", "weak", "unresolved"}
+JAZZ_VOCABULARY_VALUES = {"pending", "strong", "acceptable", "thin", "exercise_like"}
+DECISION_VALUES = {"pending", "keep", "needs_followup", "reject"}
+
+
+class FocusedListeningReviewNotesError(ValueError):
+    pass
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _as_mapping(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _compact_source_metrics(metrics: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "note_count": int(metrics.get("note_count", 0) or 0),
+        "unique_pitch_count": int(metrics.get("unique_pitch_count", 0) or 0),
+        "chord_tone_ratio": float(metrics.get("chord_tone_ratio", 0.0) or 0.0),
+        "tension_ratio": float(metrics.get("tension_ratio", 0.0) or 0.0),
+        "outside_ratio": float(metrics.get("outside_ratio", 0.0) or 0.0),
+        "root_tone_ratio": float(metrics.get("root_tone_ratio", 0.0) or 0.0),
+        "dead_air_ratio": float(metrics.get("dead_air_ratio", 0.0) or 0.0),
+        "syncopated_onset_ratio": float(metrics.get("syncopated_onset_ratio", 0.0) or 0.0),
+        "unique_bar_position_pattern_ratio": float(metrics.get("unique_bar_position_pattern_ratio", 0.0) or 0.0),
+        "duration_diversity_ratio": float(metrics.get("duration_diversity_ratio", 0.0) or 0.0),
+        "most_common_duration_ratio": float(metrics.get("most_common_duration_ratio", 0.0) or 0.0),
+        "ioi_diversity_ratio": float(metrics.get("ioi_diversity_ratio", 0.0) or 0.0),
+        "most_common_ioi_ratio": float(metrics.get("most_common_ioi_ratio", 0.0) or 0.0),
+    }
+
+
+def build_candidate_note(candidate: dict[str, Any]) -> dict[str, Any]:
+    candidate_id = str(candidate.get("candidate_id") or "").strip()
+    if not candidate_id:
+        raise FocusedListeningReviewNotesError("focused package candidate_id is required")
+    files = _as_mapping(candidate.get("review_files"))
+    source_metrics = _compact_source_metrics(_as_mapping(candidate.get("source_metrics")))
+    proxy_review = _as_mapping(candidate.get("listening"))
+    objective_review = _as_mapping(candidate.get("objective_review"))
+    return {
+        "candidate_id": candidate_id,
+        "review_metadata": dict(_as_mapping(candidate.get("review_metadata"))),
+        "review_files": {
+            "midi_path": str(files.get("midi_path") or ""),
+            "context_midi_path": str(files.get("context_midi_path") or ""),
+            "source_midi_path": str(files.get("source_midi_path") or ""),
+        },
+        "source_metrics": source_metrics,
+        "proxy_review": {
+            "status": str(proxy_review.get("status") or ""),
+            "phrase_quality": str(proxy_review.get("phrase_quality") or ""),
+            "timing": str(proxy_review.get("timing") or ""),
+            "chord_fit": str(proxy_review.get("chord_fit") or ""),
+            "issues": list(proxy_review.get("issues") or []),
+            "decision": str(proxy_review.get("decision") or ""),
+            "notes": str(proxy_review.get("notes") or ""),
+            "objective_flags": list(objective_review.get("objective_flags") or []),
+            "objective_bucket": str(objective_review.get("objective_bucket") or ""),
+        },
+        "objective_first_16_notes": list(candidate.get("objective_first_16_notes") or []),
+        "listening": {
+            "status": "pending",
+            "timing": "pending",
+            "chord_fit": "pending",
+            "phrase_continuation": "pending",
+            "landing": "pending",
+            "jazz_vocabulary": "pending",
+            "decision": "pending",
+            "notes": "",
+        },
+    }
+
+
+def build_focused_listening_review_notes(focused_package: dict[str, Any]) -> dict[str, Any]:
+    candidates = focused_package.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise FocusedListeningReviewNotesError("focused package must contain non-empty candidates")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "source_focused_review_package": str(focused_package.get("output_dir") or ""),
+        "reviewer": "",
+        "review_context": {
+            "listen_with_context_midi": True,
+            "compare_solo_and_context": True,
+            "real_listening_fields_are_separate_from_proxy_review": True,
+            "focus": ["timing", "chord_fit", "phrase_continuation", "landing", "jazz_vocabulary"],
+        },
+        "candidates": [build_candidate_note(candidate) for candidate in candidates],
+    }
+
+
+def _require_enum(value: Any, allowed: set[str], path: str) -> None:
+    if value not in allowed:
+        raise FocusedListeningReviewNotesError(f"{path} must be one of {sorted(allowed)}")
+
+
+def validate_focused_listening_review_notes(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise FocusedListeningReviewNotesError(f"schema_version must be {SCHEMA_VERSION!r}")
+    candidates = payload.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise FocusedListeningReviewNotesError("candidates must be a non-empty list")
+    seen: set[str] = set()
+    reviewed_count = 0
+    decision_counts = {key: 0 for key in DECISION_VALUES}
+    for index, candidate in enumerate(candidates):
+        if not isinstance(candidate, dict):
+            raise FocusedListeningReviewNotesError(f"candidate {index} must be an object")
+        candidate_id = str(candidate.get("candidate_id") or "").strip()
+        if not candidate_id:
+            raise FocusedListeningReviewNotesError(f"candidate {index} candidate_id is required")
+        if candidate_id in seen:
+            raise FocusedListeningReviewNotesError(f"duplicate candidate_id: {candidate_id}")
+        seen.add(candidate_id)
+        files = _as_mapping(candidate.get("review_files"))
+        if not files.get("midi_path") or not files.get("context_midi_path"):
+            raise FocusedListeningReviewNotesError(f"{candidate_id}.review_files must include midi_path and context_midi_path")
+        proxy_review = candidate.get("proxy_review")
+        if not isinstance(proxy_review, dict):
+            raise FocusedListeningReviewNotesError(f"{candidate_id}.proxy_review must be an object")
+        listening = candidate.get("listening")
+        if not isinstance(listening, dict):
+            raise FocusedListeningReviewNotesError(f"{candidate_id}.listening must be an object")
+        _require_enum(listening.get("status"), {"pending", "reviewed"}, f"{candidate_id}.listening.status")
+        _require_enum(listening.get("timing"), TIMING_VALUES, f"{candidate_id}.listening.timing")
+        _require_enum(listening.get("chord_fit"), CHORD_FIT_VALUES, f"{candidate_id}.listening.chord_fit")
+        _require_enum(
+            listening.get("phrase_continuation"),
+            PHRASE_CONTINUATION_VALUES,
+            f"{candidate_id}.listening.phrase_continuation",
+        )
+        _require_enum(listening.get("landing"), LANDING_VALUES, f"{candidate_id}.listening.landing")
+        _require_enum(
+            listening.get("jazz_vocabulary"),
+            JAZZ_VOCABULARY_VALUES,
+            f"{candidate_id}.listening.jazz_vocabulary",
+        )
+        _require_enum(listening.get("decision"), DECISION_VALUES, f"{candidate_id}.listening.decision")
+        if listening.get("status") == "reviewed":
+            reviewed_count += 1
+        decision_counts[str(listening.get("decision"))] += 1
+    return {
+        "candidate_count": len(candidates),
+        "reviewed_count": reviewed_count,
+        "pending_count": len(candidates) - reviewed_count,
+        "decision_counts": decision_counts,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build Stage B focused listening review notes")
+    parser.add_argument("--focused_package", type=str, required=True)
+    parser.add_argument("--review_notes", type=str, default=None)
+    parser.add_argument("--output_root", type=str, default=str(ROOT_DIR / "outputs" / "stage_b_focused_listening_review_notes"))
+    parser.add_argument("--run_id", type=str, default=None)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    run_dir = Path(args.output_root) / run_id
+    if args.review_notes:
+        notes_path = Path(args.review_notes)
+        notes = read_json(notes_path)
+    else:
+        focused_package_path = Path(args.focused_package)
+        focused_package = read_json(focused_package_path)
+        focused_package["output_dir"] = str(focused_package_path.parent)
+        notes = build_focused_listening_review_notes(focused_package)
+        notes_path = run_dir / "focused_listening_review_notes_template.json"
+        write_json(notes_path, notes)
+    summary = validate_focused_listening_review_notes(notes)
+    write_json(run_dir / "focused_listening_review_notes_summary.json", summary)
+    print(json.dumps({**summary, "review_notes_path": str(notes_path)}, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_focused_listening_review_notes.py
+++ b/tests/test_focused_listening_review_notes.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.build_focused_listening_review_notes import (
+    FocusedListeningReviewNotesError,
+    build_focused_listening_review_notes,
+    validate_focused_listening_review_notes,
+)
+
+
+class FocusedListeningReviewNotesTest(unittest.TestCase):
+    def sample_focused_package(self) -> dict:
+        return {
+            "output_dir": "outputs/stage_b_focused_review_package/harness_stage_b_register_safe_proxy_keep_focused_package",
+            "candidates": [
+                {
+                    "candidate_id": "data_motif_rhythm_phrase_variation_rank_1_sample_3",
+                    "review_metadata": {"mode": "data_motif_rhythm_phrase_variation", "review_rank": 1},
+                    "review_files": {
+                        "midi_path": "outputs/focused/midi/a.mid",
+                        "context_midi_path": "outputs/focused/context/a_context.mid",
+                        "source_midi_path": "outputs/source/a.mid",
+                    },
+                    "source_metrics": {
+                        "note_count": 63,
+                        "unique_pitch_count": 18,
+                        "chord_tone_ratio": 0.0,
+                        "tension_ratio": 0.349,
+                        "outside_ratio": 0.0,
+                        "root_tone_ratio": 0.032,
+                        "dead_air_ratio": 0.629,
+                        "syncopated_onset_ratio": 0.667,
+                    },
+                    "listening": {
+                        "status": "reviewed",
+                        "phrase_quality": "phrase",
+                        "timing": "acceptable",
+                        "chord_fit": "fits",
+                        "issues": ["too_repetitive"],
+                        "decision": "keep",
+                        "notes": "Proxy keep only.",
+                    },
+                    "objective_review": {
+                        "objective_flags": [],
+                        "objective_bucket": "clean",
+                    },
+                    "objective_first_16_notes": [
+                        {"start_beats": 0.0, "duration_beats": 0.25, "pitch": 70, "pitch_name": "A#4"}
+                    ],
+                }
+            ],
+        }
+
+    def test_build_template_has_pending_real_listening_fields(self) -> None:
+        notes = build_focused_listening_review_notes(self.sample_focused_package())
+        candidate = notes["candidates"][0]
+
+        self.assertEqual(notes["schema_version"], "stage_b_focused_listening_review_notes_v1")
+        self.assertTrue(notes["review_context"]["real_listening_fields_are_separate_from_proxy_review"])
+        self.assertEqual(candidate["proxy_review"]["decision"], "keep")
+        self.assertEqual(candidate["listening"]["decision"], "pending")
+        self.assertEqual(candidate["listening"]["jazz_vocabulary"], "pending")
+
+    def test_build_template_carries_files_metrics_and_first_notes(self) -> None:
+        notes = build_focused_listening_review_notes(self.sample_focused_package())
+        candidate = notes["candidates"][0]
+
+        self.assertEqual(candidate["review_files"]["midi_path"], "outputs/focused/midi/a.mid")
+        self.assertEqual(candidate["review_files"]["context_midi_path"], "outputs/focused/context/a_context.mid")
+        self.assertEqual(candidate["source_metrics"]["note_count"], 63)
+        self.assertEqual(candidate["source_metrics"]["unique_pitch_count"], 18)
+        self.assertEqual(candidate["source_metrics"]["tension_ratio"], 0.349)
+        self.assertEqual(candidate["objective_first_16_notes"][0]["pitch_name"], "A#4")
+
+    def test_validate_counts_pending_candidate(self) -> None:
+        notes = build_focused_listening_review_notes(self.sample_focused_package())
+
+        summary = validate_focused_listening_review_notes(notes)
+
+        self.assertEqual(summary["candidate_count"], 1)
+        self.assertEqual(summary["pending_count"], 1)
+        self.assertEqual(summary["decision_counts"]["pending"], 1)
+
+    def test_validate_accepts_reviewed_candidate(self) -> None:
+        notes = build_focused_listening_review_notes(self.sample_focused_package())
+        notes["candidates"][0]["listening"].update(
+            {
+                "status": "reviewed",
+                "timing": "acceptable",
+                "chord_fit": "acceptable",
+                "phrase_continuation": "acceptable",
+                "landing": "strong",
+                "jazz_vocabulary": "thin",
+                "decision": "needs_followup",
+            }
+        )
+
+        summary = validate_focused_listening_review_notes(notes)
+
+        self.assertEqual(summary["reviewed_count"], 1)
+        self.assertEqual(summary["decision_counts"]["needs_followup"], 1)
+
+    def test_validate_requires_context_midi_path(self) -> None:
+        notes = build_focused_listening_review_notes(self.sample_focused_package())
+        notes["candidates"][0]["review_files"]["context_midi_path"] = ""
+
+        with self.assertRaises(FocusedListeningReviewNotesError):
+            validate_focused_listening_review_notes(notes)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add a focused listening review notes builder for single-candidate focused packages.
- Preserve solo/context MIDI paths, source metrics, proxy review fields, objective flags, and first-note summaries while keeping real-listening fields pending.
- Add a `stage-b-focused-listening-review-notes` harness mode and document Issue #154 status.

## Validation

- `.venv/bin/python -m unittest tests.test_focused_listening_review_notes`
- `.venv/bin/python -m py_compile scripts/build_focused_listening_review_notes.py tests/test_focused_listening_review_notes.py`
- `bash scripts/agent_harness.sh stage-b-focused-listening-review-notes`
- `bash scripts/agent_harness.sh quick`

Closes #154