### PR TITLE
[codex] Stage B register-safe timing motif follow-up repair

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -188,6 +188,7 @@ Stage B에서 명시하는 것:
 76. Stage B register-safe proxy-keep focused context decision
 77. Stage B register-safe focused listening review notes
 78. Stage B register-safe focused listening review fill
+79. Stage B register-safe timing motif follow-up repair
 
 가장 최근 의미 있는 결과:
 
@@ -273,6 +274,9 @@ Stage B에서 명시하는 것:
 - Issue #154 result: candidate count `1`, pending count `1`, proxy decision `keep`; real-listening fields remain pending and must be filled before another generation repair.
 - Issue #156 fills that focused review template by Codex MIDI-focused review and downgrades the candidate to `needs_followup`.
 - Issue #156 result: timing `stiff`, chord fit `acceptable`, phrase continuation `weak`, landing `acceptable`, jazz vocabulary `thin`; next repair should target timing stiffness, motif variation, and phrase vocabulary while keeping the register-safe final cadence guardrail.
+- Issue #158 adds a partial register-safe timing/motif follow-up repair by widening recent phrase memory from `6` to `8` notes and repeated cell penalty lookback from `18` to `32`.
+- Issue #158 result: variation strict `3/3`, final landing `3/3`, max interval `4`, objective MIDI flags `{}`, avg IOI diversity `0.091`, avg most-common IOI `0.385`, avg tension `0.358`, avg root-tone `0.021`.
+- Issue #158 keeps the motif guard but does not claim the timing blocker is solved; asymmetric timing-position changes were excluded because they worsened the metrics.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -291,7 +295,7 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-이제 다음 단계는 register-safe timing motif follow-up repair다. Issue #156은 후보를 최종 keep으로 올리지 않았고, 다음 repair는 timing stiffness와 repeated phrase cells를 좁게 겨냥해야 한다.
+이제 다음 단계는 register-safe timing motif repaired proxy review다. Issue #158은 strict/objective-clean guardrail을 유지했지만 timing stiffness를 해결했다고 보지 않으므로, fresh MIDI-note/context proxy review로 partial motif guard를 keep할지 판단해야 한다.
 
 ## 6. 다음 단계 로드맵
 
@@ -817,37 +821,36 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B phrase-shape tension repaired MIDI-note proxy review
+Stage B register-safe timing motif follow-up repair
 ```
 
 결과:
 
-- docs: `docs/STAGE_B_PHRASE_SHAPE_TENSION_PROXY_REVIEW_2026-05-25.md`
-- review notes: `outputs/stage_b_listening_review_notes/harness_stage_b_phrase_shape_tension_codex_proxy/phrase_shape_tension_repaired_review_notes_codex_midi_proxy.json`
-- aggregate: `outputs/stage_b_listening_review_aggregate/harness_stage_b_phrase_shape_tension_codex_proxy/listening_review_aggregate.md`
-- reviewed candidates: `6`
-- pending candidates: `0`
-- decisions:
-  - `keep`: `1`
-  - `needs_followup`: `5`
-  - `reject`: `0`
-- proxy keep candidate:
-  - `data_motif_rhythm_phrase_variation_rank_1_sample_3`
-  - objective flags: `{}`
-  - note count: `63`
-  - unique pitch count: `28`
-  - max interval: `4`
-  - objective MIDI tension ratio: `0.540`
+- docs: `docs/STAGE_B_REGISTER_SAFE_TIMING_MOTIF_REPAIR_2026-05-27.md`
+- changed: register-safe recent phrase memory `6 -> 8`
+- changed: repeated cell penalty lookback `18 -> 32`
+- variation strict candidates: `3/3`
+- final landing resolved: `3/3`
+- max interval: `4`
+- objective MIDI flags: `{}`
+- avg IOI diversity: `0.091`
+- avg most-common IOI ratio: `0.385`
+- avg tension ratio: `0.358`
+- avg root-tone ratio: `0.021`
 
-당시 다음 작업:
+판단:
 
-- 다음 issue는 `Stage B proxy-keep rhythm candidate focused review package`로 잡는다.
-- proxy keep candidate와 context MIDI만 별도 package로 격리한다.
-- objective metrics와 first-note summary를 같이 보존한다.
-- real listening 전까지 final musical quality를 주장하지 않는다.
+- register-safe final cadence guardrail은 유지됐다.
+- phrase-cell repetition guard는 부분 개선으로 남긴다.
+- asymmetric timing-position variation은 지표를 악화시켜 제외했다.
+- timing stiffness는 아직 해결됐다고 보지 않는다.
+
+다음 작업:
+
+- 다음 issue는 `Stage B register-safe timing motif repaired proxy review`로 잡는다.
+- repaired candidate set을 MIDI-note/context 기준으로 fresh proxy review한다.
+- partial motif guard를 keep할지, data-derived timing phrase vocabulary로 넘어갈지 결정한다.
 - objective clean 후보라도 broad training으로 넘어가지 않는다.
-- real Brad/reference chord label은 아직 임의로 넣지 않는다.
-- LMDM/audio diffusion은 장기 live instrument reference로만 남기고, 현재 MVP를 audio로 pivot하지 않는다.
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest completed: Issue #156, Stage B register-safe focused listening review fill
-- 다음 권장 이슈: `Stage B register-safe timing motif follow-up repair`
+- latest completed: Issue #158, Stage B register-safe timing motif follow-up repair
+- 다음 권장 이슈: `Stage B register-safe timing motif repaired proxy review`
 
 현재 범위가 아닌 것:
 
@@ -38,6 +38,42 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 - sparse/medium 일부에서 chord-tone 반응이 약함
 
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
+
+## Latest Timing Motif Repair Result
+
+Issue #158은 Issue #156 focused listening fill에서 나온 timing stiffness, repeated pitch-class cell, thin vocabulary blocker를 generation rule 쪽에서 좁게 다시 본 작업이다.
+
+Docs:
+
+- `docs/STAGE_B_REGISTER_SAFE_TIMING_MOTIF_REPAIR_2026-05-27.md`
+
+변경:
+
+- recent phrase memory를 최근 `6`음에서 `8`음으로 확장했다.
+- repeated pitch-class cell penalty lookback을 `18`에서 `32`로 확장했다.
+- repeated 3-note/4-note pitch-class cell과 exact 4-note cell penalty를 강화했다.
+- asymmetric timing-position variation은 지표가 악화되어 최종 변경에서 제외했다.
+
+Result:
+
+- `data_motif_rhythm_phrase_variation` valid: `3/3`
+- strict: `3/3`
+- final landing resolved: `3/3`
+- max interval: `4`
+- objective MIDI flags: `{}`
+- avg syncopated onset ratio: `0.684`
+- avg unique bar-position pattern ratio: `0.958`
+- avg IOI diversity ratio: `0.091`
+- avg most-common IOI ratio: `0.385`
+- avg tension ratio: `0.358`
+- avg root-tone ratio: `0.021`
+
+Decision:
+
+- register-safe final cadence guardrail은 유지됐다.
+- phrase-cell repetition guard는 부분 개선으로 남긴다.
+- timing stiffness는 해결됐다고 보지 않는다.
+- 다음은 repaired candidate set을 fresh proxy review로 다시 판단한다.
 
 ## Latest Focused Listening Fill Result
 

--- a/docs/STAGE_B_REGISTER_SAFE_TIMING_MOTIF_REPAIR_2026-05-27.md
+++ b/docs/STAGE_B_REGISTER_SAFE_TIMING_MOTIF_REPAIR_2026-05-27.md
@@ -1,0 +1,137 @@
+# Stage B Register-Safe Timing Motif Follow-Up Repair
+
+작성일: 2026-05-27
+
+## Summary
+
+Issue #158은 Issue #156 focused listening fill에서 남은 blocker를 generation rule 쪽에서 좁게 다시 본 작업이다.
+
+Issue #156 판단:
+
+- timing: `stiff`
+- chord fit: `acceptable`
+- phrase continuation: `weak`
+- landing: `acceptable`
+- jazz vocabulary: `thin`
+- decision: `needs_followup`
+
+이번 목표는 register-safe final cadence guardrail을 유지하면서 repeated pitch-class cell과 boxed-in phrase vocabulary를 줄이는 것이다.
+
+중요한 경계:
+
+- 이 결과는 실제 오디오 청취 리뷰가 아니다.
+- MIDI note/context metric과 generated note sequence 기준의 objective repair다.
+- broad training, Brad style adaptation, product MVP 성공 근거로 해석하지 않는다.
+
+## Implementation
+
+변경 대상:
+
+- `scripts/run_stage_b_data_motif_generation_compare.py`
+- `tests/test_stage_b_data_motif_generation_compare.py`
+
+남긴 변경:
+
+- `register_safe_phrase_pitch_classes(...)`
+  - recent phrase memory를 최근 `6`음에서 `8`음으로 확장했다.
+  - development role에서 fresh pitch-class를 더 자주 앞으로 보내 repeated pitch-class cell을 덜 고르게 했다.
+- `register_safe_phrase_cell_penalty(...)`
+  - repeated cell lookback을 `18`에서 `32`로 확장했다.
+  - 최근 4음 pitch class 반복, repeated 3-note cell, repeated 4-note cell, exact 4-note cell penalty를 강화했다.
+
+제외한 변경:
+
+- asymmetric timing-position variation을 시도했지만 IOI diversity와 repetition metric이 악화되어 최종 변경에서 제외했다.
+- 따라서 이번 repair는 timing을 해결했다고 보지 않는다.
+- 최종 변경은 motif/pitch-cell repetition을 줄이는 guard에 한정한다.
+
+보존한 guardrail:
+
+- focused-context register bounds
+- max variation interval: `4`
+- final cadence landing: guide/chord tone
+- overlap-free solo-line review export
+- objective MIDI flags: `{}`
+
+## Harness Result
+
+Command:
+
+```bash
+bash scripts/agent_harness.sh stage-b-rhythm-phrase-variation
+```
+
+`data_motif_rhythm_phrase_variation` summary:
+
+| metric | value |
+|---|---:|
+| valid | `3/3` |
+| strict | `3/3` |
+| final landing resolved | `3/3` |
+| max abs interval | `4` |
+| avg syncopated onset ratio | `0.684` |
+| avg unique bar-position pattern ratio | `0.958` |
+| avg duration diversity ratio | `0.079` |
+| avg most-common duration ratio | `0.384` |
+| avg IOI diversity ratio | `0.091` |
+| avg most-common IOI ratio | `0.385` |
+| avg tension ratio | `0.358` |
+| avg root-tone ratio | `0.021` |
+| objective MIDI flag counts | `{}` |
+
+Top variation candidates:
+
+| candidate | notes | unique pitches | sync | bar-var | dur-var | ioi-var | ioi-rep | tension | max interval | landing |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| `data_motif_rhythm_phrase_variation_rank_1_sample_3` | 63 | 18 | 0.667 | 1.000 | 0.079 | 0.097 | 0.371 | 0.381 | 4 | guide |
+| `data_motif_rhythm_phrase_variation_rank_2_sample_1` | 63 | 17 | 0.683 | 1.000 | 0.079 | 0.097 | 0.419 | 0.349 | 4 | guide |
+| `data_motif_rhythm_phrase_variation_rank_3_sample_2` | 64 | 19 | 0.703 | 0.875 | 0.078 | 0.079 | 0.365 | 0.344 | 4 | guide |
+
+Objective MIDI note review for variation candidates:
+
+| candidate | objective bucket | flags | note count | unique pitches | tension | outside |
+|---|---|---|---:|---:|---:|---:|
+| `data_motif_rhythm_phrase_variation_rank_1_sample_3` | `clean` | `[]` | 63 | 18 | 0.492 | 0.000 |
+| `data_motif_rhythm_phrase_variation_rank_2_sample_1` | `clean` | `[]` | 63 | 17 | 0.476 | 0.000 |
+| `data_motif_rhythm_phrase_variation_rank_3_sample_2` | `clean` | `[]` | 64 | 19 | 0.453 | 0.031 |
+
+## Interpretation
+
+Improved or preserved:
+
+- strict/objective-clean status is preserved.
+- final guide/chord landing stays resolved for all variation samples.
+- max interval remains bounded at `4`.
+- root-tone ratio remains low.
+- the top candidate keeps the focused-context register-safe landing behavior.
+
+Still blocking:
+
+- timing stiffness is not solved.
+- repeated pitch-class cells still remain at the phrase level.
+- unique pitch count is still thin for an 8-bar line.
+- this should not be promoted to a final `keep` without a fresh proxy/listening review.
+
+Issue #158 conclusion:
+
+- keep the register-safe phrase-cell penalty repair as a partial motif guard.
+- do not claim the timing blocker is fixed.
+- run a fresh proxy review of the repaired candidates before deciding whether this repair is musically better.
+
+## Next Recommended Issue
+
+```text
+Stage B register-safe timing motif repaired proxy review
+```
+
+The next issue should fill MIDI-note/context proxy review notes for the repaired candidates and decide whether the partial motif guard is worth keeping, or whether a data-derived timing phrase vocabulary approach is needed.
+
+## Validation
+
+Executed:
+
+```bash
+.venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare
+bash scripts/agent_harness.sh stage-b-rhythm-phrase-variation
+bash scripts/agent_harness.sh quick
+```

--- a/scripts/run_stage_b_data_motif_generation_compare.py
+++ b/scripts/run_stage_b_data_motif_generation_compare.py
@@ -473,16 +473,16 @@ def register_safe_phrase_pitch_classes(
         return ordered
 
     recent_short = {int(pitch) % 12 for pitch in recent_pitches[-2:]}
-    recent_phrase = {int(pitch) % 12 for pitch in recent_pitches[-6:]}
+    recent_phrase = {int(pitch) % 12 for pitch in recent_pitches[-8:]}
     development_role = (
         int(bar_index) * 3
         + int(motif_index) * 5
         + int(local_index)
         + int(variation_index)
     ) % 6
-    if development_role in {1, 3, 5}:
+    if development_role in {0, 1, 3, 5}:
         fresh = [pitch_class for pitch_class in ordered if pitch_class not in recent_phrase]
-    elif development_role == 4:
+    elif development_role in {2, 4}:
         fresh = [pitch_class for pitch_class in ordered if pitch_class not in recent_short]
     else:
         fresh = []
@@ -1139,28 +1139,29 @@ def register_safe_phrase_cell_penalty(candidate_pitch: int, recent_pitches: Sequ
     candidate_class = candidate % 12
     penalty = 0
 
-    if candidate_class in set(recent_classes[-3:]):
-        penalty += 1
+    lookback = 32
+    if candidate_class in set(recent_classes[-4:]):
+        penalty += 2
     if len(recent_classes) >= 2:
         phrase_cells = {
             tuple(recent_classes[index : index + 3])
-            for index in range(max(0, len(recent_classes) - 18), len(recent_classes) - 2)
+            for index in range(max(0, len(recent_classes) - lookback), len(recent_classes) - 2)
         }
         if tuple(recent_classes[-2:] + [candidate_class]) in phrase_cells:
-            penalty += 3
+            penalty += 6
     if len(recent_classes) >= 3:
         phrase_cells = {
             tuple(recent_classes[index : index + 4])
-            for index in range(max(0, len(recent_classes) - 18), len(recent_classes) - 3)
+            for index in range(max(0, len(recent_classes) - lookback), len(recent_classes) - 3)
         }
         if tuple(recent_classes[-3:] + [candidate_class]) in phrase_cells:
-            penalty += 5
+            penalty += 10
         exact_cells = {
             tuple(recent[index : index + 4])
-            for index in range(max(0, len(recent) - 18), len(recent) - 3)
+            for index in range(max(0, len(recent) - lookback), len(recent) - 3)
         }
         if tuple(recent[-3:] + [candidate]) in exact_cells:
-            penalty += 7
+            penalty += 12
     return penalty
 
 

--- a/tests/test_stage_b_data_motif_generation_compare.py
+++ b/tests/test_stage_b_data_motif_generation_compare.py
@@ -305,6 +305,13 @@ class StageBDataMotifGenerationCompareTest(unittest.TestCase):
 
         self.assertGreater(repeated, fresh)
 
+    def test_register_safe_phrase_cell_penalty_uses_longer_phrase_memory(self) -> None:
+        recent = [60, 62, 64] + [65, 67, 69, 70, 72, 74, 76, 77, 79, 81] * 2 + [60, 62]
+        repeated = register_safe_phrase_cell_penalty(64, recent)
+        fresh = register_safe_phrase_cell_penalty(66, recent)
+
+        self.assertGreater(repeated, fresh)
+
     def test_focused_context_register_bounds_lifts_final_cadence_range(self) -> None:
         early_min, early_max = focused_context_register_bounds(1, 8, min_pitch=48, max_pitch=84)
         final_min, final_max = focused_context_register_bounds(7, 8, min_pitch=48, max_pitch=84)


### PR DESCRIPTION
## Summary

- Extend register-safe phrase memory and repeated pitch-class cell penalty for the Stage B rhythm phrase variation path.
- Preserve register-safe cadence guardrails while documenting that this is only a partial motif repair, not a timing-success claim.
- Update current status/core plan with Issue #158 results and next proxy review boundary.

Fixes #158

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare`
- `bash scripts/agent_harness.sh stage-b-rhythm-phrase-variation`
- `bash scripts/agent_harness.sh quick`