### PR TITLE
Stage B focused timing vocabulary repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ most-common IOI와 duration 집중은 줄었지만, source tension ratio와 IOI 
 
 현재 main 기준 최신 판단:
 
-- latest completed: Issue #182
-- 다음 권장 작업: `Stage B focused timing vocabulary follow-up repair`
+- latest completed: Issue #184
+- 다음 권장 작업: `Stage B focused timing vocabulary repaired proxy review`
 - broad training: 아직 진행하지 않음
 - Brad style adaptation: 아직 진행하지 않음
 - backend/API/product MVP: 범위 밖
@@ -265,14 +265,14 @@ bash scripts/agent_harness.sh stage-b-listening-review-aggregate
 ## 다음 작업
 
 ```text
-Stage B focused timing vocabulary follow-up repair
+Stage B focused timing vocabulary repaired proxy review
 ```
 
 목표:
 
-- focused listening fill에서 확인한 `timing=stiff`, `jazz_vocabulary=thin` 병목 개선
-- repeated 3/4-note pitch-class cell을 줄이되 register/final landing guardrail 유지
-- off-grid artifact, overlap/polyphony, max interval regression 방지
+- Issue #184 repaired 후보를 MIDI-note/context 기준으로 다시 판단
+- rank 1/3의 cell 반복 개선과 rank 2의 adjacent repeat tradeoff를 분리
+- proxy keep이 나오지 않으면 다음 repair 축을 다시 좁힘
 - proxy keep이 없으면 broad training으로 넘어가지 않음
 
 ## 문서

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -200,6 +200,7 @@ Stage B에서 명시하는 것:
 88. Stage B phrase vocabulary motif focused context decision
 89. Stage B phrase vocabulary motif focused listening review notes
 90. Stage B phrase vocabulary motif focused listening review fill
+91. Stage B focused timing vocabulary follow-up repair
 
 가장 최근 의미 있는 결과:
 
@@ -318,6 +319,9 @@ Stage B에서 명시하는 것:
 - Issue #180 result: focused notes `candidate_count=1`, pending count `1`, proxy decision `keep`; real-listening fields remain pending and must be filled before another generation repair.
 - Issue #182 fills that focused listening review note and downgrades the candidate to `needs_followup`.
 - Issue #182 result: timing `stiff`, chord fit `acceptable`, phrase continuation `acceptable`, landing `acceptable`, jazz vocabulary `thin`; next repair should target grid-derived timing and short pitch-class vocabulary while preserving focused-context register/cadence guardrails.
+- Issue #184 adds a focused timing/vocabulary follow-up repair by blocking replayed 3/4-note pitch-class cells when a safe alternative exists and preserving max interval with repeat fallback.
+- Issue #184 result: variation strict `3/3`, final landing `3/3`, max interval `4`, objective flags `{}`, unique pitch count `19-20`, stepwise interval ratio `0.460`, root-tone ratio `0.031`.
+- Issue #184 tradeoff: rank 1/3 reduce short-cell repetition, but rank 2 introduces more adjacent pitch repeat; this requires fresh proxy review before any keep claim.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -336,7 +340,7 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-이제 다음 단계는 focused timing vocabulary follow-up repair다. Issue #182는 final keep을 만들지 못했지만, 다음 repair 축을 timing stiffness와 short pitch-class vocabulary로 좁혔다.
+이제 다음 단계는 focused timing vocabulary repaired proxy review다. Issue #184는 objective-clean repair를 만들었지만, adjacent repeat tradeoff가 있어 MIDI-note/context 기준의 fresh proxy decision이 필요하다.
 
 ## 6. 다음 단계 로드맵
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest completed: Issue #182, Stage B phrase vocabulary motif focused listening review fill
-- 다음 권장 이슈: `Stage B focused timing vocabulary follow-up repair`
+- latest completed: Issue #184, Stage B focused timing vocabulary follow-up repair
+- 다음 권장 이슈: `Stage B focused timing vocabulary repaired proxy review`
 
 현재 범위가 아닌 것:
 
@@ -38,6 +38,42 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 - sparse/medium 일부에서 chord-tone 반응이 약함
 
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
+
+## Latest Focused Timing Vocabulary Follow-up Repair Result
+
+Issue #184는 Issue #182 focused listening fill에서 드러난 `timing=stiff`, `jazz_vocabulary=thin` 병목을 generation rule 쪽에서 좁게 본 작업이다.
+
+Docs:
+
+- `docs/STAGE_B_FOCUSED_TIMING_VOCABULARY_REPAIR_2026-05-27.md`
+
+Implementation:
+
+- replayed 3-note/4-note pitch-class cell을 이어 만드는 candidate pitch-class를 safe alternative가 있을 때 제외했다.
+- repeated cell penalty를 강화했다.
+- max interval 후보가 없을 때 넓은 leap 대신 repeat fallback을 사용해 max interval guardrail을 보존했다.
+
+Result:
+
+- `data_motif_rhythm_phrase_variation` valid: `3/3`
+- strict: `3/3`
+- final landing resolved: `3/3`
+- max interval: `4`
+- objective MIDI flags: `{}`
+- avg syncopated onset ratio: `0.703`
+- avg duration diversity ratio: `0.089`
+- avg most-common IOI ratio: `0.397`
+- avg tension ratio: `0.323`
+- avg root-tone ratio: `0.031`
+- repaired variation unique pitch count: `19-20`
+- repaired variation stepwise interval ratio: `0.460`
+
+Decision:
+
+- Objective-clean/register/cadence guardrails are preserved.
+- Rank 1/3 reduce 4-note pitch-class cell repetition.
+- Rank 2 introduces more adjacent pitch repeat and short-cell repetition.
+- This is a tradeoff repair, so the next step is fresh proxy review, not final keep.
 
 ## Latest Phrase Vocabulary/Motif Focused Listening Fill Result
 

--- a/docs/STAGE_B_FOCUSED_TIMING_VOCABULARY_REPAIR_2026-05-27.md
+++ b/docs/STAGE_B_FOCUSED_TIMING_VOCABULARY_REPAIR_2026-05-27.md
@@ -1,0 +1,106 @@
+# Stage B Focused Timing Vocabulary Follow-up Repair
+
+작성일: 2026-05-27
+
+## 목적
+
+Issue #184는 Issue #182 focused listening fill에서 드러난 `timing=stiff`, `jazz_vocabulary=thin` 병목을 generation rule 쪽에서 좁게 본 작업이다.
+
+중요한 경계:
+
+- 이 작업은 broad training이 아니다.
+- focused fill 후보가 final keep으로 승격된 것이 아니다.
+- 목표는 objective-clean/register/cadence guardrail을 유지하면서 short pitch-class cell 반복을 줄일 수 있는지 확인하는 것이다.
+
+## 배경
+
+Issue #182 결과:
+
+- candidate: `data_motif_rhythm_phrase_variation_rank_2_sample_2`
+- focused listening decision: `needs_followup`
+- timing: `stiff`
+- chord fit: `acceptable`
+- phrase continuation: `acceptable`
+- landing: `acceptable`
+- jazz vocabulary: `thin`
+
+다음 repair target:
+
+- repeated 3-note/4-note pitch-class cells
+- grid-derived timing feel
+- thin/mechanical phrase vocabulary
+
+유지해야 하는 guardrail:
+
+- objective-clean status
+- safe register range
+- final guide/chord landing
+- max interval
+- no overlap/polyphony
+- no off-grid artifacts
+
+## 변경
+
+- `register_safe_phrase_pitch_classes()`에서 최근 2/3개 pitch-class prefix가 과거 3/4-note cell을 재생하는 candidate pitch-class를 safe alternative가 있을 때 제외했다.
+- `register_safe_phrase_cell_penalty()`의 repeated cell penalty를 강화했다.
+- `bounded_phrase_pitch_for_pitch_classes()`에서 `allow_wider_fallback=False`인 상황에 max interval 후보가 없으면 넓은 leap 대신 repeat fallback을 허용해 max interval guardrail을 지키도록 했다.
+
+## 검증
+
+```bash
+.venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare
+RUN_ID=harness_stage_b_focused_timing_vocab_followup_repair bash scripts/agent_harness.sh stage-b-rhythm-phrase-variation
+```
+
+## 결과
+
+`data_motif_rhythm_phrase_variation` summary:
+
+| metric | issue #172 | issue #184 |
+|---|---:|---:|
+| strict valid | `3/3` | `3/3` |
+| final landing resolved | `3/3` | `3/3` |
+| max interval | `4` | `4` |
+| objective flags | `{}` | `{}` |
+| avg syncopated onset ratio | `0.703` | `0.703` |
+| avg duration diversity ratio | `0.089` | `0.089` |
+| avg most-common duration ratio | `0.406` | `0.406` |
+| avg IOI diversity ratio | `0.095` | `0.095` |
+| avg most-common IOI ratio | `0.397` | `0.397` |
+| avg tension ratio | `0.318` | `0.323` |
+| avg root-tone ratio | `0.047` | `0.031` |
+
+Objective MIDI review for repaired variation candidates:
+
+| metric | issue #172 | issue #184 |
+|---|---:|---:|
+| unique pitch count | `18-20` | `19-20` |
+| stepwise interval ratio | `0.460-0.492` | `0.460` |
+| repeated pitch interval ratio | `0.000-0.016` | `0.032-0.063` |
+| objective tension ratio | `0.438-0.500` | `0.438-0.469` |
+| objective flags | `{}` | `{}` |
+
+Pitch-class cell comparison on repaired variation review MIDI:
+
+| candidate rank | issue #172 3-cell repeats | issue #184 3-cell repeats | issue #172 4-cell repeats | issue #184 4-cell repeats | issue #184 8-cell repeats |
+|---:|---:|---:|---:|---:|---:|
+| 1 | `5` | `4` | `3` | `1` | `0` |
+| 2 | `5` | `7` | `2` | `3` | `0` |
+| 3 | `5` | `2` | `0` | `0` | `0` |
+
+## 판단
+
+Issue #184는 objective-clean guardrail을 유지했고, rank 1/3에서는 short pitch-class cell repetition을 줄였다.
+
+그러나 rank 2에서는 repeated short cells와 adjacent pitch repeat이 늘었다. 따라서 이 repair는 final keep으로 승격하지 않는다.
+
+현재 해석:
+
+- max interval, final landing, objective flags는 유지됐다.
+- root-tone ratio와 stepwise ratio는 개선됐다.
+- repeated pitch interval이 생겼기 때문에 fresh proxy review가 필요하다.
+- 다음 판단은 candidate rank 3까지 포함한 repaired set을 MIDI-note/context 기준으로 다시 채우는 것이다.
+
+## 다음 작업
+
+`Stage B focused timing vocabulary repaired proxy review`

--- a/scripts/run_stage_b_data_motif_generation_compare.py
+++ b/scripts/run_stage_b_data_motif_generation_compare.py
@@ -519,6 +519,26 @@ def register_safe_phrase_pitch_classes(
     if len(ordered) <= 1:
         return ordered
 
+    recent_classes = [int(pitch) % 12 for pitch in recent_pitches]
+    blocked_cell_classes: set[int] = set()
+    lookback = 32
+    if len(recent_classes) >= 2:
+        prefix = tuple(recent_classes[-2:])
+        for index in range(max(0, len(recent_classes) - lookback), len(recent_classes) - 2):
+            cell = tuple(recent_classes[index : index + 3])
+            if cell[:2] == prefix:
+                blocked_cell_classes.add(cell[-1])
+    if len(recent_classes) >= 3:
+        prefix = tuple(recent_classes[-3:])
+        for index in range(max(0, len(recent_classes) - lookback), len(recent_classes) - 3):
+            cell = tuple(recent_classes[index : index + 4])
+            if cell[:3] == prefix:
+                blocked_cell_classes.add(cell[-1])
+    if blocked_cell_classes:
+        safe_ordered = [pitch_class for pitch_class in ordered if pitch_class not in blocked_cell_classes]
+        if safe_ordered:
+            ordered = safe_ordered
+
     recent_short = {int(pitch) % 12 for pitch in recent_pitches[-2:]}
     recent_phrase = {int(pitch) % 12 for pitch in recent_pitches[-8:]}
     development_role = (
@@ -1188,27 +1208,27 @@ def register_safe_phrase_cell_penalty(candidate_pitch: int, recent_pitches: Sequ
 
     lookback = 32
     if candidate_class in set(recent_classes[-4:]):
-        penalty += 2
+        penalty += 3
     if len(recent_classes) >= 2:
         phrase_cells = {
             tuple(recent_classes[index : index + 3])
             for index in range(max(0, len(recent_classes) - lookback), len(recent_classes) - 2)
         }
         if tuple(recent_classes[-2:] + [candidate_class]) in phrase_cells:
-            penalty += 6
+            penalty += 14
     if len(recent_classes) >= 3:
         phrase_cells = {
             tuple(recent_classes[index : index + 4])
             for index in range(max(0, len(recent_classes) - lookback), len(recent_classes) - 3)
         }
         if tuple(recent_classes[-3:] + [candidate_class]) in phrase_cells:
-            penalty += 10
+            penalty += 22
         exact_cells = {
             tuple(recent[index : index + 4])
             for index in range(max(0, len(recent) - lookback), len(recent) - 3)
         }
         if tuple(recent[-3:] + [candidate]) in exact_cells:
-            penalty += 12
+            penalty += 28
     return penalty
 
 
@@ -1289,11 +1309,11 @@ def bounded_phrase_pitch_for_pitch_classes(
             if near:
                 candidates = near
                 prefer_primary_pitch_class = False
-            elif allow_repeat_fallback and previous % 12 in priority:
+            elif allow_repeat_fallback:
                 return previous
             prefer_primary_pitch_class = False
         else:
-            if allow_repeat_fallback and previous % 12 in priority:
+            if allow_repeat_fallback:
                 return previous
             prefer_primary_pitch_class = False
 

--- a/tests/test_stage_b_data_motif_generation_compare.py
+++ b/tests/test_stage_b_data_motif_generation_compare.py
@@ -340,6 +340,32 @@ class StageBDataMotifGenerationCompareTest(unittest.TestCase):
 
         self.assertGreater(repeated, fresh)
 
+    def test_register_safe_phrase_pitch_classes_drops_replayed_cell_when_safe_exists(self) -> None:
+        pitch_classes = register_safe_phrase_pitch_classes(
+            [4, 9],
+            recent_pitches=[60, 62, 64, 67, 60, 62],
+            bar_index=0,
+            motif_index=0,
+            local_index=0,
+            variation_index=0,
+        )
+
+        self.assertEqual(pitch_classes, [9])
+
+    def test_bounded_phrase_pitch_repeat_fallback_preserves_interval_guardrail(self) -> None:
+        pitch = bounded_phrase_pitch_for_pitch_classes(
+            [6],
+            target_pitch=66,
+            recent_pitches=[75],
+            max_interval=4,
+            allow_repeat_fallback=True,
+            allow_wider_fallback=False,
+            min_pitch=55,
+            max_pitch=76,
+        )
+
+        self.assertEqual(pitch, 75)
+
     def test_focused_context_register_bounds_lifts_final_cadence_range(self) -> None:
         early_min, early_max = focused_context_register_bounds(1, 8, min_pitch=48, max_pitch=84)
         final_min, final_max = focused_context_register_bounds(7, 8, min_pitch=48, max_pitch=84)


### PR DESCRIPTION
## Summary
- block replayed 3-note/4-note pitch-class cells when a safe alternative exists
- strengthen repeated-cell penalties and preserve max-interval guardrail with repeat fallback
- document Issue #184 metric tradeoffs and the next repaired proxy review boundary

## Results
- data_motif_rhythm_phrase_variation strict: 3/3
- final landing resolved: 3/3
- max interval: 4
- objective MIDI flags: {}
- repaired variation unique pitch count: 19-20
- stepwise interval ratio: 0.460
- avg root-tone ratio: 0.031
- tradeoff: rank 2 introduces more adjacent pitch repeat and short-cell repetition

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare
- RUN_ID=harness_stage_b_focused_timing_vocab_followup_repair bash scripts/agent_harness.sh stage-b-rhythm-phrase-variation
- bash scripts/agent_harness.sh quick
- git diff --check

Closes #184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project status documentation to reflect latest development milestone and progress, including detailed technical results and performance validation metrics

* **Tests**
  * Added new test cases to validate pitch-selection behavior and proper handling of musical interval constraint guardrails

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohhalim/fine_tuning_art-tatum_midi_solo/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->