### PR TITLE
Stage B margin-recovered phrase vocabulary keep stability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #280, Stage B margin-recovered phrase/vocabulary keep consolidation.
+- Latest functional issue completed: Issue #282, Stage B margin-recovered phrase/vocabulary keep stability comparison.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary keep stability comparison.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary qualified peer focused context review.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -482,6 +482,14 @@ bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-focused
 ```
 
 This harness fills the focused listening review notes from MIDI/context evidence and records the keep/follow-up boundary.
+
+For Stage B margin-recovered phrase/vocabulary keep stability changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-keep-stability
+```
+
+This harness compares the filled keep candidate against qualified phrase/vocabulary sweep peers and records the stability boundary.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 | context keep 후보 청감 판단 보류 | focused context keep만으로 timing/phrase/vocabulary 최종 판단 불가 | focused listening notes template 생성 | candidate `1`, pending `1`, risk `sustained_coverage_review` |
 | focused listening fill 후 keep 판정 경계 | sustained coverage가 threshold 근처라 최종 음악 품질로 과장할 위험 | MIDI/context evidence 기준으로 listening fields 채움 | timing `acceptable`, phrase `acceptable`, vocabulary `acceptable`, decision `keep`, human/audio proof는 미검증 |
 | keep 후보 과장 위험 | evidence fill의 `keep`을 broad model quality로 오해할 수 있음 | proven / not proven / next boundary로 consolidation | current margin-recovered evidence keep candidate와 human/audio 미검증 범위 분리 |
+| keep 후보 안정성 미확인 | selected keep이 단일 sample일 수 있음 | 96개 sweep 후보에서 qualified peer 분포 비교 | qualified `2/96`, seed43/61 각각 1개, narrow two-source support |
 
 ## 파이프라인 구조
 
@@ -65,7 +66,7 @@ flowchart LR
 
 ## 핵심 결과
 
-Issue #280 기준 model-core MVP:
+Issue #282 기준 model-core MVP:
 
 | 항목 | 결과 |
 |---|---|
@@ -104,6 +105,7 @@ Issue #280 기준 model-core MVP:
 | margin-recovered phrase vocabulary focused listening notes | focused listening template 생성, candidate `1`, pending `1`, review risk `sustained_coverage_review` |
 | margin-recovered phrase vocabulary focused listening fill | reviewed `1`, pending `0`, timing `acceptable`, phrase `acceptable`, vocabulary `acceptable`, decision `keep` |
 | margin-recovered phrase vocabulary keep consolidation | current evidence keep candidate 정리, human/audio proof와 broad quality claim boundary 분리 |
+| margin-recovered phrase vocabulary keep stability | qualified `2/96`, qualified source `2`, selected keep과 peer 후보 metric 동일 수준 |
 | constrained review gate | `stage-b-overlap-gate` 통과 |
 | focused candidate path | `stage-b-rhythm-phrase-variation` 통과 |
 
@@ -147,6 +149,7 @@ MVP 근거:
 - context keep 후보를 focused listening notes template으로 넘기고 timing, phrase continuation, landing, vocabulary, final decision을 pending으로 유지
 - focused listening fill에서 timing `acceptable`, phrase continuation `acceptable`, jazz vocabulary `acceptable`, final decision `keep`으로 기록하되 human/audio proof와 분리
 - margin-recovered evidence keep candidate를 정리하고 broad trained-model quality, human/audio preference, Brad style adaptation은 아직 미검증으로 유지
+- phrase/vocabulary sweep 96개 후보 중 qualified `2`개를 확인하고 selected keep 외 qualified peer가 seed `61`에도 있음을 분리
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`
@@ -161,7 +164,7 @@ MVP 근거:
 | 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab focused context `keep_for_focused_listening`, timing/repetition repair qualified `2/96`, phrase/vocabulary focused context `keep_for_focused_listening`, phrase/vocabulary focused fill `keep` |
 | 주장 경계 | reviewable MIDI 후보 생성 검증 파이프라인까지 가능, human listening preference / Brad style adaptation / broad production quality는 미검증 |
 
-Issue #280 기준 current margin-recovered evidence keep candidate:
+Issue #282 기준 current margin-recovered evidence keep candidate:
 
 | 항목 | 결과 |
 |---|---|
@@ -179,6 +182,7 @@ Issue #280 기준 current margin-recovered evidence keep candidate:
 | max interval | `7` |
 | final landing | `C5` over `Fm7`, chord tone |
 | remaining risk | `sustained_coverage_review` |
+| stability boundary | qualified `2/96`, source `2`, broad repeatability 미검증 |
 
 Issue #210 기준 current best focused review candidate:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -85,6 +85,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered phrase/vocabulary focused listening notes 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_FOCUSED_LISTENING_NOTES_2026-05-28.md`
 - margin-recovered phrase/vocabulary focused listening fill 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_FOCUSED_LISTENING_FILL_2026-05-28.md`
 - margin-recovered phrase/vocabulary keep consolidation 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_KEEP_CONSOLIDATION_2026-05-28.md`
+- margin-recovered phrase/vocabulary keep stability 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_KEEP_STABILITY_2026-05-28.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -115,6 +116,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered phrase/vocabulary focused listening notes: candidate `1`, pending `1`, prior decision `keep_for_focused_listening`, risk `sustained_coverage_review`
 - margin-recovered phrase/vocabulary focused listening fill: reviewed `1`, decision `keep`, timing `acceptable`, phrase continuation `acceptable`, jazz vocabulary `acceptable`
 - margin-recovered phrase/vocabulary keep consolidation: current evidence keep candidate 정리, proven/not proven boundary 분리
+- margin-recovered phrase/vocabulary keep stability: qualified `2/96`, qualified source `2`, stability boundary `narrow_two_source_candidate_support`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -316,6 +318,7 @@ Stage B에서 명시하는 것:
 135. Stage B margin-recovered phrase/vocabulary focused listening notes
 136. Stage B margin-recovered phrase/vocabulary focused listening fill
 137. Stage B margin-recovered phrase/vocabulary keep consolidation
+138. Stage B margin-recovered phrase/vocabulary keep stability comparison
 
 가장 최근 의미 있는 결과:
 
@@ -501,6 +504,8 @@ Stage B에서 명시하는 것:
 - Issue #278 result: reviewed `1`, decision `keep`, timing `acceptable`, chord fit `strong`, phrase continuation `acceptable`, landing `strong`, jazz vocabulary `acceptable`; sustained coverage risk remains documented and this is not human/audio proof.
 - Issue #280 consolidates that result as the current margin-recovered evidence keep candidate.
 - Issue #280 result: candidate `margin_recovered_phrase_vocab_seed_43_topk_7_temp_082_n48_sample_43` is documented as evidence keep, while human/audio preference, broad trained-model quality, Brad style adaptation, and broader repeatability remain unproven.
+- Issue #282 compares that keep candidate against the Issue #272 phrase/vocabulary sweep.
+- Issue #282 result: qualified `2/96`, qualified source count `2`, selected keep plus peer `margin_recovered_phrase_vocab_seed_61_topk_7_temp_082_n48_sample_25`, stability boundary `narrow_two_source_candidate_support`.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -519,8 +524,8 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-Issue #280은 phrase/vocabulary repair 후보를 current margin-recovered evidence keep candidate로 정리했다.
-다음 작업은 이 keep 후보가 단일 후보에 그치지 않는지 stability comparison 또는 listening comparison 경계를 별도 issue로 검증하는 것이다.
+Issue #282는 current keep 후보가 완전한 단일 sample은 아니며, 같은 sweep 안에 qualified peer가 있음을 확인했다.
+다음 작업은 qualified peer를 focused context/listening path로 넘겨 실제 fallback keep인지 확인하는 것이다.
 
 ## 6. 다음 단계 로드맵
 
@@ -1046,38 +1051,34 @@ Issue #280은 phrase/vocabulary repair 후보를 current margin-recovered eviden
 완료된 바로 전 작업:
 
 ```text
-Stage B margin-recovered phrase/vocabulary keep consolidation
+Stage B margin-recovered phrase/vocabulary keep stability comparison
 ```
 
 결과:
 
-- docs: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_KEEP_CONSOLIDATION_2026-05-28.md`
+- docs: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_KEEP_STABILITY_2026-05-28.md`
 - selected candidate: `margin_recovered_phrase_vocab_seed_43_topk_7_temp_082_n48_sample_43`
-- decision path: objective repair -> focused context -> focused listening notes -> evidence fill
-- focused context decision: `keep_for_focused_listening`
-- filled listening decision: `keep`
-- note count: `13`
-- unique pitch count: `8`
-- range: `G4-E5`
-- phrase span: `7.000` beats
-- dead-air ratio: `0.333`
-- adjacent pitch repeats: `0`
-- max interval: `7`
-- final landing: `C5` over `Fm7`, chord tone
-- review risks: `sustained_coverage_review`
+- qualified peer: `margin_recovered_phrase_vocab_seed_61_topk_7_temp_082_n48_sample_25`
+- candidate count: `96`
+- qualified candidate count: `2`
+- qualified rate: `0.020833`
+- qualified source count: `2`
+- selected metrics: notes `13`, unique `8`, dead-air `0.333`, adjacent repeat `0`, max interval `7`
+- peer metrics: notes `13`, unique `8`, dead-air `0.333`, adjacent repeat `0`, max interval `7`
+- stability boundary: `narrow_two_source_candidate_support`
 
 판단:
 
-- current margin-recovered evidence keep candidate가 정리됐다.
-- 검증된 범위와 미검증 범위를 분리했다.
+- current keep 후보가 완전한 단일 sample은 아니다.
+- 다만 qualified rate가 낮으므로 broad repeatability로 주장하지 않는다.
 - broad trained-model quality, human listening preference, Brad style adaptation은 아직 미검증이다.
 
 다음 작업:
 
-- 다음 issue는 `Stage B margin-recovered phrase/vocabulary keep stability comparison`으로 잡는다.
-- 단일 keep 후보가 broader seed/file 조건에서도 유지되는지 비교한다.
-- human/audio proof가 필요하면 별도 listening comparison issue로 분리한다.
-- broad training은 stability boundary를 먼저 본 뒤 결정한다.
+- 다음 issue는 `Stage B margin-recovered phrase/vocabulary qualified peer focused context review`로 잡는다.
+- qualified peer를 solo/context package로 격리한다.
+- peer가 context/listening path에서도 fallback keep인지 확인한다.
+- broad training은 peer review boundary를 먼저 본 뒤 결정한다.
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #280, Stage B margin-recovered phrase/vocabulary keep consolidation
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary keep stability comparison`
+- latest functional result: Issue #282, Stage B margin-recovered phrase/vocabulary keep stability comparison
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary qualified peer focused context review`
 
 현재 범위가 아닌 것:
 
@@ -1295,6 +1295,46 @@ Issue #280은 Issue #278 filled `keep` 결과를 current margin-recovered eviden
 Docs:
 
 - `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_KEEP_CONSOLIDATION_2026-05-28.md`
+
+## Current Margin-Recovered Phrase/Vocabulary Keep Stability Result
+
+Issue #282는 Issue #280 current margin-recovered evidence keep candidate가 단일 후보인지, 같은 phrase/vocabulary sweep 안에 qualified peer가 있는지 비교한 작업이다.
+
+변경:
+
+- phrase/vocabulary keep stability summary script 추가
+- repair summary의 qualified candidate count, source 분포, peer candidate 집계
+- filled keep candidate와 qualified peer를 같은 metric table로 비교
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_phrase_vocabulary_keep_stability`
+- `bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-keep-stability`
+
+결과:
+
+| 항목 | 값 |
+|---|---|
+| candidate count | `96` |
+| qualified candidate count | `2` |
+| qualified rate | `0.020833` |
+| qualified source count | `2` |
+| selected candidate | `margin_recovered_phrase_vocab_seed_43_topk_7_temp_082_n48_sample_43` |
+| qualified peer | `margin_recovered_phrase_vocab_seed_61_topk_7_temp_082_n48_sample_25` |
+| selected metrics | notes `13`, unique `8`, dead-air `0.333`, adjacent repeat `0`, max interval `7` |
+| peer metrics | notes `13`, unique `8`, dead-air `0.333`, adjacent repeat `0`, max interval `7` |
+| stability boundary | `narrow_two_source_candidate_support` |
+
+해석:
+
+- current keep 후보가 완전한 단일 sample은 아니다.
+- seed `43` source와 seed `61` source에서 각각 qualified 후보가 1개씩 나왔다.
+- qualified rate는 `2/96`으로 낮으므로 broad model quality나 robust repeatability로 주장하지 않는다.
+- 다음 단계는 qualified peer를 focused context/listening path로 넘겨 실제 fallback 후보인지 확인하는 것이다.
+
+Docs:
+
+- `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_KEEP_STABILITY_2026-05-28.md`
 
 ## Latest README Footer Section Removal Result
 

--- a/docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_KEEP_STABILITY_2026-05-28.md
+++ b/docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_KEEP_STABILITY_2026-05-28.md
@@ -1,0 +1,51 @@
+# Stage B Margin-Recovered Phrase/Vocabulary Keep Stability
+
+## 요약
+
+Issue #282는 Issue #280 current margin-recovered evidence keep candidate가 단일 후보인지, 같은 phrase/vocabulary sweep 안에 qualified peer가 있는지 비교한 작업이다.
+
+새 MIDI를 생성하지 않고, Issue #272 repair summary와 Issue #278 filled keep notes를 조인해 stability boundary를 정리했다.
+
+## 변경
+
+- phrase/vocabulary keep stability summary script 추가
+- repair summary의 qualified candidate count, source 분포, peer candidate를 집계
+- filled keep candidate와 qualified peer를 같은 metric table로 비교
+- result docs와 current plan 업데이트
+
+## 결과
+
+| 항목 | 값 |
+|---|---|
+| candidate count | `96` |
+| qualified candidate count | `2` |
+| qualified rate | `0.020833` |
+| qualified source count | `2` |
+| selected candidate | `margin_recovered_phrase_vocab_seed_43_topk_7_temp_082_n48_sample_43` |
+| qualified peer | `margin_recovered_phrase_vocab_seed_61_topk_7_temp_082_n48_sample_25` |
+| selected source | `harness_stage_b_margin_recovered_phrase_vocab_seed43_topk7_temp082_n48` |
+| peer source | `harness_stage_b_margin_recovered_phrase_vocab_seed61_topk7_temp082_n48` |
+| selected metrics | notes `13`, unique `8`, dead-air `0.333`, adjacent repeat `0`, max interval `7` |
+| peer metrics | notes `13`, unique `8`, dead-air `0.333`, adjacent repeat `0`, max interval `7` |
+| stability boundary | `narrow_two_source_candidate_support` |
+| next issue | `Stage B margin-recovered phrase/vocabulary qualified peer focused context review` |
+
+## 해석
+
+- current keep candidate가 완전히 단일 sample만은 아니다.
+- seed `43` source와 seed `61` source에서 각각 qualified 후보가 1개씩 나왔다.
+- 다만 qualified rate는 `2/96`으로 낮으므로 broad model quality나 robust repeatability로 주장하지 않는다.
+- 다음 단계는 qualified peer를 focused context/listening path로 넘겨 실제 fallback 후보인지 확인하는 것이다.
+
+## 검증
+
+```bash
+.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_phrase_vocabulary_keep_stability
+bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-keep-stability
+```
+
+## 산출물
+
+- script: `scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_keep_stability.py`
+- test: `tests/test_stage_b_margin_recovered_phrase_vocabulary_keep_stability.py`
+- summary: `outputs/stage_b_margin_recovered_phrase_vocabulary_keep_stability/harness_stage_b_margin_recovered_phrase_vocabulary_keep_stability/keep_stability_summary.json`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -76,6 +76,8 @@ Modes:
                 Build focused listening notes for the selected phrase/vocabulary candidate.
   stage-b-margin-recovered-phrase-vocabulary-focused-listening-fill
                 Fill the selected phrase/vocabulary focused listening review notes.
+  stage-b-margin-recovered-phrase-vocabulary-keep-stability
+                Compare the filled keep candidate against phrase/vocabulary sweep peers.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -220,6 +222,7 @@ run_quick() {
     scripts/build_stage_b_margin_recovered_phrase_vocabulary_focused_package.py \
     scripts/build_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes.py \
     scripts/fill_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes.py \
+    scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_keep_stability.py \
     scripts/run_stage_b_sampling_sweep.py \
     scripts/run_stage_b_coverage_ab_sweep.py \
     scripts/run_stage_b_pitch_mode_compare.py \
@@ -841,6 +844,31 @@ run_stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill() {
     --review_notes "$review_notes" \
     --expected_candidate_id "$candidate_id" \
     --expected_decision keep
+}
+
+run_stage_b_margin_recovered_phrase_vocabulary_keep_stability() {
+  local repair_run_id="${REPAIR_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_repair}"
+  local fill_run_id="${FILL_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill}"
+  local run_id="${RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_keep_stability}"
+  local candidate_id="margin_recovered_phrase_vocab_seed_43_topk_7_temp_082_n48_sample_43"
+  local repair_summary="outputs/stage_b_margin_recovered_phrase_vocabulary_repair/${repair_run_id}/phrase_vocabulary_repair_summary.json"
+  local filled_notes="outputs/stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill/${fill_run_id}/focused_listening_review_notes_filled.json"
+  if [[ ! -f "$repair_summary" ]]; then
+    print_header "Stage B margin-recovered phrase/vocabulary repair"
+    RUN_ID="$repair_run_id" run_stage_b_margin_recovered_phrase_vocabulary_repair
+  fi
+  if [[ ! -f "$filled_notes" ]]; then
+    print_header "Stage B margin-recovered phrase/vocabulary focused listening fill"
+    RUN_ID="$fill_run_id" run_stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill
+  fi
+  print_header "Stage B margin-recovered phrase/vocabulary keep stability"
+  "$PYTHON_BIN" scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_keep_stability.py \
+    --run_id "$run_id" \
+    --repair_summary "$repair_summary" \
+    --filled_notes "$filled_notes" \
+    --expected_selected_candidate_id "$candidate_id" \
+    --min_qualified_candidates 2 \
+    --require_qualified_peer
 }
 
 run_stage_b_constrained_probe() {
@@ -2028,6 +2056,9 @@ case "$MODE" in
     ;;
   stage-b-margin-recovered-phrase-vocabulary-focused-listening-fill)
     run_stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill
+    ;;
+  stage-b-margin-recovered-phrase-vocabulary-keep-stability)
+    run_stage_b_margin_recovered_phrase_vocabulary_keep_stability
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_keep_stability.py
+++ b/scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_keep_stability.py
@@ -1,0 +1,259 @@
+"""Summarize stability of the margin-recovered phrase/vocabulary evidence keep candidate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class PhraseVocabularyKeepStabilityError(ValueError):
+    pass
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def candidates_by_id(candidates: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {str(candidate.get("candidate_id") or ""): candidate for candidate in candidates}
+
+
+def compact_candidate(candidate: dict[str, Any]) -> dict[str, Any]:
+    focused = candidate.get("focused_solo_metrics") if isinstance(candidate.get("focused_solo_metrics"), dict) else {}
+    metrics = candidate.get("metrics") if isinstance(candidate.get("metrics"), dict) else {}
+    gate = candidate.get("phrase_vocabulary_gate") if isinstance(candidate.get("phrase_vocabulary_gate"), dict) else {}
+    return {
+        "candidate_id": str(candidate.get("candidate_id") or ""),
+        "source_run_id": str(candidate.get("source_run_id") or ""),
+        "sample_index": int(candidate.get("sample_index", 0) or 0),
+        "sample_seed": int(candidate.get("sample_seed", 0) or 0),
+        "repair_rank": int(candidate.get("repair_rank", 0) or 0),
+        "qualified": bool(gate.get("qualified", False)),
+        "flags": list(gate.get("flags") or []),
+        "focused_note_count": int(focused.get("focused_note_count", 0) or 0),
+        "focused_unique_pitch_count": int(focused.get("focused_unique_pitch_count", 0) or 0),
+        "focused_adjacent_pitch_repeats": int(focused.get("focused_adjacent_pitch_repeats", 0) or 0),
+        "focused_max_interval": int(focused.get("focused_max_interval", 0) or 0),
+        "focused_duplicated_3_note_chunks": int(
+            focused.get("focused_duplicated_3_note_pitch_class_chunks", 0) or 0
+        ),
+        "dead_air_ratio": float(metrics.get("dead_air_ratio", 0.0) or 0.0),
+    }
+
+
+def filled_keep_candidate(filled_notes: dict[str, Any]) -> dict[str, Any]:
+    candidates = filled_notes.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise PhraseVocabularyKeepStabilityError("filled notes must contain candidates")
+    keep_candidates = [
+        candidate
+        for candidate in candidates
+        if str(candidate.get("listening", {}).get("decision") or "") == "keep"
+    ]
+    if len(keep_candidates) != 1:
+        raise PhraseVocabularyKeepStabilityError(f"expected exactly one filled keep candidate, got {len(keep_candidates)}")
+    return keep_candidates[0]
+
+
+def stability_boundary(*, selected_is_filled_keep: bool, qualified_count: int, qualified_source_count: int) -> str:
+    if not selected_is_filled_keep:
+        return "no_filled_keep"
+    if qualified_count >= 2 and qualified_source_count >= 2:
+        return "narrow_two_source_candidate_support"
+    if qualified_count >= 2:
+        return "same_source_peer_support"
+    return "single_candidate_support_only"
+
+
+def build_stability_report(
+    repair_summary: dict[str, Any],
+    filled_notes: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> dict[str, Any]:
+    candidates = repair_summary.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise PhraseVocabularyKeepStabilityError("repair summary must contain candidates")
+    filled_keep = filled_keep_candidate(filled_notes)
+    selected_id = str(filled_keep.get("candidate_id") or "")
+    by_id = candidates_by_id(candidates)
+    selected = by_id.get(selected_id)
+    if selected is None:
+        raise PhraseVocabularyKeepStabilityError(f"filled keep candidate not found in repair summary: {selected_id}")
+    qualified = [
+        candidate
+        for candidate in candidates
+        if bool(candidate.get("phrase_vocabulary_gate", {}).get("qualified", False))
+    ]
+    qualified_sources = Counter(str(candidate.get("source_run_id") or "") for candidate in qualified)
+    peers = [candidate for candidate in qualified if str(candidate.get("candidate_id") or "") != selected_id]
+    candidate_count = int(repair_summary.get("candidate_count", len(candidates)) or len(candidates))
+    qualified_count = int(len(qualified))
+    source_count = int(len(qualified_sources))
+    filled_listening = filled_keep.get("listening") if isinstance(filled_keep.get("listening"), dict) else {}
+    selected_is_filled_keep = str(filled_listening.get("decision") or "") == "keep"
+    return {
+        "schema_version": "stage_b_margin_recovered_phrase_vocabulary_keep_stability_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_repair_summary": str(repair_summary.get("output_dir") or ""),
+        "source_filled_notes_schema": str(filled_notes.get("schema_version") or ""),
+        "candidate_count": candidate_count,
+        "qualified_candidate_count": qualified_count,
+        "qualified_rate": round(qualified_count / max(1, candidate_count), 6),
+        "qualified_source_count": source_count,
+        "qualified_sources": dict(sorted(qualified_sources.items())),
+        "selected_candidate": compact_candidate(selected),
+        "filled_keep_decision": {
+            "candidate_id": selected_id,
+            "decision": str(filled_listening.get("decision") or ""),
+            "timing": str(filled_listening.get("timing") or ""),
+            "phrase_continuation": str(filled_listening.get("phrase_continuation") or ""),
+            "jazz_vocabulary": str(filled_listening.get("jazz_vocabulary") or ""),
+            "not_human_audio_review": bool(
+                filled_keep.get("listening_fill_evidence", {}).get("not_human_audio_review", False)
+            ),
+        },
+        "qualified_peer_count": int(len(peers)),
+        "qualified_peers": [compact_candidate(candidate) for candidate in peers],
+        "stability_summary": {
+            "selected_is_filled_keep": bool(selected_is_filled_keep),
+            "has_qualified_peer": bool(peers),
+            "boundary": stability_boundary(
+                selected_is_filled_keep=selected_is_filled_keep,
+                qualified_count=qualified_count,
+                qualified_source_count=source_count,
+            ),
+            "next_recommended_issue": (
+                "Stage B margin-recovered phrase/vocabulary qualified peer focused context review"
+                if peers
+                else "Stage B margin-recovered phrase/vocabulary broader stability sweep"
+            ),
+        },
+    }
+
+
+def validate_stability(
+    report: dict[str, Any],
+    *,
+    expected_selected_candidate_id: str | None,
+    min_qualified_candidates: int,
+    require_qualified_peer: bool,
+) -> dict[str, Any]:
+    selected_id = str(report.get("selected_candidate", {}).get("candidate_id") or "")
+    if expected_selected_candidate_id and selected_id != expected_selected_candidate_id:
+        raise PhraseVocabularyKeepStabilityError(
+            f"expected selected candidate {expected_selected_candidate_id}, got {selected_id}"
+        )
+    qualified_count = int(report.get("qualified_candidate_count", 0) or 0)
+    if qualified_count < int(min_qualified_candidates):
+        raise PhraseVocabularyKeepStabilityError(
+            f"qualified_candidate_count {qualified_count} < {min_qualified_candidates}"
+        )
+    peer_count = int(report.get("qualified_peer_count", 0) or 0)
+    if require_qualified_peer and peer_count < 1:
+        raise PhraseVocabularyKeepStabilityError("expected at least one qualified peer")
+    if not bool(report.get("stability_summary", {}).get("selected_is_filled_keep", False)):
+        raise PhraseVocabularyKeepStabilityError("selected candidate must be a filled keep")
+    return {
+        "selected_candidate_id": selected_id,
+        "qualified_candidate_count": qualified_count,
+        "qualified_peer_count": peer_count,
+        "qualified_source_count": int(report.get("qualified_source_count", 0) or 0),
+        "boundary": str(report.get("stability_summary", {}).get("boundary") or ""),
+        "next_recommended_issue": str(report.get("stability_summary", {}).get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    selected = report["selected_candidate"]
+    lines = [
+        "# Stage B Margin-Recovered Phrase/Vocabulary Keep Stability",
+        "",
+        f"- candidate count: `{report['candidate_count']}`",
+        f"- qualified candidates: `{report['qualified_candidate_count']}`",
+        f"- qualified rate: `{report['qualified_rate']}`",
+        f"- qualified sources: `{report['qualified_sources']}`",
+        f"- selected candidate: `{selected['candidate_id']}`",
+        f"- stability boundary: `{report['stability_summary']['boundary']}`",
+        "",
+        "This is a sweep stability comparison, not a broad model-quality claim.",
+        "",
+        "| candidate | source | rank | sample | notes | unique | dead-air | adj repeat | max interval | flags |",
+        "|---|---|---:|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    rows = [selected] + list(report.get("qualified_peers") or [])
+    for row in rows:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(row["candidate_id"]),
+                    str(row["source_run_id"]),
+                    str(row["repair_rank"]),
+                    str(row["sample_index"]),
+                    str(row["focused_note_count"]),
+                    str(row["focused_unique_pitch_count"]),
+                    f"{float(row['dead_air_ratio']):.3f}",
+                    str(row["focused_adjacent_pitch_repeats"]),
+                    str(row["focused_max_interval"]),
+                    ",".join(row["flags"]) if row["flags"] else "ok",
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Summarize phrase/vocabulary keep stability")
+    parser.add_argument("--repair_summary", type=str, required=True)
+    parser.add_argument("--filled_notes", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_margin_recovered_phrase_vocabulary_keep_stability",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--expected_selected_candidate_id", type=str, default="")
+    parser.add_argument("--min_qualified_candidates", type=int, default=1)
+    parser.add_argument("--require_qualified_peer", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_stability_report(
+        read_json(Path(args.repair_summary)),
+        read_json(Path(args.filled_notes)),
+        output_dir=output_dir,
+    )
+    summary = validate_stability(
+        report,
+        expected_selected_candidate_id=str(args.expected_selected_candidate_id or ""),
+        min_qualified_candidates=int(args.min_qualified_candidates),
+        require_qualified_peer=bool(args.require_qualified_peer),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "keep_stability_summary.json"
+    markdown_path = output_dir / "keep_stability_summary.md"
+    write_json(report_path, report)
+    write_json(output_dir / "keep_stability_validation_summary.json", summary)
+    markdown_path.write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps({**summary, "report_path": str(report_path), "markdown_path": str(markdown_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_margin_recovered_phrase_vocabulary_keep_stability.py
+++ b/tests/test_stage_b_margin_recovered_phrase_vocabulary_keep_stability.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.summarize_stage_b_margin_recovered_phrase_vocabulary_keep_stability import (
+    build_stability_report,
+    validate_stability,
+)
+
+
+def candidate(candidate_id: str, *, source: str, rank: int, qualified: bool) -> dict:
+    return {
+        "candidate_id": candidate_id,
+        "source_run_id": source,
+        "sample_index": rank + 10,
+        "sample_seed": rank + 70,
+        "repair_rank": rank,
+        "metrics": {"dead_air_ratio": 0.33333333333333337},
+        "focused_solo_metrics": {
+            "focused_note_count": 13,
+            "focused_unique_pitch_count": 8,
+            "focused_adjacent_pitch_repeats": 0,
+            "focused_max_interval": 7,
+            "focused_duplicated_3_note_pitch_class_chunks": 0,
+        },
+        "phrase_vocabulary_gate": {"qualified": qualified, "flags": [] if qualified else ["low_pitch_variety"]},
+    }
+
+
+class StageBMarginRecoveredPhraseVocabularyKeepStabilityTest(unittest.TestCase):
+    def test_builds_stability_report_with_qualified_peer(self) -> None:
+        repair_summary = {
+            "output_dir": "outputs/repair",
+            "candidate_count": 3,
+            "candidates": [
+                candidate("selected", source="seed43", rank=1, qualified=True),
+                candidate("peer", source="seed61", rank=2, qualified=True),
+                candidate("rejected", source="seed43", rank=3, qualified=False),
+            ],
+        }
+        filled_notes = {
+            "schema_version": "stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill_v1",
+            "candidates": [
+                {
+                    "candidate_id": "selected",
+                    "listening": {
+                        "decision": "keep",
+                        "timing": "acceptable",
+                        "phrase_continuation": "acceptable",
+                        "jazz_vocabulary": "acceptable",
+                    },
+                    "listening_fill_evidence": {"not_human_audio_review": True},
+                }
+            ],
+        }
+        report = build_stability_report(repair_summary, filled_notes, output_dir=Path("outputs/stability"))
+        summary = validate_stability(
+            report,
+            expected_selected_candidate_id="selected",
+            min_qualified_candidates=2,
+            require_qualified_peer=True,
+        )
+
+        self.assertEqual(summary["qualified_candidate_count"], 2)
+        self.assertEqual(summary["qualified_peer_count"], 1)
+        self.assertEqual(summary["qualified_source_count"], 2)
+        self.assertEqual(summary["boundary"], "narrow_two_source_candidate_support")
+        self.assertTrue(report["stability_summary"]["has_qualified_peer"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a stability summary for the current margin-recovered evidence keep candidate.
- Compare the selected keep candidate against qualified peers from the phrase/vocabulary sweep.
- Update README and handoff docs with the stability boundary.

## Context
Issue #280 consolidated `margin_recovered_phrase_vocab_seed_43_topk_7_temp_082_n48_sample_43` as the current margin-recovered evidence keep candidate. This PR checks whether that result is a single sample or has qualified peer support in the same sweep.

## Scope
- Add `scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_keep_stability.py`.
- Add unit coverage for qualified peer stability reporting.
- Add `stage-b-margin-recovered-phrase-vocabulary-keep-stability` harness mode.
- Document next boundary for qualified peer focused context review.

## Result
- candidate count: `96`
- qualified candidate count: `2`
- qualified rate: `0.020833`
- qualified source count: `2`
- selected candidate: `margin_recovered_phrase_vocab_seed_43_topk_7_temp_082_n48_sample_43`
- qualified peer: `margin_recovered_phrase_vocab_seed_61_topk_7_temp_082_n48_sample_25`
- selected metrics: notes `13`, unique `8`, dead-air `0.333`, adjacent repeat `0`, max interval `7`
- peer metrics: notes `13`, unique `8`, dead-air `0.333`, adjacent repeat `0`, max interval `7`
- stability boundary: `narrow_two_source_candidate_support`

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_phrase_vocabulary_keep_stability`
- `bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-keep-stability`
- `bash scripts/agent_harness.sh quick`
- `rg -n "codex|Codex|코덱스" <changed files>`

## Risk
- Qualified `2/96` is narrow support, not broad repeatability or broad model quality.

## Follow-up
- Stage B margin-recovered phrase/vocabulary qualified peer focused context review.

Closes #282