### PR TITLE
Stage B margin-recovered phrase vocabulary distinct sample-seed remaining blocker repair target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #304, Stage B margin-recovered phrase/vocabulary distinct sample-seed focused listening fill.
+- Latest functional issue completed: Issue #306, Stage B margin-recovered phrase/vocabulary distinct sample-seed remaining blocker repair target.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary distinct sample-seed remaining blocker repair target.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary distinct sample-seed remaining blocker repair sweep.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -578,6 +578,14 @@ bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-distinc
 ```
 
 This harness fills the distinct sample-seed focused listening review notes from MIDI/context evidence and records the keep/follow-up boundary.
+
+For Stage B margin-recovered phrase/vocabulary distinct sample-seed remaining blocker changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-distinct-sample-seed-remaining-blocker
+```
+
+This harness summarizes the focused listening fill blockers and records the next repair target.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 | distinct sample-seed context 검증 필요 | distinct 후보도 focused context decision 전에는 keep 후보로 보기 어려움 | selected distinct candidate를 solo/context package로 격리해 focused context decision 실행 | decision `keep_for_focused_listening`, flags `{}`, final `D5` over `Fm7` tension |
 | distinct sample-seed 청감 판단 보류 | context keep만으로 timing/phrase/vocabulary 판단 불가 | focused listening notes template 생성 | candidate `1`, pending `1`, risks `dead_air_ratio_remaining`, `adjacent_pitch_repeats` |
 | distinct sample-seed keep 승격 실패 | distinct 후보지만 phrase span `6.750`, unique pitch `6`, adjacent repeat `1`이 남음 | MIDI/context evidence 기준 focused listening fill 실행 | phrase `weak`, vocabulary `thin`, decision `needs_followup` |
+| 다음 repair target 불명확 | `needs_followup`만으로 sweep 조건을 바로 잡기 어려움 | remaining blocker summary로 target/guardrail 분리 | target phrase span `>=7.0`, unique pitch `>=7`, adjacent repeat `0`, dead-air `<=0.35` preferred |
 
 ## 파이프라인 구조
 
@@ -77,7 +78,7 @@ flowchart LR
 
 ## 핵심 결과
 
-Issue #304 기준 model-core MVP:
+Issue #306 기준 model-core MVP:
 
 | 항목 | 결과 |
 |---|---|
@@ -128,6 +129,7 @@ Issue #304 기준 model-core MVP:
 | margin-recovered phrase vocabulary distinct sample-seed focused context | selected distinct 후보를 context package로 격리, decision `keep_for_focused_listening`, flags `{}` |
 | margin-recovered phrase vocabulary distinct sample-seed focused listening notes | focused listening template 생성, candidate `1`, pending `1`, review risks `2` |
 | margin-recovered phrase vocabulary distinct sample-seed focused listening fill | reviewed `1`, pending `0`, timing `acceptable`, phrase `weak`, vocabulary `thin`, decision `needs_followup` |
+| margin-recovered phrase vocabulary distinct sample-seed remaining blocker | remaining blockers `5`, secondary risk `1`, next repair target 정의 |
 | constrained review gate | `stage-b-overlap-gate` 통과 |
 | focused candidate path | `stage-b-rhythm-phrase-variation` 통과 |
 
@@ -183,6 +185,7 @@ MVP 근거:
 - sample seed `155` 후보를 focused context package로 격리해 max active `1`, phrase span `6.75` beats, final `D5` over `Fm7` tension, context decision `keep_for_focused_listening` 확인
 - distinct sample-seed context keep 후보를 focused listening notes template으로 넘기고 timing, phrase continuation, landing, vocabulary, final decision을 pending으로 유지
 - focused listening fill에서 timing과 landing은 acceptable이지만 phrase continuation `weak`, jazz vocabulary `thin`, decision `needs_followup`으로 distinct 후보 keep 승격 차단
+- remaining blocker summary에서 phrase span, pitch variety, adjacent repeat를 다음 repair target으로 고정하고 max interval/final landing/max active는 guardrail로 유지
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`
@@ -194,10 +197,10 @@ MVP 근거:
 | 만든 것 | symbolic MIDI 생성 모델의 dataset, tokenization, training, generation, decode, objective review, proxy review pipeline |
 | 겪은 문제 | `.mid` 파일 존재만으로 성공 판단 불가, one-note collapse, long sustain block, chord block, dead-air outlier, seed-level margin 부족 |
 | 해결 방식 | duration-explicit token 구조, grammar/coverage/chord-aware probe, overlap-free postprocess, repeatability sweep, dead-air diagnostics, proxy review scoring, repair candidate selection |
-| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab focused context `keep_for_focused_listening`, timing/repetition repair qualified `2/96`, phrase/vocabulary focused fill `keep`, selected/peer duplicate output, distinct sample-seed fill `needs_followup` |
+| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab focused context `keep_for_focused_listening`, timing/repetition repair qualified `2/96`, phrase/vocabulary focused fill `keep`, selected/peer duplicate output, distinct sample-seed remaining blocker target 정의 |
 | 주장 경계 | reviewable MIDI 후보 생성 검증 파이프라인까지 가능, human listening preference / Brad style adaptation / broad production quality는 미검증 |
 
-Issue #304 기준 current margin-recovered evidence boundary:
+Issue #306 기준 current margin-recovered evidence boundary:
 
 | 항목 | 결과 |
 |---|---|
@@ -234,6 +237,8 @@ Issue #304 기준 current margin-recovered evidence boundary:
 | distinct sample-seed review risks | `dead_air_ratio_remaining`, `adjacent_pitch_repeats` |
 | distinct sample-seed fill decision | `needs_followup` |
 | distinct sample-seed fill fields | timing `acceptable`, phrase `weak`, vocabulary `thin`, landing `acceptable` |
+| distinct sample-seed repair boundary | `distinct_sample_seed_candidate_needs_phrase_vocabulary_repair` |
+| distinct sample-seed repair target | phrase span `>=7.0`, unique pitch `>=7`, adjacent repeat `0`, dead-air `<=0.35` preferred |
 
 Issue #210 기준 current best focused review candidate:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -97,6 +97,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered phrase/vocabulary distinct sample-seed focused context 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DISTINCT_SAMPLE_SEED_FOCUSED_CONTEXT_2026-05-29.md`
 - margin-recovered phrase/vocabulary distinct sample-seed focused listening notes 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DISTINCT_SAMPLE_SEED_FOCUSED_LISTENING_NOTES_2026-05-29.md`
 - margin-recovered phrase/vocabulary distinct sample-seed focused listening fill 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DISTINCT_SAMPLE_SEED_FOCUSED_LISTENING_FILL_2026-05-29.md`
+- margin-recovered phrase/vocabulary distinct sample-seed remaining blocker 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DISTINCT_SAMPLE_SEED_REMAINING_BLOCKER_2026-05-29.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -555,6 +556,8 @@ Stage B에서 명시하는 것:
 - Issue #302 result: candidate `1`, pending `1`, review risks `dead_air_ratio_remaining` and `adjacent_pitch_repeats`.
 - Issue #304 fills the distinct sample-seed notes from MIDI/context evidence.
 - Issue #304 result: decision `needs_followup`, phrase continuation `weak`, jazz vocabulary `thin`; timing and landing remain acceptable.
+- Issue #306 summarizes the remaining blockers into the next repair target.
+- Issue #306 result: blockers `phrase_continuation_weak`, `jazz_vocabulary_thin`, `short_phrase_span`, `pitch_variety_floor`, `adjacent_pitch_repeats`; target phrase span `>= 7.0`, unique pitch `>= 7`, adjacent repeats `0`.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -573,8 +576,8 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-Issue #304는 duplicate seed `85`와 겹치지 않는 후보를 focused listening fill까지 보냈지만 `needs_followup`으로 판정했다.
-다음 작업은 distinct sample-seed 유지 상태에서 phrase span, pitch variety, adjacent repeat를 함께 개선하는 repair target을 정리하는 것이다.
+Issue #306은 duplicate seed `85`와 겹치지 않는 후보의 remaining blocker를 다음 repair target으로 고정했다.
+다음 작업은 distinct sample-seed 유지 상태에서 phrase span, pitch variety, adjacent repeat를 함께 개선하는 repair sweep이다.
 
 ## 6. 다음 단계 로드맵
 
@@ -1100,7 +1103,7 @@ Issue #304는 duplicate seed `85`와 겹치지 않는 후보를 focused listenin
 완료된 바로 전 작업:
 
 ```text
-Stage B margin-recovered phrase/vocabulary distinct sample-seed focused listening fill
+Stage B margin-recovered phrase/vocabulary distinct sample-seed remaining blocker repair target
 ```
 
 결과:
@@ -1109,37 +1112,30 @@ Stage B margin-recovered phrase/vocabulary distinct sample-seed focused listenin
 - selected source seed: `109`
 - selected sample index: `47`
 - selected sample seed: `155`
-- docs: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DISTINCT_SAMPLE_SEED_FOCUSED_LISTENING_FILL_2026-05-29.md`
-- reviewed count: `1`
-- pending count: `0`
-- timing: `acceptable`
-- chord fit: `acceptable`
-- phrase continuation: `weak`
-- landing: `acceptable`
-- jazz vocabulary: `thin`
+- docs: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DISTINCT_SAMPLE_SEED_REMAINING_BLOCKER_2026-05-29.md`
 - final decision: `needs_followup`
-- unique pitch count: `6`
-- range: `A#4-D#5`
-- phrase span: `6.750` beats
-- dead-air ratio: `0.375`
-- onset coverage: `0.5625`
-- sustained coverage: `0.78125`
-- adjacent repeats: `1`
-- max interval: `3`
-- final landing: `D5` over `Fm7`, tension
-- review risks: `dead_air_ratio_remaining`, `adjacent_pitch_repeats`
+- remaining blockers: `phrase_continuation_weak`, `jazz_vocabulary_thin`, `short_phrase_span`, `pitch_variety_floor`, `adjacent_pitch_repeats`
+- secondary risk: `dead_air_ratio_remaining`
+- repair boundary: `distinct_sample_seed_candidate_needs_phrase_vocabulary_repair`
+- target phrase span beats: `>= 7.0`
+- target unique pitch count: `>= 7`
+- target adjacent pitch repeats: `0`
+- preferred dead-air ratio: `<= 0.35`
+- preserve max interval: `< 12`
+- preserve max active notes: `<= 1`
+- preserve final note role: chord tone or tension
 
 판단:
 
-- distinct sample-seed 후보는 context blocker 없이 listening fill까지 갔지만 keep으로 승격하지 않았다.
-- timing과 landing은 acceptable이나 phrase continuation과 jazz vocabulary가 남은 blocker다.
-- remaining blocker는 phrase span `6.750`, unique pitch `6`, adjacent repeat `1`이다.
+- 다음 sweep은 phrase span, pitch variety, adjacent repeat를 같이 개선해야 한다.
+- timing, landing, max interval, max active notes는 guardrail로 유지한다.
+- sample seed `85`는 duplicate output boundary로 제외한다.
 - broad trained-model quality, human listening preference, Brad style adaptation은 아직 미검증이다.
 
 다음 작업:
 
-- 다음 issue는 `Stage B margin-recovered phrase/vocabulary distinct sample-seed remaining blocker repair target`으로 잡는다.
-- distinct sample-seed 유지 상태에서 phrase span, pitch variety, adjacent repeat를 같이 개선하는 sweep 조건을 정리한다.
+- 다음 issue는 `Stage B margin-recovered phrase/vocabulary distinct sample-seed remaining blocker repair sweep`으로 잡는다.
+- target과 guardrail을 적용해 새 distinct sample-seed 후보를 찾는다.
 - broad training은 focused context/listening boundary를 먼저 본 뒤 결정한다.
 
 ## 10. 한 문장 요약

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #304, Stage B margin-recovered phrase/vocabulary distinct sample-seed focused listening fill
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary distinct sample-seed remaining blocker repair target`
+- latest functional result: Issue #306, Stage B margin-recovered phrase/vocabulary distinct sample-seed remaining blocker repair target
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary distinct sample-seed remaining blocker repair sweep`
 
 현재 범위가 아닌 것:
 
@@ -1857,6 +1857,51 @@ Issue #304는 Issue #302 focused listening notes를 MIDI/context evidence 기준
 Docs:
 
 - `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DISTINCT_SAMPLE_SEED_FOCUSED_LISTENING_FILL_2026-05-29.md`
+
+## Current Margin-Recovered Phrase/Vocabulary Distinct Sample-Seed Remaining Blocker Result
+
+Issue #306은 Issue #304 `needs_followup` 결과를 다음 repair sweep target으로 정리한 작업이다.
+
+변경:
+
+- distinct sample-seed remaining blocker summary script 추가
+- filled notes 기반 repair target과 keep guardrail 분리
+- unit test와 harness mode 추가
+- README와 handoff docs 업데이트
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_phrase_vocabulary_distinct_sample_seed_remaining_blocker`
+- `bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-distinct-sample-seed-remaining-blocker`
+
+결과:
+
+| 항목 | 값 |
+|---|---|
+| candidate | `margin_recovered_phrase_vocab_seed_109_topk_7_temp_082_n48_sample_47` |
+| sample seed | `155` |
+| final decision | `needs_followup` |
+| repair boundary | `distinct_sample_seed_candidate_needs_phrase_vocabulary_repair` |
+| remaining blockers | `phrase_continuation_weak`, `jazz_vocabulary_thin`, `short_phrase_span`, `pitch_variety_floor`, `adjacent_pitch_repeats` |
+| secondary risks | `dead_air_ratio_remaining` |
+| target phrase span beats | `>= 7.0` |
+| target unique pitch count | `>= 7` |
+| target adjacent pitch repeats | `0` |
+| preferred dead-air ratio | `<= 0.35` |
+| preserve max interval | `< 12` |
+| preserve max active notes | `<= 1` |
+| preserve final note role | chord tone or tension |
+
+해석:
+
+- 새 repair는 phrase span, pitch variety, adjacent repeat를 같이 개선해야 한다.
+- timing, landing, max interval, max active notes는 guardrail로 유지한다.
+- sample seed `85`는 duplicate output boundary로 제외한다.
+- 이 문서는 다음 sweep 조건 정의이며 새 generated-quality claim이 아니다.
+
+Docs:
+
+- `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DISTINCT_SAMPLE_SEED_REMAINING_BLOCKER_2026-05-29.md`
 
 ## Latest README Footer Section Removal Result
 

--- a/docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DISTINCT_SAMPLE_SEED_REMAINING_BLOCKER_2026-05-29.md
+++ b/docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DISTINCT_SAMPLE_SEED_REMAINING_BLOCKER_2026-05-29.md
@@ -1,0 +1,58 @@
+# Stage B Margin-Recovered Phrase/Vocabulary Distinct Sample-Seed Remaining Blocker
+
+## 요약
+
+Issue #306은 Issue #304 `needs_followup` 결과를 다음 repair sweep의 target으로 정리한 작업이다.
+
+이 단계는 새 MIDI 후보를 만들기 전에, distinct sample-seed 후보에서 무엇을 보존하고 무엇을 고쳐야 하는지 metric 기준으로 고정하기 위한 경계다.
+
+## 변경
+
+- distinct sample-seed remaining blocker summary script 추가
+- filled notes 기반 repair target과 keep guardrail 분리
+- unit test와 harness mode 추가
+- README, CORE_PLAN, CURRENT_STATUS_AND_PLAN, AGENTS handoff 업데이트
+
+## 결과
+
+| 항목 | 값 |
+|---|---|
+| candidate | `margin_recovered_phrase_vocab_seed_109_topk_7_temp_082_n48_sample_47` |
+| sample seed | `155` |
+| final decision | `needs_followup` |
+| repair boundary | `distinct_sample_seed_candidate_needs_phrase_vocabulary_repair` |
+| remaining blockers | `phrase_continuation_weak`, `jazz_vocabulary_thin`, `short_phrase_span`, `pitch_variety_floor`, `adjacent_pitch_repeats` |
+| secondary risks | `dead_air_ratio_remaining` |
+| next recommended issue | `Stage B margin-recovered phrase/vocabulary distinct sample-seed remaining blocker repair sweep` |
+
+## Repair Target
+
+| metric | current | target |
+|---|---:|---:|
+| phrase span beats | `6.750` | `>= 7.0` |
+| unique pitch count | `6` | `>= 7` |
+| adjacent pitch repeats | `1` | `0` |
+| dead-air ratio | `0.375` | `<= 0.35` preferred |
+| max interval | `3` | `< 12` preserve |
+| max active notes | `1` | `<= 1` preserve |
+| final note role | `tension` | chord tone or tension preserve |
+
+## 해석
+
+- 새 repair는 phrase span, pitch variety, adjacent repeat를 같이 개선해야 한다.
+- timing, landing, max interval, max active notes는 guardrail로 유지한다.
+- sample seed `85`는 duplicate output boundary로 제외한다.
+- 이 문서는 다음 sweep 조건 정의이며 새 generated-quality claim이 아니다.
+
+## 검증
+
+```bash
+.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_phrase_vocabulary_distinct_sample_seed_remaining_blocker
+bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-distinct-sample-seed-remaining-blocker
+```
+
+## 산출물
+
+- script: `scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_distinct_sample_seed_remaining_blocker.py`
+- test: `tests/test_stage_b_margin_recovered_phrase_vocabulary_distinct_sample_seed_remaining_blocker.py`
+- summary: `outputs/stage_b_margin_recovered_phrase_vocabulary_distinct_sample_seed_remaining_blocker/harness_stage_b_margin_recovered_phrase_vocabulary_distinct_sample_seed_remaining_blocker/remaining_blocker_summary.json`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -100,6 +100,8 @@ Modes:
                 Build focused listening notes for the selected distinct sample-seed candidate.
   stage-b-margin-recovered-phrase-vocabulary-distinct-sample-seed-focused-listening-fill
                 Fill the selected distinct sample-seed focused listening review notes.
+  stage-b-margin-recovered-phrase-vocabulary-distinct-sample-seed-remaining-blocker
+                Summarize remaining blockers for the distinct sample-seed needs-followup candidate.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -1197,6 +1199,22 @@ run_stage_b_margin_recovered_phrase_vocabulary_distinct_sample_seed_focused_list
     --review_notes "$review_notes" \
     --expected_candidate_id "$candidate_id" \
     --expected_decision needs_followup
+}
+
+run_stage_b_margin_recovered_phrase_vocabulary_distinct_sample_seed_remaining_blocker() {
+  local fill_run_id="${FILL_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_distinct_sample_seed_focused_listening_fill}"
+  local run_id="${RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_distinct_sample_seed_remaining_blocker}"
+  local filled_notes="outputs/stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill/${fill_run_id}/focused_listening_review_notes_filled.json"
+  if [[ ! -f "$filled_notes" ]]; then
+    print_header "Stage B margin-recovered phrase/vocabulary distinct sample-seed focused listening fill"
+    RUN_ID="$fill_run_id" run_stage_b_margin_recovered_phrase_vocabulary_distinct_sample_seed_focused_listening_fill
+  fi
+  print_header "Stage B margin-recovered phrase/vocabulary distinct sample-seed remaining blocker"
+  "$PYTHON_BIN" scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_distinct_sample_seed_remaining_blocker.py \
+    --run_id "$run_id" \
+    --filled_notes "$filled_notes" \
+    --expected_decision needs_followup \
+    --require_remaining_blockers
 }
 
 run_stage_b_constrained_probe() {
@@ -2420,6 +2438,9 @@ case "$MODE" in
     ;;
   stage-b-margin-recovered-phrase-vocabulary-distinct-sample-seed-focused-listening-fill)
     run_stage_b_margin_recovered_phrase_vocabulary_distinct_sample_seed_focused_listening_fill
+    ;;
+  stage-b-margin-recovered-phrase-vocabulary-distinct-sample-seed-remaining-blocker)
+    run_stage_b_margin_recovered_phrase_vocabulary_distinct_sample_seed_remaining_blocker
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_distinct_sample_seed_remaining_blocker.py
+++ b/scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_distinct_sample_seed_remaining_blocker.py
@@ -1,0 +1,239 @@
+"""Summarize remaining blockers for the distinct sample-seed phrase/vocabulary candidate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class DistinctSampleSeedRemainingBlockerError(ValueError):
+    pass
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def only_candidate(filled_notes: dict[str, Any]) -> dict[str, Any]:
+    candidates = filled_notes.get("candidates")
+    if not isinstance(candidates, list) or len(candidates) != 1:
+        raise DistinctSampleSeedRemainingBlockerError("filled notes must contain exactly one candidate")
+    candidate = candidates[0]
+    if not isinstance(candidate, dict):
+        raise DistinctSampleSeedRemainingBlockerError("candidate must be an object")
+    return candidate
+
+
+def remaining_blockers(candidate: dict[str, Any]) -> list[str]:
+    metrics = candidate.get("focused_context_metrics") if isinstance(candidate.get("focused_context_metrics"), dict) else {}
+    listening = candidate.get("listening") if isinstance(candidate.get("listening"), dict) else {}
+    blockers: list[str] = []
+    if str(listening.get("phrase_continuation") or "") != "acceptable":
+        blockers.append("phrase_continuation_weak")
+    if str(listening.get("jazz_vocabulary") or "") != "acceptable":
+        blockers.append("jazz_vocabulary_thin")
+    if float(metrics.get("phrase_span_beats", 0.0) or 0.0) < 7.0:
+        blockers.append("short_phrase_span")
+    if int(metrics.get("unique_pitch_count", 0) or 0) < 7:
+        blockers.append("pitch_variety_floor")
+    if int(metrics.get("adjacent_pitch_repeats", 0) or 0) > 0:
+        blockers.append("adjacent_pitch_repeats")
+    return blockers
+
+
+def secondary_risks(candidate: dict[str, Any]) -> list[str]:
+    metrics = candidate.get("focused_context_metrics") if isinstance(candidate.get("focused_context_metrics"), dict) else {}
+    risks = []
+    if float(metrics.get("dead_air_ratio", 0.0) or 0.0) >= 0.35:
+        risks.append("dead_air_ratio_remaining")
+    if str(metrics.get("final_note_role") or "") not in {"chord_tone", "tension"}:
+        risks.append("final_landing_context_risk")
+    if int(metrics.get("max_interval", 0) or 0) >= 12:
+        risks.append("wide_interval_review")
+    return risks
+
+
+def compact_candidate(candidate: dict[str, Any]) -> dict[str, Any]:
+    metadata = candidate.get("review_metadata") if isinstance(candidate.get("review_metadata"), dict) else {}
+    metrics = candidate.get("focused_context_metrics") if isinstance(candidate.get("focused_context_metrics"), dict) else {}
+    listening = candidate.get("listening") if isinstance(candidate.get("listening"), dict) else {}
+    evidence = candidate.get("listening_fill_evidence") if isinstance(candidate.get("listening_fill_evidence"), dict) else {}
+    return {
+        "candidate_id": str(candidate.get("candidate_id") or ""),
+        "source_run_id": str(metadata.get("source_run_id") or ""),
+        "sample_index": int(metadata.get("sample_index", 0) or 0),
+        "sample_seed": int(metadata.get("sample_seed", 0) or 0),
+        "prior_decision": str(candidate.get("proxy_review", {}).get("decision") or ""),
+        "final_decision": str(listening.get("decision") or ""),
+        "timing": str(listening.get("timing") or ""),
+        "chord_fit": str(listening.get("chord_fit") or ""),
+        "phrase_continuation": str(listening.get("phrase_continuation") or ""),
+        "landing": str(listening.get("landing") or ""),
+        "jazz_vocabulary": str(listening.get("jazz_vocabulary") or ""),
+        "note_count": int(metrics.get("note_count", 0) or 0),
+        "unique_pitch_count": int(metrics.get("unique_pitch_count", 0) or 0),
+        "range": str(metrics.get("range") or ""),
+        "phrase_span_beats": float(metrics.get("phrase_span_beats", 0.0) or 0.0),
+        "dead_air_ratio": float(metrics.get("dead_air_ratio", 0.0) or 0.0),
+        "onset_coverage_ratio": float(metrics.get("onset_coverage_ratio", 0.0) or 0.0),
+        "sustained_coverage_ratio": float(metrics.get("sustained_coverage_ratio", 0.0) or 0.0),
+        "adjacent_pitch_repeats": int(metrics.get("adjacent_pitch_repeats", 0) or 0),
+        "max_interval": int(metrics.get("max_interval", 0) or 0),
+        "max_simultaneous_notes": int(metrics.get("max_simultaneous_notes", 0) or 0),
+        "final_note": str(metrics.get("final_note") or ""),
+        "final_chord": str(metrics.get("final_chord") or ""),
+        "final_note_role": str(metrics.get("final_note_role") or ""),
+        "not_human_audio_review": bool(evidence.get("not_human_audio_review", True)),
+        "review_risks": list(candidate.get("review_risks") or []),
+    }
+
+
+def build_remaining_blocker_report(
+    filled_notes: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> dict[str, Any]:
+    candidate = only_candidate(filled_notes)
+    compact = compact_candidate(candidate)
+    blockers = remaining_blockers(candidate)
+    risks = secondary_risks(candidate)
+    keep_guardrails = {
+        "prior_context_decision_keep": compact["prior_decision"] == "keep_for_focused_listening",
+        "timing_acceptable": compact["timing"] == "acceptable",
+        "landing_acceptable": compact["landing"] in {"strong", "acceptable"},
+        "final_role_context_safe": compact["final_note_role"] in {"chord_tone", "tension"},
+        "max_active_solo_line": compact["max_simultaneous_notes"] <= 1,
+        "wide_interval_guardrail": compact["max_interval"] < 12,
+    }
+    return {
+        "schema_version": "stage_b_margin_recovered_phrase_vocabulary_distinct_sample_seed_remaining_blocker_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_filled_notes": str(filled_notes.get("output_dir") or ""),
+        "candidate": compact,
+        "remaining_blockers": blockers,
+        "secondary_risks": risks,
+        "keep_guardrails": keep_guardrails,
+        "repair_target": {
+            "boundary": "distinct_sample_seed_candidate_needs_phrase_vocabulary_repair",
+            "action": "repair_phrase_span_pitch_variety_adjacent_repeat",
+            "target_phrase_span_beats_min": 7.0,
+            "target_unique_pitch_count_min": 7,
+            "target_adjacent_pitch_repeats_max": 0,
+            "preferred_dead_air_ratio_max": 0.35,
+            "preserve_max_interval_below": 12,
+            "preserve_max_simultaneous_notes_max": 1,
+            "preserve_final_note_role": ["chord_tone", "tension"],
+            "avoid_sample_seed": [85],
+        },
+        "claim_boundary": {
+            "current": "distinct_sample_seed_context_keep_but_listening_fill_needs_followup",
+            "not_proven": [
+                "human_audio_preference",
+                "broad_trained_model_quality",
+                "brad_style_adaptation",
+            ],
+        },
+        "next_recommended_issue": (
+            "Stage B margin-recovered phrase/vocabulary distinct sample-seed remaining blocker repair sweep"
+        ),
+    }
+
+
+def validate_remaining_blocker_report(
+    report: dict[str, Any],
+    *,
+    expected_decision: str | None,
+    require_remaining_blockers: bool,
+) -> dict[str, Any]:
+    candidate = report.get("candidate") if isinstance(report.get("candidate"), dict) else {}
+    final_decision = str(candidate.get("final_decision") or "")
+    if expected_decision and final_decision != expected_decision:
+        raise DistinctSampleSeedRemainingBlockerError(f"expected decision {expected_decision}, got {final_decision}")
+    blockers = list(report.get("remaining_blockers") or [])
+    if require_remaining_blockers and not blockers:
+        raise DistinctSampleSeedRemainingBlockerError("expected remaining blockers")
+    return {
+        "candidate_id": str(candidate.get("candidate_id") or ""),
+        "sample_seed": int(candidate.get("sample_seed", 0) or 0),
+        "final_decision": final_decision,
+        "remaining_blockers": blockers,
+        "secondary_risks": list(report.get("secondary_risks") or []),
+        "repair_boundary": str(report.get("repair_target", {}).get("boundary") or ""),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    candidate = report["candidate"]
+    target = report["repair_target"]
+    lines = [
+        "# Stage B Margin-Recovered Phrase/Vocabulary Distinct Sample-Seed Remaining Blocker",
+        "",
+        f"- candidate: `{candidate['candidate_id']}`",
+        f"- sample seed: `{candidate['sample_seed']}`",
+        f"- final decision: `{candidate['final_decision']}`",
+        f"- remaining blockers: `{report['remaining_blockers']}`",
+        f"- secondary risks: `{report['secondary_risks']}`",
+        f"- repair boundary: `{target['boundary']}`",
+        "",
+        "| metric | value | target |",
+        "|---|---:|---:|",
+        f"| phrase span beats | `{candidate['phrase_span_beats']:.3f}` | `>= {target['target_phrase_span_beats_min']:.1f}` |",
+        f"| unique pitch count | `{candidate['unique_pitch_count']}` | `>= {target['target_unique_pitch_count_min']}` |",
+        f"| adjacent pitch repeats | `{candidate['adjacent_pitch_repeats']}` | `<= {target['target_adjacent_pitch_repeats_max']}` |",
+        f"| dead-air ratio | `{candidate['dead_air_ratio']:.3f}` | `<= {target['preferred_dead_air_ratio_max']:.2f}` |",
+        f"| max interval | `{candidate['max_interval']}` | `< {target['preserve_max_interval_below']}` |",
+        "",
+        "This is a repair target summary, not a new generated-quality claim.",
+    ]
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Summarize distinct sample-seed remaining blockers")
+    parser.add_argument("--filled_notes", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_margin_recovered_phrase_vocabulary_distinct_sample_seed_remaining_blocker",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--expected_decision", type=str, default="")
+    parser.add_argument("--require_remaining_blockers", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    filled_notes_path = Path(args.filled_notes)
+    filled_notes = read_json(filled_notes_path)
+    filled_notes["output_dir"] = str(filled_notes_path.parent)
+    report = build_remaining_blocker_report(filled_notes, output_dir=output_dir)
+    summary = validate_remaining_blocker_report(
+        report,
+        expected_decision=str(args.expected_decision or ""),
+        require_remaining_blockers=bool(args.require_remaining_blockers),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "remaining_blocker_summary.json"
+    markdown_path = output_dir / "remaining_blocker_summary.md"
+    write_json(report_path, report)
+    write_json(output_dir / "remaining_blocker_validation_summary.json", summary)
+    markdown_path.write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps({**summary, "report_path": str(report_path), "markdown_path": str(markdown_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_margin_recovered_phrase_vocabulary_distinct_sample_seed_remaining_blocker.py
+++ b/tests/test_stage_b_margin_recovered_phrase_vocabulary_distinct_sample_seed_remaining_blocker.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.summarize_stage_b_margin_recovered_phrase_vocabulary_distinct_sample_seed_remaining_blocker import (
+    build_remaining_blocker_report,
+    validate_remaining_blocker_report,
+)
+
+
+class StageBMarginRecoveredPhraseVocabularyDistinctSampleSeedRemainingBlockerTest(unittest.TestCase):
+    def sample_filled_notes(self) -> dict:
+        return {
+            "output_dir": "outputs/fill",
+            "candidates": [
+                {
+                    "candidate_id": "distinct_candidate",
+                    "review_metadata": {
+                        "source_run_id": "seed109_run",
+                        "sample_index": 47,
+                        "sample_seed": 155,
+                    },
+                    "proxy_review": {"decision": "keep_for_focused_listening"},
+                    "focused_context_metrics": {
+                        "note_count": 13,
+                        "unique_pitch_count": 6,
+                        "range": "A#4-D#5",
+                        "phrase_span_beats": 6.75,
+                        "dead_air_ratio": 0.375,
+                        "onset_coverage_ratio": 0.5625,
+                        "sustained_coverage_ratio": 0.78125,
+                        "adjacent_pitch_repeats": 1,
+                        "max_interval": 3,
+                        "max_simultaneous_notes": 1,
+                        "final_note": "D5",
+                        "final_chord": "Fm7",
+                        "final_note_role": "tension",
+                    },
+                    "review_risks": ["dead_air_ratio_remaining", "adjacent_pitch_repeats"],
+                    "listening": {
+                        "timing": "acceptable",
+                        "chord_fit": "acceptable",
+                        "phrase_continuation": "weak",
+                        "landing": "acceptable",
+                        "jazz_vocabulary": "thin",
+                        "decision": "needs_followup",
+                    },
+                    "listening_fill_evidence": {
+                        "not_human_audio_review": True,
+                    },
+                }
+            ],
+        }
+
+    def test_builds_repair_target_from_needs_followup_fill(self) -> None:
+        report = build_remaining_blocker_report(
+            self.sample_filled_notes(),
+            output_dir=Path("outputs/remaining"),
+        )
+        summary = validate_remaining_blocker_report(
+            report,
+            expected_decision="needs_followup",
+            require_remaining_blockers=True,
+        )
+
+        self.assertEqual(summary["candidate_id"], "distinct_candidate")
+        self.assertEqual(summary["sample_seed"], 155)
+        self.assertEqual(summary["final_decision"], "needs_followup")
+        self.assertIn("phrase_continuation_weak", summary["remaining_blockers"])
+        self.assertIn("jazz_vocabulary_thin", summary["remaining_blockers"])
+        self.assertIn("short_phrase_span", summary["remaining_blockers"])
+        self.assertIn("pitch_variety_floor", summary["remaining_blockers"])
+        self.assertIn("adjacent_pitch_repeats", summary["remaining_blockers"])
+        self.assertIn("dead_air_ratio_remaining", summary["secondary_risks"])
+        self.assertEqual(
+            summary["repair_boundary"],
+            "distinct_sample_seed_candidate_needs_phrase_vocabulary_repair",
+        )
+        self.assertTrue(report["keep_guardrails"]["wide_interval_guardrail"])
+        self.assertEqual(report["repair_target"]["target_adjacent_pitch_repeats_max"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Summarize the remaining blockers from the distinct sample-seed needs-followup candidate.
- Add a summary script, unit coverage, and harness mode for repair target definition.
- Update README, CORE_PLAN, CURRENT_STATUS_AND_PLAN, and AGENTS handoff state to Issue #306.

## Context
Closes #306. Issue #304 filled the distinct sample-seed focused listening notes and produced final decision `needs_followup`.

## Result
- candidate: `margin_recovered_phrase_vocab_seed_109_topk_7_temp_082_n48_sample_47`
- sample seed: `155`
- final decision: `needs_followup`
- repair boundary: `distinct_sample_seed_candidate_needs_phrase_vocabulary_repair`
- remaining blockers: `phrase_continuation_weak`, `jazz_vocabulary_thin`, `short_phrase_span`, `pitch_variety_floor`, `adjacent_pitch_repeats`
- secondary risk: `dead_air_ratio_remaining`
- target phrase span beats: `>= 7.0`
- target unique pitch count: `>= 7`
- target adjacent pitch repeats: `0`
- preferred dead-air ratio: `<= 0.35`
- preserve max interval: `< 12`
- preserve max active notes: `<= 1`
- preserve final note role: chord tone or tension

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_margin_recovered_phrase_vocabulary_distinct_sample_seed_remaining_blocker`
- `bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-distinct-sample-seed-remaining-blocker`
- `bash scripts/agent_harness.sh quick`
- `rg -n "codex|Codex|코덱스" <changed files>`

## Risk
- This PR defines the next repair target; it does not create a new generated candidate.
- broad model quality, human/audio proof, and Brad style adaptation remain out of scope.

## Follow-up
- Stage B margin-recovered phrase/vocabulary distinct sample-seed remaining blocker repair sweep.