### PR TITLE
feat: Stage B margin recovered 후보 리뷰 export 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ flowchart LR
 
 ## 핵심 결과
 
-Issue #238 기준 model-core MVP:
+Issue #240 기준 model-core MVP:
 
 | 항목 | 결과 |
 |---|---|
@@ -69,6 +69,7 @@ Issue #238 기준 model-core MVP:
 | seed strict margin diagnostics | 6-file seed `17`: sample `1` dead-air, sample `2` unique pitch, sample `3` strict-valid |
 | seed margin warning gate | hard gate 유지, warning min strict per seed `2`, warning seed `17` 기록 |
 | candidate count recovery | 6 source files / 5 samples per seed / strict `12/15`, warning seed 없음 |
+| margin-recovered review export | seed별 best 후보 3개 objective metric table 추출, selected best seed `23` sample `1` |
 | constrained review gate | `stage-b-overlap-gate` 통과 |
 | focused candidate path | `stage-b-rhythm-phrase-variation` 통과 |
 
@@ -87,6 +88,7 @@ MVP 근거:
 - 6-file seed `17`의 dead-air failure와 unique-pitch failure가 서로 다른 후보에서 발생함을 sample 단위로 분리
 - per-seed strict margin warning을 repeatability summary에 추가해 aggregate pass-rate로 가려지는 후보 안정성 리스크 기록
 - samples per seed를 `3`에서 `5`로 늘려 6-file seed `17` strict margin을 `1/3`에서 `3/5`로 회복
+- 5-sample run의 seed별 best 후보를 review rank로 정리하고, dead-air 기준 selected best와 coverage가 높은 대안 후보를 분리
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -64,6 +64,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - seed strict margin 진단 문서: `docs/STAGE_B_SEED_STRICT_MARGIN_DIAGNOSTICS_2026-05-28.md`
 - seed strict margin warning gate 문서: `docs/STAGE_B_SEED_STRICT_MARGIN_WARNING_GATE_2026-05-28.md`
 - candidate count margin recovery 문서: `docs/STAGE_B_CANDIDATE_COUNT_MARGIN_RECOVERY_2026-05-28.md`
+- margin-recovered candidate review export 문서: `docs/STAGE_B_MARGIN_RECOVERED_CANDIDATE_REVIEW_EXPORT_2026-05-28.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -73,6 +74,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - seed strict margin diagnostics: 6-file seed `17` failure가 sample `1` dead-air와 sample `2` unique-pitch로 분리됨
 - seed strict margin warning gate: hard gate 유지, 6-file warning seed `17` summary 기록
 - candidate count margin recovery: 6-file 5-sample run에서 strict `12/15`, warning seed 없음
+- margin-recovered candidate review export: seed별 best 후보 3개 objective table 추출, selected best seed `23` sample `1`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -253,6 +255,7 @@ Stage B에서 명시하는 것:
 114. Stage B seed-level strict margin diagnostics
 115. Stage B per-seed strict margin warning gate
 116. Stage B candidate count margin recovery sweep
+117. Stage B margin-recovered candidate review export
 
 가장 최근 의미 있는 결과:
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #238, Stage B candidate count margin recovery sweep
-- 다음 권장 이슈: `Stage B margin-recovered candidate review export`
+- latest functional result: Issue #240, Stage B margin-recovered candidate review export
+- 다음 권장 이슈: `Stage B margin-recovered candidate listening review notes`
 
 현재 범위가 아닌 것:
 
@@ -382,6 +382,40 @@ Issue #238은 6-file 조건에서 samples per seed를 `3`에서 `5`로 늘렸을
 Docs:
 
 - `docs/STAGE_B_CANDIDATE_COUNT_MARGIN_RECOVERY_2026-05-28.md`
+
+## Current Margin-Recovered Candidate Review Export Result
+
+Issue #240은 Issue #238의 6-file / 5-sample repeatability 결과에서 seed별 best candidate 3개를 objective review table로 추출한 작업이다.
+
+변경:
+
+- repeatability summary를 읽는 candidate review export script 추가
+- selected best와 seed별 best candidate를 review rank로 정리
+- objective metric markdown/json export 생성
+- generated MIDI와 output artifact는 commit하지 않음
+
+검증:
+
+- `bash scripts/agent_harness.sh stage-b-margin-recovered-review-export`
+
+결과:
+
+| rank | selected | seed | sample | seed strict | outliers | dead-air | notes | pitches | phrase | onset | sustained | removal |
+|---:|:---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `1` | true | `23` | `1` | `4/5` | `1` | `0.375` | `9` | `4` | `0.437` | `0.312` | `0.438` | `0.357` |
+| `2` | false | `31` | `5` | `5/5` | `0` | `0.444` | `19` | `4` | `0.937` | `0.500` | `0.719` | `0.095` |
+| `3` | false | `17` | `3` | `3/5` | `1` | `0.500` | `17` | `4` | `1.000` | `0.594` | `0.844` | `0.227` |
+
+해석:
+
+- selected best는 dead-air 기준으로 seed `23`, sample `1`이다.
+- seed `31`, sample `5`는 selected best보다 dead-air는 높지만 note count와 coverage가 더 높아 listening 비교 가치가 있다.
+- seed `17`, sample `3`은 strict-valid지만 seed 내부 failure가 남아 있어 안정성은 가장 낮다.
+- 다음 작업은 rank `1`, `2`, `3` 후보를 listening review note template로 정리하는 것이다.
+
+Docs:
+
+- `docs/STAGE_B_MARGIN_RECOVERED_CANDIDATE_REVIEW_EXPORT_2026-05-28.md`
 
 ## Latest README Footer Section Removal Result
 

--- a/docs/STAGE_B_MARGIN_RECOVERED_CANDIDATE_REVIEW_EXPORT_2026-05-28.md
+++ b/docs/STAGE_B_MARGIN_RECOVERED_CANDIDATE_REVIEW_EXPORT_2026-05-28.md
@@ -1,0 +1,89 @@
+# Stage B Margin-Recovered Candidate Review Export
+
+작성일: 2026-05-28
+
+## 결론
+
+Issue #238의 6-file / 5-sample repeatability 결과에서 seed별 best candidate 3개를 objective review table로 추출했다.
+MIDI 파일은 commit하지 않고, summary JSON에서 metric만 읽어 review export를 생성했다.
+
+| rank | selected | seed | sample | seed strict | outliers | dead-air | notes | pitches | phrase | onset | sustained | removal |
+|---:|:---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `1` | true | `23` | `1` | `4/5` | `1` | `0.375` | `9` | `4` | `0.437` | `0.312` | `0.438` | `0.357` |
+| `2` | false | `31` | `5` | `5/5` | `0` | `0.444` | `19` | `4` | `0.937` | `0.500` | `0.719` | `0.095` |
+| `3` | false | `17` | `3` | `3/5` | `1` | `0.500` | `17` | `4` | `1.000` | `0.594` | `0.844` | `0.227` |
+
+selected best는 seed `23`, sample `1`이다.
+
+다만 objective metric만 보면 rank `2` seed `31` sample `5`는 dead-air가 낮고 note count, phrase/onset/sustained coverage가 더 높다.
+현재 rank는 dead-air를 가장 먼저 보는 기준이므로, 다음 단계에서는 rank `1`과 rank `2`를 listening review 대상으로 같이 봐야 한다.
+
+## 실행 조건
+
+Command:
+
+```bash
+bash scripts/agent_harness.sh stage-b-margin-recovered-review-export
+```
+
+입력:
+
+```bash
+outputs/stage_b_raw_generation_repeatability/issue_238_stage_b_candidate_count_margin_recovery/repeatability_summary.json
+```
+
+출력:
+
+```bash
+outputs/stage_b_margin_recovered_review_export/harness_stage_b_margin_recovered_review_export/candidate_review_export.json
+outputs/stage_b_margin_recovered_review_export/harness_stage_b_margin_recovered_review_export/candidate_review_export.md
+```
+
+위 출력은 generated artifact로 commit하지 않는다.
+
+## Source Summary
+
+| 항목 | 값 |
+|---|---:|
+| source run | `issue_238_stage_b_candidate_count_margin_recovery` |
+| repeatability gate | true |
+| total strict samples | `12/15` |
+| strict pass-rate | `0.800` |
+| dead-air outlier rate | `0.133` |
+| strict margin warning seeds | 없음 |
+| exported candidates | `3` |
+| selected best rank | `1` |
+
+## Seed Failure Reasons
+
+| seed | failure |
+|---:|---|
+| `17` | dead-air `1`, unique pitch `1` |
+| `23` | dead-air `1` |
+| `31` | none |
+
+## 해석
+
+증명한 것:
+
+- 5-sample margin-recovered run에서 seed별 best 후보를 reviewable metric table로 분리했다.
+- selected best는 dead-air 기준으로 seed `23`, sample `1`이다.
+- seed `31`, sample `5`는 selected best보다 dead-air는 높지만, note count와 coverage가 더 높아 listening 비교 가치가 있다.
+- seed `17`, sample `3`은 strict-valid지만 seed 내부 failure가 남아 있어 안정성은 가장 낮다.
+
+리스크:
+
+- review export는 objective metric 정리일 뿐, 청감 품질을 보장하지 않는다.
+- MIDI 파일은 generated output이므로 commit하지 않는다.
+- 현재 rank 기준은 dead-air 우선이며, phrase richness나 musicality를 직접 반영하지 않는다.
+
+## 다음 작업
+
+권장 이슈:
+
+- `Stage B margin-recovered candidate listening review notes`
+
+목표:
+
+- rank `1`, `2`, `3` 후보를 listening review note template로 정리
+- dead-air 우선 rank와 실제 청감 선호가 일치하는지 확인

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -38,6 +38,8 @@ Modes:
                 Diagnose dead-air outliers from a Stage B generation probe report.
   stage-b-seed-strict-margin-diagnostics
                 Diagnose per-seed strict margin risk from a Stage B repeatability summary.
+  stage-b-margin-recovered-review-export
+                Export review metrics from a margin-recovered Stage B repeatability summary.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -164,6 +166,7 @@ run_quick() {
     scripts/run_stage_b_raw_generation_repeatability_sweep.py \
     scripts/diagnose_stage_b_dead_air_outliers.py \
     scripts/diagnose_stage_b_seed_strict_margins.py \
+    scripts/build_stage_b_margin_recovered_review_export.py \
     scripts/run_stage_b_sampling_sweep.py \
     scripts/run_stage_b_coverage_ab_sweep.py \
     scripts/run_stage_b_pitch_mode_compare.py \
@@ -329,6 +332,16 @@ run_stage_b_seed_strict_margin_diagnostics() {
     --summary_path "$summary_path" \
     --warning_min_strict_samples_per_seed 2 \
     --expected_margin_warning_seeds 17
+}
+
+run_stage_b_margin_recovered_review_export() {
+  local run_id="${RUN_ID:-harness_stage_b_margin_recovered_review_export}"
+  local summary_path="${SUMMARY_PATH:-outputs/stage_b_raw_generation_repeatability/issue_238_stage_b_candidate_count_margin_recovery/repeatability_summary.json}"
+  print_header "Stage B margin-recovered candidate review export"
+  "$PYTHON_BIN" scripts/build_stage_b_margin_recovered_review_export.py \
+    --run_id "$run_id" \
+    --summary_path "$summary_path" \
+    --expected_candidate_count 3
 }
 
 run_stage_b_constrained_probe() {
@@ -1459,6 +1472,9 @@ case "$MODE" in
     ;;
   stage-b-seed-strict-margin-diagnostics)
     run_stage_b_seed_strict_margin_diagnostics
+    ;;
+  stage-b-margin-recovered-review-export)
+    run_stage_b_margin_recovered_review_export
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/build_stage_b_margin_recovered_review_export.py
+++ b/scripts/build_stage_b_margin_recovered_review_export.py
@@ -1,0 +1,220 @@
+"""Export review-ready candidate metrics from a Stage B repeatability summary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Sequence
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _float(source: dict[str, Any], key: str, default: float = 0.0) -> float:
+    value = source.get(key, default)
+    return float(value if value is not None else default)
+
+
+def _int(source: dict[str, Any], key: str, default: int = 0) -> int:
+    value = source.get(key, default)
+    return int(value if value is not None else default)
+
+
+def _row_by_seed(rows: Sequence[dict[str, Any]]) -> dict[int, dict[str, Any]]:
+    return {int(row.get("seed", 0) or 0): row for row in rows if isinstance(row, dict)}
+
+
+def compact_candidate(
+    candidate: dict[str, Any],
+    *,
+    selected_key: tuple[int, int] | None,
+    row: dict[str, Any] | None,
+) -> dict[str, Any]:
+    seed = _int(candidate, "seed")
+    sample_index = _int(candidate, "sample_index")
+    row = row or {}
+    return {
+        "seed": seed,
+        "sample_index": sample_index,
+        "is_selected_best": bool(selected_key == (seed, sample_index)),
+        "midi_path": str(candidate.get("midi_path", "")),
+        "dead_air_ratio": _float(candidate, "dead_air_ratio"),
+        "note_count": _int(candidate, "note_count"),
+        "unique_pitch_count": _int(candidate, "unique_pitch_count"),
+        "phrase_coverage_ratio": _float(candidate, "phrase_coverage_ratio"),
+        "onset_coverage_ratio": _float(candidate, "onset_coverage_ratio"),
+        "sustained_coverage_ratio": _float(candidate, "sustained_coverage_ratio"),
+        "postprocess_removal_ratio": _float(candidate, "postprocess_removal_ratio"),
+        "seed_sample_count": _int(row, "sample_count"),
+        "seed_strict_valid_sample_count": _int(row, "strict_valid_sample_count"),
+        "seed_dead_air_outlier_count": _int(row, "dead_air_outlier_count"),
+        "seed_failure_reasons": row.get("failure_reasons", {}) if isinstance(row.get("failure_reasons"), dict) else {},
+        "seed_strict_failure_reasons": (
+            row.get("strict_failure_reasons", {}) if isinstance(row.get("strict_failure_reasons"), dict) else {}
+        ),
+    }
+
+
+def rank_candidates(candidates: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    ranked = sorted(
+        candidates,
+        key=lambda candidate: (
+            float(candidate["dead_air_ratio"]),
+            float(candidate["postprocess_removal_ratio"]),
+            -int(candidate["note_count"]),
+            int(candidate["seed"]),
+            int(candidate["sample_index"]),
+        ),
+    )
+    return [dict(candidate, review_rank=index) for index, candidate in enumerate(ranked, start=1)]
+
+
+def build_review_export(summary_path: Path) -> dict[str, Any]:
+    source = read_json(summary_path)
+    summary = source.get("summary", {}) if isinstance(source.get("summary"), dict) else {}
+    rows = [row for row in source.get("rows", []) if isinstance(row, dict)]
+    row_lookup = _row_by_seed(rows)
+    selected = summary.get("selected_best_candidate")
+    selected_key = None
+    if isinstance(selected, dict):
+        selected_key = (_int(selected, "seed"), _int(selected, "sample_index"))
+    raw_candidates = [
+        candidate
+        for candidate in summary.get("seed_best_candidates", [])
+        if isinstance(candidate, dict)
+    ]
+    candidates = [
+        compact_candidate(
+            candidate,
+            selected_key=selected_key,
+            row=row_lookup.get(_int(candidate, "seed")),
+        )
+        for candidate in raw_candidates
+    ]
+    ranked_candidates = rank_candidates(candidates)
+    selected_rank = next(
+        (int(candidate["review_rank"]) for candidate in ranked_candidates if candidate["is_selected_best"]),
+        None,
+    )
+
+    return {
+        "source_summary_path": str(summary_path),
+        "source_run_id": str(source.get("run_id", "")),
+        "source_issue": int(source.get("issue", 0) or 0),
+        "candidate_count": int(len(ranked_candidates)),
+        "selected_best_rank": selected_rank,
+        "summary": {
+            "passed_repeatability_gate": bool(summary.get("passed_repeatability_gate", False)),
+            "total_samples": _int(summary, "total_samples"),
+            "total_strict_valid_sample_count": _int(summary, "total_strict_valid_sample_count"),
+            "strict_valid_sample_rate": _float(summary, "strict_valid_sample_rate"),
+            "dead_air_outlier_rate": _float(summary, "dead_air_outlier_rate"),
+            "strict_margin_warning_seeds": summary.get("strict_margin_warning_seeds", []),
+        },
+        "candidates": ranked_candidates,
+    }
+
+
+def _fmt(value: Any, digits: int = 3) -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, float):
+        return f"{value:.{digits}f}"
+    return str(value)
+
+
+def _reason_label(value: Any) -> str:
+    if not isinstance(value, dict) or not value:
+        return "none"
+    return ", ".join(f"{reason} ({count})" for reason, count in sorted(value.items()))
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    lines = [
+        "# Stage B Margin-Recovered Candidate Review Export",
+        "",
+        f"- source summary: `{report['source_summary_path']}`",
+        f"- source run: `{report['source_run_id']}`",
+        f"- passed repeatability gate: `{str(summary['passed_repeatability_gate']).lower()}`",
+        f"- total strict samples: `{summary['total_strict_valid_sample_count']}/{summary['total_samples']}`",
+        f"- strict pass-rate: `{summary['strict_valid_sample_rate']:.3f}`",
+        f"- dead-air outlier rate: `{summary['dead_air_outlier_rate']:.3f}`",
+        f"- strict margin warning seeds: `{summary['strict_margin_warning_seeds']}`",
+        f"- selected best rank: `{report['selected_best_rank']}`",
+        "",
+        "| rank | selected | seed | sample | seed strict | outliers | dead-air | notes | pitches | phrase | onset | sustained | removal | MIDI |",
+        "|---:|:---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for candidate in report["candidates"]:
+        lines.append(
+            "| {rank} | {selected} | {seed} | {sample} | {seed_strict}/{seed_samples} | "
+            "{outliers} | {dead_air} | {notes} | {pitches} | {phrase} | {onset} | "
+            "{sustained} | {removal} | `{midi}` |".format(
+                rank=candidate["review_rank"],
+                selected=candidate["is_selected_best"],
+                seed=candidate["seed"],
+                sample=candidate["sample_index"],
+                seed_strict=candidate["seed_strict_valid_sample_count"],
+                seed_samples=candidate["seed_sample_count"],
+                outliers=candidate["seed_dead_air_outlier_count"],
+                dead_air=_fmt(candidate["dead_air_ratio"]),
+                notes=candidate["note_count"],
+                pitches=candidate["unique_pitch_count"],
+                phrase=_fmt(candidate["phrase_coverage_ratio"]),
+                onset=_fmt(candidate["onset_coverage_ratio"]),
+                sustained=_fmt(candidate["sustained_coverage_ratio"]),
+                removal=_fmt(candidate["postprocess_removal_ratio"]),
+                midi=candidate["midi_path"],
+            )
+        )
+    lines.extend(["", "## Seed Failure Reasons", ""])
+    for candidate in report["candidates"]:
+        lines.append(
+            f"- seed `{candidate['seed']}`: "
+            f"failure `{_reason_label(candidate['seed_failure_reasons'])}`, "
+            f"strict `{_reason_label(candidate['seed_strict_failure_reasons'])}`"
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Export Stage B margin-recovered candidate review metrics")
+    parser.add_argument("--summary_path", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=str(ROOT_DIR / "outputs" / "stage_b_margin_recovered_review_export"),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--expected_candidate_count", type=int, default=None)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_review_export(Path(args.summary_path))
+    write_json(output_dir / "candidate_review_export.json", report)
+    (output_dir / "candidate_review_export.md").write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps(report, ensure_ascii=True, indent=2))
+
+    if args.expected_candidate_count is not None and report["candidate_count"] != int(args.expected_candidate_count):
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_margin_recovered_review_export.py
+++ b/tests/test_stage_b_margin_recovered_review_export.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.build_stage_b_margin_recovered_review_export import (
+    build_review_export,
+    markdown_report,
+    write_json,
+)
+
+
+class StageBMarginRecoveredReviewExportTest(unittest.TestCase):
+    def test_build_review_export_ranks_seed_best_candidates(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            summary_path = Path(tmp) / "repeatability_summary.json"
+            write_json(
+                summary_path,
+                {
+                    "run_id": "run",
+                    "issue": 999,
+                    "summary": {
+                        "passed_repeatability_gate": True,
+                        "total_samples": 15,
+                        "total_strict_valid_sample_count": 12,
+                        "strict_valid_sample_rate": 0.8,
+                        "dead_air_outlier_rate": 0.133,
+                        "strict_margin_warning_seeds": [],
+                        "selected_best_candidate": {"seed": 23, "sample_index": 1},
+                        "seed_best_candidates": [
+                            {
+                                "seed": 17,
+                                "sample_index": 3,
+                                "midi_path": "seed17.mid",
+                                "dead_air_ratio": 0.5,
+                                "note_count": 17,
+                                "unique_pitch_count": 4,
+                                "phrase_coverage_ratio": 1.0,
+                                "onset_coverage_ratio": 0.594,
+                                "sustained_coverage_ratio": 0.844,
+                                "postprocess_removal_ratio": 0.227,
+                            },
+                            {
+                                "seed": 23,
+                                "sample_index": 1,
+                                "midi_path": "seed23.mid",
+                                "dead_air_ratio": 0.375,
+                                "note_count": 9,
+                                "unique_pitch_count": 4,
+                                "phrase_coverage_ratio": 0.437,
+                                "onset_coverage_ratio": 0.313,
+                                "sustained_coverage_ratio": 0.438,
+                                "postprocess_removal_ratio": 0.357,
+                            },
+                        ],
+                    },
+                    "rows": [
+                        {
+                            "seed": 17,
+                            "sample_count": 5,
+                            "strict_valid_sample_count": 3,
+                            "dead_air_outlier_count": 1,
+                            "failure_reasons": {"dead-air ratio too high": 1},
+                            "strict_failure_reasons": {"midi_review_gate_failed": 1},
+                        },
+                        {
+                            "seed": 23,
+                            "sample_count": 5,
+                            "strict_valid_sample_count": 4,
+                            "dead_air_outlier_count": 1,
+                            "failure_reasons": {},
+                            "strict_failure_reasons": {},
+                        },
+                    ],
+                },
+            )
+
+            report = build_review_export(summary_path)
+
+        self.assertEqual(report["candidate_count"], 2)
+        self.assertEqual(report["selected_best_rank"], 1)
+        self.assertEqual(report["candidates"][0]["seed"], 23)
+        self.assertTrue(report["candidates"][0]["is_selected_best"])
+        self.assertEqual(report["candidates"][1]["seed_strict_valid_sample_count"], 3)
+
+    def test_markdown_report_contains_metric_table(self) -> None:
+        report = {
+            "source_summary_path": "summary.json",
+            "source_run_id": "run",
+            "selected_best_rank": 1,
+            "summary": {
+                "passed_repeatability_gate": True,
+                "total_samples": 15,
+                "total_strict_valid_sample_count": 12,
+                "strict_valid_sample_rate": 0.8,
+                "dead_air_outlier_rate": 0.133,
+                "strict_margin_warning_seeds": [],
+            },
+            "candidates": [
+                {
+                    "review_rank": 1,
+                    "is_selected_best": True,
+                    "seed": 23,
+                    "sample_index": 1,
+                    "seed_strict_valid_sample_count": 4,
+                    "seed_sample_count": 5,
+                    "seed_dead_air_outlier_count": 1,
+                    "dead_air_ratio": 0.375,
+                    "note_count": 9,
+                    "unique_pitch_count": 4,
+                    "phrase_coverage_ratio": 0.437,
+                    "onset_coverage_ratio": 0.313,
+                    "sustained_coverage_ratio": 0.438,
+                    "postprocess_removal_ratio": 0.357,
+                    "midi_path": "sample.mid",
+                    "seed_failure_reasons": {},
+                    "seed_strict_failure_reasons": {},
+                }
+            ],
+        }
+
+        markdown = markdown_report(report)
+
+        self.assertIn("selected best rank", markdown)
+        self.assertIn("| 1 | True | 23 | 1 | 4/5 |", markdown)
+        self.assertIn("dead-air outlier rate", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Added a review export script for seed-level best candidates from the margin-recovered repeatability run.
- Exported selected best and per-seed best objective metrics without committing generated MIDI artifacts.
- Updated README, current status, and core plan with the review export result.

## Result
- Exported 3 seed-best candidates.
- Selected best rank: 1, seed 23 sample 1.
- Rank 2 seed 31 sample 5 has higher phrase/onset/sustained coverage and should be compared in listening review.

## Validation
- bash scripts/agent_harness.sh stage-b-margin-recovered-review-export
- bash scripts/agent_harness.sh quick

Closes #240