### PR TITLE
Stage B margin-recovered pitch vocabulary sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 | 주관적 리뷰 기록 불일치 | "좋다/나쁘다" 식의 loose comment로 다음 repair target 불명확 | listening review notes schema 추가 | timing, chord fit, phrase continuation, landing, vocabulary, decision 분리 |
 | 실험 결과 과장 위험 | 단일 후보 keep을 모델 완성으로 오해 가능 | proven / not proven / remaining risk 문서화 | current best focused candidate와 broad quality claim 분리 |
 | margin-recovered 후보의 focused keep 실패 | 후보 3개 모두 pitch vocabulary 부족, rank 2는 dead-air도 높음 | 기존 seed31 checkpoint에서 top_k4 12-sample repair 후보 재선별 | sample 8에서 dead-air `0.444 -> 0.294`, focused unique pitch `4 -> 5`, remaining flag `low_pitch_variety` |
+| pitch vocabulary gate 미달 | Issue #254 후보가 dead-air는 낮지만 focused unique pitch `5`에 머무름 | seed/top-k sweep으로 48개 후보 재평가 | seed17 top_k5 sample 4에서 focused unique pitch `6`, dead-air `0.400`, qualified `1/48` |
 
 ## 파이프라인 구조
 
@@ -52,7 +53,7 @@ flowchart LR
 
 ## 핵심 결과
 
-Issue #254 기준 model-core MVP:
+Issue #256 기준 model-core MVP:
 
 | 항목 | 결과 |
 |---|---|
@@ -78,6 +79,7 @@ Issue #254 기준 model-core MVP:
 | margin-recovered focused context decision | rank `2` proxy keep을 `needs_followup`으로 하향, low pitch variety / dead-air blocker 기록 |
 | margin-recovered fallback comparison | rank `1/2/3` 전체 focused context 비교, focused keep `0/3`, 공통 blocker low pitch variety |
 | margin-recovered pitch/dead-air repair | top_k4 12-sample 재선별로 sample `8` 선택, dead-air `0.294`, focused unique pitch `5`, remaining flag `low_pitch_variety` |
+| margin-recovered pitch vocabulary sweep | seed17/31 top_k5 48개 후보 중 `1`개 qualified, selected focused unique pitch `6`, dead-air `0.400` |
 | constrained review gate | `stage-b-overlap-gate` 통과 |
 | focused candidate path | `stage-b-rhythm-phrase-variation` 통과 |
 
@@ -105,6 +107,8 @@ MVP 근거:
 - margin-recovered 후보 3개 전체를 같은 focused context 기준으로 비교해 fallback 후보 없음, low pitch variety `3/3` 확인
 - 기존 seed `31` checkpoint의 top_k4 12-sample repair에서 dead-air를 `0.444 -> 0.294`로 낮추고 focused unique pitch를 `4 -> 5`로 올린 partial repair 확인
 - repair sample `8`도 focused unique pitch gate `6`에는 미달하므로 focused keep이나 broad quality로 승격하지 않음
+- seed/top-k sweep 48개 후보 중 focused unique pitch `6`, dead-air `0.400`, note count `13`, duplicated 3-note chunk `0`인 qualified 후보 `1`개 확인
+- Issue #256 후보는 Issue #254 대비 dead-air가 `+0.106`, adjacent repeat이 `+2`라서 focused context review 전 최종 후보로 승격하지 않음
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`
@@ -116,7 +120,7 @@ MVP 근거:
 | 만든 것 | symbolic MIDI 생성 모델의 dataset, tokenization, training, generation, decode, objective review, proxy review pipeline |
 | 겪은 문제 | `.mid` 파일 존재만으로 성공 판단 불가, one-note collapse, long sustain block, chord block, dead-air outlier, seed-level margin 부족 |
 | 해결 방식 | duration-explicit token 구조, grammar/coverage/chord-aware probe, overlap-free postprocess, repeatability sweep, dead-air diagnostics, proxy review scoring, repair candidate selection |
-| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, repair sample dead-air `0.294` |
+| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab sweep qualified `1/48` |
 | 주장 경계 | reviewable MIDI 후보 생성 검증 파이프라인까지 가능, human listening preference / Brad style adaptation / broad production quality는 미검증 |
 
 Issue #210 기준 current best focused review candidate:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -72,6 +72,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered focused context decision 문서: `docs/STAGE_B_MARGIN_RECOVERED_FOCUSED_CONTEXT_DECISION_2026-05-28.md`
 - margin-recovered focused fallback comparison 문서: `docs/STAGE_B_MARGIN_RECOVERED_FOCUSED_FALLBACK_COMPARISON_2026-05-28.md`
 - margin-recovered pitch/dead-air repair 문서: `docs/STAGE_B_MARGIN_RECOVERED_PITCH_DEAD_AIR_REPAIR_2026-05-28.md`
+- margin-recovered pitch vocabulary sweep 문서: `docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_SWEEP_2026-05-28.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -89,6 +90,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered focused context decision: rank `2` proxy keep을 `needs_followup`으로 하향, low pitch variety/dead-air blocker 기록
 - margin-recovered focused fallback comparison: 후보 3개 전체 focused context 비교, focused keep `0/3`, low pitch variety `3/3`
 - margin-recovered pitch/dead-air repair: 기존 seed `31` checkpoint top_k4 12-sample 재선별, sample `8` dead-air `0.294`, focused unique pitch `5`, remaining flag `low_pitch_variety`
+- margin-recovered pitch vocabulary sweep: seed `17/31` top_k5 48개 후보 중 qualified `1`, selected unique pitch `6`, dead-air `0.400`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -277,6 +279,7 @@ Stage B에서 명시하는 것:
 122. Stage B margin-recovered focused context decision
 123. Stage B margin-recovered focused fallback comparison
 124. Stage B margin-recovered pitch/dead-air repair
+125. Stage B margin-recovered pitch vocabulary sweep
 
 가장 최근 의미 있는 결과:
 
@@ -436,6 +439,8 @@ Stage B에서 명시하는 것:
 - Issue #218 result: README now ends at execution commands and keeps the focus on implementation, problem solving, validation, and results.
 - Issue #254 runs a top_k4 12-sample repair from the existing seed `31` checkpoint and selects sample `8` as the best partial pitch/dead-air repair.
 - Issue #254 result: dead-air improves from `0.444` to `0.294`, focused unique pitch improves from `4` to `5`, and remaining flag is `low_pitch_variety`; this is not a focused keep.
+- Issue #256 runs a seed/top-k pitch vocabulary sweep over `48` candidates and finds `1` qualified candidate.
+- Issue #256 result: selected sample has focused unique pitch `6`, dead-air `0.400`, focused notes `13`, duplicated 3-note chunks `0`, but dead-air and adjacent repeats regress from Issue #254.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -454,8 +459,8 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-Issue #254는 dead-air를 줄이는 partial repair를 확인했지만 focused unique pitch가 `5`에 머물렀다.
-다음 작업은 dead-air `<= 0.40`을 유지하면서 focused unique pitch `>= 6`을 만족시키는 pitch vocabulary expansion sweep이어야 한다.
+Issue #256은 focused unique pitch `>= 6` 후보를 찾았지만 dead-air가 Issue #254 대비 `0.294 -> 0.400`으로 나빠졌다.
+다음 작업은 이 qualified 후보를 focused context review로 격리해 dead-air와 adjacent repeat tradeoff가 실제 blocker인지 확인하는 것이다.
 
 ## 6. 다음 단계 로드맵
 
@@ -981,33 +986,35 @@ Issue #254는 dead-air를 줄이는 partial repair를 확인했지만 focused un
 완료된 바로 전 작업:
 
 ```text
-Stage B margin-recovered pitch/dead-air repair
+Stage B margin-recovered pitch vocabulary sweep
 ```
 
 결과:
 
-- docs: `docs/STAGE_B_MARGIN_RECOVERED_PITCH_DEAD_AIR_REPAIR_2026-05-28.md`
-- generation samples: `12`
-- strict valid samples: `12/12`
-- grammar gate samples: `12/12`
-- selected repair candidate: `margin_recovered_repair_seed_31_sample_8`
-- dead-air: `0.444 -> 0.294`
-- focused unique pitch count: `4 -> 5`
+- docs: `docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_SWEEP_2026-05-28.md`
+- report count: `2`
+- candidate count: `48`
+- qualified candidate count: `1`
+- selected candidate: `margin_recovered_pitch_vocab_seed_17_topk_5_temp_09_n24_sample_4`
+- focused unique pitch count: `5 -> 6` compared with Issue #254
+- dead-air: `0.294 -> 0.400` compared with Issue #254
+- focused notes: `13`
 - focused max active notes: `1`
 - duplicated 3-note pitch-class chunks: `0`
-- focused keep ready: false
-- remaining flag: `low_pitch_variety`
+- adjacent pitch repeats: `3`
+- remaining flags: `[]`
 
 판단:
 
-- sample `8`은 dead-air와 pitch variety를 동시에 개선한 partial repair다.
-- focused unique pitch가 `6` 미만이라 focused keep으로 승격하지 않는다.
+- selected sample은 pitch vocabulary hard gate를 통과했다.
+- dead-air는 absolute gate 안에 있지만 Issue #254보다 나빠졌다.
+- adjacent repeat도 `1 -> 3`으로 늘었다.
 - broad trained-model quality, human listening preference, Brad style adaptation은 아직 미검증이다.
 
 다음 작업:
 
-- 다음 issue는 `Stage B margin-recovered pitch-vocabulary expansion sweep`으로 잡는다.
-- dead-air `<= 0.40`을 유지하면서 focused unique pitch `>= 6`을 만족시키는 generation/selection sweep을 분리한다.
+- 다음 issue는 `Stage B margin-recovered pitch vocabulary focused context review`로 잡는다.
+- selected sample을 context package로 격리해 dead-air와 adjacent repeat tradeoff가 실제 blocker인지 판단한다.
 - max active `1`과 repeated-cell-free 조건은 유지한다.
 - focused context에서 다시 통과하기 전에는 listening review notes로 올리지 않는다.
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #254, Stage B margin-recovered pitch/dead-air repair
-- 다음 권장 이슈: `Stage B margin-recovered pitch-vocabulary expansion sweep`
+- latest functional result: Issue #256, Stage B margin-recovered pitch vocabulary sweep
+- 다음 권장 이슈: `Stage B margin-recovered pitch vocabulary focused context review`
 
 현재 범위가 아닌 것:
 
@@ -690,6 +690,57 @@ Issue #254는 Issue #252에서 남은 low pitch variety / dead-air blocker를 br
 Docs:
 
 - `docs/STAGE_B_MARGIN_RECOVERED_PITCH_DEAD_AIR_REPAIR_2026-05-28.md`
+
+## Current Margin-Recovered Pitch Vocabulary Sweep Result
+
+Issue #256은 Issue #254 후보의 low pitch variety blocker를 seed/top-k sweep으로 좁힌 작업이다.
+
+변경:
+
+- seed `17`, seed `31` top_k5 24-sample decode 실행
+- 총 `48`개 후보를 focused solo-line 기준으로 합산 평가
+- focused unique pitch, dead-air, focused note count, repeated cell hard gate 추가
+- Issue #254 후보 대비 dead-air / pitch vocabulary tradeoff 기록
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_pitch_vocab_sweep`
+- `bash scripts/agent_harness.sh stage-b-margin-recovered-pitch-vocab-sweep`
+
+결과:
+
+| 항목 | 값 |
+|---|---|
+| report count | `2` |
+| candidate count | `48` |
+| qualified candidate count | `1` |
+| selected candidate | `margin_recovered_pitch_vocab_seed_17_topk_5_temp_09_n24_sample_4` |
+| selected sample seed | `20` |
+| focused notes | `13` |
+| focused unique pitches | `6` |
+| dead-air ratio | `0.400` |
+| onset coverage | `0.500` |
+| sustained coverage | `0.625` |
+| focused max active notes | `1` |
+| duplicated 3-note chunks | `0` |
+| adjacent pitch repeats | `3` |
+
+Issue #254 후보 대비:
+
+- focused unique pitch: `5 -> 6`
+- dead-air: `0.294 -> 0.400`
+- adjacent repeats: `1 -> 3`
+
+해석:
+
+- pitch vocabulary gate는 통과했다.
+- dead-air는 absolute gate에 들어왔지만 Issue #254보다 나빠졌다.
+- adjacent repeat도 늘었으므로 focused context review 전에는 최종 keep으로 승격하지 않는다.
+- 다음 작업은 이 qualified 후보를 focused context package로 격리해 context 위에서 체감 blocker인지 확인하는 것이다.
+
+Docs:
+
+- `docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_SWEEP_2026-05-28.md`
 
 ## Latest README Footer Section Removal Result
 

--- a/docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_SWEEP_2026-05-28.md
+++ b/docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_SWEEP_2026-05-28.md
@@ -1,0 +1,106 @@
+# Stage B Margin-Recovered Pitch Vocabulary Sweep
+
+작성일: 2026-05-28
+
+## 목적
+
+Issue #254는 dead-air를 `0.444 -> 0.294`로 줄였지만 focused unique pitch가 `4 -> 5`에 머물렀다.
+
+이 작업은 기존 checkpoint를 그대로 두고 generation seed / top-k 후보를 넓혀 focused unique pitch `>= 6`과 dead-air `<= 0.40`을 동시에 만족하는 후보가 있는지 확인한다.
+
+## 입력 조건
+
+| 항목 | 값 |
+|---|---|
+| checkpoint | `outputs/stage_b_generation_probe/issue_238_stage_b_candidate_count_margin_recovery_seed31_files6/checkpoints` |
+| seed sweep | `17`, `31` |
+| top_k | `5` |
+| temperature | `0.9` |
+| samples per seed | `24` |
+| postprocess overlap | enabled |
+| focused simultaneous limit | `1` |
+
+## 구현
+
+- `scripts/summarize_stage_b_margin_recovered_pitch_vocab_sweep.py`
+  - 여러 generation report를 하나의 sweep으로 합산
+  - focused solo-line 기준 note count, unique pitch count, dead-air, max active, repeated cell 계산
+  - hard gate 통과 후보를 우선 선택
+  - Issue #254 후보 대비 dead-air / unique pitch delta 기록
+- `stage-b-margin-recovered-pitch-vocab-sweep` harness
+  - seed `17`, seed `31` 각각 top_k5 24-sample decode
+  - 총 `48`개 후보 sweep summary 생성
+  - expected selected source / sample 검증
+
+## Gate
+
+| 기준 | 값 |
+|---|---:|
+| focused unique pitch count | `>= 6` |
+| dead-air ratio | `<= 0.40` |
+| focused note count | `>= 12` |
+| focused max active notes | `1` |
+| duplicated 3-note pitch-class chunks | `0` |
+
+## 검증
+
+```bash
+.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_pitch_vocab_sweep
+bash scripts/agent_harness.sh stage-b-margin-recovered-pitch-vocab-sweep
+```
+
+## 결과
+
+| 항목 | 값 |
+|---|---|
+| report count | `2` |
+| candidate count | `48` |
+| qualified candidate count | `1` |
+| selected candidate | `margin_recovered_pitch_vocab_seed_17_topk_5_temp_09_n24_sample_4` |
+| source run | `harness_stage_b_margin_recovered_pitch_vocab_seed17_topk5_temp090_n24` |
+| selected sample | `4` |
+| selected sample seed | `20` |
+| qualified | true |
+| remaining flags | `[]` |
+
+Selected candidate metrics:
+
+| 항목 | 값 |
+|---|---:|
+| focused notes | `13` |
+| focused unique pitches | `6` |
+| dead-air ratio | `0.400` |
+| onset coverage | `0.500` |
+| sustained coverage | `0.625` |
+| focused max active notes | `1` |
+| adjacent pitch repeats | `3` |
+| duplicated 3-note pitch-class chunks | `0` |
+| chord-tone ratio | `0.812` |
+
+Issue #254 후보 대비:
+
+| 항목 | Issue #254 sample 8 | Issue #256 selected |
+|---|---:|---:|
+| focused unique pitches | `5` | `6` |
+| dead-air ratio | `0.294` | `0.400` |
+| focused notes | `13` | `13` |
+| duplicated 3-note chunks | `0` | `0` |
+| adjacent pitch repeats | `1` | `3` |
+
+## 해석
+
+- focused unique pitch gate는 통과했다.
+- dead-air는 absolute gate `<= 0.40`에는 들어왔지만, Issue #254 후보보다 `+0.106` 나빠졌다.
+- adjacent pitch repeats도 `1 -> 3`으로 늘었다.
+- 따라서 이 결과는 pitch vocabulary gate를 통과한 후보이며, dead-air/adjacent-repeat tradeoff가 남은 상태다.
+- broad model quality, human preference, Brad style adaptation 성공으로 표현하지 않는다.
+
+## 다음 작업
+
+선택 후보를 focused context package로 격리해 chord context, register, repeated cell, phrase continuation을 다시 판단한다.
+
+다음 gate:
+
+- focused context decision이 `keep_for_focused_listening` 또는 명확한 `needs_followup`으로 분리
+- dead-air `0.400`이 context에서 체감 가능한 blocker인지 기록
+- adjacent pitch repeats `3`이 motif인지 반복 문제인지 기록

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -52,6 +52,8 @@ Modes:
                 Compare all margin-recovered candidates with focused context decisions.
   stage-b-margin-recovered-pitch-dead-air-repair
                 Run expanded top-k sampling and select a pitch/dead-air repair candidate.
+  stage-b-margin-recovered-pitch-vocab-sweep
+                Run seed/top-k sweep and select a pitch-vocabulary qualified candidate.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -184,6 +186,7 @@ run_quick() {
     scripts/build_stage_b_margin_recovered_focused_package.py \
     scripts/review_stage_b_margin_recovered_focused_context.py \
     scripts/select_stage_b_margin_recovered_repair_candidate.py \
+    scripts/summarize_stage_b_margin_recovered_pitch_vocab_sweep.py \
     scripts/run_stage_b_sampling_sweep.py \
     scripts/run_stage_b_coverage_ab_sweep.py \
     scripts/run_stage_b_pitch_mode_compare.py \
@@ -461,6 +464,59 @@ run_stage_b_margin_recovered_pitch_dead_air_repair() {
     --baseline_unique_pitch_count 4 \
     --expected_sample_index 8 \
     --require_partial_repair
+}
+
+run_stage_b_margin_recovered_pitch_vocab_sweep() {
+  local seed17_run_id="${SEED17_RUN_ID:-harness_stage_b_margin_recovered_pitch_vocab_seed17_topk5_temp090_n24}"
+  local seed31_run_id="${SEED31_RUN_ID:-harness_stage_b_margin_recovered_pitch_vocab_seed31_topk5_temp090_n24}"
+  local run_id="${RUN_ID:-harness_stage_b_margin_recovered_pitch_vocab_sweep}"
+  local checkpoint_dir="${CHECKPOINT_DIR:-outputs/stage_b_generation_probe/issue_238_stage_b_candidate_count_margin_recovery_seed31_files6/checkpoints}"
+  print_header "Stage B margin-recovered pitch vocabulary sweep seed 17"
+  "$PYTHON_BIN" scripts/run_stage_b_generation_probe.py \
+    --run_id "$seed17_run_id" \
+    --checkpoint_dir "$checkpoint_dir" \
+    --skip_prepare \
+    --skip_train \
+    --seed 17 \
+    --max_files 6 \
+    --max_sequence 96 \
+    --num_samples 24 \
+    --temperature 0.9 \
+    --top_k 5 \
+    --postprocess_overlap \
+    --max_simultaneous_notes 2 \
+    --require_valid_sample \
+    --require_strict_valid_sample \
+    --require_note_groups \
+    --issue_number 256
+
+  print_header "Stage B margin-recovered pitch vocabulary sweep seed 31"
+  "$PYTHON_BIN" scripts/run_stage_b_generation_probe.py \
+    --run_id "$seed31_run_id" \
+    --checkpoint_dir "$checkpoint_dir" \
+    --skip_prepare \
+    --skip_train \
+    --seed 31 \
+    --max_files 6 \
+    --max_sequence 96 \
+    --num_samples 24 \
+    --temperature 0.9 \
+    --top_k 5 \
+    --postprocess_overlap \
+    --max_simultaneous_notes 2 \
+    --require_valid_sample \
+    --require_strict_valid_sample \
+    --require_note_groups \
+    --issue_number 256
+
+  print_header "Stage B margin-recovered pitch vocabulary sweep summary"
+  "$PYTHON_BIN" scripts/summarize_stage_b_margin_recovered_pitch_vocab_sweep.py \
+    --run_id "$run_id" \
+    --report_path "outputs/stage_b_generation_probe/${seed17_run_id}/report.json" \
+    --report_path "outputs/stage_b_generation_probe/${seed31_run_id}/report.json" \
+    --require_qualified \
+    --expected_source_run_id "$seed17_run_id" \
+    --expected_sample_index 4
 }
 
 run_stage_b_constrained_probe() {
@@ -1612,6 +1668,9 @@ case "$MODE" in
     ;;
   stage-b-margin-recovered-pitch-dead-air-repair)
     run_stage_b_margin_recovered_pitch_dead_air_repair
+    ;;
+  stage-b-margin-recovered-pitch-vocab-sweep)
+    run_stage_b_margin_recovered_pitch_vocab_sweep
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/summarize_stage_b_margin_recovered_pitch_vocab_sweep.py
+++ b/scripts/summarize_stage_b_margin_recovered_pitch_vocab_sweep.py
@@ -1,0 +1,355 @@
+"""Summarize a Stage B margin-recovered pitch-vocabulary expansion sweep."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.build_stage_b_margin_recovered_listening_notes import write_json  # noqa: E402
+from scripts.select_stage_b_margin_recovered_repair_candidate import (  # noqa: E402
+    build_candidates,
+    read_json,
+)
+
+
+class MarginRecoveredPitchVocabSweepError(ValueError):
+    pass
+
+
+def safe_label(value: Any) -> str:
+    text = str(value)
+    text = text.replace(".", "")
+    return re.sub(r"[^A-Za-z0-9_]+", "_", text).strip("_")
+
+
+def candidate_gate_flags(
+    candidate: dict[str, Any],
+    *,
+    min_unique_pitch_count: int,
+    max_dead_air_ratio: float,
+    min_note_count: int,
+    max_simultaneous_notes: int,
+    max_duplicated_3_note_chunks: int,
+) -> list[str]:
+    focused = candidate["focused_solo_metrics"]
+    metrics = candidate["metrics"]
+    flags: list[str] = []
+    if int(focused.get("focused_unique_pitch_count", 0) or 0) < min_unique_pitch_count:
+        flags.append("low_pitch_variety")
+    if float(metrics.get("dead_air_ratio", 1.0) or 1.0) > max_dead_air_ratio:
+        flags.append("dead_air_needs_review")
+    if int(focused.get("focused_note_count", 0) or 0) < min_note_count:
+        flags.append("too_sparse_for_context_review")
+    if int(focused.get("focused_max_simultaneous_notes", 0) or 0) > max_simultaneous_notes:
+        flags.append("focused_polyphony")
+    if int(focused.get("focused_duplicated_3_note_pitch_class_chunks", 0) or 0) > max_duplicated_3_note_chunks:
+        flags.append("repeated_pitch_class_cell")
+    return flags
+
+
+def pitch_vocab_score(candidate: dict[str, Any], *, qualified: bool) -> float:
+    focused = candidate["focused_solo_metrics"]
+    metrics = candidate["metrics"]
+    temporal = candidate["temporal_coverage"]
+    score = 1000.0 if qualified else 0.0
+    score += min(10, int(focused.get("focused_unique_pitch_count", 0) or 0)) * 50.0
+    score += (1.0 - min(1.0, float(metrics.get("dead_air_ratio", 1.0) or 1.0))) * 80.0
+    score += min(16, int(focused.get("focused_note_count", 0) or 0)) * 3.0
+    score += float(temporal.get("onset_coverage_ratio", 0.0) or 0.0) * 12.0
+    score += float(temporal.get("sustained_coverage_ratio", 0.0) or 0.0) * 6.0
+    score -= int(focused.get("focused_adjacent_pitch_repeats", 0) or 0) * 1.5
+    score -= int(focused.get("focused_duplicated_3_note_pitch_class_chunks", 0) or 0) * 20.0
+    return round(float(score), 6)
+
+
+def enrich_candidates(
+    report: dict[str, Any],
+    *,
+    report_path: Path,
+    min_unique_pitch_count: int,
+    max_dead_air_ratio: float,
+    min_note_count: int,
+    max_simultaneous_notes: int,
+    max_duplicated_3_note_chunks: int,
+) -> list[dict[str, Any]]:
+    source_run_id = str(report.get("run_id") or report_path.parent.name)
+    request = dict(report.get("request") or {})
+    summary = dict(report.get("summary") or {})
+    request_seed = int(request.get("seed", 0) or 0)
+    top_k = request.get("top_k")
+    temperature = request.get("temperature")
+    sample_count = int(summary.get("sample_count", len(report.get("samples") or [])) or 0)
+    rows = build_candidates(report)
+    enriched: list[dict[str, Any]] = []
+    for row in rows:
+        row = dict(row)
+        row["source_run_id"] = source_run_id
+        row["source_report_path"] = str(report_path)
+        row["source_request"] = {
+            "seed": request_seed,
+            "top_k": top_k,
+            "temperature": temperature,
+            "sample_count": sample_count,
+        }
+        row["candidate_id"] = (
+            "margin_recovered_pitch_vocab_seed_{seed}_topk_{top_k}_temp_{temperature}_n{count}_sample_{sample}".format(
+                seed=request_seed,
+                top_k=safe_label(top_k),
+                temperature=safe_label(temperature),
+                count=sample_count,
+                sample=int(row.get("sample_index", 0) or 0),
+            )
+        )
+        flags = candidate_gate_flags(
+            row,
+            min_unique_pitch_count=min_unique_pitch_count,
+            max_dead_air_ratio=max_dead_air_ratio,
+            min_note_count=min_note_count,
+            max_simultaneous_notes=max_simultaneous_notes,
+            max_duplicated_3_note_chunks=max_duplicated_3_note_chunks,
+        )
+        row["pitch_vocab_gate"] = {
+            "qualified": not flags,
+            "flags": flags,
+        }
+        row["pitch_vocab_score"] = pitch_vocab_score(row, qualified=not flags)
+        enriched.append(row)
+    return enriched
+
+
+def build_sweep_report(
+    report_paths: list[Path],
+    *,
+    output_dir: Path,
+    previous_candidate_id: str,
+    previous_dead_air: float,
+    previous_unique_pitch_count: int,
+    min_unique_pitch_count: int,
+    max_dead_air_ratio: float,
+    min_note_count: int,
+    max_simultaneous_notes: int,
+    max_duplicated_3_note_chunks: int,
+) -> dict[str, Any]:
+    if not report_paths:
+        raise MarginRecoveredPitchVocabSweepError("at least one report path is required")
+    candidates: list[dict[str, Any]] = []
+    for path in report_paths:
+        report = read_json(path)
+        candidates.extend(
+            enrich_candidates(
+                report,
+                report_path=path,
+                min_unique_pitch_count=min_unique_pitch_count,
+                max_dead_air_ratio=max_dead_air_ratio,
+                min_note_count=min_note_count,
+                max_simultaneous_notes=max_simultaneous_notes,
+                max_duplicated_3_note_chunks=max_duplicated_3_note_chunks,
+            )
+        )
+    if not candidates:
+        raise MarginRecoveredPitchVocabSweepError("no candidates found")
+    candidates.sort(
+        key=lambda row: (
+            bool(row["pitch_vocab_gate"]["qualified"]),
+            float(row["pitch_vocab_score"]),
+            -float(row["metrics"].get("dead_air_ratio", 1.0) or 1.0),
+            int(row["focused_solo_metrics"].get("focused_unique_pitch_count", 0) or 0),
+            int(row["focused_solo_metrics"].get("focused_note_count", 0) or 0),
+        ),
+        reverse=True,
+    )
+    for index, row in enumerate(candidates, start=1):
+        row["sweep_rank"] = int(index)
+    selected = candidates[0]
+    focused = selected["focused_solo_metrics"]
+    metrics = selected["metrics"]
+    selected_dead_air = float(metrics.get("dead_air_ratio", 0.0) or 0.0)
+    selected_unique = int(focused.get("focused_unique_pitch_count", 0) or 0)
+    qualified_count = sum(1 for row in candidates if row["pitch_vocab_gate"]["qualified"])
+    return {
+        "schema_version": "stage_b_margin_recovered_pitch_vocab_sweep_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_report_paths": [str(path) for path in report_paths],
+        "thresholds": {
+            "min_focused_unique_pitch_count": int(min_unique_pitch_count),
+            "max_dead_air_ratio": float(max_dead_air_ratio),
+            "min_focused_note_count": int(min_note_count),
+            "max_focused_simultaneous_notes": int(max_simultaneous_notes),
+            "max_duplicated_3_note_pitch_class_chunks": int(max_duplicated_3_note_chunks),
+        },
+        "previous_repair_baseline": {
+            "candidate_id": previous_candidate_id,
+            "dead_air_ratio": float(previous_dead_air),
+            "focused_unique_pitch_count": int(previous_unique_pitch_count),
+        },
+        "report_count": int(len(report_paths)),
+        "candidate_count": int(len(candidates)),
+        "qualified_candidate_count": int(qualified_count),
+        "selected_candidate": selected,
+        "sweep_summary": {
+            "selected_candidate_id": selected["candidate_id"],
+            "selected_source_run_id": selected["source_run_id"],
+            "selected_sample_index": int(selected["sample_index"]),
+            "selected_sample_seed": int(selected.get("sample_seed", 0) or 0),
+            "qualified": bool(selected["pitch_vocab_gate"]["qualified"]),
+            "remaining_flags": list(selected["pitch_vocab_gate"]["flags"]),
+            "previous_dead_air_ratio": float(previous_dead_air),
+            "selected_dead_air_ratio": selected_dead_air,
+            "dead_air_delta_from_previous": round(float(previous_dead_air) - selected_dead_air, 6),
+            "previous_focused_unique_pitch_count": int(previous_unique_pitch_count),
+            "selected_focused_unique_pitch_count": selected_unique,
+            "focused_unique_pitch_delta_from_previous": int(selected_unique - previous_unique_pitch_count),
+        },
+        "candidates": candidates,
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["sweep_summary"]
+    lines = [
+        "# Stage B Margin-Recovered Pitch Vocabulary Sweep",
+        "",
+        f"- report count: `{report['report_count']}`",
+        f"- candidate count: `{report['candidate_count']}`",
+        f"- qualified candidate count: `{report['qualified_candidate_count']}`",
+        f"- selected candidate: `{summary['selected_candidate_id']}`",
+        f"- selected source run: `{summary['selected_source_run_id']}`",
+        f"- selected sample: `{summary['selected_sample_index']}`",
+        f"- selected sample seed: `{summary['selected_sample_seed']}`",
+        f"- qualified: `{summary['qualified']}`",
+        f"- remaining flags: `{summary['remaining_flags']}`",
+        f"- dead-air delta from previous: `{summary['dead_air_delta_from_previous']:.3f}`",
+        f"- focused unique pitch delta from previous: `{summary['focused_unique_pitch_delta_from_previous']}`",
+        "",
+        "| rank | candidate | qualified | score | notes | unique | dead-air | onset | sustained | dup3 | adj repeat | flags |",
+        "|---:|---|:---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for candidate in report["candidates"][:20]:
+        focused = candidate["focused_solo_metrics"]
+        metrics = candidate["metrics"]
+        temporal = candidate["temporal_coverage"]
+        gate = candidate["pitch_vocab_gate"]
+        lines.append(
+            "| {rank} | `{candidate_id}` | {qualified} | {score:.3f} | {notes} | {unique} | "
+            "{dead_air:.3f} | {onset:.3f} | {sustained:.3f} | {dup3} | {adj} | `{flags}` |".format(
+                rank=int(candidate["sweep_rank"]),
+                candidate_id=candidate["candidate_id"],
+                qualified=bool(gate["qualified"]),
+                score=float(candidate["pitch_vocab_score"]),
+                notes=int(focused["focused_note_count"]),
+                unique=int(focused["focused_unique_pitch_count"]),
+                dead_air=float(metrics.get("dead_air_ratio", 0.0) or 0.0),
+                onset=float(temporal.get("onset_coverage_ratio", 0.0) or 0.0),
+                sustained=float(temporal.get("sustained_coverage_ratio", 0.0) or 0.0),
+                dup3=int(focused["focused_duplicated_3_note_pitch_class_chunks"]),
+                adj=int(focused["focused_adjacent_pitch_repeats"]),
+                flags=list(gate["flags"]),
+            )
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def validate_sweep(
+    report: dict[str, Any],
+    *,
+    require_qualified: bool,
+    expected_source_run_id: str | None,
+    expected_sample_index: int | None,
+) -> dict[str, Any]:
+    summary = report["sweep_summary"]
+    if require_qualified and not bool(summary["qualified"]):
+        raise MarginRecoveredPitchVocabSweepError("selected candidate is not qualified")
+    if expected_source_run_id is not None and summary["selected_source_run_id"] != expected_source_run_id:
+        raise MarginRecoveredPitchVocabSweepError(
+            f"expected source run {expected_source_run_id}, got {summary['selected_source_run_id']}"
+        )
+    if expected_sample_index is not None and int(summary["selected_sample_index"]) != int(expected_sample_index):
+        raise MarginRecoveredPitchVocabSweepError(
+            f"expected sample {expected_sample_index}, got {summary['selected_sample_index']}"
+        )
+    return {
+        "report_count": int(report["report_count"]),
+        "candidate_count": int(report["candidate_count"]),
+        "qualified_candidate_count": int(report["qualified_candidate_count"]),
+        "selected_candidate_id": str(summary["selected_candidate_id"]),
+        "selected_source_run_id": str(summary["selected_source_run_id"]),
+        "selected_sample_index": int(summary["selected_sample_index"]),
+        "selected_sample_seed": int(summary["selected_sample_seed"]),
+        "qualified": bool(summary["qualified"]),
+        "dead_air_delta_from_previous": float(summary["dead_air_delta_from_previous"]),
+        "focused_unique_pitch_delta_from_previous": int(summary["focused_unique_pitch_delta_from_previous"]),
+        "remaining_flags": list(summary["remaining_flags"]),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Summarize margin-recovered pitch vocabulary sweep")
+    parser.add_argument("--report_path", action="append", required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=str(ROOT_DIR / "outputs" / "stage_b_margin_recovered_pitch_vocab_sweep"),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--previous_candidate_id", type=str, default="margin_recovered_repair_seed_31_sample_8")
+    parser.add_argument("--previous_dead_air", type=float, default=0.29411764705882354)
+    parser.add_argument("--previous_unique_pitch_count", type=int, default=5)
+    parser.add_argument("--min_unique_pitch_count", type=int, default=6)
+    parser.add_argument("--max_dead_air_ratio", type=float, default=0.40)
+    parser.add_argument("--min_note_count", type=int, default=12)
+    parser.add_argument("--max_simultaneous_notes", type=int, default=1)
+    parser.add_argument("--max_duplicated_3_note_chunks", type=int, default=0)
+    parser.add_argument("--require_qualified", action="store_true")
+    parser.add_argument("--expected_source_run_id", type=str, default=None)
+    parser.add_argument("--expected_sample_index", type=int, default=None)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report_paths = [Path(path) for path in args.report_path]
+    report = build_sweep_report(
+        report_paths,
+        output_dir=output_dir,
+        previous_candidate_id=str(args.previous_candidate_id),
+        previous_dead_air=float(args.previous_dead_air),
+        previous_unique_pitch_count=int(args.previous_unique_pitch_count),
+        min_unique_pitch_count=int(args.min_unique_pitch_count),
+        max_dead_air_ratio=float(args.max_dead_air_ratio),
+        min_note_count=int(args.min_note_count),
+        max_simultaneous_notes=int(args.max_simultaneous_notes),
+        max_duplicated_3_note_chunks=int(args.max_duplicated_3_note_chunks),
+    )
+    summary = validate_sweep(
+        report,
+        require_qualified=bool(args.require_qualified),
+        expected_source_run_id=args.expected_source_run_id,
+        expected_sample_index=args.expected_sample_index,
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "pitch_vocab_sweep_summary.json", report)
+    write_json(output_dir / "pitch_vocab_sweep_result.json", summary)
+    (output_dir / "pitch_vocab_sweep_summary.md").write_text(markdown_report(report), encoding="utf-8")
+    summary.update(
+        {
+            "summary_path": str(output_dir / "pitch_vocab_sweep_summary.json"),
+            "markdown_path": str(output_dir / "pitch_vocab_sweep_summary.md"),
+        }
+    )
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_margin_recovered_pitch_vocab_sweep.py
+++ b/tests/test_stage_b_margin_recovered_pitch_vocab_sweep.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pretty_midi
+
+from scripts.summarize_stage_b_margin_recovered_pitch_vocab_sweep import (
+    build_sweep_report,
+    validate_sweep,
+)
+
+
+def write_midi(path: Path, pitches: list[int]) -> None:
+    midi = pretty_midi.PrettyMIDI(initial_tempo=124)
+    piano = pretty_midi.Instrument(program=0, is_drum=False, name="pitch_vocab_candidate")
+    for index, pitch in enumerate(pitches):
+        start = index * 0.25
+        piano.notes.append(pretty_midi.Note(velocity=84, pitch=pitch, start=start, end=start + 0.2))
+    midi.instruments.append(piano)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    midi.write(str(path))
+
+
+def write_report(path: Path, *, run_id: str, samples: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        __import__("json").dumps(
+            {
+                "run_id": run_id,
+                "run_dir": str(path.parent),
+                "request": {"seed": 17, "top_k": 5, "temperature": 0.9},
+                "summary": {"sample_count": len(samples)},
+                "samples": samples,
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+class StageBMarginRecoveredPitchVocabSweepTest(unittest.TestCase):
+    def test_prefers_qualified_candidate_over_higher_unique_sparse_candidate(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            sparse_midi = root / "sparse.mid"
+            qualified_midi = root / "qualified.mid"
+            write_midi(sparse_midi, [60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70])
+            write_midi(qualified_midi, [60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72])
+            report_path = root / "report.json"
+            write_report(
+                report_path,
+                run_id="test_pitch_vocab_seed17_topk5",
+                samples=[
+                    {
+                        "sample_index": 1,
+                        "sample_seed": 20,
+                        "midi_path": str(sparse_midi),
+                        "valid": True,
+                        "strict_valid": True,
+                        "grammar_gate_passed": True,
+                        "metrics": {"dead_air_ratio": 0.37, "phrase_coverage_ratio": 0.7},
+                        "temporal_coverage": {"onset_coverage_ratio": 0.5, "sustained_coverage_ratio": 0.7},
+                    },
+                    {
+                        "sample_index": 2,
+                        "sample_seed": 21,
+                        "midi_path": str(qualified_midi),
+                        "valid": True,
+                        "strict_valid": True,
+                        "grammar_gate_passed": True,
+                        "metrics": {"dead_air_ratio": 0.40, "phrase_coverage_ratio": 0.8},
+                        "temporal_coverage": {"onset_coverage_ratio": 0.5, "sustained_coverage_ratio": 0.6},
+                    },
+                ],
+            )
+
+            report = build_sweep_report(
+                [report_path],
+                output_dir=root / "sweep",
+                previous_candidate_id="previous",
+                previous_dead_air=0.29411764705882354,
+                previous_unique_pitch_count=5,
+                min_unique_pitch_count=6,
+                max_dead_air_ratio=0.40,
+                min_note_count=12,
+                max_simultaneous_notes=1,
+                max_duplicated_3_note_chunks=0,
+            )
+            summary = validate_sweep(
+                report,
+                require_qualified=True,
+                expected_source_run_id="test_pitch_vocab_seed17_topk5",
+                expected_sample_index=2,
+            )
+
+            self.assertTrue(summary["qualified"])
+            self.assertEqual(summary["qualified_candidate_count"], 1)
+            self.assertEqual(summary["selected_sample_index"], 2)
+            self.assertEqual(summary["focused_unique_pitch_delta_from_previous"], 8)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add pitch vocabulary sweep summary across multiple margin-recovered generation reports
- add harness mode for seed17/seed31 top_k5 24-sample sweep
- document Issue #256 qualified candidate and dead-air/adjacent-repeat tradeoff

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_margin_recovered_pitch_vocab_sweep
- bash scripts/agent_harness.sh stage-b-margin-recovered-pitch-vocab-sweep
- bash scripts/agent_harness.sh quick

Closes #256