### PR TITLE
프로젝트 공개 기록 컨벤션 정리

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,18 @@ Keep public GitHub artifacts project-focused and tool-neutral.
 - Use issue and PR titles that describe the project change directly, for example `Stage B phrase duration repair` or `포트폴리오용 README 정리`.
 - Keep merge reports and final summaries focused on issue number, PR number, merge commit, changed files, and validation commands.
 
+## Public Record Style
+
+Write public records like a production engineering handoff.
+
+- Use structured sections when the artifact is more than a trivial change: `Summary`, `Context`, `Scope`, `Validation`, `Risk`, and `Follow-up`.
+- State the user-visible or project-visible behavior first, then implementation details.
+- Record the exact validation commands that were run, including environment/tooling failures when they happen.
+- Keep decisions evidence-based: include measured metrics, reviewed artifacts, issue links, and remaining tradeoffs.
+- Avoid vague labels such as `update`, `misc`, or `cleanup` when a specific project outcome can be named.
+- Keep commit subjects conventional and specific, with Korean bodies for context, changes, and validation when the change is non-trivial.
+- Do not claim final musical quality from proxy or objective checks alone; document it as a review boundary and name the next review step.
+
 ## Conditional Auto-Merge Policy
 
 The agent may merge a pull request without asking again only when all of the following are true:


### PR DESCRIPTION
## Summary

공개 기록을 현업 협업 문서에 가까운 형식으로 남기기 위한 기준을 AGENTS.md에 추가했습니다.

## Context

이슈와 PR이 짧은 주기로 누적되면서 변경 이유, 검증 결과, 남은 리스크를 일관되게 남기는 기준이 필요했습니다.

## Scope

- `Summary`, `Context`, `Scope`, `Validation`, `Risk`, `Follow-up` 중심의 기록 구조를 명시했습니다.
- 측정값, 검증 명령, reviewed artifact, tradeoff를 기록하도록 기준을 추가했습니다.
- proxy/objective check만으로 최종 음악 품질을 단정하지 않도록 문서화했습니다.

## Validation

- `bash scripts/agent_harness.sh quick`

## Risk

- 기능 변경은 없습니다.
- 과거 문서 정리는 이번 PR 범위에서 제외했습니다.

## Follow-up

- 이후 Stage B 이슈와 PR은 이 기록 형식을 기준으로 작성합니다.

Closes #202