### PR TITLE
feat: Stage B raw generation 반복 검증 sweep 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Issue #222 기준 model-core MVP:
 | raw generation gate | `stage-b-generation-probe` 통과 |
 | raw generation mode | `unconstrained` token sampling |
 | repair 조건 | 50 epoch tiny-overfit, top_k `4`, overlap postprocess |
+| repeatability sweep | 2 source files / 3 seeds / 9 samples |
+| repeatability result | strict `8/9`, grammar `9/9`, dead-air outlier `1` |
 | constrained review gate | `stage-b-overlap-gate` 통과 |
 | focused candidate path | `stage-b-rhythm-phrase-variation` 통과 |
 
@@ -70,6 +72,7 @@ MVP 근거:
 - raw generated samples valid/strict/grammar `5/5`
 - complete note groups `21-22`, invalid token count `0`
 - postprocess 후 note count `13-18`, unique pitch count `4-6`
+- 2-file/3-seed repeatability sweep에서 strict pass-rate `0.889`
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`
@@ -108,7 +111,8 @@ Issue #210 기준 current best focused review candidate:
 | 항목 | 상태 |
 |---|---|
 | broad unconstrained trained-model generation quality | 미검증 |
-| broad multi-seed model quality | 미검증 |
+| broad multi-seed model quality | 부분 검증 / 2-file 3-seed local sweep 통과 |
+| dead-air outlier control | 미완료 |
 | human/audio listening preference | 미검증 |
 | Brad Mehldau style adaptation | 미검증 |
 | generic jazz pianist base 완성 | 미검증 |

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -56,7 +56,9 @@ MVP가 끝났다고 볼 수 있는 조건:
 - broad trained-model quality: 미검증
 - 근거 문서: `docs/STAGE_B_MODEL_CORE_MVP_COMPLETION_AUDIT_2026-05-28.md`
 - repair 문서: `docs/STAGE_B_RAW_GENERATION_GATE_REPAIR_2026-05-28.md`
+- repeatability 문서: `docs/STAGE_B_RAW_GENERATION_REPEATABILITY_SWEEP_2026-05-28.md`
 - raw generation gate: `stage-b-generation-probe` 통과
+- raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -229,6 +231,7 @@ Stage B에서 명시하는 것:
 106. README 구현 내용 중심 재정리
 107. README 하단 참조 섹션 제거
 108. Stage B raw generation gate repair
+109. Stage B raw generation broader repeatability sweep
 
 가장 최근 의미 있는 결과:
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #222, Stage B raw generation gate repair
-- 다음 권장 이슈: `Stage B raw generation broader repeatability sweep`
+- latest functional result: Issue #224, Stage B raw generation broader repeatability sweep
+- 다음 권장 이슈: `Stage B raw generation dead-air outlier diagnostics`
 
 현재 범위가 아닌 것:
 
@@ -101,6 +101,42 @@ Issue #222는 Issue #220에서 실패한 raw generation gate를 repair한 작업
 Docs:
 
 - `docs/STAGE_B_RAW_GENERATION_GATE_REPAIR_2026-05-28.md`
+
+## Current Repeatability Sweep Result
+
+Issue #224는 raw generation gate를 2-file/3-seed 조건으로 넓혀 검증한 작업이다.
+
+검증:
+
+- `RUN_ID=issue_224_stage_b_raw_generation_repeatability_final2 bash scripts/agent_harness.sh stage-b-raw-generation-repeatability`
+
+조건:
+
+- source files: `2`
+- seeds: `17, 23, 31`
+- samples: `9`
+- epochs: `50`
+- top_k: `4`
+- overlap postprocess: enabled
+
+결과:
+
+- valid sample count: `8/9`
+- strict valid sample count: `8/9`
+- grammar gate sample count: `9/9`
+- strict pass-rate: `0.889`
+- max postprocess removal ratio: `0.429`
+- seed `31`에서 dead-air ratio outlier `1`개 발생
+
+해석:
+
+- model-core MVP는 2-file/3-seed local repeatability gate까지 통과했다.
+- broad model quality, human preference, Brad style adaptation은 아직 미검증이다.
+- 다음 작업은 dead-air outlier 원인 분리다.
+
+Docs:
+
+- `docs/STAGE_B_RAW_GENERATION_REPEATABILITY_SWEEP_2026-05-28.md`
 
 ## Latest README Footer Section Removal Result
 

--- a/docs/STAGE_B_RAW_GENERATION_REPEATABILITY_SWEEP_2026-05-28.md
+++ b/docs/STAGE_B_RAW_GENERATION_REPEATABILITY_SWEEP_2026-05-28.md
@@ -1,0 +1,84 @@
+# Stage B Raw Generation Repeatability Sweep
+
+작성일: 2026-05-28
+
+## 결론
+
+| 항목 | 판정 |
+|---|---|
+| repeatability gate | 통과 |
+| source files | `2` |
+| seeds | `17, 23, 31` |
+| total samples | `9` |
+| strict valid samples | `8` |
+| grammar gate samples | `9` |
+| dead-air outlier | `1` |
+
+## 실행 조건
+
+Command:
+
+```bash
+RUN_ID=issue_224_stage_b_raw_generation_repeatability_final2 bash scripts/agent_harness.sh stage-b-raw-generation-repeatability
+```
+
+조건:
+
+- max files: `2`
+- seeds: `17, 23, 31`
+- epochs: `50`
+- samples per seed: `3`
+- total samples: `9`
+- top_k: `4`
+- temperature: `0.9`
+- overlap postprocess: enabled
+
+## 결과
+
+| 항목 | 값 |
+|---|---:|
+| total samples | `9` |
+| valid sample count | `8` |
+| strict valid sample count | `8` |
+| grammar gate sample count | `9` |
+| valid sample rate | `0.889` |
+| strict valid sample rate | `0.889` |
+| grammar gate sample rate | `1.000` |
+| max postprocess removal ratio | `0.429` |
+| allowed max postprocess removal ratio | `0.490` |
+
+Per-seed:
+
+| seed | files | samples | strict | grammar | note count | unique pitch | phrase coverage | max removal | failure |
+|---:|---:|---:|---:|---:|---|---|---|---:|---|
+| `17` | `2` | `3` | `3` | `3` | `8-16` | `3-6` | `0.406-1.000` | `0.238` | none |
+| `23` | `2` | `3` | `3` | `3` | `12-16` | `5-5` | `0.500-0.875` | `0.429` | none |
+| `31` | `2` | `3` | `2` | `3` | `8-14` | `4-7` | `0.469-0.844` | `0.273` | dead-air `1` |
+
+## 해석
+
+증명한 것:
+
+- 1-file/1-seed가 아닌 2-file/3-seed 조건에서도 raw Stage B generation gate가 유지된다.
+- 모든 seed에서 strict-valid sample이 최소 1개 이상 생성된다.
+- grammar gate는 `9/9`로 통과했다.
+- postprocess removal ratio는 최대 `0.429`로 strict gate 한계 `0.49` 안에 남았다.
+
+남은 리스크:
+
+- seed `31`에서 dead-air ratio outlier가 1개 발생했다.
+- strict pass-rate가 `1.000`은 아니므로 broad quality claim은 아직 불가하다.
+- source file 수는 `2`로 제한되어 있다.
+- 사람이 듣는 선호나 Brad style adaptation은 검증하지 않았다.
+
+## 다음 작업
+
+권장 이슈:
+
+- `Stage B raw generation dead-air outlier diagnostics`
+
+목표:
+
+- seed `31` 실패 sample의 dead-air 위치와 token pattern 확인
+- phrase coverage는 통과하지만 dead-air가 높은 후보의 공통 원인 분리
+- next gate에서 dead-air outlier 비율을 별도 추적

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -32,6 +32,8 @@ Modes:
                 Prepare Stage B phrase windows and verify token vocab fit.
   stage-b-generation-probe
                 Run a Stage B raw decode/generation gate probe.
+  stage-b-raw-generation-repeatability
+                Run raw Stage B generation across multiple seeds and source files.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -155,6 +157,7 @@ run_quick() {
     scripts/prepare_role_dataset.py \
     scripts/run_stage_b_window_tiny_overfit.py \
     scripts/run_stage_b_generation_probe.py \
+    scripts/run_stage_b_raw_generation_repeatability_sweep.py \
     scripts/run_stage_b_sampling_sweep.py \
     scripts/run_stage_b_coverage_ab_sweep.py \
     scripts/run_stage_b_pitch_mode_compare.py \
@@ -258,6 +261,31 @@ run_stage_b_generation_probe() {
     --require_note_groups \
     --require_valid_sample \
     --require_strict_valid_sample
+}
+
+run_stage_b_raw_generation_repeatability() {
+  local run_id="${RUN_ID:-harness_stage_b_raw_generation_repeatability}"
+  print_header "Stage B raw generation repeatability sweep"
+  "$PYTHON_BIN" scripts/run_stage_b_raw_generation_repeatability_sweep.py \
+    --run_id "$run_id" \
+    --max_files 2 \
+    --seeds 17,23,31 \
+    --epochs 50 \
+    --batch_size 8 \
+    --max_sequence 96 \
+    --num_samples 3 \
+    --top_k 4 \
+    --temperature 0.9 \
+    --min_seed_count 3 \
+    --min_source_files 2 \
+    --min_strict_samples_per_seed 1 \
+    --min_overall_strict_rate 0.67 \
+    --n_layers 1 \
+    --num_heads 4 \
+    --d_model 64 \
+    --dim_feedforward 128 \
+    --lora_r 4 \
+    --lora_alpha 8
 }
 
 run_stage_b_constrained_probe() {
@@ -1379,6 +1407,9 @@ case "$MODE" in
     ;;
   stage-b-generation-probe)
     run_stage_b_generation_probe
+    ;;
+  stage-b-raw-generation-repeatability)
+    run_stage_b_raw_generation_repeatability
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/run_stage_b_raw_generation_repeatability_sweep.py
+++ b/scripts/run_stage_b_raw_generation_repeatability_sweep.py
@@ -1,0 +1,439 @@
+"""Run a broader Stage B raw generation repeatability sweep."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Sequence
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+PROBE_SCRIPT = ROOT_DIR / "scripts" / "run_stage_b_generation_probe.py"
+
+
+def parse_seed_values(raw: str) -> list[int]:
+    seeds = [int(value.strip()) for value in raw.split(",") if value.strip()]
+    if not seeds:
+        raise ValueError("--seeds must include at least one seed")
+    return seeds
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_command(cmd: list[str]) -> dict[str, Any]:
+    completed = subprocess.run(cmd, cwd=ROOT_DIR, text=True, capture_output=True, check=False)
+    return {
+        "cmd": cmd,
+        "returncode": int(completed.returncode),
+        "stdout_tail": completed.stdout[-4000:],
+        "stderr_tail": completed.stderr[-4000:],
+    }
+
+
+def probe_run_id(base_run_id: str, seed: int, max_files: int) -> str:
+    return f"{base_run_id}_seed{int(seed)}_files{int(max_files)}"
+
+
+def probe_command(args: argparse.Namespace, run_id: str, seed: int) -> list[str]:
+    return [
+        sys.executable,
+        str(PROBE_SCRIPT),
+        "--run_id",
+        run_id,
+        "--output_root",
+        str(Path(args.probe_output_root)),
+        "--issue_number",
+        str(args.issue_number),
+        "--max_files",
+        str(args.max_files),
+        "--epochs",
+        str(args.epochs),
+        "--batch_size",
+        str(args.batch_size),
+        "--max_sequence",
+        str(args.max_sequence),
+        "--num_samples",
+        str(args.num_samples),
+        "--seed",
+        str(seed),
+        "--temperature",
+        str(args.temperature),
+        "--top_k",
+        str(args.top_k),
+        "--postprocess_overlap",
+        "--max_simultaneous_notes",
+        str(args.max_simultaneous_notes),
+        "--min_valid_samples",
+        str(args.min_valid_samples),
+        "--min_strict_valid_samples",
+        str(args.min_strict_valid_samples),
+        "--max_collapse_warning_sample_rate",
+        str(args.max_collapse_warning_sample_rate),
+        "--strict_min_unique_pitches",
+        str(args.strict_min_unique_pitches),
+        "--strict_min_unique_positions",
+        str(args.strict_min_unique_positions),
+        "--strict_min_unique_position_pitch_pairs",
+        str(args.strict_min_unique_position_pitch_pairs),
+        "--strict_max_repeated_position_pitch_pair_ratio",
+        str(args.strict_max_repeated_position_pitch_pair_ratio),
+        "--strict_max_postprocess_removal_ratio",
+        str(args.strict_max_postprocess_removal_ratio),
+        "--n_layers",
+        str(args.n_layers),
+        "--num_heads",
+        str(args.num_heads),
+        "--d_model",
+        str(args.d_model),
+        "--dim_feedforward",
+        str(args.dim_feedforward),
+        "--lora_r",
+        str(args.lora_r),
+        "--lora_alpha",
+        str(args.lora_alpha),
+    ]
+
+
+def _sample_metric_values(report: dict[str, Any], key: str) -> list[float]:
+    values: list[float] = []
+    for sample in report.get("samples", []):
+        if not isinstance(sample, dict):
+            continue
+        value = sample.get("metrics", {}).get(key)
+        if value is not None:
+            values.append(float(value))
+    return values
+
+
+def _grammar_values(report: dict[str, Any], key: str) -> list[int]:
+    values: list[int] = []
+    for sample in report.get("samples", []):
+        if not isinstance(sample, dict):
+            continue
+        value = sample.get("grammar", {}).get(key)
+        if value is not None:
+            values.append(int(value))
+    return values
+
+
+def _collapse_values(report: dict[str, Any], key: str) -> list[float]:
+    values: list[float] = []
+    for sample in report.get("samples", []):
+        if not isinstance(sample, dict):
+            continue
+        value = sample.get("collapse", {}).get(key)
+        if value is not None:
+            values.append(float(value))
+    return values
+
+
+def _range(values: Sequence[float | int]) -> dict[str, float | int | None]:
+    if not values:
+        return {"min": None, "max": None}
+    return {"min": min(values), "max": max(values)}
+
+
+def range_label(value: Any, digits: int = 3) -> str:
+    if not isinstance(value, dict):
+        return "-"
+    minimum = value.get("min")
+    maximum = value.get("max")
+    if minimum is None or maximum is None:
+        return "-"
+    if isinstance(minimum, float) or isinstance(maximum, float):
+        return f"{float(minimum):.{digits}f}-{float(maximum):.{digits}f}"
+    return f"{minimum}-{maximum}"
+
+
+def reason_label(value: Any) -> str:
+    if not isinstance(value, dict) or not value:
+        return "none"
+    return ", ".join(f"{reason} ({count})" for reason, count in sorted(value.items()))
+
+
+def row_from_report(
+    seed: int,
+    run_id: str,
+    report_path: Path,
+    report: dict[str, Any] | None,
+    command_result: dict[str, Any],
+) -> dict[str, Any]:
+    if report is None:
+        return {
+            "seed": int(seed),
+            "run_id": run_id,
+            "report_path": str(report_path),
+            "returncode": int(command_result["returncode"]),
+            "sample_count": 0,
+            "valid_sample_count": 0,
+            "strict_valid_sample_count": 0,
+            "grammar_gate_sample_count": 0,
+            "passed_strict_review_gate": False,
+            "failure_reasons": {"missing_report": 1},
+            "strict_failure_reasons": {"missing_report": 1},
+            "diagnostic_failure_reasons": {"missing_report": 1},
+        }
+
+    summary = report.get("summary", {})
+    note_counts = _sample_metric_values(report, "note_count")
+    unique_pitch_counts = _sample_metric_values(report, "unique_pitch_count")
+    max_simultaneous_values = _sample_metric_values(report, "max_simultaneous_notes")
+    phrase_coverage_values = _sample_metric_values(report, "phrase_coverage_ratio")
+    complete_note_groups = _grammar_values(report, "complete_note_groups")
+    invalid_token_counts = _grammar_values(report, "invalid_token_count")
+    postprocess_removal_ratios = _collapse_values(report, "postprocess_removal_ratio")
+
+    return {
+        "seed": int(seed),
+        "run_id": run_id,
+        "report_path": str(report_path),
+        "returncode": int(command_result["returncode"]),
+        "input_file_count": int(report.get("dataset_summary", {}).get("input_file_count", 0) or 0),
+        "train_samples": int(report.get("dataset_summary", {}).get("train_samples", 0) or 0),
+        "val_samples": int(report.get("dataset_summary", {}).get("val_samples", 0) or 0),
+        "sample_count": int(summary.get("sample_count", 0) or 0),
+        "valid_sample_count": int(summary.get("valid_sample_count", 0) or 0),
+        "strict_valid_sample_count": int(summary.get("strict_valid_sample_count", 0) or 0),
+        "grammar_gate_sample_count": int(summary.get("grammar_gate_sample_count", 0) or 0),
+        "valid_sample_rate": float(summary.get("valid_sample_rate", 0.0) or 0.0),
+        "strict_valid_sample_rate": float(summary.get("strict_valid_sample_rate", 0.0) or 0.0),
+        "grammar_gate_sample_rate": float(summary.get("grammar_gate_sample_rate", 0.0) or 0.0),
+        "passed_strict_review_gate": bool(summary.get("passed_strict_review_gate", False)),
+        "collapse_warning_sample_count": int(summary.get("collapse_warning_sample_count", 0) or 0),
+        "collapse_warning_sample_rate": float(summary.get("collapse_warning_sample_rate", 0.0) or 0.0),
+        "avg_postprocess_removal_ratio": float(summary.get("avg_postprocess_removal_ratio", 0.0) or 0.0),
+        "max_postprocess_removal_ratio": float(summary.get("max_postprocess_removal_ratio", 0.0) or 0.0),
+        "avg_repeated_position_pitch_pair_ratio": float(
+            summary.get("avg_repeated_position_pitch_pair_ratio", 0.0) or 0.0
+        ),
+        "max_repeated_position_pitch_pair_ratio": float(
+            summary.get("max_repeated_position_pitch_pair_ratio", 0.0) or 0.0
+        ),
+        "note_count_range": _range(note_counts),
+        "unique_pitch_count_range": _range(unique_pitch_counts),
+        "max_simultaneous_notes_range": _range(max_simultaneous_values),
+        "phrase_coverage_ratio_range": _range(phrase_coverage_values),
+        "complete_note_group_range": _range(complete_note_groups),
+        "invalid_token_count_range": _range(invalid_token_counts),
+        "postprocess_removal_ratio_range": _range(postprocess_removal_ratios),
+        "failure_reasons": summary.get("failure_reasons", {}),
+        "diagnostic_failure_reasons": summary.get("diagnostic_failure_reasons", {}),
+        "strict_failure_reasons": summary.get("strict_failure_reasons", {}),
+    }
+
+
+def build_repeatability_summary(
+    rows: Sequence[dict[str, Any]],
+    min_seed_count: int,
+    min_source_files: int,
+    min_strict_samples_per_seed: int,
+    min_overall_strict_rate: float,
+    max_postprocess_removal_ratio: float,
+) -> dict[str, Any]:
+    total_samples = sum(int(row.get("sample_count", 0) or 0) for row in rows)
+    total_valid = sum(int(row.get("valid_sample_count", 0) or 0) for row in rows)
+    total_strict = sum(int(row.get("strict_valid_sample_count", 0) or 0) for row in rows)
+    total_grammar = sum(int(row.get("grammar_gate_sample_count", 0) or 0) for row in rows)
+    seed_values = [int(row["seed"]) for row in rows]
+    input_file_counts = [int(row.get("input_file_count", 0) or 0) for row in rows]
+    max_removal = max((float(row.get("max_postprocess_removal_ratio", 0.0) or 0.0) for row in rows), default=0.0)
+    seeds_with_strict = [
+        int(row["seed"])
+        for row in rows
+        if int(row.get("strict_valid_sample_count", 0) or 0) >= int(min_strict_samples_per_seed)
+    ]
+    failing_rows = [
+        row
+        for row in rows
+        if int(row.get("strict_valid_sample_count", 0) or 0) < int(min_strict_samples_per_seed)
+        or int(row.get("returncode", 0) or 0) != 0
+    ]
+    strict_rate = float(total_strict / total_samples) if total_samples else 0.0
+    valid_rate = float(total_valid / total_samples) if total_samples else 0.0
+    grammar_rate = float(total_grammar / total_samples) if total_samples else 0.0
+    min_observed_input_files = min(input_file_counts) if input_file_counts else 0
+
+    passed = bool(
+        len(rows) >= int(min_seed_count)
+        and min_observed_input_files >= int(min_source_files)
+        and len(seeds_with_strict) == len(rows)
+        and strict_rate >= float(min_overall_strict_rate)
+        and max_removal <= float(max_postprocess_removal_ratio)
+        and not any(int(row.get("returncode", 0) or 0) != 0 for row in rows)
+    )
+
+    return {
+        "seed_count": int(len(rows)),
+        "seed_values": seed_values,
+        "min_seed_count": int(min_seed_count),
+        "min_source_files": int(min_source_files),
+        "min_observed_input_files": int(min_observed_input_files),
+        "total_samples": int(total_samples),
+        "total_valid_sample_count": int(total_valid),
+        "total_strict_valid_sample_count": int(total_strict),
+        "total_grammar_gate_sample_count": int(total_grammar),
+        "valid_sample_rate": valid_rate,
+        "strict_valid_sample_rate": strict_rate,
+        "grammar_gate_sample_rate": grammar_rate,
+        "min_strict_samples_per_seed": int(min_strict_samples_per_seed),
+        "seeds_with_strict_sample": seeds_with_strict,
+        "min_overall_strict_rate": float(min_overall_strict_rate),
+        "max_postprocess_removal_ratio": float(max_removal),
+        "allowed_max_postprocess_removal_ratio": float(max_postprocess_removal_ratio),
+        "failing_seeds": [int(row["seed"]) for row in failing_rows],
+        "passed_repeatability_gate": passed,
+    }
+
+
+def markdown_report(rows: Sequence[dict[str, Any]], summary: dict[str, Any]) -> str:
+    lines = [
+        "# Stage B Raw Generation Repeatability Sweep",
+        "",
+        f"- passed repeatability gate: `{str(summary['passed_repeatability_gate']).lower()}`",
+        f"- seeds: `{summary['seed_values']}`",
+        f"- source files per run: `{summary['min_observed_input_files']}`",
+        f"- total samples: `{summary['total_samples']}`",
+        f"- strict pass-rate: `{summary['strict_valid_sample_rate']:.3f}`",
+        f"- grammar pass-rate: `{summary['grammar_gate_sample_rate']:.3f}`",
+        f"- max postprocess removal ratio: `{summary['max_postprocess_removal_ratio']:.3f}`",
+        "",
+        "| seed | files | samples | grammar | valid | strict | notes | pitches | max simultaneous | phrase coverage | max removal | strict gate |",
+        "|---:|---:|---:|---:|---:|---:|---|---|---|---|---:|:---:|",
+    ]
+    for row in rows:
+        lines.append(
+            "| {seed} | {input_file_count} | {sample_count} | {grammar_gate_sample_count} | "
+            "{valid_sample_count} | {strict_valid_sample_count} | {note_range} | "
+            "{pitch_range} | {simul_range} | {coverage_range} | {max_removal:.3f} | "
+            "{strict_gate} |".format(
+                seed=row["seed"],
+                input_file_count=row.get("input_file_count", 0),
+                sample_count=row.get("sample_count", 0),
+                grammar_gate_sample_count=row.get("grammar_gate_sample_count", 0),
+                valid_sample_count=row.get("valid_sample_count", 0),
+                strict_valid_sample_count=row.get("strict_valid_sample_count", 0),
+                note_range=range_label(row.get("note_count_range"), digits=0),
+                pitch_range=range_label(row.get("unique_pitch_count_range"), digits=0),
+                simul_range=range_label(row.get("max_simultaneous_notes_range"), digits=0),
+                coverage_range=range_label(row.get("phrase_coverage_ratio_range"), digits=3),
+                max_removal=float(row.get("max_postprocess_removal_ratio", 0.0) or 0.0),
+                strict_gate=bool(row.get("passed_strict_review_gate", False)),
+            )
+        )
+    lines.extend(["", "## Failure Reasons", ""])
+    for row in rows:
+        lines.append(
+            f"- seed `{row['seed']}`: failure `{reason_label(row.get('failure_reasons'))}`, "
+            f"strict `{reason_label(row.get('strict_failure_reasons'))}`"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run Stage B raw generation repeatability sweep")
+    parser.add_argument("--output_root", type=str, default=str(ROOT_DIR / "outputs" / "stage_b_raw_generation_repeatability"))
+    parser.add_argument("--probe_output_root", type=str, default=str(ROOT_DIR / "outputs" / "stage_b_generation_probe"))
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--issue_number", type=int, default=224)
+    parser.add_argument("--seeds", type=str, default="17,23,31")
+    parser.add_argument("--max_files", type=int, default=2)
+    parser.add_argument("--epochs", type=int, default=50)
+    parser.add_argument("--batch_size", type=int, default=8)
+    parser.add_argument("--max_sequence", type=int, default=96)
+    parser.add_argument("--num_samples", type=int, default=3)
+    parser.add_argument("--temperature", type=float, default=0.9)
+    parser.add_argument("--top_k", type=int, default=4)
+    parser.add_argument("--max_simultaneous_notes", type=int, default=2)
+    parser.add_argument("--min_valid_samples", type=int, default=1)
+    parser.add_argument("--min_strict_valid_samples", type=int, default=1)
+    parser.add_argument("--min_seed_count", type=int, default=3)
+    parser.add_argument("--min_source_files", type=int, default=2)
+    parser.add_argument("--min_strict_samples_per_seed", type=int, default=1)
+    parser.add_argument("--min_overall_strict_rate", type=float, default=0.67)
+    parser.add_argument("--max_allowed_postprocess_removal_ratio", type=float, default=0.49)
+    parser.add_argument("--max_collapse_warning_sample_rate", type=float, default=0.34)
+    parser.add_argument("--strict_min_unique_pitches", type=int, default=3)
+    parser.add_argument("--strict_min_unique_positions", type=int, default=3)
+    parser.add_argument("--strict_min_unique_position_pitch_pairs", type=int, default=4)
+    parser.add_argument("--strict_max_repeated_position_pitch_pair_ratio", type=float, default=0.49)
+    parser.add_argument("--strict_max_postprocess_removal_ratio", type=float, default=0.49)
+    parser.add_argument("--n_layers", type=int, default=1)
+    parser.add_argument("--num_heads", type=int, default=4)
+    parser.add_argument("--d_model", type=int, default=64)
+    parser.add_argument("--dim_feedforward", type=int, default=128)
+    parser.add_argument("--lora_r", type=int, default=4)
+    parser.add_argument("--lora_alpha", type=int, default=8)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now().strftime("%Y%m%d_%H%M%S")
+    sweep_dir = Path(args.output_root) / run_id
+    seeds = parse_seed_values(args.seeds)
+    rows: list[dict[str, Any]] = []
+    command_results: list[dict[str, Any]] = []
+
+    for seed in seeds:
+        child_run_id = probe_run_id(run_id, seed=seed, max_files=args.max_files)
+        cmd = probe_command(args, run_id=child_run_id, seed=seed)
+        command_result = run_command(cmd)
+        command_results.append(command_result)
+        report_path = Path(args.probe_output_root) / child_run_id / "report.json"
+        report = read_json(report_path) if report_path.exists() else None
+        rows.append(
+            row_from_report(
+                seed=seed,
+                run_id=child_run_id,
+                report_path=report_path,
+                report=report,
+                command_result=command_result,
+            )
+        )
+
+    summary = build_repeatability_summary(
+        rows,
+        min_seed_count=args.min_seed_count,
+        min_source_files=args.min_source_files,
+        min_strict_samples_per_seed=args.min_strict_samples_per_seed,
+        min_overall_strict_rate=args.min_overall_strict_rate,
+        max_postprocess_removal_ratio=args.max_allowed_postprocess_removal_ratio,
+    )
+    report = {
+        "run_id": run_id,
+        "issue": int(args.issue_number),
+        "config": {
+            "seeds": seeds,
+            "max_files": int(args.max_files),
+            "epochs": int(args.epochs),
+            "num_samples": int(args.num_samples),
+            "temperature": float(args.temperature),
+            "top_k": int(args.top_k),
+            "postprocess_overlap": True,
+        },
+        "summary": summary,
+        "rows": rows,
+        "command_results": command_results,
+    }
+    write_json(sweep_dir / "repeatability_summary.json", report)
+    (sweep_dir / "repeatability_summary.md").write_text(
+        markdown_report(rows, summary),
+        encoding="utf-8",
+    )
+    print(json.dumps(report, ensure_ascii=True, indent=2))
+    return 0 if summary["passed_repeatability_gate"] else 5
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_raw_generation_repeatability.py
+++ b/tests/test_stage_b_raw_generation_repeatability.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.run_stage_b_raw_generation_repeatability_sweep import (
+    build_repeatability_summary,
+    markdown_report,
+    parse_seed_values,
+    probe_run_id,
+    range_label,
+    reason_label,
+)
+
+
+class StageBRawGenerationRepeatabilityTest(unittest.TestCase):
+    def test_parse_seed_values_rejects_empty_input(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_seed_values("")
+
+    def test_probe_run_id_is_stable(self) -> None:
+        self.assertEqual(
+            probe_run_id("run", seed=17, max_files=2),
+            "run_seed17_files2",
+        )
+
+    def test_range_label_formats_compact_range(self) -> None:
+        self.assertEqual(range_label({"min": 0.5, "max": 1.0}), "0.500-1.000")
+        self.assertEqual(range_label({"min": 8, "max": 16}, digits=0), "8-16")
+
+    def test_reason_label_formats_sorted_reason_counts(self) -> None:
+        self.assertEqual(reason_label({}), "none")
+        self.assertEqual(reason_label({"b": 2, "a": 1}), "a (1), b (2)")
+
+    def test_build_repeatability_summary_requires_each_seed(self) -> None:
+        rows = [
+            {
+                "seed": 17,
+                "returncode": 0,
+                "input_file_count": 2,
+                "sample_count": 3,
+                "valid_sample_count": 3,
+                "strict_valid_sample_count": 3,
+                "grammar_gate_sample_count": 3,
+                "max_postprocess_removal_ratio": 0.2,
+            },
+            {
+                "seed": 23,
+                "returncode": 0,
+                "input_file_count": 2,
+                "sample_count": 3,
+                "valid_sample_count": 3,
+                "strict_valid_sample_count": 0,
+                "grammar_gate_sample_count": 3,
+                "max_postprocess_removal_ratio": 0.2,
+            },
+            {
+                "seed": 31,
+                "returncode": 0,
+                "input_file_count": 2,
+                "sample_count": 3,
+                "valid_sample_count": 3,
+                "strict_valid_sample_count": 3,
+                "grammar_gate_sample_count": 3,
+                "max_postprocess_removal_ratio": 0.2,
+            },
+        ]
+
+        summary = build_repeatability_summary(
+            rows,
+            min_seed_count=3,
+            min_source_files=2,
+            min_strict_samples_per_seed=1,
+            min_overall_strict_rate=0.67,
+            max_postprocess_removal_ratio=0.49,
+        )
+
+        self.assertFalse(summary["passed_repeatability_gate"])
+        self.assertEqual(summary["failing_seeds"], [23])
+
+    def test_markdown_report_contains_gate_and_seed_rows(self) -> None:
+        rows = [
+            {
+                "seed": 17,
+                "input_file_count": 2,
+                "sample_count": 3,
+                "grammar_gate_sample_count": 3,
+                "valid_sample_count": 3,
+                "strict_valid_sample_count": 3,
+                "note_count_range": {"min": 10, "max": 16},
+                "unique_pitch_count_range": {"min": 4, "max": 6},
+                "max_simultaneous_notes_range": {"min": 1, "max": 2},
+                "phrase_coverage_ratio_range": {"min": 0.8, "max": 1.0},
+                "max_postprocess_removal_ratio": 0.2,
+                "passed_strict_review_gate": True,
+                "failure_reasons": {},
+                "strict_failure_reasons": {},
+            }
+        ]
+        summary = {
+            "passed_repeatability_gate": True,
+            "seed_values": [17],
+            "min_observed_input_files": 2,
+            "total_samples": 3,
+            "strict_valid_sample_rate": 1.0,
+            "grammar_gate_sample_rate": 1.0,
+            "max_postprocess_removal_ratio": 0.2,
+        }
+
+        markdown = markdown_report(rows, summary)
+
+        self.assertIn("passed repeatability gate", markdown)
+        self.assertIn("| 17 |", markdown)
+        self.assertIn("strict pass-rate", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Added a Stage B raw generation repeatability sweep across 2 source files and 3 seeds.
- Added summary docs for Issue #224 and updated README/current plan claim boundaries.
- Wired the sweep into scripts/agent_harness.sh with focused unit coverage.

## Result
- repeatability gate: pass
- total samples: 9
- strict valid samples: 8/9
- grammar gate samples: 9/9
- max postprocess removal ratio: 0.429
- remaining risk: one seed 31 dead-air outlier

## Validation
- RUN_ID=issue_224_stage_b_raw_generation_repeatability_final2 bash scripts/agent_harness.sh stage-b-raw-generation-repeatability
- bash scripts/agent_harness.sh quick

Closes #224