### PR TITLE
[codex] Stage B data-derived timing phrase repair

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -190,6 +190,7 @@ Stage B에서 명시하는 것:
 78. Stage B register-safe focused listening review fill
 79. Stage B register-safe timing motif follow-up repair
 80. Stage B register-safe timing motif repaired proxy review
+81. Stage B data-derived timing phrase vocabulary repair
 
 가장 최근 의미 있는 결과:
 
@@ -281,6 +282,9 @@ Stage B에서 명시하는 것:
 - Issue #160 fills MIDI-note/context proxy review notes for the Issue #158 repaired candidates.
 - Issue #160 result: `reviewed=6`, `keep=0`, `needs_followup=5`, `reject=1`, timing `too_stiff=6`, objective bucket `clean=6`, objective flags `{}`.
 - Issue #160 aggregate result: `improve_phrase_vocabulary=16`, `fix_timing_grid=12`, `increase_motif_variation=3`; next generation work should use data-derived timing/phrase vocabulary instead of another local penalty tweak.
+- Issue #162 adds data-derived timing row selection for `data_motif_rhythm_phrase_variation` by preferring phrase-like `top_full_templates` while preserving review-safe position/duration shaping.
+- Issue #162 result: variation strict `3/3`, final landing `3/3`, max interval `4`, objective MIDI flags `{}`, avg syncopation `0.693`, avg tension `0.375`.
+- Issue #162 tradeoff: duration diversity fell to `0.073`, IOI diversity fell to `0.079`, and most-common IOI rose to `0.392`; this requires fresh proxy review before promoting the repair.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -299,7 +303,7 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-이제 다음 단계는 data-derived timing phrase vocabulary repair다. Issue #160은 repaired 후보를 proxy keep으로 올리지 않았고, timing/phrase vocabulary 문제가 여전히 우선순위임을 확인했다.
+이제 다음 단계는 data-derived timing phrase repaired proxy review다. Issue #162는 guardrail을 유지하며 syncopation/tension을 올렸지만 IOI/duration tradeoff가 있어 MIDI-note/context review가 필요하다.
 
 ## 6. 다음 단계 로드맵
 
@@ -825,38 +829,32 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B register-safe timing motif repaired proxy review
+Stage B data-derived timing phrase vocabulary repair
 ```
 
 결과:
 
-- docs: `docs/STAGE_B_REGISTER_SAFE_TIMING_MOTIF_REPAIRED_PROXY_REVIEW_2026-05-27.md`
-- reviewed candidates: `6`
-- pending candidates: `0`
-- decisions:
-  - `keep`: `0`
-  - `needs_followup`: `5`
-  - `reject`: `1`
-- timing: `too_stiff=6`
-- chord fit: `fits=6`
-- objective bucket: `clean=6`
+- docs: `docs/STAGE_B_DATA_DERIVED_TIMING_PHRASE_REPAIR_2026-05-27.md`
+- variation strict candidates: `3/3`
+- final landing resolved: `3/3`
+- max interval: `4`
 - objective flags: `{}`
-- aggregate:
-  - `improve_phrase_vocabulary=16`
-  - `fix_timing_grid=12`
-  - `increase_motif_variation=3`
+- avg syncopated onset ratio: `0.693`
+- avg duration diversity ratio: `0.073`
+- avg IOI diversity ratio: `0.079`
+- avg most-common IOI ratio: `0.392`
+- avg tension ratio: `0.375`
 
 판단:
 
-- Issue #158의 register-safe phrase-cell penalty guard는 partial safety improvement로 남긴다.
-- repaired 후보를 proxy `keep`으로 올리지는 않는다.
-- timing stiffness와 phrase vocabulary는 여전히 blocker다.
+- data-derived timing row selection은 reviewable tradeoff다.
+- syncopation/tension은 좋아졌지만 duration/IOI diversity는 조금 나빠졌다.
+- 이 변경을 musical improvement로 확정하지 않는다.
 
 다음 작업:
 
-- 다음 issue는 `Stage B data-derived timing phrase vocabulary repair`로 잡는다.
-- phrase-level onset/duration cell을 data-derived template에서 가져오는 쪽을 검증한다.
-- register-safe bounds, max interval, final guide/chord landing, objective-clean output은 유지한다.
+- 다음 issue는 `Stage B data-derived timing phrase repaired proxy review`로 잡는다.
+- MIDI-note/context 기준으로 tradeoff를 판단한다.
 - objective clean 후보라도 broad training으로 넘어가지 않는다.
 
 ## 10. 한 문장 요약

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest completed: Issue #160, Stage B register-safe timing motif repaired proxy review
-- 다음 권장 이슈: `Stage B data-derived timing phrase vocabulary repair`
+- latest completed: Issue #162, Stage B data-derived timing phrase vocabulary repair
+- 다음 권장 이슈: `Stage B data-derived timing phrase repaired proxy review`
 
 현재 범위가 아닌 것:
 
@@ -38,6 +38,40 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 - sparse/medium 일부에서 chord-tone 반응이 약함
 
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
+
+## Latest Data-Derived Timing Phrase Repair Result
+
+Issue #162는 Issue #160 proxy review에서 확인한 timing stiffness와 phrase vocabulary blocker를 generation rule 쪽에서 다시 좁힌 작업이다.
+
+Docs:
+
+- `docs/STAGE_B_DATA_DERIVED_TIMING_PHRASE_REPAIR_2026-05-27.md`
+
+Implementation:
+
+- `top_full_templates`에서 phrase-like timing rows를 우선 선택한다.
+- long-span/long-sustain full templates는 review-safe phrase slot에 맞지 않아 제외한다.
+- position/duration shaping은 기존 review-safe path를 유지한다.
+
+Result:
+
+- `data_motif_rhythm_phrase_variation` valid: `3/3`
+- strict: `3/3`
+- final landing resolved: `3/3`
+- max interval: `4`
+- objective MIDI flags: `{}`
+- avg syncopated onset ratio: `0.693`
+- avg unique bar-position pattern ratio: `0.958`
+- avg duration diversity ratio: `0.073`
+- avg IOI diversity ratio: `0.079`
+- avg most-common IOI ratio: `0.392`
+- avg tension ratio: `0.375`
+
+Decision:
+
+- strict/objective-clean guardrail은 유지됐다.
+- syncopation과 tension은 개선됐지만, duration/IOI diversity는 조금 후퇴했다.
+- 다음은 fresh proxy review로 이 tradeoff가 실제로 덜 mechanical한지 판단한다.
 
 ## Latest Timing Motif Repaired Proxy Review Result
 

--- a/docs/STAGE_B_DATA_DERIVED_TIMING_PHRASE_REPAIR_2026-05-27.md
+++ b/docs/STAGE_B_DATA_DERIVED_TIMING_PHRASE_REPAIR_2026-05-27.md
@@ -1,0 +1,121 @@
+# Stage B Data-Derived Timing Phrase Vocabulary Repair
+
+작성일: 2026-05-27
+
+## 목적
+
+Issue #162는 Issue #160 proxy review에서 확인한 timing stiffness와 phrase vocabulary blocker를 다시 generation rule 쪽에서 좁게 본 작업이다.
+
+목표:
+
+- penalty-only pitch-cell repair를 더 누적하지 않는다.
+- motif extraction의 `top_full_templates`에서 phrase-like timing template을 우선 사용한다.
+- register-safe bounds, max interval, final guide/chord landing, objective-clean output은 유지한다.
+
+이 결과는 symbolic MIDI generation probe이며, broad training이나 Brad style adaptation 성공 근거가 아니다.
+
+## 구현
+
+변경 대상:
+
+- `scripts/run_stage_b_data_motif_generation_compare.py`
+- `tests/test_stage_b_data_motif_generation_compare.py`
+
+추가한 guard:
+
+- `data_derived_timing_template_rows(...)`
+  - `top_full_templates`에서 position span, duration span, IOI variation이 있는 phrase-like timing rows를 먼저 고른다.
+  - local phrase slot에 들어가기 어려운 long-span template과 long-sustain template은 제외한다.
+  - phrase-like full template이 너무 적으면 기존 rhythm template을 fallback으로 붙인다.
+
+적용 방식:
+
+- `data_motif_rhythm_phrase_variation`의 rhythm row selection만 data-derived full-template 우선순위로 바꿨다.
+- position/duration shaping은 기존 review-safe `varied_phrase_positions(...)`, `varied_phrase_duration_tokens(...)`를 유지했다.
+
+제외한 방식:
+
+- full-template position/duration을 그대로 쓰는 pure data-derived timing path도 시험했지만, IOI repetition과 final landing metric이 악화되어 최종 변경에서 제외했다.
+- 따라서 이번 변경은 pure timing transplant가 아니라 data-derived row selection + existing review-safe shaping이다.
+
+## Harness Result
+
+Command:
+
+```bash
+bash scripts/agent_harness.sh stage-b-rhythm-phrase-variation
+```
+
+`data_motif_rhythm_phrase_variation` summary:
+
+| metric | Issue #158 | Issue #162 |
+|---|---:|---:|
+| valid | 3/3 | 3/3 |
+| strict | 3/3 | 3/3 |
+| final landing resolved | 3/3 | 3/3 |
+| max abs interval | 4 | 4 |
+| avg syncopated onset ratio | 0.684 | 0.693 |
+| avg unique bar-position pattern ratio | 0.958 | 0.958 |
+| avg duration diversity ratio | 0.079 | 0.073 |
+| avg most-common duration ratio | 0.384 | 0.396 |
+| avg IOI diversity ratio | 0.091 | 0.079 |
+| avg most-common IOI ratio | 0.385 | 0.392 |
+| avg tension ratio | 0.358 | 0.375 |
+| avg root-tone ratio | 0.021 | 0.021 |
+| objective MIDI flags | `{}` | `{}` |
+
+Top variation candidates:
+
+| candidate | notes | unique pitches | sync | bar-var | dur-var | ioi-var | ioi-rep | tension | landing | max interval |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
+| `data_motif_rhythm_phrase_variation_rank_1_sample_3` | 64 | 18 | 0.672 | 1.000 | 0.078 | 0.079 | 0.365 | 0.391 | guide | 4 |
+| `data_motif_rhythm_phrase_variation_rank_2_sample_1` | 64 | 16 | 0.703 | 1.000 | 0.062 | 0.079 | 0.444 | 0.391 | guide | 4 |
+| `data_motif_rhythm_phrase_variation_rank_3_sample_2` | 64 | 19 | 0.703 | 0.875 | 0.078 | 0.079 | 0.365 | 0.344 | guide | 4 |
+
+Objective MIDI note review for variation candidates:
+
+- objective bucket: `clean=3`
+- objective flags: `[]` for all variation candidates
+- note count: `64`
+- unique pitch count: `16-19`
+- outside ratio: `0.000-0.031`
+- max active notes: `1`
+
+## 해석
+
+Improved:
+
+- strict/objective-clean status is preserved.
+- final guide/chord landing is restored to `3/3`.
+- syncopated onset ratio improves from `0.684` to `0.693`.
+- source tension ratio improves from `0.358` to `0.375`.
+
+Tradeoff:
+
+- duration diversity falls from `0.079` to `0.073`.
+- IOI diversity falls from `0.091` to `0.079`.
+- most-common IOI ratio rises from `0.385` to `0.392`.
+
+Decision:
+
+- Keep the data-derived timing row selection as a reviewable tradeoff, not as a final musical improvement claim.
+- Do not promote candidates without a fresh MIDI-note/context proxy review.
+- The next issue should judge whether higher syncopation/tension is worth the small IOI/duration regression.
+
+## Next Recommended Issue
+
+```text
+Stage B data-derived timing phrase repaired proxy review
+```
+
+The next review should decide whether this tradeoff sounds less mechanical, or whether the generator should move to a stronger phrase-level duration/IOI objective instead.
+
+## 검증
+
+실행한 검증:
+
+```bash
+.venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare
+bash scripts/agent_harness.sh stage-b-rhythm-phrase-variation
+bash scripts/agent_harness.sh quick
+```

--- a/scripts/run_stage_b_data_motif_generation_compare.py
+++ b/scripts/run_stage_b_data_motif_generation_compare.py
@@ -334,6 +334,35 @@ def varied_phrase_positions(
     return repaired if len(repaired) == len(positions) else positions
 
 
+def data_derived_timing_template_rows(summary: dict[str, Any]) -> list[dict[str, Any]]:
+    full_rows = list(summary.get("top_full_templates") or [])
+    rhythm_rows = list(summary.get("top_rhythm_templates") or [])
+
+    phrase_like: list[dict[str, Any]] = []
+    for row in full_rows:
+        key = row.get("key", {})
+        deltas = [int(delta) for delta in key.get("position_deltas", [])]
+        durations = [int(step) for step in key.get("duration_steps", [])]
+        if len(deltas) < 4:
+            continue
+        gaps = [right - left for left, right in zip(deltas, deltas[1:]) if right > left]
+        has_varied_ioi = len(set(gaps)) >= 2
+        has_phrase_span = max(deltas) - min(deltas) >= 4
+        fits_local_phrase_slot = max(deltas) - min(deltas) <= 8
+        has_duration_shape = len(set(durations[: len(deltas)])) >= 2
+        has_reviewable_duration_span = bool(durations) and max(durations[: len(deltas)]) <= 8
+        if (
+            has_phrase_span
+            and fits_local_phrase_slot
+            and has_reviewable_duration_span
+            and (has_varied_ioi or has_duration_shape)
+        ):
+            phrase_like.append(row)
+    if phrase_like and len(phrase_like) < 4:
+        return phrase_like + rhythm_rows
+    return phrase_like or rhythm_rows
+
+
 def phrase_vocabulary_contour_delta(
     contour_steps: Sequence[int],
     *,
@@ -1727,7 +1756,7 @@ def data_motif_rhythm_phrase_variation_tokens(
 ) -> list[int]:
     rng = random.Random(int(seed))
     summary = template_report["summary"]
-    rhythm_rows = summary["top_rhythm_templates"]
+    timing_rows = data_derived_timing_template_rows(summary)
     contour_rows = summary["top_contour_templates"]
     tokens = [int(token) for token in primer_tokens]
     recent_pitches: list[int] = []
@@ -1758,7 +1787,7 @@ def data_motif_rhythm_phrase_variation_tokens(
         anchor = 60 + (((bar_index + seed_variation) % 3) * 4) + rng.choice([-3, 0, 3])
         for motif_index in range(motifs_per_bar):
             row_index = bar_index * motifs_per_bar + motif_index
-            rhythm = weighted_choice(rhythm_rows, rng, row_index + bar_index + seed_variation)["key"]
+            rhythm = weighted_choice(timing_rows, rng, row_index + bar_index + seed_variation)["key"]
             contour = weighted_choice(contour_rows, rng, row_index + bar_index + seed_variation)["key"]
             slot_start, slot_size = varied_phrase_slot_bounds(
                 bar_index,

--- a/tests/test_stage_b_data_motif_generation_compare.py
+++ b/tests/test_stage_b_data_motif_generation_compare.py
@@ -12,6 +12,7 @@ from scripts.run_stage_b_data_motif_generation_compare import (
     chord_tone_pitch_classes,
     analyze_contour_landing_profile,
     contour_landing_summary,
+    data_derived_timing_template_rows,
     data_motif_contour_landing_repair_tokens,
     data_motif_guide_tones_tokens,
     data_motif_phrase_recovery_tokens,
@@ -86,6 +87,24 @@ def template_report() -> dict:
                     "count": 1,
                     "key": {
                         "pitch_intervals": [0, -2, 1, 0],
+                    },
+                },
+            ],
+            "top_full_templates": [
+                {
+                    "count": 2,
+                    "key": {
+                        "position_deltas": [0, 2, 3, 5],
+                        "duration_steps": [5, 6, 8, 3],
+                        "pitch_intervals": [0, 5, 12, 6],
+                    },
+                },
+                {
+                    "count": 1,
+                    "key": {
+                        "position_deltas": [0, 1, 2, 3],
+                        "duration_steps": [2, 2, 2, 2],
+                        "pitch_intervals": [0, 1, 2, 3],
                     },
                 },
             ],
@@ -214,6 +233,12 @@ class StageBDataMotifGenerationCompareTest(unittest.TestCase):
             patterns.append(tuple(sorted(bar_positions)))
 
         self.assertGreaterEqual(len(set(patterns)), 7)
+
+    def test_data_derived_timing_template_rows_prefers_phrase_like_full_templates(self) -> None:
+        rows = data_derived_timing_template_rows(template_report()["summary"])
+
+        self.assertEqual(rows[0]["key"]["position_deltas"], [0, 2, 3, 5])
+        self.assertNotEqual(rows[0]["key"]["duration_steps"], [2, 2, 2, 2])
 
     def test_phrase_vocabulary_contour_delta_mirrors_response_motif(self) -> None:
         call_delta = phrase_vocabulary_contour_delta(


### PR DESCRIPTION
## Summary

- Prefer phrase-like `top_full_templates` for the Stage B `data_motif_rhythm_phrase_variation` timing row selection.
- Preserve existing review-safe position/duration shaping and register-safe cadence guardrails.
- Document the measured tradeoff: syncopation/tension improved, while duration/IOI diversity regressed slightly.

Fixes #162

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare`
- `bash scripts/agent_harness.sh stage-b-rhythm-phrase-variation`
- `bash scripts/agent_harness.sh quick`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project roadmap and current status documentation to reflect latest development progress.
  * Added comprehensive implementation notes for timing phrase vocabulary improvements.

* **Refactor**
  * Improved internal timing template selection logic to enhance syncopation and tension characteristics.

* **Tests**
  * Added unit tests to verify timing template filtering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohhalim/fine_tuning_art-tatum_midi_solo/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->