### PR TITLE
feat: Stage B margin recovered listening notes 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ flowchart LR
 
 ## 핵심 결과
 
-Issue #240 기준 model-core MVP:
+Issue #242 기준 model-core MVP:
 
 | 항목 | 결과 |
 |---|---|
@@ -70,6 +70,7 @@ Issue #240 기준 model-core MVP:
 | seed margin warning gate | hard gate 유지, warning min strict per seed `2`, warning seed `17` 기록 |
 | candidate count recovery | 6 source files / 5 samples per seed / strict `12/15`, warning seed 없음 |
 | margin-recovered review export | seed별 best 후보 3개 objective metric table 추출, selected best seed `23` sample `1` |
+| listening review notes | margin-recovered 후보 3개 pending review template 생성, selected best count `1` |
 | constrained review gate | `stage-b-overlap-gate` 통과 |
 | focused candidate path | `stage-b-rhythm-phrase-variation` 통과 |
 
@@ -89,6 +90,7 @@ MVP 근거:
 - per-seed strict margin warning을 repeatability summary에 추가해 aggregate pass-rate로 가려지는 후보 안정성 리스크 기록
 - samples per seed를 `3`에서 `5`로 늘려 6-file seed `17` strict margin을 `1/3`에서 `3/5`로 회복
 - 5-sample run의 seed별 best 후보를 review rank로 정리하고, dead-air 기준 selected best와 coverage가 높은 대안 후보를 분리
+- margin-recovered 후보 3개를 listening review notes template으로 묶고 실제 청감 판단 전 pending 상태로 보존
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -65,6 +65,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - seed strict margin warning gate 문서: `docs/STAGE_B_SEED_STRICT_MARGIN_WARNING_GATE_2026-05-28.md`
 - candidate count margin recovery 문서: `docs/STAGE_B_CANDIDATE_COUNT_MARGIN_RECOVERY_2026-05-28.md`
 - margin-recovered candidate review export 문서: `docs/STAGE_B_MARGIN_RECOVERED_CANDIDATE_REVIEW_EXPORT_2026-05-28.md`
+- margin-recovered listening review notes 문서: `docs/STAGE_B_MARGIN_RECOVERED_LISTENING_REVIEW_NOTES_2026-05-28.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -75,6 +76,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - seed strict margin warning gate: hard gate 유지, 6-file warning seed `17` summary 기록
 - candidate count margin recovery: 6-file 5-sample run에서 strict `12/15`, warning seed 없음
 - margin-recovered candidate review export: seed별 best 후보 3개 objective table 추출, selected best seed `23` sample `1`
+- margin-recovered listening review notes: 후보 3개 pending notes template 생성, selected best count `1`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -256,6 +258,7 @@ Stage B에서 명시하는 것:
 115. Stage B per-seed strict margin warning gate
 116. Stage B candidate count margin recovery sweep
 117. Stage B margin-recovered candidate review export
+118. Stage B margin-recovered candidate listening review notes
 
 가장 최근 의미 있는 결과:
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #240, Stage B margin-recovered candidate review export
-- 다음 권장 이슈: `Stage B margin-recovered candidate listening review notes`
+- latest functional result: Issue #242, Stage B margin-recovered candidate listening review notes
+- 다음 권장 이슈: `Stage B margin-recovered MIDI proxy review fill`
 
 현재 범위가 아닌 것:
 
@@ -416,6 +416,47 @@ Issue #240은 Issue #238의 6-file / 5-sample repeatability 결과에서 seed별
 Docs:
 
 - `docs/STAGE_B_MARGIN_RECOVERED_CANDIDATE_REVIEW_EXPORT_2026-05-28.md`
+
+## Current Margin-Recovered Listening Review Notes Result
+
+Issue #242는 Issue #240의 margin-recovered review export를 기반으로 listening review notes template을 생성한 작업이다.
+
+변경:
+
+- margin-recovered candidate review export를 notes template으로 변환하는 script 추가
+- selected best 후보가 정확히 1개인지 검증
+- 후보별 metric, seed/sample/rank, MIDI path를 notes에 보존
+- listening fields는 실제 review 전까지 `pending` 유지
+
+검증:
+
+- `bash scripts/agent_harness.sh stage-b-margin-recovered-listening-notes`
+
+결과:
+
+- candidate count: `3`
+- selected best count: `1`
+- reviewed count: `0`
+- pending count: `3`
+- decision counts: pending `3`
+
+후보:
+
+| candidate | selected | dead-air | notes | phrase | onset | sustained | decision |
+|---|:---:|---:|---:|---:|---:|---:|---|
+| `margin_recovered_rank_1_seed_23_sample_1` | true | `0.375` | `9` | `0.437` | `0.312` | `0.438` | pending |
+| `margin_recovered_rank_2_seed_31_sample_5` | false | `0.444` | `19` | `0.937` | `0.500` | `0.719` | pending |
+| `margin_recovered_rank_3_seed_17_sample_3` | false | `0.500` | `17` | `1.000` | `0.594` | `0.844` | pending |
+
+해석:
+
+- 이 단계는 review 준비이며 청감 품질 판정이 아니다.
+- rank `1`이 실제 listening preference에서도 best라고 확정한 것은 아니다.
+- 다음 작업은 MIDI note/context evidence 기준으로 pending fields를 채우는 것이다.
+
+Docs:
+
+- `docs/STAGE_B_MARGIN_RECOVERED_LISTENING_REVIEW_NOTES_2026-05-28.md`
 
 ## Latest README Footer Section Removal Result
 

--- a/docs/STAGE_B_MARGIN_RECOVERED_LISTENING_REVIEW_NOTES_2026-05-28.md
+++ b/docs/STAGE_B_MARGIN_RECOVERED_LISTENING_REVIEW_NOTES_2026-05-28.md
@@ -1,0 +1,75 @@
+# Stage B Margin-Recovered Listening Review Notes
+
+작성일: 2026-05-28
+
+## 결론
+
+Issue #240의 margin-recovered review export를 기반으로 listening review notes template을 생성했다.
+후보 3개는 모두 `pending` 상태이며, 실제 청감 판단은 아직 기록하지 않았다.
+
+| 항목 | 결과 |
+|---|---:|
+| candidate count | `3` |
+| selected best count | `1` |
+| reviewed count | `0` |
+| pending count | `3` |
+| pending decisions | `3` |
+
+## 실행 조건
+
+Command:
+
+```bash
+bash scripts/agent_harness.sh stage-b-margin-recovered-listening-notes
+```
+
+입력:
+
+```bash
+outputs/stage_b_margin_recovered_review_export/harness_stage_b_margin_recovered_review_export/candidate_review_export.json
+```
+
+출력:
+
+```bash
+outputs/stage_b_margin_recovered_listening_notes/harness_stage_b_margin_recovered_listening_notes/listening_review_notes_template.json
+outputs/stage_b_margin_recovered_listening_notes/harness_stage_b_margin_recovered_listening_notes/listening_review_notes_summary.json
+outputs/stage_b_margin_recovered_listening_notes/harness_stage_b_margin_recovered_listening_notes/listening_review_notes_template.md
+```
+
+출력은 generated artifact로 commit하지 않는다.
+
+## Candidate Notes
+
+| candidate | selected | seed | sample | rank | dead-air | notes | pitches | phrase | onset | sustained | decision |
+|---|:---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| `margin_recovered_rank_1_seed_23_sample_1` | true | `23` | `1` | `1` | `0.375` | `9` | `4` | `0.437` | `0.312` | `0.438` | pending |
+| `margin_recovered_rank_2_seed_31_sample_5` | false | `31` | `5` | `2` | `0.444` | `19` | `4` | `0.937` | `0.500` | `0.719` | pending |
+| `margin_recovered_rank_3_seed_17_sample_3` | false | `17` | `3` | `3` | `0.500` | `17` | `4` | `1.000` | `0.594` | `0.844` | pending |
+
+## 해석
+
+증명한 것:
+
+- margin-recovered 후보 3개를 동일한 listening review schema로 묶었다.
+- selected best 후보는 하나만 존재하도록 검증했다.
+- objective metric과 MIDI path는 review note 안에 보존했다.
+- 실제 청감 review field는 pending으로 유지했다.
+
+리스크:
+
+- 이 단계는 review 준비이며, 청감 품질 판정이 아니다.
+- MIDI 파일 자체는 output artifact이며 commit하지 않는다.
+- rank `1`이 실제 listening preference에서도 best라고 확정한 것은 아니다.
+
+## 다음 작업
+
+권장 이슈:
+
+- `Stage B margin-recovered MIDI proxy review fill`
+
+목표:
+
+- rank `1`, `2`, `3` 후보를 MIDI note/context evidence 기준으로 proxy review
+- timing, phrase, jazz vocabulary, decision field를 채움
+- rank 기준과 proxy review 판단이 일치하는지 기록

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -40,6 +40,8 @@ Modes:
                 Diagnose per-seed strict margin risk from a Stage B repeatability summary.
   stage-b-margin-recovered-review-export
                 Export review metrics from a margin-recovered Stage B repeatability summary.
+  stage-b-margin-recovered-listening-notes
+                Build pending listening notes for margin-recovered Stage B candidates.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -167,6 +169,7 @@ run_quick() {
     scripts/diagnose_stage_b_dead_air_outliers.py \
     scripts/diagnose_stage_b_seed_strict_margins.py \
     scripts/build_stage_b_margin_recovered_review_export.py \
+    scripts/build_stage_b_margin_recovered_listening_notes.py \
     scripts/run_stage_b_sampling_sweep.py \
     scripts/run_stage_b_coverage_ab_sweep.py \
     scripts/run_stage_b_pitch_mode_compare.py \
@@ -341,6 +344,16 @@ run_stage_b_margin_recovered_review_export() {
   "$PYTHON_BIN" scripts/build_stage_b_margin_recovered_review_export.py \
     --run_id "$run_id" \
     --summary_path "$summary_path" \
+    --expected_candidate_count 3
+}
+
+run_stage_b_margin_recovered_listening_notes() {
+  local run_id="${RUN_ID:-harness_stage_b_margin_recovered_listening_notes}"
+  local review_export="${REVIEW_EXPORT:-outputs/stage_b_margin_recovered_review_export/harness_stage_b_margin_recovered_review_export/candidate_review_export.json}"
+  print_header "Stage B margin-recovered listening review notes"
+  "$PYTHON_BIN" scripts/build_stage_b_margin_recovered_listening_notes.py \
+    --run_id "$run_id" \
+    --review_export "$review_export" \
     --expected_candidate_count 3
 }
 
@@ -1475,6 +1488,9 @@ case "$MODE" in
     ;;
   stage-b-margin-recovered-review-export)
     run_stage_b_margin_recovered_review_export
+    ;;
+  stage-b-margin-recovered-listening-notes)
+    run_stage_b_margin_recovered_listening_notes
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/build_stage_b_margin_recovered_listening_notes.py
+++ b/scripts/build_stage_b_margin_recovered_listening_notes.py
@@ -1,0 +1,235 @@
+"""Build listening review notes for Stage B margin-recovered candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SCHEMA_VERSION = "stage_b_margin_recovered_listening_notes_v1"
+
+TIMING_VALUES = {"pending", "strong", "acceptable", "stiff", "rushed", "dragging"}
+PHRASE_VALUES = {"pending", "strong", "acceptable", "weak", "broken", "exercise_like"}
+VOCAB_VALUES = {"pending", "strong", "acceptable", "thin", "too_repetitive", "too_safe"}
+DECISION_VALUES = {"pending", "keep", "needs_followup", "reject"}
+
+
+class MarginRecoveredListeningNotesError(ValueError):
+    pass
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _candidate_id(candidate: dict[str, Any]) -> str:
+    return "margin_recovered_rank_{rank}_seed_{seed}_sample_{sample}".format(
+        rank=int(candidate.get("review_rank", 0) or 0),
+        seed=int(candidate.get("seed", 0) or 0),
+        sample=int(candidate.get("sample_index", 0) or 0),
+    )
+
+
+def _float(candidate: dict[str, Any], key: str) -> float:
+    value = candidate.get(key, 0.0)
+    return float(value if value is not None else 0.0)
+
+
+def _int(candidate: dict[str, Any], key: str) -> int:
+    value = candidate.get(key, 0)
+    return int(value if value is not None else 0)
+
+
+def build_candidate_note(candidate: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "candidate_id": _candidate_id(candidate),
+        "review_metadata": {
+            "review_rank": _int(candidate, "review_rank"),
+            "is_selected_best": bool(candidate.get("is_selected_best", False)),
+            "seed": _int(candidate, "seed"),
+            "sample_index": _int(candidate, "sample_index"),
+            "seed_strict_valid_sample_count": _int(candidate, "seed_strict_valid_sample_count"),
+            "seed_sample_count": _int(candidate, "seed_sample_count"),
+            "seed_dead_air_outlier_count": _int(candidate, "seed_dead_air_outlier_count"),
+        },
+        "review_files": {
+            "midi_path": str(candidate.get("midi_path") or ""),
+        },
+        "source_metrics": {
+            "dead_air_ratio": _float(candidate, "dead_air_ratio"),
+            "note_count": _int(candidate, "note_count"),
+            "unique_pitch_count": _int(candidate, "unique_pitch_count"),
+            "phrase_coverage_ratio": _float(candidate, "phrase_coverage_ratio"),
+            "onset_coverage_ratio": _float(candidate, "onset_coverage_ratio"),
+            "sustained_coverage_ratio": _float(candidate, "sustained_coverage_ratio"),
+            "postprocess_removal_ratio": _float(candidate, "postprocess_removal_ratio"),
+        },
+        "seed_failure_reasons": candidate.get("seed_failure_reasons", {}),
+        "seed_strict_failure_reasons": candidate.get("seed_strict_failure_reasons", {}),
+        "listening": {
+            "status": "pending",
+            "timing": "pending",
+            "phrase": "pending",
+            "jazz_vocabulary": "pending",
+            "decision": "pending",
+            "notes": "",
+        },
+    }
+
+
+def build_listening_notes(review_export: dict[str, Any]) -> dict[str, Any]:
+    candidates = review_export.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise MarginRecoveredListeningNotesError("review export must contain non-empty candidates")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "source_review_export": str(review_export.get("source_summary_path", "")),
+        "source_run_id": str(review_export.get("source_run_id", "")),
+        "reviewer": "",
+        "review_context": {
+            "listen_to_generated_midi": True,
+            "compare_rank_order_with_listening_preference": True,
+            "generated_midi_files_are_not_committed": True,
+            "fields_are_pending_until_explicit_review": True,
+        },
+        "source_summary": review_export.get("summary", {}),
+        "candidates": [build_candidate_note(candidate) for candidate in candidates],
+    }
+
+
+def _require_enum(value: Any, allowed: set[str], path: str) -> None:
+    if value not in allowed:
+        raise MarginRecoveredListeningNotesError(f"{path} must be one of {sorted(allowed)}")
+
+
+def validate_listening_notes(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise MarginRecoveredListeningNotesError(f"schema_version must be {SCHEMA_VERSION!r}")
+    candidates = payload.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise MarginRecoveredListeningNotesError("candidates must be a non-empty list")
+    seen: set[str] = set()
+    decision_counts = {value: 0 for value in DECISION_VALUES}
+    reviewed_count = 0
+    selected_count = 0
+    for index, candidate in enumerate(candidates):
+        if not isinstance(candidate, dict):
+            raise MarginRecoveredListeningNotesError(f"candidate {index} must be an object")
+        candidate_id = str(candidate.get("candidate_id") or "").strip()
+        if not candidate_id:
+            raise MarginRecoveredListeningNotesError(f"candidate {index} candidate_id is required")
+        if candidate_id in seen:
+            raise MarginRecoveredListeningNotesError(f"duplicate candidate_id: {candidate_id}")
+        seen.add(candidate_id)
+        files = candidate.get("review_files")
+        if not isinstance(files, dict) or not str(files.get("midi_path") or "").strip():
+            raise MarginRecoveredListeningNotesError(f"{candidate_id}.review_files.midi_path is required")
+        metadata = candidate.get("review_metadata")
+        if not isinstance(metadata, dict):
+            raise MarginRecoveredListeningNotesError(f"{candidate_id}.review_metadata is required")
+        if metadata.get("is_selected_best"):
+            selected_count += 1
+        listening = candidate.get("listening")
+        if not isinstance(listening, dict):
+            raise MarginRecoveredListeningNotesError(f"{candidate_id}.listening is required")
+        _require_enum(listening.get("status"), {"pending", "reviewed"}, f"{candidate_id}.listening.status")
+        _require_enum(listening.get("timing"), TIMING_VALUES, f"{candidate_id}.listening.timing")
+        _require_enum(listening.get("phrase"), PHRASE_VALUES, f"{candidate_id}.listening.phrase")
+        _require_enum(
+            listening.get("jazz_vocabulary"),
+            VOCAB_VALUES,
+            f"{candidate_id}.listening.jazz_vocabulary",
+        )
+        _require_enum(listening.get("decision"), DECISION_VALUES, f"{candidate_id}.listening.decision")
+        if listening.get("status") == "reviewed":
+            reviewed_count += 1
+        decision_counts[str(listening.get("decision"))] += 1
+    if selected_count != 1:
+        raise MarginRecoveredListeningNotesError("exactly one selected best candidate is required")
+    return {
+        "candidate_count": int(len(candidates)),
+        "selected_best_count": int(selected_count),
+        "reviewed_count": int(reviewed_count),
+        "pending_count": int(len(candidates) - reviewed_count),
+        "decision_counts": decision_counts,
+    }
+
+
+def markdown_report(notes: dict[str, Any], summary: dict[str, Any]) -> str:
+    lines = [
+        "# Stage B Margin-Recovered Listening Review Notes",
+        "",
+        f"- source run: `{notes['source_run_id']}`",
+        f"- candidate count: `{summary['candidate_count']}`",
+        f"- pending count: `{summary['pending_count']}`",
+        f"- selected best count: `{summary['selected_best_count']}`",
+        "",
+        "| candidate | selected | seed | sample | rank | dead-air | notes | pitches | phrase | onset | sustained | decision |",
+        "|---|:---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for candidate in notes["candidates"]:
+        metadata = candidate["review_metadata"]
+        metrics = candidate["source_metrics"]
+        listening = candidate["listening"]
+        lines.append(
+            "| `{candidate_id}` | {selected} | {seed} | {sample} | {rank} | {dead_air:.3f} | "
+            "{notes_count} | {pitches} | {phrase:.3f} | {onset:.3f} | {sustained:.3f} | {decision} |".format(
+                candidate_id=candidate["candidate_id"],
+                selected=metadata["is_selected_best"],
+                seed=metadata["seed"],
+                sample=metadata["sample_index"],
+                rank=metadata["review_rank"],
+                dead_air=metrics["dead_air_ratio"],
+                notes_count=metrics["note_count"],
+                pitches=metrics["unique_pitch_count"],
+                phrase=metrics["phrase_coverage_ratio"],
+                onset=metrics["onset_coverage_ratio"],
+                sustained=metrics["sustained_coverage_ratio"],
+                decision=listening["decision"],
+            )
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build Stage B margin-recovered listening review notes")
+    parser.add_argument("--review_export", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=str(ROOT_DIR / "outputs" / "stage_b_margin_recovered_listening_notes"),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--expected_candidate_count", type=int, default=None)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    run_dir = Path(args.output_root) / run_id
+    review_export = read_json(Path(args.review_export))
+    notes = build_listening_notes(review_export)
+    summary = validate_listening_notes(notes)
+    write_json(run_dir / "listening_review_notes_template.json", notes)
+    write_json(run_dir / "listening_review_notes_summary.json", summary)
+    (run_dir / "listening_review_notes_template.md").write_text(markdown_report(notes, summary), encoding="utf-8")
+    print(json.dumps({**summary, "review_notes_path": str(run_dir / "listening_review_notes_template.json")}, indent=2))
+
+    if args.expected_candidate_count is not None and summary["candidate_count"] != int(args.expected_candidate_count):
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_margin_recovered_listening_notes.py
+++ b/tests/test_stage_b_margin_recovered_listening_notes.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.build_stage_b_margin_recovered_listening_notes import (
+    build_listening_notes,
+    markdown_report,
+    validate_listening_notes,
+)
+
+
+def candidate(rank: int, *, selected: bool = False) -> dict:
+    return {
+        "review_rank": rank,
+        "is_selected_best": selected,
+        "seed": 20 + rank,
+        "sample_index": rank,
+        "midi_path": f"sample_{rank}.mid",
+        "dead_air_ratio": 0.3 + rank / 10,
+        "note_count": 8 + rank,
+        "unique_pitch_count": 4,
+        "phrase_coverage_ratio": 0.5,
+        "onset_coverage_ratio": 0.4,
+        "sustained_coverage_ratio": 0.6,
+        "postprocess_removal_ratio": 0.1,
+        "seed_strict_valid_sample_count": 3,
+        "seed_sample_count": 5,
+        "seed_dead_air_outlier_count": 1,
+    }
+
+
+class StageBMarginRecoveredListeningNotesTest(unittest.TestCase):
+    def test_build_and_validate_pending_notes(self) -> None:
+        notes = build_listening_notes(
+            {
+                "source_summary_path": "summary.json",
+                "source_run_id": "run",
+                "summary": {"strict_valid_sample_rate": 0.8},
+                "candidates": [candidate(1, selected=True), candidate(2), candidate(3)],
+            }
+        )
+        summary = validate_listening_notes(notes)
+
+        self.assertEqual(summary["candidate_count"], 3)
+        self.assertEqual(summary["selected_best_count"], 1)
+        self.assertEqual(summary["pending_count"], 3)
+        self.assertEqual(notes["candidates"][0]["candidate_id"], "margin_recovered_rank_1_seed_21_sample_1")
+
+    def test_validate_requires_exactly_one_selected_candidate(self) -> None:
+        notes = build_listening_notes(
+            {
+                "source_summary_path": "summary.json",
+                "source_run_id": "run",
+                "candidates": [candidate(1), candidate(2)],
+            }
+        )
+
+        with self.assertRaises(ValueError):
+            validate_listening_notes(notes)
+
+    def test_markdown_report_lists_pending_candidates(self) -> None:
+        notes = build_listening_notes(
+            {
+                "source_summary_path": "summary.json",
+                "source_run_id": "run",
+                "candidates": [candidate(1, selected=True)],
+            }
+        )
+        summary = validate_listening_notes(notes)
+
+        markdown = markdown_report(notes, summary)
+
+        self.assertIn("candidate count", markdown)
+        self.assertIn("margin_recovered_rank_1_seed_21_sample_1", markdown)
+        self.assertIn("pending", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Added a pending listening review notes builder for margin-recovered candidates.
- Preserved candidate metrics and local MIDI paths while keeping generated artifacts out of git.
- Updated README, current status, and core plan with the notes template result.

## Result
- Candidate count: 3
- Selected best count: 1
- Reviewed count: 0
- Pending count: 3

## Validation
- bash scripts/agent_harness.sh stage-b-margin-recovered-listening-notes
- bash scripts/agent_harness.sh quick

Closes #242