### PR TITLE
Stage B margin-recovered timing/repetition focused listening fill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #268, Stage B margin-recovered timing/repetition focused listening notes.
+- Latest functional issue completed: Issue #270, Stage B margin-recovered timing/repetition focused listening fill.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered timing/repetition focused listening fill.
+- Recommended next issue: Stage B margin-recovered timing/repetition phrase/vocabulary follow-up repair.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -442,6 +442,14 @@ bash scripts/agent_harness.sh stage-b-margin-recovered-timing-repetition-focused
 ```
 
 This harness writes the focused listening review notes template for the selected timing/repetition context keep candidate.
+
+For Stage B margin-recovered timing/repetition focused listening fill changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-margin-recovered-timing-repetition-focused-listening-fill
+```
+
+This harness fills the focused listening review notes from MIDI/context evidence and records whether the candidate remains follow-up work.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 | timing/repetition repair 필요 | Issue #262 후보의 chord fit과 landing은 strong이지만 timing과 phrase continuation이 약함 | top_k7, temperature `0.86`, seed `37/41` sweep으로 dead-air와 adjacent repeat 동시 개선 후보 선택 | selected sample `39`, dead-air `0.400 -> 0.353`, adjacent repeats `3 -> 2`, unique pitch `6 -> 7` |
 | repair 후보 context 검증 필요 | objective repair만으로 final landing과 context guide 적합성 판단 불가 | solo/context package를 만들고 focused context decision 재실행 | decision `keep_for_focused_listening`, flags `{}`, final `A#4` over `Fm7` tension |
 | context keep 후보 청감 판단 보류 | context keep만으로 timing/phrase/vocabulary 최종 판단 불가 | focused listening notes template 생성 | candidate `1`, pending `1`, risks `dead_air_ratio_remaining`, `adjacent_pitch_repeats`, `wide_interval_review` |
+| focused listening fill 후 후속 개선 필요 | timing은 개선됐지만 adjacent repeat와 wide interval이 남음 | MIDI/context evidence 기준 listening fields 채움 | timing `acceptable`, phrase `weak`, vocabulary `thin`, decision `needs_followup` |
 
 ## 파이프라인 구조
 
@@ -59,7 +60,7 @@ flowchart LR
 
 ## 핵심 결과
 
-Issue #268 기준 model-core MVP:
+Issue #270 기준 model-core MVP:
 
 | 항목 | 결과 |
 |---|---|
@@ -92,6 +93,7 @@ Issue #268 기준 model-core MVP:
 | margin-recovered timing/repetition repair | seed37/41 top_k7 temp0.86 96개 후보 중 `2`개 qualified, sample `39` 선택, dead-air `0.353`, adjacent repeats `2` |
 | margin-recovered timing/repetition focused context | selected repair 후보를 solo/context package로 격리, decision `keep_for_focused_listening`, flags `{}` |
 | margin-recovered timing/repetition focused listening notes | focused listening template 생성, candidate `1`, pending `1`, review risks `3` |
+| margin-recovered timing/repetition focused listening fill | reviewed `1`, pending `0`, timing `acceptable`, phrase `weak`, vocabulary `thin`, decision `needs_followup` |
 | constrained review gate | `stage-b-overlap-gate` 통과 |
 | focused candidate path | `stage-b-rhythm-phrase-variation` 통과 |
 
@@ -129,6 +131,7 @@ MVP 근거:
 - Issue #264 후보는 Issue #262 대비 objective timing/repetition metric은 개선됐지만, focused context/listening 재검증 전 최종 keep으로 보지 않음
 - timing/repetition repair 후보를 solo/context package로 격리해 range `C#4-G5`, phrase span `6.5` beats, max active `1`, final `A#4` over `Fm7` tension, context decision `keep_for_focused_listening` 확인
 - context keep 후보를 focused listening notes template으로 넘기고 timing, phrase continuation, landing, vocabulary, final decision을 pending으로 유지
+- focused listening fill에서 timing은 `acceptable`로 개선됐지만 adjacent repeats `2`, max interval `16` 때문에 phrase continuation `weak`, jazz vocabulary `thin`, decision `needs_followup`으로 기록
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -79,6 +79,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered timing/repetition repair 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_REPAIR_2026-05-28.md`
 - margin-recovered timing/repetition focused context 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_CONTEXT_2026-05-28.md`
 - margin-recovered timing/repetition focused listening notes 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_NOTES_2026-05-28.md`
+- margin-recovered timing/repetition focused listening fill 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_FILL_2026-05-28.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -103,6 +104,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered timing/repetition repair: seed `37/41` top_k7 temp0.86 96개 후보 중 qualified `2`, selected sample `39`, dead-air `0.353`, adjacent repeats `2`
 - margin-recovered timing/repetition focused context: selected repair 후보 focused context decision `keep_for_focused_listening`, flags `{}`
 - margin-recovered timing/repetition focused listening notes: candidate `1`, pending `1`, prior decision `keep_for_focused_listening`, risks `dead_air_ratio_remaining` / `adjacent_pitch_repeats` / `wide_interval_review`
+- margin-recovered timing/repetition focused listening fill: reviewed `1`, decision `needs_followup`, timing `acceptable`, phrase continuation `weak`, jazz vocabulary `thin`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -298,6 +300,7 @@ Stage B에서 명시하는 것:
 129. Stage B margin-recovered pitch vocabulary timing/repetition follow-up repair
 130. Stage B margin-recovered timing/repetition focused context review
 131. Stage B margin-recovered timing/repetition focused listening notes
+132. Stage B margin-recovered timing/repetition focused listening fill
 
 가장 최근 의미 있는 결과:
 
@@ -471,6 +474,8 @@ Stage B에서 명시하는 것:
 - Issue #266 result: focused context decision `keep_for_focused_listening`, flags `{}`, note count `14`, unique pitch `7`, range `C#4-G5`, phrase span `6.5` beats, final `A#4` over `Fm7` tension.
 - Issue #268 creates focused listening notes for that context keep candidate.
 - Issue #268 result: candidate `1`, pending `1`, prior decision `keep_for_focused_listening`, review risks `dead_air_ratio_remaining`, `adjacent_pitch_repeats`, and `wide_interval_review`.
+- Issue #270 fills that focused listening note from MIDI/context evidence.
+- Issue #270 result: timing improves to `acceptable`, chord fit `acceptable`, landing `acceptable`, but phrase continuation is `weak`, jazz vocabulary is `thin`, and decision remains `needs_followup` because adjacent repeats `2` and max interval `16` remain.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -489,8 +494,8 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-Issue #268은 timing/repetition repair 후보를 focused listening notes template으로 넘겼다.
-다음 작업은 실제 timing, phrase continuation, vocabulary field를 다시 채우는 것이다.
+Issue #270은 timing/repetition repair 후보의 focused listening fill을 완료했고, 결과는 `needs_followup`이다.
+다음 작업은 adjacent repeats와 wide interval을 줄이는 phrase/vocabulary follow-up repair다.
 
 ## 6. 다음 단계 로드맵
 
@@ -1016,18 +1021,22 @@ Issue #268은 timing/repetition repair 후보를 focused listening notes templat
 완료된 바로 전 작업:
 
 ```text
-Stage B margin-recovered timing/repetition focused listening notes
+Stage B margin-recovered timing/repetition focused listening fill
 ```
 
 결과:
 
-- docs: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_NOTES_2026-05-28.md`
+- docs: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_FILL_2026-05-28.md`
 - selected candidate: `margin_recovered_timing_repetition_seed_37_topk_7_temp_086_n48_sample_39`
-- candidate count: `1`
-- reviewed count: `0`
-- pending count: `1`
+- reviewed count: `1`
+- pending count: `0`
 - prior decision: `keep_for_focused_listening`
-- listening decision: `pending`
+- final decision: `needs_followup`
+- timing: `acceptable`
+- chord fit: `acceptable`
+- phrase continuation: `weak`
+- landing: `acceptable`
+- jazz vocabulary: `thin`
 - review risks: `dead_air_ratio_remaining`, `adjacent_pitch_repeats`, `wide_interval_review`
 - dead-air ratio: `0.353`
 - adjacent pitch repeats: `2`
@@ -1038,16 +1047,15 @@ Stage B margin-recovered timing/repetition focused listening notes
 
 판단:
 
-- focused listening review 입력은 준비됐다.
-- 아직 focused listening fill을 다시 통과한 것은 아니다.
+- timing은 Issue #262보다 개선됐다.
+- phrase continuation과 vocabulary는 아직 blocker다.
 - broad trained-model quality, human listening preference, Brad style adaptation은 아직 미검증이다.
 
 다음 작업:
 
-- 다음 issue는 `Stage B margin-recovered timing/repetition focused listening fill`로 잡는다.
-- MIDI/context evidence 기준으로 timing, chord fit, phrase continuation, landing, vocabulary를 채운다.
-- risk 3개가 final decision에 어떤 영향을 주는지 기록한다.
-- focused listening fill에서 다시 keep이 나오기 전에는 최종 keep으로 주장하지 않는다.
+- 다음 issue는 `Stage B margin-recovered timing/repetition phrase/vocabulary follow-up repair`로 잡는다.
+- adjacent repeats와 max interval을 줄이면서 dead-air `< 0.400`, focused unique pitch `>= 6`, max active `1`을 유지한다.
+- focused listening fill에서 keep이 나오기 전에는 최종 keep으로 주장하지 않는다.
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #268, Stage B margin-recovered timing/repetition focused listening notes
-- 다음 권장 이슈: `Stage B margin-recovered timing/repetition focused listening fill`
+- latest functional result: Issue #270, Stage B margin-recovered timing/repetition focused listening fill
+- 다음 권장 이슈: `Stage B margin-recovered timing/repetition phrase/vocabulary follow-up repair`
 
 현재 범위가 아닌 것:
 
@@ -1012,6 +1012,52 @@ Issue #268은 Issue #266 focused context keep 후보를 focused listening review
 Docs:
 
 - `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_NOTES_2026-05-28.md`
+
+## Current Margin-Recovered Timing/Repetition Focused Listening Fill Result
+
+Issue #270은 Issue #268 pending notes를 MIDI/context evidence 기준으로 채운 작업이다.
+
+변경:
+
+- timing/repetition focused listening fill script 추가
+- pending notes를 reviewed 상태로 전환
+- timing, chord fit, phrase continuation, landing, jazz vocabulary, decision 기록
+- dead-air, adjacent repeat, max interval, final landing evidence 보존
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_timing_repetition_focused_listening_fill`
+- `bash scripts/agent_harness.sh stage-b-margin-recovered-timing-repetition-focused-listening-fill`
+
+결과:
+
+| 항목 | 값 |
+|---|---|
+| candidate | `margin_recovered_timing_repetition_seed_37_topk_7_temp_086_n48_sample_39` |
+| reviewed count | `1` |
+| pending count | `0` |
+| prior decision | `keep_for_focused_listening` |
+| final decision | `needs_followup` |
+| timing | `acceptable` |
+| chord fit | `acceptable` |
+| phrase continuation | `weak` |
+| landing | `acceptable` |
+| jazz vocabulary | `thin` |
+| dead-air ratio | `0.353` |
+| adjacent pitch repeats | `2` |
+| max interval | `16` |
+| final landing | `A#4` over `Fm7`, tension |
+
+해석:
+
+- timing은 Issue #262의 `stiff`에서 `acceptable`로 개선됐다.
+- final landing은 outside가 아니라 tension이다.
+- adjacent repeats와 wide interval 때문에 phrase continuation과 vocabulary는 아직 blocker다.
+- 다음 작업은 adjacent repeats와 max interval을 줄이는 phrase/vocabulary follow-up repair다.
+
+Docs:
+
+- `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_FILL_2026-05-28.md`
 
 ## Latest README Footer Section Removal Result
 

--- a/docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_FILL_2026-05-28.md
+++ b/docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_FILL_2026-05-28.md
@@ -1,0 +1,55 @@
+# Stage B Margin-Recovered Timing/Repetition Focused Listening Fill
+
+## 요약
+
+Issue #270은 Issue #268 pending focused listening notes를 MIDI/context evidence 기준으로 채운 작업이다.
+
+Issue #264/#266에서 objective timing과 context blocker는 개선됐지만, 실제 listening decision에서는 phrase continuation과 vocabulary risk를 다시 판단해야 했다.
+
+## 변경
+
+- timing/repetition focused listening fill script 추가
+- pending notes를 reviewed 상태로 채움
+- timing, chord fit, phrase continuation, landing, jazz vocabulary, decision 기록
+- evidence에 dead-air, adjacent repeat, max interval, final landing, review risks 보존
+
+## 결과
+
+| 항목 | 값 |
+|---|---|
+| candidate | `margin_recovered_timing_repetition_seed_37_topk_7_temp_086_n48_sample_39` |
+| reviewed count | `1` |
+| pending count | `0` |
+| prior decision | `keep_for_focused_listening` |
+| final decision | `needs_followup` |
+| timing | `acceptable` |
+| chord fit | `acceptable` |
+| phrase continuation | `weak` |
+| landing | `acceptable` |
+| jazz vocabulary | `thin` |
+| dead-air ratio | `0.353` |
+| adjacent pitch repeats | `2` |
+| max interval | `16` |
+| final landing | `A#4` over `Fm7`, tension |
+
+## 해석
+
+- Issue #262 대비 dead-air가 내려가 timing은 `stiff`에서 `acceptable`로 개선됐다.
+- final landing은 outside가 아니라 tension이므로 landing blocker는 아니다.
+- adjacent repeats와 wide interval 때문에 phrase continuation은 `weak`, jazz vocabulary는 `thin`으로 남았다.
+- 따라서 focused listening fill 기준 최종 decision은 `needs_followup`이다.
+- 이 결과는 broad model quality나 human/audio preference proof가 아니다.
+
+## 검증
+
+```bash
+.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_timing_repetition_focused_listening_fill
+bash scripts/agent_harness.sh stage-b-margin-recovered-timing-repetition-focused-listening-fill
+```
+
+## 산출물
+
+- script: `scripts/fill_stage_b_margin_recovered_timing_repetition_focused_listening_notes.py`
+- test: `tests/test_stage_b_margin_recovered_timing_repetition_focused_listening_fill.py`
+- filled notes: `outputs/stage_b_margin_recovered_timing_repetition_focused_listening_fill/harness_stage_b_margin_recovered_timing_repetition_focused_listening_fill/focused_listening_review_notes_filled.json`
+- markdown: `outputs/stage_b_margin_recovered_timing_repetition_focused_listening_fill/harness_stage_b_margin_recovered_timing_repetition_focused_listening_fill/focused_listening_review_notes_filled.md`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -66,6 +66,8 @@ Modes:
                 Package and review the selected timing/repetition repair candidate in context.
   stage-b-margin-recovered-timing-repetition-focused-listening-notes
                 Build focused listening notes for the selected timing/repetition candidate.
+  stage-b-margin-recovered-timing-repetition-focused-listening-fill
+                Fill the selected timing/repetition focused listening review notes.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -205,6 +207,7 @@ run_quick() {
     scripts/summarize_stage_b_margin_recovered_timing_repetition_repair.py \
     scripts/build_stage_b_margin_recovered_timing_repetition_focused_package.py \
     scripts/build_stage_b_margin_recovered_timing_repetition_focused_listening_notes.py \
+    scripts/fill_stage_b_margin_recovered_timing_repetition_focused_listening_notes.py \
     scripts/run_stage_b_sampling_sweep.py \
     scripts/run_stage_b_coverage_ab_sweep.py \
     scripts/run_stage_b_pitch_mode_compare.py \
@@ -694,6 +697,23 @@ run_stage_b_margin_recovered_timing_repetition_focused_listening_notes() {
     --focused_context_decision "$decision_path" \
     --expected_candidate_id "$candidate_id" \
     --expected_prior_decision keep_for_focused_listening
+}
+
+run_stage_b_margin_recovered_timing_repetition_focused_listening_fill() {
+  local notes_run_id="${NOTES_RUN_ID:-harness_stage_b_margin_recovered_timing_repetition_focused_listening_notes}"
+  local run_id="${RUN_ID:-harness_stage_b_margin_recovered_timing_repetition_focused_listening_fill}"
+  local candidate_id="margin_recovered_timing_repetition_seed_37_topk_7_temp_086_n48_sample_39"
+  local review_notes="outputs/stage_b_margin_recovered_timing_repetition_focused_listening_notes/${notes_run_id}/focused_listening_review_notes_template.json"
+  if [[ ! -f "$review_notes" ]]; then
+    print_header "Stage B margin-recovered timing/repetition focused listening notes"
+    RUN_ID="$notes_run_id" run_stage_b_margin_recovered_timing_repetition_focused_listening_notes
+  fi
+  print_header "Stage B margin-recovered timing/repetition focused listening fill"
+  "$PYTHON_BIN" scripts/fill_stage_b_margin_recovered_timing_repetition_focused_listening_notes.py \
+    --run_id "$run_id" \
+    --review_notes "$review_notes" \
+    --expected_candidate_id "$candidate_id" \
+    --expected_decision needs_followup
 }
 
 run_stage_b_constrained_probe() {
@@ -1866,6 +1886,9 @@ case "$MODE" in
     ;;
   stage-b-margin-recovered-timing-repetition-focused-listening-notes)
     run_stage_b_margin_recovered_timing_repetition_focused_listening_notes
+    ;;
+  stage-b-margin-recovered-timing-repetition-focused-listening-fill)
+    run_stage_b_margin_recovered_timing_repetition_focused_listening_fill
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/fill_stage_b_margin_recovered_timing_repetition_focused_listening_notes.py
+++ b/scripts/fill_stage_b_margin_recovered_timing_repetition_focused_listening_notes.py
@@ -1,0 +1,196 @@
+"""Fill timing/repetition focused listening notes from MIDI/context evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.build_stage_b_margin_recovered_listening_notes import write_json  # noqa: E402
+from scripts.build_stage_b_margin_recovered_timing_repetition_focused_listening_notes import (  # noqa: E402
+    read_json,
+    validate_notes,
+)
+
+
+class TimingRepetitionFocusedListeningFillError(ValueError):
+    pass
+
+
+def fill_candidate(candidate: dict[str, Any]) -> dict[str, Any]:
+    filled = json.loads(json.dumps(candidate))
+    metrics = filled.get("focused_context_metrics") if isinstance(filled.get("focused_context_metrics"), dict) else {}
+    risks = set(str(risk) for risk in filled.get("review_risks", []))
+    dead_air = float(metrics.get("dead_air_ratio", 0.0) or 0.0)
+    adjacent_repeats = int(metrics.get("adjacent_pitch_repeats", 0) or 0)
+    unique_pitch = int(metrics.get("unique_pitch_count", 0) or 0)
+    phrase_span = float(metrics.get("phrase_span_beats", 0.0) or 0.0)
+    max_interval = int(metrics.get("max_interval", 0) or 0)
+    final_role = str(metrics.get("final_note_role") or "")
+    timing = "stiff" if dead_air >= 0.40 else "acceptable"
+    chord_fit = "strong" if final_role == "chord_tone" else "acceptable" if final_role == "tension" else "unclear"
+    phrase_continuation = "weak" if phrase_span < 7.0 or max_interval >= 12 else "acceptable"
+    landing = "strong" if final_role == "chord_tone" else "acceptable" if final_role == "tension" else "weak"
+    jazz_vocabulary = "thin" if adjacent_repeats > 0 or max_interval >= 12 else "acceptable"
+    decision = "needs_followup"
+    if (
+        timing == "acceptable"
+        and phrase_continuation == "acceptable"
+        and landing in {"strong", "acceptable"}
+        and jazz_vocabulary == "acceptable"
+    ):
+        decision = "keep"
+    if unique_pitch < 4 or phrase_span < 4.0:
+        decision = "reject"
+    filled["listening"] = {
+        "status": "reviewed",
+        "timing": timing,
+        "chord_fit": chord_fit,
+        "phrase_continuation": phrase_continuation,
+        "landing": landing,
+        "jazz_vocabulary": jazz_vocabulary,
+        "decision": decision,
+        "notes": (
+            "MIDI/context evidence fill. Timing improved below the previous dead-air gate, "
+            "but adjacent repeats and a wide interval remain review risks."
+        ),
+    }
+    filled["listening_fill_evidence"] = {
+        "not_human_audio_review": True,
+        "dead_air_ratio": dead_air,
+        "adjacent_pitch_repeats": adjacent_repeats,
+        "phrase_span_beats": phrase_span,
+        "max_interval": max_interval,
+        "final_note": str(metrics.get("final_note") or ""),
+        "final_chord": str(metrics.get("final_chord") or ""),
+        "final_note_role": final_role,
+        "review_risks": sorted(risks),
+        "improved_from_pitch_vocab_fill": {
+            "timing": timing == "acceptable",
+            "dead_air_below_previous_gate": dead_air < 0.40,
+        },
+    }
+    return filled
+
+
+def fill_notes(notes: dict[str, Any]) -> dict[str, Any]:
+    candidates = notes.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise TimingRepetitionFocusedListeningFillError("notes must contain candidates")
+    filled = json.loads(json.dumps(notes))
+    filled["schema_version"] = "stage_b_margin_recovered_timing_repetition_focused_listening_fill_v1"
+    filled["filled_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    filled["fill_method"] = {
+        "source": "MIDI/context evidence",
+        "not_human_audio_review": True,
+    }
+    filled["candidates"] = [fill_candidate(candidate) for candidate in candidates]
+    return filled
+
+
+def markdown_report(notes: dict[str, Any], summary: dict[str, Any]) -> str:
+    lines = [
+        "# Stage B Timing/Repetition Focused Listening Fill",
+        "",
+        f"- candidate count: `{summary['candidate_count']}`",
+        f"- reviewed count: `{summary['reviewed_count']}`",
+        f"- pending count: `{summary['pending_count']}`",
+        f"- decisions: `{summary['decision_counts']}`",
+        "",
+        "This is a MIDI/context evidence fill, not a human audio listening proof.",
+        "",
+        "| candidate | timing | chord fit | phrase | landing | vocabulary | decision | risks |",
+        "|---|---|---|---|---|---|---|---|",
+    ]
+    for candidate in notes["candidates"]:
+        listening = candidate["listening"]
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(candidate.get("candidate_id") or ""),
+                    str(listening.get("timing") or ""),
+                    str(listening.get("chord_fit") or ""),
+                    str(listening.get("phrase_continuation") or ""),
+                    str(listening.get("landing") or ""),
+                    str(listening.get("jazz_vocabulary") or ""),
+                    str(listening.get("decision") or ""),
+                    ",".join(candidate.get("review_risks") or []),
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def validate_fill(
+    notes: dict[str, Any],
+    *,
+    expected_candidate_id: str | None,
+    expected_decision: str | None,
+) -> dict[str, Any]:
+    generic_notes = dict(notes)
+    generic_notes["schema_version"] = "stage_b_margin_recovered_timing_repetition_focused_listening_notes_v1"
+    summary = validate_notes(
+        generic_notes,
+        expected_candidate_id=expected_candidate_id,
+        expected_prior_decision="keep_for_focused_listening",
+    )
+    if expected_decision:
+        decisions = [str(candidate.get("listening", {}).get("decision") or "") for candidate in notes["candidates"]]
+        if decisions != [expected_decision]:
+            raise TimingRepetitionFocusedListeningFillError(
+                f"expected decision {expected_decision}, got {decisions}"
+            )
+    return summary
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Fill timing/repetition focused listening notes")
+    parser.add_argument("--review_notes", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=str(ROOT_DIR / "outputs" / "stage_b_margin_recovered_timing_repetition_focused_listening_fill"),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--expected_candidate_id", type=str, default="")
+    parser.add_argument("--expected_decision", type=str, default="")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    notes = read_json(Path(args.review_notes))
+    filled = fill_notes(notes)
+    summary = validate_fill(
+        filled,
+        expected_candidate_id=str(args.expected_candidate_id or ""),
+        expected_decision=str(args.expected_decision or ""),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    filled_path = output_dir / "focused_listening_review_notes_filled.json"
+    markdown_path = output_dir / "focused_listening_review_notes_filled.md"
+    write_json(filled_path, filled)
+    write_json(output_dir / "focused_listening_review_notes_fill_summary.json", summary)
+    markdown_path.write_text(markdown_report(filled, summary), encoding="utf-8")
+    print(
+        json.dumps(
+            {**summary, "filled_notes_path": str(filled_path), "markdown_path": str(markdown_path)},
+            ensure_ascii=True,
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_margin_recovered_timing_repetition_focused_listening_fill.py
+++ b/tests/test_stage_b_margin_recovered_timing_repetition_focused_listening_fill.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.fill_stage_b_margin_recovered_timing_repetition_focused_listening_notes import (
+    fill_notes,
+    validate_fill,
+)
+
+
+class StageBMarginRecoveredTimingRepetitionFocusedListeningFillTest(unittest.TestCase):
+    def sample_notes(self) -> dict:
+        return {
+            "schema_version": "stage_b_margin_recovered_timing_repetition_focused_listening_notes_v1",
+            "candidates": [
+                {
+                    "candidate_id": "timing_repetition_candidate",
+                    "review_files": {
+                        "midi_path": "outputs/timing.mid",
+                        "context_midi_path": "outputs/timing_context.mid",
+                    },
+                    "proxy_review": {
+                        "decision": "keep_for_focused_listening",
+                    },
+                    "focused_context_metrics": {
+                        "note_count": 14,
+                        "unique_pitch_count": 7,
+                        "phrase_span_beats": 6.5,
+                        "dead_air_ratio": 0.35294117647058826,
+                        "adjacent_pitch_repeats": 2,
+                        "duplicated_3_note_pitch_class_chunks": 0,
+                        "max_simultaneous_notes": 1,
+                        "max_interval": 16,
+                        "final_note": "A#4",
+                        "final_chord": "Fm7",
+                        "final_note_role": "tension",
+                    },
+                    "review_risks": [
+                        "dead_air_ratio_remaining",
+                        "adjacent_pitch_repeats",
+                        "wide_interval_review",
+                    ],
+                    "listening": {
+                        "status": "pending",
+                        "timing": "pending",
+                        "chord_fit": "pending",
+                        "phrase_continuation": "pending",
+                        "landing": "pending",
+                        "jazz_vocabulary": "pending",
+                        "decision": "pending",
+                        "notes": "",
+                    },
+                }
+            ],
+        }
+
+    def test_fill_marks_timing_improved_but_followup_needed(self) -> None:
+        filled = fill_notes(self.sample_notes())
+        summary = validate_fill(
+            filled,
+            expected_candidate_id="timing_repetition_candidate",
+            expected_decision="needs_followup",
+        )
+        candidate = filled["candidates"][0]
+
+        self.assertEqual(summary["reviewed_count"], 1)
+        self.assertEqual(summary["pending_count"], 0)
+        self.assertEqual(candidate["listening"]["timing"], "acceptable")
+        self.assertEqual(candidate["listening"]["chord_fit"], "acceptable")
+        self.assertEqual(candidate["listening"]["phrase_continuation"], "weak")
+        self.assertEqual(candidate["listening"]["landing"], "acceptable")
+        self.assertEqual(candidate["listening"]["jazz_vocabulary"], "thin")
+        self.assertEqual(candidate["listening"]["decision"], "needs_followup")
+        self.assertTrue(candidate["listening_fill_evidence"]["improved_from_pitch_vocab_fill"]["timing"])
+        self.assertTrue(candidate["listening_fill_evidence"]["not_human_audio_review"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a focused listening fill script for the timing/repetition candidate
- fill pending notes from MIDI/context evidence
- document the improved timing and remaining phrase/vocabulary blockers

## Result
- selected candidate: `margin_recovered_timing_repetition_seed_37_topk_7_temp_086_n48_sample_39`
- reviewed count: `1`
- pending count: `0`
- final decision: `needs_followup`
- timing: `acceptable`
- chord fit: `acceptable`
- phrase continuation: `weak`
- landing: `acceptable`
- jazz vocabulary: `thin`
- evidence: dead-air `0.353`, adjacent repeats `2`, max interval `16`, final `A#4` over `Fm7` tension

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_timing_repetition_focused_listening_fill`
- `bash scripts/agent_harness.sh stage-b-margin-recovered-timing-repetition-focused-listening-fill`
- `bash scripts/agent_harness.sh quick`
- `rg -n "codex|Codex|코덱스" ...changed files`

## Risk
- This is a MIDI/context evidence fill, not human audio proof.
- Next repair target is adjacent repeats and wide interval while preserving dead-air and pitch-vocabulary gates.

Closes #270