### PR TITLE
Stage B duration IOI repaired proxy review

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,14 +168,14 @@ Issue #168에서는 `data_motif_rhythm_phrase_variation`에 phrase-level duratio
 | avg IOI diversity ratio | 0.079 | 0.111 |
 | avg most-common IOI ratio | 0.392 | 0.481 |
 
-duration/IOI diversity는 개선됐지만 most-common IOI 반복은 악화됐습니다. 그래서 이 변경도 "성공"으로 확정하지 않고, 다음 proxy review에서 tradeoff로 판단합니다.
+duration/IOI diversity는 개선됐지만 most-common IOI 반복은 악화됐습니다. 이어진 proxy review에서도 `keep` 후보는 나오지 않아, 다음 병목은 phrase vocabulary와 motif variation으로 좁혔습니다.
 
 ## 현재 상태
 
 현재 main 기준 최신 판단:
 
-- latest completed: Issue #168
-- 다음 권장 작업: `Stage B duration IOI repaired proxy review`
+- latest completed: Issue #170
+- 다음 권장 작업: `Stage B phrase vocabulary motif variation repair`
 - broad training: 아직 진행하지 않음
 - Brad style adaptation: 아직 진행하지 않음
 - backend/API/product MVP: 범위 밖
@@ -263,14 +263,14 @@ bash scripts/agent_harness.sh stage-b-listening-review-aggregate
 ## 다음 작업
 
 ```text
-Stage B duration IOI repaired proxy review
+Stage B phrase vocabulary motif variation repair
 ```
 
 목표:
 
-- Issue #168의 duration/IOI objective repair 후보를 MIDI-note/context 기준으로 검토
-- IOI diversity 개선이 실제로 덜 mechanical한 phrase로 이어졌는지 확인
-- most-common IOI 악화 tradeoff를 proxy review에서 분리
+- Issue #168의 IOI diversity 개선은 가능한 한 유지
+- small-cell mechanical contour와 scalar/exercise 느낌 줄이기
+- most-common IOI repetition을 unique IOI count와 함께 개선
 - proxy keep이 없으면 broad training으로 넘어가지 않음
 
 ## 문서

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -292,6 +292,9 @@ Stage B에서 명시하는 것:
 - Issue #168 adds phrase-level duration/IOI bar-position planning for `data_motif_rhythm_phrase_variation` and ranks review candidates by IOI diversity before duration diversity.
 - Issue #168 result: variation strict `3/3`, final landing `3/3`, max interval `4`, objective MIDI flags `{}`, duration diversity `0.078`, IOI diversity `0.111`, tension `0.375`.
 - Issue #168 tradeoff: most-common IOI worsened to `0.481`, so this is an objective-diversity repair, not a musical keep.
+- Issue #170 fills MIDI-note/context proxy review notes for the Issue #168 repaired candidates.
+- Issue #170 result: `reviewed=6`, `keep=0`, `needs_followup=4`, `reject=2`, timing `acceptable=2`, `too_stiff=4`, objective bucket `clean=6`, objective flags `{}`.
+- Issue #170 aggregate result: `improve_phrase_vocabulary=12`, `fix_timing_grid=8`, `increase_motif_variation=4`; next generation work should reduce small-cell mechanical contour while preserving objective-clean guardrails.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -310,7 +313,7 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-이제 다음 단계는 duration IOI repaired proxy review다. Issue #168은 duration/IOI diversity를 개선했지만 most-common IOI 반복 tradeoff가 남았고, proxy keep 여부는 아직 확인되지 않았다.
+이제 다음 단계는 phrase vocabulary motif variation repair다. Issue #170은 proxy keep이 없음을 확인했고, 가장 큰 blocker는 phrase vocabulary와 motif variation이다.
 
 ## 6. 다음 단계 로드맵
 
@@ -866,8 +869,9 @@ Stage B data-derived timing phrase repaired proxy review
 
 다음 작업:
 
-- 다음 issue는 `Stage B duration IOI repaired proxy review`로 잡는다.
-- Issue #168 후보를 MIDI-note/context 기준으로 채워, 늘어난 IOI 종류가 실제로 덜 mechanical한지 확인한다.
+- 다음 issue는 `Stage B phrase vocabulary motif variation repair`로 잡는다.
+- Issue #168의 IOI diversity 개선은 가능한 한 유지한다.
+- small-cell mechanical contour와 most-common IOI repetition을 함께 줄인다.
 - objective clean 후보라도 proxy keep이 없으면 broad training으로 넘어가지 않는다.
 
 ## 10. 한 문장 요약

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest completed: Issue #168, Stage B phrase-level duration IOI objective repair
-- 다음 권장 이슈: `Stage B duration IOI repaired proxy review`
+- latest completed: Issue #170, Stage B duration IOI repaired proxy review
+- 다음 권장 이슈: `Stage B phrase vocabulary motif variation repair`
 
 현재 범위가 아닌 것:
 
@@ -39,7 +39,46 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
-## Latest Duration/IOI Objective Repair Result
+## Latest Duration/IOI Repaired Proxy Review Result
+
+Issue #170은 Issue #168 duration/IOI objective repair 이후의 후보를 MIDI-note/context 기준으로 다시 채운 proxy review다.
+
+Docs:
+
+- `docs/STAGE_B_DURATION_IOI_REPAIRED_PROXY_REVIEW_2026-05-27.md`
+
+Result:
+
+- reviewed candidates: `6`
+- pending candidates: `0`
+- decisions:
+  - `keep`: `0`
+  - `needs_followup`: `4`
+  - `reject`: `2`
+- timing:
+  - `acceptable`: `2`
+  - `too_stiff`: `4`
+- phrase quality:
+  - `phrase`: `2`
+  - `fragment`: `3`
+  - `exercise`: `1`
+- chord fit: `fits=6`
+- objective bucket: `clean=6`
+- objective flags: `{}`
+
+Aggregate follow-up signals:
+
+- `improve_phrase_vocabulary`: `12`
+- `fix_timing_grid`: `8`
+- `increase_motif_variation`: `4`
+
+Decision:
+
+- Issue #168은 objective duration/IOI diversity repair로 유지한다.
+- 그러나 proxy `keep` 후보는 아직 없다.
+- 다음은 small-cell mechanical contour를 줄이는 phrase vocabulary/motif variation repair다.
+
+## Previous Duration/IOI Objective Repair Result
 
 Issue #168은 Issue #164 이후 남은 phrase-level duration/IOI 병목을 generation rule 쪽에서 좁게 본 작업이다.
 

--- a/docs/STAGE_B_DURATION_IOI_REPAIRED_PROXY_REVIEW_2026-05-27.md
+++ b/docs/STAGE_B_DURATION_IOI_REPAIRED_PROXY_REVIEW_2026-05-27.md
@@ -1,0 +1,124 @@
+# Stage B Duration/IOI Repaired Proxy Review
+
+작성일: 2026-05-27
+
+## 목적
+
+Issue #170은 Issue #168 duration/IOI objective repair 이후의 후보를 MIDI-note/context 기준으로 채운 proxy review다.
+
+중요한 경계:
+
+- 실제 오디오 청취 리뷰가 아니다.
+- MIDI note sequence, context MIDI path, objective MIDI metrics, Issue #168 metric tradeoff를 기준으로 판단했다.
+- objective-clean status는 최종 음악 품질이나 broad training 준비 완료를 의미하지 않는다.
+- `outputs/` 아래 filled review notes와 aggregate는 생성 artifact라 커밋하지 않는다.
+
+## 입력
+
+Generated artifacts:
+
+- review manifest:
+  - `outputs/stage_b_data_motif_review/harness_stage_b_duration_ioi_objective_repair/review_manifest.json`
+- objective MIDI review:
+  - `outputs/stage_b_objective_midi_review/harness_stage_b_duration_ioi_objective_repair/objective_midi_note_review.json`
+- proxy-filled notes:
+  - `outputs/stage_b_listening_review_notes/harness_stage_b_duration_ioi_proxy_review/duration_ioi_proxy_review_notes.json`
+- aggregate:
+  - `outputs/stage_b_listening_review_aggregate/harness_stage_b_duration_ioi_proxy_review/listening_review_aggregate.md`
+
+## Review Result
+
+Decision counts:
+
+| decision | count |
+|---|---:|
+| `keep` | 0 |
+| `needs_followup` | 4 |
+| `reject` | 2 |
+
+Quality counts:
+
+| field | result |
+|---|---|
+| phrase quality | `phrase=2`, `fragment=3`, `exercise=1` |
+| timing | `acceptable=2`, `too_stiff=4` |
+| chord fit | `fits=6` |
+| objective bucket | `clean=6` |
+| objective flags | `{}` |
+
+Candidate decisions:
+
+| candidate | phrase | timing | chord fit | decision | reason |
+|---|---|---|---|---|---|
+| `data_motif_contour_landing_repair_rank_1_sample_1` | `fragment` | `too_stiff` | `fits` | `reject` | contour baseline remains low-register/grid fragment |
+| `data_motif_contour_landing_repair_rank_2_sample_2` | `fragment` | `too_stiff` | `fits` | `needs_followup` | context-compatible baseline, but not duration/IOI repair evidence |
+| `data_motif_contour_landing_repair_rank_3_sample_3` | `fragment` | `too_stiff` | `fits` | `reject` | low-register contour material and prior timing profile |
+| `data_motif_rhythm_phrase_variation_rank_1_sample_1` | `phrase` | `acceptable` | `fits` | `needs_followup` | best repaired surface, but cell-driven and thin pitch vocabulary |
+| `data_motif_rhythm_phrase_variation_rank_2_sample_3` | `phrase` | `acceptable` | `fits` | `needs_followup` | safe register and visible IOI gap vocabulary, but repeated small-cell contour |
+| `data_motif_rhythm_phrase_variation_rank_3_sample_2` | `exercise` | `too_stiff` | `fits` | `needs_followup` | high stepwise ratio and most-common IOI repetition |
+
+Aggregate follow-up signals:
+
+| code | count | interpretation |
+|---|---:|---|
+| `improve_phrase_vocabulary` | 12 | strongest remaining blocker |
+| `fix_timing_grid` | 8 | IOI diversity rose, but timing is still grid-heavy |
+| `increase_motif_variation` | 4 | repaired candidates still lean on small repeated cells |
+
+## Best Candidate Judgment
+
+Best repaired candidate:
+
+- candidate: `data_motif_rhythm_phrase_variation_rank_1_sample_1`
+- decision: `needs_followup`
+- objective bucket: `clean`
+- objective flags: `[]`
+- note count: `64`
+- unique pitch count: `16`
+- syncopated onset ratio: `0.672`
+- duration diversity ratio: `0.094`
+- IOI diversity ratio: `0.111`
+- most-common IOI ratio: `0.460`
+- source tension ratio: `0.375`
+- objective tension ratio: `0.484`
+- final landing: `guide`
+- max interval: `4`
+
+Why not keep:
+
+- IOI diversity improved, but the line still has a high most-common IOI ratio.
+- unique pitch count is thin for an 8-bar phrase.
+- stepwise/chromatic movement remains high enough to read as controlled exercise material.
+- phrase vocabulary and motif variation remain stronger blockers than raw objective cleanliness.
+
+## Decision
+
+Issue #170 conclusion:
+
+- Do not promote any candidate to proxy `keep`.
+- Keep Issue #168 as an objective duration/IOI diversity repair, not as a final musical improvement.
+- The next generation issue should target phrase vocabulary and motif variation while preserving objective-clean guardrails.
+- Broad training, Brad style adaptation, backend/API, and audio pivot remain premature.
+
+Recommended next issue:
+
+```text
+Stage B phrase vocabulary motif variation repair
+```
+
+Target:
+
+- reduce small-cell mechanical contour
+- keep Issue #168 IOI diversity improvement where possible
+- reduce most-common IOI repetition rather than only increasing unique IOI count
+- preserve register-safe bounds, max interval, final guide/chord landing, and objective-clean MIDI output
+
+## 검증
+
+실행한 검증:
+
+```bash
+.venv/bin/python scripts/build_listening_review_notes.py --run_id harness_stage_b_duration_ioi_proxy_review --review_manifest outputs/stage_b_data_motif_review/harness_stage_b_duration_ioi_objective_repair/review_manifest.json --objective_midi_review_report outputs/stage_b_objective_midi_review/harness_stage_b_duration_ioi_objective_repair/objective_midi_note_review.json --source_review_markdown outputs/stage_b_data_motif_review/harness_stage_b_duration_ioi_objective_repair/review_candidates.md
+.venv/bin/python scripts/build_listening_review_notes.py --run_id harness_stage_b_duration_ioi_proxy_review --review_notes outputs/stage_b_listening_review_notes/harness_stage_b_duration_ioi_proxy_review/duration_ioi_proxy_review_notes.json
+.venv/bin/python scripts/summarize_listening_review_notes.py --run_id harness_stage_b_duration_ioi_proxy_review --review_notes outputs/stage_b_listening_review_notes/harness_stage_b_duration_ioi_proxy_review/duration_ioi_proxy_review_notes.json
+```


### PR DESCRIPTION
## 변경 내용
- Issue #168 repaired 후보 6개를 MIDI-note/context 기준으로 proxy review했습니다.
- 결과를 신규 문서와 README, CORE_PLAN, CURRENT_STATUS_AND_PLAN에 반영했습니다.
- 생성 규칙은 변경하지 않았고, generated output artifact는 커밋하지 않았습니다.

## 결과
- reviewed candidates: `6`
- `keep`: `0`
- `needs_followup`: `4`
- `reject`: `2`
- timing: `acceptable=2`, `too_stiff=4`
- phrase quality: `phrase=2`, `fragment=3`, `exercise=1`
- objective bucket: `clean=6`
- objective flags: `{}`

## 판단
- Issue #168은 objective duration/IOI diversity repair로 유지합니다.
- proxy `keep` 후보는 아직 없습니다.
- 다음 작업은 phrase vocabulary와 motif variation repair입니다.

## 검증
- `.venv/bin/python scripts/build_listening_review_notes.py --run_id harness_stage_b_duration_ioi_proxy_review --review_manifest outputs/stage_b_data_motif_review/harness_stage_b_duration_ioi_objective_repair/review_manifest.json --objective_midi_review_report outputs/stage_b_objective_midi_review/harness_stage_b_duration_ioi_objective_repair/objective_midi_note_review.json --source_review_markdown outputs/stage_b_data_motif_review/harness_stage_b_duration_ioi_objective_repair/review_candidates.md`
- `.venv/bin/python scripts/build_listening_review_notes.py --run_id harness_stage_b_duration_ioi_proxy_review --review_notes outputs/stage_b_listening_review_notes/harness_stage_b_duration_ioi_proxy_review/duration_ioi_proxy_review_notes.json`
- `.venv/bin/python scripts/summarize_listening_review_notes.py --run_id harness_stage_b_duration_ioi_proxy_review --review_notes outputs/stage_b_listening_review_notes/harness_stage_b_duration_ioi_proxy_review/duration_ioi_proxy_review_notes.json`
- `bash scripts/agent_harness.sh quick`

Closes #170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal project status and planning documentation to reflect the latest completed work and next priorities.
  * Added documentation for Stage B review results and analysis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohhalim/fine_tuning_art-tatum_midi_solo/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->