### PR TITLE
Stage B focused timing vocabulary follow-up repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ most-common IOI와 duration 집중은 줄었지만, source tension ratio와 IOI 
 
 현재 main 기준 최신 판단:
 
-- latest completed: Issue #194
-- 다음 권장 작업: `Stage B focused timing vocabulary listening follow-up repair`
+- latest completed: Issue #196
+- 다음 권장 작업: `Stage B focused timing vocabulary listening follow-up repaired proxy review`
 - broad training: 아직 진행하지 않음
 - Brad style adaptation: 아직 진행하지 않음
 - backend/API/product MVP: 범위 밖
@@ -265,15 +265,15 @@ bash scripts/agent_harness.sh stage-b-listening-review-aggregate
 ## 다음 작업
 
 ```text
-Stage B focused timing vocabulary listening follow-up repair
+Stage B focused timing vocabulary listening follow-up repaired proxy review
 ```
 
 목표:
 
-- focused listening fill에서 남은 `timing=stiff`, `jazz_vocabulary=thin` 병목을 generation rule 쪽에서 좁힘
-- adjacent pitch repeat와 duplicated 3-note pitch-class cell을 줄임
-- source tension/chord color를 늘리되 outside-note drift는 만들지 않음
-- final guide landing, max interval, objective-clean guardrail은 유지
+- Issue #196 repaired 후보를 MIDI-note/context 기준으로 다시 판단
+- rank 2의 adjacent repeat/short-cell improvement가 proxy keep으로 이어지는지 확인
+- source tension 하락과 rank 1/3 short-cell tradeoff를 분리
+- proxy keep이 없으면 chord-color/timing repair 축을 다시 좁힘
 
 ## 문서
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -206,6 +206,7 @@ Stage B에서 명시하는 것:
 94. Stage B focused timing vocabulary focused context decision
 95. Stage B focused timing vocabulary focused listening review notes
 96. Stage B focused timing vocabulary focused listening review fill
+97. Stage B focused timing vocabulary listening follow-up repair
 
 가장 최근 의미 있는 결과:
 
@@ -339,6 +340,9 @@ Stage B에서 명시하는 것:
 - Issue #192 result: focused notes `candidate_count=1`, pending count `1`, proxy decision `keep`; real-listening fields remain pending and must be filled before another generation repair.
 - Issue #194 fills that focused listening review note and downgrades the candidate to `needs_followup`.
 - Issue #194 result: timing `stiff`, chord fit `acceptable`, phrase continuation `acceptable`, landing `strong`, jazz vocabulary `thin`; next repair should target adjacent repeats, duplicated 3-note cells, timing stiffness, and chord-color/tension while preserving focused-context register/cadence guardrails.
+- Issue #196 adds a focused listening follow-up repair by avoiding immediate pitch-class reuse when safe alternatives exist and by trying tension/recovery/next-guide alternatives before repeat fallback.
+- Issue #196 result: variation strict `3/3`, final landing `3/3`, max interval `4`, objective flags `{}`, adjacent pitch repeats reduced to `0` for all three repaired candidates.
+- Issue #196 tradeoff: rank 2 improves duplicated 3/4-note cells to `0`, but avg source tension falls to `0.307` and rank 1/3 duplicated 3-note cells increase; this requires fresh proxy review before any keep claim.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -357,7 +361,7 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-이제 다음 단계는 focused timing vocabulary listening follow-up repair다. Issue #194는 focused context candidate를 final keep으로 올리지 않았고, remaining blocker를 timing/vocabulary/chord color로 좁혔다.
+이제 다음 단계는 focused timing vocabulary listening follow-up repaired proxy review다. Issue #196은 adjacent repeat를 고쳤지만 source tension과 short-cell tradeoff가 있어 MIDI-note/context 기준의 fresh decision이 필요하다.
 
 ## 6. 다음 단계 로드맵
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest completed: Issue #194, Stage B focused timing vocabulary focused listening review fill
-- 다음 권장 이슈: `Stage B focused timing vocabulary listening follow-up repair`
+- latest completed: Issue #196, Stage B focused timing vocabulary listening follow-up repair
+- 다음 권장 이슈: `Stage B focused timing vocabulary listening follow-up repaired proxy review`
 
 현재 범위가 아닌 것:
 
@@ -39,7 +39,48 @@ Stage A는 아직 실사용 가능한 jazz solo model이 아니다.
 
 따라서 지금의 목표는 "그럴듯한 제품 MVP"가 아니라, 전체 dataset 품질과 작은 probe를 통해 model training path를 검증하는 것이다.
 
-## Latest Focused Timing Vocabulary Focused Listening Fill Result
+## Latest Focused Timing Vocabulary Listening Follow-up Repair Result
+
+Issue #196은 Issue #194 focused listening fill에서 남은 `timing=stiff`, `jazz_vocabulary=thin` 병목을 generation rule 쪽에서 좁게 본 작업이다.
+
+Docs:
+
+- `docs/STAGE_B_FOCUSED_TIMING_VOCABULARY_LISTENING_FOLLOWUP_REPAIR_2026-05-27.md`
+
+Implementation:
+
+- safe alternative가 있을 때 직전 pitch-class를 후보에서 제외했다.
+- repeat fallback 직전에 tension/recovery/next-guide pitch-class 대체 후보를 시도했다.
+- fallback 후보는 최근에 쓰지 않은 실제 pitch를 우선 선택한다.
+
+Result:
+
+- `data_motif_rhythm_phrase_variation` valid: `3/3`
+- strict: `3/3`
+- final landing resolved: `3/3`
+- max interval: `4`
+- objective MIDI flags: `{}`
+- avg syncopated onset ratio: `0.703`
+- avg duration diversity ratio: `0.089`
+- avg most-common IOI ratio: `0.397`
+- avg source tension ratio: `0.307`
+- avg root-tone ratio: `0.036`
+
+Pitch-cell effect:
+
+- rank 1 adjacent repeats: `2 -> 0`
+- rank 2 adjacent repeats: `4 -> 0`
+- rank 3 adjacent repeats: `2 -> 0`
+- rank 2 duplicated 3-note cells: `7 -> 0`
+- rank 2 duplicated 4-note cells: `3 -> 0`
+
+Decision:
+
+- Objective-clean/register/cadence guardrails are preserved.
+- Rank 2 has the clearest repair signal.
+- Source tension fell and rank 1/3 short-cell repeats increased, so this is a fresh proxy review target, not final keep.
+
+## Previous Focused Timing Vocabulary Focused Listening Fill Result
 
 Issue #194는 Issue #192 focused listening review notes template을 MIDI-note/context evidence 기준으로 채운 작업이다.
 

--- a/docs/STAGE_B_FOCUSED_TIMING_VOCABULARY_LISTENING_FOLLOWUP_REPAIR_2026-05-27.md
+++ b/docs/STAGE_B_FOCUSED_TIMING_VOCABULARY_LISTENING_FOLLOWUP_REPAIR_2026-05-27.md
@@ -1,0 +1,114 @@
+# Stage B Focused Timing Vocabulary Listening Follow-up Repair
+
+작성일: 2026-05-27
+
+## 목적
+
+Issue #196은 Issue #194 focused listening fill에서 남은 `timing=stiff`, `jazz_vocabulary=thin` 병목을 generation rule 쪽에서 좁게 본 작업이다.
+
+중요한 경계:
+
+- 이 작업은 broad training이 아니다.
+- focused fill 후보가 final keep으로 승격된 것이 아니다.
+- 목표는 max interval, final landing, objective-clean guardrail을 유지하면서 adjacent pitch repeat와 short-cell replay를 줄이는 것이다.
+
+## 배경
+
+Issue #194 결과:
+
+- candidate: `data_motif_rhythm_phrase_variation_rank_3_sample_3`
+- focused listening decision: `needs_followup`
+- timing: `stiff`
+- chord fit: `acceptable`
+- phrase continuation: `acceptable`
+- landing: `strong`
+- jazz vocabulary: `thin`
+
+다음 repair target:
+
+- adjacent pitch repeats
+- duplicated 3-note pitch-class cells
+- grid-derived timing feel
+- low source tension / thin chord color
+
+유지해야 하는 guardrail:
+
+- objective-clean status
+- safe register range
+- final guide/chord landing
+- max interval
+- no overlap/polyphony
+- no duplicated 4-note/8-note pitch-class chunks where possible
+
+## 변경
+
+- `register_safe_phrase_pitch_classes()`에서 safe alternative가 있을 때 직전 pitch-class를 후보에서 제외했다.
+- `bounded_phrase_pitch_for_pitch_classes()`에 repeat fallback 직전의 safe color fallback 후보를 추가했다.
+- repeat fallback이 필요할 때 최근에 쓰지 않은 실제 pitch를 우선 선택해 unique pitch vocabulary가 무너지지 않게 했다.
+- `data_motif_rhythm_phrase_variation`의 line pitch 선택에서 tension, recovery, next guide-tone pitch-class를 repeat fallback 대체 후보로 넘겼다.
+
+## 검증
+
+```bash
+.venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare
+RUN_ID=harness_stage_b_focused_timing_vocab_listening_followup_repair bash scripts/agent_harness.sh stage-b-rhythm-phrase-variation
+```
+
+## 결과
+
+`data_motif_rhythm_phrase_variation` summary:
+
+| metric | issue #184 | issue #196 |
+|---|---:|---:|
+| strict valid | `3/3` | `3/3` |
+| final landing resolved | `3/3` | `3/3` |
+| max interval | `4` | `4` |
+| objective flags | `{}` | `{}` |
+| avg syncopated onset ratio | `0.703` | `0.703` |
+| avg duration diversity ratio | `0.089` | `0.089` |
+| avg most-common IOI ratio | `0.397` | `0.397` |
+| avg source tension ratio | `0.323` | `0.307` |
+| avg root-tone ratio | `0.031` | `0.036` |
+
+Pitch-cell comparison on repaired variation review MIDI:
+
+| candidate rank | issue #184 adjacent repeats | issue #196 adjacent repeats | issue #184 3-cell repeats | issue #196 3-cell repeats | issue #196 4-cell repeats | issue #196 8-cell repeats |
+|---:|---:|---:|---:|---:|---:|---:|
+| 1 | `2` | `0` | `4` | `6` | `2` | `0` |
+| 2 | `4` | `0` | `7` | `0` | `0` | `0` |
+| 3 | `2` | `0` | `2` | `5` | `0` | `0` |
+
+Objective MIDI review for repaired variation candidates:
+
+| candidate | unique pitches | repeated pitch ratio | objective tension | outside ratio | flags |
+|---|---:|---:|---:|---:|---|
+| rank 1 | `20` | `0.000` | `0.406` | `0.000` | `[]` |
+| rank 2 | `19` | `0.000` | `0.469` | `0.016` | `[]` |
+| rank 3 | `20` | `0.000` | `0.453` | `0.000` | `[]` |
+
+## 판단
+
+Issue #196은 adjacent pitch repeat를 세 후보 모두에서 제거했고 objective-clean guardrail을 유지했다.
+
+가장 좋은 신호:
+
+- rank 2는 adjacent repeats `4 -> 0`, 3-cell repeats `7 -> 0`, 4-cell repeats `3 -> 0`으로 개선됐다.
+- objective flags는 여전히 없다.
+- max interval과 final landing guardrail이 유지됐다.
+
+남은 tradeoff:
+
+- avg source tension ratio가 `0.323 -> 0.307`로 낮아졌다.
+- rank 1/3의 duplicated 3-note pitch-class cells는 늘었다.
+- 따라서 이 repair는 final keep이 아니라 fresh proxy review 대상이다.
+
+## 다음 작업
+
+`Stage B focused timing vocabulary listening follow-up repaired proxy review`
+
+목표:
+
+- Issue #196 repaired 후보를 MIDI-note/context 기준으로 다시 판단한다.
+- rank 2의 repeat/cell improvement가 proxy keep으로 이어지는지 확인한다.
+- source tension 하락과 rank 1/3 short-cell tradeoff를 분리한다.
+- proxy keep이 없으면 chord-color/timing repair 축을 다시 좁힌다.

--- a/scripts/run_stage_b_data_motif_generation_compare.py
+++ b/scripts/run_stage_b_data_motif_generation_compare.py
@@ -539,6 +539,11 @@ def register_safe_phrase_pitch_classes(
         if safe_ordered:
             ordered = safe_ordered
 
+    if recent_classes and len(ordered) > 1:
+        non_repeating_ordered = [pitch_class for pitch_class in ordered if pitch_class != recent_classes[-1]]
+        if non_repeating_ordered:
+            ordered = non_repeating_ordered
+
     recent_short = {int(pitch) % 12 for pitch in recent_pitches[-2:]}
     recent_phrase = {int(pitch) % 12 for pitch in recent_pitches[-8:]}
     development_role = (
@@ -1242,6 +1247,7 @@ def bounded_phrase_pitch_for_pitch_classes(
     allow_wider_fallback: bool = True,
     avoid_repeated_cells: bool = False,
     preferred_abs_intervals: Sequence[int] | None = None,
+    repeat_fallback_pitch_classes: Sequence[int] | None = None,
     min_pitch: int = PIANO_PITCH_MIN,
     max_pitch: int = PIANO_PITCH_MAX,
 ) -> int:
@@ -1255,6 +1261,11 @@ def bounded_phrase_pitch_for_pitch_classes(
 
     recent = list(recent_pitches or [])
     priority = {pitch_class: index for index, pitch_class in enumerate(ordered_classes)}
+    fallback_classes: list[int] = []
+    for pitch_class in repeat_fallback_pitch_classes or []:
+        normalized = int(pitch_class) % 12
+        if normalized not in fallback_classes:
+            fallback_classes.append(normalized)
 
     def cell_penalty(pitch: int) -> int:
         if not avoid_repeated_cells:
@@ -1284,6 +1295,42 @@ def bounded_phrase_pitch_for_pitch_classes(
         class_reuse = sum(1 for value in recent_window[-12:] if value % 12 == pitch % 12)
         return exact_reuse * 4 + class_reuse * 2
 
+    def repeat_fallback_pitch(previous: int) -> int:
+        fallback_priority = {
+            pitch_class: index
+            for index, pitch_class in enumerate(fallback_classes)
+            if pitch_class != int(previous) % 12
+        }
+        if not fallback_priority:
+            return int(previous)
+        fallback_candidates = [
+            pitch
+            for pitch in range(int(min_pitch), int(max_pitch) + 1)
+            if pitch % 12 in fallback_priority
+            and 1 <= abs(int(pitch) - int(previous)) <= int(max_interval)
+        ]
+        if not fallback_candidates:
+            return int(previous)
+        recent_window = [int(value) for value in recent[-32:]]
+        fresh_fallback_candidates = [pitch for pitch in fallback_candidates if int(pitch) not in recent_window]
+        if fresh_fallback_candidates:
+            fallback_candidates = fresh_fallback_candidates
+        return int(
+            min(
+                fallback_candidates,
+                key=lambda pitch: (
+                    cell_penalty(int(pitch)),
+                    reuse_penalty(int(pitch)),
+                    interval_penalty(int(pitch)),
+                    abs(int(pitch) - int(previous)),
+                    fallback_priority[int(pitch) % 12],
+                    abs(int(pitch) - int(target_pitch)),
+                    abs(int(pitch) - 67),
+                    int(pitch),
+                ),
+            )
+        )
+
     candidates = [
         pitch
         for pitch in range(int(min_pitch), int(max_pitch) + 1)
@@ -1310,11 +1357,11 @@ def bounded_phrase_pitch_for_pitch_classes(
                 candidates = near
                 prefer_primary_pitch_class = False
             elif allow_repeat_fallback:
-                return previous
+                return repeat_fallback_pitch(previous)
             prefer_primary_pitch_class = False
         else:
             if allow_repeat_fallback:
-                return previous
+                return repeat_fallback_pitch(previous)
             prefer_primary_pitch_class = False
 
     if recent and not prefer_primary_pitch_class:
@@ -2033,6 +2080,11 @@ def data_motif_rhythm_phrase_variation_tokens(
                         allow_wider_fallback=False,
                         avoid_repeated_cells=True,
                         preferred_abs_intervals=(3, 4),
+                        repeat_fallback_pitch_classes=(
+                            sorted(tension_pitch_classes(chord))
+                            + phrase_recovery_pitch_classes(chord, next_chord)
+                            + sorted(guide_tone_pitch_classes(next_chord))
+                        ),
                         min_pitch=bar_min_pitch,
                         max_pitch=bar_max_pitch,
                     )

--- a/tests/test_stage_b_data_motif_generation_compare.py
+++ b/tests/test_stage_b_data_motif_generation_compare.py
@@ -304,6 +304,18 @@ class StageBDataMotifGenerationCompareTest(unittest.TestCase):
         self.assertEqual(classes[0], 9)
         self.assertIn(0, classes)
 
+    def test_register_safe_phrase_pitch_classes_drops_immediate_repeat_when_safe_exists(self) -> None:
+        classes = register_safe_phrase_pitch_classes(
+            [7, 9],
+            recent_pitches=[60, 64, 67],
+            bar_index=0,
+            motif_index=0,
+            local_index=0,
+            variation_index=0,
+        )
+
+        self.assertEqual(classes, [9])
+
     def test_register_safe_phrase_target_pitch_stays_inside_register_window(self) -> None:
         high = register_safe_phrase_target_pitch(
             78,
@@ -365,6 +377,21 @@ class StageBDataMotifGenerationCompareTest(unittest.TestCase):
         )
 
         self.assertEqual(pitch, 75)
+
+    def test_bounded_phrase_pitch_repeat_fallback_uses_safe_color_alternative(self) -> None:
+        pitch = bounded_phrase_pitch_for_pitch_classes(
+            [6],
+            target_pitch=66,
+            recent_pitches=[75],
+            max_interval=4,
+            allow_repeat_fallback=True,
+            allow_wider_fallback=False,
+            repeat_fallback_pitch_classes=[2, 5],
+            min_pitch=55,
+            max_pitch=76,
+        )
+
+        self.assertEqual(pitch, 74)
 
     def test_focused_context_register_bounds_lifts_final_cadence_range(self) -> None:
         early_min, early_max = focused_context_register_bounds(1, 8, min_pitch=48, max_pitch=84)
@@ -814,11 +841,15 @@ class StageBDataMotifGenerationCompareTest(unittest.TestCase):
         profile = analyze_contour_landing_profile(tokens, chords=chords, primer_size=len(primer))
         pitches = [int(group["pitch"]) for group in groups]
         final_bar_pitches = [int(group["pitch"]) for group in groups if int(group["bar"]) == 7]
+        adjacent_repeated_pitch_count = sum(
+            1 for left, right in zip(pitches, pitches[1:]) if int(left) == int(right)
+        )
 
         self.assertTrue(grammar["grammar_valid"])
         self.assertGreaterEqual(len(groups), 63)
         self.assertGreaterEqual(len(set(pitches)), 18)
         self.assertLessEqual(max(pitches), 79)
+        self.assertEqual(adjacent_repeated_pitch_count, 0)
         self.assertGreaterEqual(min(final_bar_pitches), 60)
         four_note_cells = [tuple(pitches[index : index + 4]) for index in range(len(pitches) - 3)]
         self.assertEqual(len(four_note_cells), len(set(four_note_cells)))


### PR DESCRIPTION
## Summary
- Add a focused listening follow-up repair for data_motif_rhythm_phrase_variation.
- Avoid immediate pitch-class reuse when safe alternatives exist.
- Try tension/recovery/next-guide pitch classes before falling back to exact pitch repeat.
- Document the repair result and remaining source-tension/short-cell tradeoff.

## Result
- data_motif_rhythm_phrase_variation strict: 3/3
- final landing resolved: 3/3
- max interval: 4
- objective flags: {}
- adjacent pitch repeats: 0 for all three repaired variation candidates
- rank 2 duplicated 3-note cells: 7 -> 0
- rank 2 duplicated 4-note cells: 3 -> 0

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_data_motif_generation_compare
- RUN_ID=harness_stage_b_focused_timing_vocab_listening_followup_repair bash scripts/agent_harness.sh stage-b-rhythm-phrase-variation
- git diff --check
- bash scripts/agent_harness.sh quick

Closes #196