### PR TITLE
Stage B margin-recovered phrase vocabulary focused listening fill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #276, Stage B margin-recovered phrase/vocabulary focused listening notes.
+- Latest functional issue completed: Issue #278, Stage B margin-recovered phrase/vocabulary focused listening fill.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary focused listening fill.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary keep consolidation.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -474,6 +474,14 @@ bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-focused
 ```
 
 This harness writes the focused listening review notes template for the selected phrase/vocabulary context keep candidate.
+
+For Stage B margin-recovered phrase/vocabulary focused listening fill changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-focused-listening-fill
+```
+
+This harness fills the focused listening review notes from MIDI/context evidence and records the keep/follow-up boundary.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 | phrase/vocabulary blocker | adjacent repeat `2`, max interval `16`이 phrase/vocabulary risk로 남음 | top_k7, temperature `0.82`, seed `43/61` sweep으로 후보 재선택 | sample `43`, adjacent repeats `0`, max interval `7`, dead-air `0.333`, unique pitch `8` |
 | phrase/vocabulary repair 후보 context 검증 필요 | objective gate 통과만으로 final landing과 context guide 적합성 판단 불가 | solo/context package를 만들고 focused context decision 재실행 | decision `keep_for_focused_listening`, flags `{}`, final `C5` over `Fm7` chord tone |
 | context keep 후보 청감 판단 보류 | focused context keep만으로 timing/phrase/vocabulary 최종 판단 불가 | focused listening notes template 생성 | candidate `1`, pending `1`, risk `sustained_coverage_review` |
+| focused listening fill 후 keep 판정 경계 | sustained coverage가 threshold 근처라 최종 음악 품질로 과장할 위험 | MIDI/context evidence 기준으로 listening fields 채움 | timing `acceptable`, phrase `acceptable`, vocabulary `acceptable`, decision `keep`, human/audio proof는 미검증 |
 
 ## 파이프라인 구조
 
@@ -63,7 +64,7 @@ flowchart LR
 
 ## 핵심 결과
 
-Issue #276 기준 model-core MVP:
+Issue #278 기준 model-core MVP:
 
 | 항목 | 결과 |
 |---|---|
@@ -100,6 +101,7 @@ Issue #276 기준 model-core MVP:
 | margin-recovered phrase vocabulary repair | seed43/61 top_k7 temp0.82 96개 후보 중 `2`개 qualified, sample `43` 선택, adjacent repeats `0`, max interval `7` |
 | margin-recovered phrase vocabulary focused context | selected repair 후보를 solo/context package로 격리, decision `keep_for_focused_listening`, flags `{}` |
 | margin-recovered phrase vocabulary focused listening notes | focused listening template 생성, candidate `1`, pending `1`, review risk `sustained_coverage_review` |
+| margin-recovered phrase vocabulary focused listening fill | reviewed `1`, pending `0`, timing `acceptable`, phrase `acceptable`, vocabulary `acceptable`, decision `keep` |
 | constrained review gate | `stage-b-overlap-gate` 통과 |
 | focused candidate path | `stage-b-rhythm-phrase-variation` 통과 |
 
@@ -141,6 +143,7 @@ MVP 근거:
 - phrase/vocabulary repair sweep에서 focused unique pitch `8`, note count `13`, max active `1`, duplicated 3-note chunk `0`, dead-air `0.333`, adjacent repeats `0`, max interval `7`인 qualified 후보 선택
 - phrase/vocabulary repair 후보를 solo/context package로 격리해 range `G4-E5`, phrase span `7.0` beats, max active `1`, final `C5` over `Fm7` chord tone, context decision `keep_for_focused_listening` 확인
 - context keep 후보를 focused listening notes template으로 넘기고 timing, phrase continuation, landing, vocabulary, final decision을 pending으로 유지
+- focused listening fill에서 timing `acceptable`, phrase continuation `acceptable`, jazz vocabulary `acceptable`, final decision `keep`으로 기록하되 human/audio proof와 분리
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`
@@ -152,7 +155,7 @@ MVP 근거:
 | 만든 것 | symbolic MIDI 생성 모델의 dataset, tokenization, training, generation, decode, objective review, proxy review pipeline |
 | 겪은 문제 | `.mid` 파일 존재만으로 성공 판단 불가, one-note collapse, long sustain block, chord block, dead-air outlier, seed-level margin 부족 |
 | 해결 방식 | duration-explicit token 구조, grammar/coverage/chord-aware probe, overlap-free postprocess, repeatability sweep, dead-air diagnostics, proxy review scoring, repair candidate selection |
-| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab focused context `keep_for_focused_listening`, timing/repetition repair qualified `2/96`, phrase/vocabulary focused context `keep_for_focused_listening`, phrase/vocabulary listening notes pending `1` |
+| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab focused context `keep_for_focused_listening`, timing/repetition repair qualified `2/96`, phrase/vocabulary focused context `keep_for_focused_listening`, phrase/vocabulary focused fill `keep` |
 | 주장 경계 | reviewable MIDI 후보 생성 검증 파이프라인까지 가능, human listening preference / Brad style adaptation / broad production quality는 미검증 |
 
 Issue #210 기준 current best focused review candidate:

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -83,6 +83,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered phrase/vocabulary repair 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_REPAIR_2026-05-28.md`
 - margin-recovered phrase/vocabulary focused context 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_FOCUSED_CONTEXT_2026-05-28.md`
 - margin-recovered phrase/vocabulary focused listening notes 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_FOCUSED_LISTENING_NOTES_2026-05-28.md`
+- margin-recovered phrase/vocabulary focused listening fill 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_FOCUSED_LISTENING_FILL_2026-05-28.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -111,6 +112,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered phrase/vocabulary repair: seed `43/61` top_k7 temp0.82 96개 후보 중 qualified `2`, selected sample `43`, adjacent repeats `0`, max interval `7`, dead-air `0.333`
 - margin-recovered phrase/vocabulary focused context: selected repair 후보 focused context decision `keep_for_focused_listening`, flags `{}`, final `C5` over `Fm7` chord tone
 - margin-recovered phrase/vocabulary focused listening notes: candidate `1`, pending `1`, prior decision `keep_for_focused_listening`, risk `sustained_coverage_review`
+- margin-recovered phrase/vocabulary focused listening fill: reviewed `1`, decision `keep`, timing `acceptable`, phrase continuation `acceptable`, jazz vocabulary `acceptable`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -310,6 +312,7 @@ Stage B에서 명시하는 것:
 133. Stage B margin-recovered timing/repetition phrase/vocabulary follow-up repair
 134. Stage B margin-recovered phrase/vocabulary focused context review
 135. Stage B margin-recovered phrase/vocabulary focused listening notes
+136. Stage B margin-recovered phrase/vocabulary focused listening fill
 
 가장 최근 의미 있는 결과:
 
@@ -491,6 +494,8 @@ Stage B에서 명시하는 것:
 - Issue #274 result: focused context decision `keep_for_focused_listening`, flags `{}`, note count `13`, unique pitch `8`, range `G4-E5`, phrase span `7.0` beats, max active `1`, final `C5` over `Fm7` chord tone.
 - Issue #276 creates focused listening notes for that context keep candidate.
 - Issue #276 result: candidate `1`, pending `1`, prior decision `keep_for_focused_listening`, review risk `sustained_coverage_review`; adjacent repeat and wide interval risks do not reappear.
+- Issue #278 fills that focused listening note from MIDI/context evidence.
+- Issue #278 result: reviewed `1`, decision `keep`, timing `acceptable`, chord fit `strong`, phrase continuation `acceptable`, landing `strong`, jazz vocabulary `acceptable`; sustained coverage risk remains documented and this is not human/audio proof.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -509,8 +514,8 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-Issue #276은 phrase/vocabulary repair 후보의 focused listening notes template을 만들었고, 실제 청감 판단 필드는 pending으로 유지했다.
-다음 작업은 이 notes를 MIDI/context evidence 기준으로 채워 timing, phrase continuation, landing, vocabulary, final decision을 기록하는 것이다.
+Issue #278은 phrase/vocabulary repair 후보를 MIDI/context evidence 기준으로 filled listening `keep`까지 올렸다.
+다음 작업은 이 결과를 current margin-recovered keep candidate로 consolidation하되, human/audio proof와 broad model quality claim boundary를 분리하는 것이다.
 
 ## 6. 다음 단계 로드맵
 
@@ -1036,18 +1041,23 @@ Issue #276은 phrase/vocabulary repair 후보의 focused listening notes templat
 완료된 바로 전 작업:
 
 ```text
-Stage B margin-recovered phrase/vocabulary focused listening notes
+Stage B margin-recovered phrase/vocabulary focused listening fill
 ```
 
 결과:
 
-- docs: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_FOCUSED_LISTENING_NOTES_2026-05-28.md`
+- docs: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_FOCUSED_LISTENING_FILL_2026-05-28.md`
 - selected candidate: `margin_recovered_phrase_vocab_seed_43_topk_7_temp_082_n48_sample_43`
 - candidate count: `1`
-- reviewed count: `0`
-- pending count: `1`
+- reviewed count: `1`
+- pending count: `0`
 - prior decision: `keep_for_focused_listening`
-- listening decision: `pending`
+- timing: `acceptable`
+- chord fit: `strong`
+- phrase continuation: `acceptable`
+- landing: `strong`
+- jazz vocabulary: `acceptable`
+- final decision: `keep`
 - note count: `13`
 - unique pitch count: `8`
 - range: `G4-E5`
@@ -1060,17 +1070,17 @@ Stage B margin-recovered phrase/vocabulary focused listening notes
 
 판단:
 
-- focused context keep 후보를 listening notes template으로 넘겼다.
-- 실제 청감 판단 필드는 모두 pending이다.
-- adjacent repeat와 wide interval risks는 재등장하지 않았다.
+- focused listening fill 기준 keep 후보가 생겼다.
+- sustained coverage risk는 evidence에 남겼지만 phrase span과 interval gate를 통과해 blocker로 보지는 않았다.
+- 이 keep은 MIDI/context evidence 기준이며 human/audio proof는 아니다.
 - broad trained-model quality, human listening preference, Brad style adaptation은 아직 미검증이다.
 
 다음 작업:
 
-- 다음 issue는 `Stage B margin-recovered phrase/vocabulary focused listening fill`로 잡는다.
-- focused listening notes를 MIDI/context evidence 기준으로 채운다.
-- sustained coverage risk가 실제 phrase continuation blocker인지 판단한다.
-- focused listening fill에서 keep이 나오기 전에는 최종 keep으로 주장하지 않는다.
+- 다음 issue는 `Stage B margin-recovered phrase/vocabulary keep consolidation`으로 잡는다.
+- filled keep 후보를 current margin-recovered candidate로 정리한다.
+- human/audio proof, broad trained-model quality, Brad style adaptation 미검증 경계를 문서화한다.
+- 이후 broad training으로 바로 넘어가기 전에 candidate stability나 listening comparison 경계를 분리한다.
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #276, Stage B margin-recovered phrase/vocabulary focused listening notes
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary focused listening fill`
+- latest functional result: Issue #278, Stage B margin-recovered phrase/vocabulary focused listening fill
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary keep consolidation`
 
 현재 범위가 아닌 것:
 
@@ -1204,6 +1204,52 @@ Issue #276은 Issue #274 focused context keep 후보를 focused listening review
 Docs:
 
 - `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_FOCUSED_LISTENING_NOTES_2026-05-28.md`
+
+## Current Margin-Recovered Phrase/Vocabulary Focused Listening Fill Result
+
+Issue #278은 Issue #276 focused listening notes를 MIDI/context evidence 기준으로 채운 작업이다.
+
+변경:
+
+- phrase/vocabulary focused listening notes fill script 추가
+- focused context metrics를 listening field로 변환
+- sustained coverage risk를 evidence로 보존하고, adjacent repeat / wide interval blocker repair 상태를 함께 기록
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill`
+- `bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-focused-listening-fill`
+
+결과:
+
+| 항목 | 값 |
+|---|---|
+| candidate | `margin_recovered_phrase_vocab_seed_43_topk_7_temp_082_n48_sample_43` |
+| reviewed count | `1` |
+| pending count | `0` |
+| timing | `acceptable` |
+| chord fit | `strong` |
+| phrase continuation | `acceptable` |
+| landing | `strong` |
+| jazz vocabulary | `acceptable` |
+| final decision | `keep` |
+| dead-air ratio | `0.333` |
+| sustained coverage | `0.594` |
+| adjacent pitch repeats | `0` |
+| max interval | `7` |
+| final landing | `C5` over `Fm7`, chord tone |
+| review risks | `sustained_coverage_review` |
+
+해석:
+
+- focused listening fill 기준 keep 후보가 생겼다.
+- Issue #270의 blocker였던 adjacent repeat와 wide interval은 repair 상태로 유지됐다.
+- sustained coverage는 threshold 근처라 evidence risk로 남긴다.
+- 이 keep은 MIDI/context evidence 기준이며 human/audio proof는 아니다.
+
+Docs:
+
+- `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_FOCUSED_LISTENING_FILL_2026-05-28.md`
 
 ## Latest README Footer Section Removal Result
 

--- a/docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_FOCUSED_LISTENING_FILL_2026-05-28.md
+++ b/docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_FOCUSED_LISTENING_FILL_2026-05-28.md
@@ -1,0 +1,54 @@
+# Stage B Margin-Recovered Phrase/Vocabulary Focused Listening Fill
+
+## 요약
+
+Issue #278은 Issue #276 focused listening notes를 MIDI/context evidence 기준으로 채운 작업이다.
+
+이 단계는 pending 상태였던 timing, chord fit, phrase continuation, landing, jazz vocabulary, decision field를 metric/context evidence로 채우되, human audio listening proof나 broad model quality로 과장하지 않는 경계다.
+
+## 변경
+
+- phrase/vocabulary focused listening notes fill script 추가
+- focused context metrics를 listening field로 변환
+- sustained coverage risk를 evidence로 보존하고, adjacent repeat / wide interval blocker repair 상태를 함께 기록
+- result docs와 current plan 업데이트
+
+## 결과
+
+| 항목 | 값 |
+|---|---|
+| candidate | `margin_recovered_phrase_vocab_seed_43_topk_7_temp_082_n48_sample_43` |
+| reviewed count | `1` |
+| pending count | `0` |
+| timing | `acceptable` |
+| chord fit | `strong` |
+| phrase continuation | `acceptable` |
+| landing | `strong` |
+| jazz vocabulary | `acceptable` |
+| final decision | `keep` |
+| dead-air ratio | `0.333` |
+| sustained coverage | `0.594` |
+| adjacent pitch repeats | `0` |
+| max interval | `7` |
+| final landing | `C5` over `Fm7`, chord tone |
+| review risks | `sustained_coverage_review` |
+
+## 해석
+
+- Issue #270의 blocker였던 adjacent repeats와 wide interval은 repair 상태로 유지됐다.
+- final landing은 chord tone이고, focused context blocker도 없다.
+- sustained coverage가 `0.594`로 threshold 근처라 evidence에는 risk로 남긴다.
+- decision `keep`은 MIDI/context evidence fill 기준의 keep이며, human/audio preference나 broad model quality proof는 아니다.
+
+## 검증
+
+```bash
+.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill
+bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-focused-listening-fill
+```
+
+## 산출물
+
+- script: `scripts/fill_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes.py`
+- test: `tests/test_stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill.py`
+- filled notes: `outputs/stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill/harness_stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill/focused_listening_review_notes_filled.json`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -74,6 +74,8 @@ Modes:
                 Package and review the selected phrase/vocabulary repair candidate in context.
   stage-b-margin-recovered-phrase-vocabulary-focused-listening-notes
                 Build focused listening notes for the selected phrase/vocabulary candidate.
+  stage-b-margin-recovered-phrase-vocabulary-focused-listening-fill
+                Fill the selected phrase/vocabulary focused listening review notes.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -217,6 +219,7 @@ run_quick() {
     scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_repair.py \
     scripts/build_stage_b_margin_recovered_phrase_vocabulary_focused_package.py \
     scripts/build_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes.py \
+    scripts/fill_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes.py \
     scripts/run_stage_b_sampling_sweep.py \
     scripts/run_stage_b_coverage_ab_sweep.py \
     scripts/run_stage_b_pitch_mode_compare.py \
@@ -821,6 +824,23 @@ run_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes() {
     --focused_context_decision "$decision_path" \
     --expected_candidate_id "$candidate_id" \
     --expected_prior_decision keep_for_focused_listening
+}
+
+run_stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill() {
+  local notes_run_id="${NOTES_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes}"
+  local run_id="${RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill}"
+  local candidate_id="margin_recovered_phrase_vocab_seed_43_topk_7_temp_082_n48_sample_43"
+  local review_notes="outputs/stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes/${notes_run_id}/focused_listening_review_notes_template.json"
+  if [[ ! -f "$review_notes" ]]; then
+    print_header "Stage B margin-recovered phrase/vocabulary focused listening notes"
+    RUN_ID="$notes_run_id" run_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes
+  fi
+  print_header "Stage B margin-recovered phrase/vocabulary focused listening fill"
+  "$PYTHON_BIN" scripts/fill_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes.py \
+    --run_id "$run_id" \
+    --review_notes "$review_notes" \
+    --expected_candidate_id "$candidate_id" \
+    --expected_decision keep
 }
 
 run_stage_b_constrained_probe() {
@@ -2005,6 +2025,9 @@ case "$MODE" in
     ;;
   stage-b-margin-recovered-phrase-vocabulary-focused-listening-notes)
     run_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes
+    ;;
+  stage-b-margin-recovered-phrase-vocabulary-focused-listening-fill)
+    run_stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/fill_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes.py
+++ b/scripts/fill_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes.py
@@ -1,0 +1,200 @@
+"""Fill phrase/vocabulary focused listening notes from MIDI/context evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.build_stage_b_margin_recovered_listening_notes import write_json  # noqa: E402
+from scripts.build_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes import (  # noqa: E402
+    read_json,
+    validate_notes,
+)
+
+
+class PhraseVocabularyFocusedListeningFillError(ValueError):
+    pass
+
+
+def fill_candidate(candidate: dict[str, Any]) -> dict[str, Any]:
+    filled = json.loads(json.dumps(candidate))
+    metrics = filled.get("focused_context_metrics") if isinstance(filled.get("focused_context_metrics"), dict) else {}
+    risks = set(str(risk) for risk in filled.get("review_risks", []))
+    dead_air = float(metrics.get("dead_air_ratio", 0.0) or 0.0)
+    adjacent_repeats = int(metrics.get("adjacent_pitch_repeats", 0) or 0)
+    unique_pitch = int(metrics.get("unique_pitch_count", 0) or 0)
+    phrase_span = float(metrics.get("phrase_span_beats", 0.0) or 0.0)
+    sustained_coverage = float(metrics.get("sustained_coverage_ratio", 0.0) or 0.0)
+    max_interval = int(metrics.get("max_interval", 0) or 0)
+    final_role = str(metrics.get("final_note_role") or "")
+    timing = "stiff" if dead_air >= 0.40 else "acceptable"
+    chord_fit = "strong" if final_role == "chord_tone" else "acceptable" if final_role == "tension" else "unclear"
+    phrase_continuation = "weak" if phrase_span < 7.0 or max_interval >= 12 or sustained_coverage < 0.55 else "acceptable"
+    landing = "strong" if final_role == "chord_tone" else "acceptable" if final_role == "tension" else "weak"
+    jazz_vocabulary = "thin" if adjacent_repeats > 0 or max_interval >= 12 or unique_pitch < 7 else "acceptable"
+    decision = "needs_followup"
+    if (
+        timing == "acceptable"
+        and phrase_continuation == "acceptable"
+        and landing in {"strong", "acceptable"}
+        and jazz_vocabulary == "acceptable"
+    ):
+        decision = "keep"
+    if unique_pitch < 4 or phrase_span < 4.0:
+        decision = "reject"
+    filled["listening"] = {
+        "status": "reviewed",
+        "timing": timing,
+        "chord_fit": chord_fit,
+        "phrase_continuation": phrase_continuation,
+        "landing": landing,
+        "jazz_vocabulary": jazz_vocabulary,
+        "decision": decision,
+        "notes": (
+            "MIDI/context evidence fill. Adjacent repeats and wide interval blockers are repaired; "
+            "sustained coverage remains near the review threshold, so this is not human audio proof."
+        ),
+    }
+    filled["listening_fill_evidence"] = {
+        "not_human_audio_review": True,
+        "dead_air_ratio": dead_air,
+        "adjacent_pitch_repeats": adjacent_repeats,
+        "unique_pitch_count": unique_pitch,
+        "phrase_span_beats": phrase_span,
+        "sustained_coverage_ratio": sustained_coverage,
+        "max_interval": max_interval,
+        "final_note": str(metrics.get("final_note") or ""),
+        "final_chord": str(metrics.get("final_chord") or ""),
+        "final_note_role": final_role,
+        "review_risks": sorted(risks),
+        "risk_interpretation": {
+            "sustained_coverage_review": "non_blocking_if_phrase_span_and_interval_gate_pass",
+            "adjacent_repeat_blocker_repaired": adjacent_repeats == 0,
+            "wide_interval_blocker_repaired": max_interval < 12,
+        },
+    }
+    return filled
+
+
+def fill_notes(notes: dict[str, Any]) -> dict[str, Any]:
+    candidates = notes.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise PhraseVocabularyFocusedListeningFillError("notes must contain candidates")
+    filled = json.loads(json.dumps(notes))
+    filled["schema_version"] = "stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill_v1"
+    filled["filled_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    filled["fill_method"] = {
+        "source": "MIDI/context evidence",
+        "not_human_audio_review": True,
+    }
+    filled["candidates"] = [fill_candidate(candidate) for candidate in candidates]
+    return filled
+
+
+def markdown_report(notes: dict[str, Any], summary: dict[str, Any]) -> str:
+    lines = [
+        "# Stage B Phrase/Vocabulary Focused Listening Fill",
+        "",
+        f"- candidate count: `{summary['candidate_count']}`",
+        f"- reviewed count: `{summary['reviewed_count']}`",
+        f"- pending count: `{summary['pending_count']}`",
+        f"- decisions: `{summary['decision_counts']}`",
+        "",
+        "This is a MIDI/context evidence fill, not a human audio listening proof.",
+        "",
+        "| candidate | timing | chord fit | phrase | landing | vocabulary | decision | risks |",
+        "|---|---|---|---|---|---|---|---|",
+    ]
+    for candidate in notes["candidates"]:
+        listening = candidate["listening"]
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(candidate.get("candidate_id") or ""),
+                    str(listening.get("timing") or ""),
+                    str(listening.get("chord_fit") or ""),
+                    str(listening.get("phrase_continuation") or ""),
+                    str(listening.get("landing") or ""),
+                    str(listening.get("jazz_vocabulary") or ""),
+                    str(listening.get("decision") or ""),
+                    ",".join(candidate.get("review_risks") or []),
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def validate_fill(
+    notes: dict[str, Any],
+    *,
+    expected_candidate_id: str | None,
+    expected_decision: str | None,
+) -> dict[str, Any]:
+    generic_notes = dict(notes)
+    generic_notes["schema_version"] = "stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes_v1"
+    summary = validate_notes(
+        generic_notes,
+        expected_candidate_id=expected_candidate_id,
+        expected_prior_decision="keep_for_focused_listening",
+    )
+    if expected_decision:
+        decisions = [str(candidate.get("listening", {}).get("decision") or "") for candidate in notes["candidates"]]
+        if decisions != [expected_decision]:
+            raise PhraseVocabularyFocusedListeningFillError(
+                f"expected decision {expected_decision}, got {decisions}"
+            )
+    return summary
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Fill phrase/vocabulary focused listening notes")
+    parser.add_argument("--review_notes", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=str(ROOT_DIR / "outputs" / "stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill"),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--expected_candidate_id", type=str, default="")
+    parser.add_argument("--expected_decision", type=str, default="")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    notes = read_json(Path(args.review_notes))
+    filled = fill_notes(notes)
+    summary = validate_fill(
+        filled,
+        expected_candidate_id=str(args.expected_candidate_id or ""),
+        expected_decision=str(args.expected_decision or ""),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    filled_path = output_dir / "focused_listening_review_notes_filled.json"
+    markdown_path = output_dir / "focused_listening_review_notes_filled.md"
+    write_json(filled_path, filled)
+    write_json(output_dir / "focused_listening_review_notes_fill_summary.json", summary)
+    markdown_path.write_text(markdown_report(filled, summary), encoding="utf-8")
+    print(
+        json.dumps(
+            {**summary, "filled_notes_path": str(filled_path), "markdown_path": str(markdown_path)},
+            ensure_ascii=True,
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill.py
+++ b/tests/test_stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.fill_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes import (
+    fill_notes,
+    validate_fill,
+)
+
+
+class StageBMarginRecoveredPhraseVocabularyFocusedListeningFillTest(unittest.TestCase):
+    def sample_notes(self) -> dict:
+        return {
+            "schema_version": "stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes_v1",
+            "candidates": [
+                {
+                    "candidate_id": "phrase_vocabulary_candidate",
+                    "review_files": {
+                        "midi_path": "outputs/phrase_vocab.mid",
+                        "context_midi_path": "outputs/phrase_vocab_context.mid",
+                    },
+                    "proxy_review": {
+                        "decision": "keep_for_focused_listening",
+                    },
+                    "focused_context_metrics": {
+                        "note_count": 13,
+                        "unique_pitch_count": 8,
+                        "phrase_span_beats": 7.0,
+                        "dead_air_ratio": 0.33333333333333337,
+                        "onset_coverage_ratio": 0.5,
+                        "sustained_coverage_ratio": 0.59375,
+                        "adjacent_pitch_repeats": 0,
+                        "duplicated_3_note_pitch_class_chunks": 0,
+                        "max_simultaneous_notes": 1,
+                        "max_interval": 7,
+                        "final_note": "C5",
+                        "final_chord": "Fm7",
+                        "final_note_role": "chord_tone",
+                    },
+                    "review_risks": ["sustained_coverage_review"],
+                    "listening": {
+                        "status": "pending",
+                        "timing": "pending",
+                        "chord_fit": "pending",
+                        "phrase_continuation": "pending",
+                        "landing": "pending",
+                        "jazz_vocabulary": "pending",
+                        "decision": "pending",
+                        "notes": "",
+                    },
+                }
+            ],
+        }
+
+    def test_fill_marks_repaired_candidate_keep_with_sustained_coverage_evidence(self) -> None:
+        filled = fill_notes(self.sample_notes())
+        summary = validate_fill(
+            filled,
+            expected_candidate_id="phrase_vocabulary_candidate",
+            expected_decision="keep",
+        )
+        candidate = filled["candidates"][0]
+
+        self.assertEqual(summary["reviewed_count"], 1)
+        self.assertEqual(summary["pending_count"], 0)
+        self.assertEqual(candidate["listening"]["timing"], "acceptable")
+        self.assertEqual(candidate["listening"]["chord_fit"], "strong")
+        self.assertEqual(candidate["listening"]["phrase_continuation"], "acceptable")
+        self.assertEqual(candidate["listening"]["landing"], "strong")
+        self.assertEqual(candidate["listening"]["jazz_vocabulary"], "acceptable")
+        self.assertEqual(candidate["listening"]["decision"], "keep")
+        self.assertTrue(candidate["listening_fill_evidence"]["not_human_audio_review"])
+        self.assertTrue(
+            candidate["listening_fill_evidence"]["risk_interpretation"]["adjacent_repeat_blocker_repaired"]
+        )
+        self.assertTrue(
+            candidate["listening_fill_evidence"]["risk_interpretation"]["wide_interval_blocker_repaired"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a focused listening fill for the phrase/vocabulary candidate.
- Convert MIDI/context evidence into timing, chord fit, phrase continuation, landing, jazz vocabulary, and decision fields.
- Update README, handoff docs, and harness documentation with Issue #278 results.

## Context
Issue #276 created pending listening notes for `margin_recovered_phrase_vocab_seed_43_topk_7_temp_082_n48_sample_43`. This PR fills those notes from MIDI/context evidence while keeping the human/audio proof boundary explicit.

## Scope
- Add `scripts/fill_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes.py`.
- Add unit coverage for keep decision and sustained coverage evidence.
- Add `stage-b-margin-recovered-phrase-vocabulary-focused-listening-fill` harness mode.
- Document the keep decision and remaining claim boundary.

## Result
- reviewed count: `1`
- pending count: `0`
- timing: `acceptable`
- chord fit: `strong`
- phrase continuation: `acceptable`
- landing: `strong`
- jazz vocabulary: `acceptable`
- final decision: `keep`
- dead-air ratio: `0.333`
- sustained coverage: `0.594`
- adjacent pitch repeats: `0`
- max interval: `7`
- final landing: `C5` over `Fm7`, chord tone
- review risk: `sustained_coverage_review`

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill`
- `bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-focused-listening-fill`
- `bash scripts/agent_harness.sh quick`
- `rg -n "codex|Codex|코덱스" <changed files>`

## Risk
- `keep` is a MIDI/context evidence decision, not human audio listening proof.
- Sustained coverage remains near the review threshold and is preserved as evidence.

## Follow-up
- Stage B margin-recovered phrase/vocabulary keep consolidation.

Closes #278