### PR TITLE
Stage B margin-recovered timing/repetition focused context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #264, Stage B margin-recovered pitch vocabulary timing/repetition follow-up repair.
+- Latest functional issue completed: Issue #266, Stage B margin-recovered timing/repetition focused context review.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered timing/repetition focused context review.
+- Recommended next issue: Stage B margin-recovered timing/repetition focused listening notes.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -426,6 +426,14 @@ bash scripts/agent_harness.sh stage-b-margin-recovered-timing-repetition-repair
 ```
 
 This harness tests whether the selected pitch-vocabulary candidate can keep focused unique pitch coverage while reducing dead-air and adjacent pitch repetition.
+
+For Stage B margin-recovered timing/repetition focused context changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-margin-recovered-timing-repetition-focused-context
+```
+
+This harness packages the selected timing/repetition repair candidate with chord/bass context and verifies focused context decision readiness.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 | 청감 리뷰 기록 누락 위험 | context keep 후보라도 실제 timing/phrase/vocabulary 판단은 별도 기록 필요 | focused listening notes template 생성 | candidate `1`, pending `1`, risks `dead_air_ratio_at_gate`, `adjacent_pitch_repeats` |
 | focused listening fill 후 최종 keep 실패 | dead-air가 gate 상한이고 adjacent repeat가 남음 | MIDI/context evidence 기준 listening fields 채움 | timing `stiff`, phrase `weak`, vocabulary `thin`, decision `needs_followup` |
 | timing/repetition repair 필요 | Issue #262 후보의 chord fit과 landing은 strong이지만 timing과 phrase continuation이 약함 | top_k7, temperature `0.86`, seed `37/41` sweep으로 dead-air와 adjacent repeat 동시 개선 후보 선택 | selected sample `39`, dead-air `0.400 -> 0.353`, adjacent repeats `3 -> 2`, unique pitch `6 -> 7` |
+| repair 후보 context 검증 필요 | objective repair만으로 final landing과 context guide 적합성 판단 불가 | solo/context package를 만들고 focused context decision 재실행 | decision `keep_for_focused_listening`, flags `{}`, final `A#4` over `Fm7` tension |
 
 ## 파이프라인 구조
 
@@ -57,7 +58,7 @@ flowchart LR
 
 ## 핵심 결과
 
-Issue #264 기준 model-core MVP:
+Issue #266 기준 model-core MVP:
 
 | 항목 | 결과 |
 |---|---|
@@ -88,6 +89,7 @@ Issue #264 기준 model-core MVP:
 | margin-recovered pitch vocabulary focused listening notes | focused listening template 생성, candidate `1`, pending `1`, prior decision `keep_for_focused_listening` |
 | margin-recovered pitch vocabulary focused listening fill | reviewed `1`, pending `0`, decision `needs_followup`, timing `stiff`, vocabulary `thin` |
 | margin-recovered timing/repetition repair | seed37/41 top_k7 temp0.86 96개 후보 중 `2`개 qualified, sample `39` 선택, dead-air `0.353`, adjacent repeats `2` |
+| margin-recovered timing/repetition focused context | selected repair 후보를 solo/context package로 격리, decision `keep_for_focused_listening`, flags `{}` |
 | constrained review gate | `stage-b-overlap-gate` 통과 |
 | focused candidate path | `stage-b-rhythm-phrase-variation` 통과 |
 
@@ -123,6 +125,7 @@ MVP 근거:
 - focused listening fill에서 chord fit과 landing은 `strong`이지만 timing `stiff`, phrase continuation `weak`, jazz vocabulary `thin`으로 `needs_followup` 판정
 - timing/repetition repair sweep에서 focused unique pitch `7`, note count `14`, max active `1`, duplicated 3-note chunk `0`, dead-air `0.353`, adjacent repeats `2`인 qualified 후보 선택
 - Issue #264 후보는 Issue #262 대비 objective timing/repetition metric은 개선됐지만, focused context/listening 재검증 전 최종 keep으로 보지 않음
+- timing/repetition repair 후보를 solo/context package로 격리해 range `C#4-G5`, phrase span `6.5` beats, max active `1`, final `A#4` over `Fm7` tension, context decision `keep_for_focused_listening` 확인
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`
@@ -134,7 +137,7 @@ MVP 근거:
 | 만든 것 | symbolic MIDI 생성 모델의 dataset, tokenization, training, generation, decode, objective review, proxy review pipeline |
 | 겪은 문제 | `.mid` 파일 존재만으로 성공 판단 불가, one-note collapse, long sustain block, chord block, dead-air outlier, seed-level margin 부족 |
 | 해결 방식 | duration-explicit token 구조, grammar/coverage/chord-aware probe, overlap-free postprocess, repeatability sweep, dead-air diagnostics, proxy review scoring, repair candidate selection |
-| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab focused context `keep_for_focused_listening`, timing/repetition repair qualified `2/96` |
+| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab focused context `keep_for_focused_listening`, timing/repetition repair qualified `2/96`, timing/repetition focused context `keep_for_focused_listening` |
 | 주장 경계 | reviewable MIDI 후보 생성 검증 파이프라인까지 가능, human listening preference / Brad style adaptation / broad production quality는 미검증 |
 
 Issue #210 기준 current best focused review candidate:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -77,6 +77,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered pitch vocabulary focused listening notes 문서: `docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_FOCUSED_LISTENING_NOTES_2026-05-28.md`
 - margin-recovered pitch vocabulary focused listening fill 문서: `docs/STAGE_B_MARGIN_RECOVERED_PITCH_VOCAB_FOCUSED_LISTENING_FILL_2026-05-28.md`
 - margin-recovered timing/repetition repair 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_REPAIR_2026-05-28.md`
+- margin-recovered timing/repetition focused context 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_CONTEXT_2026-05-28.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -99,6 +100,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered pitch vocabulary focused listening notes: candidate `1`, pending `1`, prior decision `keep_for_focused_listening`, risks `dead_air_ratio_at_gate` / `adjacent_pitch_repeats`
 - margin-recovered pitch vocabulary focused listening fill: reviewed `1`, decision `needs_followup`, timing `stiff`, chord fit `strong`, vocabulary `thin`
 - margin-recovered timing/repetition repair: seed `37/41` top_k7 temp0.86 96개 후보 중 qualified `2`, selected sample `39`, dead-air `0.353`, adjacent repeats `2`
+- margin-recovered timing/repetition focused context: selected repair 후보 focused context decision `keep_for_focused_listening`, flags `{}`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -292,6 +294,7 @@ Stage B에서 명시하는 것:
 127. Stage B margin-recovered pitch vocabulary focused listening notes
 128. Stage B margin-recovered pitch vocabulary focused listening fill
 129. Stage B margin-recovered pitch vocabulary timing/repetition follow-up repair
+130. Stage B margin-recovered timing/repetition focused context review
 
 가장 최근 의미 있는 결과:
 
@@ -461,6 +464,8 @@ Stage B에서 명시하는 것:
 - Issue #262 result: timing `stiff`, chord fit `strong`, phrase continuation `weak`, landing `strong`, jazz vocabulary `thin`.
 - Issue #264 runs a top_k7 temperature `0.86` timing/repetition sweep over seed `37/41`.
 - Issue #264 result: selected sample `39` keeps focused unique pitch `7`, max active `1`, duplicated 3-note chunks `0`, and improves dead-air `0.400 -> 0.353` plus adjacent repeats `3 -> 2`; focused context/listening 재검증은 아직 남아 있다.
+- Issue #266 isolates that timing/repetition repair candidate into a focused solo/context package and reviews it against context MIDI.
+- Issue #266 result: focused context decision `keep_for_focused_listening`, flags `{}`, note count `14`, unique pitch `7`, range `C#4-G5`, phrase span `6.5` beats, final `A#4` over `Fm7` tension.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -479,8 +484,8 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-Issue #264는 pitch vocabulary gate를 유지하면서 dead-air와 adjacent repeats를 줄인 qualified 후보를 찾았다.
-다음 작업은 이 후보를 focused solo/context package로 격리하고 context decision과 focused listening fill을 다시 실행하는 것이다.
+Issue #266은 timing/repetition repair 후보를 focused context 기준으로 다시 검증했고 blocker 없이 listening review로 보낼 수 있음을 확인했다.
+다음 작업은 focused listening notes를 만들고 실제 timing, phrase continuation, vocabulary field를 다시 채우는 것이다.
 
 ## 6. 다음 단계 로드맵
 
@@ -1006,35 +1011,36 @@ Issue #264는 pitch vocabulary gate를 유지하면서 dead-air와 adjacent repe
 완료된 바로 전 작업:
 
 ```text
-Stage B margin-recovered pitch vocabulary timing/repetition follow-up repair
+Stage B margin-recovered timing/repetition focused context review
 ```
 
 결과:
 
-- docs: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_REPAIR_2026-05-28.md`
+- docs: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_CONTEXT_2026-05-28.md`
 - selected candidate: `margin_recovered_timing_repetition_seed_37_topk_7_temp_086_n48_sample_39`
-- selected source run: `harness_stage_b_margin_recovered_timing_repetition_seed37_topk7_temp086_n48`
-- selected sample seed: `75`
-- qualified candidates: `2/96`
+- copied MIDI files: `2`
+- focused context decision: `keep_for_focused_listening`
+- decision flags: `{}`
 - dead-air ratio: `0.353`
 - adjacent pitch repeats: `2`
 - focused unique pitch count: `7`
 - focused note count: `14`
 - focused max active notes: `1`
 - duplicated 3-note chunks: `0`
-- remaining flags: `[]`
+- phrase span: `6.5` beats
+- final landing: `A#4` over `Fm7`, tension
 
 판단:
 
-- objective timing/repetition metric은 Issue #262 후보보다 개선됐다.
-- 아직 focused context package와 focused listening fill을 다시 통과한 것은 아니다.
+- focused context blocker는 없다.
+- 아직 focused listening fill을 다시 통과한 것은 아니다.
 - broad trained-model quality, human listening preference, Brad style adaptation은 아직 미검증이다.
 
 다음 작업:
 
-- 다음 issue는 `Stage B margin-recovered timing/repetition focused context review`로 잡는다.
-- selected candidate를 solo/context package로 격리한다.
-- final landing, phrase span, context guide, max active, repeated cell을 다시 검증한다.
+- 다음 issue는 `Stage B margin-recovered timing/repetition focused listening notes`로 잡는다.
+- selected context keep 후보의 focused listening review notes를 만든다.
+- timing, phrase continuation, landing, vocabulary는 pending field로 남긴다.
 - focused listening fill에서 다시 keep이 나오기 전에는 최종 keep으로 주장하지 않는다.
 
 ## 10. 한 문장 요약

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #264, Stage B margin-recovered pitch vocabulary timing/repetition follow-up repair
-- 다음 권장 이슈: `Stage B margin-recovered timing/repetition focused context review`
+- latest functional result: Issue #266, Stage B margin-recovered timing/repetition focused context review
+- 다음 권장 이슈: `Stage B margin-recovered timing/repetition focused listening notes`
 
 현재 범위가 아닌 것:
 
@@ -923,6 +923,51 @@ Issue #262 후보 대비:
 Docs:
 
 - `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_REPAIR_2026-05-28.md`
+
+## Current Margin-Recovered Timing/Repetition Focused Context Result
+
+Issue #266은 Issue #264 selected candidate를 solo/context package로 격리하고 focused context decision을 다시 실행한 작업이다.
+
+변경:
+
+- timing/repetition repair summary 기반 focused package builder 추가
+- selected candidate solo-line MIDI와 context MIDI 생성/복사
+- 기존 focused context decision 기준으로 final landing, context guide, max active, repeated cell 재검증
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_timing_repetition_focused_package`
+- `bash scripts/agent_harness.sh stage-b-margin-recovered-timing-repetition-focused-context`
+
+결과:
+
+| 항목 | 값 |
+|---|---|
+| candidate | `margin_recovered_timing_repetition_seed_37_topk_7_temp_086_n48_sample_39` |
+| copied MIDI files | `2` |
+| focused context decision | `keep_for_focused_listening` |
+| decision flags | `{}` |
+| note count | `14` |
+| unique pitch count | `7` |
+| range | `C#4-G5` |
+| phrase span | `6.500` beats |
+| max active notes | `1` |
+| dead-air ratio | `0.353` |
+| adjacent pitch repeats | `2` |
+| duplicated 3-note chunks | `0` |
+| final landing | `A#4` over `Fm7`, tension |
+| context tracks | chord guide, bass root guide, solo |
+
+해석:
+
+- focused context blocker는 발견되지 않았다.
+- final note는 outside가 아니라 tension이다.
+- 이 결과는 focused listening review 진입 조건이다.
+- 아직 human/audio preference나 broad model quality proof는 아니다.
+
+Docs:
+
+- `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_CONTEXT_2026-05-28.md`
 
 ## Latest README Footer Section Removal Result
 

--- a/docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_CONTEXT_2026-05-28.md
+++ b/docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_CONTEXT_2026-05-28.md
@@ -1,0 +1,56 @@
+# Stage B Margin-Recovered Timing/Repetition Focused Context
+
+## 요약
+
+Issue #266은 Issue #264에서 선택한 timing/repetition repair 후보를 solo/context package로 격리하고, focused context 기준으로 다시 검증한 작업이다.
+
+이 단계는 objective repair 후보를 바로 최종 후보로 올리지 않고, chord guide, bass guide, solo track이 포함된 context MIDI 안에서 solo-line 조건과 final landing을 다시 확인하기 위한 경계다.
+
+## 변경
+
+- timing/repetition repair summary를 입력으로 받는 focused package builder 추가
+- selected candidate의 solo-line MIDI와 context MIDI 복사/생성
+- 기존 focused context decision 로직으로 note count, unique pitch, phrase span, max active, repeated cell, final landing 검증
+- result docs와 current plan 업데이트
+
+## 결과
+
+| 항목 | 값 |
+|---|---|
+| candidate | `margin_recovered_timing_repetition_seed_37_topk_7_temp_086_n48_sample_39` |
+| copied MIDI files | `2` |
+| focused context decision | `keep_for_focused_listening` |
+| decision flags | `{}` |
+| note count | `14` |
+| unique pitch count | `7` |
+| range | `C#4-G5` |
+| phrase span | `6.500` beats |
+| max active notes | `1` |
+| dead-air ratio | `0.353` |
+| onset coverage | `0.500` |
+| sustained coverage | `0.688` |
+| adjacent pitch repeats | `2` |
+| duplicated 3-note pitch-class chunks | `0` |
+| final landing | `A#4` over `Fm7`, tension |
+| context tracks | chord guide, bass root guide, solo |
+
+## 해석
+
+- focused context blocker는 발견되지 않았다.
+- solo-line max active `1`, phrase span `6.5` beats, context guide 존재 조건을 만족했다.
+- final note는 `Fm7` 위 tension으로 처리되어 outside landing blocker가 아니다.
+- 이 결과는 focused listening review 진입 조건이지, human/audio preference나 broad model quality proof가 아니다.
+
+## 검증
+
+```bash
+.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_timing_repetition_focused_package
+bash scripts/agent_harness.sh stage-b-margin-recovered-timing-repetition-focused-context
+```
+
+## 산출물
+
+- script: `scripts/build_stage_b_margin_recovered_timing_repetition_focused_package.py`
+- test: `tests/test_stage_b_margin_recovered_timing_repetition_focused_package.py`
+- package: `outputs/stage_b_margin_recovered_timing_repetition_focused_package/harness_stage_b_margin_recovered_timing_repetition_focused_package/focused_review_package.json`
+- decision: `outputs/stage_b_margin_recovered_focused_context_decision/harness_stage_b_margin_recovered_timing_repetition_focused_context_decision/focused_context_decision.json`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -62,6 +62,8 @@ Modes:
                 Fill the selected pitch-vocabulary focused listening review notes.
   stage-b-margin-recovered-timing-repetition-repair
                 Run top-k/temperature repair sweep and select a timing/repetition improved candidate.
+  stage-b-margin-recovered-timing-repetition-focused-context
+                Package and review the selected timing/repetition repair candidate in context.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -199,6 +201,7 @@ run_quick() {
     scripts/build_stage_b_margin_recovered_pitch_vocab_focused_listening_notes.py \
     scripts/fill_stage_b_margin_recovered_pitch_vocab_focused_listening_notes.py \
     scripts/summarize_stage_b_margin_recovered_timing_repetition_repair.py \
+    scripts/build_stage_b_margin_recovered_timing_repetition_focused_package.py \
     scripts/run_stage_b_sampling_sweep.py \
     scripts/run_stage_b_coverage_ab_sweep.py \
     scripts/run_stage_b_pitch_mode_compare.py \
@@ -644,6 +647,30 @@ run_stage_b_margin_recovered_timing_repetition_repair() {
     --require_timing_repetition_improvement \
     --expected_source_run_id "$seed37_run_id" \
     --expected_sample_index 39
+}
+
+run_stage_b_margin_recovered_timing_repetition_focused_context() {
+  local repair_run_id="${REPAIR_RUN_ID:-harness_stage_b_margin_recovered_timing_repetition_repair}"
+  local package_run_id="${PACKAGE_RUN_ID:-harness_stage_b_margin_recovered_timing_repetition_focused_package}"
+  local decision_run_id="${RUN_ID:-harness_stage_b_margin_recovered_timing_repetition_focused_context_decision}"
+  local candidate_id="margin_recovered_timing_repetition_seed_37_topk_7_temp_086_n48_sample_39"
+  local repair_summary="outputs/stage_b_margin_recovered_timing_repetition_repair/${repair_run_id}/timing_repetition_repair_summary.json"
+  if [[ ! -f "$repair_summary" ]]; then
+    print_header "Stage B margin-recovered timing/repetition repair"
+    RUN_ID="$repair_run_id" run_stage_b_margin_recovered_timing_repetition_repair
+  fi
+  print_header "Stage B margin-recovered timing/repetition focused package"
+  "$PYTHON_BIN" scripts/build_stage_b_margin_recovered_timing_repetition_focused_package.py \
+    --run_id "$package_run_id" \
+    --repair_summary "$repair_summary" \
+    --expected_candidate_id "$candidate_id"
+
+  print_header "Stage B margin-recovered timing/repetition focused context decision"
+  "$PYTHON_BIN" scripts/review_stage_b_margin_recovered_focused_context.py \
+    --run_id "$decision_run_id" \
+    --focused_package "outputs/stage_b_margin_recovered_timing_repetition_focused_package/${package_run_id}/focused_review_package.json" \
+    --expected_candidate_id "$candidate_id" \
+    --expected_decision keep_for_focused_listening
 }
 
 run_stage_b_constrained_probe() {
@@ -1810,6 +1837,9 @@ case "$MODE" in
     ;;
   stage-b-margin-recovered-timing-repetition-repair)
     run_stage_b_margin_recovered_timing_repetition_repair
+    ;;
+  stage-b-margin-recovered-timing-repetition-focused-context)
+    run_stage_b_margin_recovered_timing_repetition_focused_context
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/build_stage_b_margin_recovered_timing_repetition_focused_package.py
+++ b/scripts/build_stage_b_margin_recovered_timing_repetition_focused_package.py
@@ -1,0 +1,171 @@
+"""Build a focused package from a margin-recovered timing/repetition repair result."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.build_stage_b_margin_recovered_focused_package import (  # noqa: E402
+    build_margin_recovered_focused_package,
+    markdown_report,
+    read_json,
+    validate_package,
+)
+from scripts.build_stage_b_margin_recovered_listening_notes import write_json  # noqa: E402
+
+
+class MarginRecoveredTimingRepetitionFocusedPackageError(ValueError):
+    pass
+
+
+DEFAULT_DECISION = "timing_repetition_qualified"
+
+
+def selected_candidate(repair_summary: dict[str, Any]) -> dict[str, Any]:
+    candidate = repair_summary.get("selected_candidate")
+    if not isinstance(candidate, dict):
+        raise MarginRecoveredTimingRepetitionFocusedPackageError(
+            "repair summary must contain selected_candidate"
+        )
+    return candidate
+
+
+def review_notes_from_repair(
+    repair_summary: dict[str, Any],
+    *,
+    decision: str = DEFAULT_DECISION,
+) -> dict[str, Any]:
+    candidate = selected_candidate(repair_summary)
+    candidate_id = str(candidate.get("candidate_id") or "")
+    midi_path = str(candidate.get("midi_path") or "")
+    if not candidate_id:
+        raise MarginRecoveredTimingRepetitionFocusedPackageError("selected candidate_id is required")
+    if not midi_path:
+        raise MarginRecoveredTimingRepetitionFocusedPackageError("selected candidate midi_path is required")
+    metrics = dict(candidate.get("metrics") or {})
+    temporal = dict(candidate.get("temporal_coverage") or {})
+    focused = dict(candidate.get("focused_solo_metrics") or {})
+    gate = candidate.get("timing_repetition_gate") if isinstance(candidate.get("timing_repetition_gate"), dict) else {}
+    summary = repair_summary.get("repair_summary") if isinstance(repair_summary.get("repair_summary"), dict) else {}
+    return {
+        "schema_version": "stage_b_margin_recovered_timing_repetition_focused_review_notes_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "source_timing_repetition_repair": str(repair_summary.get("output_dir") or ""),
+        "candidates": [
+            {
+                "candidate_id": candidate_id,
+                "review_metadata": {
+                    "mode": "margin_recovered_timing_repetition_repair",
+                    "review_rank": 1,
+                    "source_run_id": str(candidate.get("source_run_id") or ""),
+                    "sample_index": int(candidate.get("sample_index", 0) or 0),
+                    "sample_seed": int(candidate.get("sample_seed", 0) or 0),
+                },
+                "review_files": {
+                    "midi_path": midi_path,
+                },
+                "source_metrics": {
+                    **metrics,
+                    **temporal,
+                    "focused_note_count": int(focused.get("focused_note_count", 0) or 0),
+                    "focused_unique_pitch_count": int(focused.get("focused_unique_pitch_count", 0) or 0),
+                    "focused_adjacent_pitch_repeats": int(focused.get("focused_adjacent_pitch_repeats", 0) or 0),
+                    "focused_duplicated_3_note_pitch_class_chunks": int(
+                        focused.get("focused_duplicated_3_note_pitch_class_chunks", 0) or 0
+                    ),
+                    "previous_dead_air_delta": float(summary.get("dead_air_delta_from_previous", 0.0) or 0.0),
+                    "previous_adjacent_pitch_repeat_delta": int(
+                        summary.get("adjacent_pitch_repeat_delta_from_previous", 0) or 0
+                    ),
+                    "previous_unique_pitch_delta": int(
+                        summary.get("focused_unique_pitch_delta_from_previous", 0) or 0
+                    ),
+                    "previous_note_delta": int(summary.get("focused_note_delta_from_previous", 0) or 0),
+                },
+                "listening": {
+                    "decision": str(decision),
+                    "phrase_quality": "pending_context",
+                    "timing": "pending_context",
+                    "chord_fit": "pending_context",
+                    "jazz_vocabulary": "pending_context",
+                    "notes": "Selected by timing/repetition repair; not a human listening decision.",
+                },
+                "objective_review": {
+                    "objective_flags": list(gate.get("flags") or []),
+                    "qualified": bool(gate.get("qualified", False)),
+                },
+            }
+        ],
+    }
+
+
+def build_timing_repetition_focused_package(
+    repair_summary: dict[str, Any],
+    *,
+    output_dir: Path,
+    decision: str = DEFAULT_DECISION,
+) -> dict[str, Any]:
+    review_notes = review_notes_from_repair(repair_summary, decision=decision)
+    package = build_margin_recovered_focused_package(
+        review_notes,
+        output_dir=output_dir,
+        decision=decision,
+    )
+    package["source_timing_repetition_repair"] = str(repair_summary.get("output_dir") or "")
+    package["timing_repetition_repair_summary"] = dict(repair_summary.get("repair_summary") or {})
+    return package
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build focused package from timing/repetition repair")
+    parser.add_argument("--repair_summary", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=str(ROOT_DIR / "outputs" / "stage_b_margin_recovered_timing_repetition_focused_package"),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--decision", type=str, default=DEFAULT_DECISION)
+    parser.add_argument("--expected_candidate_id", type=str, default="")
+    parser.add_argument("--min_candidates", type=int, default=1)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    repair_summary = read_json(Path(args.repair_summary))
+    package = build_timing_repetition_focused_package(
+        repair_summary,
+        output_dir=output_dir,
+        decision=str(args.decision),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "focused_review_package.json", package)
+    (output_dir / "focused_review_package.md").write_text(markdown_report(package), encoding="utf-8")
+    summary = validate_package(
+        package,
+        expected_candidate_id=str(args.expected_candidate_id or ""),
+        min_candidates=int(args.min_candidates),
+    )
+    summary.update(
+        {
+            "package_path": str(output_dir / "focused_review_package.json"),
+            "markdown_path": str(output_dir / "focused_review_package.md"),
+        }
+    )
+    write_json(output_dir / "focused_review_package_summary.json", summary)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_margin_recovered_timing_repetition_focused_package.py
+++ b/tests/test_stage_b_margin_recovered_timing_repetition_focused_package.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pretty_midi
+
+from scripts.build_stage_b_margin_recovered_timing_repetition_focused_package import (
+    DEFAULT_DECISION,
+    build_timing_repetition_focused_package,
+    validate_package,
+)
+
+
+def write_midi(path: Path) -> None:
+    midi = pretty_midi.PrettyMIDI(initial_tempo=124)
+    piano = pretty_midi.Instrument(program=0, is_drum=False, name="timing_repetition")
+    for index, pitch in enumerate([61, 63, 65, 68, 70, 72, 74, 72, 70, 68, 65, 63, 61, 67]):
+        start = index * 0.25
+        piano.notes.append(pretty_midi.Note(velocity=84, pitch=pitch, start=start, end=start + 0.2))
+    midi.instruments.append(piano)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    midi.write(str(path))
+
+
+def write_report(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "request": {
+                    "chord_progression": ["Cm7", "Fm7", "Bb7", "Ebmaj7"],
+                    "bpm": 124,
+                    "bars": 2,
+                }
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def repair_summary(root: Path) -> dict:
+    sample_path = root / "generation" / "samples" / "stage_b_sample_39.mid"
+    write_midi(sample_path)
+    write_report(root / "generation" / "report.json")
+    return {
+        "output_dir": str(root / "repair"),
+        "repair_summary": {
+            "selected_candidate_id": "timing_repetition_candidate",
+            "dead_air_delta_from_previous": 0.047059,
+            "adjacent_pitch_repeat_delta_from_previous": 1,
+            "focused_unique_pitch_delta_from_previous": 1,
+            "focused_note_delta_from_previous": 1,
+        },
+        "selected_candidate": {
+            "candidate_id": "timing_repetition_candidate",
+            "sample_index": 39,
+            "sample_seed": 75,
+            "source_run_id": "test_timing_repetition_run",
+            "midi_path": str(sample_path),
+            "metrics": {
+                "note_count": 18,
+                "unique_pitch_count": 7,
+                "dead_air_ratio": 0.35294117647058826,
+            },
+            "temporal_coverage": {
+                "onset_coverage_ratio": 0.5,
+                "sustained_coverage_ratio": 0.6875,
+            },
+            "focused_solo_metrics": {
+                "focused_note_count": 14,
+                "focused_unique_pitch_count": 7,
+                "focused_adjacent_pitch_repeats": 2,
+                "focused_duplicated_3_note_pitch_class_chunks": 0,
+            },
+            "timing_repetition_gate": {
+                "qualified": True,
+                "flags": [],
+            },
+        },
+    }
+
+
+class StageBMarginRecoveredTimingRepetitionFocusedPackageTest(unittest.TestCase):
+    def test_builds_focused_package_from_selected_repair_candidate(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            package = build_timing_repetition_focused_package(
+                repair_summary(root),
+                output_dir=root / "package",
+                decision=DEFAULT_DECISION,
+            )
+            summary = validate_package(
+                package,
+                expected_candidate_id="timing_repetition_candidate",
+                min_candidates=1,
+            )
+
+            self.assertEqual(summary["candidate_count"], 1)
+            self.assertEqual(summary["candidate_ids"], ["timing_repetition_candidate"])
+            candidate = package["candidates"][0]
+            self.assertTrue(Path(candidate["review_files"]["midi_path"]).exists())
+            self.assertTrue(Path(candidate["review_files"]["context_midi_path"]).exists())
+            self.assertEqual(candidate["listening"]["decision"], DEFAULT_DECISION)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a focused package builder for the timing/repetition repair summary
- package the selected repair candidate with solo-line MIDI and context MIDI
- run focused context decision for the selected candidate and document the result

## Result
- selected candidate: `margin_recovered_timing_repetition_seed_37_topk_7_temp_086_n48_sample_39`
- copied MIDI files: `2`
- focused context decision: `keep_for_focused_listening`
- decision flags: `{}`
- note count: `14`
- unique pitch count: `7`
- phrase span: `6.5` beats
- final landing: `A#4` over `Fm7`, tension

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_timing_repetition_focused_package`
- `bash scripts/agent_harness.sh stage-b-margin-recovered-timing-repetition-focused-context`
- `bash scripts/agent_harness.sh quick`
- `rg -n "codex|Codex|코덱스" ...changed files`

## Risk
- This is focused context readiness, not a final listening keep.
- Next step is focused listening notes and fill for timing, phrase continuation, landing, and vocabulary fields.

Closes #266