### PR TITLE
test: Stage B dead-air outlier 진단 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ flowchart LR
 
 ## 핵심 결과
 
-Issue #222 기준 model-core MVP:
+Issue #226 기준 model-core MVP:
 
 | 항목 | 결과 |
 |---|---|
@@ -62,6 +62,7 @@ Issue #222 기준 model-core MVP:
 | repair 조건 | 50 epoch tiny-overfit, top_k `4`, overlap postprocess |
 | repeatability sweep | 2 source files / 3 seeds / 9 samples |
 | repeatability result | strict `8/9`, grammar `9/9`, dead-air outlier `1` |
+| dead-air diagnostics | seed `31` sample `1`, dead-air `0.857`, collapse warning false |
 | constrained review gate | `stage-b-overlap-gate` 통과 |
 | focused candidate path | `stage-b-rhythm-phrase-variation` 통과 |
 
@@ -73,6 +74,7 @@ MVP 근거:
 - complete note groups `21-22`, invalid token count `0`
 - postprocess 후 note count `13-18`, unique pitch count `4-6`
 - 2-file/3-seed repeatability sweep에서 strict pass-rate `0.889`
+- dead-air outlier가 collapse/postprocess 문제가 아니라 낮은 onset/sustained coverage 문제임을 분리
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -57,8 +57,10 @@ MVP가 끝났다고 볼 수 있는 조건:
 - 근거 문서: `docs/STAGE_B_MODEL_CORE_MVP_COMPLETION_AUDIT_2026-05-28.md`
 - repair 문서: `docs/STAGE_B_RAW_GENERATION_GATE_REPAIR_2026-05-28.md`
 - repeatability 문서: `docs/STAGE_B_RAW_GENERATION_REPEATABILITY_SWEEP_2026-05-28.md`
+- dead-air 진단 문서: `docs/STAGE_B_DEAD_AIR_OUTLIER_DIAGNOSTICS_2026-05-28.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
+- raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -232,6 +234,7 @@ Stage B에서 명시하는 것:
 107. README 하단 참조 섹션 제거
 108. Stage B raw generation gate repair
 109. Stage B raw generation broader repeatability sweep
+110. Stage B raw generation dead-air outlier diagnostics
 
 가장 최근 의미 있는 결과:
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #224, Stage B raw generation broader repeatability sweep
-- 다음 권장 이슈: `Stage B raw generation dead-air outlier diagnostics`
+- latest functional result: Issue #226, Stage B raw generation dead-air outlier diagnostics
+- 다음 권장 이슈: `Stage B dead-air-aware candidate selection gate`
 
 현재 범위가 아닌 것:
 
@@ -137,6 +137,38 @@ Issue #224는 raw generation gate를 2-file/3-seed 조건으로 넓혀 검증한
 Docs:
 
 - `docs/STAGE_B_RAW_GENERATION_REPEATABILITY_SWEEP_2026-05-28.md`
+
+## Current Dead-Air Outlier Diagnostics Result
+
+Issue #226은 Issue #224의 seed `31` dead-air outlier 원인을 분리한 작업이다.
+
+검증:
+
+- `REPORT_PATH=outputs/stage_b_generation_probe/issue_224_stage_b_raw_generation_repeatability_final2_seed31_files2/report.json RUN_ID=issue_226_stage_b_dead_air_diagnostics bash scripts/agent_harness.sh stage-b-dead-air-diagnostics`
+
+결과:
+
+- outlier sample: `1`
+- dead-air ratio: `0.857`
+- dead-air gate: `0.800`
+- phrase coverage: `0.469`
+- onset coverage: `0.250`
+- sustained coverage: `0.375`
+- tail empty steps: `11`
+- longest sustained empty run: `10`
+- dead-air start gaps: `6/7`
+- postprocess removal ratio: `0.273`
+- collapse warning: false
+
+해석:
+
+- 실패 원인은 collapse나 postprocess 과다 제거가 아니다.
+- phrase span은 일부 확보했지만 onset/sustained coverage가 낮아 180ms 이상 start gap 비율이 과도한 후보다.
+- 다음 작업은 raw 후보 중 dead-air가 낮은 strict-valid candidate를 우선 선택하는 gate다.
+
+Docs:
+
+- `docs/STAGE_B_DEAD_AIR_OUTLIER_DIAGNOSTICS_2026-05-28.md`
 
 ## Latest README Footer Section Removal Result
 

--- a/docs/STAGE_B_DEAD_AIR_OUTLIER_DIAGNOSTICS_2026-05-28.md
+++ b/docs/STAGE_B_DEAD_AIR_OUTLIER_DIAGNOSTICS_2026-05-28.md
@@ -1,0 +1,90 @@
+# Stage B Dead-Air Outlier Diagnostics
+
+작성일: 2026-05-28
+
+## 결론
+
+| 항목 | 값 |
+|---|---:|
+| source issue | `#224` |
+| source seed | `31` |
+| sample count | `3` |
+| outlier sample | `1` |
+| dead-air ratio | `0.857` |
+| dead-air gate | `0.800` |
+| strict valid samples | `2/3` |
+
+Issue #224의 repeatability sweep에서 발생한 outlier는 sample `1`이었다.
+
+원인은 collapse나 postprocess 과다 제거가 아니라, 낮은 onset/sustained coverage와 phrase 후반 공백이다.
+
+## 실행 조건
+
+Command:
+
+```bash
+REPORT_PATH=outputs/stage_b_generation_probe/issue_224_stage_b_raw_generation_repeatability_final2_seed31_files2/report.json RUN_ID=issue_226_stage_b_dead_air_diagnostics bash scripts/agent_harness.sh stage-b-dead-air-diagnostics
+```
+
+입력:
+
+- source report: `outputs/stage_b_generation_probe/issue_224_stage_b_raw_generation_repeatability_final2_seed31_files2/report.json`
+- dead-air threshold: `0.180s`
+- dead-air gate: `0.800`
+- density: `medium`
+- bpm: `124`
+- bars: `2`
+
+## 결과
+
+| sample | valid | strict | notes | pitches | dead-air | phrase | onset | sustained | span | head | tail | longest sustained empty | removed |
+|---:|:---:|:---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `1` | false | false | `8` | `4` | `0.857` | `0.469` | `0.250` | `0.375` | `0.469` | `6` | `11` | `10` | `3` |
+| `2` | true | true | `9` | `4` | `0.750` | `0.562` | `0.281` | `0.531` | `0.562` | `6` | `8` | `8` | `2` |
+| `3` | true | true | `14` | `7` | `0.769` | `0.844` | `0.469` | `0.781` | `0.844` | `5` | `0` | `5` | `4` |
+
+Outlier sample `1`의 dead-air gap:
+
+| from | to | start gap sec | silent gap sec |
+|---:|---:|---:|---:|
+| `1` | `2` | `0.363` | `0.000` |
+| `2` | `3` | `0.242` | `0.121` |
+| `3` | `4` | `0.242` | `0.121` |
+| `5` | `6` | `0.242` | `0.121` |
+| `6` | `7` | `0.242` | `0.121` |
+| `7` | `8` | `0.242` | `0.000` |
+
+## 해석
+
+증상:
+
+- sample `1`은 note count `8`, unique pitch count `4`로 최소 수량 조건은 통과한다.
+- phrase coverage `0.469`도 medium 기준 최소 `0.350`은 넘는다.
+- 하지만 onset coverage가 `0.250`, sustained coverage가 `0.375`로 낮다.
+- tail empty가 `11` steps이고 longest sustained empty가 `10` steps다.
+- start-to-start gap 기준 dead-air gap이 `6/7`이라 dead-air ratio가 `0.857`로 gate `0.800`을 넘는다.
+
+아닌 것:
+
+- collapse warning은 false다.
+- repeated position/pitch pair ratio는 `0.091`로 strict 한계 안이다.
+- postprocess removal ratio는 `0.273`으로 strict 한계 `0.490` 안이다.
+- sample `2`, `3`도 leading duration token 때문에 `grammar_valid=false`지만, 현재 grammar gate 실패 원인은 아니다.
+
+정리:
+
+- 이 outlier는 "MIDI 파일 생성 실패"가 아니다.
+- "전체 phrase span은 일부 확보했지만, onset 밀도와 sustained coverage가 낮아 180ms 이상 start gap 비율이 과도한 후보"다.
+- 다음 개선은 모델 구조보다 candidate selection 또는 dead-air-aware sampling/retry 쪽이 작고 검증 가능하다.
+
+## 다음 작업
+
+권장 이슈:
+
+- `Stage B dead-air-aware candidate selection gate`
+
+목표:
+
+- raw generation 후보 중 dead-air ratio가 낮은 strict-valid 후보를 우선 선택
+- repeatability sweep summary에 dead-air outlier count/rate 별도 기록
+- outlier가 있어도 candidate set 안에서 reviewable MIDI를 안정적으로 고르는 기준 추가

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -34,6 +34,8 @@ Modes:
                 Run a Stage B raw decode/generation gate probe.
   stage-b-raw-generation-repeatability
                 Run raw Stage B generation across multiple seeds and source files.
+  stage-b-dead-air-diagnostics
+                Diagnose dead-air outliers from a Stage B generation probe report.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -158,6 +160,7 @@ run_quick() {
     scripts/run_stage_b_window_tiny_overfit.py \
     scripts/run_stage_b_generation_probe.py \
     scripts/run_stage_b_raw_generation_repeatability_sweep.py \
+    scripts/diagnose_stage_b_dead_air_outliers.py \
     scripts/run_stage_b_sampling_sweep.py \
     scripts/run_stage_b_coverage_ab_sweep.py \
     scripts/run_stage_b_pitch_mode_compare.py \
@@ -286,6 +289,16 @@ run_stage_b_raw_generation_repeatability() {
     --dim_feedforward 128 \
     --lora_r 4 \
     --lora_alpha 8
+}
+
+run_stage_b_dead_air_diagnostics() {
+  local run_id="${RUN_ID:-harness_stage_b_dead_air_diagnostics}"
+  local report_path="${REPORT_PATH:-outputs/stage_b_generation_probe/issue_224_stage_b_raw_generation_repeatability_final2_seed31_files2/report.json}"
+  print_header "Stage B dead-air diagnostics"
+  "$PYTHON_BIN" scripts/diagnose_stage_b_dead_air_outliers.py \
+    --run_id "$run_id" \
+    --report_path "$report_path" \
+    --expected_outliers 1
 }
 
 run_stage_b_constrained_probe() {
@@ -1410,6 +1423,9 @@ case "$MODE" in
     ;;
   stage-b-raw-generation-repeatability)
     run_stage_b_raw_generation_repeatability
+    ;;
+  stage-b-dead-air-diagnostics)
+    run_stage_b_dead_air_diagnostics
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/diagnose_stage_b_dead_air_outliers.py
+++ b/scripts/diagnose_stage_b_dead_air_outliers.py
@@ -1,0 +1,301 @@
+"""Diagnose Stage B raw generation samples that fail the dead-air gate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Sequence
+
+import pretty_midi
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def non_drum_notes(midi_path: Path) -> list[pretty_midi.Note]:
+    midi = pretty_midi.PrettyMIDI(str(midi_path))
+    notes: list[pretty_midi.Note] = []
+    for instrument in midi.instruments:
+        if not instrument.is_drum:
+            notes.extend(instrument.notes)
+    return sorted(notes, key=lambda note: (float(note.start), int(note.pitch), float(note.end)))
+
+
+def note_rows(notes: Sequence[pretty_midi.Note]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for index, note in enumerate(notes, start=1):
+        rows.append(
+            {
+                "index": int(index),
+                "start_sec": float(note.start),
+                "end_sec": float(note.end),
+                "duration_sec": max(0.0, float(note.end) - float(note.start)),
+                "pitch": int(note.pitch),
+                "velocity": int(note.velocity),
+            }
+        )
+    return rows
+
+
+def start_gap_rows(notes: Sequence[pretty_midi.Note], threshold_sec: float) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    ordered = sorted(notes, key=lambda note: (float(note.start), int(note.pitch), float(note.end)))
+    for index in range(1, len(ordered)):
+        previous = ordered[index - 1]
+        current = ordered[index]
+        start_gap = max(0.0, float(current.start) - float(previous.start))
+        silent_gap = max(0.0, float(current.start) - float(previous.end))
+        rows.append(
+            {
+                "from_note": int(index),
+                "to_note": int(index + 1),
+                "from_pitch": int(previous.pitch),
+                "to_pitch": int(current.pitch),
+                "from_start_sec": float(previous.start),
+                "to_start_sec": float(current.start),
+                "start_gap_sec": start_gap,
+                "silent_gap_sec": silent_gap,
+                "is_dead_air_gap": bool(start_gap >= float(threshold_sec)),
+            }
+        )
+    return rows
+
+
+def _nested_float(source: dict[str, Any], section: str, key: str, default: float = 0.0) -> float:
+    value = source.get(section, {}).get(key, default)
+    return float(value if value is not None else default)
+
+
+def _nested_int(source: dict[str, Any], section: str, key: str, default: int = 0) -> int:
+    value = source.get(section, {}).get(key, default)
+    return int(value if value is not None else default)
+
+
+def _reason_contains_dead_air(sample: dict[str, Any]) -> bool:
+    reason = str(sample.get("failure_reason") or sample.get("diagnostic_failure_reason") or "")
+    return "dead-air" in reason
+
+
+def compact_sample(
+    sample: dict[str, Any],
+    threshold_sec: float,
+    dead_air_gate: float,
+) -> dict[str, Any]:
+    midi_path = Path(str(sample.get("midi_path", "")))
+    notes = non_drum_notes(midi_path) if midi_path.exists() else []
+    gaps = start_gap_rows(notes, threshold_sec=threshold_sec)
+    dead_air_gaps = [row for row in gaps if row["is_dead_air_gap"]]
+    max_start_gap_sec = max((float(row["start_gap_sec"]) for row in gaps), default=0.0)
+    dead_air_ratio = _nested_float(sample, "metrics", "dead_air_ratio")
+    postprocess = sample.get("postprocess", {}) if isinstance(sample.get("postprocess"), dict) else {}
+    removed_note_count = int(postprocess.get("removed_note_count", 0) or 0)
+
+    return {
+        "sample_index": int(sample.get("sample_index", 0) or 0),
+        "valid": bool(sample.get("valid", False)),
+        "strict_valid": bool(sample.get("strict_valid", False)),
+        "failure_reason": sample.get("failure_reason"),
+        "dead_air_outlier": bool(dead_air_ratio >= float(dead_air_gate) or _reason_contains_dead_air(sample)),
+        "midi_path": str(midi_path),
+        "note_count": _nested_int(sample, "metrics", "note_count"),
+        "unique_pitch_count": _nested_int(sample, "metrics", "unique_pitch_count"),
+        "dead_air_ratio": dead_air_ratio,
+        "phrase_coverage_ratio": _nested_float(sample, "metrics", "phrase_coverage_ratio"),
+        "onset_coverage_ratio": _nested_float(sample, "temporal_coverage", "onset_coverage_ratio"),
+        "sustained_coverage_ratio": _nested_float(sample, "temporal_coverage", "sustained_coverage_ratio"),
+        "position_span_ratio": _nested_float(sample, "temporal_coverage", "position_span_ratio"),
+        "head_empty_steps": _nested_int(sample, "temporal_coverage", "head_empty_steps"),
+        "tail_empty_steps": _nested_int(sample, "temporal_coverage", "tail_empty_steps"),
+        "longest_onset_empty_run_steps": _nested_int(sample, "temporal_coverage", "longest_onset_empty_run_steps"),
+        "longest_sustained_empty_run_steps": _nested_int(
+            sample,
+            "temporal_coverage",
+            "longest_sustained_empty_run_steps",
+        ),
+        "postprocess_removed_note_count": removed_note_count,
+        "postprocess_removal_ratio": _nested_float(sample, "collapse", "postprocess_removal_ratio"),
+        "collapse_warning": bool(sample.get("collapse", {}).get("collapse_warning", False)),
+        "repeated_position_pitch_pair_ratio": _nested_float(
+            sample,
+            "collapse",
+            "repeated_position_pitch_pair_ratio",
+        ),
+        "grammar_valid": bool(sample.get("grammar", {}).get("grammar_valid", False)),
+        "invalid_token_count": _nested_int(sample, "grammar", "invalid_token_count"),
+        "invalid_tokens_head": sample.get("grammar", {}).get("invalid_tokens_head", []),
+        "generated_token_names_head": sample.get("generated_token_names_head", []),
+        "gap_count": int(len(gaps)),
+        "dead_air_gap_count": int(len(dead_air_gaps)),
+        "max_start_gap_sec": max_start_gap_sec,
+        "dead_air_gaps": dead_air_gaps,
+        "note_rows_head": note_rows(notes[:16]),
+    }
+
+
+def build_summary(sample_rows: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    outliers = [row for row in sample_rows if row["dead_air_outlier"]]
+    strict_rows = [row for row in sample_rows if row["strict_valid"]]
+    dead_air_values = [float(row["dead_air_ratio"]) for row in sample_rows]
+    return {
+        "sample_count": int(len(sample_rows)),
+        "dead_air_outlier_count": int(len(outliers)),
+        "outlier_sample_indices": [int(row["sample_index"]) for row in outliers],
+        "strict_valid_sample_count": int(len(strict_rows)),
+        "max_dead_air_ratio": max(dead_air_values) if dead_air_values else 0.0,
+        "min_dead_air_ratio": min(dead_air_values) if dead_air_values else 0.0,
+        "max_start_gap_sec": max((float(row["max_start_gap_sec"]) for row in sample_rows), default=0.0),
+        "max_head_empty_steps": max((int(row["head_empty_steps"]) for row in sample_rows), default=0),
+        "max_tail_empty_steps": max((int(row["tail_empty_steps"]) for row in sample_rows), default=0),
+        "max_longest_sustained_empty_run_steps": max(
+            (int(row["longest_sustained_empty_run_steps"]) for row in sample_rows),
+            default=0,
+        ),
+    }
+
+
+def _fmt(value: Any, digits: int = 3) -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, float):
+        return f"{value:.{digits}f}"
+    return str(value)
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    lines = [
+        "# Stage B Dead-Air Outlier Diagnostics",
+        "",
+        f"- source report: `{report['source_report_path']}`",
+        f"- dead-air gate: `{report['dead_air_gate']:.3f}`",
+        f"- threshold sec: `{report['dead_air_threshold_sec']:.3f}`",
+        f"- sample count: `{summary['sample_count']}`",
+        f"- outlier count: `{summary['dead_air_outlier_count']}`",
+        f"- outlier sample indices: `{summary['outlier_sample_indices']}`",
+        "",
+        "| sample | valid | strict | notes | pitches | dead-air | phrase | onset | sustained | span | head | tail | longest sustained empty | removed | max start gap | reason |",
+        "|---:|:---:|:---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for row in report["samples"]:
+        lines.append(
+            "| {sample_index} | {valid} | {strict_valid} | {note_count} | {unique_pitch_count} | "
+            "{dead_air_ratio} | {phrase_coverage_ratio} | {onset_coverage_ratio} | "
+            "{sustained_coverage_ratio} | {position_span_ratio} | {head_empty_steps} | "
+            "{tail_empty_steps} | {longest_sustained_empty_run_steps} | "
+            "{postprocess_removed_note_count} | {max_start_gap_sec} | {reason} |".format(
+                sample_index=row["sample_index"],
+                valid=row["valid"],
+                strict_valid=row["strict_valid"],
+                note_count=row["note_count"],
+                unique_pitch_count=row["unique_pitch_count"],
+                dead_air_ratio=_fmt(row["dead_air_ratio"]),
+                phrase_coverage_ratio=_fmt(row["phrase_coverage_ratio"]),
+                onset_coverage_ratio=_fmt(row["onset_coverage_ratio"]),
+                sustained_coverage_ratio=_fmt(row["sustained_coverage_ratio"]),
+                position_span_ratio=_fmt(row["position_span_ratio"]),
+                head_empty_steps=row["head_empty_steps"],
+                tail_empty_steps=row["tail_empty_steps"],
+                longest_sustained_empty_run_steps=row["longest_sustained_empty_run_steps"],
+                postprocess_removed_note_count=row["postprocess_removed_note_count"],
+                max_start_gap_sec=_fmt(row["max_start_gap_sec"]),
+                reason=row.get("failure_reason") or "none",
+            )
+        )
+    lines.extend(["", "## Outlier Gap Detail", ""])
+    for row in report["samples"]:
+        if not row["dead_air_outlier"]:
+            continue
+        lines.append(f"### Sample {row['sample_index']}")
+        lines.append("")
+        lines.append(
+            "- pattern: "
+            f"head empty `{row['head_empty_steps']}` steps, "
+            f"tail empty `{row['tail_empty_steps']}` steps, "
+            f"sustained coverage `{row['sustained_coverage_ratio']:.3f}`, "
+            f"dead-air gaps `{row['dead_air_gap_count']}/{row['gap_count']}`"
+        )
+        lines.append("- first generated tokens:")
+        token_names = row.get("generated_token_names_head", [])
+        lines.append("  - " + ", ".join(str(token) for token in token_names[:16]))
+        lines.append("")
+        lines.append("| from | to | from pitch | to pitch | start gap sec | silent gap sec |")
+        lines.append("|---:|---:|---:|---:|---:|---:|")
+        for gap in row["dead_air_gaps"]:
+            lines.append(
+                "| {from_note} | {to_note} | {from_pitch} | {to_pitch} | {start_gap_sec:.3f} | {silent_gap_sec:.3f} |".format(
+                    **gap
+                )
+            )
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_diagnostic_report(
+    source_report_path: Path,
+    dead_air_threshold_ms: float,
+    dead_air_gate: float,
+) -> dict[str, Any]:
+    source = read_json(source_report_path)
+    threshold_sec = float(dead_air_threshold_ms) / 1000.0
+    sample_rows = [
+        compact_sample(sample, threshold_sec=threshold_sec, dead_air_gate=dead_air_gate)
+        for sample in source.get("samples", [])
+        if isinstance(sample, dict)
+    ]
+    return {
+        "source_report_path": str(source_report_path),
+        "source_run_id": str(source.get("run_id", "")),
+        "source_issue": int(source.get("issue", 0) or 0),
+        "request": source.get("request", {}),
+        "dead_air_threshold_sec": threshold_sec,
+        "dead_air_gate": float(dead_air_gate),
+        "summary": build_summary(sample_rows),
+        "samples": sample_rows,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Diagnose Stage B dead-air outlier samples")
+    parser.add_argument("--report_path", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=str(ROOT_DIR / "outputs" / "stage_b_dead_air_diagnostics"),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--dead_air_threshold_ms", type=float, default=180.0)
+    parser.add_argument("--dead_air_gate", type=float, default=0.8)
+    parser.add_argument("--expected_outliers", type=int, default=None)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_diagnostic_report(
+        source_report_path=Path(args.report_path),
+        dead_air_threshold_ms=args.dead_air_threshold_ms,
+        dead_air_gate=args.dead_air_gate,
+    )
+    write_json(output_dir / "dead_air_diagnostics.json", report)
+    (output_dir / "dead_air_diagnostics.md").write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps(report, ensure_ascii=True, indent=2))
+    if args.expected_outliers is not None and report["summary"]["dead_air_outlier_count"] != int(args.expected_outliers):
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_dead_air_diagnostics.py
+++ b/tests/test_stage_b_dead_air_diagnostics.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+import pretty_midi
+
+from scripts.diagnose_stage_b_dead_air_outliers import (
+    build_summary,
+    compact_sample,
+    markdown_report,
+    start_gap_rows,
+)
+
+
+class StageBDeadAirDiagnosticsTest(unittest.TestCase):
+    def test_start_gap_rows_marks_dead_air_gaps(self) -> None:
+        notes = [
+            SimpleNamespace(start=0.0, end=0.1, pitch=60),
+            SimpleNamespace(start=0.12, end=0.2, pitch=62),
+            SimpleNamespace(start=0.4, end=0.5, pitch=64),
+        ]
+
+        gaps = start_gap_rows(notes, threshold_sec=0.18)
+
+        self.assertEqual(len(gaps), 2)
+        self.assertFalse(gaps[0]["is_dead_air_gap"])
+        self.assertTrue(gaps[1]["is_dead_air_gap"])
+        self.assertAlmostEqual(gaps[1]["start_gap_sec"], 0.28)
+
+    def test_compact_sample_summarizes_outlier_midi(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            midi_path = Path(tmp) / "sample.mid"
+            midi = pretty_midi.PrettyMIDI(initial_tempo=124)
+            instrument = pretty_midi.Instrument(program=0, is_drum=False)
+            instrument.notes.extend(
+                [
+                    pretty_midi.Note(velocity=80, pitch=60, start=0.0, end=0.1),
+                    pretty_midi.Note(velocity=82, pitch=62, start=0.25, end=0.35),
+                    pretty_midi.Note(velocity=84, pitch=64, start=0.5, end=0.6),
+                ]
+            )
+            midi.instruments.append(instrument)
+            midi.write(str(midi_path))
+
+            row = compact_sample(
+                {
+                    "sample_index": 1,
+                    "midi_path": str(midi_path),
+                    "valid": False,
+                    "strict_valid": False,
+                    "failure_reason": "dead-air ratio too high: 1.000 >= 0.800",
+                    "metrics": {
+                        "note_count": 3,
+                        "unique_pitch_count": 3,
+                        "dead_air_ratio": 1.0,
+                        "phrase_coverage_ratio": 0.5,
+                    },
+                    "temporal_coverage": {
+                        "onset_coverage_ratio": 0.2,
+                        "sustained_coverage_ratio": 0.3,
+                        "position_span_ratio": 0.5,
+                        "head_empty_steps": 2,
+                        "tail_empty_steps": 8,
+                        "longest_onset_empty_run_steps": 8,
+                        "longest_sustained_empty_run_steps": 6,
+                    },
+                    "collapse": {
+                        "postprocess_removal_ratio": 0.2,
+                        "collapse_warning": False,
+                        "repeated_position_pitch_pair_ratio": 0.0,
+                    },
+                    "grammar": {"grammar_valid": False, "invalid_token_count": 1},
+                    "postprocess": {"removed_note_count": 1},
+                    "generated_token_names_head": ["POSITION_0", "VELOCITY_3"],
+                },
+                threshold_sec=0.18,
+                dead_air_gate=0.8,
+            )
+
+        self.assertTrue(row["dead_air_outlier"])
+        self.assertEqual(row["dead_air_gap_count"], 2)
+        self.assertEqual(row["postprocess_removed_note_count"], 1)
+        self.assertEqual(row["note_rows_head"][0]["pitch"], 60)
+
+    def test_markdown_report_lists_outlier_detail(self) -> None:
+        sample = {
+            "sample_index": 1,
+            "valid": False,
+            "strict_valid": False,
+            "note_count": 8,
+            "unique_pitch_count": 4,
+            "dead_air_ratio": 0.857,
+            "phrase_coverage_ratio": 0.469,
+            "onset_coverage_ratio": 0.25,
+            "sustained_coverage_ratio": 0.375,
+            "position_span_ratio": 0.469,
+            "head_empty_steps": 6,
+            "tail_empty_steps": 11,
+            "longest_sustained_empty_run_steps": 10,
+            "postprocess_removed_note_count": 3,
+            "max_start_gap_sec": 0.484,
+            "failure_reason": "dead-air ratio too high",
+            "dead_air_outlier": True,
+            "dead_air_gap_count": 6,
+            "gap_count": 7,
+            "generated_token_names_head": ["NOTE_DURATION_3", "POSITION_4"],
+            "dead_air_gaps": [
+                {
+                    "from_note": 1,
+                    "to_note": 2,
+                    "from_pitch": 60,
+                    "to_pitch": 62,
+                    "start_gap_sec": 0.25,
+                    "silent_gap_sec": 0.15,
+                }
+            ],
+        }
+        report = {
+            "source_report_path": "report.json",
+            "dead_air_gate": 0.8,
+            "dead_air_threshold_sec": 0.18,
+            "summary": build_summary([sample]),
+            "samples": [sample],
+        }
+
+        markdown = markdown_report(report)
+
+        self.assertIn("outlier sample indices", markdown)
+        self.assertIn("Sample 1", markdown)
+        self.assertIn("dead-air gaps `6/7`", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Added a focused diagnostic script for Stage B dead-air outliers using probe reports and MIDI note timing.
- Added a harness mode and unit tests for the diagnostic path.
- Documented the Issue #224 seed 31 outlier result and updated README/current plan boundaries.

## Result
- outlier sample: seed 31 sample 1
- dead-air ratio: 0.857 against gate 0.800
- onset coverage: 0.250
- sustained coverage: 0.375
- tail empty steps: 11
- dead-air start gaps: 6/7
- collapse warning: false
- postprocess removal ratio: 0.273

## Validation
- REPORT_PATH=outputs/stage_b_generation_probe/issue_224_stage_b_raw_generation_repeatability_final2_seed31_files2/report.json RUN_ID=issue_226_stage_b_dead_air_diagnostics bash scripts/agent_harness.sh stage-b-dead-air-diagnostics
- bash scripts/agent_harness.sh quick

Closes #226