### PR TITLE
Stage B margin-recovered pitch/dead-air repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 | final landing 검증 부족 | 마지막 음이 chord context와 맞는지 판단 어려움 | context MIDI, chord guide, bass root guide와 함께 focused context review 구성 | focused 후보 final landing `D5` over `Ebmaj7` 확인 |
 | 주관적 리뷰 기록 불일치 | "좋다/나쁘다" 식의 loose comment로 다음 repair target 불명확 | listening review notes schema 추가 | timing, chord fit, phrase continuation, landing, vocabulary, decision 분리 |
 | 실험 결과 과장 위험 | 단일 후보 keep을 모델 완성으로 오해 가능 | proven / not proven / remaining risk 문서화 | current best focused candidate와 broad quality claim 분리 |
+| margin-recovered 후보의 focused keep 실패 | 후보 3개 모두 pitch vocabulary 부족, rank 2는 dead-air도 높음 | 기존 seed31 checkpoint에서 top_k4 12-sample repair 후보 재선별 | sample 8에서 dead-air `0.444 -> 0.294`, focused unique pitch `4 -> 5`, remaining flag `low_pitch_variety` |
 
 ## 파이프라인 구조
 
@@ -51,7 +52,7 @@ flowchart LR
 
 ## 핵심 결과
 
-Issue #252 기준 model-core MVP:
+Issue #254 기준 model-core MVP:
 
 | 항목 | 결과 |
 |---|---|
@@ -76,6 +77,7 @@ Issue #252 기준 model-core MVP:
 | margin-recovered focused package | rank `2` 후보만 solo/context review package로 격리, focused solo-line max active `1` |
 | margin-recovered focused context decision | rank `2` proxy keep을 `needs_followup`으로 하향, low pitch variety / dead-air blocker 기록 |
 | margin-recovered fallback comparison | rank `1/2/3` 전체 focused context 비교, focused keep `0/3`, 공통 blocker low pitch variety |
+| margin-recovered pitch/dead-air repair | top_k4 12-sample 재선별로 sample `8` 선택, dead-air `0.294`, focused unique pitch `5`, remaining flag `low_pitch_variety` |
 | constrained review gate | `stage-b-overlap-gate` 통과 |
 | focused candidate path | `stage-b-rhythm-phrase-variation` 통과 |
 
@@ -101,6 +103,8 @@ MVP 근거:
 - rank `2` 후보를 focused package로 격리하고 source note count `19` -> focused solo-line note count `14`, max simultaneous notes `2` -> `1` 변환 기록
 - focused context decision에서 unique pitch `4`, dead-air `0.444`로 `needs_followup` 판정해 proxy keep을 최종 후보로 과장하지 않음
 - margin-recovered 후보 3개 전체를 같은 focused context 기준으로 비교해 fallback 후보 없음, low pitch variety `3/3` 확인
+- 기존 seed `31` checkpoint의 top_k4 12-sample repair에서 dead-air를 `0.444 -> 0.294`로 낮추고 focused unique pitch를 `4 -> 5`로 올린 partial repair 확인
+- repair sample `8`도 focused unique pitch gate `6`에는 미달하므로 focused keep이나 broad quality로 승격하지 않음
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`
@@ -111,8 +115,8 @@ MVP 근거:
 |---|---|
 | 만든 것 | symbolic MIDI 생성 모델의 dataset, tokenization, training, generation, decode, objective review, proxy review pipeline |
 | 겪은 문제 | `.mid` 파일 존재만으로 성공 판단 불가, one-note collapse, long sustain block, chord block, dead-air outlier, seed-level margin 부족 |
-| 해결 방식 | duration-explicit token 구조, grammar/coverage/chord-aware probe, overlap-free postprocess, repeatability sweep, dead-air diagnostics, proxy review scoring |
-| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3` |
+| 해결 방식 | duration-explicit token 구조, grammar/coverage/chord-aware probe, overlap-free postprocess, repeatability sweep, dead-air diagnostics, proxy review scoring, repair candidate selection |
+| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, repair sample dead-air `0.294` |
 | 주장 경계 | reviewable MIDI 후보 생성 검증 파이프라인까지 가능, human listening preference / Brad style adaptation / broad production quality는 미검증 |
 
 Issue #210 기준 current best focused review candidate:
@@ -150,7 +154,7 @@ Issue #210 기준 current best focused review candidate:
 |---|---|
 | broad unconstrained trained-model generation quality | 미검증 |
 | broad multi-seed model quality | 부분 검증 / 6-file 3-seed 5-sample local sweep hard gate 통과, seed-level margin warning 해소 |
-| dead-air outlier control | 부분 검증 / candidate selection gate 추가, 생성 자체 억제는 미완료 |
+| dead-air outlier control | 부분 검증 / candidate selection gate와 sample-level repair 추가, pitch vocabulary gate는 미완료 |
 | human/audio listening preference | 미검증 |
 | Brad Mehldau style adaptation | 미검증 |
 | generic jazz pianist base 완성 | 미검증 |

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -71,6 +71,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered proxy keep focused package 문서: `docs/STAGE_B_MARGIN_RECOVERED_PROXY_KEEP_FOCUSED_PACKAGE_2026-05-28.md`
 - margin-recovered focused context decision 문서: `docs/STAGE_B_MARGIN_RECOVERED_FOCUSED_CONTEXT_DECISION_2026-05-28.md`
 - margin-recovered focused fallback comparison 문서: `docs/STAGE_B_MARGIN_RECOVERED_FOCUSED_FALLBACK_COMPARISON_2026-05-28.md`
+- margin-recovered pitch/dead-air repair 문서: `docs/STAGE_B_MARGIN_RECOVERED_PITCH_DEAD_AIR_REPAIR_2026-05-28.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -87,6 +88,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered proxy keep focused package: rank `2` 후보 1개를 solo/context review package로 격리, focused max simultaneous notes `1`
 - margin-recovered focused context decision: rank `2` proxy keep을 `needs_followup`으로 하향, low pitch variety/dead-air blocker 기록
 - margin-recovered focused fallback comparison: 후보 3개 전체 focused context 비교, focused keep `0/3`, low pitch variety `3/3`
+- margin-recovered pitch/dead-air repair: 기존 seed `31` checkpoint top_k4 12-sample 재선별, sample `8` dead-air `0.294`, focused unique pitch `5`, remaining flag `low_pitch_variety`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -274,6 +276,7 @@ Stage B에서 명시하는 것:
 121. Stage B margin-recovered proxy keep focused package
 122. Stage B margin-recovered focused context decision
 123. Stage B margin-recovered focused fallback comparison
+124. Stage B margin-recovered pitch/dead-air repair
 
 가장 최근 의미 있는 결과:
 
@@ -431,6 +434,8 @@ Stage B에서 명시하는 것:
 - Issue #216 result: README now shows what was built, what failed, how it was fixed, and what the measured result is; the previous portfolio-point section is removed.
 - Issue #218 removes the README footer reference sections.
 - Issue #218 result: README now ends at execution commands and keeps the focus on implementation, problem solving, validation, and results.
+- Issue #254 runs a top_k4 12-sample repair from the existing seed `31` checkpoint and selects sample `8` as the best partial pitch/dead-air repair.
+- Issue #254 result: dead-air improves from `0.444` to `0.294`, focused unique pitch improves from `4` to `5`, and remaining flag is `low_pitch_variety`; this is not a focused keep.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -449,8 +454,8 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-현재 다음 단계는 margin-recovered focused fallback comparison에서 확인한 low pitch variety / dead-air blocker를 좁게 repair하는 것이다.
-Issue #252는 fallback 후보가 없음을 확인했으므로, 다음 작업은 broad training이 아니라 pitch vocabulary와 spacing을 함께 보는 generation/selection repair여야 한다.
+Issue #254는 dead-air를 줄이는 partial repair를 확인했지만 focused unique pitch가 `5`에 머물렀다.
+다음 작업은 dead-air `<= 0.40`을 유지하면서 focused unique pitch `>= 6`을 만족시키는 pitch vocabulary expansion sweep이어야 한다.
 
 ## 6. 다음 단계 로드맵
 
@@ -976,31 +981,33 @@ Issue #252는 fallback 후보가 없음을 확인했으므로, 다음 작업은 
 완료된 바로 전 작업:
 
 ```text
-Stage B margin-recovered focused fallback comparison
+Stage B margin-recovered pitch/dead-air repair
 ```
 
 결과:
 
-- docs: `docs/STAGE_B_MARGIN_RECOVERED_FOCUSED_FALLBACK_COMPARISON_2026-05-28.md`
-- candidates compared: `3`
-- focused keep: `0/3`
-- focused needs_followup: `3/3`
-- low pitch variety: `3/3`
-- dead-air needs review: `2/3`
-- too sparse for context review: `2/3`
-- best relative candidate remains rank `2`, but not focused keep
-- claim boundary: focused context metric decision이며 human listening proof가 아님
+- docs: `docs/STAGE_B_MARGIN_RECOVERED_PITCH_DEAD_AIR_REPAIR_2026-05-28.md`
+- generation samples: `12`
+- strict valid samples: `12/12`
+- grammar gate samples: `12/12`
+- selected repair candidate: `margin_recovered_repair_seed_31_sample_8`
+- dead-air: `0.444 -> 0.294`
+- focused unique pitch count: `4 -> 5`
+- focused max active notes: `1`
+- duplicated 3-note pitch-class chunks: `0`
+- focused keep ready: false
+- remaining flag: `low_pitch_variety`
 
 판단:
 
-- margin-recovered 후보군 안에는 focused listening으로 올릴 fallback이 없다.
-- 현재 주장 가능한 것은 focused context gate가 fallback 후보 부재까지 분리했다는 것이다.
+- sample `8`은 dead-air와 pitch variety를 동시에 개선한 partial repair다.
+- focused unique pitch가 `6` 미만이라 focused keep으로 승격하지 않는다.
 - broad trained-model quality, human listening preference, Brad style adaptation은 아직 미검증이다.
 
 다음 작업:
 
-- 다음 issue는 `Stage B margin-recovered pitch-vocabulary dead-air repair`로 잡는다.
-- low pitch variety와 dead-air를 줄이는 generation/selection repair를 분리한다.
+- 다음 issue는 `Stage B margin-recovered pitch-vocabulary expansion sweep`으로 잡는다.
+- dead-air `<= 0.40`을 유지하면서 focused unique pitch `>= 6`을 만족시키는 generation/selection sweep을 분리한다.
 - max active `1`과 repeated-cell-free 조건은 유지한다.
 - focused context에서 다시 통과하기 전에는 listening review notes로 올리지 않는다.
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #252, Stage B margin-recovered focused fallback comparison
-- 다음 권장 이슈: `Stage B margin-recovered pitch-vocabulary dead-air repair`
+- latest functional result: Issue #254, Stage B margin-recovered pitch/dead-air repair
+- 다음 권장 이슈: `Stage B margin-recovered pitch-vocabulary expansion sweep`
 
 현재 범위가 아닌 것:
 
@@ -649,6 +649,47 @@ Issue #252는 margin-recovered 후보 3개 전체를 focused solo/context metric
 Docs:
 
 - `docs/STAGE_B_MARGIN_RECOVERED_FOCUSED_FALLBACK_COMPARISON_2026-05-28.md`
+
+## Current Margin-Recovered Pitch/Dead-Air Repair Result
+
+Issue #254는 Issue #252에서 남은 low pitch variety / dead-air blocker를 broad training 없이 좁게 repair한 작업이다.
+
+변경:
+
+- 기존 seed `31` 6-file checkpoint를 사용해 top_k4 12-sample decode 실행
+- generation report의 sample MIDI를 focused solo-line 기준으로 다시 읽는 selector 추가
+- baseline 대비 dead-air delta, focused unique pitch delta, remaining flags 기록
+- `stage-b-margin-recovered-pitch-dead-air-repair` harness 추가
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_repair_candidate_selection`
+- `bash scripts/agent_harness.sh stage-b-margin-recovered-pitch-dead-air-repair`
+
+결과:
+
+| 항목 | baseline rank 2 sample 5 | repair sample 8 |
+|---|---:|---:|
+| focused notes | `14` | `13` |
+| focused unique pitches | `4` | `5` |
+| dead-air ratio | `0.444` | `0.294` |
+| onset coverage | `0.500` | `0.594` |
+| sustained coverage | `0.719` | `0.781` |
+| focused max active notes | `1` | `1` |
+| duplicated 3-note pitch-class chunks | `0` | `0` |
+| adjacent pitch repeats | `3` | `1` |
+| focused keep ready | false | false |
+
+해석:
+
+- sample `8`은 dead-air와 unique pitch를 동시에 개선한 partial repair다.
+- focused keep 기준으로는 아직 low pitch variety가 남는다.
+- 이 결과는 model quality나 style adaptation 성공이 아니라 pitch/dead-air blocker를 한 단계 좁힌 evidence다.
+- 다음 작업은 dead-air `<= 0.40`을 유지하면서 focused unique pitch `>= 6`을 만족시키는 pitch vocabulary expansion sweep이다.
+
+Docs:
+
+- `docs/STAGE_B_MARGIN_RECOVERED_PITCH_DEAD_AIR_REPAIR_2026-05-28.md`
 
 ## Latest README Footer Section Removal Result
 

--- a/docs/STAGE_B_MARGIN_RECOVERED_PITCH_DEAD_AIR_REPAIR_2026-05-28.md
+++ b/docs/STAGE_B_MARGIN_RECOVERED_PITCH_DEAD_AIR_REPAIR_2026-05-28.md
@@ -1,0 +1,98 @@
+# Stage B Margin-Recovered Pitch/Dead-Air Repair
+
+작성일: 2026-05-28
+
+## 목적
+
+Issue #252에서 margin-recovered 후보 3개 모두 focused context 기준 `needs_followup`으로 남았다.
+
+공통 blocker:
+
+- low pitch variety: `3/3`
+- dead-air issue: rank `2`, rank `3`
+- focused keep fallback: `0/3`
+
+이 작업은 broad training으로 바로 확장하지 않고, 기존 seed `31` 6-file checkpoint에서 sampling 후보 수를 늘려 pitch vocabulary와 dead-air가 같이 개선되는 후보가 있는지 확인한다.
+
+## 입력 조건
+
+| 항목 | 값 |
+|---|---|
+| checkpoint | `outputs/stage_b_generation_probe/issue_238_stage_b_candidate_count_margin_recovery_seed31_files6/checkpoints` |
+| seed | `31` |
+| max files | `6` |
+| max sequence | `96` |
+| samples | `12` |
+| temperature | `0.9` |
+| top_k | `4` |
+| postprocess overlap | enabled |
+| baseline | `margin_recovered_rank_2_seed_31_sample_5` |
+
+## 구현
+
+- `scripts/select_stage_b_margin_recovered_repair_candidate.py`
+  - generation report의 sample MIDI를 다시 읽어 focused solo-line metrics 계산
+  - simultaneous limit `1` 기준 focused note count, unique pitch count, repeated cell, adjacent repeat 계산
+  - dead-air, focused unique pitch, note count, onset/sustained coverage, repeated cell penalty를 합산해 repair candidate ranking 생성
+  - baseline 대비 dead-air / unique pitch delta와 remaining flags 기록
+- `stage-b-margin-recovered-pitch-dead-air-repair` harness
+  - 기존 checkpoint로 12-sample top_k4 decode 실행
+  - repair selector 실행
+  - expected selected sample `8` 검증
+
+## 검증
+
+```bash
+.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_repair_candidate_selection
+bash scripts/agent_harness.sh stage-b-margin-recovered-pitch-dead-air-repair
+```
+
+## 결과
+
+| 항목 | baseline rank 2 sample 5 | repair sample 8 |
+|---|---:|---:|
+| focused notes | `14` | `13` |
+| focused unique pitches | `4` | `5` |
+| dead-air ratio | `0.444` | `0.294` |
+| onset coverage | `0.500` | `0.594` |
+| sustained coverage | `0.719` | `0.781` |
+| focused max active notes | `1` | `1` |
+| duplicated 3-note pitch-class chunks | `0` | `0` |
+| adjacent pitch repeats | `3` | `1` |
+| focused keep ready | false | false |
+
+선택 결과:
+
+| 항목 | 값 |
+|---|---|
+| selected candidate | `margin_recovered_repair_seed_31_sample_8` |
+| selected sample | `8` |
+| candidate count | `12` |
+| strict valid samples | `12/12` |
+| grammar gate samples | `12/12` |
+| dead-air delta | `0.150` |
+| focused unique pitch delta | `+1` |
+| remaining flags | `low_pitch_variety` |
+
+## 해석
+
+- dead-air는 baseline `0.444`에서 `0.294`로 줄었다.
+- focused unique pitch는 `4`에서 `5`로 늘었다.
+- focused max active notes는 `1`로 유지되어 solo-line postprocess 경계는 유지된다.
+- duplicated 3-note pitch-class chunk는 `0`으로 유지된다.
+- 하지만 focused unique pitch가 gate 기준 `6`에 못 미쳐 focused keep으로 승격하지 않는다.
+
+따라서 이 결과는 partial repair다.
+
+## 다음 작업
+
+다음 issue는 dead-air를 유지하면서 focused unique pitch를 최소 `6` 이상으로 올리는 pitch vocabulary expansion sweep이어야 한다.
+
+성공 기준:
+
+- focused unique pitch count `>= 6`
+- dead-air ratio `<= 0.40`
+- focused note count `>= 12`
+- focused max active notes `1`
+- duplicated 3-note pitch-class chunks `0`
+- broad model quality나 style adaptation 성공으로 표현하지 않음

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -50,6 +50,8 @@ Modes:
                 Review the margin-recovered focused package against solo/context MIDI metrics.
   stage-b-margin-recovered-focused-fallback-comparison
                 Compare all margin-recovered candidates with focused context decisions.
+  stage-b-margin-recovered-pitch-dead-air-repair
+                Run expanded top-k sampling and select a pitch/dead-air repair candidate.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -181,6 +183,7 @@ run_quick() {
     scripts/fill_stage_b_margin_recovered_proxy_review.py \
     scripts/build_stage_b_margin_recovered_focused_package.py \
     scripts/review_stage_b_margin_recovered_focused_context.py \
+    scripts/select_stage_b_margin_recovered_repair_candidate.py \
     scripts/run_stage_b_sampling_sweep.py \
     scripts/run_stage_b_coverage_ab_sweep.py \
     scripts/run_stage_b_pitch_mode_compare.py \
@@ -424,6 +427,40 @@ run_stage_b_margin_recovered_focused_fallback_comparison() {
     --run_id "$run_id" \
     --focused_package "outputs/stage_b_margin_recovered_focused_package/${package_run_id}/focused_review_package.json" \
     --expected_candidate_count 3
+}
+
+run_stage_b_margin_recovered_pitch_dead_air_repair() {
+  local generation_run_id="${GENERATION_RUN_ID:-harness_stage_b_margin_recovered_pitch_dead_air_repair_generation}"
+  local run_id="${RUN_ID:-harness_stage_b_margin_recovered_pitch_dead_air_repair_selection}"
+  local checkpoint_dir="${CHECKPOINT_DIR:-outputs/stage_b_generation_probe/issue_238_stage_b_candidate_count_margin_recovery_seed31_files6/checkpoints}"
+  print_header "Stage B margin-recovered pitch/dead-air repair generation"
+  "$PYTHON_BIN" scripts/run_stage_b_generation_probe.py \
+    --run_id "$generation_run_id" \
+    --checkpoint_dir "$checkpoint_dir" \
+    --skip_prepare \
+    --skip_train \
+    --seed 31 \
+    --max_files 6 \
+    --max_sequence 96 \
+    --num_samples 12 \
+    --temperature 0.9 \
+    --top_k 4 \
+    --postprocess_overlap \
+    --max_simultaneous_notes 2 \
+    --require_valid_sample \
+    --require_strict_valid_sample \
+    --require_note_groups \
+    --issue_number 254
+
+  print_header "Stage B margin-recovered pitch/dead-air repair selection"
+  "$PYTHON_BIN" scripts/select_stage_b_margin_recovered_repair_candidate.py \
+    --run_id "$run_id" \
+    --report_path "outputs/stage_b_generation_probe/${generation_run_id}/report.json" \
+    --baseline_candidate_id margin_recovered_rank_2_seed_31_sample_5 \
+    --baseline_dead_air 0.4444444444444444 \
+    --baseline_unique_pitch_count 4 \
+    --expected_sample_index 8 \
+    --require_partial_repair
 }
 
 run_stage_b_constrained_probe() {
@@ -1572,6 +1609,9 @@ case "$MODE" in
     ;;
   stage-b-margin-recovered-focused-fallback-comparison)
     run_stage_b_margin_recovered_focused_fallback_comparison
+    ;;
+  stage-b-margin-recovered-pitch-dead-air-repair)
+    run_stage_b_margin_recovered_pitch_dead_air_repair
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/select_stage_b_margin_recovered_repair_candidate.py
+++ b/scripts/select_stage_b_margin_recovered_repair_candidate.py
@@ -1,0 +1,291 @@
+"""Select a Stage B margin-recovered repair candidate from an expanded generation report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pretty_midi
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.build_stage_b_margin_recovered_listening_notes import write_json  # noqa: E402
+from scripts.review_stage_b_margin_recovered_focused_context import (  # noqa: E402
+    duplicated_pitch_class_chunks,
+    max_simultaneous_notes,
+)
+from scripts.run_stage_b_generation_probe import postprocess_stage_b_midi  # noqa: E402
+
+
+class MarginRecoveredRepairSelectionError(ValueError):
+    pass
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def non_drum_notes(midi: pretty_midi.PrettyMIDI) -> list[pretty_midi.Note]:
+    notes: list[pretty_midi.Note] = []
+    for instrument in midi.instruments:
+        if not instrument.is_drum:
+            notes.extend(instrument.notes)
+    return sorted(notes, key=lambda note: (float(note.start), int(note.pitch), float(note.end)))
+
+
+def focused_solo_metrics(midi_path: Path) -> dict[str, Any]:
+    midi = pretty_midi.PrettyMIDI(str(midi_path))
+    postprocess = postprocess_stage_b_midi(midi, simultaneous_limit=1)
+    notes = non_drum_notes(midi)
+    pitches = [int(note.pitch) for note in notes]
+    intervals = [pitches[index + 1] - pitches[index] for index in range(len(pitches) - 1)]
+    return {
+        "focused_note_count": int(len(notes)),
+        "focused_unique_pitch_count": int(len(set(pitches))),
+        "focused_pitch_min": int(min(pitches)) if pitches else None,
+        "focused_pitch_max": int(max(pitches)) if pitches else None,
+        "focused_max_simultaneous_notes": max_simultaneous_notes(notes),
+        "focused_adjacent_pitch_repeats": int(sum(1 for interval in intervals if interval == 0)),
+        "focused_duplicated_3_note_pitch_class_chunks": duplicated_pitch_class_chunks(pitches, 3),
+        "focused_postprocess_removed_note_count": int(postprocess.get("removed_note_count", 0) or 0),
+        "focused_postprocess_removal_ratio": (
+            float(postprocess.get("removed_note_count", 0) or 0)
+            / max(1.0, float(postprocess.get("before_note_count", 0) or 0))
+        ),
+    }
+
+
+def candidate_score(candidate: dict[str, Any]) -> float:
+    metrics = candidate["metrics"]
+    focused = candidate["focused_solo_metrics"]
+    score = 0.0
+    score += (1.0 - min(1.0, float(metrics.get("dead_air_ratio", 1.0) or 1.0))) * 60.0
+    score += min(8, int(focused.get("focused_unique_pitch_count", 0) or 0)) * 6.0
+    score += min(14, int(focused.get("focused_note_count", 0) or 0)) * 1.0
+    score += float(candidate.get("temporal_coverage", {}).get("onset_coverage_ratio", 0.0) or 0.0) * 10.0
+    score += float(candidate.get("temporal_coverage", {}).get("sustained_coverage_ratio", 0.0) or 0.0) * 5.0
+    score += float(metrics.get("phrase_coverage_ratio", 0.0) or 0.0) * 5.0
+    score -= int(focused.get("focused_adjacent_pitch_repeats", 0) or 0) * 1.0
+    score -= int(focused.get("focused_duplicated_3_note_pitch_class_chunks", 0) or 0) * 8.0
+    score -= float(focused.get("focused_postprocess_removal_ratio", 0.0) or 0.0) * 6.0
+    if not bool(candidate.get("strict_valid", False)):
+        score -= 25.0
+    return round(float(score), 6)
+
+
+def build_candidates(report: dict[str, Any]) -> list[dict[str, Any]]:
+    samples = report.get("samples")
+    if not isinstance(samples, list) or not samples:
+        raise MarginRecoveredRepairSelectionError("report must contain non-empty samples")
+    rows: list[dict[str, Any]] = []
+    seed = int(report.get("request", {}).get("seed", 0) or 0)
+    for sample in samples:
+        if not isinstance(sample, dict):
+            continue
+        midi_path = Path(str(sample.get("midi_path") or ""))
+        if not midi_path.exists():
+            continue
+        row = {
+            "candidate_id": "margin_recovered_repair_seed_{seed}_sample_{sample}".format(
+                seed=seed,
+                sample=int(sample.get("sample_index", 0) or 0),
+            ),
+            "sample_index": int(sample.get("sample_index", 0) or 0),
+            "sample_seed": int(sample.get("sample_seed", seed) or seed),
+            "midi_path": str(midi_path),
+            "valid": bool(sample.get("valid", False)),
+            "strict_valid": bool(sample.get("strict_valid", False)),
+            "grammar_gate_passed": bool(sample.get("grammar_gate_passed", False)),
+            "metrics": dict(sample.get("metrics") or {}),
+            "temporal_coverage": dict(sample.get("temporal_coverage") or {}),
+            "focused_solo_metrics": focused_solo_metrics(midi_path),
+        }
+        row["repair_score"] = candidate_score(row)
+        rows.append(row)
+    if not rows:
+        raise MarginRecoveredRepairSelectionError("no readable sample MIDI files found")
+    rows.sort(
+        key=lambda row: (
+            -float(row["repair_score"]),
+            float(row["metrics"].get("dead_air_ratio", 1.0) or 1.0),
+            -int(row["focused_solo_metrics"].get("focused_unique_pitch_count", 0) or 0),
+            int(row["sample_index"]),
+        )
+    )
+    for index, row in enumerate(rows, start=1):
+        row["repair_rank"] = int(index)
+    return rows
+
+
+def build_selection_report(
+    generation_report: dict[str, Any],
+    *,
+    output_dir: Path,
+    baseline_candidate_id: str,
+    baseline_dead_air: float,
+    baseline_unique_pitch_count: int,
+) -> dict[str, Any]:
+    candidates = build_candidates(generation_report)
+    selected = candidates[0]
+    selected_metrics = selected["metrics"]
+    selected_focused = selected["focused_solo_metrics"]
+    dead_air_delta = float(baseline_dead_air) - float(selected_metrics.get("dead_air_ratio", 0.0) or 0.0)
+    unique_delta = int(selected_focused.get("focused_unique_pitch_count", 0) or 0) - int(baseline_unique_pitch_count)
+    remaining_flags: list[str] = []
+    if int(selected_focused.get("focused_unique_pitch_count", 0) or 0) < 6:
+        remaining_flags.append("low_pitch_variety")
+    if float(selected_metrics.get("dead_air_ratio", 0.0) or 0.0) > 0.40:
+        remaining_flags.append("dead_air_needs_review")
+    if int(selected_focused.get("focused_note_count", 0) or 0) < 12:
+        remaining_flags.append("too_sparse_for_context_review")
+    if int(selected_focused.get("focused_duplicated_3_note_pitch_class_chunks", 0) or 0) > 0:
+        remaining_flags.append("repeated_pitch_class_cell")
+    return {
+        "schema_version": "stage_b_margin_recovered_pitch_dead_air_repair_selection_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_generation_report": str(generation_report.get("run_dir") or generation_report.get("run_id") or ""),
+        "baseline": {
+            "candidate_id": baseline_candidate_id,
+            "dead_air_ratio": float(baseline_dead_air),
+            "focused_unique_pitch_count": int(baseline_unique_pitch_count),
+        },
+        "candidate_count": int(len(candidates)),
+        "selected_candidate": selected,
+        "repair_summary": {
+            "selected_candidate_id": selected["candidate_id"],
+            "selected_sample_index": int(selected["sample_index"]),
+            "baseline_dead_air_ratio": float(baseline_dead_air),
+            "selected_dead_air_ratio": float(selected_metrics.get("dead_air_ratio", 0.0) or 0.0),
+            "dead_air_delta": round(float(dead_air_delta), 6),
+            "baseline_focused_unique_pitch_count": int(baseline_unique_pitch_count),
+            "selected_focused_unique_pitch_count": int(
+                selected_focused.get("focused_unique_pitch_count", 0) or 0
+            ),
+            "focused_unique_pitch_delta": int(unique_delta),
+            "remaining_flags": remaining_flags,
+            "partial_repair": bool(dead_air_delta > 0.0 or unique_delta > 0),
+            "focused_keep_ready": not remaining_flags,
+        },
+        "candidates": candidates,
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["repair_summary"]
+    lines = [
+        "# Stage B Margin-Recovered Pitch/Dead-Air Repair Selection",
+        "",
+        f"- candidate count: `{report['candidate_count']}`",
+        f"- selected candidate: `{summary['selected_candidate_id']}`",
+        f"- selected sample: `{summary['selected_sample_index']}`",
+        f"- dead-air delta: `{summary['dead_air_delta']:.3f}`",
+        f"- focused unique pitch delta: `{summary['focused_unique_pitch_delta']}`",
+        f"- focused keep ready: `{summary['focused_keep_ready']}`",
+        f"- remaining flags: `{summary['remaining_flags']}`",
+        "",
+        "| rank | candidate | strict | score | notes | unique | dead-air | onset | sustained | dup3 | adj repeat |",
+        "|---:|---|:---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for candidate in report["candidates"]:
+        focused = candidate["focused_solo_metrics"]
+        metrics = candidate["metrics"]
+        temporal = candidate["temporal_coverage"]
+        lines.append(
+            "| {rank} | `{candidate_id}` | {strict} | {score:.3f} | {notes} | {unique} | "
+            "{dead_air:.3f} | {onset:.3f} | {sustained:.3f} | {dup3} | {adj} |".format(
+                rank=candidate["repair_rank"],
+                candidate_id=candidate["candidate_id"],
+                strict=candidate["strict_valid"],
+                score=float(candidate["repair_score"]),
+                notes=int(focused["focused_note_count"]),
+                unique=int(focused["focused_unique_pitch_count"]),
+                dead_air=float(metrics.get("dead_air_ratio", 0.0) or 0.0),
+                onset=float(temporal.get("onset_coverage_ratio", 0.0) or 0.0),
+                sustained=float(temporal.get("sustained_coverage_ratio", 0.0) or 0.0),
+                dup3=int(focused["focused_duplicated_3_note_pitch_class_chunks"]),
+                adj=int(focused["focused_adjacent_pitch_repeats"]),
+            )
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def validate_selection(
+    report: dict[str, Any],
+    *,
+    expected_sample_index: int | None,
+    require_partial_repair: bool,
+) -> dict[str, Any]:
+    summary = report["repair_summary"]
+    if expected_sample_index is not None and int(summary["selected_sample_index"]) != int(expected_sample_index):
+        raise MarginRecoveredRepairSelectionError(
+            f"expected sample {expected_sample_index}, got {summary['selected_sample_index']}"
+        )
+    if require_partial_repair and not bool(summary["partial_repair"]):
+        raise MarginRecoveredRepairSelectionError("selected candidate did not improve baseline")
+    return {
+        "candidate_count": int(report["candidate_count"]),
+        "selected_candidate_id": str(summary["selected_candidate_id"]),
+        "selected_sample_index": int(summary["selected_sample_index"]),
+        "dead_air_delta": float(summary["dead_air_delta"]),
+        "focused_unique_pitch_delta": int(summary["focused_unique_pitch_delta"]),
+        "focused_keep_ready": bool(summary["focused_keep_ready"]),
+        "remaining_flags": list(summary["remaining_flags"]),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Select margin-recovered pitch/dead-air repair candidate")
+    parser.add_argument("--report_path", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=str(ROOT_DIR / "outputs" / "stage_b_margin_recovered_pitch_dead_air_repair"),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--baseline_candidate_id", type=str, default="margin_recovered_rank_2_seed_31_sample_5")
+    parser.add_argument("--baseline_dead_air", type=float, default=0.4444444444444444)
+    parser.add_argument("--baseline_unique_pitch_count", type=int, default=4)
+    parser.add_argument("--expected_sample_index", type=int, default=None)
+    parser.add_argument("--require_partial_repair", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    generation_report = read_json(Path(args.report_path))
+    report = build_selection_report(
+        generation_report,
+        output_dir=output_dir,
+        baseline_candidate_id=str(args.baseline_candidate_id),
+        baseline_dead_air=float(args.baseline_dead_air),
+        baseline_unique_pitch_count=int(args.baseline_unique_pitch_count),
+    )
+    summary = validate_selection(
+        report,
+        expected_sample_index=args.expected_sample_index,
+        require_partial_repair=bool(args.require_partial_repair),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "repair_candidate_selection.json", report)
+    write_json(output_dir / "repair_candidate_selection_summary.json", summary)
+    (output_dir / "repair_candidate_selection.md").write_text(markdown_report(report), encoding="utf-8")
+    summary.update(
+        {
+            "selection_path": str(output_dir / "repair_candidate_selection.json"),
+            "markdown_path": str(output_dir / "repair_candidate_selection.md"),
+        }
+    )
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_margin_recovered_repair_candidate_selection.py
+++ b/tests/test_stage_b_margin_recovered_repair_candidate_selection.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pretty_midi
+
+from scripts.select_stage_b_margin_recovered_repair_candidate import (
+    build_selection_report,
+    validate_selection,
+)
+
+
+def write_midi(path: Path, pitches: list[int]) -> None:
+    midi = pretty_midi.PrettyMIDI(initial_tempo=124)
+    piano = pretty_midi.Instrument(program=0, is_drum=False, name="repair_candidate")
+    for index, pitch in enumerate(pitches):
+        start = index * 0.25
+        piano.notes.append(pretty_midi.Note(velocity=84, pitch=pitch, start=start, end=start + 0.2))
+    midi.instruments.append(piano)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    midi.write(str(path))
+
+
+def sample_report(root: Path) -> dict:
+    first = root / "sample_1.mid"
+    second = root / "sample_2.mid"
+    write_midi(first, [60, 62, 64, 65])
+    write_midi(second, [60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71])
+    return {
+        "run_id": "test_repair",
+        "run_dir": str(root),
+        "request": {"seed": 31},
+        "samples": [
+            {
+                "sample_index": 1,
+                "sample_seed": 31,
+                "midi_path": str(first),
+                "valid": True,
+                "strict_valid": True,
+                "grammar_gate_passed": True,
+                "metrics": {"dead_air_ratio": 0.35, "phrase_coverage_ratio": 0.5},
+                "temporal_coverage": {"onset_coverage_ratio": 0.3, "sustained_coverage_ratio": 0.4},
+            },
+            {
+                "sample_index": 2,
+                "sample_seed": 32,
+                "midi_path": str(second),
+                "valid": True,
+                "strict_valid": True,
+                "grammar_gate_passed": True,
+                "metrics": {"dead_air_ratio": 0.25, "phrase_coverage_ratio": 0.8},
+                "temporal_coverage": {"onset_coverage_ratio": 0.6, "sustained_coverage_ratio": 0.8},
+            },
+        ],
+    }
+
+
+class StageBMarginRecoveredRepairSelectionTest(unittest.TestCase):
+    def test_selects_candidate_that_improves_dead_air_and_pitch_variety(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            report = build_selection_report(
+                sample_report(Path(temp_dir)),
+                output_dir=Path(temp_dir) / "selection",
+                baseline_candidate_id="baseline",
+                baseline_dead_air=0.44,
+                baseline_unique_pitch_count=4,
+            )
+            summary = validate_selection(report, expected_sample_index=2, require_partial_repair=True)
+
+            self.assertEqual(summary["selected_sample_index"], 2)
+            self.assertGreater(summary["dead_air_delta"], 0.0)
+            self.assertGreater(summary["focused_unique_pitch_delta"], 0)
+            self.assertTrue(summary["focused_keep_ready"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add repair candidate selector for expanded margin-recovered Stage B generation reports
- add harness mode for top_k4 12-sample seed31 repair selection
- document Issue #254 partial repair result and update README/status claim boundary

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_margin_recovered_repair_candidate_selection
- bash scripts/agent_harness.sh stage-b-margin-recovered-pitch-dead-air-repair
- bash scripts/agent_harness.sh quick

Closes #254