### PR TITLE
Stage B focused timing vocabulary listening fill

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ most-common IOI와 duration 집중은 줄었지만, source tension ratio와 IOI 
 
 현재 main 기준 최신 판단:
 
-- latest completed: Issue #192
-- 다음 권장 작업: `Stage B focused timing vocabulary focused listening review fill`
+- latest completed: Issue #194
+- 다음 권장 작업: `Stage B focused timing vocabulary listening follow-up repair`
 - broad training: 아직 진행하지 않음
 - Brad style adaptation: 아직 진행하지 않음
 - backend/API/product MVP: 범위 밖
@@ -265,15 +265,15 @@ bash scripts/agent_harness.sh stage-b-listening-review-aggregate
 ## 다음 작업
 
 ```text
-Stage B focused timing vocabulary focused listening review fill
+Stage B focused timing vocabulary listening follow-up repair
 ```
 
 목표:
 
-- Issue #192 focused listening review notes template의 pending fields를 채움
-- timing, chord fit, phrase continuation, landing, jazz vocabulary를 분리 평가
-- `keep`이면 다음 model-core 경계를 정의
-- `needs_followup`이면 다음 repair 축을 timing, phrase vocabulary, motif variation, chord color 중 하나로 좁힘
+- focused listening fill에서 남은 `timing=stiff`, `jazz_vocabulary=thin` 병목을 generation rule 쪽에서 좁힘
+- adjacent pitch repeat와 duplicated 3-note pitch-class cell을 줄임
+- source tension/chord color를 늘리되 outside-note drift는 만들지 않음
+- final guide landing, max interval, objective-clean guardrail은 유지
 
 ## 문서
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -205,6 +205,7 @@ Stage B에서 명시하는 것:
 93. Stage B focused timing vocabulary proxy keep focused package
 94. Stage B focused timing vocabulary focused context decision
 95. Stage B focused timing vocabulary focused listening review notes
+96. Stage B focused timing vocabulary focused listening review fill
 
 가장 최근 의미 있는 결과:
 
@@ -336,6 +337,8 @@ Stage B에서 명시하는 것:
 - Issue #190 result: solo range `G3-G5`, final landing `D5` over `Ebmaj7`, max interval `4`, duplicated 4/8-note pitch-class chunks `0`, objective flags `[]`; remaining risks are adjacent repeats, duplicated 3-note cells, quantized timing, and low source tension.
 - Issue #192 creates a one-candidate focused listening review notes template from the Issue #190 focused-context keep.
 - Issue #192 result: focused notes `candidate_count=1`, pending count `1`, proxy decision `keep`; real-listening fields remain pending and must be filled before another generation repair.
+- Issue #194 fills that focused listening review note and downgrades the candidate to `needs_followup`.
+- Issue #194 result: timing `stiff`, chord fit `acceptable`, phrase continuation `acceptable`, landing `strong`, jazz vocabulary `thin`; next repair should target adjacent repeats, duplicated 3-note cells, timing stiffness, and chord-color/tension while preserving focused-context register/cadence guardrails.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -354,7 +357,7 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-이제 다음 단계는 focused timing vocabulary focused listening review fill이다. Issue #192는 템플릿만 만들었고, timing/chord fit/phrase continuation/landing/jazz vocabulary 판단은 아직 pending이다.
+이제 다음 단계는 focused timing vocabulary listening follow-up repair다. Issue #194는 focused context candidate를 final keep으로 올리지 않았고, remaining blocker를 timing/vocabulary/chord color로 좁혔다.
 
 ## 6. 다음 단계 로드맵
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest completed: Issue #192, Stage B focused timing vocabulary focused listening review notes
-- 다음 권장 이슈: `Stage B focused timing vocabulary focused listening review fill`
+- latest completed: Issue #194, Stage B focused timing vocabulary focused listening review fill
+- 다음 권장 이슈: `Stage B focused timing vocabulary listening follow-up repair`
 
 현재 범위가 아닌 것:
 
@@ -39,7 +39,40 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
-## Latest Focused Timing Vocabulary Focused Listening Review Notes Result
+## Latest Focused Timing Vocabulary Focused Listening Fill Result
+
+Issue #194는 Issue #192 focused listening review notes template을 MIDI-note/context evidence 기준으로 채운 작업이다.
+
+Docs:
+
+- `docs/STAGE_B_FOCUSED_TIMING_VOCABULARY_FOCUSED_LISTENING_FILL_2026-05-27.md`
+
+Filled notes:
+
+- `outputs/stage_b_focused_listening_review_notes/harness_stage_b_focused_timing_vocab_focused_listening_notes/focused_listening_review_notes_filled.json`
+
+Filled result:
+
+- candidate count: `1`
+- reviewed count: `1`
+- pending count: `0`
+- decision:
+  - `keep`: `0`
+  - `needs_followup`: `1`
+  - `reject`: `0`
+- timing: `stiff`
+- chord fit: `acceptable`
+- phrase continuation: `acceptable`
+- landing: `strong`
+- jazz vocabulary: `thin`
+
+Decision:
+
+- The candidate survives focused context register/cadence checks and has a strong guide landing.
+- It does not survive as final keep because timing remains grid-derived and vocabulary reads thin/mechanical.
+- Next repair should target adjacent repeats, duplicated 3-note cells, and chord-color/tension while preserving objective-clean/register/cadence guardrails.
+
+## Previous Focused Timing Vocabulary Focused Listening Review Notes Result
 
 Issue #192는 Issue #190에서 `keep_for_focused_listening`으로 남은 단일 후보를 focused listening review notes template으로 만든 작업이다.
 

--- a/docs/STAGE_B_FOCUSED_TIMING_VOCABULARY_FOCUSED_LISTENING_FILL_2026-05-27.md
+++ b/docs/STAGE_B_FOCUSED_TIMING_VOCABULARY_FOCUSED_LISTENING_FILL_2026-05-27.md
@@ -1,0 +1,97 @@
+# Stage B Focused Timing Vocabulary Focused Listening Fill
+
+작성일: 2026-05-27
+
+## 목적
+
+Issue #194는 Issue #192 focused listening review notes template을 MIDI-note/context evidence 기준으로 채운 작업이다.
+
+중요한 경계:
+
+- 실제 오디오 청취 결과가 아니다.
+- focused context MIDI-note 판단을 structured listening fields에 기록한 것이다.
+- `needs_followup`은 objective-clean 후보가 쓸모없다는 뜻이 아니라, final keep으로 올리기 전 다음 repair 축이 남았다는 뜻이다.
+
+## 입력
+
+Focused listening notes template:
+
+- `outputs/stage_b_focused_listening_review_notes/harness_stage_b_focused_timing_vocab_focused_listening_notes/focused_listening_review_notes_template.json`
+
+Filled notes:
+
+- `outputs/stage_b_focused_listening_review_notes/harness_stage_b_focused_timing_vocab_focused_listening_notes/focused_listening_review_notes_filled.json`
+
+후보:
+
+- `data_motif_rhythm_phrase_variation_rank_3_sample_3`
+
+## Filled Result
+
+Validation summary:
+
+| field | value |
+|---|---:|
+| candidate count | `1` |
+| reviewed count | `1` |
+| pending count | `0` |
+| keep | `0` |
+| needs followup | `1` |
+| reject | `0` |
+
+Focused listening fields:
+
+| field | value |
+|---|---|
+| timing | `stiff` |
+| chord fit | `acceptable` |
+| phrase continuation | `acceptable` |
+| landing | `strong` |
+| jazz vocabulary | `thin` |
+| decision | `needs_followup` |
+
+Why not keep:
+
+- The candidate survives focused context register and cadence checks.
+- Solo range is usable at `G3-G5`.
+- Final landing is a `D5` guide tone over `Ebmaj7`.
+- There are no duplicated 4-note or 8-note pitch-class chunks.
+- However timing is still grid-derived.
+- Adjacent repeated pitches and duplicated 3-note cells remain.
+- Source tension ratio is low at `0.297`, so jazz vocabulary still reads thin rather than conversational.
+
+## Decision
+
+Issue #194 conclusion:
+
+- Do not promote the focused candidate to final keep.
+- Keep it as a useful diagnostic seed.
+- The next generation repair should target timing stiffness, short-cell vocabulary, and chord color while preserving:
+  - objective-clean status
+  - safe register range
+  - final guide/chord landing
+  - no overlap/polyphony
+  - max interval guardrail
+  - zero duplicated 4-note/8-note pitch-class chunks
+
+Recommended next issue:
+
+```text
+Stage B focused timing vocabulary listening follow-up repair
+```
+
+Target:
+
+- reduce grid-derived timing stiffness without creating off-grid artifacts
+- reduce adjacent pitch repeats and duplicated 3-note pitch-class cells
+- increase chord-color/tension usage without outside-note drift
+- preserve the Issue #190 focused-context register/cadence guardrails
+- re-run objective and proxy review before claiming quality
+
+## 검증
+
+실행한 검증:
+
+```bash
+.venv/bin/python scripts/build_focused_listening_review_notes.py --run_id harness_stage_b_focused_timing_vocab_focused_listening_notes --focused_package outputs/stage_b_focused_review_package/harness_stage_b_focused_timing_vocab_proxy_keep_focused_package/focused_review_package.json --review_notes outputs/stage_b_focused_listening_review_notes/harness_stage_b_focused_timing_vocab_focused_listening_notes/focused_listening_review_notes_filled.json
+```


### PR DESCRIPTION
## Summary
- Document the Issue #194 focused listening review fill.
- Record the needs_followup decision and the remaining timing/vocabulary/chord-color blockers.
- Update README, CORE_PLAN, and CURRENT_STATUS_AND_PLAN so the next boundary is a focused timing vocabulary listening follow-up repair.

## Validation
- .venv/bin/python scripts/build_focused_listening_review_notes.py --run_id harness_stage_b_focused_timing_vocab_focused_listening_notes --focused_package outputs/stage_b_focused_review_package/harness_stage_b_focused_timing_vocab_proxy_keep_focused_package/focused_review_package.json --review_notes outputs/stage_b_focused_listening_review_notes/harness_stage_b_focused_timing_vocab_focused_listening_notes/focused_listening_review_notes_filled.json
- git diff --check
- bash scripts/agent_harness.sh quick

Closes #194