### PR TITLE
test: Stage B seed strict margin 진단 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Issue #232 기준 model-core MVP:
 | candidate selection gate | selected best seed `17` sample `3`, dead-air `0.333` |
 | broader source gate | 3 source files / strict `7/9`, dead-air outlier rate `0.222`, selected best dead-air `0.222` |
 | larger source boundary | 4/5/6 source files hard gate 통과, 6-file seed `17` strict margin `1/3` |
+| seed strict margin diagnostics | 6-file seed `17`: sample `1` dead-air, sample `2` unique pitch, sample `3` strict-valid |
 | constrained review gate | `stage-b-overlap-gate` 통과 |
 | focused candidate path | `stage-b-rhythm-phrase-variation` 통과 |
 
@@ -81,6 +82,7 @@ MVP 근거:
 - dead-air outlier rate `0.111`을 기록하고 strict-valid 후보 중 best candidate를 선택
 - 3-file repeatability에서 strict `7/9`, dead-air outlier rate `0.222 <= 0.250` 확인
 - 4/5/6-file repeatability hard gate 통과, 6-file seed `17`에서 strict `1/3` 및 unique pitch failure 확인
+- 6-file seed `17`의 dead-air failure와 unique-pitch failure가 서로 다른 후보에서 발생함을 sample 단위로 분리
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -61,12 +61,14 @@ MVP가 끝났다고 볼 수 있는 조건:
 - candidate gate 문서: `docs/STAGE_B_DEAD_AIR_AWARE_CANDIDATE_GATE_2026-05-28.md`
 - broader source 문서: `docs/STAGE_B_BROADER_SOURCE_CANDIDATE_GATE_2026-05-28.md`
 - larger source boundary 문서: `docs/STAGE_B_LARGER_SOURCE_RISK_BOUNDARY_2026-05-28.md`
+- seed strict margin 진단 문서: `docs/STAGE_B_SEED_STRICT_MARGIN_DIAGNOSTICS_2026-05-28.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
 - raw generation candidate selection gate: selected best seed `17` sample `3`, dead-air `0.333`
 - broader source candidate gate: 3-file/3-seed sweep 통과, strict `7/9`, dead-air outlier rate `0.222`
 - larger source risk boundary: 4/5/6-file hard gate 통과, 6-file seed `17` strict `1/3`
+- seed strict margin diagnostics: 6-file seed `17` failure가 sample `1` dead-air와 sample `2` unique-pitch로 분리됨
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -244,6 +246,7 @@ Stage B에서 명시하는 것:
 111. Stage B dead-air-aware candidate selection gate
 112. Stage B broader source repeatability with candidate gate
 113. Stage B larger source repeatability risk boundary
+114. Stage B seed-level strict margin diagnostics
 
 가장 최근 의미 있는 결과:
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #232, Stage B larger source repeatability risk boundary
-- 다음 권장 이슈: `Stage B seed-level strict margin diagnostics`
+- latest functional result: Issue #234, Stage B seed-level strict margin diagnostics
+- 다음 권장 이슈: `Stage B per-seed strict margin warning gate`
 
 현재 범위가 아닌 것:
 
@@ -267,6 +267,49 @@ Issue #232는 source file 수를 `4`, `5`, `6`까지 늘렸을 때 repeatability
 Docs:
 
 - `docs/STAGE_B_LARGER_SOURCE_RISK_BOUNDARY_2026-05-28.md`
+
+## Current Seed Strict Margin Diagnostics Result
+
+Issue #234는 Issue #232의 6-file run에서 seed `17`만 strict `1/3`까지 내려간 원인을 sample 단위로 분리한 작업이다.
+
+변경:
+
+- repeatability summary와 seed별 generation report를 읽는 진단 스크립트 추가
+- seed별 strict margin warning, dead-air sample, unique-pitch sample, overlap sample 분류
+- `stage-b-seed-strict-margin-diagnostics` harness mode 추가
+
+검증:
+
+- `bash scripts/agent_harness.sh stage-b-seed-strict-margin-diagnostics`
+
+결과:
+
+- source run: `issue_232_stage_b_larger_source_risk_boundary_files6`
+- hard min strict per seed: `1`
+- warning min strict per seed: `2`
+- margin warning seeds: `17`
+- dead-air + unique-pitch overlap seeds: 없음
+- dead-air + unique-pitch separate seeds: `17`
+
+seed `17` sample breakdown:
+
+| sample | strict | issue |
+|---:|:---:|---|
+| `1` | false | dead-air ratio `0.857 >= 0.800` |
+| `2` | false | unique pitch count `2 < 3` |
+| `3` | true | strict-valid best candidate |
+
+해석:
+
+- 6-file 조건의 hard gate는 아직 유지된다.
+- seed `17`도 strict-valid 후보가 하나 남는다.
+- dead-air failure와 unique-pitch failure는 같은 후보에 겹친 collapse가 아니다.
+- aggregate strict pass-rate만 보면 seed별 margin 감소를 놓칠 수 있다.
+- 다음 작업은 per-seed strict margin을 hard gate와 분리된 warning/soft gate로 repeatability summary에 포함하는 것이다.
+
+Docs:
+
+- `docs/STAGE_B_SEED_STRICT_MARGIN_DIAGNOSTICS_2026-05-28.md`
 
 ## Latest README Footer Section Removal Result
 

--- a/docs/STAGE_B_SEED_STRICT_MARGIN_DIAGNOSTICS_2026-05-28.md
+++ b/docs/STAGE_B_SEED_STRICT_MARGIN_DIAGNOSTICS_2026-05-28.md
@@ -1,0 +1,88 @@
+# Stage B Seed Strict Margin Diagnostics
+
+작성일: 2026-05-28
+
+## 결론
+
+Issue #232의 6-file repeatability run에서 seed `17`만 strict margin warning에 걸렸다.
+
+| 항목 | 결과 |
+|---|---|
+| source run | `issue_232_stage_b_larger_source_risk_boundary_files6` |
+| hard min strict per seed | `1` |
+| warning min strict per seed | `2` |
+| margin warning seeds | `17` |
+| dead-air + unique-pitch overlap seeds | 없음 |
+| dead-air + unique-pitch separate seeds | `17` |
+
+seed `17`의 실패는 한 후보에 겹친 문제가 아니라 서로 다른 후보에서 발생했다.
+
+- sample `1`: dead-air failure
+- sample `2`: unique pitch failure
+- sample `3`: strict-valid best candidate
+
+따라서 현재 hard gate를 바로 실패 처리할 근거는 부족하다.
+다만 seed별 strict 후보가 1개만 남는 상태는 후보 선택 안정성이 낮으므로, 다음 단계에서는 per-seed strict margin을 warning 또는 soft gate로 repeatability summary에 포함시키는 것이 맞다.
+
+## 실행 조건
+
+Command:
+
+```bash
+bash scripts/agent_harness.sh stage-b-seed-strict-margin-diagnostics
+```
+
+내부 입력:
+
+```bash
+SUMMARY_PATH=outputs/stage_b_raw_generation_repeatability/issue_232_stage_b_larger_source_risk_boundary_files6/repeatability_summary.json
+```
+
+Gate:
+
+- hard min strict per seed: `1`
+- warning min strict per seed: `2`
+- expected margin warning seeds: `17`
+
+## Seed Summary
+
+| seed | samples | strict | margin warning | dead-air samples | unique-pitch samples | overlap samples | best sample | best dead-air |
+|---:|---:|---:|:---:|---|---|---|---:|---:|
+| `17` | `3` | `1` | true | `1` | `2` | 없음 | `3` | `0.500` |
+| `23` | `3` | `3` | false | 없음 | 없음 | 없음 | `1` | `0.375` |
+| `31` | `3` | `3` | false | 없음 | 없음 | 없음 | `2` | `0.636` |
+
+## Seed 17 Sample Detail
+
+| sample | strict | notes | pitches | dead-air | phrase | onset | sustained | tail | removal | reason |
+|---:|:---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| `1` | false | `15` | `3` | `0.857` | `1.000` | `0.312` | `0.844` | `0` | `0.250` | dead-air ratio too high |
+| `2` | false | `8` | `2` | `0.714` | `0.437` | `0.250` | `0.375` | `17` | `0.200` | unique pitch count too low |
+| `3` | true | `17` | `4` | `0.500` | `1.000` | `0.594` | `0.844` | `0` | `0.227` | none |
+
+## 해석
+
+증명한 것:
+
+- 6-file 조건의 hard gate는 아직 유지된다.
+- seed `17`도 strict-valid 후보가 하나 남는다.
+- dead-air failure와 unique-pitch failure는 같은 후보에 겹친 collapse가 아니다.
+- unique-pitch failure sample은 tail empty `17`로 phrase 후반이 비어 있고 pitch diversity도 낮다.
+
+리스크:
+
+- seed `17`은 strict-valid 후보가 `1/3`뿐이라 candidate selection 안정성이 낮다.
+- aggregate strict pass-rate만 보면 seed별 margin 감소를 놓칠 수 있다.
+- 현재 결과는 objective metric 진단이며, broad listening quality나 style adaptation을 증명하지 않는다.
+
+## 다음 작업
+
+권장 이슈:
+
+- `Stage B per-seed strict margin warning gate`
+
+목표:
+
+- repeatability summary에 warning min strict per seed를 선택적으로 기록
+- hard gate와 soft warning을 분리
+- margin warning seed와 sample-level failure breakdown을 summary markdown에 포함

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -36,6 +36,8 @@ Modes:
                 Run raw Stage B generation across multiple seeds and source files.
   stage-b-dead-air-diagnostics
                 Diagnose dead-air outliers from a Stage B generation probe report.
+  stage-b-seed-strict-margin-diagnostics
+                Diagnose per-seed strict margin risk from a Stage B repeatability summary.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -161,6 +163,7 @@ run_quick() {
     scripts/run_stage_b_generation_probe.py \
     scripts/run_stage_b_raw_generation_repeatability_sweep.py \
     scripts/diagnose_stage_b_dead_air_outliers.py \
+    scripts/diagnose_stage_b_seed_strict_margins.py \
     scripts/run_stage_b_sampling_sweep.py \
     scripts/run_stage_b_coverage_ab_sweep.py \
     scripts/run_stage_b_pitch_mode_compare.py \
@@ -313,6 +316,17 @@ run_stage_b_dead_air_diagnostics() {
     --run_id "$run_id" \
     --report_path "$report_path" \
     --expected_outliers 1
+}
+
+run_stage_b_seed_strict_margin_diagnostics() {
+  local run_id="${RUN_ID:-harness_stage_b_seed_strict_margin_diagnostics}"
+  local summary_path="${SUMMARY_PATH:-outputs/stage_b_raw_generation_repeatability/issue_232_stage_b_larger_source_risk_boundary_files6/repeatability_summary.json}"
+  print_header "Stage B seed strict margin diagnostics"
+  "$PYTHON_BIN" scripts/diagnose_stage_b_seed_strict_margins.py \
+    --run_id "$run_id" \
+    --summary_path "$summary_path" \
+    --warning_min_strict_samples_per_seed 2 \
+    --expected_margin_warning_seeds 17
 }
 
 run_stage_b_constrained_probe() {
@@ -1440,6 +1454,9 @@ case "$MODE" in
     ;;
   stage-b-dead-air-diagnostics)
     run_stage_b_dead_air_diagnostics
+    ;;
+  stage-b-seed-strict-margin-diagnostics)
+    run_stage_b_seed_strict_margin_diagnostics
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/diagnose_stage_b_seed_strict_margins.py
+++ b/scripts/diagnose_stage_b_seed_strict_margins.py
@@ -1,0 +1,342 @@
+"""Diagnose per-seed strict margin risk from a Stage B repeatability sweep."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Sequence
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _resolve_path(raw_path: str, source_path: Path) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path
+    source_parent = source_path.parent
+    candidate = source_parent / path
+    if candidate.exists():
+        return candidate
+    return ROOT_DIR / path
+
+
+def _nested_float(source: dict[str, Any], section: str, key: str, default: float = 0.0) -> float:
+    value = source.get(section, {}).get(key, default)
+    return float(value if value is not None else default)
+
+
+def _nested_int(source: dict[str, Any], section: str, key: str, default: int = 0) -> int:
+    value = source.get(section, {}).get(key, default)
+    return int(value if value is not None else default)
+
+
+def _reason_text(sample: dict[str, Any]) -> str:
+    values = [
+        sample.get("failure_reason"),
+        sample.get("diagnostic_failure_reason"),
+    ]
+    return " | ".join(str(value) for value in values if value)
+
+
+def failure_tags(sample: dict[str, Any], dead_air_gate: float, min_unique_pitches: int) -> list[str]:
+    tags: list[str] = []
+    reason = _reason_text(sample).lower()
+    dead_air_ratio = _nested_float(sample, "metrics", "dead_air_ratio")
+    unique_pitch_count = _nested_int(sample, "metrics", "unique_pitch_count")
+    grammar = sample.get("grammar", {}) if isinstance(sample.get("grammar"), dict) else {}
+    postprocess_removal = _nested_float(sample, "collapse", "postprocess_removal_ratio")
+
+    if not bool(sample.get("strict_valid", False)):
+        tags.append("strict_invalid")
+    if "dead-air" in reason or dead_air_ratio >= float(dead_air_gate):
+        tags.append("dead_air")
+    if "unique pitch" in reason or unique_pitch_count < int(min_unique_pitches):
+        tags.append("unique_pitch")
+    if not bool(sample.get("strict_valid", False)) and not bool(grammar.get("grammar_valid", True)):
+        tags.append("grammar")
+    if "postprocess" in reason:
+        tags.append("postprocess")
+    if postprocess_removal > 0.49:
+        tags.append("postprocess_margin")
+    return tags
+
+
+def compact_sample(
+    seed: int,
+    sample: dict[str, Any],
+    dead_air_gate: float,
+    min_unique_pitches: int,
+) -> dict[str, Any]:
+    tags = failure_tags(sample, dead_air_gate=dead_air_gate, min_unique_pitches=min_unique_pitches)
+    return {
+        "seed": int(seed),
+        "sample_index": int(sample.get("sample_index", 0) or 0),
+        "valid": bool(sample.get("valid", False)),
+        "strict_valid": bool(sample.get("strict_valid", False)),
+        "grammar_valid": bool(sample.get("grammar", {}).get("grammar_valid", False)),
+        "failure_reason": sample.get("failure_reason"),
+        "diagnostic_failure_reason": sample.get("diagnostic_failure_reason"),
+        "failure_tags": tags,
+        "note_count": _nested_int(sample, "metrics", "note_count"),
+        "unique_pitch_count": _nested_int(sample, "metrics", "unique_pitch_count"),
+        "dead_air_ratio": _nested_float(sample, "metrics", "dead_air_ratio"),
+        "phrase_coverage_ratio": _nested_float(sample, "metrics", "phrase_coverage_ratio"),
+        "onset_coverage_ratio": _nested_float(sample, "temporal_coverage", "onset_coverage_ratio"),
+        "sustained_coverage_ratio": _nested_float(sample, "temporal_coverage", "sustained_coverage_ratio"),
+        "position_span_ratio": _nested_float(sample, "temporal_coverage", "position_span_ratio"),
+        "head_empty_steps": _nested_int(sample, "temporal_coverage", "head_empty_steps"),
+        "tail_empty_steps": _nested_int(sample, "temporal_coverage", "tail_empty_steps"),
+        "postprocess_removal_ratio": _nested_float(sample, "collapse", "postprocess_removal_ratio"),
+    }
+
+
+def _tag_indices(samples: Sequence[dict[str, Any]], tag: str) -> list[int]:
+    return [int(sample["sample_index"]) for sample in samples if tag in sample.get("failure_tags", [])]
+
+
+def summarize_seed(
+    row: dict[str, Any],
+    samples: Sequence[dict[str, Any]],
+    warning_min_strict_samples_per_seed: int,
+) -> dict[str, Any]:
+    strict_count = sum(1 for sample in samples if bool(sample.get("strict_valid", False)))
+    sample_count = len(samples)
+    tag_counts = Counter(tag for sample in samples for tag in sample.get("failure_tags", []))
+    dead_air_indices = _tag_indices(samples, "dead_air")
+    unique_pitch_indices = _tag_indices(samples, "unique_pitch")
+    overlap_indices = [
+        int(sample["sample_index"])
+        for sample in samples
+        if "dead_air" in sample.get("failure_tags", []) and "unique_pitch" in sample.get("failure_tags", [])
+    ]
+    best = row.get("best_strict_candidate") if isinstance(row.get("best_strict_candidate"), dict) else None
+    return {
+        "seed": int(row.get("seed", 0) or 0),
+        "report_path": str(row.get("report_path", "")),
+        "sample_count": int(sample_count),
+        "strict_valid_sample_count": int(strict_count),
+        "strict_margin": int(strict_count - int(warning_min_strict_samples_per_seed)),
+        "margin_warning": bool(strict_count < int(warning_min_strict_samples_per_seed)),
+        "dead_air_sample_indices": dead_air_indices,
+        "unique_pitch_sample_indices": unique_pitch_indices,
+        "dead_air_unique_pitch_overlap_indices": overlap_indices,
+        "dead_air_unique_pitch_failures_separate": bool(dead_air_indices and unique_pitch_indices and not overlap_indices),
+        "failure_tag_counts": dict(sorted(tag_counts.items())),
+        "best_strict_candidate": best,
+    }
+
+
+def load_seed_samples(
+    source_summary_path: Path,
+    row: dict[str, Any],
+    dead_air_gate: float,
+    min_unique_pitches: int,
+) -> list[dict[str, Any]]:
+    report_path = _resolve_path(str(row.get("report_path", "")), source_summary_path)
+    report = read_json(report_path)
+    seed = int(row.get("seed", report.get("seed", 0)) or 0)
+    return [
+        compact_sample(seed, sample, dead_air_gate=dead_air_gate, min_unique_pitches=min_unique_pitches)
+        for sample in report.get("samples", [])
+        if isinstance(sample, dict)
+    ]
+
+
+def build_diagnostic_report(
+    source_summary_path: Path,
+    warning_min_strict_samples_per_seed: int,
+    dead_air_gate: float,
+    min_unique_pitches: int,
+) -> dict[str, Any]:
+    source = read_json(source_summary_path)
+    rows = [row for row in source.get("rows", []) if isinstance(row, dict)]
+    seed_reports: list[dict[str, Any]] = []
+    sample_rows: list[dict[str, Any]] = []
+
+    for row in rows:
+        seed_samples = load_seed_samples(
+            source_summary_path,
+            row,
+            dead_air_gate=dead_air_gate,
+            min_unique_pitches=min_unique_pitches,
+        )
+        sample_rows.extend(seed_samples)
+        seed_reports.append(
+            summarize_seed(
+                row,
+                seed_samples,
+                warning_min_strict_samples_per_seed=warning_min_strict_samples_per_seed,
+            )
+        )
+
+    warning_seeds = [int(seed["seed"]) for seed in seed_reports if seed["margin_warning"]]
+    separate_failure_seeds = [
+        int(seed["seed"]) for seed in seed_reports if seed["dead_air_unique_pitch_failures_separate"]
+    ]
+    overlap_seeds = [
+        int(seed["seed"]) for seed in seed_reports if seed["dead_air_unique_pitch_overlap_indices"]
+    ]
+    source_summary = source.get("summary", {}) if isinstance(source.get("summary"), dict) else {}
+
+    return {
+        "source_summary_path": str(source_summary_path),
+        "source_run_id": str(source.get("run_id", "")),
+        "source_issue": int(source.get("issue", 0) or 0),
+        "hard_min_strict_samples_per_seed": int(source_summary.get("min_strict_samples_per_seed", 1) or 1),
+        "warning_min_strict_samples_per_seed": int(warning_min_strict_samples_per_seed),
+        "dead_air_gate": float(dead_air_gate),
+        "min_unique_pitches": int(min_unique_pitches),
+        "summary": {
+            "seed_count": int(len(seed_reports)),
+            "sample_count": int(len(sample_rows)),
+            "margin_warning_seed_count": int(len(warning_seeds)),
+            "margin_warning_seeds": warning_seeds,
+            "dead_air_unique_pitch_overlap_seed_count": int(len(overlap_seeds)),
+            "dead_air_unique_pitch_overlap_seeds": overlap_seeds,
+            "dead_air_unique_pitch_separate_seed_count": int(len(separate_failure_seeds)),
+            "dead_air_unique_pitch_separate_seeds": separate_failure_seeds,
+        },
+        "seeds": seed_reports,
+        "samples": sorted(sample_rows, key=lambda sample: (int(sample["seed"]), int(sample["sample_index"]))),
+    }
+
+
+def _fmt(value: Any, digits: int = 3) -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, float):
+        return f"{value:.{digits}f}"
+    return str(value)
+
+
+def _indices_label(values: Sequence[int]) -> str:
+    return ", ".join(str(value) for value in values) if values else "-"
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    lines = [
+        "# Stage B Seed Strict Margin Diagnostics",
+        "",
+        f"- source summary: `{report['source_summary_path']}`",
+        f"- hard min strict per seed: `{report['hard_min_strict_samples_per_seed']}`",
+        f"- warning min strict per seed: `{report['warning_min_strict_samples_per_seed']}`",
+        f"- strict margin warning seeds: `{summary['margin_warning_seeds']}`",
+        f"- dead-air + unique-pitch overlap seeds: `{summary['dead_air_unique_pitch_overlap_seeds']}`",
+        f"- dead-air + unique-pitch separate seeds: `{summary['dead_air_unique_pitch_separate_seeds']}`",
+        "",
+        "| seed | samples | strict | margin warning | dead-air samples | unique-pitch samples | overlap samples | best strict sample | best dead-air | failure tags |",
+        "|---:|---:|---:|:---:|---|---|---|---:|---:|---|",
+    ]
+    for seed in report["seeds"]:
+        best = seed.get("best_strict_candidate") if isinstance(seed.get("best_strict_candidate"), dict) else None
+        tag_label = ", ".join(
+            f"{tag} {count}" for tag, count in seed.get("failure_tag_counts", {}).items()
+        ) or "none"
+        lines.append(
+            "| {seed} | {sample_count} | {strict_valid_sample_count} | {margin_warning} | "
+            "{dead_air_samples} | {unique_pitch_samples} | {overlap_samples} | {best_sample} | "
+            "{best_dead_air} | {tags} |".format(
+                seed=seed["seed"],
+                sample_count=seed["sample_count"],
+                strict_valid_sample_count=seed["strict_valid_sample_count"],
+                margin_warning=seed["margin_warning"],
+                dead_air_samples=_indices_label(seed["dead_air_sample_indices"]),
+                unique_pitch_samples=_indices_label(seed["unique_pitch_sample_indices"]),
+                overlap_samples=_indices_label(seed["dead_air_unique_pitch_overlap_indices"]),
+                best_sample=best.get("sample_index", "-") if best else "-",
+                best_dead_air=_fmt(float(best.get("dead_air_ratio", 0.0)), 3) if best else "-",
+                tags=tag_label,
+            )
+        )
+
+    warning_seeds = {int(seed["seed"]) for seed in report["seeds"] if seed["margin_warning"]}
+    if warning_seeds:
+        lines.extend(["", "## Margin Warning Samples", ""])
+        lines.append(
+            "| seed | sample | strict | notes | pitches | dead-air | phrase | onset | sustained | tail | removal | tags | reason |"
+        )
+        lines.append("|---:|---:|:---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|")
+        for sample in report["samples"]:
+            if int(sample["seed"]) not in warning_seeds:
+                continue
+            lines.append(
+                "| {seed} | {sample_index} | {strict_valid} | {note_count} | {unique_pitch_count} | "
+                "{dead_air_ratio} | {phrase_coverage_ratio} | {onset_coverage_ratio} | "
+                "{sustained_coverage_ratio} | {tail_empty_steps} | {postprocess_removal_ratio} | "
+                "{tags} | {reason} |".format(
+                    seed=sample["seed"],
+                    sample_index=sample["sample_index"],
+                    strict_valid=sample["strict_valid"],
+                    note_count=sample["note_count"],
+                    unique_pitch_count=sample["unique_pitch_count"],
+                    dead_air_ratio=_fmt(sample["dead_air_ratio"]),
+                    phrase_coverage_ratio=_fmt(sample["phrase_coverage_ratio"]),
+                    onset_coverage_ratio=_fmt(sample["onset_coverage_ratio"]),
+                    sustained_coverage_ratio=_fmt(sample["sustained_coverage_ratio"]),
+                    tail_empty_steps=sample["tail_empty_steps"],
+                    postprocess_removal_ratio=_fmt(sample["postprocess_removal_ratio"]),
+                    tags=", ".join(sample["failure_tags"]) or "none",
+                    reason=sample.get("failure_reason") or "none",
+                )
+            )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Diagnose Stage B seed strict margin risk")
+    parser.add_argument("--summary_path", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=str(ROOT_DIR / "outputs" / "stage_b_seed_strict_margin_diagnostics"),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--warning_min_strict_samples_per_seed", type=int, default=2)
+    parser.add_argument("--dead_air_gate", type=float, default=0.8)
+    parser.add_argument("--min_unique_pitches", type=int, default=3)
+    parser.add_argument("--expected_margin_warning_seeds", type=str, default=None)
+    return parser
+
+
+def _parse_seed_list(raw: str | None) -> list[int] | None:
+    if raw is None:
+        return None
+    return [int(value.strip()) for value in raw.split(",") if value.strip()]
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_diagnostic_report(
+        source_summary_path=Path(args.summary_path),
+        warning_min_strict_samples_per_seed=args.warning_min_strict_samples_per_seed,
+        dead_air_gate=args.dead_air_gate,
+        min_unique_pitches=args.min_unique_pitches,
+    )
+    write_json(output_dir / "seed_strict_margin_diagnostics.json", report)
+    (output_dir / "seed_strict_margin_diagnostics.md").write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps(report, ensure_ascii=True, indent=2))
+
+    expected = _parse_seed_list(args.expected_margin_warning_seeds)
+    if expected is not None and report["summary"]["margin_warning_seeds"] != expected:
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_seed_strict_margin_diagnostics.py
+++ b/tests/test_stage_b_seed_strict_margin_diagnostics.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.diagnose_stage_b_seed_strict_margins import (
+    build_diagnostic_report,
+    failure_tags,
+    markdown_report,
+    write_json,
+)
+
+
+def sample(
+    index: int,
+    *,
+    strict: bool,
+    reason: str | None,
+    pitches: int,
+    dead_air: float,
+) -> dict:
+    return {
+        "sample_index": index,
+        "valid": strict,
+        "strict_valid": strict,
+        "failure_reason": reason,
+        "diagnostic_failure_reason": reason,
+        "metrics": {
+            "note_count": 12,
+            "unique_pitch_count": pitches,
+            "dead_air_ratio": dead_air,
+            "phrase_coverage_ratio": 0.75,
+        },
+        "temporal_coverage": {
+            "onset_coverage_ratio": 0.5,
+            "sustained_coverage_ratio": 0.625,
+            "position_span_ratio": 0.75,
+            "head_empty_steps": 1,
+            "tail_empty_steps": 0,
+        },
+        "collapse": {"postprocess_removal_ratio": 0.1},
+        "grammar": {"grammar_valid": True},
+    }
+
+
+class StageBSeedStrictMarginDiagnosticsTest(unittest.TestCase):
+    def test_failure_tags_split_dead_air_and_unique_pitch(self) -> None:
+        dead_air_tags = failure_tags(
+            sample(1, strict=False, reason="dead-air ratio too high: 0.857 >= 0.800", pitches=3, dead_air=0.857),
+            dead_air_gate=0.8,
+            min_unique_pitches=3,
+        )
+        pitch_tags = failure_tags(
+            sample(2, strict=False, reason="unique pitch count too low: 2 < 3", pitches=2, dead_air=0.714),
+            dead_air_gate=0.8,
+            min_unique_pitches=3,
+        )
+
+        self.assertIn("dead_air", dead_air_tags)
+        self.assertNotIn("unique_pitch", dead_air_tags)
+        self.assertIn("unique_pitch", pitch_tags)
+        self.assertNotIn("dead_air", pitch_tags)
+
+    def test_build_diagnostic_report_marks_seed_margin_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            seed17_report = root / "seed17_report.json"
+            seed23_report = root / "seed23_report.json"
+            summary_path = root / "repeatability_summary.json"
+
+            write_json(
+                seed17_report,
+                {
+                    "samples": [
+                        sample(
+                            1,
+                            strict=False,
+                            reason="dead-air ratio too high: 0.857 >= 0.800",
+                            pitches=3,
+                            dead_air=0.857,
+                        ),
+                        sample(
+                            2,
+                            strict=False,
+                            reason="unique pitch count too low: 2 < 3",
+                            pitches=2,
+                            dead_air=0.714,
+                        ),
+                        sample(3, strict=True, reason=None, pitches=4, dead_air=0.5),
+                    ]
+                },
+            )
+            write_json(
+                seed23_report,
+                {
+                    "samples": [
+                        sample(1, strict=True, reason=None, pitches=4, dead_air=0.375),
+                        sample(2, strict=True, reason=None, pitches=5, dead_air=0.5),
+                        sample(3, strict=True, reason=None, pitches=4, dead_air=0.625),
+                    ]
+                },
+            )
+            write_json(
+                summary_path,
+                {
+                    "run_id": "unit",
+                    "issue": 999,
+                    "summary": {"min_strict_samples_per_seed": 1},
+                    "rows": [
+                        {
+                            "seed": 17,
+                            "report_path": str(seed17_report),
+                            "best_strict_candidate": {"sample_index": 3, "dead_air_ratio": 0.5},
+                        },
+                        {
+                            "seed": 23,
+                            "report_path": str(seed23_report),
+                            "best_strict_candidate": {"sample_index": 1, "dead_air_ratio": 0.375},
+                        },
+                    ],
+                },
+            )
+
+            report = build_diagnostic_report(
+                summary_path,
+                warning_min_strict_samples_per_seed=2,
+                dead_air_gate=0.8,
+                min_unique_pitches=3,
+            )
+
+        self.assertEqual(report["summary"]["margin_warning_seeds"], [17])
+        self.assertEqual(report["summary"]["dead_air_unique_pitch_overlap_seeds"], [])
+        self.assertEqual(report["summary"]["dead_air_unique_pitch_separate_seeds"], [17])
+        seed17 = report["seeds"][0]
+        self.assertTrue(seed17["margin_warning"])
+        self.assertEqual(seed17["dead_air_sample_indices"], [1])
+        self.assertEqual(seed17["unique_pitch_sample_indices"], [2])
+        self.assertEqual(seed17["dead_air_unique_pitch_overlap_indices"], [])
+
+    def test_markdown_report_lists_warning_samples(self) -> None:
+        report = {
+            "source_summary_path": "summary.json",
+            "hard_min_strict_samples_per_seed": 1,
+            "warning_min_strict_samples_per_seed": 2,
+            "summary": {
+                "margin_warning_seeds": [17],
+                "dead_air_unique_pitch_overlap_seeds": [],
+                "dead_air_unique_pitch_separate_seeds": [17],
+            },
+            "seeds": [
+                {
+                    "seed": 17,
+                    "sample_count": 3,
+                    "strict_valid_sample_count": 1,
+                    "margin_warning": True,
+                    "dead_air_sample_indices": [1],
+                    "unique_pitch_sample_indices": [2],
+                    "dead_air_unique_pitch_overlap_indices": [],
+                    "failure_tag_counts": {"dead_air": 1, "strict_invalid": 2, "unique_pitch": 1},
+                    "best_strict_candidate": {"sample_index": 3, "dead_air_ratio": 0.5},
+                }
+            ],
+            "samples": [
+                {
+                    "seed": 17,
+                    "sample_index": 1,
+                    "strict_valid": False,
+                    "note_count": 15,
+                    "unique_pitch_count": 3,
+                    "dead_air_ratio": 0.857,
+                    "phrase_coverage_ratio": 1.0,
+                    "onset_coverage_ratio": 0.3125,
+                    "sustained_coverage_ratio": 0.84375,
+                    "tail_empty_steps": 0,
+                    "postprocess_removal_ratio": 0.25,
+                    "failure_tags": ["strict_invalid", "dead_air"],
+                    "failure_reason": "dead-air ratio too high",
+                }
+            ],
+        }
+
+        markdown = markdown_report(report)
+
+        self.assertIn("strict margin warning seeds: `[17]`", markdown)
+        self.assertIn("dead-air + unique-pitch separate seeds: `[17]`", markdown)
+        self.assertIn("| 17 | 1 | False | 15 | 3 | 0.857", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Added a seed-level strict margin diagnostic script for Stage B repeatability summaries.
- Added a harness mode and unit tests for sample-level dead-air/unique-pitch failure separation.
- Documented the Issue #232 6-file seed 17 diagnosis and updated current project status.

## Result
- Margin warning seeds: 17
- Dead-air + unique-pitch overlap seeds: none
- Dead-air + unique-pitch separate seeds: 17
- Seed 17 sample 1 failed dead-air, sample 2 failed unique pitch, sample 3 remained strict-valid.

## Validation
- bash scripts/agent_harness.sh stage-b-seed-strict-margin-diagnostics
- bash scripts/agent_harness.sh quick

Closes #234