### PR TITLE
Stage B margin-recovered timing/repetition repair

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #111, Stage B clean context phrase diagnostics.
+- Latest functional issue completed: Issue #264, Stage B margin-recovered pitch vocabulary timing/repetition follow-up repair.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B clean listening review notes for the 3 objective-clean context candidates.
+- Recommended next issue: Stage B margin-recovered timing/repetition focused context review.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -418,6 +418,14 @@ bash scripts/agent_harness.sh stage-b-longer-phrase-probe
 ```
 
 This harness tests a 4-bar coverage+chord-aware constrained phrase and exports the top review MIDI candidates. It exists because short 2-bar candidates can be valid but still feel unfinished.
+
+For Stage B margin-recovered timing/repetition repair changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-margin-recovered-timing-repetition-repair
+```
+
+This harness tests whether the selected pitch-vocabulary candidate can keep focused unique pitch coverage while reducing dead-air and adjacent pitch repetition.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 | context review 전 후보 과장 위험 | pitch vocabulary gate 통과만으로 listening 후보라고 보기 어려움 | selected candidate를 solo/context package로 격리해 focused context decision 실행 | decision `keep_for_focused_listening`, flags `{}`, max active `1`, final `G#4` over `Fm7` chord tone |
 | 청감 리뷰 기록 누락 위험 | context keep 후보라도 실제 timing/phrase/vocabulary 판단은 별도 기록 필요 | focused listening notes template 생성 | candidate `1`, pending `1`, risks `dead_air_ratio_at_gate`, `adjacent_pitch_repeats` |
 | focused listening fill 후 최종 keep 실패 | dead-air가 gate 상한이고 adjacent repeat가 남음 | MIDI/context evidence 기준 listening fields 채움 | timing `stiff`, phrase `weak`, vocabulary `thin`, decision `needs_followup` |
+| timing/repetition repair 필요 | Issue #262 후보의 chord fit과 landing은 strong이지만 timing과 phrase continuation이 약함 | top_k7, temperature `0.86`, seed `37/41` sweep으로 dead-air와 adjacent repeat 동시 개선 후보 선택 | selected sample `39`, dead-air `0.400 -> 0.353`, adjacent repeats `3 -> 2`, unique pitch `6 -> 7` |
 
 ## 파이프라인 구조
 
@@ -56,7 +57,7 @@ flowchart LR
 
 ## 핵심 결과
 
-Issue #262 기준 model-core MVP:
+Issue #264 기준 model-core MVP:
 
 | 항목 | 결과 |
 |---|---|
@@ -86,6 +87,7 @@ Issue #262 기준 model-core MVP:
 | margin-recovered pitch vocabulary focused context | selected qualified 후보를 context package로 격리, decision `keep_for_focused_listening`, flags `{}` |
 | margin-recovered pitch vocabulary focused listening notes | focused listening template 생성, candidate `1`, pending `1`, prior decision `keep_for_focused_listening` |
 | margin-recovered pitch vocabulary focused listening fill | reviewed `1`, pending `0`, decision `needs_followup`, timing `stiff`, vocabulary `thin` |
+| margin-recovered timing/repetition repair | seed37/41 top_k7 temp0.86 96개 후보 중 `2`개 qualified, sample `39` 선택, dead-air `0.353`, adjacent repeats `2` |
 | constrained review gate | `stage-b-overlap-gate` 통과 |
 | focused candidate path | `stage-b-rhythm-phrase-variation` 통과 |
 
@@ -119,6 +121,8 @@ MVP 근거:
 - focused context keep은 listening review 진입 조건이며, dead-air `0.400`과 adjacent repeats `3`은 다음 review risk로 유지
 - focused listening notes template에 prior decision `keep_for_focused_listening`, pending fields, review risks `dead_air_ratio_at_gate` / `adjacent_pitch_repeats` 기록
 - focused listening fill에서 chord fit과 landing은 `strong`이지만 timing `stiff`, phrase continuation `weak`, jazz vocabulary `thin`으로 `needs_followup` 판정
+- timing/repetition repair sweep에서 focused unique pitch `7`, note count `14`, max active `1`, duplicated 3-note chunk `0`, dead-air `0.353`, adjacent repeats `2`인 qualified 후보 선택
+- Issue #264 후보는 Issue #262 대비 objective timing/repetition metric은 개선됐지만, focused context/listening 재검증 전 최종 keep으로 보지 않음
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`
@@ -130,7 +134,7 @@ MVP 근거:
 | 만든 것 | symbolic MIDI 생성 모델의 dataset, tokenization, training, generation, decode, objective review, proxy review pipeline |
 | 겪은 문제 | `.mid` 파일 존재만으로 성공 판단 불가, one-note collapse, long sustain block, chord block, dead-air outlier, seed-level margin 부족 |
 | 해결 방식 | duration-explicit token 구조, grammar/coverage/chord-aware probe, overlap-free postprocess, repeatability sweep, dead-air diagnostics, proxy review scoring, repair candidate selection |
-| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab focused context `keep_for_focused_listening` |
+| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab focused context `keep_for_focused_listening`, timing/repetition repair qualified `2/96` |
 | 주장 경계 | reviewable MIDI 후보 생성 검증 파이프라인까지 가능, human listening preference / Brad style adaptation / broad production quality는 미검증 |
 
 Issue #210 기준 current best focused review candidate:
@@ -168,7 +172,7 @@ Issue #210 기준 current best focused review candidate:
 |---|---|
 | broad unconstrained trained-model generation quality | 미검증 |
 | broad multi-seed model quality | 부분 검증 / 6-file 3-seed 5-sample local sweep hard gate 통과, seed-level margin warning 해소 |
-| dead-air outlier control | 부분 검증 / candidate selection gate와 sample-level repair 추가, pitch vocabulary gate는 미완료 |
+| dead-air outlier control | 부분 검증 / candidate selection gate, pitch vocabulary gate, timing/repetition repair 추가 |
 | human/audio listening preference | 미검증 |
 | Brad Mehldau style adaptation | 미검증 |
 | generic jazz pianist base 완성 | 미검증 |

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -76,6 +76,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered pitch vocabulary focused context 문서: `docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_FOCUSED_CONTEXT_2026-05-28.md`
 - margin-recovered pitch vocabulary focused listening notes 문서: `docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_FOCUSED_LISTENING_NOTES_2026-05-28.md`
 - margin-recovered pitch vocabulary focused listening fill 문서: `docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_FOCUSED_LISTENING_FILL_2026-05-28.md`
+- margin-recovered timing/repetition repair 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_REPAIR_2026-05-28.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -97,6 +98,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered pitch vocabulary focused context: selected qualified 후보 focused context decision `keep_for_focused_listening`, flags `{}`
 - margin-recovered pitch vocabulary focused listening notes: candidate `1`, pending `1`, prior decision `keep_for_focused_listening`, risks `dead_air_ratio_at_gate` / `adjacent_pitch_repeats`
 - margin-recovered pitch vocabulary focused listening fill: reviewed `1`, decision `needs_followup`, timing `stiff`, chord fit `strong`, vocabulary `thin`
+- margin-recovered timing/repetition repair: seed `37/41` top_k7 temp0.86 96개 후보 중 qualified `2`, selected sample `39`, dead-air `0.353`, adjacent repeats `2`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -289,6 +291,7 @@ Stage B에서 명시하는 것:
 126. Stage B margin-recovered pitch vocabulary focused context review
 127. Stage B margin-recovered pitch vocabulary focused listening notes
 128. Stage B margin-recovered pitch vocabulary focused listening fill
+129. Stage B margin-recovered pitch vocabulary timing/repetition follow-up repair
 
 가장 최근 의미 있는 결과:
 
@@ -456,6 +459,8 @@ Stage B에서 명시하는 것:
 - Issue #260 result: candidate `1`, pending `1`, prior decision `keep_for_focused_listening`, risks `dead_air_ratio_at_gate` and `adjacent_pitch_repeats`.
 - Issue #262 fills the focused listening notes from MIDI/context evidence and downgrades the candidate to `needs_followup`.
 - Issue #262 result: timing `stiff`, chord fit `strong`, phrase continuation `weak`, landing `strong`, jazz vocabulary `thin`.
+- Issue #264 runs a top_k7 temperature `0.86` timing/repetition sweep over seed `37/41`.
+- Issue #264 result: selected sample `39` keeps focused unique pitch `7`, max active `1`, duplicated 3-note chunks `0`, and improves dead-air `0.400 -> 0.353` plus adjacent repeats `3 -> 2`; focused context/listening 재검증은 아직 남아 있다.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -474,8 +479,8 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-Issue #262는 focused listening fill에서 selected candidate를 `needs_followup`으로 내렸다.
-다음 작업은 pitch vocabulary gate를 유지하면서 dead-air와 adjacent repeats를 줄이는 timing/repetition follow-up repair다.
+Issue #264는 pitch vocabulary gate를 유지하면서 dead-air와 adjacent repeats를 줄인 qualified 후보를 찾았다.
+다음 작업은 이 후보를 focused solo/context package로 격리하고 context decision과 focused listening fill을 다시 실행하는 것이다.
 
 ## 6. 다음 단계 로드맵
 
@@ -1001,37 +1006,35 @@ Issue #262는 focused listening fill에서 selected candidate를 `needs_followup
 완료된 바로 전 작업:
 
 ```text
-Stage B margin-recovered pitch vocabulary focused listening fill
+Stage B margin-recovered pitch vocabulary timing/repetition follow-up repair
 ```
 
 결과:
 
-- docs: `docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_FOCUSED_LISTENING_FILL_2026-05-28.md`
-- selected candidate: `margin_recovered_pitch_vocab_seed_17_topk_5_temp_09_n24_sample_4`
-- reviewed count: `1`
-- pending count: `0`
-- prior decision: `keep_for_focused_listening`
-- final decision: `needs_followup`
-- timing: `stiff`
-- chord fit: `strong`
-- phrase continuation: `weak`
-- landing: `strong`
-- jazz vocabulary: `thin`
-- dead-air ratio: `0.400`
-- adjacent pitch repeats: `3`
-- final note: `G#4` over `Fm7`, chord tone
+- docs: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_REPAIR_2026-05-28.md`
+- selected candidate: `margin_recovered_timing_repetition_seed_37_topk_7_temp_086_n48_sample_39`
+- selected source run: `harness_stage_b_margin_recovered_timing_repetition_seed37_topk7_temp086_n48`
+- selected sample seed: `75`
+- qualified candidates: `2/96`
+- dead-air ratio: `0.353`
+- adjacent pitch repeats: `2`
+- focused unique pitch count: `7`
+- focused note count: `14`
+- focused max active notes: `1`
+- duplicated 3-note chunks: `0`
+- remaining flags: `[]`
 
 판단:
 
-- chord fit과 landing은 blocker가 아니다.
-- timing, phrase continuation, vocabulary가 blocker다.
+- objective timing/repetition metric은 Issue #262 후보보다 개선됐다.
+- 아직 focused context package와 focused listening fill을 다시 통과한 것은 아니다.
 - broad trained-model quality, human listening preference, Brad style adaptation은 아직 미검증이다.
 
 다음 작업:
 
-- 다음 issue는 `Stage B margin-recovered pitch vocabulary timing/repetition follow-up repair`로 잡는다.
-- pitch vocabulary gate를 유지하면서 dead-air와 adjacent repeats를 줄인다.
-- max active `1`과 repeated-cell-free 조건은 유지한다.
+- 다음 issue는 `Stage B margin-recovered timing/repetition focused context review`로 잡는다.
+- selected candidate를 solo/context package로 격리한다.
+- final landing, phrase span, context guide, max active, repeated cell을 다시 검증한다.
 - focused listening fill에서 다시 keep이 나오기 전에는 최종 keep으로 주장하지 않는다.
 
 ## 10. 한 문장 요약

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #262, Stage B margin-recovered pitch vocabulary focused listening fill
-- 다음 권장 이슈: `Stage B margin-recovered pitch vocabulary timing/repetition follow-up repair`
+- latest functional result: Issue #264, Stage B margin-recovered pitch vocabulary timing/repetition follow-up repair
+- 다음 권장 이슈: `Stage B margin-recovered timing/repetition focused context review`
 
 현재 범위가 아닌 것:
 
@@ -866,11 +866,63 @@ Issue #262는 Issue #260 pending notes를 MIDI/context evidence 기준으로 채
 
 - chord fit과 landing은 blocker가 아니다.
 - timing, phrase continuation, vocabulary가 blocker다.
-- 다음 작업은 pitch vocabulary gate를 유지하면서 dead-air와 adjacent repeats를 줄이는 follow-up repair다.
+- 이 결과가 Issue #264 timing/repetition follow-up repair의 입력이 됐다.
 
 Docs:
 
 - `docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_FOCUSED_LISTENING_FILL_2026-05-28.md`
+
+## Current Margin-Recovered Timing/Repetition Repair Result
+
+Issue #264는 Issue #262에서 남은 timing/repetition blocker를 focused metric 기준으로 좁게 repair한 작업이다.
+
+변경:
+
+- timing/repetition repair summary script 추가
+- seed `37/41`, top_k `7`, temperature `0.86`, n `48` generation harness 추가
+- qualified gate를 `dead_air < 0.400`, `adjacent repeats < 3`, `focused unique pitch >= 6`, `focused notes >= 12`, `max active = 1`, `dup3 = 0`로 고정
+- 이전 pitch-vocabulary 후보 대비 dead-air, adjacent repeat, unique pitch, note count delta 기록
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_timing_repetition_repair`
+- `bash scripts/agent_harness.sh stage-b-margin-recovered-timing-repetition-repair`
+
+결과:
+
+| 항목 | 값 |
+|---|---|
+| candidate | `margin_recovered_timing_repetition_seed_37_topk_7_temp_086_n48_sample_39` |
+| source run | `harness_stage_b_margin_recovered_timing_repetition_seed37_topk7_temp086_n48` |
+| sample seed | `75` |
+| qualified candidates | `2/96` |
+| focused note count | `14` |
+| focused unique pitch count | `7` |
+| focused max active notes | `1` |
+| duplicated 3-note chunks | `0` |
+| dead-air ratio | `0.353` |
+| adjacent pitch repeats | `2` |
+| remaining flags | `[]` |
+
+Issue #262 후보 대비:
+
+| 항목 | 이전 | 이번 | 변화 |
+|---|---:|---:|---:|
+| dead-air ratio | `0.400` | `0.353` | `+0.047` 개선 |
+| adjacent pitch repeats | `3` | `2` | `+1` 개선 |
+| focused unique pitch count | `6` | `7` | `+1` |
+| focused note count | `13` | `14` | `+1` |
+
+해석:
+
+- pitch vocabulary gate를 유지하면서 dead-air와 adjacent repeat는 개선됐다.
+- selected candidate는 objective gate 기준 qualified candidate다.
+- 아직 focused context package와 focused listening fill을 다시 통과한 것은 아니다.
+- 다음 작업은 selected candidate를 solo/context package로 격리하고 context decision을 다시 실행하는 것이다.
+
+Docs:
+
+- `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_REPAIR_2026-05-28.md`
 
 ## Latest README Footer Section Removal Result
 

--- a/docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_REPAIR_2026-05-28.md
+++ b/docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_REPAIR_2026-05-28.md
@@ -1,0 +1,68 @@
+# Stage B Margin-Recovered Timing/Repetition Repair
+
+## 요약
+
+Issue #264는 Issue #262 focused listening fill에서 남은 timing/repetition 문제를 좁게 repair한 작업이다.
+
+이전 pitch-vocabulary 후보는 focused unique pitch `6`, max active `1`, duplicated 3-note chunk `0` 조건은 만족했지만, dead-air가 gate 상한 `0.400`에 걸렸고 adjacent pitch repeats가 `3`으로 남아 focused listening fill에서 `needs_followup`으로 내려갔다.
+
+이번 작업은 같은 checkpoint에서 top-k/temperature 조건을 조정해 pitch vocabulary gate를 유지하면서 dead-air와 adjacent repeat를 동시에 줄이는 후보를 다시 선택했다.
+
+## 변경
+
+- timing/repetition repair sweep summary script 추가
+- seed `37/41`, top_k `7`, temperature `0.86`, n `48` generation harness 추가
+- qualified gate를 `dead_air < 0.400`, `adjacent repeats < 3`, `focused unique pitch >= 6`, `focused notes >= 12`, `max active = 1`, `dup3 = 0`로 고정
+- 이전 Issue #262 후보 대비 delta를 summary JSON/Markdown에 기록
+
+## 결과
+
+| 항목 | 값 |
+|---|---|
+| selected candidate | `margin_recovered_timing_repetition_seed_37_topk_7_temp_086_n48_sample_39` |
+| source run | `harness_stage_b_margin_recovered_timing_repetition_seed37_topk7_temp086_n48` |
+| selected sample | `39` |
+| selected sample seed | `75` |
+| report count | `2` |
+| candidate count | `96` |
+| qualified candidate count | `2` |
+| qualified | `true` |
+| remaining flags | `[]` |
+| focused note count | `14` |
+| focused unique pitch count | `7` |
+| focused max active notes | `1` |
+| duplicated 3-note pitch-class chunks | `0` |
+| dead-air ratio | `0.353` |
+| adjacent pitch repeats | `2` |
+| onset coverage | `0.500` |
+| sustained coverage | `0.688` |
+
+Issue #262 후보 대비:
+
+| 항목 | 이전 | 이번 | 변화 |
+|---|---:|---:|---:|
+| dead-air ratio | `0.400` | `0.353` | `+0.047` 개선 |
+| adjacent pitch repeats | `3` | `2` | `+1` 개선 |
+| focused unique pitch count | `6` | `7` | `+1` |
+| focused note count | `13` | `14` | `+1` |
+
+## 해석
+
+- pitch vocabulary gate를 유지하면서 timing/repetition objective는 개선됐다.
+- selected candidate는 objective gate 기준 qualified candidate다.
+- 아직 focused context package와 focused listening fill을 다시 통과한 것은 아니다.
+- human listening preference, broad model quality, Brad style adaptation은 여전히 미검증이다.
+
+## 검증
+
+```bash
+.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_timing_repetition_repair
+bash scripts/agent_harness.sh stage-b-margin-recovered-timing-repetition-repair
+```
+
+## 산출물
+
+- script: `scripts/summarize_stage_b_margin_recovered_timing_repetition_repair.py`
+- test: `tests/test_stage_b_margin_recovered_timing_repetition_repair.py`
+- harness: `stage-b-margin-recovered-timing-repetition-repair`
+- summary: `outputs/stage_b_margin_recovered_timing_repetition_repair/harness_stage_b_margin_recovered_timing_repetition_repair/timing_repetition_repair_summary.json`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -60,6 +60,8 @@ Modes:
                 Build focused listening notes for the selected pitch-vocabulary candidate.
   stage-b-margin-recovered-pitch-vocab-focused-listening-fill
                 Fill the selected pitch-vocabulary focused listening review notes.
+  stage-b-margin-recovered-timing-repetition-repair
+                Run top-k/temperature repair sweep and select a timing/repetition improved candidate.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -196,6 +198,7 @@ run_quick() {
     scripts/build_stage_b_margin_recovered_pitch_vocab_focused_package.py \
     scripts/build_stage_b_margin_recovered_pitch_vocab_focused_listening_notes.py \
     scripts/fill_stage_b_margin_recovered_pitch_vocab_focused_listening_notes.py \
+    scripts/summarize_stage_b_margin_recovered_timing_repetition_repair.py \
     scripts/run_stage_b_sampling_sweep.py \
     scripts/run_stage_b_coverage_ab_sweep.py \
     scripts/run_stage_b_pitch_mode_compare.py \
@@ -587,6 +590,60 @@ run_stage_b_margin_recovered_pitch_vocab_focused_listening_fill() {
     --review_notes "$review_notes" \
     --expected_candidate_id "$candidate_id" \
     --expected_decision needs_followup
+}
+
+run_stage_b_margin_recovered_timing_repetition_repair() {
+  local seed37_run_id="${SEED37_RUN_ID:-harness_stage_b_margin_recovered_timing_repetition_seed37_topk7_temp086_n48}"
+  local seed41_run_id="${SEED41_RUN_ID:-harness_stage_b_margin_recovered_timing_repetition_seed41_topk7_temp086_n48}"
+  local run_id="${RUN_ID:-harness_stage_b_margin_recovered_timing_repetition_repair}"
+  local checkpoint_dir="${CHECKPOINT_DIR:-outputs/stage_b_generation_probe/issue_238_stage_b_candidate_count_margin_recovery_seed31_files6/checkpoints}"
+  print_header "Stage B margin-recovered timing/repetition repair seed 37"
+  "$PYTHON_BIN" scripts/run_stage_b_generation_probe.py \
+    --run_id "$seed37_run_id" \
+    --checkpoint_dir "$checkpoint_dir" \
+    --skip_prepare \
+    --skip_train \
+    --seed 37 \
+    --max_files 6 \
+    --max_sequence 96 \
+    --num_samples 48 \
+    --temperature 0.86 \
+    --top_k 7 \
+    --postprocess_overlap \
+    --max_simultaneous_notes 2 \
+    --require_valid_sample \
+    --require_strict_valid_sample \
+    --require_note_groups \
+    --issue_number 264
+
+  print_header "Stage B margin-recovered timing/repetition repair seed 41"
+  "$PYTHON_BIN" scripts/run_stage_b_generation_probe.py \
+    --run_id "$seed41_run_id" \
+    --checkpoint_dir "$checkpoint_dir" \
+    --skip_prepare \
+    --skip_train \
+    --seed 41 \
+    --max_files 6 \
+    --max_sequence 96 \
+    --num_samples 48 \
+    --temperature 0.86 \
+    --top_k 7 \
+    --postprocess_overlap \
+    --max_simultaneous_notes 2 \
+    --require_valid_sample \
+    --require_strict_valid_sample \
+    --require_note_groups \
+    --issue_number 264
+
+  print_header "Stage B margin-recovered timing/repetition repair summary"
+  "$PYTHON_BIN" scripts/summarize_stage_b_margin_recovered_timing_repetition_repair.py \
+    --run_id "$run_id" \
+    --report_path "outputs/stage_b_generation_probe/${seed37_run_id}/report.json" \
+    --report_path "outputs/stage_b_generation_probe/${seed41_run_id}/report.json" \
+    --require_qualified \
+    --require_timing_repetition_improvement \
+    --expected_source_run_id "$seed37_run_id" \
+    --expected_sample_index 39
 }
 
 run_stage_b_constrained_probe() {
@@ -1750,6 +1807,9 @@ case "$MODE" in
     ;;
   stage-b-margin-recovered-pitch-vocab-focused-listening-fill)
     run_stage_b_margin_recovered_pitch_vocab_focused_listening_fill
+    ;;
+  stage-b-margin-recovered-timing-repetition-repair)
+    run_stage_b_margin_recovered_timing_repetition_repair
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/summarize_stage_b_margin_recovered_timing_repetition_repair.py
+++ b/scripts/summarize_stage_b_margin_recovered_timing_repetition_repair.py
@@ -1,0 +1,405 @@
+"""Summarize a Stage B timing/repetition repair sweep for a pitch-vocab candidate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.build_stage_b_margin_recovered_listening_notes import write_json  # noqa: E402
+from scripts.select_stage_b_margin_recovered_repair_candidate import (  # noqa: E402
+    build_candidates,
+    read_json,
+)
+from scripts.summarize_stage_b_margin_recovered_pitch_vocab_sweep import safe_label  # noqa: E402
+
+
+class MarginRecoveredTimingRepetitionRepairError(ValueError):
+    pass
+
+
+def float_value(value: Any, default: float) -> float:
+    if value is None:
+        return float(default)
+    return float(value)
+
+
+def candidate_gate_flags(
+    candidate: dict[str, Any],
+    *,
+    min_unique_pitch_count: int,
+    max_dead_air_ratio_exclusive: float,
+    min_note_count: int,
+    max_simultaneous_notes: int,
+    max_duplicated_3_note_chunks: int,
+    max_adjacent_pitch_repeats_exclusive: int,
+) -> list[str]:
+    focused = candidate["focused_solo_metrics"]
+    metrics = candidate["metrics"]
+    flags: list[str] = []
+    if int(focused.get("focused_unique_pitch_count", 0) or 0) < min_unique_pitch_count:
+        flags.append("low_pitch_variety")
+    if float_value(metrics.get("dead_air_ratio"), 1.0) >= max_dead_air_ratio_exclusive:
+        flags.append("dead_air_not_repaired")
+    if int(focused.get("focused_note_count", 0) or 0) < min_note_count:
+        flags.append("too_sparse_for_context_review")
+    if int(focused.get("focused_max_simultaneous_notes", 0) or 0) > max_simultaneous_notes:
+        flags.append("focused_polyphony")
+    if int(focused.get("focused_duplicated_3_note_pitch_class_chunks", 0) or 0) > max_duplicated_3_note_chunks:
+        flags.append("repeated_pitch_class_cell")
+    if int(focused.get("focused_adjacent_pitch_repeats", 0) or 0) >= max_adjacent_pitch_repeats_exclusive:
+        flags.append("adjacent_repetition_not_repaired")
+    return flags
+
+
+def repair_score(candidate: dict[str, Any], *, qualified: bool) -> float:
+    focused = candidate["focused_solo_metrics"]
+    metrics = candidate["metrics"]
+    temporal = candidate["temporal_coverage"]
+    score = 1000.0 if qualified else 0.0
+    score += (1.0 - min(1.0, float_value(metrics.get("dead_air_ratio"), 1.0))) * 160.0
+    score += min(10, int(focused.get("focused_unique_pitch_count", 0) or 0)) * 24.0
+    score += min(16, int(focused.get("focused_note_count", 0) or 0)) * 4.0
+    score += float(temporal.get("onset_coverage_ratio", 0.0) or 0.0) * 18.0
+    score += float(temporal.get("sustained_coverage_ratio", 0.0) or 0.0) * 8.0
+    score -= int(focused.get("focused_adjacent_pitch_repeats", 0) or 0) * 12.0
+    score -= int(focused.get("focused_duplicated_3_note_pitch_class_chunks", 0) or 0) * 40.0
+    return round(float(score), 6)
+
+
+def enrich_candidates(
+    report: dict[str, Any],
+    *,
+    report_path: Path,
+    min_unique_pitch_count: int,
+    max_dead_air_ratio_exclusive: float,
+    min_note_count: int,
+    max_simultaneous_notes: int,
+    max_duplicated_3_note_chunks: int,
+    max_adjacent_pitch_repeats_exclusive: int,
+) -> list[dict[str, Any]]:
+    source_run_id = str(report.get("run_id") or report_path.parent.name)
+    request = dict(report.get("request") or {})
+    summary = dict(report.get("summary") or {})
+    request_seed = int(request.get("seed", 0) or 0)
+    top_k = request.get("top_k")
+    temperature = request.get("temperature")
+    sample_count = int(summary.get("sample_count", len(report.get("samples") or [])) or 0)
+    rows = build_candidates(report)
+    enriched: list[dict[str, Any]] = []
+    for row in rows:
+        row = dict(row)
+        row["source_run_id"] = source_run_id
+        row["source_report_path"] = str(report_path)
+        row["source_request"] = {
+            "seed": request_seed,
+            "top_k": top_k,
+            "temperature": temperature,
+            "sample_count": sample_count,
+        }
+        row["candidate_id"] = (
+            "margin_recovered_timing_repetition_seed_{seed}_topk_{top_k}_temp_{temperature}_n{count}_sample_{sample}".format(
+                seed=request_seed,
+                top_k=safe_label(top_k),
+                temperature=safe_label(temperature),
+                count=sample_count,
+                sample=int(row.get("sample_index", 0) or 0),
+            )
+        )
+        flags = candidate_gate_flags(
+            row,
+            min_unique_pitch_count=min_unique_pitch_count,
+            max_dead_air_ratio_exclusive=max_dead_air_ratio_exclusive,
+            min_note_count=min_note_count,
+            max_simultaneous_notes=max_simultaneous_notes,
+            max_duplicated_3_note_chunks=max_duplicated_3_note_chunks,
+            max_adjacent_pitch_repeats_exclusive=max_adjacent_pitch_repeats_exclusive,
+        )
+        row["timing_repetition_gate"] = {
+            "qualified": not flags,
+            "flags": flags,
+        }
+        row["timing_repetition_score"] = repair_score(row, qualified=not flags)
+        enriched.append(row)
+    return enriched
+
+
+def build_repair_report(
+    report_paths: list[Path],
+    *,
+    output_dir: Path,
+    previous_candidate_id: str,
+    previous_dead_air: float,
+    previous_unique_pitch_count: int,
+    previous_note_count: int,
+    previous_adjacent_pitch_repeats: int,
+    min_unique_pitch_count: int,
+    max_dead_air_ratio_exclusive: float,
+    min_note_count: int,
+    max_simultaneous_notes: int,
+    max_duplicated_3_note_chunks: int,
+    max_adjacent_pitch_repeats_exclusive: int,
+) -> dict[str, Any]:
+    if not report_paths:
+        raise MarginRecoveredTimingRepetitionRepairError("at least one report path is required")
+    candidates: list[dict[str, Any]] = []
+    for path in report_paths:
+        report = read_json(path)
+        candidates.extend(
+            enrich_candidates(
+                report,
+                report_path=path,
+                min_unique_pitch_count=min_unique_pitch_count,
+                max_dead_air_ratio_exclusive=max_dead_air_ratio_exclusive,
+                min_note_count=min_note_count,
+                max_simultaneous_notes=max_simultaneous_notes,
+                max_duplicated_3_note_chunks=max_duplicated_3_note_chunks,
+                max_adjacent_pitch_repeats_exclusive=max_adjacent_pitch_repeats_exclusive,
+            )
+        )
+    if not candidates:
+        raise MarginRecoveredTimingRepetitionRepairError("no candidates found")
+    candidates.sort(
+        key=lambda row: (
+            not bool(row["timing_repetition_gate"]["qualified"]),
+            -float(row["timing_repetition_score"]),
+            float_value(row["metrics"].get("dead_air_ratio"), 1.0),
+            int(row["focused_solo_metrics"].get("focused_adjacent_pitch_repeats", 0) or 0),
+            -int(row["focused_solo_metrics"].get("focused_unique_pitch_count", 0) or 0),
+            -int(row["focused_solo_metrics"].get("focused_note_count", 0) or 0),
+            str(row["source_run_id"]),
+            int(row["sample_index"]),
+        )
+    )
+    for index, row in enumerate(candidates, start=1):
+        row["repair_rank"] = int(index)
+    selected = candidates[0]
+    focused = selected["focused_solo_metrics"]
+    metrics = selected["metrics"]
+    selected_dead_air = float(metrics.get("dead_air_ratio", 0.0) or 0.0)
+    selected_unique = int(focused.get("focused_unique_pitch_count", 0) or 0)
+    selected_note_count = int(focused.get("focused_note_count", 0) or 0)
+    selected_adjacent_repeats = int(focused.get("focused_adjacent_pitch_repeats", 0) or 0)
+    qualified_count = sum(1 for row in candidates if row["timing_repetition_gate"]["qualified"])
+    return {
+        "schema_version": "stage_b_margin_recovered_timing_repetition_repair_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_report_paths": [str(path) for path in report_paths],
+        "thresholds": {
+            "min_focused_unique_pitch_count": int(min_unique_pitch_count),
+            "max_dead_air_ratio_exclusive": float(max_dead_air_ratio_exclusive),
+            "min_focused_note_count": int(min_note_count),
+            "max_focused_simultaneous_notes": int(max_simultaneous_notes),
+            "max_duplicated_3_note_pitch_class_chunks": int(max_duplicated_3_note_chunks),
+            "max_adjacent_pitch_repeats_exclusive": int(max_adjacent_pitch_repeats_exclusive),
+        },
+        "previous_pitch_vocab_candidate": {
+            "candidate_id": previous_candidate_id,
+            "dead_air_ratio": float(previous_dead_air),
+            "focused_unique_pitch_count": int(previous_unique_pitch_count),
+            "focused_note_count": int(previous_note_count),
+            "focused_adjacent_pitch_repeats": int(previous_adjacent_pitch_repeats),
+        },
+        "report_count": int(len(report_paths)),
+        "candidate_count": int(len(candidates)),
+        "qualified_candidate_count": int(qualified_count),
+        "selected_candidate": selected,
+        "repair_summary": {
+            "selected_candidate_id": selected["candidate_id"],
+            "selected_source_run_id": selected["source_run_id"],
+            "selected_sample_index": int(selected["sample_index"]),
+            "selected_sample_seed": int(selected.get("sample_seed", 0) or 0),
+            "qualified": bool(selected["timing_repetition_gate"]["qualified"]),
+            "remaining_flags": list(selected["timing_repetition_gate"]["flags"]),
+            "previous_dead_air_ratio": float(previous_dead_air),
+            "selected_dead_air_ratio": selected_dead_air,
+            "dead_air_delta_from_previous": round(float(previous_dead_air) - selected_dead_air, 6),
+            "previous_focused_unique_pitch_count": int(previous_unique_pitch_count),
+            "selected_focused_unique_pitch_count": selected_unique,
+            "focused_unique_pitch_delta_from_previous": int(selected_unique - previous_unique_pitch_count),
+            "previous_focused_note_count": int(previous_note_count),
+            "selected_focused_note_count": selected_note_count,
+            "focused_note_delta_from_previous": int(selected_note_count - previous_note_count),
+            "previous_adjacent_pitch_repeats": int(previous_adjacent_pitch_repeats),
+            "selected_adjacent_pitch_repeats": selected_adjacent_repeats,
+            "adjacent_pitch_repeat_delta_from_previous": int(
+                previous_adjacent_pitch_repeats - selected_adjacent_repeats
+            ),
+            "timing_repetition_improved": bool(
+                selected_dead_air < float(previous_dead_air)
+                and selected_adjacent_repeats < int(previous_adjacent_pitch_repeats)
+            ),
+        },
+        "candidates": candidates,
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["repair_summary"]
+    lines = [
+        "# Stage B Margin-Recovered Timing/Repetition Repair",
+        "",
+        f"- report count: `{report['report_count']}`",
+        f"- candidate count: `{report['candidate_count']}`",
+        f"- qualified candidate count: `{report['qualified_candidate_count']}`",
+        f"- selected candidate: `{summary['selected_candidate_id']}`",
+        f"- selected source run: `{summary['selected_source_run_id']}`",
+        f"- selected sample: `{summary['selected_sample_index']}`",
+        f"- selected sample seed: `{summary['selected_sample_seed']}`",
+        f"- qualified: `{summary['qualified']}`",
+        f"- remaining flags: `{summary['remaining_flags']}`",
+        f"- dead-air delta from previous: `{summary['dead_air_delta_from_previous']:.3f}`",
+        f"- adjacent repeat delta from previous: `{summary['adjacent_pitch_repeat_delta_from_previous']}`",
+        f"- focused unique pitch delta from previous: `{summary['focused_unique_pitch_delta_from_previous']}`",
+        f"- focused note delta from previous: `{summary['focused_note_delta_from_previous']}`",
+        "",
+        "| rank | candidate | qualified | score | notes | unique | dead-air | onset | sustained | dup3 | adj repeat | flags |",
+        "|---:|---|:---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for candidate in report["candidates"][:20]:
+        focused = candidate["focused_solo_metrics"]
+        metrics = candidate["metrics"]
+        temporal = candidate["temporal_coverage"]
+        gate = candidate["timing_repetition_gate"]
+        lines.append(
+            "| {rank} | `{candidate_id}` | {qualified} | {score:.3f} | {notes} | {unique} | "
+            "{dead_air:.3f} | {onset:.3f} | {sustained:.3f} | {dup3} | {adj} | `{flags}` |".format(
+                rank=int(candidate["repair_rank"]),
+                candidate_id=candidate["candidate_id"],
+                qualified=bool(gate["qualified"]),
+                score=float(candidate["timing_repetition_score"]),
+                notes=int(focused["focused_note_count"]),
+                unique=int(focused["focused_unique_pitch_count"]),
+                dead_air=float(metrics.get("dead_air_ratio", 0.0) or 0.0),
+                onset=float(temporal.get("onset_coverage_ratio", 0.0) or 0.0),
+                sustained=float(temporal.get("sustained_coverage_ratio", 0.0) or 0.0),
+                dup3=int(focused["focused_duplicated_3_note_pitch_class_chunks"]),
+                adj=int(focused["focused_adjacent_pitch_repeats"]),
+                flags=list(gate["flags"]),
+            )
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def validate_repair(
+    report: dict[str, Any],
+    *,
+    require_qualified: bool,
+    require_timing_repetition_improvement: bool,
+    expected_source_run_id: str | None,
+    expected_sample_index: int | None,
+) -> dict[str, Any]:
+    summary = report["repair_summary"]
+    if require_qualified and not bool(summary["qualified"]):
+        raise MarginRecoveredTimingRepetitionRepairError("selected candidate is not qualified")
+    if require_timing_repetition_improvement and not bool(summary["timing_repetition_improved"]):
+        raise MarginRecoveredTimingRepetitionRepairError("selected candidate did not improve timing/repetition")
+    if expected_source_run_id is not None and summary["selected_source_run_id"] != expected_source_run_id:
+        raise MarginRecoveredTimingRepetitionRepairError(
+            f"expected source run {expected_source_run_id}, got {summary['selected_source_run_id']}"
+        )
+    if expected_sample_index is not None and int(summary["selected_sample_index"]) != int(expected_sample_index):
+        raise MarginRecoveredTimingRepetitionRepairError(
+            f"expected sample {expected_sample_index}, got {summary['selected_sample_index']}"
+        )
+    return {
+        "report_count": int(report["report_count"]),
+        "candidate_count": int(report["candidate_count"]),
+        "qualified_candidate_count": int(report["qualified_candidate_count"]),
+        "selected_candidate_id": str(summary["selected_candidate_id"]),
+        "selected_source_run_id": str(summary["selected_source_run_id"]),
+        "selected_sample_index": int(summary["selected_sample_index"]),
+        "selected_sample_seed": int(summary["selected_sample_seed"]),
+        "qualified": bool(summary["qualified"]),
+        "timing_repetition_improved": bool(summary["timing_repetition_improved"]),
+        "dead_air_delta_from_previous": float(summary["dead_air_delta_from_previous"]),
+        "adjacent_pitch_repeat_delta_from_previous": int(
+            summary["adjacent_pitch_repeat_delta_from_previous"]
+        ),
+        "focused_unique_pitch_delta_from_previous": int(summary["focused_unique_pitch_delta_from_previous"]),
+        "focused_note_delta_from_previous": int(summary["focused_note_delta_from_previous"]),
+        "remaining_flags": list(summary["remaining_flags"]),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Summarize margin-recovered timing/repetition repair sweep")
+    parser.add_argument("--report_path", action="append", required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=str(ROOT_DIR / "outputs" / "stage_b_margin_recovered_timing_repetition_repair"),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument(
+        "--previous_candidate_id",
+        type=str,
+        default="margin_recovered_pitch_vocab_seed_17_topk_5_temp_09_n24_sample_4",
+    )
+    parser.add_argument("--previous_dead_air", type=float, default=0.40)
+    parser.add_argument("--previous_unique_pitch_count", type=int, default=6)
+    parser.add_argument("--previous_note_count", type=int, default=13)
+    parser.add_argument("--previous_adjacent_pitch_repeats", type=int, default=3)
+    parser.add_argument("--min_unique_pitch_count", type=int, default=6)
+    parser.add_argument("--max_dead_air_ratio_exclusive", type=float, default=0.40)
+    parser.add_argument("--min_note_count", type=int, default=12)
+    parser.add_argument("--max_simultaneous_notes", type=int, default=1)
+    parser.add_argument("--max_duplicated_3_note_chunks", type=int, default=0)
+    parser.add_argument("--max_adjacent_pitch_repeats_exclusive", type=int, default=3)
+    parser.add_argument("--require_qualified", action="store_true")
+    parser.add_argument("--require_timing_repetition_improvement", action="store_true")
+    parser.add_argument("--expected_source_run_id", type=str, default=None)
+    parser.add_argument("--expected_sample_index", type=int, default=None)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report_paths = [Path(path) for path in args.report_path]
+    report = build_repair_report(
+        report_paths,
+        output_dir=output_dir,
+        previous_candidate_id=str(args.previous_candidate_id),
+        previous_dead_air=float(args.previous_dead_air),
+        previous_unique_pitch_count=int(args.previous_unique_pitch_count),
+        previous_note_count=int(args.previous_note_count),
+        previous_adjacent_pitch_repeats=int(args.previous_adjacent_pitch_repeats),
+        min_unique_pitch_count=int(args.min_unique_pitch_count),
+        max_dead_air_ratio_exclusive=float(args.max_dead_air_ratio_exclusive),
+        min_note_count=int(args.min_note_count),
+        max_simultaneous_notes=int(args.max_simultaneous_notes),
+        max_duplicated_3_note_chunks=int(args.max_duplicated_3_note_chunks),
+        max_adjacent_pitch_repeats_exclusive=int(args.max_adjacent_pitch_repeats_exclusive),
+    )
+    summary = validate_repair(
+        report,
+        require_qualified=bool(args.require_qualified),
+        require_timing_repetition_improvement=bool(args.require_timing_repetition_improvement),
+        expected_source_run_id=args.expected_source_run_id,
+        expected_sample_index=args.expected_sample_index,
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "timing_repetition_repair_summary.json", report)
+    write_json(output_dir / "timing_repetition_repair_result.json", summary)
+    (output_dir / "timing_repetition_repair_summary.md").write_text(markdown_report(report), encoding="utf-8")
+    summary.update(
+        {
+            "summary_path": str(output_dir / "timing_repetition_repair_summary.json"),
+            "markdown_path": str(output_dir / "timing_repetition_repair_summary.md"),
+        }
+    )
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_margin_recovered_timing_repetition_repair.py
+++ b/tests/test_stage_b_margin_recovered_timing_repetition_repair.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pretty_midi
+
+from scripts.summarize_stage_b_margin_recovered_timing_repetition_repair import (
+    build_repair_report,
+    validate_repair,
+)
+
+
+def write_midi(path: Path, pitches: list[int]) -> None:
+    midi = pretty_midi.PrettyMIDI(initial_tempo=124)
+    piano = pretty_midi.Instrument(program=0, is_drum=False, name="timing_repetition_candidate")
+    for index, pitch in enumerate(pitches):
+        start = index * 0.25
+        piano.notes.append(pretty_midi.Note(velocity=84, pitch=pitch, start=start, end=start + 0.2))
+    midi.instruments.append(piano)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    midi.write(str(path))
+
+
+def write_report(path: Path, *, run_id: str, seed: int, samples: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "run_id": run_id,
+                "run_dir": str(path.parent),
+                "request": {"seed": seed, "top_k": 7, "temperature": 0.86},
+                "summary": {"sample_count": len(samples)},
+                "samples": samples,
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+class StageBMarginRecoveredTimingRepetitionRepairTest(unittest.TestCase):
+    def test_requires_dead_air_and_adjacent_repeat_repair(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            sparse_midi = root / "sparse.mid"
+            edge_dead_air_midi = root / "edge_dead_air.mid"
+            qualified_midi = root / "qualified.mid"
+            write_midi(sparse_midi, [60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70])
+            write_midi(edge_dead_air_midi, [60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72])
+            write_midi(qualified_midi, [60, 60, 61, 62, 63, 64, 65, 66, 66, 67, 68, 69, 70, 71])
+            report_path = root / "report.json"
+            write_report(
+                report_path,
+                run_id="test_timing_seed37_topk7",
+                seed=37,
+                samples=[
+                    {
+                        "sample_index": 1,
+                        "sample_seed": 56,
+                        "midi_path": str(sparse_midi),
+                        "valid": True,
+                        "strict_valid": True,
+                        "grammar_gate_passed": True,
+                        "metrics": {"dead_air_ratio": 0.33, "phrase_coverage_ratio": 0.7},
+                        "temporal_coverage": {"onset_coverage_ratio": 0.5, "sustained_coverage_ratio": 0.7},
+                    },
+                    {
+                        "sample_index": 2,
+                        "sample_seed": 64,
+                        "midi_path": str(edge_dead_air_midi),
+                        "valid": True,
+                        "strict_valid": True,
+                        "grammar_gate_passed": True,
+                        "metrics": {"dead_air_ratio": 0.40, "phrase_coverage_ratio": 0.8},
+                        "temporal_coverage": {"onset_coverage_ratio": 0.5, "sustained_coverage_ratio": 0.6},
+                    },
+                    {
+                        "sample_index": 3,
+                        "sample_seed": 75,
+                        "midi_path": str(qualified_midi),
+                        "valid": True,
+                        "strict_valid": True,
+                        "grammar_gate_passed": True,
+                        "metrics": {"dead_air_ratio": 0.35, "phrase_coverage_ratio": 0.8},
+                        "temporal_coverage": {"onset_coverage_ratio": 0.5, "sustained_coverage_ratio": 0.7},
+                    },
+                ],
+            )
+
+            report = build_repair_report(
+                [report_path],
+                output_dir=root / "repair",
+                previous_candidate_id="previous",
+                previous_dead_air=0.40,
+                previous_unique_pitch_count=6,
+                previous_note_count=13,
+                previous_adjacent_pitch_repeats=3,
+                min_unique_pitch_count=6,
+                max_dead_air_ratio_exclusive=0.40,
+                min_note_count=12,
+                max_simultaneous_notes=1,
+                max_duplicated_3_note_chunks=0,
+                max_adjacent_pitch_repeats_exclusive=3,
+            )
+            summary = validate_repair(
+                report,
+                require_qualified=True,
+                require_timing_repetition_improvement=True,
+                expected_source_run_id="test_timing_seed37_topk7",
+                expected_sample_index=3,
+            )
+
+            self.assertTrue(summary["qualified"])
+            self.assertTrue(summary["timing_repetition_improved"])
+            self.assertEqual(summary["qualified_candidate_count"], 1)
+            self.assertEqual(summary["selected_sample_index"], 3)
+            self.assertAlmostEqual(summary["dead_air_delta_from_previous"], 0.05)
+            self.assertEqual(summary["adjacent_pitch_repeat_delta_from_previous"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a timing/repetition repair summary script for the selected pitch-vocabulary candidate
- add a harness mode that runs seed 37/41, top_k 7, temperature 0.86, n 48 generation and selects a qualified repair candidate
- document Issue #264 results in README, Core Plan, Current Status, and a focused result note

## Result
- selected candidate: `margin_recovered_timing_repetition_seed_37_topk_7_temp_086_n48_sample_39`
- qualified candidates: `2/96`
- dead-air: `0.400 -> 0.353`
- adjacent pitch repeats: `3 -> 2`
- focused unique pitch count: `6 -> 7`
- focused max active notes: `1`
- duplicated 3-note chunks: `0`

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_timing_repetition_repair`
- `bash scripts/agent_harness.sh stage-b-margin-recovered-timing-repetition-repair`
- `bash scripts/agent_harness.sh quick`
- `rg -n "codex|Codex|코덱스" ...changed files`

## Risk
- This is an objective timing/repetition repair, not a final focused listening keep.
- Next step is focused solo/context packaging and context/listening review for the selected candidate.

Closes #264