### PR TITLE
Stage B margin-recovered phrase vocabulary repair

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #270, Stage B margin-recovered timing/repetition focused listening fill.
+- Latest functional issue completed: Issue #272, Stage B margin-recovered timing/repetition phrase/vocabulary follow-up repair.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered timing/repetition phrase/vocabulary follow-up repair.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary focused context review.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -450,6 +450,14 @@ bash scripts/agent_harness.sh stage-b-margin-recovered-timing-repetition-focused
 ```
 
 This harness fills the focused listening review notes from MIDI/context evidence and records whether the candidate remains follow-up work.
+
+For Stage B margin-recovered phrase/vocabulary repair changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-repair
+```
+
+This harness tests whether the timing/repetition candidate can keep dead-air and pitch coverage while reducing adjacent repeats and wide intervals.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 | repair 후보 context 검증 필요 | objective repair만으로 final landing과 context guide 적합성 판단 불가 | solo/context package를 만들고 focused context decision 재실행 | decision `keep_for_focused_listening`, flags `{}`, final `A#4` over `Fm7` tension |
 | context keep 후보 청감 판단 보류 | context keep만으로 timing/phrase/vocabulary 최종 판단 불가 | focused listening notes template 생성 | candidate `1`, pending `1`, risks `dead_air_ratio_remaining`, `adjacent_pitch_repeats`, `wide_interval_review` |
 | focused listening fill 후 후속 개선 필요 | timing은 개선됐지만 adjacent repeat와 wide interval이 남음 | MIDI/context evidence 기준 listening fields 채움 | timing `acceptable`, phrase `weak`, vocabulary `thin`, decision `needs_followup` |
+| phrase/vocabulary blocker | adjacent repeat `2`, max interval `16`이 phrase/vocabulary risk로 남음 | top_k7, temperature `0.82`, seed `43/61` sweep으로 후보 재선택 | sample `43`, adjacent repeats `0`, max interval `7`, dead-air `0.333`, unique pitch `8` |
 
 ## 파이프라인 구조
 
@@ -60,7 +61,7 @@ flowchart LR
 
 ## 핵심 결과
 
-Issue #270 기준 model-core MVP:
+Issue #272 기준 model-core MVP:
 
 | 항목 | 결과 |
 |---|---|
@@ -94,6 +95,7 @@ Issue #270 기준 model-core MVP:
 | margin-recovered timing/repetition focused context | selected repair 후보를 solo/context package로 격리, decision `keep_for_focused_listening`, flags `{}` |
 | margin-recovered timing/repetition focused listening notes | focused listening template 생성, candidate `1`, pending `1`, review risks `3` |
 | margin-recovered timing/repetition focused listening fill | reviewed `1`, pending `0`, timing `acceptable`, phrase `weak`, vocabulary `thin`, decision `needs_followup` |
+| margin-recovered phrase vocabulary repair | seed43/61 top_k7 temp0.82 96개 후보 중 `2`개 qualified, sample `43` 선택, adjacent repeats `0`, max interval `7` |
 | constrained review gate | `stage-b-overlap-gate` 통과 |
 | focused candidate path | `stage-b-rhythm-phrase-variation` 통과 |
 
@@ -132,6 +134,7 @@ MVP 근거:
 - timing/repetition repair 후보를 solo/context package로 격리해 range `C#4-G5`, phrase span `6.5` beats, max active `1`, final `A#4` over `Fm7` tension, context decision `keep_for_focused_listening` 확인
 - context keep 후보를 focused listening notes template으로 넘기고 timing, phrase continuation, landing, vocabulary, final decision을 pending으로 유지
 - focused listening fill에서 timing은 `acceptable`로 개선됐지만 adjacent repeats `2`, max interval `16` 때문에 phrase continuation `weak`, jazz vocabulary `thin`, decision `needs_followup`으로 기록
+- phrase/vocabulary repair sweep에서 focused unique pitch `8`, note count `13`, max active `1`, duplicated 3-note chunk `0`, dead-air `0.333`, adjacent repeats `0`, max interval `7`인 qualified 후보 선택
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`
@@ -143,7 +146,7 @@ MVP 근거:
 | 만든 것 | symbolic MIDI 생성 모델의 dataset, tokenization, training, generation, decode, objective review, proxy review pipeline |
 | 겪은 문제 | `.mid` 파일 존재만으로 성공 판단 불가, one-note collapse, long sustain block, chord block, dead-air outlier, seed-level margin 부족 |
 | 해결 방식 | duration-explicit token 구조, grammar/coverage/chord-aware probe, overlap-free postprocess, repeatability sweep, dead-air diagnostics, proxy review scoring, repair candidate selection |
-| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab focused context `keep_for_focused_listening`, timing/repetition repair qualified `2/96`, timing/repetition focused context `keep_for_focused_listening` |
+| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab focused context `keep_for_focused_listening`, timing/repetition repair qualified `2/96`, phrase/vocabulary repair qualified `2/96`, adjacent repeats `0`, max interval `7` |
 | 주장 경계 | reviewable MIDI 후보 생성 검증 파이프라인까지 가능, human listening preference / Brad style adaptation / broad production quality는 미검증 |
 
 Issue #210 기준 current best focused review candidate:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -80,6 +80,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered timing/repetition focused context 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_CONTEXT_2026-05-28.md`
 - margin-recovered timing/repetition focused listening notes 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_NOTES_2026-05-28.md`
 - margin-recovered timing/repetition focused listening fill 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_FILL_2026-05-28.md`
+- margin-recovered phrase/vocabulary repair 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_REPAIR_2026-05-28.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -105,6 +106,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered timing/repetition focused context: selected repair 후보 focused context decision `keep_for_focused_listening`, flags `{}`
 - margin-recovered timing/repetition focused listening notes: candidate `1`, pending `1`, prior decision `keep_for_focused_listening`, risks `dead_air_ratio_remaining` / `adjacent_pitch_repeats` / `wide_interval_review`
 - margin-recovered timing/repetition focused listening fill: reviewed `1`, decision `needs_followup`, timing `acceptable`, phrase continuation `weak`, jazz vocabulary `thin`
+- margin-recovered phrase/vocabulary repair: seed `43/61` top_k7 temp0.82 96개 후보 중 qualified `2`, selected sample `43`, adjacent repeats `0`, max interval `7`, dead-air `0.333`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -301,6 +303,7 @@ Stage B에서 명시하는 것:
 130. Stage B margin-recovered timing/repetition focused context review
 131. Stage B margin-recovered timing/repetition focused listening notes
 132. Stage B margin-recovered timing/repetition focused listening fill
+133. Stage B margin-recovered timing/repetition phrase/vocabulary follow-up repair
 
 가장 최근 의미 있는 결과:
 
@@ -476,6 +479,8 @@ Stage B에서 명시하는 것:
 - Issue #268 result: candidate `1`, pending `1`, prior decision `keep_for_focused_listening`, review risks `dead_air_ratio_remaining`, `adjacent_pitch_repeats`, and `wide_interval_review`.
 - Issue #270 fills that focused listening note from MIDI/context evidence.
 - Issue #270 result: timing improves to `acceptable`, chord fit `acceptable`, landing `acceptable`, but phrase continuation is `weak`, jazz vocabulary is `thin`, and decision remains `needs_followup` because adjacent repeats `2` and max interval `16` remain.
+- Issue #272 runs a phrase/vocabulary repair sweep over seed `43/61`, top_k `7`, temperature `0.82`.
+- Issue #272 result: selected sample `43` keeps dead-air `< 0.400`, focused unique pitch `8`, focused notes `13`, max active `1`, dup3 `0`, and improves adjacent repeats `2 -> 0` plus max interval `16 -> 7`; focused context/listening 재검증은 아직 남아 있다.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -494,8 +499,8 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-Issue #270은 timing/repetition repair 후보의 focused listening fill을 완료했고, 결과는 `needs_followup`이다.
-다음 작업은 adjacent repeats와 wide interval을 줄이는 phrase/vocabulary follow-up repair다.
+Issue #272는 adjacent repeats와 wide interval을 objective gate 기준으로 줄인 새 후보를 찾았다.
+다음 작업은 이 후보를 focused solo/context package로 격리하고 context decision을 다시 실행하는 것이다.
 
 ## 6. 다음 단계 로드맵
 
@@ -1021,40 +1026,34 @@ Issue #270은 timing/repetition repair 후보의 focused listening fill을 완�
 완료된 바로 전 작업:
 
 ```text
-Stage B margin-recovered timing/repetition focused listening fill
+Stage B margin-recovered timing/repetition phrase/vocabulary follow-up repair
 ```
 
 결과:
 
-- docs: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_FILL_2026-05-28.md`
-- selected candidate: `margin_recovered_timing_repetition_seed_37_topk_7_temp_086_n48_sample_39`
-- reviewed count: `1`
-- pending count: `0`
-- prior decision: `keep_for_focused_listening`
-- final decision: `needs_followup`
-- timing: `acceptable`
-- chord fit: `acceptable`
-- phrase continuation: `weak`
-- landing: `acceptable`
-- jazz vocabulary: `thin`
-- review risks: `dead_air_ratio_remaining`, `adjacent_pitch_repeats`, `wide_interval_review`
-- dead-air ratio: `0.353`
-- adjacent pitch repeats: `2`
-- focused unique pitch count: `7`
-- focused note count: `14`
-- phrase span: `6.5` beats
-- final landing: `A#4` over `Fm7`, tension
+- docs: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_REPAIR_2026-05-28.md`
+- selected candidate: `margin_recovered_phrase_vocab_seed_43_topk_7_temp_082_n48_sample_43`
+- selected source run: `harness_stage_b_margin_recovered_phrase_vocab_seed43_topk7_temp082_n48`
+- selected sample seed: `85`
+- qualified candidates: `2/96`
+- dead-air ratio: `0.333`
+- adjacent pitch repeats: `0`
+- focused unique pitch count: `8`
+- focused note count: `13`
+- max interval: `7`
+- remaining flags: `[]`
 
 판단:
 
-- timing은 Issue #262보다 개선됐다.
-- phrase continuation과 vocabulary는 아직 blocker다.
+- phrase/vocabulary objective blockers는 Issue #270 후보보다 개선됐다.
+- 아직 focused context package와 focused listening fill을 다시 통과한 것은 아니다.
 - broad trained-model quality, human listening preference, Brad style adaptation은 아직 미검증이다.
 
 다음 작업:
 
-- 다음 issue는 `Stage B margin-recovered timing/repetition phrase/vocabulary follow-up repair`로 잡는다.
-- adjacent repeats와 max interval을 줄이면서 dead-air `< 0.400`, focused unique pitch `>= 6`, max active `1`을 유지한다.
+- 다음 issue는 `Stage B margin-recovered phrase/vocabulary focused context review`로 잡는다.
+- selected candidate를 solo/context package로 격리한다.
+- final landing, phrase span, context guide, max active, repeated cell을 다시 검증한다.
 - focused listening fill에서 keep이 나오기 전에는 최종 keep으로 주장하지 않는다.
 
 ## 10. 한 문장 요약

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #270, Stage B margin-recovered timing/repetition focused listening fill
-- 다음 권장 이슈: `Stage B margin-recovered timing/repetition phrase/vocabulary follow-up repair`
+- latest functional result: Issue #272, Stage B margin-recovered timing/repetition phrase/vocabulary follow-up repair
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary focused context review`
 
 현재 범위가 아닌 것:
 
@@ -1058,6 +1058,60 @@ Issue #270은 Issue #268 pending notes를 MIDI/context evidence 기준으로 채
 Docs:
 
 - `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_FILL_2026-05-28.md`
+
+## Current Margin-Recovered Phrase/Vocabulary Repair Result
+
+Issue #272는 Issue #270에서 남은 adjacent repeat / wide interval blocker를 좁게 repair한 작업이다.
+
+변경:
+
+- phrase/vocabulary repair summary script 추가
+- seed `43/61`, top_k `7`, temperature `0.82`, n `48` generation harness 추가
+- qualified gate를 `dead_air < 0.400`, `adjacent repeats < 2`, `max interval < 12`, `focused unique pitch >= 6`, `focused notes >= 12`, `max active = 1`, `dup3 = 0`로 고정
+- Issue #270 후보 대비 adjacent repeat, max interval, dead-air, unique pitch delta 기록
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_phrase_vocabulary_repair`
+- `bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-repair`
+
+결과:
+
+| 항목 | 값 |
+|---|---|
+| candidate | `margin_recovered_phrase_vocab_seed_43_topk_7_temp_082_n48_sample_43` |
+| source run | `harness_stage_b_margin_recovered_phrase_vocab_seed43_topk7_temp082_n48` |
+| sample seed | `85` |
+| qualified candidates | `2/96` |
+| focused note count | `13` |
+| focused unique pitch count | `8` |
+| focused max active notes | `1` |
+| duplicated 3-note chunks | `0` |
+| dead-air ratio | `0.333` |
+| adjacent pitch repeats | `0` |
+| max interval | `7` |
+| remaining flags | `[]` |
+
+Issue #270 후보 대비:
+
+| 항목 | 이전 | 이번 | 변화 |
+|---|---:|---:|---:|
+| dead-air ratio | `0.353` | `0.333` | `+0.020` 개선 |
+| adjacent pitch repeats | `2` | `0` | `+2` 개선 |
+| max interval | `16` | `7` | `+9` 개선 |
+| focused unique pitch count | `7` | `8` | `+1` |
+| focused note count | `14` | `13` | `-1` |
+
+해석:
+
+- phrase/vocabulary objective blockers는 개선됐다.
+- dead-air와 pitch vocabulary gate는 유지됐다.
+- 아직 focused context package와 focused listening fill을 다시 통과한 것은 아니다.
+- 다음 작업은 selected candidate를 solo/context package로 격리하고 context decision을 다시 실행하는 것이다.
+
+Docs:
+
+- `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_REPAIR_2026-05-28.md`
 
 ## Latest README Footer Section Removal Result
 

--- a/docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_REPAIR_2026-05-28.md
+++ b/docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_REPAIR_2026-05-28.md
@@ -1,0 +1,71 @@
+# Stage B Margin-Recovered Phrase/Vocabulary Repair
+
+## 요약
+
+Issue #272는 Issue #270 focused listening fill에서 남은 phrase continuation / jazz vocabulary blocker를 좁게 repair한 작업이다.
+
+Issue #270 후보는 timing은 `acceptable`로 개선됐지만, adjacent repeats `2`와 max interval `16` 때문에 phrase continuation `weak`, jazz vocabulary `thin`, decision `needs_followup`으로 남았다.
+
+이번 작업은 seed/top-k/temperature sweep에서 adjacent repeat와 wide interval을 동시에 낮추는 후보를 선택했다.
+
+## 변경
+
+- phrase/vocabulary repair summary script 추가
+- seed `43/61`, top_k `7`, temperature `0.82`, n `48` generation harness 추가
+- qualified gate를 `dead_air < 0.400`, `adjacent repeats < 2`, `max interval < 12`, `focused unique pitch >= 6`, `focused notes >= 12`, `max active = 1`, `dup3 = 0`로 고정
+- Issue #270 후보 대비 dead-air, adjacent repeat, max interval, unique pitch, note count delta 기록
+
+## 결과
+
+| 항목 | 값 |
+|---|---|
+| selected candidate | `margin_recovered_phrase_vocab_seed_43_topk_7_temp_082_n48_sample_43` |
+| source run | `harness_stage_b_margin_recovered_phrase_vocab_seed43_topk7_temp082_n48` |
+| selected sample | `43` |
+| selected sample seed | `85` |
+| report count | `2` |
+| candidate count | `96` |
+| qualified candidate count | `2` |
+| qualified | `true` |
+| remaining flags | `[]` |
+| focused note count | `13` |
+| focused unique pitch count | `8` |
+| focused max active notes | `1` |
+| duplicated 3-note pitch-class chunks | `0` |
+| dead-air ratio | `0.333` |
+| adjacent pitch repeats | `0` |
+| max interval | `7` |
+| onset coverage | `0.500` |
+| sustained coverage | `0.594` |
+
+Issue #270 후보 대비:
+
+| 항목 | 이전 | 이번 | 변화 |
+|---|---:|---:|---:|
+| dead-air ratio | `0.353` | `0.333` | `+0.020` 개선 |
+| adjacent pitch repeats | `2` | `0` | `+2` 개선 |
+| max interval | `16` | `7` | `+9` 개선 |
+| focused unique pitch count | `7` | `8` | `+1` |
+| focused note count | `14` | `13` | `-1` |
+
+## 해석
+
+- Issue #270의 phrase/vocabulary blocker였던 adjacent repeats와 wide interval은 objective gate 기준으로 개선됐다.
+- dead-air와 pitch vocabulary gate도 유지됐다.
+- note count는 `1`개 줄었지만 focused review gate의 최소 조건은 유지한다.
+- 아직 focused context package와 focused listening fill을 다시 통과한 것은 아니다.
+- broad model quality나 human/audio preference proof는 아니다.
+
+## 검증
+
+```bash
+.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_phrase_vocabulary_repair
+bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-repair
+```
+
+## 산출물
+
+- script: `scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_repair.py`
+- test: `tests/test_stage_b_margin_recovered_phrase_vocabulary_repair.py`
+- harness: `stage-b-margin-recovered-phrase-vocabulary-repair`
+- summary: `outputs/stage_b_margin_recovered_phrase_vocabulary_repair/harness_stage_b_margin_recovered_phrase_vocabulary_repair/phrase_vocabulary_repair_summary.json`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -68,6 +68,8 @@ Modes:
                 Build focused listening notes for the selected timing/repetition candidate.
   stage-b-margin-recovered-timing-repetition-focused-listening-fill
                 Fill the selected timing/repetition focused listening review notes.
+  stage-b-margin-recovered-phrase-vocabulary-repair
+                Run phrase/vocabulary repair sweep and select a reduced-repeat/interval candidate.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -208,6 +210,7 @@ run_quick() {
     scripts/build_stage_b_margin_recovered_timing_repetition_focused_package.py \
     scripts/build_stage_b_margin_recovered_timing_repetition_focused_listening_notes.py \
     scripts/fill_stage_b_margin_recovered_timing_repetition_focused_listening_notes.py \
+    scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_repair.py \
     scripts/run_stage_b_sampling_sweep.py \
     scripts/run_stage_b_coverage_ab_sweep.py \
     scripts/run_stage_b_pitch_mode_compare.py \
@@ -714,6 +717,60 @@ run_stage_b_margin_recovered_timing_repetition_focused_listening_fill() {
     --review_notes "$review_notes" \
     --expected_candidate_id "$candidate_id" \
     --expected_decision needs_followup
+}
+
+run_stage_b_margin_recovered_phrase_vocabulary_repair() {
+  local seed43_run_id="${SEED43_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocab_seed43_topk7_temp082_n48}"
+  local seed61_run_id="${SEED61_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocab_seed61_topk7_temp082_n48}"
+  local run_id="${RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_repair}"
+  local checkpoint_dir="${CHECKPOINT_DIR:-outputs/stage_b_generation_probe/issue_238_stage_b_candidate_count_margin_recovery_seed31_files6/checkpoints}"
+  print_header "Stage B margin-recovered phrase/vocabulary repair seed 43"
+  "$PYTHON_BIN" scripts/run_stage_b_generation_probe.py \
+    --run_id "$seed43_run_id" \
+    --checkpoint_dir "$checkpoint_dir" \
+    --skip_prepare \
+    --skip_train \
+    --seed 43 \
+    --max_files 6 \
+    --max_sequence 96 \
+    --num_samples 48 \
+    --temperature 0.82 \
+    --top_k 7 \
+    --postprocess_overlap \
+    --max_simultaneous_notes 2 \
+    --require_valid_sample \
+    --require_strict_valid_sample \
+    --require_note_groups \
+    --issue_number 272
+
+  print_header "Stage B margin-recovered phrase/vocabulary repair seed 61"
+  "$PYTHON_BIN" scripts/run_stage_b_generation_probe.py \
+    --run_id "$seed61_run_id" \
+    --checkpoint_dir "$checkpoint_dir" \
+    --skip_prepare \
+    --skip_train \
+    --seed 61 \
+    --max_files 6 \
+    --max_sequence 96 \
+    --num_samples 48 \
+    --temperature 0.82 \
+    --top_k 7 \
+    --postprocess_overlap \
+    --max_simultaneous_notes 2 \
+    --require_valid_sample \
+    --require_strict_valid_sample \
+    --require_note_groups \
+    --issue_number 272
+
+  print_header "Stage B margin-recovered phrase/vocabulary repair summary"
+  "$PYTHON_BIN" scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_repair.py \
+    --run_id "$run_id" \
+    --report_path "outputs/stage_b_generation_probe/${seed43_run_id}/report.json" \
+    --report_path "outputs/stage_b_generation_probe/${seed61_run_id}/report.json" \
+    --require_qualified \
+    --require_phrase_vocabulary_improvement \
+    --expected_source_run_id "$seed43_run_id" \
+    --expected_sample_index 43
 }
 
 run_stage_b_constrained_probe() {
@@ -1889,6 +1946,9 @@ case "$MODE" in
     ;;
   stage-b-margin-recovered-timing-repetition-focused-listening-fill)
     run_stage_b_margin_recovered_timing_repetition_focused_listening_fill
+    ;;
+  stage-b-margin-recovered-phrase-vocabulary-repair)
+    run_stage_b_margin_recovered_phrase_vocabulary_repair
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_repair.py
+++ b/scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_repair.py
@@ -1,0 +1,434 @@
+"""Summarize a Stage B phrase/vocabulary repair sweep for the timing/repetition candidate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pretty_midi
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.build_stage_b_margin_recovered_listening_notes import write_json  # noqa: E402
+from scripts.select_stage_b_margin_recovered_repair_candidate import (  # noqa: E402
+    build_candidates,
+    non_drum_notes,
+    read_json,
+)
+from scripts.run_stage_b_generation_probe import postprocess_stage_b_midi  # noqa: E402
+from scripts.summarize_stage_b_margin_recovered_pitch_vocab_sweep import safe_label  # noqa: E402
+from scripts.summarize_stage_b_margin_recovered_timing_repetition_repair import float_value  # noqa: E402
+
+
+class MarginRecoveredPhraseVocabularyRepairError(ValueError):
+    pass
+
+
+def focused_max_interval(midi_path: Path) -> int:
+    midi = pretty_midi.PrettyMIDI(str(midi_path))
+    postprocess_stage_b_midi(midi, simultaneous_limit=1)
+    pitches = [int(note.pitch) for note in non_drum_notes(midi)]
+    intervals = [abs(pitches[index + 1] - pitches[index]) for index in range(len(pitches) - 1)]
+    return int(max(intervals, default=0))
+
+
+def candidate_gate_flags(
+    candidate: dict[str, Any],
+    *,
+    min_unique_pitch_count: int,
+    max_dead_air_ratio_exclusive: float,
+    min_note_count: int,
+    max_simultaneous_notes: int,
+    max_duplicated_3_note_chunks: int,
+    max_adjacent_pitch_repeats_exclusive: int,
+    max_interval_exclusive: int,
+) -> list[str]:
+    focused = candidate["focused_solo_metrics"]
+    metrics = candidate["metrics"]
+    flags: list[str] = []
+    if int(focused.get("focused_unique_pitch_count", 0) or 0) < min_unique_pitch_count:
+        flags.append("low_pitch_variety")
+    if float_value(metrics.get("dead_air_ratio"), 1.0) >= max_dead_air_ratio_exclusive:
+        flags.append("dead_air_not_repaired")
+    if int(focused.get("focused_note_count", 0) or 0) < min_note_count:
+        flags.append("too_sparse_for_context_review")
+    if int(focused.get("focused_max_simultaneous_notes", 0) or 0) > max_simultaneous_notes:
+        flags.append("focused_polyphony")
+    if int(focused.get("focused_duplicated_3_note_pitch_class_chunks", 0) or 0) > max_duplicated_3_note_chunks:
+        flags.append("repeated_pitch_class_cell")
+    if int(focused.get("focused_adjacent_pitch_repeats", 0) or 0) >= max_adjacent_pitch_repeats_exclusive:
+        flags.append("adjacent_repetition_not_repaired")
+    if int(focused.get("focused_max_interval", 0) or 0) >= max_interval_exclusive:
+        flags.append("wide_interval_not_repaired")
+    return flags
+
+
+def repair_score(candidate: dict[str, Any], *, qualified: bool) -> float:
+    focused = candidate["focused_solo_metrics"]
+    metrics = candidate["metrics"]
+    temporal = candidate["temporal_coverage"]
+    score = 1000.0 if qualified else 0.0
+    score += (1.0 - min(1.0, float_value(metrics.get("dead_air_ratio"), 1.0))) * 180.0
+    score += min(10, int(focused.get("focused_unique_pitch_count", 0) or 0)) * 24.0
+    score += min(16, int(focused.get("focused_note_count", 0) or 0)) * 3.0
+    score += float(temporal.get("onset_coverage_ratio", 0.0) or 0.0) * 20.0
+    score += float(temporal.get("sustained_coverage_ratio", 0.0) or 0.0) * 10.0
+    score -= int(focused.get("focused_adjacent_pitch_repeats", 0) or 0) * 20.0
+    score -= max(0, int(focused.get("focused_max_interval", 0) or 0) - 7) * 8.0
+    score -= int(focused.get("focused_duplicated_3_note_pitch_class_chunks", 0) or 0) * 40.0
+    return round(float(score), 6)
+
+
+def enrich_candidates(
+    report: dict[str, Any],
+    *,
+    report_path: Path,
+    min_unique_pitch_count: int,
+    max_dead_air_ratio_exclusive: float,
+    min_note_count: int,
+    max_simultaneous_notes: int,
+    max_duplicated_3_note_chunks: int,
+    max_adjacent_pitch_repeats_exclusive: int,
+    max_interval_exclusive: int,
+) -> list[dict[str, Any]]:
+    source_run_id = str(report.get("run_id") or report_path.parent.name)
+    request = dict(report.get("request") or {})
+    summary = dict(report.get("summary") or {})
+    request_seed = int(request.get("seed", 0) or 0)
+    top_k = request.get("top_k")
+    temperature = request.get("temperature")
+    sample_count = int(summary.get("sample_count", len(report.get("samples") or [])) or 0)
+    rows = build_candidates(report)
+    enriched: list[dict[str, Any]] = []
+    for row in rows:
+        row = dict(row)
+        focused = dict(row["focused_solo_metrics"])
+        focused["focused_max_interval"] = focused_max_interval(Path(str(row["midi_path"])))
+        row["focused_solo_metrics"] = focused
+        row["source_run_id"] = source_run_id
+        row["source_report_path"] = str(report_path)
+        row["source_request"] = {
+            "seed": request_seed,
+            "top_k": top_k,
+            "temperature": temperature,
+            "sample_count": sample_count,
+        }
+        row["candidate_id"] = (
+            "margin_recovered_phrase_vocab_seed_{seed}_topk_{top_k}_temp_{temperature}_n{count}_sample_{sample}".format(
+                seed=request_seed,
+                top_k=safe_label(top_k),
+                temperature=safe_label(temperature),
+                count=sample_count,
+                sample=int(row.get("sample_index", 0) or 0),
+            )
+        )
+        flags = candidate_gate_flags(
+            row,
+            min_unique_pitch_count=min_unique_pitch_count,
+            max_dead_air_ratio_exclusive=max_dead_air_ratio_exclusive,
+            min_note_count=min_note_count,
+            max_simultaneous_notes=max_simultaneous_notes,
+            max_duplicated_3_note_chunks=max_duplicated_3_note_chunks,
+            max_adjacent_pitch_repeats_exclusive=max_adjacent_pitch_repeats_exclusive,
+            max_interval_exclusive=max_interval_exclusive,
+        )
+        row["phrase_vocabulary_gate"] = {
+            "qualified": not flags,
+            "flags": flags,
+        }
+        row["phrase_vocabulary_score"] = repair_score(row, qualified=not flags)
+        enriched.append(row)
+    return enriched
+
+
+def build_repair_report(
+    report_paths: list[Path],
+    *,
+    output_dir: Path,
+    previous_candidate_id: str,
+    previous_dead_air: float,
+    previous_unique_pitch_count: int,
+    previous_note_count: int,
+    previous_adjacent_pitch_repeats: int,
+    previous_max_interval: int,
+    min_unique_pitch_count: int,
+    max_dead_air_ratio_exclusive: float,
+    min_note_count: int,
+    max_simultaneous_notes: int,
+    max_duplicated_3_note_chunks: int,
+    max_adjacent_pitch_repeats_exclusive: int,
+    max_interval_exclusive: int,
+) -> dict[str, Any]:
+    if not report_paths:
+        raise MarginRecoveredPhraseVocabularyRepairError("at least one report path is required")
+    candidates: list[dict[str, Any]] = []
+    for path in report_paths:
+        report = read_json(path)
+        candidates.extend(
+            enrich_candidates(
+                report,
+                report_path=path,
+                min_unique_pitch_count=min_unique_pitch_count,
+                max_dead_air_ratio_exclusive=max_dead_air_ratio_exclusive,
+                min_note_count=min_note_count,
+                max_simultaneous_notes=max_simultaneous_notes,
+                max_duplicated_3_note_chunks=max_duplicated_3_note_chunks,
+                max_adjacent_pitch_repeats_exclusive=max_adjacent_pitch_repeats_exclusive,
+                max_interval_exclusive=max_interval_exclusive,
+            )
+        )
+    if not candidates:
+        raise MarginRecoveredPhraseVocabularyRepairError("no candidates found")
+    candidates.sort(
+        key=lambda row: (
+            not bool(row["phrase_vocabulary_gate"]["qualified"]),
+            -float(row["phrase_vocabulary_score"]),
+            int(row["focused_solo_metrics"].get("focused_adjacent_pitch_repeats", 0) or 0),
+            int(row["focused_solo_metrics"].get("focused_max_interval", 0) or 0),
+            float_value(row["metrics"].get("dead_air_ratio"), 1.0),
+            -int(row["focused_solo_metrics"].get("focused_unique_pitch_count", 0) or 0),
+            -int(row["focused_solo_metrics"].get("focused_note_count", 0) or 0),
+            str(row["source_run_id"]),
+            int(row["sample_index"]),
+        )
+    )
+    for index, row in enumerate(candidates, start=1):
+        row["repair_rank"] = int(index)
+    selected = candidates[0]
+    focused = selected["focused_solo_metrics"]
+    metrics = selected["metrics"]
+    selected_dead_air = float_value(metrics.get("dead_air_ratio"), 0.0)
+    selected_unique = int(focused.get("focused_unique_pitch_count", 0) or 0)
+    selected_note_count = int(focused.get("focused_note_count", 0) or 0)
+    selected_adjacent_repeats = int(focused.get("focused_adjacent_pitch_repeats", 0) or 0)
+    selected_max_interval = int(focused.get("focused_max_interval", 0) or 0)
+    qualified_count = sum(1 for row in candidates if row["phrase_vocabulary_gate"]["qualified"])
+    return {
+        "schema_version": "stage_b_margin_recovered_phrase_vocabulary_repair_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_report_paths": [str(path) for path in report_paths],
+        "thresholds": {
+            "min_focused_unique_pitch_count": int(min_unique_pitch_count),
+            "max_dead_air_ratio_exclusive": float(max_dead_air_ratio_exclusive),
+            "min_focused_note_count": int(min_note_count),
+            "max_focused_simultaneous_notes": int(max_simultaneous_notes),
+            "max_duplicated_3_note_pitch_class_chunks": int(max_duplicated_3_note_chunks),
+            "max_adjacent_pitch_repeats_exclusive": int(max_adjacent_pitch_repeats_exclusive),
+            "max_interval_exclusive": int(max_interval_exclusive),
+        },
+        "previous_timing_repetition_candidate": {
+            "candidate_id": previous_candidate_id,
+            "dead_air_ratio": float(previous_dead_air),
+            "focused_unique_pitch_count": int(previous_unique_pitch_count),
+            "focused_note_count": int(previous_note_count),
+            "focused_adjacent_pitch_repeats": int(previous_adjacent_pitch_repeats),
+            "focused_max_interval": int(previous_max_interval),
+        },
+        "report_count": int(len(report_paths)),
+        "candidate_count": int(len(candidates)),
+        "qualified_candidate_count": int(qualified_count),
+        "selected_candidate": selected,
+        "repair_summary": {
+            "selected_candidate_id": selected["candidate_id"],
+            "selected_source_run_id": selected["source_run_id"],
+            "selected_sample_index": int(selected["sample_index"]),
+            "selected_sample_seed": int(selected.get("sample_seed", 0) or 0),
+            "qualified": bool(selected["phrase_vocabulary_gate"]["qualified"]),
+            "remaining_flags": list(selected["phrase_vocabulary_gate"]["flags"]),
+            "previous_dead_air_ratio": float(previous_dead_air),
+            "selected_dead_air_ratio": selected_dead_air,
+            "dead_air_delta_from_previous": round(float(previous_dead_air) - selected_dead_air, 6),
+            "previous_focused_unique_pitch_count": int(previous_unique_pitch_count),
+            "selected_focused_unique_pitch_count": selected_unique,
+            "focused_unique_pitch_delta_from_previous": int(selected_unique - previous_unique_pitch_count),
+            "previous_focused_note_count": int(previous_note_count),
+            "selected_focused_note_count": selected_note_count,
+            "focused_note_delta_from_previous": int(selected_note_count - previous_note_count),
+            "previous_adjacent_pitch_repeats": int(previous_adjacent_pitch_repeats),
+            "selected_adjacent_pitch_repeats": selected_adjacent_repeats,
+            "adjacent_pitch_repeat_delta_from_previous": int(
+                previous_adjacent_pitch_repeats - selected_adjacent_repeats
+            ),
+            "previous_max_interval": int(previous_max_interval),
+            "selected_max_interval": selected_max_interval,
+            "max_interval_delta_from_previous": int(previous_max_interval - selected_max_interval),
+            "phrase_vocabulary_improved": bool(
+                selected_adjacent_repeats < int(previous_adjacent_pitch_repeats)
+                and selected_max_interval < int(previous_max_interval)
+            ),
+        },
+        "candidates": candidates,
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["repair_summary"]
+    lines = [
+        "# Stage B Margin-Recovered Phrase/Vocabulary Repair",
+        "",
+        f"- report count: `{report['report_count']}`",
+        f"- candidate count: `{report['candidate_count']}`",
+        f"- qualified candidate count: `{report['qualified_candidate_count']}`",
+        f"- selected candidate: `{summary['selected_candidate_id']}`",
+        f"- selected source run: `{summary['selected_source_run_id']}`",
+        f"- selected sample: `{summary['selected_sample_index']}`",
+        f"- selected sample seed: `{summary['selected_sample_seed']}`",
+        f"- qualified: `{summary['qualified']}`",
+        f"- remaining flags: `{summary['remaining_flags']}`",
+        f"- adjacent repeat delta from previous: `{summary['adjacent_pitch_repeat_delta_from_previous']}`",
+        f"- max interval delta from previous: `{summary['max_interval_delta_from_previous']}`",
+        "",
+        "| rank | candidate | qualified | score | notes | unique | dead-air | onset | sustained | adj repeat | max interval | flags |",
+        "|---:|---|:---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for candidate in report["candidates"][:20]:
+        focused = candidate["focused_solo_metrics"]
+        metrics = candidate["metrics"]
+        temporal = candidate["temporal_coverage"]
+        gate = candidate["phrase_vocabulary_gate"]
+        lines.append(
+            "| {rank} | `{candidate_id}` | {qualified} | {score:.3f} | {notes} | {unique} | "
+            "{dead_air:.3f} | {onset:.3f} | {sustained:.3f} | {adj} | {max_interval} | `{flags}` |".format(
+                rank=int(candidate["repair_rank"]),
+                candidate_id=candidate["candidate_id"],
+                qualified=bool(gate["qualified"]),
+                score=float(candidate["phrase_vocabulary_score"]),
+                notes=int(focused["focused_note_count"]),
+                unique=int(focused["focused_unique_pitch_count"]),
+                dead_air=float_value(metrics.get("dead_air_ratio"), 0.0),
+                onset=float(temporal.get("onset_coverage_ratio", 0.0) or 0.0),
+                sustained=float(temporal.get("sustained_coverage_ratio", 0.0) or 0.0),
+                adj=int(focused["focused_adjacent_pitch_repeats"]),
+                max_interval=int(focused["focused_max_interval"]),
+                flags=list(gate["flags"]),
+            )
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def validate_repair(
+    report: dict[str, Any],
+    *,
+    require_qualified: bool,
+    require_phrase_vocabulary_improvement: bool,
+    expected_source_run_id: str | None,
+    expected_sample_index: int | None,
+) -> dict[str, Any]:
+    summary = report["repair_summary"]
+    if require_qualified and not bool(summary["qualified"]):
+        raise MarginRecoveredPhraseVocabularyRepairError("selected candidate is not qualified")
+    if require_phrase_vocabulary_improvement and not bool(summary["phrase_vocabulary_improved"]):
+        raise MarginRecoveredPhraseVocabularyRepairError(
+            "selected candidate did not improve phrase/vocabulary blockers"
+        )
+    if expected_source_run_id is not None and summary["selected_source_run_id"] != expected_source_run_id:
+        raise MarginRecoveredPhraseVocabularyRepairError(
+            f"expected source run {expected_source_run_id}, got {summary['selected_source_run_id']}"
+        )
+    if expected_sample_index is not None and int(summary["selected_sample_index"]) != int(expected_sample_index):
+        raise MarginRecoveredPhraseVocabularyRepairError(
+            f"expected sample {expected_sample_index}, got {summary['selected_sample_index']}"
+        )
+    return {
+        "report_count": int(report["report_count"]),
+        "candidate_count": int(report["candidate_count"]),
+        "qualified_candidate_count": int(report["qualified_candidate_count"]),
+        "selected_candidate_id": str(summary["selected_candidate_id"]),
+        "selected_source_run_id": str(summary["selected_source_run_id"]),
+        "selected_sample_index": int(summary["selected_sample_index"]),
+        "selected_sample_seed": int(summary["selected_sample_seed"]),
+        "qualified": bool(summary["qualified"]),
+        "phrase_vocabulary_improved": bool(summary["phrase_vocabulary_improved"]),
+        "dead_air_delta_from_previous": float(summary["dead_air_delta_from_previous"]),
+        "adjacent_pitch_repeat_delta_from_previous": int(summary["adjacent_pitch_repeat_delta_from_previous"]),
+        "max_interval_delta_from_previous": int(summary["max_interval_delta_from_previous"]),
+        "focused_unique_pitch_delta_from_previous": int(summary["focused_unique_pitch_delta_from_previous"]),
+        "focused_note_delta_from_previous": int(summary["focused_note_delta_from_previous"]),
+        "remaining_flags": list(summary["remaining_flags"]),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Summarize margin-recovered phrase/vocabulary repair sweep")
+    parser.add_argument("--report_path", action="append", required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=str(ROOT_DIR / "outputs" / "stage_b_margin_recovered_phrase_vocabulary_repair"),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument(
+        "--previous_candidate_id",
+        type=str,
+        default="margin_recovered_timing_repetition_seed_37_topk_7_temp_086_n48_sample_39",
+    )
+    parser.add_argument("--previous_dead_air", type=float, default=0.35294117647058826)
+    parser.add_argument("--previous_unique_pitch_count", type=int, default=7)
+    parser.add_argument("--previous_note_count", type=int, default=14)
+    parser.add_argument("--previous_adjacent_pitch_repeats", type=int, default=2)
+    parser.add_argument("--previous_max_interval", type=int, default=16)
+    parser.add_argument("--min_unique_pitch_count", type=int, default=6)
+    parser.add_argument("--max_dead_air_ratio_exclusive", type=float, default=0.40)
+    parser.add_argument("--min_note_count", type=int, default=12)
+    parser.add_argument("--max_simultaneous_notes", type=int, default=1)
+    parser.add_argument("--max_duplicated_3_note_chunks", type=int, default=0)
+    parser.add_argument("--max_adjacent_pitch_repeats_exclusive", type=int, default=2)
+    parser.add_argument("--max_interval_exclusive", type=int, default=12)
+    parser.add_argument("--require_qualified", action="store_true")
+    parser.add_argument("--require_phrase_vocabulary_improvement", action="store_true")
+    parser.add_argument("--expected_source_run_id", type=str, default=None)
+    parser.add_argument("--expected_sample_index", type=int, default=None)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report_paths = [Path(path) for path in args.report_path]
+    report = build_repair_report(
+        report_paths,
+        output_dir=output_dir,
+        previous_candidate_id=str(args.previous_candidate_id),
+        previous_dead_air=float(args.previous_dead_air),
+        previous_unique_pitch_count=int(args.previous_unique_pitch_count),
+        previous_note_count=int(args.previous_note_count),
+        previous_adjacent_pitch_repeats=int(args.previous_adjacent_pitch_repeats),
+        previous_max_interval=int(args.previous_max_interval),
+        min_unique_pitch_count=int(args.min_unique_pitch_count),
+        max_dead_air_ratio_exclusive=float(args.max_dead_air_ratio_exclusive),
+        min_note_count=int(args.min_note_count),
+        max_simultaneous_notes=int(args.max_simultaneous_notes),
+        max_duplicated_3_note_chunks=int(args.max_duplicated_3_note_chunks),
+        max_adjacent_pitch_repeats_exclusive=int(args.max_adjacent_pitch_repeats_exclusive),
+        max_interval_exclusive=int(args.max_interval_exclusive),
+    )
+    summary = validate_repair(
+        report,
+        require_qualified=bool(args.require_qualified),
+        require_phrase_vocabulary_improvement=bool(args.require_phrase_vocabulary_improvement),
+        expected_source_run_id=args.expected_source_run_id,
+        expected_sample_index=args.expected_sample_index,
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "phrase_vocabulary_repair_summary.json", report)
+    write_json(output_dir / "phrase_vocabulary_repair_result.json", summary)
+    (output_dir / "phrase_vocabulary_repair_summary.md").write_text(markdown_report(report), encoding="utf-8")
+    summary.update(
+        {
+            "summary_path": str(output_dir / "phrase_vocabulary_repair_summary.json"),
+            "markdown_path": str(output_dir / "phrase_vocabulary_repair_summary.md"),
+        }
+    )
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_margin_recovered_phrase_vocabulary_repair.py
+++ b/tests/test_stage_b_margin_recovered_phrase_vocabulary_repair.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pretty_midi
+
+from scripts.summarize_stage_b_margin_recovered_phrase_vocabulary_repair import (
+    build_repair_report,
+    validate_repair,
+)
+
+
+def write_midi(path: Path, pitches: list[int]) -> None:
+    midi = pretty_midi.PrettyMIDI(initial_tempo=124)
+    piano = pretty_midi.Instrument(program=0, is_drum=False, name="phrase_vocab_candidate")
+    for index, pitch in enumerate(pitches):
+        start = index * 0.25
+        piano.notes.append(pretty_midi.Note(velocity=84, pitch=pitch, start=start, end=start + 0.2))
+    midi.instruments.append(piano)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    midi.write(str(path))
+
+
+def write_report(path: Path, *, run_id: str, seed: int, samples: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "run_id": run_id,
+                "run_dir": str(path.parent),
+                "request": {"seed": seed, "top_k": 7, "temperature": 0.82},
+                "summary": {"sample_count": len(samples)},
+                "samples": samples,
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+class StageBMarginRecoveredPhraseVocabularyRepairTest(unittest.TestCase):
+    def test_prefers_adjacent_and_interval_repaired_candidate(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            dead_air_edge_midi = root / "dead_air_edge.mid"
+            wide_interval_midi = root / "wide_interval.mid"
+            qualified_midi = root / "qualified.mid"
+            write_midi(dead_air_edge_midi, [60, 62, 64, 65, 67, 69, 71, 72, 74, 76, 77, 79])
+            write_midi(wide_interval_midi, [60, 76, 62, 64, 65, 67, 69, 71, 72, 74, 76, 77, 79])
+            write_midi(qualified_midi, [60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71])
+            report_path = root / "report.json"
+            write_report(
+                report_path,
+                run_id="test_phrase_vocab_seed43_topk7",
+                seed=43,
+                samples=[
+                    {
+                        "sample_index": 1,
+                        "sample_seed": 81,
+                        "midi_path": str(dead_air_edge_midi),
+                        "valid": True,
+                        "strict_valid": True,
+                        "grammar_gate_passed": True,
+                        "metrics": {"dead_air_ratio": 0.40, "phrase_coverage_ratio": 0.8},
+                        "temporal_coverage": {"onset_coverage_ratio": 0.5, "sustained_coverage_ratio": 0.7},
+                    },
+                    {
+                        "sample_index": 2,
+                        "sample_seed": 82,
+                        "midi_path": str(wide_interval_midi),
+                        "valid": True,
+                        "strict_valid": True,
+                        "grammar_gate_passed": True,
+                        "metrics": {"dead_air_ratio": 0.33, "phrase_coverage_ratio": 0.8},
+                        "temporal_coverage": {"onset_coverage_ratio": 0.5, "sustained_coverage_ratio": 0.7},
+                    },
+                    {
+                        "sample_index": 3,
+                        "sample_seed": 85,
+                        "midi_path": str(qualified_midi),
+                        "valid": True,
+                        "strict_valid": True,
+                        "grammar_gate_passed": True,
+                        "metrics": {"dead_air_ratio": 0.33, "phrase_coverage_ratio": 0.8},
+                        "temporal_coverage": {"onset_coverage_ratio": 0.5, "sustained_coverage_ratio": 0.7},
+                    },
+                ],
+            )
+
+            report = build_repair_report(
+                [report_path],
+                output_dir=root / "repair",
+                previous_candidate_id="previous",
+                previous_dead_air=0.35294117647058826,
+                previous_unique_pitch_count=7,
+                previous_note_count=14,
+                previous_adjacent_pitch_repeats=2,
+                previous_max_interval=16,
+                min_unique_pitch_count=6,
+                max_dead_air_ratio_exclusive=0.40,
+                min_note_count=12,
+                max_simultaneous_notes=1,
+                max_duplicated_3_note_chunks=0,
+                max_adjacent_pitch_repeats_exclusive=2,
+                max_interval_exclusive=12,
+            )
+            summary = validate_repair(
+                report,
+                require_qualified=True,
+                require_phrase_vocabulary_improvement=True,
+                expected_source_run_id="test_phrase_vocab_seed43_topk7",
+                expected_sample_index=3,
+            )
+
+            self.assertTrue(summary["qualified"])
+            self.assertTrue(summary["phrase_vocabulary_improved"])
+            self.assertEqual(summary["qualified_candidate_count"], 1)
+            self.assertEqual(summary["selected_sample_index"], 3)
+            self.assertEqual(summary["adjacent_pitch_repeat_delta_from_previous"], 2)
+            self.assertGreater(summary["max_interval_delta_from_previous"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a Stage B margin-recovered phrase/vocabulary repair sweep summary.
- Select a candidate that keeps dead-air and pitch coverage while reducing adjacent repeats and max interval.
- Update README, handoff docs, and harness documentation with Issue #272 results.

## Context
Issue #270 left phrase continuation and jazz vocabulary as follow-up work because adjacent repeats remained at 2 and max interval remained at 16. This PR adds a focused sweep over seeds 43/61, top_k 7, temperature 0.82, n 48.

## Scope
- Add `scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_repair.py`.
- Add unit coverage for candidate selection and validation.
- Add `stage-b-margin-recovered-phrase-vocabulary-repair` harness mode.
- Document the selected candidate and remaining review boundary.

## Result
- selected candidate: `margin_recovered_phrase_vocab_seed_43_topk_7_temp_082_n48_sample_43`
- qualified candidates: `2/96`
- dead-air ratio: `0.333`
- focused unique pitch count: `8`
- focused note count: `13`
- adjacent pitch repeats: `0`
- max interval: `7`
- remaining flags: `[]`

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_phrase_vocabulary_repair`
- `bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-repair`
- `bash scripts/agent_harness.sh quick`
- `rg -n "codex|Codex|코덱스" <changed files>`

## Risk
- This is objective MIDI repair evidence, not broad trained-model quality or human listening preference proof.
- Focused context package and focused listening fill still need to be rerun for the selected candidate.

## Follow-up
- Stage B margin-recovered phrase/vocabulary focused context review.

Closes #272