### PR TITLE
Stage B pitch vocabulary focused listening fill

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 | pitch vocabulary gate 미달 | Issue #254 후보가 dead-air는 낮지만 focused unique pitch `5`에 머무름 | seed/top-k sweep으로 48개 후보 재평가 | seed17 top_k5 sample 4에서 focused unique pitch `6`, dead-air `0.400`, qualified `1/48` |
 | context review 전 후보 과장 위험 | pitch vocabulary gate 통과만으로 listening 후보라고 보기 어려움 | selected candidate를 solo/context package로 격리해 focused context decision 실행 | decision `keep_for_focused_listening`, flags `{}`, max active `1`, final `G#4` over `Fm7` chord tone |
 | 청감 리뷰 기록 누락 위험 | context keep 후보라도 실제 timing/phrase/vocabulary 판단은 별도 기록 필요 | focused listening notes template 생성 | candidate `1`, pending `1`, risks `dead_air_ratio_at_gate`, `adjacent_pitch_repeats` |
+| focused listening fill 후 최종 keep 실패 | dead-air가 gate 상한이고 adjacent repeat가 남음 | MIDI/context evidence 기준 listening fields 채움 | timing `stiff`, phrase `weak`, vocabulary `thin`, decision `needs_followup` |
 
 ## 파이프라인 구조
 
@@ -55,7 +56,7 @@ flowchart LR
 
 ## 핵심 결과
 
-Issue #260 기준 model-core MVP:
+Issue #262 기준 model-core MVP:
 
 | 항목 | 결과 |
 |---|---|
@@ -84,6 +85,7 @@ Issue #260 기준 model-core MVP:
 | margin-recovered pitch vocabulary sweep | seed17/31 top_k5 48개 후보 중 `1`개 qualified, selected focused unique pitch `6`, dead-air `0.400` |
 | margin-recovered pitch vocabulary focused context | selected qualified 후보를 context package로 격리, decision `keep_for_focused_listening`, flags `{}` |
 | margin-recovered pitch vocabulary focused listening notes | focused listening template 생성, candidate `1`, pending `1`, prior decision `keep_for_focused_listening` |
+| margin-recovered pitch vocabulary focused listening fill | reviewed `1`, pending `0`, decision `needs_followup`, timing `stiff`, vocabulary `thin` |
 | constrained review gate | `stage-b-overlap-gate` 통과 |
 | focused candidate path | `stage-b-rhythm-phrase-variation` 통과 |
 
@@ -116,6 +118,7 @@ MVP 근거:
 - selected pitch-vocab 후보를 focused context package로 격리해 context guide 존재, max active `1`, final landing chord tone, decision `keep_for_focused_listening` 확인
 - focused context keep은 listening review 진입 조건이며, dead-air `0.400`과 adjacent repeats `3`은 다음 review risk로 유지
 - focused listening notes template에 prior decision `keep_for_focused_listening`, pending fields, review risks `dead_air_ratio_at_gate` / `adjacent_pitch_repeats` 기록
+- focused listening fill에서 chord fit과 landing은 `strong`이지만 timing `stiff`, phrase continuation `weak`, jazz vocabulary `thin`으로 `needs_followup` 판정
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -75,6 +75,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered pitch vocabulary sweep 문서: `docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_SWEEP_2026-05-28.md`
 - margin-recovered pitch vocabulary focused context 문서: `docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_FOCUSED_CONTEXT_2026-05-28.md`
 - margin-recovered pitch vocabulary focused listening notes 문서: `docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_FOCUSED_LISTENING_NOTES_2026-05-28.md`
+- margin-recovered pitch vocabulary focused listening fill 문서: `docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_FOCUSED_LISTENING_FILL_2026-05-28.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -95,6 +96,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered pitch vocabulary sweep: seed `17/31` top_k5 48개 후보 중 qualified `1`, selected unique pitch `6`, dead-air `0.400`
 - margin-recovered pitch vocabulary focused context: selected qualified 후보 focused context decision `keep_for_focused_listening`, flags `{}`
 - margin-recovered pitch vocabulary focused listening notes: candidate `1`, pending `1`, prior decision `keep_for_focused_listening`, risks `dead_air_ratio_at_gate` / `adjacent_pitch_repeats`
+- margin-recovered pitch vocabulary focused listening fill: reviewed `1`, decision `needs_followup`, timing `stiff`, chord fit `strong`, vocabulary `thin`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -286,6 +288,7 @@ Stage B에서 명시하는 것:
 125. Stage B margin-recovered pitch vocabulary sweep
 126. Stage B margin-recovered pitch vocabulary focused context review
 127. Stage B margin-recovered pitch vocabulary focused listening notes
+128. Stage B margin-recovered pitch vocabulary focused listening fill
 
 가장 최근 의미 있는 결과:
 
@@ -451,6 +454,8 @@ Stage B에서 명시하는 것:
 - Issue #258 result: focused context flags `{}`, max active `1`, final `G#4` over `Fm7` chord tone, with dead-air `0.400` and adjacent repeats `3` kept as listening-review risks.
 - Issue #260 creates focused listening review notes for that candidate with pending listening fields and explicit risks.
 - Issue #260 result: candidate `1`, pending `1`, prior decision `keep_for_focused_listening`, risks `dead_air_ratio_at_gate` and `adjacent_pitch_repeats`.
+- Issue #262 fills the focused listening notes from MIDI/context evidence and downgrades the candidate to `needs_followup`.
+- Issue #262 result: timing `stiff`, chord fit `strong`, phrase continuation `weak`, landing `strong`, jazz vocabulary `thin`.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -469,8 +474,8 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-Issue #260은 focused listening review notes를 만들었고 실제 listening decision은 아직 `pending`이다.
-다음 작업은 MIDI/context evidence를 기준으로 timing, phrase continuation, landing, vocabulary를 채우는 focused listening fill이다.
+Issue #262는 focused listening fill에서 selected candidate를 `needs_followup`으로 내렸다.
+다음 작업은 pitch vocabulary gate를 유지하면서 dead-air와 adjacent repeats를 줄이는 timing/repetition follow-up repair다.
 
 ## 6. 다음 단계 로드맵
 
@@ -996,35 +1001,38 @@ Issue #260은 focused listening review notes를 만들었고 실제 listening de
 완료된 바로 전 작업:
 
 ```text
-Stage B margin-recovered pitch vocabulary focused listening notes
+Stage B margin-recovered pitch vocabulary focused listening fill
 ```
 
 결과:
 
-- docs: `docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_FOCUSED_LISTENING_NOTES_2026-05-28.md`
+- docs: `docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_FOCUSED_LISTENING_FILL_2026-05-28.md`
 - selected candidate: `margin_recovered_pitch_vocab_seed_17_topk_5_temp_09_n24_sample_4`
-- candidate count: `1`
-- reviewed count: `0`
-- pending count: `1`
+- reviewed count: `1`
+- pending count: `0`
 - prior decision: `keep_for_focused_listening`
-- listening decision: `pending`
-- review risks: `dead_air_ratio_at_gate`, `adjacent_pitch_repeats`
+- final decision: `needs_followup`
+- timing: `stiff`
+- chord fit: `strong`
+- phrase continuation: `weak`
+- landing: `strong`
+- jazz vocabulary: `thin`
 - dead-air ratio: `0.400`
 - adjacent pitch repeats: `3`
 - final note: `G#4` over `Fm7`, chord tone
 
 판단:
 
-- focused listening review notes template은 준비됐다.
-- 실제 listening decision은 아직 없다.
+- chord fit과 landing은 blocker가 아니다.
+- timing, phrase continuation, vocabulary가 blocker다.
 - broad trained-model quality, human listening preference, Brad style adaptation은 아직 미검증이다.
 
 다음 작업:
 
-- 다음 issue는 `Stage B margin-recovered pitch vocabulary focused listening fill`로 잡는다.
-- MIDI/context evidence를 기준으로 timing / phrase continuation / landing / vocabulary / decision을 채운다.
+- 다음 issue는 `Stage B margin-recovered pitch vocabulary timing/repetition follow-up repair`로 잡는다.
+- pitch vocabulary gate를 유지하면서 dead-air와 adjacent repeats를 줄인다.
 - max active `1`과 repeated-cell-free 조건은 유지한다.
-- fill 전에는 최종 keep으로 주장하지 않는다.
+- focused listening fill에서 다시 keep이 나오기 전에는 최종 keep으로 주장하지 않는다.
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #260, Stage B margin-recovered pitch vocabulary focused listening notes
-- 다음 권장 이슈: `Stage B margin-recovered pitch vocabulary focused listening fill`
+- latest functional result: Issue #262, Stage B margin-recovered pitch vocabulary focused listening fill
+- 다음 권장 이슈: `Stage B margin-recovered pitch vocabulary timing/repetition follow-up repair`
 
 현재 범위가 아닌 것:
 
@@ -829,6 +829,48 @@ Issue #260은 Issue #258 focused context keep 후보를 focused listening review
 Docs:
 
 - `docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_FOCUSED_LISTENING_NOTES_2026-05-28.md`
+
+## Current Margin-Recovered Pitch Vocabulary Focused Listening Fill Result
+
+Issue #262는 Issue #260 pending notes를 MIDI/context evidence 기준으로 채운 작업이다.
+
+변경:
+
+- focused listening notes fill script 추가
+- dead-air, adjacent repeat, phrase span, final landing evidence를 fill output에 보존
+- timing / phrase continuation / vocabulary risk를 decision에 반영
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_pitch_vocab_focused_listening_fill`
+- `bash scripts/agent_harness.sh stage-b-margin-recovered-pitch-vocab-focused-listening-fill`
+
+결과:
+
+| 항목 | 값 |
+|---|---|
+| candidate | `margin_recovered_pitch_vocab_seed_17_topk_5_temp_09_n24_sample_4` |
+| reviewed count | `1` |
+| pending count | `0` |
+| prior decision | `keep_for_focused_listening` |
+| final decision | `needs_followup` |
+| timing | `stiff` |
+| chord fit | `strong` |
+| phrase continuation | `weak` |
+| landing | `strong` |
+| jazz vocabulary | `thin` |
+| dead-air ratio | `0.400` |
+| adjacent pitch repeats | `3` |
+
+해석:
+
+- chord fit과 landing은 blocker가 아니다.
+- timing, phrase continuation, vocabulary가 blocker다.
+- 다음 작업은 pitch vocabulary gate를 유지하면서 dead-air와 adjacent repeats를 줄이는 follow-up repair다.
+
+Docs:
+
+- `docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_FOCUSED_LISTENING_FILL_2026-05-28.md`
 
 ## Latest README Footer Section Removal Result
 

--- a/docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_FOCUSED_LISTENING_FILL_2026-05-28.md
+++ b/docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_FOCUSED_LISTENING_FILL_2026-05-28.md
@@ -1,0 +1,83 @@
+# Stage B Margin-Recovered Pitch Vocabulary Focused Listening Fill
+
+작성일: 2026-05-28
+
+## 목적
+
+Issue #260 focused listening notes template의 pending fields를 MIDI/context evidence 기준으로 채운다.
+
+이 작업은 human/audio listening proof가 아니라, 기존 metric과 context decision을 근거로 다음 repair 방향을 분리하는 proxy fill이다.
+
+## 입력
+
+| 항목 | 값 |
+|---|---|
+| candidate | `margin_recovered_pitch_vocab_seed_17_topk_5_temp_09_n24_sample_4` |
+| prior decision | `keep_for_focused_listening` |
+| review risks | `dead_air_ratio_at_gate`, `adjacent_pitch_repeats` |
+
+## 구현
+
+- `scripts/fill_stage_b_margin_recovered_pitch_vocab_focused_listening_notes.py`
+  - focused listening notes template를 읽어 reviewed state로 채움
+  - dead-air, adjacent repeat, phrase span, final landing evidence를 보존
+  - timing / phrase continuation / jazz vocabulary risk를 decision에 반영
+- `stage-b-margin-recovered-pitch-vocab-focused-listening-fill` harness
+  - notes template이 없으면 Issue #260 harness 선행 실행
+  - expected decision `needs_followup` 검증
+
+## 검증
+
+```bash
+.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_pitch_vocab_focused_listening_fill
+bash scripts/agent_harness.sh stage-b-margin-recovered-pitch-vocab-focused-listening-fill
+```
+
+## 결과
+
+| 항목 | 값 |
+|---|---|
+| candidate count | `1` |
+| reviewed count | `1` |
+| pending count | `0` |
+| prior decision | `keep_for_focused_listening` |
+| final decision | `needs_followup` |
+| timing | `stiff` |
+| chord fit | `strong` |
+| phrase continuation | `weak` |
+| landing | `strong` |
+| jazz vocabulary | `thin` |
+
+Evidence:
+
+| 항목 | 값 |
+|---|---:|
+| dead-air ratio | `0.400` |
+| adjacent pitch repeats | `3` |
+| phrase span | `6.250` beats |
+| final note | `G#4` over `Fm7`, chord tone |
+
+## 해석
+
+- chord fit과 landing은 blocker가 아니다.
+- timing은 dead-air가 gate 상한에 붙어 있어 `stiff`로 기록한다.
+- phrase continuation은 span과 dead-air tradeoff 때문에 `weak`으로 둔다.
+- jazz vocabulary는 adjacent repeats와 unique pitch 경계 때문에 `thin`으로 둔다.
+- 따라서 selected pitch-vocab 후보는 final keep이 아니라 `needs_followup`이다.
+
+## 다음 작업
+
+다음 issue는 pitch vocabulary를 유지하면서 dead-air와 adjacent repeats를 줄이는 follow-up repair다.
+
+유지 조건:
+
+- focused unique pitch count `>= 6`
+- focused max active notes `1`
+- duplicated 3-note chunks `0`
+- final landing chord tone 또는 tension
+
+개선 목표:
+
+- dead-air ratio `< 0.400`
+- adjacent pitch repeats `< 3`
+- phrase continuation `acceptable` 이상

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -58,6 +58,8 @@ Modes:
                 Package and review the selected pitch-vocabulary sweep candidate in context.
   stage-b-margin-recovered-pitch-vocab-focused-listening-notes
                 Build focused listening notes for the selected pitch-vocabulary candidate.
+  stage-b-margin-recovered-pitch-vocab-focused-listening-fill
+                Fill the selected pitch-vocabulary focused listening review notes.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -193,6 +195,7 @@ run_quick() {
     scripts/summarize_stage_b_margin_recovered_pitch_vocab_sweep.py \
     scripts/build_stage_b_margin_recovered_pitch_vocab_focused_package.py \
     scripts/build_stage_b_margin_recovered_pitch_vocab_focused_listening_notes.py \
+    scripts/fill_stage_b_margin_recovered_pitch_vocab_focused_listening_notes.py \
     scripts/run_stage_b_sampling_sweep.py \
     scripts/run_stage_b_coverage_ab_sweep.py \
     scripts/run_stage_b_pitch_mode_compare.py \
@@ -567,6 +570,23 @@ run_stage_b_margin_recovered_pitch_vocab_focused_listening_notes() {
     --focused_context_decision "$decision_path" \
     --expected_candidate_id "$candidate_id" \
     --expected_prior_decision keep_for_focused_listening
+}
+
+run_stage_b_margin_recovered_pitch_vocab_focused_listening_fill() {
+  local notes_run_id="${NOTES_RUN_ID:-harness_stage_b_margin_recovered_pitch_vocab_focused_listening_notes}"
+  local run_id="${RUN_ID:-harness_stage_b_margin_recovered_pitch_vocab_focused_listening_fill}"
+  local candidate_id="margin_recovered_pitch_vocab_seed_17_topk_5_temp_09_n24_sample_4"
+  local review_notes="outputs/stage_b_margin_recovered_pitch_vocab_focused_listening_notes/${notes_run_id}/focused_listening_review_notes_template.json"
+  if [[ ! -f "$review_notes" ]]; then
+    print_header "Stage B margin-recovered pitch vocabulary focused listening notes"
+    RUN_ID="$notes_run_id" run_stage_b_margin_recovered_pitch_vocab_focused_listening_notes
+  fi
+  print_header "Stage B margin-recovered pitch vocabulary focused listening fill"
+  "$PYTHON_BIN" scripts/fill_stage_b_margin_recovered_pitch_vocab_focused_listening_notes.py \
+    --run_id "$run_id" \
+    --review_notes "$review_notes" \
+    --expected_candidate_id "$candidate_id" \
+    --expected_decision needs_followup
 }
 
 run_stage_b_constrained_probe() {
@@ -1727,6 +1747,9 @@ case "$MODE" in
     ;;
   stage-b-margin-recovered-pitch-vocab-focused-listening-notes)
     run_stage_b_margin_recovered_pitch_vocab_focused_listening_notes
+    ;;
+  stage-b-margin-recovered-pitch-vocab-focused-listening-fill)
+    run_stage_b_margin_recovered_pitch_vocab_focused_listening_fill
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/fill_stage_b_margin_recovered_pitch_vocab_focused_listening_notes.py
+++ b/scripts/fill_stage_b_margin_recovered_pitch_vocab_focused_listening_notes.py
@@ -1,0 +1,179 @@
+"""Fill pitch-vocabulary focused listening notes from MIDI/context evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.build_stage_b_margin_recovered_listening_notes import write_json  # noqa: E402
+from scripts.build_stage_b_margin_recovered_pitch_vocab_focused_listening_notes import (  # noqa: E402
+    read_json,
+    validate_notes,
+)
+
+
+class PitchVocabFocusedListeningFillError(ValueError):
+    pass
+
+
+def fill_candidate(candidate: dict[str, Any]) -> dict[str, Any]:
+    filled = json.loads(json.dumps(candidate))
+    metrics = filled.get("focused_context_metrics") if isinstance(filled.get("focused_context_metrics"), dict) else {}
+    risks = set(str(risk) for risk in filled.get("review_risks", []))
+    dead_air = float(metrics.get("dead_air_ratio", 0.0) or 0.0)
+    adjacent_repeats = int(metrics.get("adjacent_pitch_repeats", 0) or 0)
+    unique_pitch = int(metrics.get("unique_pitch_count", 0) or 0)
+    phrase_span = float(metrics.get("phrase_span_beats", 0.0) or 0.0)
+    final_role = str(metrics.get("final_note_role") or "")
+    timing = "stiff" if dead_air >= 0.40 or "dead_air_ratio_at_gate" in risks else "acceptable"
+    chord_fit = "strong" if final_role == "chord_tone" else "acceptable" if final_role == "tension" else "unclear"
+    phrase_continuation = "weak" if phrase_span < 7.0 or dead_air >= 0.40 else "acceptable"
+    landing = "strong" if final_role == "chord_tone" else "acceptable" if final_role == "tension" else "weak"
+    jazz_vocabulary = "thin" if adjacent_repeats > 0 or unique_pitch <= 6 else "acceptable"
+    decision = "needs_followup"
+    if timing == "acceptable" and phrase_continuation == "acceptable" and jazz_vocabulary == "acceptable":
+        decision = "keep"
+    if unique_pitch < 4 or phrase_span < 4.0:
+        decision = "reject"
+    filled["listening"] = {
+        "status": "reviewed",
+        "timing": timing,
+        "chord_fit": chord_fit,
+        "phrase_continuation": phrase_continuation,
+        "landing": landing,
+        "jazz_vocabulary": jazz_vocabulary,
+        "decision": decision,
+        "notes": (
+            "MIDI/context evidence fill. Dead-air is at the gate and adjacent pitch repeats remain; "
+            "treat as follow-up, not final listening proof."
+        ),
+    }
+    filled["listening_fill_evidence"] = {
+        "not_human_audio_review": True,
+        "dead_air_ratio": dead_air,
+        "adjacent_pitch_repeats": adjacent_repeats,
+        "phrase_span_beats": phrase_span,
+        "final_note": str(metrics.get("final_note") or ""),
+        "final_chord": str(metrics.get("final_chord") or ""),
+        "final_note_role": final_role,
+        "review_risks": sorted(risks),
+    }
+    return filled
+
+
+def fill_notes(notes: dict[str, Any]) -> dict[str, Any]:
+    candidates = notes.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise PitchVocabFocusedListeningFillError("notes must contain candidates")
+    filled = json.loads(json.dumps(notes))
+    filled["schema_version"] = "stage_b_margin_recovered_pitch_vocab_focused_listening_fill_v1"
+    filled["filled_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    filled["fill_method"] = {
+        "source": "MIDI/context evidence",
+        "not_human_audio_review": True,
+    }
+    filled["candidates"] = [fill_candidate(candidate) for candidate in candidates]
+    return filled
+
+
+def markdown_report(notes: dict[str, Any], summary: dict[str, Any]) -> str:
+    lines = [
+        "# Stage B Margin-Recovered Pitch Vocabulary Focused Listening Fill",
+        "",
+        f"- candidate count: `{summary['candidate_count']}`",
+        f"- reviewed count: `{summary['reviewed_count']}`",
+        f"- pending count: `{summary['pending_count']}`",
+        f"- decisions: `{summary['decision_counts']}`",
+        "",
+        "This is a MIDI/context evidence fill, not a human audio listening proof.",
+        "",
+        "| candidate | timing | chord fit | phrase | landing | vocabulary | decision | risks |",
+        "|---|---|---|---|---|---|---|---|",
+    ]
+    for candidate in notes["candidates"]:
+        listening = candidate["listening"]
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(candidate.get("candidate_id") or ""),
+                    str(listening.get("timing") or ""),
+                    str(listening.get("chord_fit") or ""),
+                    str(listening.get("phrase_continuation") or ""),
+                    str(listening.get("landing") or ""),
+                    str(listening.get("jazz_vocabulary") or ""),
+                    str(listening.get("decision") or ""),
+                    ",".join(candidate.get("review_risks") or []),
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def validate_fill(
+    notes: dict[str, Any],
+    *,
+    expected_candidate_id: str | None,
+    expected_decision: str | None,
+) -> dict[str, Any]:
+    generic_notes = dict(notes)
+    generic_notes["schema_version"] = "stage_b_margin_recovered_pitch_vocab_focused_listening_notes_v1"
+    summary = validate_notes(
+        generic_notes,
+        expected_candidate_id=expected_candidate_id,
+        expected_prior_decision="keep_for_focused_listening",
+    )
+    if expected_decision:
+        decisions = [str(candidate.get("listening", {}).get("decision") or "") for candidate in notes["candidates"]]
+        if decisions != [expected_decision]:
+            raise PitchVocabFocusedListeningFillError(f"expected decision {expected_decision}, got {decisions}")
+    return summary
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Fill pitch vocabulary focused listening notes")
+    parser.add_argument("--review_notes", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=str(ROOT_DIR / "outputs" / "stage_b_margin_recovered_pitch_vocab_focused_listening_fill"),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--expected_candidate_id", type=str, default="")
+    parser.add_argument("--expected_decision", type=str, default="")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    notes = read_json(Path(args.review_notes))
+    filled = fill_notes(notes)
+    summary = validate_fill(
+        filled,
+        expected_candidate_id=str(args.expected_candidate_id or ""),
+        expected_decision=str(args.expected_decision or ""),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    filled_path = output_dir / "focused_listening_review_notes_filled.json"
+    write_json(filled_path, filled)
+    write_json(output_dir / "focused_listening_review_notes_fill_summary.json", summary)
+    (output_dir / "focused_listening_review_notes_filled.md").write_text(
+        markdown_report(filled, summary),
+        encoding="utf-8",
+    )
+    print(json.dumps({**summary, "filled_notes_path": str(filled_path)}, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_margin_recovered_pitch_vocab_focused_listening_fill.py
+++ b/tests/test_stage_b_margin_recovered_pitch_vocab_focused_listening_fill.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.fill_stage_b_margin_recovered_pitch_vocab_focused_listening_notes import (
+    fill_notes,
+    validate_fill,
+)
+
+
+class StageBMarginRecoveredPitchVocabFocusedListeningFillTest(unittest.TestCase):
+    def sample_notes(self) -> dict:
+        return {
+            "schema_version": "stage_b_margin_recovered_pitch_vocab_focused_listening_notes_v1",
+            "candidates": [
+                {
+                    "candidate_id": "pitch_vocab_candidate",
+                    "review_files": {
+                        "midi_path": "outputs/pitch.mid",
+                        "context_midi_path": "outputs/pitch_context.mid",
+                    },
+                    "proxy_review": {
+                        "decision": "keep_for_focused_listening",
+                    },
+                    "focused_context_metrics": {
+                        "note_count": 13,
+                        "unique_pitch_count": 6,
+                        "phrase_span_beats": 6.25,
+                        "dead_air_ratio": 0.4,
+                        "adjacent_pitch_repeats": 3,
+                        "duplicated_3_note_pitch_class_chunks": 0,
+                        "max_simultaneous_notes": 1,
+                        "final_note": "G#4",
+                        "final_chord": "Fm7",
+                        "final_note_role": "chord_tone",
+                    },
+                    "review_risks": ["dead_air_ratio_at_gate", "adjacent_pitch_repeats"],
+                    "listening": {
+                        "status": "pending",
+                        "timing": "pending",
+                        "chord_fit": "pending",
+                        "phrase_continuation": "pending",
+                        "landing": "pending",
+                        "jazz_vocabulary": "pending",
+                        "decision": "pending",
+                        "notes": "",
+                    },
+                }
+            ],
+        }
+
+    def test_fill_marks_candidate_as_needs_followup_with_evidence(self) -> None:
+        filled = fill_notes(self.sample_notes())
+        summary = validate_fill(
+            filled,
+            expected_candidate_id="pitch_vocab_candidate",
+            expected_decision="needs_followup",
+        )
+        candidate = filled["candidates"][0]
+
+        self.assertEqual(summary["reviewed_count"], 1)
+        self.assertEqual(summary["pending_count"], 0)
+        self.assertEqual(candidate["listening"]["timing"], "stiff")
+        self.assertEqual(candidate["listening"]["chord_fit"], "strong")
+        self.assertEqual(candidate["listening"]["decision"], "needs_followup")
+        self.assertTrue(candidate["listening_fill_evidence"]["not_human_audio_review"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add MIDI/context evidence fill for pitch vocabulary focused listening notes
- mark the selected candidate as needs_followup with timing/phrase/vocabulary rationale
- document Issue #262 result and next repair boundary

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_margin_recovered_pitch_vocab_focused_listening_fill
- bash scripts/agent_harness.sh stage-b-margin-recovered-pitch-vocab-focused-listening-fill
- bash scripts/agent_harness.sh quick

Closes #262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Stage B margin-recovered pitch vocabulary focused listening process documentation with execution details, outcomes, and verification procedures.
  * Added comprehensive results documentation including decision criteria and quality metrics.

* **Tests**
  * Added test coverage for pitch vocabulary focused listening fill functionality.

* **Chores**
  * Enhanced internal workflow tooling to support automated focused listening fill operations with validation and reporting capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohhalim/fine_tuning_art-tatum_midi_solo/pull/263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->