### PR TITLE
[codex] Stage B timing motif repaired proxy review

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -189,6 +189,7 @@ Stage B에서 명시하는 것:
 77. Stage B register-safe focused listening review notes
 78. Stage B register-safe focused listening review fill
 79. Stage B register-safe timing motif follow-up repair
+80. Stage B register-safe timing motif repaired proxy review
 
 가장 최근 의미 있는 결과:
 
@@ -277,6 +278,9 @@ Stage B에서 명시하는 것:
 - Issue #158 adds a partial register-safe timing/motif follow-up repair by widening recent phrase memory from `6` to `8` notes and repeated cell penalty lookback from `18` to `32`.
 - Issue #158 result: variation strict `3/3`, final landing `3/3`, max interval `4`, objective MIDI flags `{}`, avg IOI diversity `0.091`, avg most-common IOI `0.385`, avg tension `0.358`, avg root-tone `0.021`.
 - Issue #158 keeps the motif guard but does not claim the timing blocker is solved; asymmetric timing-position changes were excluded because they worsened the metrics.
+- Issue #160 fills MIDI-note/context proxy review notes for the Issue #158 repaired candidates.
+- Issue #160 result: `reviewed=6`, `keep=0`, `needs_followup=5`, `reject=1`, timing `too_stiff=6`, objective bucket `clean=6`, objective flags `{}`.
+- Issue #160 aggregate result: `improve_phrase_vocabulary=16`, `fix_timing_grid=12`, `increase_motif_variation=3`; next generation work should use data-derived timing/phrase vocabulary instead of another local penalty tweak.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -295,7 +299,7 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-이제 다음 단계는 register-safe timing motif repaired proxy review다. Issue #158은 strict/objective-clean guardrail을 유지했지만 timing stiffness를 해결했다고 보지 않으므로, fresh MIDI-note/context proxy review로 partial motif guard를 keep할지 판단해야 한다.
+이제 다음 단계는 data-derived timing phrase vocabulary repair다. Issue #160은 repaired 후보를 proxy keep으로 올리지 않았고, timing/phrase vocabulary 문제가 여전히 우선순위임을 확인했다.
 
 ## 6. 다음 단계 로드맵
 
@@ -821,35 +825,38 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B register-safe timing motif follow-up repair
+Stage B register-safe timing motif repaired proxy review
 ```
 
 결과:
 
-- docs: `docs/STAGE_B_REGISTER_SAFE_TIMING_MOTIF_REPAIR_2026-05-27.md`
-- changed: register-safe recent phrase memory `6 -> 8`
-- changed: repeated cell penalty lookback `18 -> 32`
-- variation strict candidates: `3/3`
-- final landing resolved: `3/3`
-- max interval: `4`
-- objective MIDI flags: `{}`
-- avg IOI diversity: `0.091`
-- avg most-common IOI ratio: `0.385`
-- avg tension ratio: `0.358`
-- avg root-tone ratio: `0.021`
+- docs: `docs/STAGE_B_REGISTER_SAFE_TIMING_MOTIF_REPAIRED_PROXY_REVIEW_2026-05-27.md`
+- reviewed candidates: `6`
+- pending candidates: `0`
+- decisions:
+  - `keep`: `0`
+  - `needs_followup`: `5`
+  - `reject`: `1`
+- timing: `too_stiff=6`
+- chord fit: `fits=6`
+- objective bucket: `clean=6`
+- objective flags: `{}`
+- aggregate:
+  - `improve_phrase_vocabulary=16`
+  - `fix_timing_grid=12`
+  - `increase_motif_variation=3`
 
 판단:
 
-- register-safe final cadence guardrail은 유지됐다.
-- phrase-cell repetition guard는 부분 개선으로 남긴다.
-- asymmetric timing-position variation은 지표를 악화시켜 제외했다.
-- timing stiffness는 아직 해결됐다고 보지 않는다.
+- Issue #158의 register-safe phrase-cell penalty guard는 partial safety improvement로 남긴다.
+- repaired 후보를 proxy `keep`으로 올리지는 않는다.
+- timing stiffness와 phrase vocabulary는 여전히 blocker다.
 
 다음 작업:
 
-- 다음 issue는 `Stage B register-safe timing motif repaired proxy review`로 잡는다.
-- repaired candidate set을 MIDI-note/context 기준으로 fresh proxy review한다.
-- partial motif guard를 keep할지, data-derived timing phrase vocabulary로 넘어갈지 결정한다.
+- 다음 issue는 `Stage B data-derived timing phrase vocabulary repair`로 잡는다.
+- phrase-level onset/duration cell을 data-derived template에서 가져오는 쪽을 검증한다.
+- register-safe bounds, max interval, final guide/chord landing, objective-clean output은 유지한다.
 - objective clean 후보라도 broad training으로 넘어가지 않는다.
 
 ## 10. 한 문장 요약

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest completed: Issue #158, Stage B register-safe timing motif follow-up repair
-- 다음 권장 이슈: `Stage B register-safe timing motif repaired proxy review`
+- latest completed: Issue #160, Stage B register-safe timing motif repaired proxy review
+- 다음 권장 이슈: `Stage B data-derived timing phrase vocabulary repair`
 
 현재 범위가 아닌 것:
 
@@ -38,6 +38,39 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 - sparse/medium 일부에서 chord-tone 반응이 약함
 
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
+
+## Latest Timing Motif Repaired Proxy Review Result
+
+Issue #160은 Issue #158 register-safe timing motif follow-up repair 이후의 후보를 MIDI-note/context 기준으로 다시 채운 proxy review다.
+
+Docs:
+
+- `docs/STAGE_B_REGISTER_SAFE_TIMING_MOTIF_REPAIRED_PROXY_REVIEW_2026-05-27.md`
+
+Result:
+
+- reviewed candidates: `6`
+- pending candidates: `0`
+- decisions:
+  - `keep`: `0`
+  - `needs_followup`: `5`
+  - `reject`: `1`
+- timing: `too_stiff=6`
+- chord fit: `fits=6`
+- objective bucket: `clean=6`
+- objective flags: `{}`
+
+Aggregate follow-up signals:
+
+- `improve_phrase_vocabulary`: `16`
+- `fix_timing_grid`: `12`
+- `increase_motif_variation`: `3`
+
+Decision:
+
+- Issue #158의 register-safe phrase-cell penalty guard는 partial safety improvement로 유지할 수 있다.
+- 그러나 repaired candidate를 proxy `keep`으로 올리지는 않는다.
+- 다음은 같은 penalty를 더 누적하는 것이 아니라 data-derived timing/phrase vocabulary repair다.
 
 ## Latest Timing Motif Repair Result
 

--- a/docs/STAGE_B_REGISTER_SAFE_TIMING_MOTIF_REPAIRED_PROXY_REVIEW_2026-05-27.md
+++ b/docs/STAGE_B_REGISTER_SAFE_TIMING_MOTIF_REPAIRED_PROXY_REVIEW_2026-05-27.md
@@ -1,0 +1,130 @@
+# Stage B Register-Safe Timing Motif Repaired Proxy Review
+
+작성일: 2026-05-27
+
+## 목적
+
+Issue #160은 Issue #158 register-safe timing motif follow-up repair 이후의 후보를 MIDI-note/context 기준으로 다시 채운 proxy review다.
+
+중요한 경계:
+
+- 실제 오디오 청취 리뷰가 아니다.
+- MIDI note sequence, context MIDI path, objective MIDI metrics, first-note summary, Issue #156 focused listening fill 결과를 함께 본 proxy review다.
+- objective-clean status는 최종 음악 품질이나 broad training 준비 완료를 의미하지 않는다.
+- `outputs/` 아래 filled review notes와 aggregate는 생성 artifact라 커밋하지 않는다.
+
+## 입력
+
+Review 대상:
+
+- `data_motif_contour_landing_repair` baseline 후보 3개
+- `data_motif_rhythm_phrase_variation` Issue #158 repaired 후보 3개
+
+Generated artifacts:
+
+- review manifest:
+  - `outputs/stage_b_data_motif_review/harness_stage_b_rhythm_phrase_variation/review_manifest.json`
+- objective MIDI review:
+  - `outputs/stage_b_objective_midi_review/harness_stage_b_rhythm_phrase_variation/objective_midi_note_review.json`
+- proxy-filled notes:
+  - `outputs/stage_b_listening_review_notes/harness_stage_b_timing_motif_repaired_codex_proxy/timing_motif_repaired_review_notes_codex_midi_proxy.json`
+- aggregate:
+  - `outputs/stage_b_listening_review_aggregate/harness_stage_b_timing_motif_repaired_codex_proxy/listening_review_aggregate.md`
+
+## Review Result
+
+Decision counts:
+
+| decision | count |
+|---|---:|
+| `keep` | 0 |
+| `needs_followup` | 5 |
+| `reject` | 1 |
+
+Quality counts:
+
+| field | result |
+|---|---|
+| phrase quality | `phrase=1`, `fragment=4`, `exercise=1` |
+| timing | `too_stiff=6` |
+| chord fit | `fits=6` |
+| objective bucket | `clean=6` |
+| objective flags | `{}` |
+
+Candidate decisions:
+
+| candidate | phrase | timing | chord fit | decision | reason |
+|---|---|---|---|---|---|
+| `data_motif_contour_landing_repair_rank_1_sample_1` | `fragment` | `too_stiff` | `fits` | `reject` | low-register contour artifact remains baseline failure evidence |
+| `data_motif_contour_landing_repair_rank_2_sample_2` | `fragment` | `too_stiff` | `fits` | `needs_followup` | usable final landing, but low-register cells and grid movement remain |
+| `data_motif_contour_landing_repair_rank_3_sample_3` | `fragment` | `too_stiff` | `fits` | `needs_followup` | context-compatible notes, but still mechanical contour fragment |
+| `data_motif_rhythm_phrase_variation_rank_1_sample_3` | `phrase` | `too_stiff` | `fits` | `needs_followup` | best repaired variation, but not enough to override Issue #156 stiff/thin focused finding |
+| `data_motif_rhythm_phrase_variation_rank_2_sample_1` | `fragment` | `too_stiff` | `fits` | `needs_followup` | objective-clean but still bounded scalar/chromatic cells |
+| `data_motif_rhythm_phrase_variation_rank_3_sample_2` | `exercise` | `too_stiff` | `fits` | `needs_followup` | widest pitch count, but full-grid neighboring motion reads as exercise |
+
+Aggregate follow-up signals:
+
+| code | count | interpretation |
+|---|---:|---|
+| `improve_phrase_vocabulary` | 16 | strongest remaining blocker |
+| `fix_timing_grid` | 12 | timing surface still reads grid-derived |
+| `increase_motif_variation` | 3 | repeated cells remain despite partial penalty repair |
+
+## Best Candidate Judgment
+
+Best repaired variation candidate:
+
+- candidate: `data_motif_rhythm_phrase_variation_rank_1_sample_3`
+- decision: `needs_followup`
+- objective bucket: `clean`
+- objective flags: `[]`
+- note count: `63`
+- unique pitch count: `18`
+- pitch range: `G3-D#5`
+- max active notes: `1`
+- off-sixteenth-grid count: `0`
+- stepwise interval ratio: `0.468`
+- chromatic interval ratio: `0.274`
+- chord-tone ratio: `0.508`
+- tension ratio: `0.492`
+- outside ratio: `0.000`
+
+Why not keep:
+
+- Issue #156 already exposed this candidate family as stiff/thin under focused review.
+- Issue #158 mostly changed pitch-cell pressure, not the audible timing surface.
+- the candidate is objective-clean but still relies on repeated bounded cells.
+- unique pitch count remains thin for an 8-bar phrase.
+
+## Decision
+
+Issue #160 conclusion:
+
+- Do not promote any repaired candidate to proxy `keep`.
+- Keep the Issue #158 guard as a partial safety improvement, but do not keep pushing the same penalty-only approach.
+- The next generation issue should target timing and phrase vocabulary from a data-derived phrase template, not another local cell-penalty tweak.
+- Broad training, Brad style adaptation, backend/API, and audio pivot remain premature.
+
+Recommended next issue:
+
+```text
+Stage B data-derived timing phrase vocabulary repair
+```
+
+Target:
+
+- derive longer timing/phrase cells from real phrase templates or the existing motif catalog
+- vary onset/duration cells at phrase level instead of only penalizing repeated pitch-class cells
+- preserve register-safe bounds, max interval, final guide/chord landing, and objective-clean review output
+
+## 검증
+
+실행한 검증:
+
+```bash
+.venv/bin/python scripts/build_listening_review_notes.py --run_id harness_stage_b_timing_motif_repaired_codex_proxy --review_manifest outputs/stage_b_data_motif_review/harness_stage_b_rhythm_phrase_variation/review_manifest.json --objective_midi_review_report outputs/stage_b_objective_midi_review/harness_stage_b_rhythm_phrase_variation/objective_midi_note_review.json --source_review_markdown outputs/stage_b_data_motif_review/harness_stage_b_rhythm_phrase_variation/review_candidates.md
+.venv/bin/python scripts/build_listening_review_notes.py --run_id harness_stage_b_timing_motif_repaired_codex_proxy --review_notes outputs/stage_b_listening_review_notes/harness_stage_b_timing_motif_repaired_codex_proxy/timing_motif_repaired_review_notes_codex_midi_proxy.json
+.venv/bin/python scripts/summarize_listening_review_notes.py --run_id harness_stage_b_timing_motif_repaired_codex_proxy --review_notes outputs/stage_b_listening_review_notes/harness_stage_b_timing_motif_repaired_codex_proxy/timing_motif_repaired_review_notes_codex_midi_proxy.json
+RUN_ID=harness_stage_b_timing_motif_repaired_codex_proxy bash scripts/agent_harness.sh stage-b-listening-review-aggregate
+bash scripts/agent_harness.sh quick
+```


### PR DESCRIPTION
## Summary

- Record the MIDI-note/context proxy review for the Issue #158 register-safe timing motif repaired candidates.
- Mark all repaired variation candidates as follow-up instead of proxy keep because timing stiffness and phrase-vocabulary blockers remain.
- Update current status/core plan with the next boundary: data-derived timing phrase vocabulary repair.

Fixes #160

## Validation

- `.venv/bin/python scripts/build_listening_review_notes.py --run_id harness_stage_b_timing_motif_repaired_codex_proxy --review_manifest outputs/stage_b_data_motif_review/harness_stage_b_rhythm_phrase_variation/review_manifest.json --objective_midi_review_report outputs/stage_b_objective_midi_review/harness_stage_b_rhythm_phrase_variation/objective_midi_note_review.json --source_review_markdown outputs/stage_b_data_motif_review/harness_stage_b_rhythm_phrase_variation/review_candidates.md`
- `.venv/bin/python scripts/build_listening_review_notes.py --run_id harness_stage_b_timing_motif_repaired_codex_proxy --review_notes outputs/stage_b_listening_review_notes/harness_stage_b_timing_motif_repaired_codex_proxy/timing_motif_repaired_review_notes_codex_midi_proxy.json`
- `.venv/bin/python scripts/summarize_listening_review_notes.py --run_id harness_stage_b_timing_motif_repaired_codex_proxy --review_notes outputs/stage_b_listening_review_notes/harness_stage_b_timing_motif_repaired_codex_proxy/timing_motif_repaired_review_notes_codex_midi_proxy.json`
- `RUN_ID=harness_stage_b_timing_motif_repaired_codex_proxy bash scripts/agent_harness.sh stage-b-listening-review-aggregate`
- `bash scripts/agent_harness.sh quick`