### PR TITLE
[codex] Stage B focused listening fill 기록

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -187,6 +187,7 @@ Stage B에서 명시하는 것:
 75. Stage B register-safe proxy-keep focused context package
 76. Stage B register-safe proxy-keep focused context decision
 77. Stage B register-safe focused listening review notes
+78. Stage B register-safe focused listening review fill
 
 가장 최근 의미 있는 결과:
 
@@ -270,6 +271,8 @@ Stage B에서 명시하는 것:
 - Issue #152 result: the prior C6-to-G3 focused-context blocker is gone; remaining risks are repeated pitch-class cells, grid-derived timing, and chromatic color handling that needs real listening review.
 - Issue #154 creates a one-candidate focused listening review notes template from the focused package.
 - Issue #154 result: candidate count `1`, pending count `1`, proxy decision `keep`; real-listening fields remain pending and must be filled before another generation repair.
+- Issue #156 fills that focused review template by Codex MIDI-focused review and downgrades the candidate to `needs_followup`.
+- Issue #156 result: timing `stiff`, chord fit `acceptable`, phrase continuation `weak`, landing `acceptable`, jazz vocabulary `thin`; next repair should target timing stiffness, motif variation, and phrase vocabulary while keeping the register-safe final cadence guardrail.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -288,7 +291,7 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-이제 다음 단계는 register-safe focused listening review fill이다. Issue #154는 notes template만 만들었고, 실제 listening note가 채워지기 전까지 broad training 또는 추가 generation repair 근거가 아니다.
+이제 다음 단계는 register-safe timing motif follow-up repair다. Issue #156은 후보를 최종 keep으로 올리지 않았고, 다음 repair는 timing stiffness와 repeated phrase cells를 좁게 겨냥해야 한다.
 
 ## 6. 다음 단계 로드맵
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest completed: Issue #154, Stage B register-safe focused listening review notes
-- 다음 권장 이슈: `Stage B register-safe focused listening review fill`
+- latest completed: Issue #156, Stage B register-safe focused listening review fill
+- 다음 권장 이슈: `Stage B register-safe timing motif follow-up repair`
 
 현재 범위가 아닌 것:
 
@@ -39,7 +39,47 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
-## Latest Focused Listening Notes Result
+## Latest Focused Listening Fill Result
+
+Issue #156은 Issue #154 focused listening review notes template을 Codex MIDI-focused review 기준으로 채운 작업이다.
+
+Docs:
+
+- `docs/STAGE_B_REGISTER_SAFE_FOCUSED_LISTENING_FILL_2026-05-27.md`
+
+중요한 전제:
+
+- 실제 오디오 청취 리뷰가 아니다.
+- MIDI note sequence, solo/context MIDI path, chord/bass guide context, objective metrics를 근거로 채운 focused review다.
+- broad training이나 style adaptation claim으로 해석하지 않는다.
+
+Result:
+
+- candidate count: `1`
+- reviewed count: `1`
+- pending count: `0`
+- decision:
+  - `keep`: `0`
+  - `needs_followup`: `1`
+  - `reject`: `0`
+
+Candidate:
+
+- `data_motif_rhythm_phrase_variation_rank_1_sample_3`
+- timing: `stiff`
+- chord fit: `acceptable`
+- phrase continuation: `weak`
+- landing: `acceptable`
+- jazz vocabulary: `thin`
+- decision: `needs_followup`
+
+Decision:
+
+- Do not promote the candidate to final `keep`.
+- Keep the register-safe repair and final cadence guardrail.
+- Next work should target timing stiffness, motif variation, and phrase vocabulary without reopening the C6-to-G3 register blocker.
+
+## Previous Focused Listening Notes Result
 
 Issue #154는 Issue #152에서 `keep_for_focused_listening`으로 판단한 단일 후보를 실제 청취용 review notes template으로 만든 작업이다.
 

--- a/docs/STAGE_B_REGISTER_SAFE_FOCUSED_LISTENING_FILL_2026-05-27.md
+++ b/docs/STAGE_B_REGISTER_SAFE_FOCUSED_LISTENING_FILL_2026-05-27.md
@@ -1,0 +1,106 @@
+# Stage B Register-Safe Focused Listening Review Fill
+
+작성일: 2026-05-27
+
+## 목적
+
+Issue #156은 Issue #154 focused listening review notes template을 Codex MIDI-focused review 기준으로 채운 작업이다.
+
+중요한 경계:
+
+- 실제 오디오 청취 리뷰가 아니다.
+- 사용자가 Codex의 MIDI note/context 판단으로 진행하도록 승인했기 때문에, MIDI note sequence, solo/context MIDI path, chord/bass guide context, objective metrics를 근거로 채웠다.
+- 이 결과는 broad training이나 Brad style adaptation 성공 근거가 아니다.
+
+## 입력
+
+Review notes template:
+
+- `outputs/stage_b_focused_listening_review_notes/harness_stage_b_focused_listening_review_notes/focused_listening_review_notes_template.json`
+
+Focused package:
+
+- `outputs/stage_b_focused_review_package/harness_stage_b_register_safe_proxy_keep_focused_package/focused_review_package.json`
+
+Filled review notes:
+
+- `outputs/stage_b_focused_listening_review_notes/harness_stage_b_register_safe_focused_codex_fill/focused_listening_review_notes_codex_midi_fill.json`
+
+## Review Result
+
+Summary:
+
+| field | value |
+|---|---:|
+| candidate count | `1` |
+| reviewed count | `1` |
+| pending count | `0` |
+| keep | `0` |
+| needs_followup | `1` |
+| reject | `0` |
+
+Candidate decision:
+
+| candidate | timing | chord fit | phrase continuation | landing | jazz vocabulary | decision |
+|---|---|---|---|---|---|---|
+| `data_motif_rhythm_phrase_variation_rank_1_sample_3` | `stiff` | `acceptable` | `weak` | `acceptable` | `thin` | `needs_followup` |
+
+## 판단 근거
+
+Positive evidence:
+
+- prior register blocker is repaired
+- pitch range stays in `G3-G5`
+- final landing is `G4`
+- objective flags: `[]`
+- max active notes: `1`
+- off-sixteenth-grid count: `0`
+- context MIDI has solo/chord guide/bass guide tracks
+
+Blocking evidence:
+
+- timing still reads as grid-derived rather than natural jazz phrasing
+- repeated pitch-class cells remain
+- unique pitch count is `18`, thin for an 8-bar line
+- phrase continuation is usable as a diagnostic seed but not strong enough for a keep
+- jazz vocabulary still feels like bounded chord-tone/tension enumeration
+
+## Decision
+
+Focused listening review fill:
+
+| field | value |
+|---|---|
+| prior proxy decision | `keep` |
+| Codex MIDI-focused decision | `needs_followup` |
+| keep as diagnostic seed | `yes` |
+| ready for broad training | `no` |
+| ready for style adaptation claim | `no` |
+
+Issue #156 conclusion:
+
+- Do not promote the candidate to final `keep`.
+- Keep the register-safe repair and final cadence guardrail.
+- Next work should target timing stiffness, motif variation, and phrase vocabulary without reopening the C6-to-G3 register blocker.
+
+Recommended next issue:
+
+```text
+Stage B register-safe timing motif follow-up repair
+```
+
+Target:
+
+- reduce grid-stiff timing while keeping overlap-free/objective-clean output
+- strengthen motif variation beyond repeated pitch-class cells
+- widen phrase vocabulary without breaking register-safe bounds
+- preserve final `G4`-style right-hand landing behavior
+
+## 검증
+
+실행한 검증:
+
+```bash
+.venv/bin/python scripts/build_focused_listening_review_notes.py --focused_package outputs/stage_b_focused_review_package/harness_stage_b_register_safe_proxy_keep_focused_package/focused_review_package.json --run_id harness_stage_b_register_safe_focused_codex_fill --review_notes outputs/stage_b_focused_listening_review_notes/harness_stage_b_register_safe_focused_codex_fill/focused_listening_review_notes_codex_midi_fill.json
+bash scripts/agent_harness.sh quick
+```


### PR DESCRIPTION
## Summary

- Fill the focused review decision from Codex MIDI note/context analysis.
- Downgrade the register-safe proxy keep candidate to `needs_followup` instead of final keep.
- Update current/core planning docs with the next timing/motif follow-up repair boundary.

## Validation

- `.venv/bin/python scripts/build_focused_listening_review_notes.py --focused_package outputs/stage_b_focused_review_package/harness_stage_b_register_safe_proxy_keep_focused_package/focused_review_package.json --run_id harness_stage_b_register_safe_focused_codex_fill --review_notes outputs/stage_b_focused_listening_review_notes/harness_stage_b_register_safe_focused_codex_fill/focused_listening_review_notes_codex_midi_fill.json`
- `bash scripts/agent_harness.sh quick`

Closes #156