### PR TITLE
Stage B pitch vocabulary focused context review

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 | 실험 결과 과장 위험 | 단일 후보 keep을 모델 완성으로 오해 가능 | proven / not proven / remaining risk 문서화 | current best focused candidate와 broad quality claim 분리 |
 | margin-recovered 후보의 focused keep 실패 | 후보 3개 모두 pitch vocabulary 부족, rank 2는 dead-air도 높음 | 기존 seed31 checkpoint에서 top_k4 12-sample repair 후보 재선별 | sample 8에서 dead-air `0.444 -> 0.294`, focused unique pitch `4 -> 5`, remaining flag `low_pitch_variety` |
 | pitch vocabulary gate 미달 | Issue #254 후보가 dead-air는 낮지만 focused unique pitch `5`에 머무름 | seed/top-k sweep으로 48개 후보 재평가 | seed17 top_k5 sample 4에서 focused unique pitch `6`, dead-air `0.400`, qualified `1/48` |
+| context review 전 후보 과장 위험 | pitch vocabulary gate 통과만으로 listening 후보라고 보기 어려움 | selected candidate를 solo/context package로 격리해 focused context decision 실행 | decision `keep_for_focused_listening`, flags `{}`, max active `1`, final `G#4` over `Fm7` chord tone |
 
 ## 파이프라인 구조
 
@@ -53,7 +54,7 @@ flowchart LR
 
 ## 핵심 결과
 
-Issue #256 기준 model-core MVP:
+Issue #258 기준 model-core MVP:
 
 | 항목 | 결과 |
 |---|---|
@@ -80,6 +81,7 @@ Issue #256 기준 model-core MVP:
 | margin-recovered fallback comparison | rank `1/2/3` 전체 focused context 비교, focused keep `0/3`, 공통 blocker low pitch variety |
 | margin-recovered pitch/dead-air repair | top_k4 12-sample 재선별로 sample `8` 선택, dead-air `0.294`, focused unique pitch `5`, remaining flag `low_pitch_variety` |
 | margin-recovered pitch vocabulary sweep | seed17/31 top_k5 48개 후보 중 `1`개 qualified, selected focused unique pitch `6`, dead-air `0.400` |
+| margin-recovered pitch vocabulary focused context | selected qualified 후보를 context package로 격리, decision `keep_for_focused_listening`, flags `{}` |
 | constrained review gate | `stage-b-overlap-gate` 통과 |
 | focused candidate path | `stage-b-rhythm-phrase-variation` 통과 |
 
@@ -109,6 +111,8 @@ MVP 근거:
 - repair sample `8`도 focused unique pitch gate `6`에는 미달하므로 focused keep이나 broad quality로 승격하지 않음
 - seed/top-k sweep 48개 후보 중 focused unique pitch `6`, dead-air `0.400`, note count `13`, duplicated 3-note chunk `0`인 qualified 후보 `1`개 확인
 - Issue #256 후보는 Issue #254 대비 dead-air가 `+0.106`, adjacent repeat이 `+2`라서 focused context review 전 최종 후보로 승격하지 않음
+- selected pitch-vocab 후보를 focused context package로 격리해 context guide 존재, max active `1`, final landing chord tone, decision `keep_for_focused_listening` 확인
+- focused context keep은 listening review 진입 조건이며, dead-air `0.400`과 adjacent repeats `3`은 다음 review risk로 유지
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`
@@ -120,7 +124,7 @@ MVP 근거:
 | 만든 것 | symbolic MIDI 생성 모델의 dataset, tokenization, training, generation, decode, objective review, proxy review pipeline |
 | 겪은 문제 | `.mid` 파일 존재만으로 성공 판단 불가, one-note collapse, long sustain block, chord block, dead-air outlier, seed-level margin 부족 |
 | 해결 방식 | duration-explicit token 구조, grammar/coverage/chord-aware probe, overlap-free postprocess, repeatability sweep, dead-air diagnostics, proxy review scoring, repair candidate selection |
-| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab sweep qualified `1/48` |
+| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab focused context `keep_for_focused_listening` |
 | 주장 경계 | reviewable MIDI 후보 생성 검증 파이프라인까지 가능, human listening preference / Brad style adaptation / broad production quality는 미검증 |
 
 Issue #210 기준 current best focused review candidate:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -73,6 +73,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered focused fallback comparison 문서: `docs/STAGE_B_MARGIN_RECOVERED_FOCUSED_FALLBACK_COMPARISON_2026-05-28.md`
 - margin-recovered pitch/dead-air repair 문서: `docs/STAGE_B_MARGIN_RECOVERED_PITCH_DEAD_AIR_REPAIR_2026-05-28.md`
 - margin-recovered pitch vocabulary sweep 문서: `docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_SWEEP_2026-05-28.md`
+- margin-recovered pitch vocabulary focused context 문서: `docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_FOCUSED_CONTEXT_2026-05-28.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -91,6 +92,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered focused fallback comparison: 후보 3개 전체 focused context 비교, focused keep `0/3`, low pitch variety `3/3`
 - margin-recovered pitch/dead-air repair: 기존 seed `31` checkpoint top_k4 12-sample 재선별, sample `8` dead-air `0.294`, focused unique pitch `5`, remaining flag `low_pitch_variety`
 - margin-recovered pitch vocabulary sweep: seed `17/31` top_k5 48개 후보 중 qualified `1`, selected unique pitch `6`, dead-air `0.400`
+- margin-recovered pitch vocabulary focused context: selected qualified 후보 focused context decision `keep_for_focused_listening`, flags `{}`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -280,6 +282,7 @@ Stage B에서 명시하는 것:
 123. Stage B margin-recovered focused fallback comparison
 124. Stage B margin-recovered pitch/dead-air repair
 125. Stage B margin-recovered pitch vocabulary sweep
+126. Stage B margin-recovered pitch vocabulary focused context review
 
 가장 최근 의미 있는 결과:
 
@@ -441,6 +444,8 @@ Stage B에서 명시하는 것:
 - Issue #254 result: dead-air improves from `0.444` to `0.294`, focused unique pitch improves from `4` to `5`, and remaining flag is `low_pitch_variety`; this is not a focused keep.
 - Issue #256 runs a seed/top-k pitch vocabulary sweep over `48` candidates and finds `1` qualified candidate.
 - Issue #256 result: selected sample has focused unique pitch `6`, dead-air `0.400`, focused notes `13`, duplicated 3-note chunks `0`, but dead-air and adjacent repeats regress from Issue #254.
+- Issue #258 isolates that selected pitch-vocabulary candidate into focused solo/context review and marks it `keep_for_focused_listening`.
+- Issue #258 result: focused context flags `{}`, max active `1`, final `G#4` over `Fm7` chord tone, with dead-air `0.400` and adjacent repeats `3` kept as listening-review risks.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -459,8 +464,8 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-Issue #256은 focused unique pitch `>= 6` 후보를 찾았지만 dead-air가 Issue #254 대비 `0.294 -> 0.400`으로 나빠졌다.
-다음 작업은 이 qualified 후보를 focused context review로 격리해 dead-air와 adjacent repeat tradeoff가 실제 blocker인지 확인하는 것이다.
+Issue #258은 pitch-vocabulary selected candidate를 focused context review까지 올렸고 `keep_for_focused_listening`으로 분리했다.
+다음 작업은 focused listening review notes를 만들어 dead-air와 adjacent repeat tradeoff를 pending review field로 넘기는 것이다.
 
 ## 6. 다음 단계 로드맵
 
@@ -986,37 +991,37 @@ Issue #256은 focused unique pitch `>= 6` 후보를 찾았지만 dead-air가 Iss
 완료된 바로 전 작업:
 
 ```text
-Stage B margin-recovered pitch vocabulary sweep
+Stage B margin-recovered pitch vocabulary focused context review
 ```
 
 결과:
 
-- docs: `docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_SWEEP_2026-05-28.md`
-- report count: `2`
-- candidate count: `48`
-- qualified candidate count: `1`
+- docs: `docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_FOCUSED_CONTEXT_2026-05-28.md`
 - selected candidate: `margin_recovered_pitch_vocab_seed_17_topk_5_temp_09_n24_sample_4`
-- focused unique pitch count: `5 -> 6` compared with Issue #254
-- dead-air: `0.294 -> 0.400` compared with Issue #254
+- focused context decision: `keep_for_focused_listening`
+- decision flags: `{}`
 - focused notes: `13`
+- unique pitch count: `6`
+- phrase span: `6.250` beats
+- dead-air: `0.400`
 - focused max active notes: `1`
 - duplicated 3-note pitch-class chunks: `0`
 - adjacent pitch repeats: `3`
-- remaining flags: `[]`
+- final note: `G#4` over `Fm7`, chord tone
+- context tracks: chord guide / bass guide / solo present
 
 판단:
 
-- selected sample은 pitch vocabulary hard gate를 통과했다.
-- dead-air는 absolute gate 안에 있지만 Issue #254보다 나빠졌다.
-- adjacent repeat도 `1 -> 3`으로 늘었다.
+- selected sample은 focused context metric gate를 통과했다.
+- dead-air `0.400`과 adjacent repeats `3`은 focused listening review risk로 남긴다.
 - broad trained-model quality, human listening preference, Brad style adaptation은 아직 미검증이다.
 
 다음 작업:
 
-- 다음 issue는 `Stage B margin-recovered pitch vocabulary focused context review`로 잡는다.
-- selected sample을 context package로 격리해 dead-air와 adjacent repeat tradeoff가 실제 blocker인지 판단한다.
+- 다음 issue는 `Stage B margin-recovered pitch vocabulary focused listening notes`로 잡는다.
+- selected sample을 focused listening notes template로 넘기고 timing / phrase continuation / vocabulary를 pending field로 기록한다.
 - max active `1`과 repeated-cell-free 조건은 유지한다.
-- focused context에서 다시 통과하기 전에는 listening review notes로 올리지 않는다.
+- 실제 listening fill 전에는 최종 keep으로 주장하지 않는다.
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #256, Stage B margin-recovered pitch vocabulary sweep
-- 다음 권장 이슈: `Stage B margin-recovered pitch vocabulary focused context review`
+- latest functional result: Issue #258, Stage B margin-recovered pitch vocabulary focused context review
+- 다음 권장 이슈: `Stage B margin-recovered pitch vocabulary focused listening notes`
 
 현재 범위가 아닌 것:
 
@@ -741,6 +741,53 @@ Issue #254 후보 대비:
 Docs:
 
 - `docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_SWEEP_2026-05-28.md`
+
+## Current Margin-Recovered Pitch Vocabulary Focused Context Result
+
+Issue #258은 Issue #256 selected candidate를 solo/context package로 격리하고 focused context decision을 실행한 작업이다.
+
+변경:
+
+- pitch vocabulary sweep summary selected candidate를 focused review notes 형태로 변환
+- 기존 margin-recovered focused package builder 재사용
+- solo-line MIDI와 chord/bass context MIDI 생성
+- focused context decision으로 keep/follow-up boundary 판단
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_pitch_vocab_focused_package`
+- `bash scripts/agent_harness.sh stage-b-margin-recovered-pitch-vocab-focused-context`
+
+결과:
+
+| 항목 | 값 |
+|---|---|
+| candidate | `margin_recovered_pitch_vocab_seed_17_topk_5_temp_09_n24_sample_4` |
+| package candidate count | `1` |
+| copied MIDI files | `2` |
+| focused context decision | `keep_for_focused_listening` |
+| decision flags | `{}` |
+| source note count | `16` |
+| focused note count | `13` |
+| focused max active notes | `1` |
+| unique pitch count | `6` |
+| range | `D#4-C5` |
+| phrase span | `6.250` beats |
+| dead-air ratio | `0.400` |
+| adjacent pitch repeats | `3` |
+| duplicated 3-note chunks | `0` |
+| final note | `G#4` over `Fm7`, chord tone |
+| context tracks | chord guide / bass guide / solo present |
+
+해석:
+
+- pitch vocabulary selected candidate는 focused context metric gate를 통과했다.
+- 이 결과는 focused listening notes로 올릴 수 있다는 뜻이지 human/audio preference 증명이 아니다.
+- dead-air가 gate 상한 `0.400`에 붙어 있고 adjacent repeats `3`이 남아 있어 다음 review risk로 기록해야 한다.
+
+Docs:
+
+- `docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_FOCUSED_CONTEXT_2026-05-28.md`
 
 ## Latest README Footer Section Removal Result
 

--- a/docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_FOCUSED_CONTEXT_2026-05-28.md
+++ b/docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_FOCUSED_CONTEXT_2026-05-28.md
@@ -1,0 +1,97 @@
+# Stage B Margin-Recovered Pitch Vocabulary Focused Context Review
+
+작성일: 2026-05-28
+
+## 목적
+
+Issue #256에서 pitch vocabulary hard gate를 통과한 후보를 focused solo/context review package로 격리한다.
+
+확인 대상:
+
+- context MIDI 생성 가능 여부
+- solo-line max active `1` 유지 여부
+- pitch vocabulary gate 통과 후보가 context 위에서도 blocker 없이 유지되는지
+- dead-air `0.400`과 adjacent repeats `3`이 다음 review risk로 남는지
+
+## 입력 후보
+
+| 항목 | 값 |
+|---|---|
+| candidate | `margin_recovered_pitch_vocab_seed_17_topk_5_temp_09_n24_sample_4` |
+| source run | `harness_stage_b_margin_recovered_pitch_vocab_seed17_topk5_temp090_n24` |
+| sample | `4` |
+| sample seed | `20` |
+| previous decision | `pitch_vocab_qualified` |
+
+## 구현
+
+- `scripts/build_stage_b_margin_recovered_pitch_vocab_focused_package.py`
+  - pitch vocabulary sweep summary의 selected candidate를 focused review notes 형태로 변환
+  - 기존 margin-recovered focused package builder 재사용
+  - solo-line MIDI와 chord/bass context MIDI 생성
+- `stage-b-margin-recovered-pitch-vocab-focused-context` harness
+  - sweep summary가 없으면 pitch vocab sweep 먼저 실행
+  - selected candidate focused package 생성
+  - focused context decision 실행
+
+## 검증
+
+```bash
+.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_pitch_vocab_focused_package
+bash scripts/agent_harness.sh stage-b-margin-recovered-pitch-vocab-focused-context
+```
+
+## 결과
+
+Focused package:
+
+| 항목 | 값 |
+|---|---:|
+| candidate count | `1` |
+| copied MIDI files | `2` |
+| source note count | `16` |
+| focused note count | `13` |
+| removed notes | `3` |
+| source max active | `2` |
+| focused max active | `1` |
+| context bars | `2` |
+
+Focused context decision:
+
+| 항목 | 값 |
+|---|---|
+| decision | `keep_for_focused_listening` |
+| decision flags | `[]` |
+| note count | `13` |
+| unique pitch count | `6` |
+| range | `D#4-C5` |
+| phrase span | `6.250` beats |
+| max active notes | `1` |
+| dead-air ratio | `0.400` |
+| onset coverage | `0.500` |
+| sustained coverage | `0.625` |
+| adjacent pitch repeats | `3` |
+| duplicated 3-note chunks | `0` |
+| final note | `G#4` over `Fm7`, chord tone |
+| context tracks | chord guide / bass guide / solo present |
+
+## 해석
+
+- selected candidate는 focused context metric gate를 통과했다.
+- context MIDI에는 chord guide, bass guide, solo track이 모두 있다.
+- solo-line postprocess 후 max active notes는 `1`이다.
+- final landing은 `G#4` over `Fm7` chord tone이다.
+- 하지만 dead-air는 gate 상한 `0.400`에 붙어 있고, adjacent pitch repeats는 `3`이다.
+- 이 결과는 focused listening notes로 올릴 수 있다는 의미이며, 실제 human/audio listening preference나 broad model quality 증명은 아니다.
+
+## 다음 작업
+
+다음 issue는 focused listening review notes 생성이다.
+
+기록해야 할 risk:
+
+- dead-air `0.400`
+- adjacent pitch repeats `3`
+- phrase span `6.250` beats
+- final landing chord-tone 여부
+- timing / phrase continuation / jazz vocabulary는 pending 상태로 유지

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -54,6 +54,8 @@ Modes:
                 Run expanded top-k sampling and select a pitch/dead-air repair candidate.
   stage-b-margin-recovered-pitch-vocab-sweep
                 Run seed/top-k sweep and select a pitch-vocabulary qualified candidate.
+  stage-b-margin-recovered-pitch-vocab-focused-context
+                Package and review the selected pitch-vocabulary sweep candidate in context.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -187,6 +189,7 @@ run_quick() {
     scripts/review_stage_b_margin_recovered_focused_context.py \
     scripts/select_stage_b_margin_recovered_repair_candidate.py \
     scripts/summarize_stage_b_margin_recovered_pitch_vocab_sweep.py \
+    scripts/build_stage_b_margin_recovered_pitch_vocab_focused_package.py \
     scripts/run_stage_b_sampling_sweep.py \
     scripts/run_stage_b_coverage_ab_sweep.py \
     scripts/run_stage_b_pitch_mode_compare.py \
@@ -517,6 +520,30 @@ run_stage_b_margin_recovered_pitch_vocab_sweep() {
     --require_qualified \
     --expected_source_run_id "$seed17_run_id" \
     --expected_sample_index 4
+}
+
+run_stage_b_margin_recovered_pitch_vocab_focused_context() {
+  local sweep_run_id="${SWEEP_RUN_ID:-harness_stage_b_margin_recovered_pitch_vocab_sweep}"
+  local package_run_id="${PACKAGE_RUN_ID:-harness_stage_b_margin_recovered_pitch_vocab_focused_package}"
+  local decision_run_id="${RUN_ID:-harness_stage_b_margin_recovered_pitch_vocab_focused_context_decision}"
+  local candidate_id="margin_recovered_pitch_vocab_seed_17_topk_5_temp_09_n24_sample_4"
+  local sweep_summary="outputs/stage_b_margin_recovered_pitch_vocab_sweep/${sweep_run_id}/pitch_vocab_sweep_summary.json"
+  if [[ ! -f "$sweep_summary" ]]; then
+    print_header "Stage B margin-recovered pitch vocabulary sweep"
+    RUN_ID="$sweep_run_id" run_stage_b_margin_recovered_pitch_vocab_sweep
+  fi
+  print_header "Stage B margin-recovered pitch vocabulary focused package"
+  "$PYTHON_BIN" scripts/build_stage_b_margin_recovered_pitch_vocab_focused_package.py \
+    --run_id "$package_run_id" \
+    --sweep_summary "$sweep_summary" \
+    --expected_candidate_id "$candidate_id"
+
+  print_header "Stage B margin-recovered pitch vocabulary focused context decision"
+  "$PYTHON_BIN" scripts/review_stage_b_margin_recovered_focused_context.py \
+    --run_id "$decision_run_id" \
+    --focused_package "outputs/stage_b_margin_recovered_pitch_vocab_focused_package/${package_run_id}/focused_review_package.json" \
+    --expected_candidate_id "$candidate_id" \
+    --expected_decision keep_for_focused_listening
 }
 
 run_stage_b_constrained_probe() {
@@ -1671,6 +1698,9 @@ case "$MODE" in
     ;;
   stage-b-margin-recovered-pitch-vocab-sweep)
     run_stage_b_margin_recovered_pitch_vocab_sweep
+    ;;
+  stage-b-margin-recovered-pitch-vocab-focused-context)
+    run_stage_b_margin_recovered_pitch_vocab_focused_context
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/build_stage_b_margin_recovered_pitch_vocab_focused_package.py
+++ b/scripts/build_stage_b_margin_recovered_pitch_vocab_focused_package.py
@@ -1,0 +1,165 @@
+"""Build a focused package from a margin-recovered pitch vocabulary sweep result."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.build_stage_b_margin_recovered_focused_package import (  # noqa: E402
+    build_margin_recovered_focused_package,
+    markdown_report,
+    read_json,
+    validate_package,
+)
+from scripts.build_stage_b_margin_recovered_listening_notes import write_json  # noqa: E402
+
+
+class MarginRecoveredPitchVocabFocusedPackageError(ValueError):
+    pass
+
+
+DEFAULT_DECISION = "pitch_vocab_qualified"
+
+
+def selected_candidate(sweep_summary: dict[str, Any]) -> dict[str, Any]:
+    candidate = sweep_summary.get("selected_candidate")
+    if not isinstance(candidate, dict):
+        raise MarginRecoveredPitchVocabFocusedPackageError("sweep summary must contain selected_candidate")
+    return candidate
+
+
+def review_notes_from_sweep(
+    sweep_summary: dict[str, Any],
+    *,
+    decision: str = DEFAULT_DECISION,
+) -> dict[str, Any]:
+    candidate = selected_candidate(sweep_summary)
+    candidate_id = str(candidate.get("candidate_id") or "")
+    midi_path = str(candidate.get("midi_path") or "")
+    if not candidate_id:
+        raise MarginRecoveredPitchVocabFocusedPackageError("selected candidate_id is required")
+    if not midi_path:
+        raise MarginRecoveredPitchVocabFocusedPackageError("selected candidate midi_path is required")
+    metrics = dict(candidate.get("metrics") or {})
+    temporal = dict(candidate.get("temporal_coverage") or {})
+    focused = dict(candidate.get("focused_solo_metrics") or {})
+    gate = candidate.get("pitch_vocab_gate") if isinstance(candidate.get("pitch_vocab_gate"), dict) else {}
+    summary = sweep_summary.get("sweep_summary") if isinstance(sweep_summary.get("sweep_summary"), dict) else {}
+    return {
+        "schema_version": "stage_b_margin_recovered_pitch_vocab_focused_review_notes_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "source_pitch_vocab_sweep": str(sweep_summary.get("output_dir") or ""),
+        "candidates": [
+            {
+                "candidate_id": candidate_id,
+                "review_metadata": {
+                    "mode": "margin_recovered_pitch_vocab_sweep",
+                    "review_rank": 1,
+                    "source_run_id": str(candidate.get("source_run_id") or ""),
+                    "sample_index": int(candidate.get("sample_index", 0) or 0),
+                    "sample_seed": int(candidate.get("sample_seed", 0) or 0),
+                },
+                "review_files": {
+                    "midi_path": midi_path,
+                },
+                "source_metrics": {
+                    **metrics,
+                    **temporal,
+                    "focused_note_count": int(focused.get("focused_note_count", 0) or 0),
+                    "focused_unique_pitch_count": int(focused.get("focused_unique_pitch_count", 0) or 0),
+                    "focused_adjacent_pitch_repeats": int(focused.get("focused_adjacent_pitch_repeats", 0) or 0),
+                    "focused_duplicated_3_note_pitch_class_chunks": int(
+                        focused.get("focused_duplicated_3_note_pitch_class_chunks", 0) or 0
+                    ),
+                    "previous_dead_air_delta": float(summary.get("dead_air_delta_from_previous", 0.0) or 0.0),
+                    "previous_unique_pitch_delta": int(
+                        summary.get("focused_unique_pitch_delta_from_previous", 0) or 0
+                    ),
+                },
+                "listening": {
+                    "decision": str(decision),
+                    "phrase_quality": "pending_context",
+                    "timing": "pending_context",
+                    "chord_fit": "pending_context",
+                    "jazz_vocabulary": "pending_context",
+                    "notes": "Selected by pitch vocabulary sweep; not a human listening decision.",
+                },
+                "objective_review": {
+                    "objective_flags": list(gate.get("flags") or []),
+                    "qualified": bool(gate.get("qualified", False)),
+                },
+            }
+        ],
+    }
+
+
+def build_pitch_vocab_focused_package(
+    sweep_summary: dict[str, Any],
+    *,
+    output_dir: Path,
+    decision: str = DEFAULT_DECISION,
+) -> dict[str, Any]:
+    review_notes = review_notes_from_sweep(sweep_summary, decision=decision)
+    package = build_margin_recovered_focused_package(
+        review_notes,
+        output_dir=output_dir,
+        decision=decision,
+    )
+    package["source_pitch_vocab_sweep"] = str(sweep_summary.get("output_dir") or "")
+    package["pitch_vocab_sweep_summary"] = dict(sweep_summary.get("sweep_summary") or {})
+    return package
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build focused package from pitch vocabulary sweep")
+    parser.add_argument("--sweep_summary", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=str(ROOT_DIR / "outputs" / "stage_b_margin_recovered_pitch_vocab_focused_package"),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--decision", type=str, default=DEFAULT_DECISION)
+    parser.add_argument("--expected_candidate_id", type=str, default="")
+    parser.add_argument("--min_candidates", type=int, default=1)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    sweep_summary = read_json(Path(args.sweep_summary))
+    package = build_pitch_vocab_focused_package(
+        sweep_summary,
+        output_dir=output_dir,
+        decision=str(args.decision),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "focused_review_package.json", package)
+    (output_dir / "focused_review_package.md").write_text(markdown_report(package), encoding="utf-8")
+    summary = validate_package(
+        package,
+        expected_candidate_id=str(args.expected_candidate_id or ""),
+        min_candidates=int(args.min_candidates),
+    )
+    summary.update(
+        {
+            "package_path": str(output_dir / "focused_review_package.json"),
+            "markdown_path": str(output_dir / "focused_review_package.md"),
+        }
+    )
+    write_json(output_dir / "focused_review_package_summary.json", summary)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_margin_recovered_pitch_vocab_focused_package.py
+++ b/tests/test_stage_b_margin_recovered_pitch_vocab_focused_package.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pretty_midi
+
+from scripts.build_stage_b_margin_recovered_pitch_vocab_focused_package import (
+    DEFAULT_DECISION,
+    build_pitch_vocab_focused_package,
+    validate_package,
+)
+
+
+def write_midi(path: Path) -> None:
+    midi = pretty_midi.PrettyMIDI(initial_tempo=124)
+    piano = pretty_midi.Instrument(program=0, is_drum=False, name="pitch_vocab")
+    for index, pitch in enumerate([63, 65, 67, 68, 70, 72, 70, 68, 67, 65, 63, 65, 67]):
+        start = index * 0.25
+        piano.notes.append(pretty_midi.Note(velocity=84, pitch=pitch, start=start, end=start + 0.2))
+    midi.instruments.append(piano)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    midi.write(str(path))
+
+
+def write_report(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "request": {
+                    "chord_progression": ["Cm7", "Fm7", "Bb7", "Ebmaj7"],
+                    "bpm": 124,
+                    "bars": 2,
+                }
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def sweep_summary(root: Path) -> dict:
+    sample_path = root / "generation" / "samples" / "stage_b_sample_4.mid"
+    write_midi(sample_path)
+    write_report(root / "generation" / "report.json")
+    return {
+        "output_dir": str(root / "sweep"),
+        "sweep_summary": {
+            "selected_candidate_id": "pitch_vocab_candidate",
+            "dead_air_delta_from_previous": -0.105882,
+            "focused_unique_pitch_delta_from_previous": 1,
+        },
+        "selected_candidate": {
+            "candidate_id": "pitch_vocab_candidate",
+            "sample_index": 4,
+            "sample_seed": 20,
+            "source_run_id": "test_pitch_vocab_run",
+            "midi_path": str(sample_path),
+            "metrics": {
+                "note_count": 16,
+                "unique_pitch_count": 6,
+                "dead_air_ratio": 0.4,
+            },
+            "temporal_coverage": {
+                "onset_coverage_ratio": 0.5,
+                "sustained_coverage_ratio": 0.625,
+            },
+            "focused_solo_metrics": {
+                "focused_note_count": 13,
+                "focused_unique_pitch_count": 6,
+                "focused_adjacent_pitch_repeats": 3,
+                "focused_duplicated_3_note_pitch_class_chunks": 0,
+            },
+            "pitch_vocab_gate": {
+                "qualified": True,
+                "flags": [],
+            },
+        },
+    }
+
+
+class StageBMarginRecoveredPitchVocabFocusedPackageTest(unittest.TestCase):
+    def test_builds_focused_package_from_selected_sweep_candidate(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            package = build_pitch_vocab_focused_package(
+                sweep_summary(root),
+                output_dir=root / "package",
+                decision=DEFAULT_DECISION,
+            )
+            summary = validate_package(
+                package,
+                expected_candidate_id="pitch_vocab_candidate",
+                min_candidates=1,
+            )
+
+            self.assertEqual(summary["candidate_count"], 1)
+            self.assertEqual(summary["candidate_ids"], ["pitch_vocab_candidate"])
+            candidate = package["candidates"][0]
+            self.assertTrue(Path(candidate["review_files"]["midi_path"]).exists())
+            self.assertTrue(Path(candidate["review_files"]["context_midi_path"]).exists())
+            self.assertEqual(candidate["listening"]["decision"], DEFAULT_DECISION)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add adapter to build a focused context package from the pitch vocabulary sweep selected candidate
- add harness mode for focused package and focused context decision
- document Issue #258 context decision and remaining listening-review risks

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_margin_recovered_pitch_vocab_focused_package
- bash scripts/agent_harness.sh stage-b-margin-recovered-pitch-vocab-focused-context
- bash scripts/agent_harness.sh quick

Closes #258