### PR TITLE
feat: Stage B dead-air 후보 선택 gate 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ flowchart LR
 
 ## 핵심 결과
 
-Issue #226 기준 model-core MVP:
+Issue #228 기준 model-core MVP:
 
 | 항목 | 결과 |
 |---|---|
@@ -63,6 +63,7 @@ Issue #226 기준 model-core MVP:
 | repeatability sweep | 2 source files / 3 seeds / 9 samples |
 | repeatability result | strict `8/9`, grammar `9/9`, dead-air outlier `1` |
 | dead-air diagnostics | seed `31` sample `1`, dead-air `0.857`, collapse warning false |
+| candidate selection gate | selected best seed `17` sample `3`, dead-air `0.333` |
 | constrained review gate | `stage-b-overlap-gate` 통과 |
 | focused candidate path | `stage-b-rhythm-phrase-variation` 통과 |
 
@@ -75,6 +76,7 @@ MVP 근거:
 - postprocess 후 note count `13-18`, unique pitch count `4-6`
 - 2-file/3-seed repeatability sweep에서 strict pass-rate `0.889`
 - dead-air outlier가 collapse/postprocess 문제가 아니라 낮은 onset/sustained coverage 문제임을 분리
+- dead-air outlier rate `0.111`을 기록하고 strict-valid 후보 중 best candidate를 선택
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`
@@ -114,7 +116,7 @@ Issue #210 기준 current best focused review candidate:
 |---|---|
 | broad unconstrained trained-model generation quality | 미검증 |
 | broad multi-seed model quality | 부분 검증 / 2-file 3-seed local sweep 통과 |
-| dead-air outlier control | 미완료 |
+| dead-air outlier control | 부분 검증 / candidate selection gate 추가, 생성 자체 억제는 미완료 |
 | human/audio listening preference | 미검증 |
 | Brad Mehldau style adaptation | 미검증 |
 | generic jazz pianist base 완성 | 미검증 |

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -58,9 +58,11 @@ MVP가 끝났다고 볼 수 있는 조건:
 - repair 문서: `docs/STAGE_B_RAW_GENERATION_GATE_REPAIR_2026-05-28.md`
 - repeatability 문서: `docs/STAGE_B_RAW_GENERATION_REPEATABILITY_SWEEP_2026-05-28.md`
 - dead-air 진단 문서: `docs/STAGE_B_DEAD_AIR_OUTLIER_DIAGNOSTICS_2026-05-28.md`
+- candidate gate 문서: `docs/STAGE_B_DEAD_AIR_AWARE_CANDIDATE_GATE_2026-05-28.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
+- raw generation candidate selection gate: selected best seed `17` sample `3`, dead-air `0.333`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -235,6 +237,7 @@ Stage B에서 명시하는 것:
 108. Stage B raw generation gate repair
 109. Stage B raw generation broader repeatability sweep
 110. Stage B raw generation dead-air outlier diagnostics
+111. Stage B dead-air-aware candidate selection gate
 
 가장 최근 의미 있는 결과:
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #226, Stage B raw generation dead-air outlier diagnostics
-- 다음 권장 이슈: `Stage B dead-air-aware candidate selection gate`
+- latest functional result: Issue #228, Stage B dead-air-aware candidate selection gate
+- 다음 권장 이슈: `Stage B broader source repeatability with candidate gate`
 
 현재 범위가 아닌 것:
 
@@ -169,6 +169,36 @@ Issue #226은 Issue #224의 seed `31` dead-air outlier 원인을 분리한 작�
 Docs:
 
 - `docs/STAGE_B_DEAD_AIR_OUTLIER_DIAGNOSTICS_2026-05-28.md`
+
+## Current Dead-Air-Aware Candidate Gate Result
+
+Issue #228은 repeatability sweep에 dead-air outlier 집계와 strict-valid 후보 선택 기준을 추가한 작업이다.
+
+검증:
+
+- `ISSUE_NUMBER=228 RUN_ID=issue_228_stage_b_dead_air_candidate_gate bash scripts/agent_harness.sh stage-b-raw-generation-repeatability`
+
+결과:
+
+- total samples: `9`
+- strict valid sample count: `8/9`
+- grammar gate sample count: `9/9`
+- dead-air outlier count: `1`
+- dead-air outlier rate: `0.111`
+- max allowed outlier rate: `0.250`
+- selected best candidate: seed `17`, sample `3`
+- selected best dead-air ratio: `0.333`
+- seed `31` best strict candidate: sample `2`, dead-air `0.750`
+
+해석:
+
+- outlier를 숨기지 않고 별도 rate로 기록한다.
+- outlier가 있는 seed에서도 strict-valid 대체 후보를 선택할 수 있다.
+- 다음 작업은 source file 수를 늘려 candidate selection gate가 유지되는지 확인하는 것이다.
+
+Docs:
+
+- `docs/STAGE_B_DEAD_AIR_AWARE_CANDIDATE_GATE_2026-05-28.md`
 
 ## Latest README Footer Section Removal Result
 

--- a/docs/STAGE_B_DEAD_AIR_AWARE_CANDIDATE_GATE_2026-05-28.md
+++ b/docs/STAGE_B_DEAD_AIR_AWARE_CANDIDATE_GATE_2026-05-28.md
@@ -1,0 +1,90 @@
+# Stage B Dead-Air-Aware Candidate Gate
+
+작성일: 2026-05-28
+
+## 결론
+
+| 항목 | 값 |
+|---|---:|
+| repeatability gate | 통과 |
+| source files | `2` |
+| seeds | `17, 23, 31` |
+| total samples | `9` |
+| strict valid samples | `8` |
+| dead-air outliers | `1` |
+| dead-air outlier rate | `0.111` |
+| max allowed outlier rate | `0.250` |
+| selected best candidate | seed `17`, sample `3` |
+| selected best dead-air | `0.333` |
+
+Issue #228은 repeatability sweep에 dead-air-aware candidate selection을 추가한 작업이다.
+
+Outlier를 숨기지 않고 `1/9`로 기록하면서, strict-valid 후보 중 dead-air가 가장 낮은 후보를 seed별/전체 기준으로 선택한다.
+
+## 실행 조건
+
+Command:
+
+```bash
+ISSUE_NUMBER=228 RUN_ID=issue_228_stage_b_dead_air_candidate_gate bash scripts/agent_harness.sh stage-b-raw-generation-repeatability
+```
+
+조건:
+
+- max files: `2`
+- seeds: `17, 23, 31`
+- epochs: `50`
+- samples per seed: `3`
+- total samples: `9`
+- top_k: `4`
+- temperature: `0.9`
+- overlap postprocess: enabled
+- dead-air gate: `0.800`
+- max dead-air outlier rate: `0.250`
+
+## 결과
+
+| seed | samples | strict | dead-air outliers | best sample | best dead-air | notes | pitches | phrase coverage | max removal |
+|---:|---:|---:|---:|---:|---:|---|---|---|---:|
+| `17` | `3` | `3` | `0` | `3` | `0.333` | `8-16` | `3-6` | `0.406-1.000` | `0.238` |
+| `23` | `3` | `3` | `0` | `1` | `0.364` | `12-16` | `5-5` | `0.500-0.875` | `0.429` |
+| `31` | `3` | `2` | `1` | `2` | `0.750` | `8-14` | `4-7` | `0.469-0.844` | `0.273` |
+
+전체 selected best:
+
+- seed: `17`
+- sample: `3`
+- dead-air ratio: `0.333`
+- note count: `16`
+- unique pitch count: `6`
+- phrase coverage: `1.000`
+- onset coverage: `0.500`
+- sustained coverage: `0.781`
+- postprocess removal ratio: `0.238`
+
+## 해석
+
+증명한 것:
+
+- repeatability sweep는 outlier를 성공으로 덮지 않고 dead-air outlier count/rate를 별도 집계한다.
+- seed `31`에는 outlier가 남아 있지만, 같은 seed 안에서 strict-valid 대체 후보 sample `2`를 선택할 수 있다.
+- 전체 후보군 기준으로는 seed `17` sample `3`이 가장 낮은 dead-air ratio를 가진 strict-valid 후보로 선택된다.
+- gate는 `strict 8/9`, `dead-air outlier rate 0.111 <= 0.250`, seed별 best 후보 존재 조건을 동시에 만족했다.
+
+아직 아닌 것:
+
+- dead-air outlier 생성 자체를 제거한 것은 아니다.
+- source file 수는 여전히 `2`로 제한되어 있다.
+- 사람이 듣는 선호나 Brad style adaptation은 검증하지 않았다.
+
+## 다음 작업
+
+권장 이슈:
+
+- `Stage B broader source repeatability with candidate gate`
+
+목표:
+
+- source file 수를 `3+`로 늘려 candidate selection gate 유지 여부 확인
+- selected best candidate의 dead-air/coverage 분포 기록
+- outlier rate가 증가하는 seed/file 조건 분리

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -268,9 +268,11 @@ run_stage_b_generation_probe() {
 
 run_stage_b_raw_generation_repeatability() {
   local run_id="${RUN_ID:-harness_stage_b_raw_generation_repeatability}"
+  local issue_number="${ISSUE_NUMBER:-0}"
   print_header "Stage B raw generation repeatability sweep"
   "$PYTHON_BIN" scripts/run_stage_b_raw_generation_repeatability_sweep.py \
     --run_id "$run_id" \
+    --issue_number "$issue_number" \
     --max_files 2 \
     --seeds 17,23,31 \
     --epochs 50 \
@@ -283,6 +285,8 @@ run_stage_b_raw_generation_repeatability() {
     --min_source_files 2 \
     --min_strict_samples_per_seed 1 \
     --min_overall_strict_rate 0.67 \
+    --dead_air_gate 0.8 \
+    --max_dead_air_outlier_rate 0.25 \
     --n_layers 1 \
     --num_heads 4 \
     --d_model 64 \

--- a/scripts/run_stage_b_raw_generation_repeatability_sweep.py
+++ b/scripts/run_stage_b_raw_generation_repeatability_sweep.py
@@ -162,12 +162,55 @@ def reason_label(value: Any) -> str:
     return ", ".join(f"{reason} ({count})" for reason, count in sorted(value.items()))
 
 
+def sample_float(sample: dict[str, Any], section: str, key: str, default: float = 0.0) -> float:
+    value = sample.get(section, {}).get(key, default)
+    return float(value if value is not None else default)
+
+
+def sample_int(sample: dict[str, Any], section: str, key: str, default: int = 0) -> int:
+    value = sample.get(section, {}).get(key, default)
+    return int(value if value is not None else default)
+
+
+def candidate_summary(seed: int, run_id: str, sample: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "seed": int(seed),
+        "run_id": run_id,
+        "sample_index": int(sample.get("sample_index", 0) or 0),
+        "midi_path": str(sample.get("midi_path", "")),
+        "dead_air_ratio": sample_float(sample, "metrics", "dead_air_ratio"),
+        "note_count": sample_int(sample, "metrics", "note_count"),
+        "unique_pitch_count": sample_int(sample, "metrics", "unique_pitch_count"),
+        "phrase_coverage_ratio": sample_float(sample, "metrics", "phrase_coverage_ratio"),
+        "onset_coverage_ratio": sample_float(sample, "temporal_coverage", "onset_coverage_ratio"),
+        "sustained_coverage_ratio": sample_float(sample, "temporal_coverage", "sustained_coverage_ratio"),
+        "postprocess_removal_ratio": sample_float(sample, "collapse", "postprocess_removal_ratio"),
+    }
+
+
+def best_strict_candidate(seed: int, run_id: str, samples: Sequence[dict[str, Any]]) -> dict[str, Any] | None:
+    strict_candidates = [sample for sample in samples if bool(sample.get("strict_valid", False))]
+    if not strict_candidates:
+        return None
+    best = sorted(
+        strict_candidates,
+        key=lambda sample: (
+            sample_float(sample, "metrics", "dead_air_ratio"),
+            sample_float(sample, "collapse", "postprocess_removal_ratio"),
+            -sample_int(sample, "metrics", "note_count"),
+            int(sample.get("sample_index", 0) or 0),
+        ),
+    )[0]
+    return candidate_summary(seed, run_id, best)
+
+
 def row_from_report(
     seed: int,
     run_id: str,
     report_path: Path,
     report: dict[str, Any] | None,
     command_result: dict[str, Any],
+    dead_air_gate: float,
 ) -> dict[str, Any]:
     if report is None:
         return {
@@ -180,19 +223,24 @@ def row_from_report(
             "strict_valid_sample_count": 0,
             "grammar_gate_sample_count": 0,
             "passed_strict_review_gate": False,
+            "dead_air_outlier_count": 0,
+            "best_strict_candidate": None,
             "failure_reasons": {"missing_report": 1},
             "strict_failure_reasons": {"missing_report": 1},
             "diagnostic_failure_reasons": {"missing_report": 1},
         }
 
     summary = report.get("summary", {})
+    samples = [sample for sample in report.get("samples", []) if isinstance(sample, dict)]
     note_counts = _sample_metric_values(report, "note_count")
     unique_pitch_counts = _sample_metric_values(report, "unique_pitch_count")
     max_simultaneous_values = _sample_metric_values(report, "max_simultaneous_notes")
     phrase_coverage_values = _sample_metric_values(report, "phrase_coverage_ratio")
+    dead_air_ratios = _sample_metric_values(report, "dead_air_ratio")
     complete_note_groups = _grammar_values(report, "complete_note_groups")
     invalid_token_counts = _grammar_values(report, "invalid_token_count")
     postprocess_removal_ratios = _collapse_values(report, "postprocess_removal_ratio")
+    dead_air_outlier_count = sum(1 for value in dead_air_ratios if float(value) >= float(dead_air_gate))
 
     return {
         "seed": int(seed),
@@ -227,6 +275,10 @@ def row_from_report(
         "complete_note_group_range": _range(complete_note_groups),
         "invalid_token_count_range": _range(invalid_token_counts),
         "postprocess_removal_ratio_range": _range(postprocess_removal_ratios),
+        "dead_air_ratio_range": _range(dead_air_ratios),
+        "dead_air_outlier_count": int(dead_air_outlier_count),
+        "dead_air_gate": float(dead_air_gate),
+        "best_strict_candidate": best_strict_candidate(seed, run_id, samples),
         "failure_reasons": summary.get("failure_reasons", {}),
         "diagnostic_failure_reasons": summary.get("diagnostic_failure_reasons", {}),
         "strict_failure_reasons": summary.get("strict_failure_reasons", {}),
@@ -240,6 +292,7 @@ def build_repeatability_summary(
     min_strict_samples_per_seed: int,
     min_overall_strict_rate: float,
     max_postprocess_removal_ratio: float,
+    max_dead_air_outlier_rate: float,
 ) -> dict[str, Any]:
     total_samples = sum(int(row.get("sample_count", 0) or 0) for row in rows)
     total_valid = sum(int(row.get("valid_sample_count", 0) or 0) for row in rows)
@@ -263,6 +316,27 @@ def build_repeatability_summary(
     valid_rate = float(total_valid / total_samples) if total_samples else 0.0
     grammar_rate = float(total_grammar / total_samples) if total_samples else 0.0
     min_observed_input_files = min(input_file_counts) if input_file_counts else 0
+    total_dead_air_outliers = sum(int(row.get("dead_air_outlier_count", 0) or 0) for row in rows)
+    dead_air_outlier_rate = float(total_dead_air_outliers / total_samples) if total_samples else 0.0
+    seed_best_candidates = [
+        row.get("best_strict_candidate")
+        for row in rows
+        if isinstance(row.get("best_strict_candidate"), dict)
+    ]
+    selected_best_candidate = (
+        sorted(
+            seed_best_candidates,
+            key=lambda candidate: (
+                float(candidate.get("dead_air_ratio", 0.0) or 0.0),
+                float(candidate.get("postprocess_removal_ratio", 0.0) or 0.0),
+                -int(candidate.get("note_count", 0) or 0),
+                int(candidate.get("seed", 0) or 0),
+                int(candidate.get("sample_index", 0) or 0),
+            ),
+        )[0]
+        if seed_best_candidates
+        else None
+    )
 
     passed = bool(
         len(rows) >= int(min_seed_count)
@@ -270,6 +344,8 @@ def build_repeatability_summary(
         and len(seeds_with_strict) == len(rows)
         and strict_rate >= float(min_overall_strict_rate)
         and max_removal <= float(max_postprocess_removal_ratio)
+        and len(seed_best_candidates) == len(rows)
+        and dead_air_outlier_rate <= float(max_dead_air_outlier_rate)
         and not any(int(row.get("returncode", 0) or 0) != 0 for row in rows)
     )
 
@@ -291,12 +367,23 @@ def build_repeatability_summary(
         "min_overall_strict_rate": float(min_overall_strict_rate),
         "max_postprocess_removal_ratio": float(max_removal),
         "allowed_max_postprocess_removal_ratio": float(max_postprocess_removal_ratio),
+        "total_dead_air_outlier_count": int(total_dead_air_outliers),
+        "dead_air_outlier_rate": dead_air_outlier_rate,
+        "max_dead_air_outlier_rate": float(max_dead_air_outlier_rate),
+        "seed_best_candidates": seed_best_candidates,
+        "selected_best_candidate": selected_best_candidate,
         "failing_seeds": [int(row["seed"]) for row in failing_rows],
         "passed_repeatability_gate": passed,
     }
 
 
 def markdown_report(rows: Sequence[dict[str, Any]], summary: dict[str, Any]) -> str:
+    selected = summary.get("selected_best_candidate") if isinstance(summary.get("selected_best_candidate"), dict) else None
+    selected_label = (
+        f"seed {selected['seed']} sample {selected['sample_index']} dead-air {float(selected['dead_air_ratio']):.3f}"
+        if selected
+        else "none"
+    )
     lines = [
         "# Stage B Raw Generation Repeatability Sweep",
         "",
@@ -307,15 +394,18 @@ def markdown_report(rows: Sequence[dict[str, Any]], summary: dict[str, Any]) -> 
         f"- strict pass-rate: `{summary['strict_valid_sample_rate']:.3f}`",
         f"- grammar pass-rate: `{summary['grammar_gate_sample_rate']:.3f}`",
         f"- max postprocess removal ratio: `{summary['max_postprocess_removal_ratio']:.3f}`",
+        f"- dead-air outlier rate: `{summary['dead_air_outlier_rate']:.3f}`",
+        f"- selected best candidate: `{selected_label}`",
         "",
-        "| seed | files | samples | grammar | valid | strict | notes | pitches | max simultaneous | phrase coverage | max removal | strict gate |",
-        "|---:|---:|---:|---:|---:|---:|---|---|---|---|---:|:---:|",
+        "| seed | files | samples | grammar | valid | strict | dead-air outliers | best sample | best dead-air | notes | pitches | phrase coverage | max removal | strict gate |",
+        "|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|---|---:|:---:|",
     ]
     for row in rows:
+        best = row.get("best_strict_candidate") if isinstance(row.get("best_strict_candidate"), dict) else None
         lines.append(
             "| {seed} | {input_file_count} | {sample_count} | {grammar_gate_sample_count} | "
-            "{valid_sample_count} | {strict_valid_sample_count} | {note_range} | "
-            "{pitch_range} | {simul_range} | {coverage_range} | {max_removal:.3f} | "
+            "{valid_sample_count} | {strict_valid_sample_count} | {dead_air_outlier_count} | "
+            "{best_sample} | {best_dead_air} | {note_range} | {pitch_range} | {coverage_range} | {max_removal:.3f} | "
             "{strict_gate} |".format(
                 seed=row["seed"],
                 input_file_count=row.get("input_file_count", 0),
@@ -323,9 +413,11 @@ def markdown_report(rows: Sequence[dict[str, Any]], summary: dict[str, Any]) -> 
                 grammar_gate_sample_count=row.get("grammar_gate_sample_count", 0),
                 valid_sample_count=row.get("valid_sample_count", 0),
                 strict_valid_sample_count=row.get("strict_valid_sample_count", 0),
+                dead_air_outlier_count=row.get("dead_air_outlier_count", 0),
+                best_sample=best.get("sample_index", "-") if best else "-",
+                best_dead_air=f"{float(best.get('dead_air_ratio', 0.0)):.3f}" if best else "-",
                 note_range=range_label(row.get("note_count_range"), digits=0),
                 pitch_range=range_label(row.get("unique_pitch_count_range"), digits=0),
-                simul_range=range_label(row.get("max_simultaneous_notes_range"), digits=0),
                 coverage_range=range_label(row.get("phrase_coverage_ratio_range"), digits=3),
                 max_removal=float(row.get("max_postprocess_removal_ratio", 0.0) or 0.0),
                 strict_gate=bool(row.get("passed_strict_review_gate", False)),
@@ -345,7 +437,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--output_root", type=str, default=str(ROOT_DIR / "outputs" / "stage_b_raw_generation_repeatability"))
     parser.add_argument("--probe_output_root", type=str, default=str(ROOT_DIR / "outputs" / "stage_b_generation_probe"))
     parser.add_argument("--run_id", type=str, default=None)
-    parser.add_argument("--issue_number", type=int, default=224)
+    parser.add_argument("--issue_number", type=int, default=0)
     parser.add_argument("--seeds", type=str, default="17,23,31")
     parser.add_argument("--max_files", type=int, default=2)
     parser.add_argument("--epochs", type=int, default=50)
@@ -362,6 +454,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--min_strict_samples_per_seed", type=int, default=1)
     parser.add_argument("--min_overall_strict_rate", type=float, default=0.67)
     parser.add_argument("--max_allowed_postprocess_removal_ratio", type=float, default=0.49)
+    parser.add_argument("--dead_air_gate", type=float, default=0.8)
+    parser.add_argument("--max_dead_air_outlier_rate", type=float, default=0.25)
     parser.add_argument("--max_collapse_warning_sample_rate", type=float, default=0.34)
     parser.add_argument("--strict_min_unique_pitches", type=int, default=3)
     parser.add_argument("--strict_min_unique_positions", type=int, default=3)
@@ -399,6 +493,7 @@ def main() -> int:
                 report_path=report_path,
                 report=report,
                 command_result=command_result,
+                dead_air_gate=args.dead_air_gate,
             )
         )
 
@@ -409,6 +504,7 @@ def main() -> int:
         min_strict_samples_per_seed=args.min_strict_samples_per_seed,
         min_overall_strict_rate=args.min_overall_strict_rate,
         max_postprocess_removal_ratio=args.max_allowed_postprocess_removal_ratio,
+        max_dead_air_outlier_rate=args.max_dead_air_outlier_rate,
     )
     report = {
         "run_id": run_id,
@@ -421,6 +517,8 @@ def main() -> int:
             "temperature": float(args.temperature),
             "top_k": int(args.top_k),
             "postprocess_overlap": True,
+            "dead_air_gate": float(args.dead_air_gate),
+            "max_dead_air_outlier_rate": float(args.max_dead_air_outlier_rate),
         },
         "summary": summary,
         "rows": rows,

--- a/tests/test_stage_b_raw_generation_repeatability.py
+++ b/tests/test_stage_b_raw_generation_repeatability.py
@@ -4,6 +4,7 @@ import unittest
 
 from scripts.run_stage_b_raw_generation_repeatability_sweep import (
     build_repeatability_summary,
+    best_strict_candidate,
     markdown_report,
     parse_seed_values,
     probe_run_id,
@@ -42,6 +43,8 @@ class StageBRawGenerationRepeatabilityTest(unittest.TestCase):
                 "strict_valid_sample_count": 3,
                 "grammar_gate_sample_count": 3,
                 "max_postprocess_removal_ratio": 0.2,
+                "dead_air_outlier_count": 0,
+                "best_strict_candidate": {"seed": 17, "sample_index": 1, "dead_air_ratio": 0.5},
             },
             {
                 "seed": 23,
@@ -52,6 +55,8 @@ class StageBRawGenerationRepeatabilityTest(unittest.TestCase):
                 "strict_valid_sample_count": 0,
                 "grammar_gate_sample_count": 3,
                 "max_postprocess_removal_ratio": 0.2,
+                "dead_air_outlier_count": 0,
+                "best_strict_candidate": None,
             },
             {
                 "seed": 31,
@@ -62,6 +67,8 @@ class StageBRawGenerationRepeatabilityTest(unittest.TestCase):
                 "strict_valid_sample_count": 3,
                 "grammar_gate_sample_count": 3,
                 "max_postprocess_removal_ratio": 0.2,
+                "dead_air_outlier_count": 0,
+                "best_strict_candidate": {"seed": 31, "sample_index": 2, "dead_air_ratio": 0.7},
             },
         ]
 
@@ -72,10 +79,96 @@ class StageBRawGenerationRepeatabilityTest(unittest.TestCase):
             min_strict_samples_per_seed=1,
             min_overall_strict_rate=0.67,
             max_postprocess_removal_ratio=0.49,
+            max_dead_air_outlier_rate=0.25,
         )
 
         self.assertFalse(summary["passed_repeatability_gate"])
         self.assertEqual(summary["failing_seeds"], [23])
+
+    def test_best_strict_candidate_prefers_low_dead_air(self) -> None:
+        candidate = best_strict_candidate(
+            17,
+            "run",
+            [
+                {
+                    "sample_index": 1,
+                    "strict_valid": True,
+                    "metrics": {"dead_air_ratio": 0.7, "note_count": 12},
+                    "collapse": {"postprocess_removal_ratio": 0.1},
+                },
+                {
+                    "sample_index": 2,
+                    "strict_valid": True,
+                    "metrics": {"dead_air_ratio": 0.4, "note_count": 8},
+                    "collapse": {"postprocess_removal_ratio": 0.2},
+                },
+                {
+                    "sample_index": 3,
+                    "strict_valid": False,
+                    "metrics": {"dead_air_ratio": 0.1, "note_count": 16},
+                    "collapse": {"postprocess_removal_ratio": 0.0},
+                },
+            ],
+        )
+
+        self.assertIsNotNone(candidate)
+        self.assertEqual(candidate["sample_index"], 2)
+        self.assertEqual(candidate["dead_air_ratio"], 0.4)
+
+    def test_build_repeatability_summary_tracks_dead_air_candidate_gate(self) -> None:
+        rows = [
+            {
+                "seed": 17,
+                "returncode": 0,
+                "input_file_count": 2,
+                "sample_count": 3,
+                "valid_sample_count": 3,
+                "strict_valid_sample_count": 3,
+                "grammar_gate_sample_count": 3,
+                "max_postprocess_removal_ratio": 0.2,
+                "dead_air_outlier_count": 1,
+                "best_strict_candidate": {
+                    "seed": 17,
+                    "sample_index": 2,
+                    "dead_air_ratio": 0.6,
+                    "postprocess_removal_ratio": 0.1,
+                    "note_count": 12,
+                },
+            },
+            {
+                "seed": 23,
+                "returncode": 0,
+                "input_file_count": 2,
+                "sample_count": 3,
+                "valid_sample_count": 3,
+                "strict_valid_sample_count": 3,
+                "grammar_gate_sample_count": 3,
+                "max_postprocess_removal_ratio": 0.2,
+                "dead_air_outlier_count": 0,
+                "best_strict_candidate": {
+                    "seed": 23,
+                    "sample_index": 1,
+                    "dead_air_ratio": 0.4,
+                    "postprocess_removal_ratio": 0.2,
+                    "note_count": 10,
+                },
+            },
+        ]
+
+        summary = build_repeatability_summary(
+            rows,
+            min_seed_count=2,
+            min_source_files=2,
+            min_strict_samples_per_seed=1,
+            min_overall_strict_rate=0.67,
+            max_postprocess_removal_ratio=0.49,
+            max_dead_air_outlier_rate=0.25,
+        )
+
+        self.assertTrue(summary["passed_repeatability_gate"])
+        self.assertEqual(summary["total_dead_air_outlier_count"], 1)
+        self.assertAlmostEqual(summary["dead_air_outlier_rate"], 1 / 6)
+        self.assertEqual(summary["selected_best_candidate"]["seed"], 23)
 
     def test_markdown_report_contains_gate_and_seed_rows(self) -> None:
         rows = [
@@ -91,6 +184,12 @@ class StageBRawGenerationRepeatabilityTest(unittest.TestCase):
                 "max_simultaneous_notes_range": {"min": 1, "max": 2},
                 "phrase_coverage_ratio_range": {"min": 0.8, "max": 1.0},
                 "max_postprocess_removal_ratio": 0.2,
+                "dead_air_outlier_count": 0,
+                "best_strict_candidate": {
+                    "seed": 17,
+                    "sample_index": 2,
+                    "dead_air_ratio": 0.4,
+                },
                 "passed_strict_review_gate": True,
                 "failure_reasons": {},
                 "strict_failure_reasons": {},
@@ -104,6 +203,8 @@ class StageBRawGenerationRepeatabilityTest(unittest.TestCase):
             "strict_valid_sample_rate": 1.0,
             "grammar_gate_sample_rate": 1.0,
             "max_postprocess_removal_ratio": 0.2,
+            "dead_air_outlier_rate": 0.0,
+            "selected_best_candidate": {"seed": 17, "sample_index": 2, "dead_air_ratio": 0.4},
         }
 
         markdown = markdown_report(rows, summary)
@@ -111,6 +212,7 @@ class StageBRawGenerationRepeatabilityTest(unittest.TestCase):
         self.assertIn("passed repeatability gate", markdown)
         self.assertIn("| 17 |", markdown)
         self.assertIn("strict pass-rate", markdown)
+        self.assertIn("selected best candidate", markdown)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Added dead-air outlier count/rate to the Stage B raw generation repeatability sweep.
- Added seed-level and overall best strict-valid candidate selection using dead-air ratio first.
- Updated harness/docs/README with the measured candidate gate result.

## Result
- repeatability gate: pass
- total samples: 9
- strict valid samples: 8/9
- grammar gate samples: 9/9
- dead-air outlier count: 1
- dead-air outlier rate: 0.111 <= 0.250
- selected best candidate: seed 17 sample 3
- selected best dead-air ratio: 0.333
- seed 31 best strict candidate: sample 2, dead-air 0.750

## Validation
- ISSUE_NUMBER=228 RUN_ID=issue_228_stage_b_dead_air_candidate_gate bash scripts/agent_harness.sh stage-b-raw-generation-repeatability
- bash scripts/agent_harness.sh quick

Closes #228