### PR TITLE
Stage B margin-recovered phrase vocabulary human listening comparison boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #290, Stage B margin-recovered phrase/vocabulary two-candidate keep consolidation.
+- Latest functional issue completed: Issue #292, Stage B margin-recovered phrase/vocabulary human listening comparison boundary.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary human listening comparison boundary.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary duplicate-candidate source divergence audit.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -522,6 +522,14 @@ bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-two-can
 ```
 
 This harness joins selected and peer filled keep notes with the stability summary and records the two-candidate evidence boundary.
+
+For Stage B margin-recovered phrase/vocabulary human listening comparison boundary changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-human-listening-comparison
+```
+
+This harness prepares pending human listening fields and verifies whether selected and peer keep candidates are distinct enough for A/B listening comparison.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@
 | peer 청감 판단 보류 | peer context keep만으로 selected keep과 같은 fallback인지 판단 불가 | peer focused listening notes template 생성 | candidate `1`, pending `1`, risk `sustained_coverage_review` |
 | peer fallback keep 여부 미확정 | peer notes가 pending 상태라 selected keep과 비교 불가 | peer notes를 MIDI/context evidence 기준으로 fill | timing `acceptable`, phrase `acceptable`, vocabulary `acceptable`, decision `keep` |
 | two-candidate claim boundary 필요 | selected/peer 모두 keep이지만 broad model quality로 과장될 수 있음 | stability summary와 두 filled notes를 조인해 evidence boundary 정리 | keep `2`, qualified `2/96`, source `2`, boundary `two_candidate_midi_context_keep_support` |
+| human listening 비교 과장 위험 | selected/peer가 다른 source 후보여도 실제 MIDI content가 같을 수 있음 | human listening comparison boundary에서 note signature와 metric fingerprint 비교 | note sequence match `true`, human status `pending`, A/B 선호 claim 없음 |
 
 ## 파이프라인 구조
 
@@ -70,7 +71,7 @@ flowchart LR
 
 ## 핵심 결과
 
-Issue #290 기준 model-core MVP:
+Issue #292 기준 model-core MVP:
 
 | 항목 | 결과 |
 |---|---|
@@ -114,6 +115,7 @@ Issue #290 기준 model-core MVP:
 | margin-recovered phrase vocabulary peer focused listening notes | peer focused listening template 생성, candidate `1`, pending `1`, review risk `sustained_coverage_review` |
 | margin-recovered phrase vocabulary peer focused listening fill | peer reviewed `1`, decision `keep`, timing `acceptable`, phrase `acceptable`, vocabulary `acceptable` |
 | margin-recovered phrase vocabulary two-candidate keep | selected/peer keep `2`, qualified `2/96`, source `2`, boundary `two_candidate_midi_context_keep_support` |
+| margin-recovered phrase vocabulary human listening comparison | human status `pending`, note sequence match `true`, boundary `pending_human_review_same_midi_content` |
 | constrained review gate | `stage-b-overlap-gate` 통과 |
 | focused candidate path | `stage-b-rhythm-phrase-variation` 통과 |
 
@@ -162,6 +164,7 @@ MVP 근거:
 - qualified peer 후보를 focused listening notes template으로 넘기고 selected keep과 같은 risk boundary를 보존
 - qualified peer 후보도 focused listening fill 기준 decision `keep`으로 기록해 selected keep 외 fallback keep 후보 확보
 - selected keep과 peer keep을 같은 summary로 조인해 two-candidate MIDI/context evidence boundary를 `two_candidate_midi_context_keep_support`로 기록
+- selected/peer 후보의 note signature가 동일함을 확인해 human listening comparison을 pending으로 두고 동일 렌더 A/B 선호 claim을 차단
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`
@@ -173,10 +176,10 @@ MVP 근거:
 | 만든 것 | symbolic MIDI 생성 모델의 dataset, tokenization, training, generation, decode, objective review, proxy review pipeline |
 | 겪은 문제 | `.mid` 파일 존재만으로 성공 판단 불가, one-note collapse, long sustain block, chord block, dead-air outlier, seed-level margin 부족 |
 | 해결 방식 | duration-explicit token 구조, grammar/coverage/chord-aware probe, overlap-free postprocess, repeatability sweep, dead-air diagnostics, proxy review scoring, repair candidate selection |
-| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab focused context `keep_for_focused_listening`, timing/repetition repair qualified `2/96`, phrase/vocabulary focused fill `keep`, two-candidate keep `2` |
+| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab focused context `keep_for_focused_listening`, timing/repetition repair qualified `2/96`, phrase/vocabulary focused fill `keep`, two-candidate keep `2`, selected/peer note sequence match |
 | 주장 경계 | reviewable MIDI 후보 생성 검증 파이프라인까지 가능, human listening preference / Brad style adaptation / broad production quality는 미검증 |
 
-Issue #290 기준 current margin-recovered two-candidate evidence boundary:
+Issue #292 기준 current margin-recovered two-candidate evidence boundary:
 
 | 항목 | 결과 |
 |---|---|
@@ -200,6 +203,7 @@ Issue #290 기준 current margin-recovered two-candidate evidence boundary:
 | remaining risk | `sustained_coverage_review` |
 | evidence boundary | `two_candidate_midi_context_keep_support` |
 | claim boundary | human/audio proof, broad repeatability, Brad style adaptation 미검증 |
+| human comparison boundary | `pending_human_review_same_midi_content`, same-render A/B 선호 claim 불가 |
 
 Issue #210 기준 current best focused review candidate:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -90,6 +90,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered phrase/vocabulary qualified peer focused listening notes 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_QUALIFIED_PEER_FOCUSED_LISTENING_NOTES_2026-05-28.md`
 - margin-recovered phrase/vocabulary qualified peer focused listening fill 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_QUALIFIED_PEER_FOCUSED_LISTENING_FILL_2026-05-28.md`
 - margin-recovered phrase/vocabulary two-candidate keep consolidation 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_TWO_CANDIDATE_KEEP_CONSOLIDATION_2026-05-29.md`
+- margin-recovered phrase/vocabulary human listening comparison boundary 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_HUMAN_LISTENING_COMPARISON_BOUNDARY_2026-05-29.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -125,6 +126,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered phrase/vocabulary qualified peer focused listening notes: peer candidate `1`, pending `1`, prior decision `keep_for_focused_listening`, risk `sustained_coverage_review`
 - margin-recovered phrase/vocabulary qualified peer focused listening fill: peer decision `keep`, timing `acceptable`, phrase continuation `acceptable`, jazz vocabulary `acceptable`
 - margin-recovered phrase/vocabulary two-candidate keep: selected/peer keep `2`, qualified `2/96`, source `2`, boundary `two_candidate_midi_context_keep_support`
+- margin-recovered phrase/vocabulary human listening comparison: human status `pending`, note sequence match `true`, boundary `pending_human_review_same_midi_content`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -331,6 +333,7 @@ Stage B에서 명시하는 것:
 140. Stage B margin-recovered phrase/vocabulary qualified peer focused listening notes
 141. Stage B margin-recovered phrase/vocabulary qualified peer focused listening fill
 142. Stage B margin-recovered phrase/vocabulary two-candidate keep consolidation
+143. Stage B margin-recovered phrase/vocabulary human listening comparison boundary
 
 가장 최근 의미 있는 결과:
 
@@ -526,6 +529,8 @@ Stage B에서 명시하는 것:
 - Issue #288 result: peer decision `keep`, timing `acceptable`, chord fit `strong`, phrase continuation `acceptable`, landing `strong`, jazz vocabulary `acceptable`; selected and peer candidates now both have filled evidence keep decisions.
 - Issue #290 joins the keep stability summary with selected and peer filled notes.
 - Issue #290 result: keep candidates `2`, qualified `2/96`, qualified sources `2`, boundary `two_candidate_midi_context_keep_support`; this remains MIDI/context evidence, not human/audio proof.
+- Issue #292 prepares the selected/peer pair for human listening comparison and keeps preference fields pending.
+- Issue #292 result: note sequence match `true`, metric fingerprint match `true`, boundary `pending_human_review_same_midi_content`; same-render A/B preference is not meaningful until source divergence is audited.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -544,8 +549,8 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-Issue #290은 selected keep과 peer keep을 함께 묶어 two-candidate evidence keep boundary를 정리했다.
-다음 작업은 human listening 또는 audio-rendered comparison 기준으로 이 boundary를 별도 검증하는 것이다.
+Issue #292는 selected/peer pair를 human listening comparison boundary로 넘겼고, 두 후보가 같은 note sequence로 수렴했음을 확인했다.
+다음 작업은 duplicate-candidate source divergence를 audit해 source diversity가 output diversity로 이어지지 않은 원인을 분리하는 것이다.
 
 ## 6. 다음 단계 로드맵
 
@@ -1071,18 +1076,19 @@ Issue #290은 selected keep과 peer keep을 함께 묶어 two-candidate evidence
 완료된 바로 전 작업:
 
 ```text
-Stage B margin-recovered phrase/vocabulary two-candidate keep consolidation
+Stage B margin-recovered phrase/vocabulary human listening comparison boundary
 ```
 
 결과:
 
-- docs: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_TWO_CANDIDATE_KEEP_CONSOLIDATION_2026-05-29.md`
+- docs: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_HUMAN_LISTENING_COMPARISON_BOUNDARY_2026-05-29.md`
 - selected candidate: `margin_recovered_phrase_vocab_seed_43_topk_7_temp_082_n48_sample_43`
 - peer candidate: `margin_recovered_phrase_vocab_seed_61_topk_7_temp_082_n48_sample_25`
-- keep candidate count: `2`
-- qualified candidate count: `2/96`
-- qualified source count: `2`
-- boundary: `two_candidate_midi_context_keep_support`
+- human listening status: `pending`
+- preference claimed: `false`
+- note sequence match: `true`
+- metric fingerprint match: `true`
+- boundary: `pending_human_review_same_midi_content`
 - timing: `acceptable`
 - chord fit: `strong`
 - phrase continuation: `acceptable`
@@ -1101,15 +1107,15 @@ Stage B margin-recovered phrase/vocabulary two-candidate keep consolidation
 
 판단:
 
-- selected keep 외 fallback keep 후보가 evidence 기준으로 확보됐고, 두 후보를 같은 summary boundary로 묶었다.
-- 단일 sample claim보다는 강하지만, qualified rate `2/96`이라 robust repeatability는 아니다.
+- selected/peer가 다른 source run에서 나왔지만 실제 note sequence와 metric fingerprint는 동일하다.
+- human listening comparison field는 pending이며, 같은 렌더 기준 A/B preference는 주장하지 않는다.
 - broad trained-model quality, human listening preference, Brad style adaptation은 아직 미검증이다.
 
 다음 작업:
 
-- 다음 issue는 `Stage B margin-recovered phrase/vocabulary human listening comparison boundary`로 잡는다.
-- selected/peer keep 후보를 사람이 듣는 비교 기준 또는 audio-rendered review 기준으로 분리한다.
-- broad training은 이 boundary를 먼저 본 뒤 결정한다.
+- 다음 issue는 `Stage B margin-recovered phrase/vocabulary duplicate-candidate source divergence audit`로 잡는다.
+- source run과 sample index가 다른데 같은 note sequence로 수렴한 원인을 분리한다.
+- broad training은 duplicate/source diversity boundary를 먼저 본 뒤 결정한다.
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #290, Stage B margin-recovered phrase/vocabulary two-candidate keep consolidation
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary human listening comparison boundary`
+- latest functional result: Issue #292, Stage B margin-recovered phrase/vocabulary human listening comparison boundary
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duplicate-candidate source divergence audit`
 
 현재 범위가 아닌 것:
 
@@ -1526,6 +1526,51 @@ Issue #290은 selected keep 후보와 qualified peer keep 후보를 하나의 ev
 Docs:
 
 - `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_TWO_CANDIDATE_KEEP_CONSOLIDATION_2026-05-29.md`
+
+## Current Margin-Recovered Phrase/Vocabulary Human Listening Comparison Boundary Result
+
+Issue #292는 selected keep 후보와 peer keep 후보를 human/audio review 대상으로 넘기기 전에, 비교 가능한 후보인지 확인하고 사람 평가 필드를 `pending`으로 분리한 작업이다.
+
+변경:
+
+- human listening comparison boundary script 추가
+- selected/peer filled notes와 two-candidate keep summary를 조인하는 harness mode 추가
+- selected/peer 후보의 MIDI 경로, context MIDI 경로, pending human listening fields 기록
+- note signature와 metric fingerprint 동일 여부를 objective comparison으로 기록
+- README와 handoff docs 업데이트
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison`
+- `bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-human-listening-comparison`
+
+결과:
+
+| 항목 | 값 |
+|---|---|
+| candidate count | `2` |
+| human listening status | `pending` |
+| preference claimed | `false` |
+| note sequence match | `true` |
+| metric fingerprint match | `true` |
+| complete note signature | `true` |
+| selected note count | `13` |
+| peer note count | `13` |
+| selected candidate | `margin_recovered_phrase_vocab_seed_43_topk_7_temp_082_n48_sample_43` |
+| peer candidate | `margin_recovered_phrase_vocab_seed_61_topk_7_temp_082_n48_sample_25` |
+| boundary | `pending_human_review_same_midi_content` |
+| listenability | `not_meaningful_as_ab_if_same_render` |
+
+해석:
+
+- selected 후보와 peer 후보는 source run과 sample index는 다르지만 note signature와 metric fingerprint가 동일하다.
+- human listening field는 모두 `pending`이며 선호 판단은 기록하지 않았다.
+- 동일 MIDI content를 같은 악기/템포/context로 렌더한다면 A/B 청감 비교는 의미가 약하다.
+- 다음은 source diversity가 output diversity로 이어지지 않은 원인을 audit하는 것이다.
+
+Docs:
+
+- `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_HUMAN_LISTENING_COMPARISON_BOUNDARY_2026-05-29.md`
 
 ## Latest README Footer Section Removal Result
 

--- a/docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_HUMAN_LISTENING_COMPARISON_BOUNDARY_2026-05-29.md
+++ b/docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_HUMAN_LISTENING_COMPARISON_BOUNDARY_2026-05-29.md
@@ -1,0 +1,60 @@
+# Stage B Margin-Recovered Phrase/Vocabulary Human Listening Comparison Boundary
+
+## 요약
+
+Issue #292는 selected keep 후보와 peer keep 후보를 human/audio review 대상으로 넘기기 전에, 비교 가능한 후보인지 확인하고 사람 평가 필드를 `pending`으로 분리한 작업이다.
+
+이 단계는 사람이 들었다는 결론을 내리지 않는다. 두 후보가 실제 MIDI content 기준으로 다른지 먼저 확인하고, 동일 content라면 A/B 선호 비교를 과장하지 않는다.
+
+## 변경
+
+- human listening comparison boundary script 추가
+- selected/peer filled notes와 two-candidate keep summary를 조인하는 harness mode 추가
+- selected/peer 후보의 MIDI 경로, context MIDI 경로, pending human listening fields 기록
+- note signature와 metric fingerprint 동일 여부를 objective comparison으로 기록
+- README와 handoff docs 업데이트
+
+## 결과
+
+| 항목 | 값 |
+|---|---|
+| candidate count | `2` |
+| human listening status | `pending` |
+| preference claimed | `false` |
+| note sequence match | `true` |
+| metric fingerprint match | `true` |
+| complete note signature | `true` |
+| selected note count | `13` |
+| peer note count | `13` |
+| boundary | `pending_human_review_same_midi_content` |
+| listenability | `not_meaningful_as_ab_if_same_render` |
+
+| role | candidate | prior decision | human status | notes | unique | dead-air | sustained | final landing | risk |
+|---|---|---|---|---:|---:|---:|---:|---|---|
+| selected | `margin_recovered_phrase_vocab_seed_43_topk_7_temp_082_n48_sample_43` | `keep` | `pending` | `13` | `8` | `0.333` | `0.594` | `C5` over `Fm7`, chord tone | `sustained_coverage_review` |
+| peer | `margin_recovered_phrase_vocab_seed_61_topk_7_temp_082_n48_sample_25` | `keep` | `pending` | `13` | `8` | `0.333` | `0.594` | `C5` over `Fm7`, chord tone | `sustained_coverage_review` |
+
+## 해석
+
+- selected 후보와 peer 후보는 source run과 sample index는 다르지만 note signature와 metric fingerprint가 동일하다.
+- human listening field는 모두 `pending`이며 선호 판단은 기록하지 않았다.
+- 동일 MIDI content를 같은 악기/템포/context로 렌더한다면 A/B 청감 비교는 의미가 약하다.
+- 이 결과는 two-source support를 부정하지는 않지만, source diversity가 실제 output diversity로 이어졌는지는 별도 audit이 필요하다.
+
+## 검증
+
+```bash
+.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison
+bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-human-listening-comparison
+```
+
+## 산출물
+
+- script: `scripts/build_stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison.py`
+- test: `tests/test_stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison.py`
+- summary: `outputs/stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison/harness_stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison/human_listening_comparison_boundary.json`
+
+## 다음 경계
+
+- `Stage B margin-recovered phrase/vocabulary duplicate-candidate source divergence audit`
+- seed/source가 달라도 같은 MIDI content로 수렴한 원인을 분리한다.

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -86,6 +86,8 @@ Modes:
                 Fill the qualified phrase/vocabulary peer focused listening review notes.
   stage-b-margin-recovered-phrase-vocabulary-two-candidate-keep
                 Consolidate selected and peer phrase/vocabulary keep candidates.
+  stage-b-margin-recovered-phrase-vocabulary-human-listening-comparison
+                Build pending human-listening comparison boundary for selected and peer keep candidates.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -232,6 +234,7 @@ run_quick() {
     scripts/fill_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes.py \
     scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_keep_stability.py \
     scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_two_candidate_keep.py \
+    scripts/build_stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison.py \
     scripts/run_stage_b_sampling_sweep.py \
     scripts/run_stage_b_coverage_ab_sweep.py \
     scripts/run_stage_b_pitch_mode_compare.py \
@@ -972,6 +975,38 @@ run_stage_b_margin_recovered_phrase_vocabulary_two_candidate_keep() {
     --min_qualified_sources 2 \
     --max_qualified_rate 0.05 \
     --require_not_human_audio_review
+}
+
+run_stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison() {
+  local two_candidate_run_id="${TWO_CANDIDATE_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_two_candidate_keep}"
+  local selected_fill_run_id="${SELECTED_FILL_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill}"
+  local peer_fill_run_id="${PEER_FILL_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_peer_focused_listening_fill}"
+  local run_id="${RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison}"
+  local two_candidate_keep="outputs/stage_b_margin_recovered_phrase_vocabulary_two_candidate_keep/${two_candidate_run_id}/two_candidate_keep_summary.json"
+  local selected_filled_notes="outputs/stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill/${selected_fill_run_id}/focused_listening_review_notes_filled.json"
+  local peer_filled_notes="outputs/stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill/${peer_fill_run_id}/focused_listening_review_notes_filled.json"
+  if [[ ! -f "$two_candidate_keep" ]]; then
+    print_header "Stage B margin-recovered phrase/vocabulary two-candidate keep"
+    RUN_ID="$two_candidate_run_id" run_stage_b_margin_recovered_phrase_vocabulary_two_candidate_keep
+  fi
+  if [[ ! -f "$selected_filled_notes" ]]; then
+    print_header "Stage B margin-recovered phrase/vocabulary focused listening fill"
+    RUN_ID="$selected_fill_run_id" run_stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill
+  fi
+  if [[ ! -f "$peer_filled_notes" ]]; then
+    print_header "Stage B margin-recovered phrase/vocabulary peer focused listening fill"
+    RUN_ID="$peer_fill_run_id" run_stage_b_margin_recovered_phrase_vocabulary_peer_focused_listening_fill
+  fi
+  print_header "Stage B margin-recovered phrase/vocabulary human listening comparison boundary"
+  "$PYTHON_BIN" scripts/build_stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison.py \
+    --run_id "$run_id" \
+    --two_candidate_keep "$two_candidate_keep" \
+    --selected_filled_notes "$selected_filled_notes" \
+    --peer_filled_notes "$peer_filled_notes" \
+    --min_candidates 2 \
+    --require_pending \
+    --require_no_preference \
+    --expect_note_sequence_match
 }
 
 run_stage_b_constrained_probe() {
@@ -2174,6 +2209,9 @@ case "$MODE" in
     ;;
   stage-b-margin-recovered-phrase-vocabulary-two-candidate-keep)
     run_stage_b_margin_recovered_phrase_vocabulary_two_candidate_keep
+    ;;
+  stage-b-margin-recovered-phrase-vocabulary-human-listening-comparison)
+    run_stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/build_stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison.py
+++ b/scripts/build_stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison.py
@@ -1,0 +1,342 @@
+"""Build a human-listening comparison boundary for two phrase/vocabulary keep candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class PhraseVocabularyHumanListeningComparisonError(ValueError):
+    pass
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def keep_candidate(filled_notes: dict[str, Any], *, role: str) -> dict[str, Any]:
+    candidates = filled_notes.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise PhraseVocabularyHumanListeningComparisonError(f"{role} filled notes must contain candidates")
+    keep_candidates = [
+        candidate
+        for candidate in candidates
+        if str(candidate.get("listening", {}).get("decision") or "") == "keep"
+    ]
+    if len(keep_candidates) != 1:
+        raise PhraseVocabularyHumanListeningComparisonError(
+            f"expected exactly one {role} keep candidate, got {len(keep_candidates)}"
+        )
+    return keep_candidates[0]
+
+
+def note_signature(candidate: dict[str, Any]) -> list[dict[str, Any]]:
+    notes = candidate.get("objective_first_16_notes")
+    if not isinstance(notes, list):
+        return []
+    signature = []
+    for note in notes:
+        if not isinstance(note, dict):
+            continue
+        signature.append(
+            {
+                "pitch": int(note.get("pitch", 0) or 0),
+                "start_sec": round(float(note.get("start_sec", 0.0) or 0.0), 6),
+                "duration_sec": round(
+                    float(note.get("end_sec", 0.0) or 0.0) - float(note.get("start_sec", 0.0) or 0.0),
+                    6,
+                ),
+                "velocity": int(note.get("velocity", 0) or 0),
+            }
+        )
+    return signature
+
+
+def metric_fingerprint(candidate: dict[str, Any]) -> dict[str, Any]:
+    metrics = (
+        candidate.get("focused_context_metrics")
+        if isinstance(candidate.get("focused_context_metrics"), dict)
+        else {}
+    )
+    return {
+        "note_count": int(metrics.get("note_count", 0) or 0),
+        "unique_pitch_count": int(metrics.get("unique_pitch_count", 0) or 0),
+        "range": str(metrics.get("range") or ""),
+        "phrase_span_beats": round(float(metrics.get("phrase_span_beats", 0.0) or 0.0), 3),
+        "dead_air_ratio": round(float(metrics.get("dead_air_ratio", 0.0) or 0.0), 3),
+        "sustained_coverage_ratio": round(float(metrics.get("sustained_coverage_ratio", 0.0) or 0.0), 3),
+        "adjacent_pitch_repeats": int(metrics.get("adjacent_pitch_repeats", 0) or 0),
+        "max_interval": int(metrics.get("max_interval", 0) or 0),
+        "final_note": str(metrics.get("final_note") or ""),
+        "final_chord": str(metrics.get("final_chord") or ""),
+        "final_note_role": str(metrics.get("final_note_role") or ""),
+    }
+
+
+def compact_candidate(candidate: dict[str, Any], *, role: str) -> dict[str, Any]:
+    metadata = candidate.get("review_metadata") if isinstance(candidate.get("review_metadata"), dict) else {}
+    files = candidate.get("review_files") if isinstance(candidate.get("review_files"), dict) else {}
+    listening = candidate.get("listening") if isinstance(candidate.get("listening"), dict) else {}
+    evidence = (
+        candidate.get("listening_fill_evidence")
+        if isinstance(candidate.get("listening_fill_evidence"), dict)
+        else {}
+    )
+    return {
+        "role": role,
+        "candidate_id": str(candidate.get("candidate_id") or ""),
+        "source_run_id": str(metadata.get("source_run_id") or ""),
+        "sample_index": int(metadata.get("sample_index", 0) or 0),
+        "sample_seed": int(metadata.get("sample_seed", 0) or 0),
+        "midi_path": str(files.get("midi_path") or ""),
+        "context_midi_path": str(files.get("context_midi_path") or ""),
+        "source_midi_path": str(files.get("source_midi_path") or ""),
+        "prior_evidence_decision": str(listening.get("decision") or ""),
+        "prior_timing": str(listening.get("timing") or ""),
+        "prior_chord_fit": str(listening.get("chord_fit") or ""),
+        "prior_phrase_continuation": str(listening.get("phrase_continuation") or ""),
+        "prior_landing": str(listening.get("landing") or ""),
+        "prior_jazz_vocabulary": str(listening.get("jazz_vocabulary") or ""),
+        "metric_fingerprint": metric_fingerprint(candidate),
+        "note_signature": note_signature(candidate),
+        "review_risks": list(candidate.get("review_risks") or []),
+        "not_human_audio_review": bool(evidence.get("not_human_audio_review", False)),
+        "human_listening": {
+            "status": "pending",
+            "comparison_preference": "pending",
+            "timing_preference": "pending",
+            "phrase_preference": "pending",
+            "vocabulary_preference": "pending",
+            "audio_render_used": "",
+            "reviewer": "",
+            "notes": "",
+        },
+    }
+
+
+def build_human_listening_comparison(
+    two_candidate_keep: dict[str, Any],
+    selected_filled_notes: dict[str, Any],
+    peer_filled_notes: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> dict[str, Any]:
+    selected = compact_candidate(keep_candidate(selected_filled_notes, role="selected"), role="selected")
+    peer = compact_candidate(keep_candidate(peer_filled_notes, role="peer"), role="peer")
+    keep_ids = {
+        str(candidate.get("candidate_id") or "")
+        for candidate in two_candidate_keep.get("keep_candidates", [])
+        if isinstance(candidate, dict)
+    }
+    for candidate in (selected, peer):
+        if candidate["candidate_id"] not in keep_ids:
+            raise PhraseVocabularyHumanListeningComparisonError(
+                f"candidate not found in two-candidate keep summary: {candidate['candidate_id']}"
+            )
+
+    note_sequence_match = selected["note_signature"] == peer["note_signature"]
+    metric_fingerprint_match = selected["metric_fingerprint"] == peer["metric_fingerprint"]
+    complete_signature = all(
+        len(candidate["note_signature"]) >= candidate["metric_fingerprint"]["note_count"]
+        for candidate in (selected, peer)
+    )
+    if note_sequence_match and complete_signature:
+        comparison_boundary = "pending_human_review_same_midi_content"
+        listenability = "not_meaningful_as_ab_if_same_render"
+    else:
+        comparison_boundary = "pending_human_review_distinct_midi_content"
+        listenability = "requires_audio_render_or_human_listening"
+
+    return {
+        "schema_version": "stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_two_candidate_keep_schema": str(two_candidate_keep.get("schema_version") or ""),
+        "candidates": [selected, peer],
+        "objective_comparison": {
+            "note_sequence_match": note_sequence_match,
+            "metric_fingerprint_match": metric_fingerprint_match,
+            "complete_note_signature": complete_signature,
+            "selected_note_signature_count": len(selected["note_signature"]),
+            "peer_note_signature_count": len(peer["note_signature"]),
+            "candidate_note_count": selected["metric_fingerprint"]["note_count"],
+        },
+        "human_listening_boundary": {
+            "boundary": comparison_boundary,
+            "listenability": listenability,
+            "status": "pending",
+            "preference_claimed": False,
+            "not_human_audio_review": True,
+            "requires_audio_render_or_human_review": True,
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "audio_rendered_quality",
+            "broad_trained_model_quality",
+            "robust_repeatability",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": "Stage B margin-recovered phrase/vocabulary duplicate-candidate source divergence audit"
+        if note_sequence_match
+        else "Stage B margin-recovered phrase/vocabulary human listening fill",
+    }
+
+
+def validate_human_listening_comparison(
+    report: dict[str, Any],
+    *,
+    min_candidates: int,
+    require_pending: bool,
+    require_no_preference: bool,
+    expect_note_sequence_match: bool | None,
+) -> dict[str, Any]:
+    candidates = report.get("candidates")
+    if not isinstance(candidates, list):
+        raise PhraseVocabularyHumanListeningComparisonError("report candidates must be a list")
+    if len(candidates) < min_candidates:
+        raise PhraseVocabularyHumanListeningComparisonError(f"candidate count {len(candidates)} < {min_candidates}")
+    if require_pending:
+        statuses = [str(candidate.get("human_listening", {}).get("status") or "") for candidate in candidates]
+        if any(status != "pending" for status in statuses):
+            raise PhraseVocabularyHumanListeningComparisonError(f"expected pending human statuses, got {statuses}")
+    preference_claimed = bool(report.get("human_listening_boundary", {}).get("preference_claimed", True))
+    if require_no_preference and preference_claimed:
+        raise PhraseVocabularyHumanListeningComparisonError("human preference must not be claimed")
+    note_sequence_match = bool(report.get("objective_comparison", {}).get("note_sequence_match", False))
+    if expect_note_sequence_match is not None and note_sequence_match != expect_note_sequence_match:
+        raise PhraseVocabularyHumanListeningComparisonError(
+            f"note_sequence_match expected {expect_note_sequence_match}, got {note_sequence_match}"
+        )
+    return {
+        "candidate_count": len(candidates),
+        "human_statuses": [
+            str(candidate.get("human_listening", {}).get("status") or "") for candidate in candidates
+        ],
+        "note_sequence_match": note_sequence_match,
+        "metric_fingerprint_match": bool(
+            report.get("objective_comparison", {}).get("metric_fingerprint_match", False)
+        ),
+        "boundary": str(report.get("human_listening_boundary", {}).get("boundary") or ""),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    objective = report["objective_comparison"]
+    boundary = report["human_listening_boundary"]
+    lines = [
+        "# Stage B Margin-Recovered Phrase/Vocabulary Human Listening Comparison",
+        "",
+        f"- candidates: `{len(report.get('candidates') or [])}`",
+        f"- human status: `{boundary['status']}`",
+        f"- boundary: `{boundary['boundary']}`",
+        f"- note sequence match: `{objective['note_sequence_match']}`",
+        f"- metric fingerprint match: `{objective['metric_fingerprint_match']}`",
+        "",
+        "This file prepares a human/audio review boundary. It does not claim a listening preference.",
+        "",
+        "| role | candidate | source | sample | prior decision | human status | notes | unique | dead-air | sustained | final landing | risk |",
+        "|---|---|---|---:|---|---|---:|---:|---:|---:|---|---|",
+    ]
+    for candidate in report.get("candidates", []):
+        metrics = candidate["metric_fingerprint"]
+        final = f"{metrics['final_note']} over {metrics['final_chord']} ({metrics['final_note_role']})"
+        risk = ",".join(candidate["review_risks"]) if candidate["review_risks"] else "none"
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(candidate["role"]),
+                    str(candidate["candidate_id"]),
+                    str(candidate["source_run_id"]),
+                    str(candidate["sample_index"]),
+                    str(candidate["prior_evidence_decision"]),
+                    str(candidate["human_listening"]["status"]),
+                    str(metrics["note_count"]),
+                    str(metrics["unique_pitch_count"]),
+                    f"{float(metrics['dead_air_ratio']):.3f}",
+                    f"{float(metrics['sustained_coverage_ratio']):.3f}",
+                    final,
+                    risk,
+                ]
+            )
+            + " |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Review Boundary",
+            "",
+            f"- preference claimed: `{boundary['preference_claimed']}`",
+            f"- listenability: `{boundary['listenability']}`",
+            f"- next recommended issue: `{report['next_recommended_issue']}`",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build human listening comparison boundary")
+    parser.add_argument("--two_candidate_keep", type=str, required=True)
+    parser.add_argument("--selected_filled_notes", type=str, required=True)
+    parser.add_argument("--peer_filled_notes", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--min_candidates", type=int, default=2)
+    parser.add_argument("--require_pending", action="store_true")
+    parser.add_argument("--require_no_preference", action="store_true")
+    parser.add_argument("--expect_note_sequence_match", action="store_true")
+    parser.add_argument("--expect_note_sequence_diff", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if args.expect_note_sequence_match and args.expect_note_sequence_diff:
+        raise PhraseVocabularyHumanListeningComparisonError(
+            "only one of --expect_note_sequence_match or --expect_note_sequence_diff is allowed"
+        )
+    expected_match: bool | None = None
+    if args.expect_note_sequence_match:
+        expected_match = True
+    elif args.expect_note_sequence_diff:
+        expected_match = False
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_human_listening_comparison(
+        read_json(Path(args.two_candidate_keep)),
+        read_json(Path(args.selected_filled_notes)),
+        read_json(Path(args.peer_filled_notes)),
+        output_dir=output_dir,
+    )
+    summary = validate_human_listening_comparison(
+        report,
+        min_candidates=int(args.min_candidates),
+        require_pending=bool(args.require_pending),
+        require_no_preference=bool(args.require_no_preference),
+        expect_note_sequence_match=expected_match,
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "human_listening_comparison_boundary.json"
+    markdown_path = output_dir / "human_listening_comparison_boundary.md"
+    write_json(report_path, report)
+    write_json(output_dir / "human_listening_comparison_validation_summary.json", summary)
+    markdown_path.write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps({**summary, "report_path": str(report_path), "markdown_path": str(markdown_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison.py
+++ b/tests/test_stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.build_stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison import (
+    PhraseVocabularyHumanListeningComparisonError,
+    build_human_listening_comparison,
+    validate_human_listening_comparison,
+)
+
+
+def filled_notes(candidate_id: str, *, source: str, pitch: int = 72) -> dict:
+    return {
+        "schema_version": "stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill_v1",
+        "candidates": [
+            {
+                "candidate_id": candidate_id,
+                "review_metadata": {
+                    "source_run_id": source,
+                    "sample_index": 25,
+                    "sample_seed": 85,
+                },
+                "review_files": {
+                    "midi_path": f"outputs/{candidate_id}.mid",
+                    "context_midi_path": f"outputs/{candidate_id}_context.mid",
+                    "source_midi_path": f"outputs/{candidate_id}_source.mid",
+                },
+                "listening": {
+                    "decision": "keep",
+                    "timing": "acceptable",
+                    "chord_fit": "strong",
+                    "phrase_continuation": "acceptable",
+                    "landing": "strong",
+                    "jazz_vocabulary": "acceptable",
+                },
+                "focused_context_metrics": {
+                    "note_count": 1,
+                    "unique_pitch_count": 1,
+                    "range": "C5-C5",
+                    "phrase_span_beats": 1.0,
+                    "dead_air_ratio": 0.0,
+                    "sustained_coverage_ratio": 1.0,
+                    "adjacent_pitch_repeats": 0,
+                    "max_interval": 0,
+                    "final_note": "C5",
+                    "final_chord": "Fm7",
+                    "final_note_role": "chord_tone",
+                },
+                "objective_first_16_notes": [
+                    {
+                        "pitch": pitch,
+                        "start_sec": 0.0,
+                        "end_sec": 0.25,
+                        "velocity": 71,
+                    }
+                ],
+                "review_risks": [],
+                "listening_fill_evidence": {"not_human_audio_review": True},
+            }
+        ],
+    }
+
+
+class StageBMarginRecoveredPhraseVocabularyHumanListeningComparisonTest(unittest.TestCase):
+    def test_builds_pending_boundary_for_same_note_sequence(self) -> None:
+        two_candidate_keep = {
+            "schema_version": "stage_b_margin_recovered_phrase_vocabulary_two_candidate_keep_v1",
+            "keep_candidates": [
+                {"candidate_id": "selected"},
+                {"candidate_id": "peer"},
+            ],
+        }
+
+        report = build_human_listening_comparison(
+            two_candidate_keep,
+            filled_notes("selected", source="seed43"),
+            filled_notes("peer", source="seed61"),
+            output_dir=Path("outputs/human_boundary"),
+        )
+        summary = validate_human_listening_comparison(
+            report,
+            min_candidates=2,
+            require_pending=True,
+            require_no_preference=True,
+            expect_note_sequence_match=True,
+        )
+
+        self.assertEqual(summary["candidate_count"], 2)
+        self.assertTrue(summary["note_sequence_match"])
+        self.assertEqual(summary["boundary"], "pending_human_review_same_midi_content")
+        self.assertEqual(report["candidates"][0]["human_listening"]["status"], "pending")
+        self.assertFalse(report["human_listening_boundary"]["preference_claimed"])
+
+    def test_rejects_unexpected_note_sequence_match(self) -> None:
+        two_candidate_keep = {
+            "keep_candidates": [
+                {"candidate_id": "selected"},
+                {"candidate_id": "peer"},
+            ],
+        }
+        report = build_human_listening_comparison(
+            two_candidate_keep,
+            filled_notes("selected", source="seed43", pitch=72),
+            filled_notes("peer", source="seed61", pitch=73),
+            output_dir=Path("outputs/human_boundary"),
+        )
+
+        with self.assertRaises(PhraseVocabularyHumanListeningComparisonError):
+            validate_human_listening_comparison(
+                report,
+                min_candidates=2,
+                require_pending=True,
+                require_no_preference=True,
+                expect_note_sequence_match=True,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Build a human-listening comparison boundary for the selected and peer phrase/vocabulary keep candidates.
- Keep human preference fields pending and avoid claiming subjective audio proof.
- Add objective note-sequence and metric-fingerprint comparison before any A/B listening claim.

## Context
Closes #292. Issue #290 consolidated two MIDI/context evidence keep candidates. This PR checks whether those candidates are actually distinct enough for a meaningful human/audio A/B comparison.

## Result
- candidate count: `2`
- human listening status: `pending`
- preference claimed: `false`
- note sequence match: `true`
- metric fingerprint match: `true`
- complete note signature: `true`
- boundary: `pending_human_review_same_midi_content`
- listenability: `not_meaningful_as_ab_if_same_render`

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison`
- `bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-human-listening-comparison`
- `bash scripts/agent_harness.sh quick`
- `rg -n "codex|Codex|코덱스" <changed files>`

## Risk
- This does not record a human preference or rendered-audio quality result.
- selected and peer came from different source runs, but their note signatures match, so same-render A/B listening is not meaningful until source divergence is audited.

## Follow-up
- Stage B margin-recovered phrase/vocabulary duplicate-candidate source divergence audit.