### PR TITLE
feat: Stage B margin recovered fallback 비교 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ flowchart LR
 
 ## 핵심 결과
 
-Issue #250 기준 model-core MVP:
+Issue #252 기준 model-core MVP:
 
 | 항목 | 결과 |
 |---|---|
@@ -75,6 +75,7 @@ Issue #250 기준 model-core MVP:
 | proxy keep consolidation | dead-air 단일 기준 selected best와 phrase-rich proxy keep 후보의 claim boundary 문서화 |
 | margin-recovered focused package | rank `2` 후보만 solo/context review package로 격리, focused solo-line max active `1` |
 | margin-recovered focused context decision | rank `2` proxy keep을 `needs_followup`으로 하향, low pitch variety / dead-air blocker 기록 |
+| margin-recovered fallback comparison | rank `1/2/3` 전체 focused context 비교, focused keep `0/3`, 공통 blocker low pitch variety |
 | constrained review gate | `stage-b-overlap-gate` 통과 |
 | focused candidate path | `stage-b-rhythm-phrase-variation` 통과 |
 
@@ -99,6 +100,7 @@ MVP 근거:
 - rank `2` seed `31` sample `5`는 MIDI metric proxy keep이며, human listening preference나 broad model quality claim과 분리
 - rank `2` 후보를 focused package로 격리하고 source note count `19` -> focused solo-line note count `14`, max simultaneous notes `2` -> `1` 변환 기록
 - focused context decision에서 unique pitch `4`, dead-air `0.444`로 `needs_followup` 판정해 proxy keep을 최종 후보로 과장하지 않음
+- margin-recovered 후보 3개 전체를 같은 focused context 기준으로 비교해 fallback 후보 없음, low pitch variety `3/3` 확인
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`
@@ -110,7 +112,7 @@ MVP 근거:
 | 만든 것 | symbolic MIDI 생성 모델의 dataset, tokenization, training, generation, decode, objective review, proxy review pipeline |
 | 겪은 문제 | `.mid` 파일 존재만으로 성공 판단 불가, one-note collapse, long sustain block, chord block, dead-air outlier, seed-level margin 부족 |
 | 해결 방식 | duration-explicit token 구조, grammar/coverage/chord-aware probe, overlap-free postprocess, repeatability sweep, dead-air diagnostics, proxy review scoring |
-| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, proxy keep 후보 focused context에서 `needs_followup` 판정 |
+| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3` |
 | 주장 경계 | reviewable MIDI 후보 생성 검증 파이프라인까지 가능, human listening preference / Brad style adaptation / broad production quality는 미검증 |
 
 Issue #210 기준 current best focused review candidate:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -70,6 +70,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered proxy keep consolidation 문서: `docs/STAGE_B_MARGIN_RECOVERED_PROXY_KEEP_CONSOLIDATION_2026-05-28.md`
 - margin-recovered proxy keep focused package 문서: `docs/STAGE_B_MARGIN_RECOVERED_PROXY_KEEP_FOCUSED_PACKAGE_2026-05-28.md`
 - margin-recovered focused context decision 문서: `docs/STAGE_B_MARGIN_RECOVERED_FOCUSED_CONTEXT_DECISION_2026-05-28.md`
+- margin-recovered focused fallback comparison 문서: `docs/STAGE_B_MARGIN_RECOVERED_FOCUSED_FALLBACK_COMPARISON_2026-05-28.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -85,6 +86,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered proxy keep consolidation: dead-air 단일 기준 selected best와 phrase-rich proxy keep 후보의 claim boundary 정리
 - margin-recovered proxy keep focused package: rank `2` 후보 1개를 solo/context review package로 격리, focused max simultaneous notes `1`
 - margin-recovered focused context decision: rank `2` proxy keep을 `needs_followup`으로 하향, low pitch variety/dead-air blocker 기록
+- margin-recovered focused fallback comparison: 후보 3개 전체 focused context 비교, focused keep `0/3`, low pitch variety `3/3`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -271,6 +273,7 @@ Stage B에서 명시하는 것:
 120. Stage B margin-recovered proxy keep consolidation
 121. Stage B margin-recovered proxy keep focused package
 122. Stage B margin-recovered focused context decision
+123. Stage B margin-recovered focused fallback comparison
 
 가장 최근 의미 있는 결과:
 
@@ -446,8 +449,8 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-현재 다음 단계는 margin-recovered focused context decision에서 나온 low pitch variety / dead-air blocker를 좁게 follow-up하는 것이다.
-Issue #250은 proxy keep 후보를 focused context에서 `needs_followup`으로 내렸으므로, 다음 작업은 broad training이 아니라 pitch vocabulary와 spacing을 함께 보는 repair 또는 fallback comparison이어야 한다.
+현재 다음 단계는 margin-recovered focused fallback comparison에서 확인한 low pitch variety / dead-air blocker를 좁게 repair하는 것이다.
+Issue #252는 fallback 후보가 없음을 확인했으므로, 다음 작업은 broad training이 아니라 pitch vocabulary와 spacing을 함께 보는 generation/selection repair여야 한다.
 
 ## 6. 다음 단계 로드맵
 
@@ -973,32 +976,31 @@ Issue #250은 proxy keep 후보를 focused context에서 `needs_followup`으로 
 완료된 바로 전 작업:
 
 ```text
-Stage B margin-recovered focused context decision
+Stage B margin-recovered focused fallback comparison
 ```
 
 결과:
 
-- docs: `docs/STAGE_B_MARGIN_RECOVERED_FOCUSED_CONTEXT_DECISION_2026-05-28.md`
-- proxy keep candidate: `margin_recovered_rank_2_seed_31_sample_5`
-- prior proxy decision: `keep`
-- focused context decision: `needs_followup`
-- decision flags: `low_pitch_variety`, `dead_air_needs_review`
-- focused note count: `14`
-- unique pitch count: `4`
-- max active notes: `1`
-- final note: `C5` over `Bb7`, tension
+- docs: `docs/STAGE_B_MARGIN_RECOVERED_FOCUSED_FALLBACK_COMPARISON_2026-05-28.md`
+- candidates compared: `3`
+- focused keep: `0/3`
+- focused needs_followup: `3/3`
+- low pitch variety: `3/3`
+- dead-air needs review: `2/3`
+- too sparse for context review: `2/3`
+- best relative candidate remains rank `2`, but not focused keep
 - claim boundary: focused context metric decision이며 human listening proof가 아님
 
 판단:
 
-- proxy keep 후보를 final candidate로 올리지 않는다.
-- 현재 주장 가능한 것은 focused context gate가 proxy keep을 다시 내릴 수 있다는 것이다.
+- margin-recovered 후보군 안에는 focused listening으로 올릴 fallback이 없다.
+- 현재 주장 가능한 것은 focused context gate가 fallback 후보 부재까지 분리했다는 것이다.
 - broad trained-model quality, human listening preference, Brad style adaptation은 아직 미검증이다.
 
 다음 작업:
 
-- 다음 issue는 `Stage B margin-recovered focused pitch-vocabulary dead-air follow-up`으로 잡는다.
-- low pitch variety와 dead-air를 줄이는 repair 또는 후보 fallback comparison을 분리한다.
+- 다음 issue는 `Stage B margin-recovered pitch-vocabulary dead-air repair`로 잡는다.
+- low pitch variety와 dead-air를 줄이는 generation/selection repair를 분리한다.
 - max active `1`과 repeated-cell-free 조건은 유지한다.
 - focused context에서 다시 통과하기 전에는 listening review notes로 올리지 않는다.
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #250, Stage B margin-recovered focused context decision
-- 다음 권장 이슈: `Stage B margin-recovered focused pitch-vocabulary dead-air follow-up`
+- latest functional result: Issue #252, Stage B margin-recovered focused fallback comparison
+- 다음 권장 이슈: `Stage B margin-recovered pitch-vocabulary dead-air repair`
 
 현재 범위가 아닌 것:
 
@@ -614,6 +614,41 @@ Issue #250은 Issue #248 focused package의 단일 proxy keep 후보를 solo/con
 Docs:
 
 - `docs/STAGE_B_MARGIN_RECOVERED_FOCUSED_CONTEXT_DECISION_2026-05-28.md`
+
+## Current Margin-Recovered Focused Fallback Comparison Result
+
+Issue #252는 margin-recovered 후보 3개 전체를 focused solo/context metric 기준으로 비교한 작업이다.
+
+변경:
+
+- focused package builder에서 decision `all` 지원
+- margin-recovered 후보 3개 전체 focused package 생성
+- 후보 3개 전체 focused context decision 실행
+- fallback 후보 유무와 blocker aggregate 기록
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_focused_review_package tests.test_stage_b_margin_recovered_focused_package tests.test_stage_b_margin_recovered_focused_context_decision`
+- `bash scripts/agent_harness.sh stage-b-margin-recovered-focused-fallback-comparison`
+
+결과:
+
+| candidate | prior | focused decision | notes | unique | dead-air | flags |
+|---|---|---|---:|---:|---:|---|
+| `margin_recovered_rank_1_seed_23_sample_1` | needs_followup | needs_followup | `4` | `4` | `0.375` | too_sparse, low_pitch_variety, short_phrase_span |
+| `margin_recovered_rank_2_seed_31_sample_5` | keep | needs_followup | `14` | `4` | `0.444` | low_pitch_variety, dead_air_needs_review |
+| `margin_recovered_rank_3_seed_17_sample_3` | needs_followup | needs_followup | `11` | `4` | `0.500` | too_sparse, low_pitch_variety, dead_air_needs_review |
+
+해석:
+
+- margin-recovered 후보군 안에는 focused listening으로 올릴 fallback 후보가 없다.
+- low pitch variety는 `3/3` 후보에서 공통 blocker다.
+- rank `2`는 상대적으로 가장 낫지만 focused keep으로 승격하지 않는다.
+- 다음 작업은 fallback 선택이 아니라 pitch vocabulary와 dead-air를 함께 줄이는 repair다.
+
+Docs:
+
+- `docs/STAGE_B_MARGIN_RECOVERED_FOCUSED_FALLBACK_COMPARISON_2026-05-28.md`
 
 ## Latest README Footer Section Removal Result
 

--- a/docs/STAGE_B_MARGIN_RECOVERED_FOCUSED_FALLBACK_COMPARISON_2026-05-28.md
+++ b/docs/STAGE_B_MARGIN_RECOVERED_FOCUSED_FALLBACK_COMPARISON_2026-05-28.md
@@ -1,0 +1,87 @@
+# Stage B Margin-Recovered Focused Fallback Comparison
+
+작성일: 2026-05-28
+
+## 목적
+
+Issue #252는 margin-recovered 후보 3개 전체를 focused solo/context metric 기준으로 비교해 fallback 후보가 있는지 확인한 작업이다.
+
+Issue #250에서 rank `2` proxy keep 후보가 `needs_followup`으로 내려갔기 때문에, 바로 generation repair로 가기 전에 rank `1`, `3` 후보도 같은 기준으로 비교했다.
+
+## 입력
+
+Proxy-filled review notes:
+
+- `outputs/stage_b_margin_recovered_proxy_review/harness_stage_b_margin_recovered_proxy_review/listening_review_notes_proxy_filled.json`
+
+All-candidate focused package:
+
+- `outputs/stage_b_margin_recovered_focused_package/harness_stage_b_margin_recovered_focused_fallback_package/focused_review_package.json`
+
+Focused fallback decision:
+
+- `outputs/stage_b_margin_recovered_focused_context_decision/harness_stage_b_margin_recovered_focused_fallback_decision/focused_context_decision.json`
+
+## 구현
+
+| 단계 | 내용 |
+|---|---|
+| all-candidate package | focused package builder에서 decision `all` 지원 |
+| context decision | 후보 3개 전체에 동일한 focused context metric 적용 |
+| fallback comparison | proxy keep 후보와 needs_followup 후보를 같은 기준으로 비교 |
+| blocker aggregation | 후보별 decision flag와 전체 flag count 기록 |
+
+## Result
+
+Focused fallback comparison:
+
+| candidate | prior decision | focused decision | notes | unique | range | span | max active | dead-air | final | flags |
+|---|---|---|---:|---:|---|---:|---:|---:|---|---|
+| `margin_recovered_rank_1_seed_23_sample_1` | needs_followup | needs_followup | `4` | `4` | `C5-E5` | `3.500` | `1` | `0.375` | `C5` over `Fm7`, chord tone | too_sparse, low_pitch_variety, short_phrase_span |
+| `margin_recovered_rank_2_seed_31_sample_5` | keep | needs_followup | `14` | `4` | `D#4-C5` | `7.500` | `1` | `0.444` | `C5` over `Bb7`, tension | low_pitch_variety, dead_air_needs_review |
+| `margin_recovered_rank_3_seed_17_sample_3` | needs_followup | needs_followup | `11` | `4` | `C#4-G#4` | `7.750` | `1` | `0.500` | `G#4` over `Fm7`, chord tone | too_sparse, low_pitch_variety, dead_air_needs_review |
+
+Aggregate:
+
+| field | value |
+|---|---:|
+| candidate count | `3` |
+| focused `keep_for_focused_listening` | `0` |
+| focused `needs_followup` | `3` |
+| low pitch variety | `3` |
+| dead-air needs review | `2` |
+| too sparse for context review | `2` |
+| short phrase span | `1` |
+
+## 판단
+
+Issue #252 결과, margin-recovered 후보군 안에는 focused listening으로 올릴 fallback 후보가 없다.
+
+확인한 점:
+
+- 모든 후보가 max active `1` solo-line artifact로 변환 가능하다.
+- final landing은 chord tone 또는 tension으로 기록된다.
+- 그러나 세 후보 모두 unique pitch count `4`로 낮다.
+- rank `1`은 너무 짧고 sparse하다.
+- rank `2`는 proxy keep이었지만 dead-air와 pitch variety가 남는다.
+- rank `3`은 phrase span은 길지만 focused solo-line 변환 후 note count `11`, unique pitch `4`, dead-air `0.500`이다.
+
+## 다음 작업
+
+`Stage B margin-recovered pitch-vocabulary dead-air repair`
+
+목표:
+
+- unique pitch count를 늘린다.
+- dead-air ratio를 낮춘다.
+- max active `1`과 repeated-cell-free 조건을 유지한다.
+- fallback 후보 선택으로 해결하려 하지 않고 generation/selection repair target을 분리한다.
+
+## 검증
+
+실행한 검증:
+
+```bash
+.venv/bin/python -m unittest tests.test_focused_review_package tests.test_stage_b_margin_recovered_focused_package tests.test_stage_b_margin_recovered_focused_context_decision
+bash scripts/agent_harness.sh stage-b-margin-recovered-focused-fallback-comparison
+```

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -48,6 +48,8 @@ Modes:
                 Build a focused solo/context package for the margin-recovered proxy keep.
   stage-b-margin-recovered-focused-context-decision
                 Review the margin-recovered focused package against solo/context MIDI metrics.
+  stage-b-margin-recovered-focused-fallback-comparison
+                Compare all margin-recovered candidates with focused context decisions.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -405,6 +407,23 @@ run_stage_b_margin_recovered_focused_context_decision() {
     --focused_package "$focused_package" \
     --expected_candidate_id margin_recovered_rank_2_seed_31_sample_5 \
     --expected_decision needs_followup
+}
+
+run_stage_b_margin_recovered_focused_fallback_comparison() {
+  local package_run_id="${PACKAGE_RUN_ID:-harness_stage_b_margin_recovered_focused_fallback_package}"
+  local run_id="${RUN_ID:-harness_stage_b_margin_recovered_focused_fallback_decision}"
+  local review_notes="${REVIEW_NOTES:-outputs/stage_b_margin_recovered_proxy_review/harness_stage_b_margin_recovered_proxy_review/listening_review_notes_proxy_filled.json}"
+  print_header "Stage B margin-recovered all-candidate focused package"
+  "$PYTHON_BIN" scripts/build_stage_b_margin_recovered_focused_package.py \
+    --run_id "$package_run_id" \
+    --review_notes "$review_notes" \
+    --decision all \
+    --min_candidates 3
+  print_header "Stage B margin-recovered focused fallback comparison"
+  "$PYTHON_BIN" scripts/review_stage_b_margin_recovered_focused_context.py \
+    --run_id "$run_id" \
+    --focused_package "outputs/stage_b_margin_recovered_focused_package/${package_run_id}/focused_review_package.json" \
+    --expected_candidate_count 3
 }
 
 run_stage_b_constrained_probe() {
@@ -1550,6 +1569,9 @@ case "$MODE" in
     ;;
   stage-b-margin-recovered-focused-context-decision)
     run_stage_b_margin_recovered_focused_context_decision
+    ;;
+  stage-b-margin-recovered-focused-fallback-comparison)
+    run_stage_b_margin_recovered_focused_fallback_comparison
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/build_focused_review_package.py
+++ b/scripts/build_focused_review_package.py
@@ -63,7 +63,7 @@ def selected_review_candidates(review_notes: dict[str, Any], *, decision: str) -
         listening = candidate.get("listening")
         if not isinstance(listening, dict):
             raise FocusedReviewPackageError("candidate listening review must be an object")
-        if str(listening.get("decision") or "") == decision:
+        if str(decision) == "all" or str(listening.get("decision") or "") == decision:
             selected.append(candidate)
     selected.sort(
         key=lambda item: (

--- a/scripts/build_stage_b_margin_recovered_focused_package.py
+++ b/scripts/build_stage_b_margin_recovered_focused_package.py
@@ -131,7 +131,7 @@ def selected_keep_candidates(review_notes: dict[str, Any], *, decision: str) -> 
         if not isinstance(candidate, dict):
             raise MarginRecoveredFocusedPackageError("candidate must be an object")
         listening = candidate.get("listening") if isinstance(candidate.get("listening"), dict) else {}
-        if str(listening.get("decision") or "") == decision:
+        if str(decision) == "all" or str(listening.get("decision") or "") == decision:
             selected.append(candidate)
     return selected
 

--- a/scripts/review_stage_b_margin_recovered_focused_context.py
+++ b/scripts/review_stage_b_margin_recovered_focused_context.py
@@ -329,10 +329,13 @@ def validate_decision(
     *,
     expected_candidate_id: str | None,
     expected_decision: str | None,
+    expected_candidate_count: int | None = None,
 ) -> dict[str, Any]:
     candidates = report.get("candidates")
     if not isinstance(candidates, list) or not candidates:
         raise FocusedContextDecisionError("report candidates must be non-empty")
+    if expected_candidate_count is not None and len(candidates) != int(expected_candidate_count):
+        raise FocusedContextDecisionError(f"expected {expected_candidate_count} candidates, got {len(candidates)}")
     if expected_candidate_id:
         actual = [str(candidate.get("candidate_id") or "") for candidate in candidates]
         if actual != [expected_candidate_id]:
@@ -360,6 +363,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--expected_candidate_id", type=str, default="")
     parser.add_argument("--expected_decision", type=str, default="")
+    parser.add_argument("--expected_candidate_count", type=int, default=None)
     return parser
 
 
@@ -375,6 +379,7 @@ def main() -> int:
         report,
         expected_candidate_id=str(args.expected_candidate_id or ""),
         expected_decision=str(args.expected_decision or ""),
+        expected_candidate_count=args.expected_candidate_count,
     )
     output_dir.mkdir(parents=True, exist_ok=True)
     write_json(output_dir / "focused_context_decision.json", report)

--- a/tests/test_stage_b_margin_recovered_focused_package.py
+++ b/tests/test_stage_b_margin_recovered_focused_package.py
@@ -87,6 +87,18 @@ class MarginRecoveredFocusedPackageTest(unittest.TestCase):
             self.assertTrue(Path(candidate["review_files"]["midi_path"]).exists())
             self.assertTrue(Path(candidate["review_files"]["context_midi_path"]).exists())
 
+    def test_build_package_supports_all_decision_filter(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            package = build_margin_recovered_focused_package(
+                sample_review_notes(root),
+                output_dir=root / "focused",
+                decision="all",
+            )
+
+            self.assertEqual(package["decision_filter"], "all")
+            self.assertEqual(package["candidate_count"], 1)
+
     def test_validate_rejects_unexpected_candidate(self) -> None:
         package = {
             "candidates": [


### PR DESCRIPTION
## Summary

- Support all-candidate focused packages with decision=all.
- Add a fallback comparison harness for the three margin-recovered candidates.
- Document that all three candidates remain needs_followup under focused context metrics.

## Validation

- .venv/bin/python -m unittest tests.test_focused_review_package tests.test_stage_b_margin_recovered_focused_package tests.test_stage_b_margin_recovered_focused_context_decision
- bash scripts/agent_harness.sh stage-b-margin-recovered-focused-fallback-comparison
- rg -n "codex|Codex|코덱스" README.md docs/CURRENT_STATUS_AND_PLAN.md docs/CORE_PLAN.md docs/STAGE_B_MARGIN_RECOVERED_FOCUSED_FALLBACK_COMPARISON_2026-05-28.md scripts/agent_harness.sh scripts/build_focused_review_package.py scripts/build_stage_b_margin_recovered_focused_package.py scripts/review_stage_b_margin_recovered_focused_context.py tests/test_stage_b_margin_recovered_focused_package.py
- git diff --check
- bash scripts/agent_harness.sh quick

Closes #252
