### PR TITLE
[codex] Stage B data-derived timing phrase proxy review

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -191,6 +191,7 @@ Stage B에서 명시하는 것:
 79. Stage B register-safe timing motif follow-up repair
 80. Stage B register-safe timing motif repaired proxy review
 81. Stage B data-derived timing phrase vocabulary repair
+82. Stage B data-derived timing phrase repaired proxy review
 
 가장 최근 의미 있는 결과:
 
@@ -285,6 +286,9 @@ Stage B에서 명시하는 것:
 - Issue #162 adds data-derived timing row selection for `data_motif_rhythm_phrase_variation` by preferring phrase-like `top_full_templates` while preserving review-safe position/duration shaping.
 - Issue #162 result: variation strict `3/3`, final landing `3/3`, max interval `4`, objective MIDI flags `{}`, avg syncopation `0.693`, avg tension `0.375`.
 - Issue #162 tradeoff: duration diversity fell to `0.073`, IOI diversity fell to `0.079`, and most-common IOI rose to `0.392`; this requires fresh proxy review before promoting the repair.
+- Issue #164 fills MIDI-note/context proxy review notes for the Issue #162 repaired candidates.
+- Issue #164 result: `reviewed=6`, `keep=0`, `needs_followup=5`, `reject=1`, timing `acceptable=2`, `too_stiff=4`, objective bucket `clean=6`, objective flags `{}`.
+- Issue #164 aggregate result: `improve_phrase_vocabulary=16`, `fix_timing_grid=8`, `increase_motif_variation=3`; next generation work should improve duration/IOI objective directly.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -303,7 +307,7 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-이제 다음 단계는 data-derived timing phrase repaired proxy review다. Issue #162는 guardrail을 유지하며 syncopation/tension을 올렸지만 IOI/duration tradeoff가 있어 MIDI-note/context review가 필요하다.
+이제 다음 단계는 phrase-level duration IOI objective repair다. Issue #164는 timing count를 낮췄지만 proxy keep을 만들지 못했고, phrase vocabulary와 duration/IOI objective가 다음 blocker다.
 
 ## 6. 다음 단계 로드맵
 
@@ -829,32 +833,38 @@ Stage B에서 명시하는 것:
 완료된 바로 전 작업:
 
 ```text
-Stage B data-derived timing phrase vocabulary repair
+Stage B data-derived timing phrase repaired proxy review
 ```
 
 결과:
 
-- docs: `docs/STAGE_B_DATA_DERIVED_TIMING_PHRASE_REPAIR_2026-05-27.md`
-- variation strict candidates: `3/3`
-- final landing resolved: `3/3`
-- max interval: `4`
+- docs: `docs/STAGE_B_DATA_DERIVED_TIMING_PHRASE_PROXY_REVIEW_2026-05-27.md`
+- reviewed candidates: `6`
+- pending candidates: `0`
+- decisions:
+  - `keep`: `0`
+  - `needs_followup`: `5`
+  - `reject`: `1`
+- timing:
+  - `acceptable`: `2`
+  - `too_stiff`: `4`
+- objective bucket: `clean=6`
 - objective flags: `{}`
-- avg syncopated onset ratio: `0.693`
-- avg duration diversity ratio: `0.073`
-- avg IOI diversity ratio: `0.079`
-- avg most-common IOI ratio: `0.392`
-- avg tension ratio: `0.375`
+- aggregate:
+  - `improve_phrase_vocabulary=16`
+  - `fix_timing_grid=8`
+  - `increase_motif_variation=3`
 
 판단:
 
-- data-derived timing row selection은 reviewable tradeoff다.
-- syncopation/tension은 좋아졌지만 duration/IOI diversity는 조금 나빠졌다.
-- 이 변경을 musical improvement로 확정하지 않는다.
+- Issue #162는 reviewable timing/tension tradeoff지만 proxy keep은 아니다.
+- timing count는 줄었지만 phrase vocabulary가 여전히 최상위 blocker다.
+- duration/IOI objective를 직접 봐야 한다.
 
 다음 작업:
 
-- 다음 issue는 `Stage B data-derived timing phrase repaired proxy review`로 잡는다.
-- MIDI-note/context 기준으로 tradeoff를 판단한다.
+- 다음 issue는 `Stage B phrase-level duration IOI objective repair`로 잡는다.
+- syncopation/tension을 되도록 유지하면서 duration/IOI diversity를 직접 개선한다.
 - objective clean 후보라도 broad training으로 넘어가지 않는다.
 
 ## 10. 한 문장 요약

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest completed: Issue #162, Stage B data-derived timing phrase vocabulary repair
-- 다음 권장 이슈: `Stage B data-derived timing phrase repaired proxy review`
+- latest completed: Issue #164, Stage B data-derived timing phrase repaired proxy review
+- 다음 권장 이슈: `Stage B phrase-level duration IOI objective repair`
 
 현재 범위가 아닌 것:
 
@@ -38,6 +38,41 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 - sparse/medium 일부에서 chord-tone 반응이 약함
 
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
+
+## Latest Data-Derived Timing Phrase Proxy Review Result
+
+Issue #164는 Issue #162 data-derived timing phrase vocabulary repair 이후의 후보를 MIDI-note/context 기준으로 다시 채운 proxy review다.
+
+Docs:
+
+- `docs/STAGE_B_DATA_DERIVED_TIMING_PHRASE_PROXY_REVIEW_2026-05-27.md`
+
+Result:
+
+- reviewed candidates: `6`
+- pending candidates: `0`
+- decisions:
+  - `keep`: `0`
+  - `needs_followup`: `5`
+  - `reject`: `1`
+- timing:
+  - `acceptable`: `2`
+  - `too_stiff`: `4`
+- chord fit: `fits=6`
+- objective bucket: `clean=6`
+- objective flags: `{}`
+
+Aggregate follow-up signals:
+
+- `improve_phrase_vocabulary`: `16`
+- `fix_timing_grid`: `8`
+- `increase_motif_variation`: `3`
+
+Decision:
+
+- Issue #162는 reviewable timing/tension tradeoff로 유지할 수 있다.
+- 그러나 proxy `keep` 후보는 아직 없다.
+- 다음은 row selection이 아니라 duration/IOI objective를 직접 개선하는 단계다.
 
 ## Latest Data-Derived Timing Phrase Repair Result
 

--- a/docs/STAGE_B_DATA_DERIVED_TIMING_PHRASE_PROXY_REVIEW_2026-05-27.md
+++ b/docs/STAGE_B_DATA_DERIVED_TIMING_PHRASE_PROXY_REVIEW_2026-05-27.md
@@ -1,0 +1,124 @@
+# Stage B Data-Derived Timing Phrase Repaired Proxy Review
+
+작성일: 2026-05-27
+
+## 목적
+
+Issue #164는 Issue #162 data-derived timing phrase vocabulary repair 이후의 후보를 MIDI-note/context 기준으로 다시 채운 proxy review다.
+
+중요한 경계:
+
+- 실제 오디오 청취 리뷰가 아니다.
+- MIDI note sequence, context MIDI path, objective MIDI metrics, Issue #160 proxy review 결과, Issue #162 metric tradeoff를 기준으로 판단했다.
+- objective-clean status는 최종 음악 품질이나 broad training 준비 완료를 의미하지 않는다.
+- `outputs/` 아래 filled review notes와 aggregate는 생성 artifact라 커밋하지 않는다.
+
+## 입력
+
+Generated artifacts:
+
+- review manifest:
+  - `outputs/stage_b_data_motif_review/harness_stage_b_rhythm_phrase_variation/review_manifest.json`
+- objective MIDI review:
+  - `outputs/stage_b_objective_midi_review/harness_stage_b_rhythm_phrase_variation/objective_midi_note_review.json`
+- proxy-filled notes:
+  - `outputs/stage_b_listening_review_notes/harness_stage_b_data_derived_timing_phrase_codex_proxy/data_derived_timing_phrase_review_notes_codex_midi_proxy.json`
+- aggregate:
+  - `outputs/stage_b_listening_review_aggregate/harness_stage_b_data_derived_timing_phrase_codex_proxy/listening_review_aggregate.md`
+
+## Review Result
+
+Decision counts:
+
+| decision | count |
+|---|---:|
+| `keep` | 0 |
+| `needs_followup` | 5 |
+| `reject` | 1 |
+
+Quality counts:
+
+| field | result |
+|---|---|
+| phrase quality | `phrase=1`, `fragment=4`, `exercise=1` |
+| timing | `acceptable=2`, `too_stiff=4` |
+| chord fit | `fits=6` |
+| objective bucket | `clean=6` |
+| objective flags | `{}` |
+
+Candidate decisions:
+
+| candidate | phrase | timing | chord fit | decision | reason |
+|---|---|---|---|---|---|
+| `data_motif_contour_landing_repair_rank_1_sample_1` | `fragment` | `too_stiff` | `fits` | `reject` | baseline low-register contour artifact |
+| `data_motif_contour_landing_repair_rank_2_sample_2` | `fragment` | `too_stiff` | `fits` | `needs_followup` | baseline contour fragment and grid movement |
+| `data_motif_contour_landing_repair_rank_3_sample_3` | `fragment` | `too_stiff` | `fits` | `needs_followup` | baseline context-compatible but not timing repair evidence |
+| `data_motif_rhythm_phrase_variation_rank_1_sample_3` | `phrase` | `acceptable` | `fits` | `needs_followup` | best repaired candidate, but still quantized/cell-driven |
+| `data_motif_rhythm_phrase_variation_rank_2_sample_1` | `fragment` | `too_stiff` | `fits` | `needs_followup` | low unique pitch count and high IOI repetition |
+| `data_motif_rhythm_phrase_variation_rank_3_sample_2` | `exercise` | `acceptable` | `fits` | `needs_followup` | wider pitch count, but scalar/exercise-like contour |
+
+Aggregate follow-up signals:
+
+| code | count | interpretation |
+|---|---:|---|
+| `improve_phrase_vocabulary` | 16 | strongest remaining blocker |
+| `fix_timing_grid` | 8 | improved from Issue #160, but not solved |
+| `increase_motif_variation` | 3 | repeated cells remain |
+
+## Best Candidate Judgment
+
+Best repaired candidate:
+
+- candidate: `data_motif_rhythm_phrase_variation_rank_1_sample_3`
+- decision: `needs_followup`
+- objective bucket: `clean`
+- objective flags: `[]`
+- note count: `64`
+- unique pitch count: `18`
+- syncopated onset ratio: `0.672`
+- duration diversity ratio: `0.078`
+- most-common IOI ratio: `0.365`
+- source tension ratio: `0.391`
+- objective tension ratio: `0.484`
+- final landing: `guide`
+- max interval: `4`
+
+Why not keep:
+
+- it is the best repaired candidate, but not clearly enough beyond the Issue #156 focused blocker.
+- the line remains quantized and cell-driven.
+- unique pitch count stays thin for an 8-bar phrase.
+- phrase vocabulary is still the top aggregate blocker.
+
+## Decision
+
+Issue #164 conclusion:
+
+- Do not promote any candidate to proxy `keep`.
+- Keep Issue #162 as a reviewable timing/tension tradeoff, not as a final quality improvement.
+- The next generation issue should target phrase vocabulary with an explicit duration/IOI objective instead of another row-selection tweak.
+- Broad training, Brad style adaptation, backend/API, and audio pivot remain premature.
+
+Recommended next issue:
+
+```text
+Stage B phrase-level duration IOI objective repair
+```
+
+Target:
+
+- preserve Issue #162 syncopation/tension gains where possible
+- improve duration diversity and IOI diversity directly
+- keep register-safe bounds, max interval, final guide/chord landing, and objective-clean MIDI output
+
+## 검증
+
+실행한 검증:
+
+```bash
+.venv/bin/python scripts/build_listening_review_notes.py --run_id harness_stage_b_data_derived_timing_phrase_codex_proxy --review_manifest outputs/stage_b_data_motif_review/harness_stage_b_rhythm_phrase_variation/review_manifest.json --objective_midi_review_report outputs/stage_b_objective_midi_review/harness_stage_b_rhythm_phrase_variation/objective_midi_note_review.json --source_review_markdown outputs/stage_b_data_motif_review/harness_stage_b_rhythm_phrase_variation/review_candidates.md
+.venv/bin/python scripts/build_listening_review_notes.py --run_id harness_stage_b_data_derived_timing_phrase_codex_proxy --review_notes outputs/stage_b_listening_review_notes/harness_stage_b_data_derived_timing_phrase_codex_proxy/data_derived_timing_phrase_review_notes_codex_midi_proxy.json
+.venv/bin/python scripts/summarize_listening_review_notes.py --run_id harness_stage_b_data_derived_timing_phrase_codex_proxy --review_notes outputs/stage_b_listening_review_notes/harness_stage_b_data_derived_timing_phrase_codex_proxy/data_derived_timing_phrase_review_notes_codex_midi_proxy.json
+RUN_ID=harness_stage_b_data_derived_timing_phrase_codex_proxy bash scripts/agent_harness.sh stage-b-listening-review-aggregate
+bash scripts/agent_harness.sh quick
+```


### PR DESCRIPTION
## Summary

- Record the MIDI-note/context proxy review for Issue #162 data-derived timing phrase repaired candidates.
- Keep all repaired candidates at `needs_followup`; no proxy keep candidate was promoted.
- Update the next boundary to phrase-level duration/IOI objective repair.

Fixes #164

## Validation

- `.venv/bin/python scripts/build_listening_review_notes.py --run_id harness_stage_b_data_derived_timing_phrase_codex_proxy --review_manifest outputs/stage_b_data_motif_review/harness_stage_b_rhythm_phrase_variation/review_manifest.json --objective_midi_review_report outputs/stage_b_objective_midi_review/harness_stage_b_rhythm_phrase_variation/objective_midi_note_review.json --source_review_markdown outputs/stage_b_data_motif_review/harness_stage_b_rhythm_phrase_variation/review_candidates.md`
- `.venv/bin/python scripts/build_listening_review_notes.py --run_id harness_stage_b_data_derived_timing_phrase_codex_proxy --review_notes outputs/stage_b_listening_review_notes/harness_stage_b_data_derived_timing_phrase_codex_proxy/data_derived_timing_phrase_review_notes_codex_midi_proxy.json`
- `.venv/bin/python scripts/summarize_listening_review_notes.py --run_id harness_stage_b_data_derived_timing_phrase_codex_proxy --review_notes outputs/stage_b_listening_review_notes/harness_stage_b_data_derived_timing_phrase_codex_proxy/data_derived_timing_phrase_review_notes_codex_midi_proxy.json`
- `RUN_ID=harness_stage_b_data_derived_timing_phrase_codex_proxy bash scripts/agent_harness.sh stage-b-listening-review-aggregate`
- `bash scripts/agent_harness.sh quick`