### PR TITLE
feat: Stage B seed margin warning gate 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ flowchart LR
 
 ## 핵심 결과
 
-Issue #232 기준 model-core MVP:
+Issue #236 기준 model-core MVP:
 
 | 항목 | 결과 |
 |---|---|
@@ -67,6 +67,7 @@ Issue #232 기준 model-core MVP:
 | broader source gate | 3 source files / strict `7/9`, dead-air outlier rate `0.222`, selected best dead-air `0.222` |
 | larger source boundary | 4/5/6 source files hard gate 통과, 6-file seed `17` strict margin `1/3` |
 | seed strict margin diagnostics | 6-file seed `17`: sample `1` dead-air, sample `2` unique pitch, sample `3` strict-valid |
+| seed margin warning gate | hard gate 유지, warning min strict per seed `2`, warning seed `17` 기록 |
 | constrained review gate | `stage-b-overlap-gate` 통과 |
 | focused candidate path | `stage-b-rhythm-phrase-variation` 통과 |
 
@@ -83,6 +84,7 @@ MVP 근거:
 - 3-file repeatability에서 strict `7/9`, dead-air outlier rate `0.222 <= 0.250` 확인
 - 4/5/6-file repeatability hard gate 통과, 6-file seed `17`에서 strict `1/3` 및 unique pitch failure 확인
 - 6-file seed `17`의 dead-air failure와 unique-pitch failure가 서로 다른 후보에서 발생함을 sample 단위로 분리
+- per-seed strict margin warning을 repeatability summary에 추가해 aggregate pass-rate로 가려지는 후보 안정성 리스크 기록
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -62,6 +62,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - broader source 문서: `docs/STAGE_B_BROADER_SOURCE_CANDIDATE_GATE_2026-05-28.md`
 - larger source boundary 문서: `docs/STAGE_B_LARGER_SOURCE_RISK_BOUNDARY_2026-05-28.md`
 - seed strict margin 진단 문서: `docs/STAGE_B_SEED_STRICT_MARGIN_DIAGNOSTICS_2026-05-28.md`
+- seed strict margin warning gate 문서: `docs/STAGE_B_SEED_STRICT_MARGIN_WARNING_GATE_2026-05-28.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -69,6 +70,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - broader source candidate gate: 3-file/3-seed sweep 통과, strict `7/9`, dead-air outlier rate `0.222`
 - larger source risk boundary: 4/5/6-file hard gate 통과, 6-file seed `17` strict `1/3`
 - seed strict margin diagnostics: 6-file seed `17` failure가 sample `1` dead-air와 sample `2` unique-pitch로 분리됨
+- seed strict margin warning gate: hard gate 유지, 6-file warning seed `17` summary 기록
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -247,6 +249,7 @@ Stage B에서 명시하는 것:
 112. Stage B broader source repeatability with candidate gate
 113. Stage B larger source repeatability risk boundary
 114. Stage B seed-level strict margin diagnostics
+115. Stage B per-seed strict margin warning gate
 
 가장 최근 의미 있는 결과:
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #234, Stage B seed-level strict margin diagnostics
-- 다음 권장 이슈: `Stage B per-seed strict margin warning gate`
+- latest functional result: Issue #236, Stage B per-seed strict margin warning gate
+- 다음 권장 이슈: `Stage B candidate count margin recovery sweep`
 
 현재 범위가 아닌 것:
 
@@ -310,6 +310,45 @@ seed `17` sample breakdown:
 Docs:
 
 - `docs/STAGE_B_SEED_STRICT_MARGIN_DIAGNOSTICS_2026-05-28.md`
+
+## Current Seed Strict Margin Warning Gate Result
+
+Issue #236은 repeatability summary에 seed별 strict margin warning을 추가한 작업이다.
+
+변경:
+
+- `--warning_min_strict_samples_per_seed` 인자 추가
+- `strict_margin_warning_seed_count`, `strict_margin_warning_seeds`, `strict_margin_warning_rows` summary 추가
+- summary markdown의 seed table에 `margin warning` column 추가
+- harness에서 `WARNING_MIN_STRICT_SAMPLES_PER_SEED` 환경 변수 연결
+
+검증:
+
+- `bash scripts/agent_harness.sh stage-b-raw-generation-repeatability`
+- `ISSUE_NUMBER=236 MAX_FILES=6 MIN_SOURCE_FILES=6 RUN_ID=issue_236_stage_b_seed_strict_margin_warning_gate bash scripts/agent_harness.sh stage-b-raw-generation-repeatability`
+
+6-file 결과:
+
+- repeatability gate: 통과
+- strict valid samples: `7/9`
+- grammar gate samples: `9/9`
+- dead-air outlier rate: `0.111`
+- hard min strict per seed: `1`
+- warning min strict per seed: `2`
+- strict margin warning seeds: `17`
+- selected best candidate: seed `23`, sample `1`, dead-air `0.375`
+
+해석:
+
+- hard gate와 soft warning이 분리됐다.
+- 6-file run은 기존 hard gate를 계속 통과한다.
+- seed `17`의 strict margin risk가 aggregate pass-rate에 묻히지 않고 summary에 직접 드러난다.
+- warning은 실패 처리가 아니라 다음 실험 우선순위 신호다.
+- 다음 작업은 samples per seed를 늘렸을 때 seed `17` margin warning이 줄어드는지 확인하는 것이다.
+
+Docs:
+
+- `docs/STAGE_B_SEED_STRICT_MARGIN_WARNING_GATE_2026-05-28.md`
 
 ## Latest README Footer Section Removal Result
 

--- a/docs/STAGE_B_SEED_STRICT_MARGIN_WARNING_GATE_2026-05-28.md
+++ b/docs/STAGE_B_SEED_STRICT_MARGIN_WARNING_GATE_2026-05-28.md
@@ -1,0 +1,90 @@
+# Stage B Seed Strict Margin Warning Gate
+
+작성일: 2026-05-28
+
+## 결론
+
+repeatability summary에 seed별 strict margin warning을 추가했다.
+기존 hard gate는 유지하고, seed별 strict-valid 후보 수가 warning 기준보다 낮을 때만 별도 경고로 기록한다.
+
+Issue #236 6-file 검증 결과:
+
+| 항목 | 결과 |
+|---|---|
+| repeatability gate | 통과 |
+| source files | `6` |
+| seeds | `17, 23, 31` |
+| total samples | `9` |
+| strict valid samples | `7/9` |
+| grammar gate samples | `9/9` |
+| dead-air outlier rate | `0.111` |
+| hard min strict per seed | `1` |
+| warning min strict per seed | `2` |
+| strict margin warning seeds | `17` |
+| selected best candidate | seed `23`, sample `1`, dead-air `0.375` |
+
+## 변경 내용
+
+- `run_stage_b_raw_generation_repeatability_sweep.py`
+  - `--warning_min_strict_samples_per_seed` 인자 추가
+  - `strict_margin_warning_seed_count` 기록
+  - `strict_margin_warning_seeds` 기록
+  - `strict_margin_warning_rows` 기록
+- `repeatability_summary.md`
+  - warning 기준과 warning seed 목록 출력
+  - seed table에 `margin warning` column 추가
+- `agent_harness.sh`
+  - `WARNING_MIN_STRICT_SAMPLES_PER_SEED` 환경 변수 연결
+
+## 실행 조건
+
+Commands:
+
+```bash
+bash scripts/agent_harness.sh stage-b-raw-generation-repeatability
+ISSUE_NUMBER=236 MAX_FILES=6 MIN_SOURCE_FILES=6 RUN_ID=issue_236_stage_b_seed_strict_margin_warning_gate bash scripts/agent_harness.sh stage-b-raw-generation-repeatability
+```
+
+공통 조건:
+
+- epochs: `50`
+- samples per seed: `3`
+- top_k: `4`
+- temperature: `0.9`
+- hard min strict per seed: `1`
+- warning min strict per seed: `2`
+- max dead-air outlier rate: `0.250`
+
+## 6-File Seed Summary
+
+| seed | strict | margin warning | dead-air outliers | best sample | best dead-air |
+|---:|---:|:---:|---:|---:|---:|
+| `17` | `1/3` | true | `1` | `3` | `0.500` |
+| `23` | `3/3` | false | `0` | `1` | `0.375` |
+| `31` | `3/3` | false | `0` | `2` | `0.636` |
+
+## 해석
+
+증명한 것:
+
+- hard gate와 soft warning이 분리됐다.
+- 6-file run은 기존 hard gate를 계속 통과한다.
+- seed `17`의 strict margin risk가 aggregate pass-rate에 묻히지 않고 summary에 직접 드러난다.
+- warning은 실패 처리가 아니라 다음 실험 우선순위 신호로 남는다.
+
+리스크:
+
+- warning seed가 있다는 것은 candidate selection 안정성이 낮다는 뜻이다.
+- warning만 추가했을 뿐, seed `17`의 실패를 줄인 것은 아니다.
+- broad quality나 Brad style adaptation은 여전히 증명되지 않았다.
+
+## 다음 작업
+
+권장 이슈:
+
+- `Stage B candidate count margin recovery sweep`
+
+목표:
+
+- 6-file 조건에서 samples per seed를 늘렸을 때 seed `17` margin warning이 줄어드는지 확인
+- candidate count 증가가 hard gate 안정성과 selected best quality에 미치는 영향 기록

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -282,6 +282,7 @@ run_stage_b_raw_generation_repeatability() {
   local top_k="${TOP_K:-4}"
   local temperature="${TEMPERATURE:-0.9}"
   local max_dead_air_outlier_rate="${MAX_DEAD_AIR_OUTLIER_RATE:-0.25}"
+  local warning_min_strict_samples_per_seed="${WARNING_MIN_STRICT_SAMPLES_PER_SEED:-2}"
   print_header "Stage B raw generation repeatability sweep"
   "$PYTHON_BIN" scripts/run_stage_b_raw_generation_repeatability_sweep.py \
     --run_id "$run_id" \
@@ -298,6 +299,7 @@ run_stage_b_raw_generation_repeatability() {
     --min_source_files "$min_source_files" \
     --min_strict_samples_per_seed 1 \
     --min_overall_strict_rate 0.67 \
+    --warning_min_strict_samples_per_seed "$warning_min_strict_samples_per_seed" \
     --dead_air_gate 0.8 \
     --max_dead_air_outlier_rate "$max_dead_air_outlier_rate" \
     --n_layers 1 \

--- a/scripts/run_stage_b_raw_generation_repeatability_sweep.py
+++ b/scripts/run_stage_b_raw_generation_repeatability_sweep.py
@@ -293,6 +293,7 @@ def build_repeatability_summary(
     min_overall_strict_rate: float,
     max_postprocess_removal_ratio: float,
     max_dead_air_outlier_rate: float,
+    warning_min_strict_samples_per_seed: int = 2,
 ) -> dict[str, Any]:
     total_samples = sum(int(row.get("sample_count", 0) or 0) for row in rows)
     total_valid = sum(int(row.get("valid_sample_count", 0) or 0) for row in rows)
@@ -322,6 +323,19 @@ def build_repeatability_summary(
         row.get("best_strict_candidate")
         for row in rows
         if isinstance(row.get("best_strict_candidate"), dict)
+    ]
+    strict_margin_warning_rows = [
+        {
+            "seed": int(row["seed"]),
+            "sample_count": int(row.get("sample_count", 0) or 0),
+            "strict_valid_sample_count": int(row.get("strict_valid_sample_count", 0) or 0),
+            "warning_min_strict_samples_per_seed": int(warning_min_strict_samples_per_seed),
+            "strict_margin": int(
+                int(row.get("strict_valid_sample_count", 0) or 0) - int(warning_min_strict_samples_per_seed)
+            ),
+        }
+        for row in rows
+        if int(row.get("strict_valid_sample_count", 0) or 0) < int(warning_min_strict_samples_per_seed)
     ]
     selected_best_candidate = (
         sorted(
@@ -370,6 +384,10 @@ def build_repeatability_summary(
         "total_dead_air_outlier_count": int(total_dead_air_outliers),
         "dead_air_outlier_rate": dead_air_outlier_rate,
         "max_dead_air_outlier_rate": float(max_dead_air_outlier_rate),
+        "warning_min_strict_samples_per_seed": int(warning_min_strict_samples_per_seed),
+        "strict_margin_warning_seed_count": int(len(strict_margin_warning_rows)),
+        "strict_margin_warning_seeds": [int(row["seed"]) for row in strict_margin_warning_rows],
+        "strict_margin_warning_rows": strict_margin_warning_rows,
         "seed_best_candidates": seed_best_candidates,
         "selected_best_candidate": selected_best_candidate,
         "failing_seeds": [int(row["seed"]) for row in failing_rows],
@@ -395,16 +413,19 @@ def markdown_report(rows: Sequence[dict[str, Any]], summary: dict[str, Any]) -> 
         f"- grammar pass-rate: `{summary['grammar_gate_sample_rate']:.3f}`",
         f"- max postprocess removal ratio: `{summary['max_postprocess_removal_ratio']:.3f}`",
         f"- dead-air outlier rate: `{summary['dead_air_outlier_rate']:.3f}`",
+        f"- warning min strict per seed: `{summary.get('warning_min_strict_samples_per_seed', 0)}`",
+        f"- strict margin warning seeds: `{summary.get('strict_margin_warning_seeds', [])}`",
         f"- selected best candidate: `{selected_label}`",
         "",
-        "| seed | files | samples | grammar | valid | strict | dead-air outliers | best sample | best dead-air | notes | pitches | phrase coverage | max removal | strict gate |",
-        "|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|---|---:|:---:|",
+        "| seed | files | samples | grammar | valid | strict | margin warning | dead-air outliers | best sample | best dead-air | notes | pitches | phrase coverage | max removal | strict gate |",
+        "|---:|---:|---:|---:|---:|---:|:---:|---:|---:|---:|---|---|---|---:|:---:|",
     ]
+    warning_seeds = set(int(seed) for seed in summary.get("strict_margin_warning_seeds", []))
     for row in rows:
         best = row.get("best_strict_candidate") if isinstance(row.get("best_strict_candidate"), dict) else None
         lines.append(
             "| {seed} | {input_file_count} | {sample_count} | {grammar_gate_sample_count} | "
-            "{valid_sample_count} | {strict_valid_sample_count} | {dead_air_outlier_count} | "
+            "{valid_sample_count} | {strict_valid_sample_count} | {margin_warning} | {dead_air_outlier_count} | "
             "{best_sample} | {best_dead_air} | {note_range} | {pitch_range} | {coverage_range} | {max_removal:.3f} | "
             "{strict_gate} |".format(
                 seed=row["seed"],
@@ -413,6 +434,7 @@ def markdown_report(rows: Sequence[dict[str, Any]], summary: dict[str, Any]) -> 
                 grammar_gate_sample_count=row.get("grammar_gate_sample_count", 0),
                 valid_sample_count=row.get("valid_sample_count", 0),
                 strict_valid_sample_count=row.get("strict_valid_sample_count", 0),
+                margin_warning=int(row["seed"]) in warning_seeds,
                 dead_air_outlier_count=row.get("dead_air_outlier_count", 0),
                 best_sample=best.get("sample_index", "-") if best else "-",
                 best_dead_air=f"{float(best.get('dead_air_ratio', 0.0)):.3f}" if best else "-",
@@ -453,6 +475,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--min_source_files", type=int, default=2)
     parser.add_argument("--min_strict_samples_per_seed", type=int, default=1)
     parser.add_argument("--min_overall_strict_rate", type=float, default=0.67)
+    parser.add_argument("--warning_min_strict_samples_per_seed", type=int, default=2)
     parser.add_argument("--max_allowed_postprocess_removal_ratio", type=float, default=0.49)
     parser.add_argument("--dead_air_gate", type=float, default=0.8)
     parser.add_argument("--max_dead_air_outlier_rate", type=float, default=0.25)
@@ -505,6 +528,7 @@ def main() -> int:
         min_overall_strict_rate=args.min_overall_strict_rate,
         max_postprocess_removal_ratio=args.max_allowed_postprocess_removal_ratio,
         max_dead_air_outlier_rate=args.max_dead_air_outlier_rate,
+        warning_min_strict_samples_per_seed=args.warning_min_strict_samples_per_seed,
     )
     report = {
         "run_id": run_id,
@@ -519,6 +543,7 @@ def main() -> int:
             "postprocess_overlap": True,
             "dead_air_gate": float(args.dead_air_gate),
             "max_dead_air_outlier_rate": float(args.max_dead_air_outlier_rate),
+            "warning_min_strict_samples_per_seed": int(args.warning_min_strict_samples_per_seed),
         },
         "summary": summary,
         "rows": rows,

--- a/tests/test_stage_b_raw_generation_repeatability.py
+++ b/tests/test_stage_b_raw_generation_repeatability.py
@@ -170,6 +170,80 @@ class StageBRawGenerationRepeatabilityTest(unittest.TestCase):
         self.assertAlmostEqual(summary["dead_air_outlier_rate"], 1 / 6)
         self.assertEqual(summary["selected_best_candidate"]["seed"], 23)
 
+    def test_build_repeatability_summary_warns_without_failing_gate(self) -> None:
+        rows = [
+            {
+                "seed": 17,
+                "returncode": 0,
+                "input_file_count": 6,
+                "sample_count": 3,
+                "valid_sample_count": 1,
+                "strict_valid_sample_count": 1,
+                "grammar_gate_sample_count": 3,
+                "max_postprocess_removal_ratio": 0.25,
+                "dead_air_outlier_count": 1,
+                "best_strict_candidate": {
+                    "seed": 17,
+                    "sample_index": 3,
+                    "dead_air_ratio": 0.5,
+                    "postprocess_removal_ratio": 0.2,
+                    "note_count": 17,
+                },
+            },
+            {
+                "seed": 23,
+                "returncode": 0,
+                "input_file_count": 6,
+                "sample_count": 3,
+                "valid_sample_count": 3,
+                "strict_valid_sample_count": 3,
+                "grammar_gate_sample_count": 3,
+                "max_postprocess_removal_ratio": 0.35,
+                "dead_air_outlier_count": 0,
+                "best_strict_candidate": {
+                    "seed": 23,
+                    "sample_index": 1,
+                    "dead_air_ratio": 0.375,
+                    "postprocess_removal_ratio": 0.35,
+                    "note_count": 9,
+                },
+            },
+            {
+                "seed": 31,
+                "returncode": 0,
+                "input_file_count": 6,
+                "sample_count": 3,
+                "valid_sample_count": 3,
+                "strict_valid_sample_count": 3,
+                "grammar_gate_sample_count": 3,
+                "max_postprocess_removal_ratio": 0.42,
+                "dead_air_outlier_count": 0,
+                "best_strict_candidate": {
+                    "seed": 31,
+                    "sample_index": 2,
+                    "dead_air_ratio": 0.636,
+                    "postprocess_removal_ratio": 0.42,
+                    "note_count": 12,
+                },
+            },
+        ]
+
+        summary = build_repeatability_summary(
+            rows,
+            min_seed_count=3,
+            min_source_files=6,
+            min_strict_samples_per_seed=1,
+            min_overall_strict_rate=0.67,
+            max_postprocess_removal_ratio=0.49,
+            max_dead_air_outlier_rate=0.25,
+            warning_min_strict_samples_per_seed=2,
+        )
+
+        self.assertTrue(summary["passed_repeatability_gate"])
+        self.assertEqual(summary["strict_margin_warning_seed_count"], 1)
+        self.assertEqual(summary["strict_margin_warning_seeds"], [17])
+        self.assertEqual(summary["strict_margin_warning_rows"][0]["strict_margin"], -1)
+
     def test_markdown_report_contains_gate_and_seed_rows(self) -> None:
         rows = [
             {
@@ -204,6 +278,8 @@ class StageBRawGenerationRepeatabilityTest(unittest.TestCase):
             "grammar_gate_sample_rate": 1.0,
             "max_postprocess_removal_ratio": 0.2,
             "dead_air_outlier_rate": 0.0,
+            "warning_min_strict_samples_per_seed": 2,
+            "strict_margin_warning_seeds": [17],
             "selected_best_candidate": {"seed": 17, "sample_index": 2, "dead_air_ratio": 0.4},
         }
 
@@ -212,6 +288,7 @@ class StageBRawGenerationRepeatabilityTest(unittest.TestCase):
         self.assertIn("passed repeatability gate", markdown)
         self.assertIn("| 17 |", markdown)
         self.assertIn("strict pass-rate", markdown)
+        self.assertIn("strict margin warning seeds", markdown)
         self.assertIn("selected best candidate", markdown)
 
 


### PR DESCRIPTION
## Summary
- Added a configurable per-seed strict margin warning to the Stage B raw generation repeatability summary.
- Kept the existing hard gate behavior unchanged.
- Updated markdown output, harness env wiring, tests, README, and status docs.

## Result
- Default 2-file sweep passed with no strict margin warning seeds.
- 6-file sweep passed the hard gate and recorded strict margin warning seed 17.
- Selected best candidate remained seed 23 sample 1 with dead-air 0.375 in the 6-file run.

## Validation
- bash scripts/agent_harness.sh stage-b-raw-generation-repeatability
- ISSUE_NUMBER=236 MAX_FILES=6 MIN_SOURCE_FILES=6 RUN_ID=issue_236_stage_b_seed_strict_margin_warning_gate bash scripts/agent_harness.sh stage-b-raw-generation-repeatability
- bash scripts/agent_harness.sh quick

Closes #236