### PR TITLE
Stage B margin-recovered phrase vocabulary focused listening notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #274, Stage B margin-recovered phrase/vocabulary focused context review.
+- Latest functional issue completed: Issue #276, Stage B margin-recovered phrase/vocabulary focused listening notes.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary focused listening notes.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary focused listening fill.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -466,6 +466,14 @@ bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-focused
 ```
 
 This harness packages the selected phrase/vocabulary repair candidate with chord/bass context and verifies focused context decision readiness.
+
+For Stage B margin-recovered phrase/vocabulary focused listening notes changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-focused-listening-notes
+```
+
+This harness writes the focused listening review notes template for the selected phrase/vocabulary context keep candidate.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 | focused listening fill 후 후속 개선 필요 | timing은 개선됐지만 adjacent repeat와 wide interval이 남음 | MIDI/context evidence 기준 listening fields 채움 | timing `acceptable`, phrase `weak`, vocabulary `thin`, decision `needs_followup` |
 | phrase/vocabulary blocker | adjacent repeat `2`, max interval `16`이 phrase/vocabulary risk로 남음 | top_k7, temperature `0.82`, seed `43/61` sweep으로 후보 재선택 | sample `43`, adjacent repeats `0`, max interval `7`, dead-air `0.333`, unique pitch `8` |
 | phrase/vocabulary repair 후보 context 검증 필요 | objective gate 통과만으로 final landing과 context guide 적합성 판단 불가 | solo/context package를 만들고 focused context decision 재실행 | decision `keep_for_focused_listening`, flags `{}`, final `C5` over `Fm7` chord tone |
+| context keep 후보 청감 판단 보류 | focused context keep만으로 timing/phrase/vocabulary 최종 판단 불가 | focused listening notes template 생성 | candidate `1`, pending `1`, risk `sustained_coverage_review` |
 
 ## 파이프라인 구조
 
@@ -62,7 +63,7 @@ flowchart LR
 
 ## 핵심 결과
 
-Issue #274 기준 model-core MVP:
+Issue #276 기준 model-core MVP:
 
 | 항목 | 결과 |
 |---|---|
@@ -98,6 +99,7 @@ Issue #274 기준 model-core MVP:
 | margin-recovered timing/repetition focused listening fill | reviewed `1`, pending `0`, timing `acceptable`, phrase `weak`, vocabulary `thin`, decision `needs_followup` |
 | margin-recovered phrase vocabulary repair | seed43/61 top_k7 temp0.82 96개 후보 중 `2`개 qualified, sample `43` 선택, adjacent repeats `0`, max interval `7` |
 | margin-recovered phrase vocabulary focused context | selected repair 후보를 solo/context package로 격리, decision `keep_for_focused_listening`, flags `{}` |
+| margin-recovered phrase vocabulary focused listening notes | focused listening template 생성, candidate `1`, pending `1`, review risk `sustained_coverage_review` |
 | constrained review gate | `stage-b-overlap-gate` 통과 |
 | focused candidate path | `stage-b-rhythm-phrase-variation` 통과 |
 
@@ -138,6 +140,7 @@ MVP 근거:
 - focused listening fill에서 timing은 `acceptable`로 개선됐지만 adjacent repeats `2`, max interval `16` 때문에 phrase continuation `weak`, jazz vocabulary `thin`, decision `needs_followup`으로 기록
 - phrase/vocabulary repair sweep에서 focused unique pitch `8`, note count `13`, max active `1`, duplicated 3-note chunk `0`, dead-air `0.333`, adjacent repeats `0`, max interval `7`인 qualified 후보 선택
 - phrase/vocabulary repair 후보를 solo/context package로 격리해 range `G4-E5`, phrase span `7.0` beats, max active `1`, final `C5` over `Fm7` chord tone, context decision `keep_for_focused_listening` 확인
+- context keep 후보를 focused listening notes template으로 넘기고 timing, phrase continuation, landing, vocabulary, final decision을 pending으로 유지
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`
@@ -149,7 +152,7 @@ MVP 근거:
 | 만든 것 | symbolic MIDI 생성 모델의 dataset, tokenization, training, generation, decode, objective review, proxy review pipeline |
 | 겪은 문제 | `.mid` 파일 존재만으로 성공 판단 불가, one-note collapse, long sustain block, chord block, dead-air outlier, seed-level margin 부족 |
 | 해결 방식 | duration-explicit token 구조, grammar/coverage/chord-aware probe, overlap-free postprocess, repeatability sweep, dead-air diagnostics, proxy review scoring, repair candidate selection |
-| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab focused context `keep_for_focused_listening`, timing/repetition repair qualified `2/96`, phrase/vocabulary repair qualified `2/96`, phrase/vocabulary focused context `keep_for_focused_listening` |
+| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab focused context `keep_for_focused_listening`, timing/repetition repair qualified `2/96`, phrase/vocabulary focused context `keep_for_focused_listening`, phrase/vocabulary listening notes pending `1` |
 | 주장 경계 | reviewable MIDI 후보 생성 검증 파이프라인까지 가능, human listening preference / Brad style adaptation / broad production quality는 미검증 |
 
 Issue #210 기준 current best focused review candidate:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -82,6 +82,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered timing/repetition focused listening fill 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_FILL_2026-05-28.md`
 - margin-recovered phrase/vocabulary repair 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_REPAIR_2026-05-28.md`
 - margin-recovered phrase/vocabulary focused context 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_FOCUSED_CONTEXT_2026-05-28.md`
+- margin-recovered phrase/vocabulary focused listening notes 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_FOCUSED_LISTENING_NOTES_2026-05-28.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -109,6 +110,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered timing/repetition focused listening fill: reviewed `1`, decision `needs_followup`, timing `acceptable`, phrase continuation `weak`, jazz vocabulary `thin`
 - margin-recovered phrase/vocabulary repair: seed `43/61` top_k7 temp0.82 96개 후보 중 qualified `2`, selected sample `43`, adjacent repeats `0`, max interval `7`, dead-air `0.333`
 - margin-recovered phrase/vocabulary focused context: selected repair 후보 focused context decision `keep_for_focused_listening`, flags `{}`, final `C5` over `Fm7` chord tone
+- margin-recovered phrase/vocabulary focused listening notes: candidate `1`, pending `1`, prior decision `keep_for_focused_listening`, risk `sustained_coverage_review`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -307,6 +309,7 @@ Stage B에서 명시하는 것:
 132. Stage B margin-recovered timing/repetition focused listening fill
 133. Stage B margin-recovered timing/repetition phrase/vocabulary follow-up repair
 134. Stage B margin-recovered phrase/vocabulary focused context review
+135. Stage B margin-recovered phrase/vocabulary focused listening notes
 
 가장 최근 의미 있는 결과:
 
@@ -486,6 +489,8 @@ Stage B에서 명시하는 것:
 - Issue #272 result: selected sample `43` keeps dead-air `< 0.400`, focused unique pitch `8`, focused notes `13`, max active `1`, dup3 `0`, and improves adjacent repeats `2 -> 0` plus max interval `16 -> 7`; focused context/listening 재검증은 아직 남아 있다.
 - Issue #274 isolates that phrase/vocabulary repair candidate into a focused solo/context package and reviews it against context MIDI.
 - Issue #274 result: focused context decision `keep_for_focused_listening`, flags `{}`, note count `13`, unique pitch `8`, range `G4-E5`, phrase span `7.0` beats, max active `1`, final `C5` over `Fm7` chord tone.
+- Issue #276 creates focused listening notes for that context keep candidate.
+- Issue #276 result: candidate `1`, pending `1`, prior decision `keep_for_focused_listening`, review risk `sustained_coverage_review`; adjacent repeat and wide interval risks do not reappear.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -504,8 +509,8 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-Issue #274는 phrase/vocabulary repair 후보를 focused solo/context package로 격리했고 context decision `keep_for_focused_listening`을 확인했다.
-다음 작업은 이 후보의 focused listening review notes를 만들고 timing, phrase continuation, landing, vocabulary 판단을 pending field로 넘기는 것이다.
+Issue #276은 phrase/vocabulary repair 후보의 focused listening notes template을 만들었고, 실제 청감 판단 필드는 pending으로 유지했다.
+다음 작업은 이 notes를 MIDI/context evidence 기준으로 채워 timing, phrase continuation, landing, vocabulary, final decision을 기록하는 것이다.
 
 ## 6. 다음 단계 로드맵
 
@@ -1031,38 +1036,40 @@ Issue #274는 phrase/vocabulary repair 후보를 focused solo/context package로
 완료된 바로 전 작업:
 
 ```text
-Stage B margin-recovered phrase/vocabulary focused context review
+Stage B margin-recovered phrase/vocabulary focused listening notes
 ```
 
 결과:
 
-- docs: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_FOCUSED_CONTEXT_2026-05-28.md`
+- docs: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_FOCUSED_LISTENING_NOTES_2026-05-28.md`
 - selected candidate: `margin_recovered_phrase_vocab_seed_43_topk_7_temp_082_n48_sample_43`
-- copied MIDI files: `2`
-- focused context decision: `keep_for_focused_listening`
-- decision flags: `{}`
+- candidate count: `1`
+- reviewed count: `0`
+- pending count: `1`
+- prior decision: `keep_for_focused_listening`
+- listening decision: `pending`
 - note count: `13`
 - unique pitch count: `8`
 - range: `G4-E5`
 - phrase span: `7.000` beats
-- max active notes: `1`
 - dead-air ratio: `0.333`
 - adjacent pitch repeats: `0`
 - max interval: `7`
-- duplicated 3-note chunks: `0`
 - final landing: `C5` over `Fm7`, chord tone
+- review risks: `sustained_coverage_review`
 
 판단:
 
-- focused context blocker는 발견되지 않았다.
-- 이 결과는 focused listening review 진입 조건이다.
+- focused context keep 후보를 listening notes template으로 넘겼다.
+- 실제 청감 판단 필드는 모두 pending이다.
+- adjacent repeat와 wide interval risks는 재등장하지 않았다.
 - broad trained-model quality, human listening preference, Brad style adaptation은 아직 미검증이다.
 
 다음 작업:
 
-- 다음 issue는 `Stage B margin-recovered phrase/vocabulary focused listening notes`로 잡는다.
-- focused package와 context decision을 listening review notes template으로 넘긴다.
-- timing, phrase continuation, landing, vocabulary, decision field를 pending으로 유지한다.
+- 다음 issue는 `Stage B margin-recovered phrase/vocabulary focused listening fill`로 잡는다.
+- focused listening notes를 MIDI/context evidence 기준으로 채운다.
+- sustained coverage risk가 실제 phrase continuation blocker인지 판단한다.
 - focused listening fill에서 keep이 나오기 전에는 최종 keep으로 주장하지 않는다.
 
 ## 10. 한 문장 요약

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #274, Stage B margin-recovered phrase/vocabulary focused context review
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary focused listening notes`
+- latest functional result: Issue #276, Stage B margin-recovered phrase/vocabulary focused listening notes
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary focused listening fill`
 
 현재 범위가 아닌 것:
 
@@ -1158,6 +1158,52 @@ Issue #274는 Issue #272 selected candidate를 solo/context package로 격리하
 Docs:
 
 - `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_FOCUSED_CONTEXT_2026-05-28.md`
+
+## Current Margin-Recovered Phrase/Vocabulary Focused Listening Notes Result
+
+Issue #276은 Issue #274 focused context keep 후보를 focused listening review notes template으로 넘긴 작업이다.
+
+변경:
+
+- phrase/vocabulary focused package와 focused context decision을 함께 읽는 notes wrapper 추가
+- focused context metrics, prior decision, review risks를 notes candidate에 보존
+- adjacent repeat / wide interval repair 상태가 notes risk에 다시 올라오지 않는지 단위 테스트로 확인
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes`
+- `bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-focused-listening-notes`
+
+결과:
+
+| 항목 | 값 |
+|---|---|
+| candidate | `margin_recovered_phrase_vocab_seed_43_topk_7_temp_082_n48_sample_43` |
+| candidate count | `1` |
+| reviewed count | `0` |
+| pending count | `1` |
+| prior decision | `keep_for_focused_listening` |
+| listening decision | `pending` |
+| note count | `13` |
+| unique pitch count | `8` |
+| range | `G4-E5` |
+| phrase span | `7.000` beats |
+| dead-air ratio | `0.333` |
+| adjacent pitch repeats | `0` |
+| max interval | `7` |
+| final landing | `C5` over `Fm7`, chord tone |
+| review risks | `sustained_coverage_review` |
+
+해석:
+
+- focused context keep 후보를 listening notes template으로 넘겼다.
+- 실제 청감 판단 필드는 모두 `pending`이다.
+- Issue #270의 blocker였던 adjacent repeat와 wide interval은 notes risk로 재등장하지 않았다.
+- sustained coverage가 `0.594`라서 청감 fill에서 phrase continuity를 다시 확인해야 한다.
+
+Docs:
+
+- `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_FOCUSED_LISTENING_NOTES_2026-05-28.md`
 
 ## Latest README Footer Section Removal Result
 

--- a/docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_FOCUSED_LISTENING_NOTES_2026-05-28.md
+++ b/docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_FOCUSED_LISTENING_NOTES_2026-05-28.md
@@ -1,0 +1,57 @@
+# Stage B Margin-Recovered Phrase/Vocabulary Focused Listening Notes
+
+## 요약
+
+Issue #276은 Issue #274 focused context keep 후보를 focused listening review notes template으로 넘긴 작업이다.
+
+이 단계는 context decision을 최종 청감 판단으로 과장하지 않고, timing, chord fit, phrase continuation, landing, jazz vocabulary, decision field를 pending 상태로 분리해 기록하기 위한 경계다.
+
+## 변경
+
+- phrase/vocabulary focused package와 focused context decision을 함께 읽는 notes wrapper 추가
+- focused context metrics, prior decision, review risks를 notes candidate에 보존
+- adjacent repeat / wide interval repair 상태가 notes risk에 다시 올라오지 않는지 단위 테스트로 확인
+- result docs와 current plan 업데이트
+
+## 결과
+
+| 항목 | 값 |
+|---|---|
+| candidate | `margin_recovered_phrase_vocab_seed_43_topk_7_temp_082_n48_sample_43` |
+| candidate count | `1` |
+| reviewed count | `0` |
+| pending count | `1` |
+| prior decision | `keep_for_focused_listening` |
+| listening decision | `pending` |
+| note count | `13` |
+| unique pitch count | `8` |
+| range | `G4-E5` |
+| phrase span | `7.000` beats |
+| dead-air ratio | `0.333` |
+| onset coverage | `0.500` |
+| sustained coverage | `0.594` |
+| adjacent pitch repeats | `0` |
+| max interval | `7` |
+| final landing | `C5` over `Fm7`, chord tone |
+| review risks | `sustained_coverage_review` |
+
+## 해석
+
+- focused context keep 후보를 listening notes template으로 넘겼다.
+- 실제 청감 판단 필드는 모두 `pending`이다.
+- Issue #270의 blocker였던 adjacent repeat와 wide interval은 notes risk로 재등장하지 않았다.
+- sustained coverage가 `0.594`라서 청감 fill에서 phrase continuity를 다시 확인해야 한다.
+- 아직 human/audio preference나 broad model quality proof는 아니다.
+
+## 검증
+
+```bash
+.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes
+bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-focused-listening-notes
+```
+
+## 산출물
+
+- script: `scripts/build_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes.py`
+- test: `tests/test_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes.py`
+- notes: `outputs/stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes/harness_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes/focused_listening_review_notes_template.json`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -72,6 +72,8 @@ Modes:
                 Run phrase/vocabulary repair sweep and select a reduced-repeat/interval candidate.
   stage-b-margin-recovered-phrase-vocabulary-focused-context
                 Package and review the selected phrase/vocabulary repair candidate in context.
+  stage-b-margin-recovered-phrase-vocabulary-focused-listening-notes
+                Build focused listening notes for the selected phrase/vocabulary candidate.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -214,6 +216,7 @@ run_quick() {
     scripts/fill_stage_b_margin_recovered_timing_repetition_focused_listening_notes.py \
     scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_repair.py \
     scripts/build_stage_b_margin_recovered_phrase_vocabulary_focused_package.py \
+    scripts/build_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes.py \
     scripts/run_stage_b_sampling_sweep.py \
     scripts/run_stage_b_coverage_ab_sweep.py \
     scripts/run_stage_b_pitch_mode_compare.py \
@@ -798,6 +801,26 @@ run_stage_b_margin_recovered_phrase_vocabulary_focused_context() {
     --focused_package "outputs/stage_b_margin_recovered_phrase_vocabulary_focused_package/${package_run_id}/focused_review_package.json" \
     --expected_candidate_id "$candidate_id" \
     --expected_decision keep_for_focused_listening
+}
+
+run_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes() {
+  local package_run_id="${PACKAGE_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_focused_package}"
+  local decision_run_id="${DECISION_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_focused_context_decision}"
+  local run_id="${RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes}"
+  local candidate_id="margin_recovered_phrase_vocab_seed_43_topk_7_temp_082_n48_sample_43"
+  local package_path="outputs/stage_b_margin_recovered_phrase_vocabulary_focused_package/${package_run_id}/focused_review_package.json"
+  local decision_path="outputs/stage_b_margin_recovered_focused_context_decision/${decision_run_id}/focused_context_decision.json"
+  if [[ ! -f "$package_path" || ! -f "$decision_path" ]]; then
+    print_header "Stage B margin-recovered phrase/vocabulary focused context"
+    PACKAGE_RUN_ID="$package_run_id" RUN_ID="$decision_run_id" run_stage_b_margin_recovered_phrase_vocabulary_focused_context
+  fi
+  print_header "Stage B margin-recovered phrase/vocabulary focused listening notes"
+  "$PYTHON_BIN" scripts/build_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes.py \
+    --run_id "$run_id" \
+    --focused_package "$package_path" \
+    --focused_context_decision "$decision_path" \
+    --expected_candidate_id "$candidate_id" \
+    --expected_prior_decision keep_for_focused_listening
 }
 
 run_stage_b_constrained_probe() {
@@ -1979,6 +2002,9 @@ case "$MODE" in
     ;;
   stage-b-margin-recovered-phrase-vocabulary-focused-context)
     run_stage_b_margin_recovered_phrase_vocabulary_focused_context
+    ;;
+  stage-b-margin-recovered-phrase-vocabulary-focused-listening-notes)
+    run_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/build_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes.py
+++ b/scripts/build_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes.py
@@ -1,0 +1,228 @@
+"""Build focused listening notes for the margin-recovered phrase/vocabulary candidate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.build_focused_listening_review_notes import (  # noqa: E402
+    build_focused_listening_review_notes,
+    validate_focused_listening_review_notes,
+)
+from scripts.build_stage_b_margin_recovered_listening_notes import write_json  # noqa: E402
+from scripts.build_stage_b_margin_recovered_phrase_vocabulary_focused_package import read_json  # noqa: E402
+
+
+class PhraseVocabularyFocusedListeningNotesError(ValueError):
+    pass
+
+
+def decisions_by_candidate(report: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    candidates = report.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise PhraseVocabularyFocusedListeningNotesError("focused context decision must contain candidates")
+    rows: dict[str, dict[str, Any]] = {}
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            continue
+        candidate_id = str(candidate.get("candidate_id") or "")
+        if candidate_id:
+            rows[candidate_id] = candidate
+    return rows
+
+
+def review_risks(metrics: dict[str, Any]) -> list[str]:
+    risks = []
+    if float(metrics.get("dead_air_ratio", 0.0) or 0.0) >= 0.35:
+        risks.append("dead_air_ratio_remaining")
+    if float(metrics.get("sustained_coverage_ratio", 0.0) or 0.0) < 0.60:
+        risks.append("sustained_coverage_review")
+    if int(metrics.get("adjacent_pitch_repeats", 0) or 0) > 0:
+        risks.append("adjacent_pitch_repeats")
+    if int(metrics.get("max_interval", 0) or 0) >= 12:
+        risks.append("wide_interval_review")
+    return risks
+
+
+def build_phrase_vocabulary_focused_listening_notes(
+    focused_package: dict[str, Any],
+    focused_context_decision: dict[str, Any],
+) -> dict[str, Any]:
+    notes = build_focused_listening_review_notes(focused_package)
+    notes["schema_version"] = "stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes_v1"
+    notes["source_focused_context_decision"] = str(focused_context_decision.get("output_dir") or "")
+    notes["review_context"]["focus"].extend(
+        ["phrase_vocabulary_repair_followup", "sustained_coverage_review"]
+    )
+    decisions = decisions_by_candidate(focused_context_decision)
+    for candidate in notes["candidates"]:
+        candidate_id = str(candidate.get("candidate_id") or "")
+        decision = decisions.get(candidate_id)
+        if not decision:
+            raise PhraseVocabularyFocusedListeningNotesError(
+                f"missing focused context decision for {candidate_id}"
+            )
+        metrics = dict(decision.get("metrics") or {})
+        context_summary = dict(decision.get("context_summary") or {})
+        candidate["proxy_review"]["decision"] = str(decision.get("focused_context_decision") or "")
+        candidate["proxy_review"]["decision_flags"] = list(decision.get("decision_flags") or [])
+        candidate["focused_context_metrics"] = {
+            "note_count": int(metrics.get("note_count", 0) or 0),
+            "unique_pitch_count": int(metrics.get("unique_pitch_count", 0) or 0),
+            "range": str(metrics.get("range") or ""),
+            "phrase_span_beats": float(metrics.get("phrase_span_beats", 0.0) or 0.0),
+            "dead_air_ratio": float(metrics.get("dead_air_ratio", 0.0) or 0.0),
+            "onset_coverage_ratio": float(metrics.get("onset_coverage_ratio", 0.0) or 0.0),
+            "sustained_coverage_ratio": float(metrics.get("sustained_coverage_ratio", 0.0) or 0.0),
+            "adjacent_pitch_repeats": int(metrics.get("adjacent_pitch_repeats", 0) or 0),
+            "duplicated_3_note_pitch_class_chunks": int(
+                metrics.get("duplicated_3_note_pitch_class_chunks", 0) or 0
+            ),
+            "max_simultaneous_notes": int(metrics.get("max_simultaneous_notes", 0) or 0),
+            "max_interval": int(metrics.get("max_interval", 0) or 0),
+            "final_note": str(metrics.get("final_note") or ""),
+            "final_chord": str(metrics.get("final_chord") or ""),
+            "final_note_role": str(metrics.get("final_note_role") or ""),
+        }
+        candidate["focused_context_summary"] = {
+            "has_chord_guide": bool(context_summary.get("has_chord_guide", False)),
+            "has_bass_guide": bool(context_summary.get("has_bass_guide", False)),
+            "has_solo_track": bool(context_summary.get("has_solo_track", False)),
+        }
+        candidate["review_risks"] = review_risks(metrics)
+    return notes
+
+
+def markdown_report(notes: dict[str, Any]) -> str:
+    lines = [
+        "# Stage B Phrase/Vocabulary Focused Listening Notes",
+        "",
+        f"- candidate count: `{len(notes.get('candidates') or [])}`",
+        f"- source focused package: `{notes.get('source_focused_review_package')}`",
+        f"- source focused context decision: `{notes.get('source_focused_context_decision')}`",
+        "",
+        "| candidate | prior decision | listening decision | notes | unique | span | dead-air | adj repeat | max interval | final | risks |",
+        "|---|---|---|---:|---:|---:|---:|---:|---:|---|---|",
+    ]
+    for candidate in notes.get("candidates") or []:
+        metrics = candidate.get("focused_context_metrics") if isinstance(candidate.get("focused_context_metrics"), dict) else {}
+        listening = candidate.get("listening") if isinstance(candidate.get("listening"), dict) else {}
+        proxy = candidate.get("proxy_review") if isinstance(candidate.get("proxy_review"), dict) else {}
+        final = f"{metrics.get('final_note')} over {metrics.get('final_chord')} ({metrics.get('final_note_role')})"
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(candidate.get("candidate_id") or ""),
+                    str(proxy.get("decision") or ""),
+                    str(listening.get("decision") or ""),
+                    str(metrics.get("note_count", 0)),
+                    str(metrics.get("unique_pitch_count", 0)),
+                    f"{float(metrics.get('phrase_span_beats', 0.0) or 0.0):.3f}",
+                    f"{float(metrics.get('dead_air_ratio', 0.0) or 0.0):.3f}",
+                    str(metrics.get("adjacent_pitch_repeats", 0)),
+                    str(metrics.get("max_interval", 0)),
+                    final,
+                    ",".join(candidate.get("review_risks") or []) or "none",
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def validate_notes(
+    notes: dict[str, Any],
+    *,
+    expected_candidate_id: str | None,
+    expected_prior_decision: str | None,
+) -> dict[str, Any]:
+    generic_notes = dict(notes)
+    generic_notes["schema_version"] = "stage_b_focused_listening_review_notes_v1"
+    summary = validate_focused_listening_review_notes(generic_notes)
+    candidates = notes.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise PhraseVocabularyFocusedListeningNotesError("notes must contain candidates")
+    if expected_candidate_id:
+        actual = [str(candidate.get("candidate_id") or "") for candidate in candidates]
+        if actual != [expected_candidate_id]:
+            raise PhraseVocabularyFocusedListeningNotesError(
+                f"expected candidate {expected_candidate_id}, got {actual}"
+            )
+    if expected_prior_decision:
+        decisions = [str(candidate.get("proxy_review", {}).get("decision") or "") for candidate in candidates]
+        if decisions != [expected_prior_decision]:
+            raise PhraseVocabularyFocusedListeningNotesError(
+                f"expected prior decision {expected_prior_decision}, got {decisions}"
+            )
+    summary.update(
+        {
+            "candidate_ids": [str(candidate.get("candidate_id") or "") for candidate in candidates],
+            "prior_decisions": [
+                str(candidate.get("proxy_review", {}).get("decision") or "") for candidate in candidates
+            ],
+            "review_risks": {
+                str(candidate.get("candidate_id") or ""): list(candidate.get("review_risks") or [])
+                for candidate in candidates
+            },
+        }
+    )
+    return summary
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build phrase/vocabulary focused listening notes")
+    parser.add_argument("--focused_package", type=str, required=True)
+    parser.add_argument("--focused_context_decision", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=str(ROOT_DIR / "outputs" / "stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes"),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--expected_candidate_id", type=str, default="")
+    parser.add_argument("--expected_prior_decision", type=str, default="")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    focused_package_path = Path(args.focused_package)
+    focused_context_decision_path = Path(args.focused_context_decision)
+    focused_package = read_json(focused_package_path)
+    focused_package["output_dir"] = str(focused_package_path.parent)
+    focused_context_decision = read_json(focused_context_decision_path)
+    focused_context_decision["output_dir"] = str(focused_context_decision_path.parent)
+    notes = build_phrase_vocabulary_focused_listening_notes(focused_package, focused_context_decision)
+    summary = validate_notes(
+        notes,
+        expected_candidate_id=str(args.expected_candidate_id or ""),
+        expected_prior_decision=str(args.expected_prior_decision or ""),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    notes_path = output_dir / "focused_listening_review_notes_template.json"
+    markdown_path = output_dir / "focused_listening_review_notes_template.md"
+    write_json(notes_path, notes)
+    write_json(output_dir / "focused_listening_review_notes_summary.json", summary)
+    markdown_path.write_text(markdown_report(notes), encoding="utf-8")
+    print(
+        json.dumps(
+            {**summary, "review_notes_path": str(notes_path), "markdown_path": str(markdown_path)},
+            ensure_ascii=True,
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes.py
+++ b/tests/test_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.build_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes import (
+    build_phrase_vocabulary_focused_listening_notes,
+    validate_notes,
+)
+
+
+class StageBMarginRecoveredPhraseVocabularyFocusedListeningNotesTest(unittest.TestCase):
+    def sample_package(self) -> dict:
+        return {
+            "output_dir": "outputs/package",
+            "candidates": [
+                {
+                    "candidate_id": "phrase_vocabulary_candidate",
+                    "review_metadata": {"mode": "margin_recovered_phrase_vocabulary_repair", "review_rank": 1},
+                    "review_files": {
+                        "midi_path": "outputs/package/midi/phrase_vocab.mid",
+                        "context_midi_path": "outputs/package/context/phrase_vocab_context.mid",
+                        "source_midi_path": "outputs/source/phrase_vocab.mid",
+                    },
+                    "source_metrics": {
+                        "note_count": 13,
+                        "unique_pitch_count": 8,
+                        "dead_air_ratio": 0.33333333333333337,
+                    },
+                    "listening": {
+                        "decision": "phrase_vocabulary_qualified",
+                        "phrase_quality": "pending_context",
+                        "timing": "pending_context",
+                        "chord_fit": "pending_context",
+                        "issues": [],
+                        "notes": "",
+                    },
+                    "objective_review": {"objective_flags": [], "objective_bucket": "clean"},
+                    "objective_first_16_notes": [{"pitch": 72, "pitch_name": "C5"}],
+                }
+            ],
+        }
+
+    def sample_decision(self) -> dict:
+        return {
+            "output_dir": "outputs/decision",
+            "candidates": [
+                {
+                    "candidate_id": "phrase_vocabulary_candidate",
+                    "focused_context_decision": "keep_for_focused_listening",
+                    "decision_flags": [],
+                    "metrics": {
+                        "note_count": 13,
+                        "unique_pitch_count": 8,
+                        "range": "G4-E5",
+                        "phrase_span_beats": 7.0,
+                        "dead_air_ratio": 0.33333333333333337,
+                        "onset_coverage_ratio": 0.5,
+                        "sustained_coverage_ratio": 0.59375,
+                        "adjacent_pitch_repeats": 0,
+                        "duplicated_3_note_pitch_class_chunks": 0,
+                        "max_simultaneous_notes": 1,
+                        "max_interval": 7,
+                        "final_note": "C5",
+                        "final_chord": "Fm7",
+                        "final_note_role": "chord_tone",
+                    },
+                    "context_summary": {
+                        "has_chord_guide": True,
+                        "has_bass_guide": True,
+                        "has_solo_track": True,
+                    },
+                }
+            ],
+        }
+
+    def test_builds_pending_notes_with_context_decision_and_improved_risks(self) -> None:
+        notes = build_phrase_vocabulary_focused_listening_notes(self.sample_package(), self.sample_decision())
+        summary = validate_notes(
+            notes,
+            expected_candidate_id="phrase_vocabulary_candidate",
+            expected_prior_decision="keep_for_focused_listening",
+        )
+
+        candidate = notes["candidates"][0]
+        self.assertEqual(summary["candidate_count"], 1)
+        self.assertEqual(summary["pending_count"], 1)
+        self.assertEqual(candidate["proxy_review"]["decision"], "keep_for_focused_listening")
+        self.assertEqual(candidate["focused_context_metrics"]["adjacent_pitch_repeats"], 0)
+        self.assertEqual(candidate["focused_context_metrics"]["max_interval"], 7)
+        self.assertNotIn("adjacent_pitch_repeats", candidate["review_risks"])
+        self.assertNotIn("wide_interval_review", candidate["review_risks"])
+        self.assertIn("sustained_coverage_review", candidate["review_risks"])
+        self.assertEqual(candidate["listening"]["decision"], "pending")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add focused listening notes generation for the phrase/vocabulary focused context keep candidate.
- Preserve focused context metrics, prior decision, and review risks in the notes template.
- Update README, handoff docs, and harness documentation with Issue #276 results.

## Context
Issue #274 marked `margin_recovered_phrase_vocab_seed_43_topk_7_temp_082_n48_sample_43` as `keep_for_focused_listening`. This PR creates the pending listening notes template before any filled listening decision.

## Scope
- Add `scripts/build_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes.py`.
- Add unit coverage for pending notes and improved risk carryover.
- Add `stage-b-margin-recovered-phrase-vocabulary-focused-listening-notes` harness mode.
- Document the pending review boundary.

## Result
- candidate count: `1`
- reviewed count: `0`
- pending count: `1`
- prior decision: `keep_for_focused_listening`
- listening decision: `pending`
- note count: `13`
- unique pitch count: `8`
- phrase span: `7.000` beats
- dead-air ratio: `0.333`
- adjacent pitch repeats: `0`
- max interval: `7`
- final landing: `C5` over `Fm7`, chord tone
- review risk: `sustained_coverage_review`

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes`
- `bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-focused-listening-notes`
- `bash scripts/agent_harness.sh quick`
- `rg -n "codex|Codex|코덱스" <changed files>`

## Risk
- This is a pending listening review template, not a filled human/audio preference decision.
- Sustained coverage remains a focused listening review risk.

## Follow-up
- Stage B margin-recovered phrase/vocabulary focused listening fill.

Closes #276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Stage B margin-recovered phrase/vocabulary focused listening notes workflow with accompanying CLI tool for generating notes.

* **Documentation**
  * Updated project progress tracking and roadmap documentation.
  * Added comprehensive documentation for the new focused listening notes workflow and execution details.
  * Enhanced validation/pipeline documentation with risk tracking for the new workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohhalim/fine_tuning_art-tatum_midi_solo/pull/277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->