### PR TITLE
Stage B margin-recovered phrase vocabulary coverage-aware adjacent-repeat constrained repair

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #310, Stage B margin-recovered phrase/vocabulary distinct sample-seed dead-air adjacent-repeat targeted repair.
+- Latest functional issue completed: Issue #312, Stage B margin-recovered phrase/vocabulary coverage-aware adjacent-repeat constrained repair.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary coverage-aware adjacent-repeat constrained repair.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill repair.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -602,6 +602,14 @@ bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-distinc
 ```
 
 This harness runs a lower-temperature checkpoint-based sampling sweep against the dead-air and adjacent-repeat target.
+
+For Stage B margin-recovered phrase/vocabulary coverage-aware adjacent constrained repair changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-coverage-aware-adjacent-constrained-repair
+```
+
+This harness runs coverage-aware constrained decoding to reduce adjacent pitch repeats and records the remaining dead-air boundary.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@
 | 다음 repair target 불명확 | `needs_followup`만으로 sweep 조건을 바로 잡기 어려움 | remaining blocker summary로 target/guardrail 분리 | target phrase span `>=7.0`, unique pitch `>=7`, adjacent repeat `0`, dead-air `<=0.35` preferred |
 | target-qualified 후보 미발견 | 추가 sampling에서도 pitch variety와 adjacent/dead-air target 동시 충족 실패 | seed `181/223`, top_k8, temp `0.90/0.86` sweep 실행 | target-qualified `0/96`, partial 후보 unique `9`, dead-air `0.3889`, adjacent repeat `1` |
 | sampling 조정 한계 | lower temperature/top_k에서도 dead-air와 adjacent repeat 동시 해결 실패 | seed `269/311`, top_k7, temp `0.80/0.78` sweep 실행 | target-qualified `0/96`, partial 후보 unique `7`, max interval `7`, dead-air `0.3889`, adjacent repeat `1` |
+| adjacent repeat 직접 제어 후 dead-air 악화 | constrained decoding으로 repeat는 줄었지만 duration/coverage 공백이 남음 | coverage-aware positions + chord-aware repeat window 적용 | adjacent repeat `0`, unique `9`, dead-air `0.5714`, target-qualified `0/48` |
 
 ## 파이프라인 구조
 
@@ -80,7 +81,7 @@ flowchart LR
 
 ## 핵심 결과
 
-Issue #310 기준 model-core MVP:
+Issue #312 기준 model-core MVP:
 
 | 항목 | 결과 |
 |---|---|
@@ -134,6 +135,7 @@ Issue #310 기준 model-core MVP:
 | margin-recovered phrase vocabulary distinct sample-seed remaining blocker | remaining blockers `5`, secondary risk `1`, next repair target 정의 |
 | margin-recovered phrase vocabulary distinct sample-seed remaining blocker repair sweep | seed181/223 96개 후보 중 target-qualified `0`, partial candidate sample seed `250` |
 | margin-recovered phrase vocabulary distinct sample-seed dead-air adjacent repair | seed269/311 96개 후보 중 target-qualified `0`, sampling 조정 한계 기록 |
+| margin-recovered phrase vocabulary coverage-aware adjacent constrained repair | constrained decoding으로 adjacent repeat `0` 달성, dead-air `0.5714`로 target 실패 |
 | constrained review gate | `stage-b-overlap-gate` 통과 |
 | focused candidate path | `stage-b-rhythm-phrase-variation` 통과 |
 
@@ -192,6 +194,7 @@ MVP 근거:
 - remaining blocker summary에서 phrase span, pitch variety, adjacent repeat를 다음 repair target으로 고정하고 max interval/final landing/max active는 guardrail로 유지
 - seed `181/223` 추가 sweep에서 focused unique pitch `9` partial candidate를 찾았지만 dead-air와 adjacent repeat target을 동시에 통과하지 못함
 - seed `269/311` lower-temperature sweep에서도 target-qualified 후보가 없어 다음 경계를 sampling 반복이 아닌 constrained decoding/postprocess 제어로 이동
+- coverage-aware constrained decoding에서 adjacent repeat와 pitch variety는 개선됐지만 dead-air가 악화되어 duration/coverage fill repair 필요성 분리
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`
@@ -203,10 +206,10 @@ MVP 근거:
 | 만든 것 | symbolic MIDI 생성 모델의 dataset, tokenization, training, generation, decode, objective review, proxy review pipeline |
 | 겪은 문제 | `.mid` 파일 존재만으로 성공 판단 불가, one-note collapse, long sustain block, chord block, dead-air outlier, seed-level margin 부족 |
 | 해결 방식 | duration-explicit token 구조, grammar/coverage/chord-aware probe, overlap-free postprocess, repeatability sweep, dead-air diagnostics, proxy review scoring, repair candidate selection |
-| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab focused context `keep_for_focused_listening`, timing/repetition repair qualified `2/96`, phrase/vocabulary focused fill `keep`, selected/peer duplicate output, distinct sample-seed targeted repair target-qualified `0/96` |
+| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab focused context `keep_for_focused_listening`, timing/repetition repair qualified `2/96`, phrase/vocabulary focused fill `keep`, selected/peer duplicate output, constrained adjacent repair target-qualified `0/48` |
 | 주장 경계 | reviewable MIDI 후보 생성 검증 파이프라인까지 가능, human listening preference / Brad style adaptation / broad production quality는 미검증 |
 
-Issue #310 기준 current margin-recovered evidence boundary:
+Issue #312 기준 current margin-recovered evidence boundary:
 
 | 항목 | 결과 |
 |---|---|
@@ -249,6 +252,8 @@ Issue #310 기준 current margin-recovered evidence boundary:
 | distinct sample-seed partial candidate | sample seed `250`, unique pitch `9`, dead-air `0.3889`, adjacent repeat `1`, max interval `11` |
 | distinct sample-seed targeted repair result | target-qualified `0/96` |
 | distinct sample-seed targeted partial candidate | sample seed `341`, unique pitch `7`, dead-air `0.3889`, adjacent repeat `1`, max interval `7` |
+| constrained adjacent repair result | target-qualified `0/48` |
+| constrained adjacent partial candidate | sample seed `355`, unique pitch `9`, dead-air `0.5714`, adjacent repeat `0`, max interval `7` |
 
 Issue #210 기준 current best focused review candidate:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -100,6 +100,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered phrase/vocabulary distinct sample-seed remaining blocker 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DISTINCT_SAMPLE_SEED_REMAINING_BLOCKER_2026-05-29.md`
 - margin-recovered phrase/vocabulary distinct sample-seed remaining blocker repair sweep 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DISTINCT_SAMPLE_SEED_REMAINING_BLOCKER_REPAIR_SWEEP_2026-05-29.md`
 - margin-recovered phrase/vocabulary distinct sample-seed dead-air adjacent repair 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DISTINCT_SAMPLE_SEED_DEAD_AIR_ADJACENT_REPAIR_2026-05-29.md`
+- margin-recovered phrase/vocabulary coverage-aware adjacent constrained repair 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_COVERAGE_AWARE_ADJACENT_CONSTRAINED_REPAIR_2026-05-29.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -564,6 +565,8 @@ Stage B에서 명시하는 것:
 - Issue #308 result: target-qualified `0/96`; best partial candidate sample seed `250`, focused unique pitch `9`, dead-air `0.3889`, adjacent repeats `1`.
 - Issue #310 runs a lower-temperature/top_k targeted repair sweep for dead-air and adjacent repeats.
 - Issue #310 result: target-qualified `0/96`; best partial candidate sample seed `341`, focused unique pitch `7`, dead-air `0.3889`, adjacent repeats `1`, max interval `7`.
+- Issue #312 runs coverage-aware constrained decoding with chord-aware repeat window.
+- Issue #312 result: target-qualified `0/48`; best partial candidate sample seed `355`, focused unique pitch `9`, dead-air `0.5714`, adjacent repeats `0`, max interval `7`.
 - 이것은 아직 unconstrained model quality나 Brad style adaptation 성공을 의미하지 않는다.
 
 중요한 해석:
@@ -582,8 +585,8 @@ Stage B에서 명시하는 것:
 - 하지만 `top_k=1`에서는 같은 position/pitch 반복 collapse가 발생한다.
 
 따라서 다음 단계도 곧바로 broad training이 아니다.
-Issue #310은 lower-temperature/top_k sampling 조정에서도 target-qualified 후보를 찾지 못했다.
-다음 작업은 sampling 반복이 아니라 generation/decoding 단계에서 coverage와 adjacent repeat를 직접 제어하는 constrained repair다.
+Issue #312는 constrained decoding으로 adjacent repeat를 줄였지만 dead-air가 악화되어 target-qualified 후보를 찾지 못했다.
+다음 작업은 duration/coverage fill repair로 dead-air를 직접 낮추는 것이다.
 
 ## 6. 다음 단계 로드맵
 
@@ -1109,7 +1112,7 @@ Issue #310은 lower-temperature/top_k sampling 조정에서도 target-qualified 
 완료된 바로 전 작업:
 
 ```text
-Stage B margin-recovered phrase/vocabulary distinct sample-seed dead-air adjacent-repeat targeted repair
+Stage B margin-recovered phrase/vocabulary coverage-aware adjacent-repeat constrained repair
 ```
 
 결과:
@@ -1118,29 +1121,29 @@ Stage B margin-recovered phrase/vocabulary distinct sample-seed dead-air adjacen
 - selected source seed: `109`
 - selected sample index: `47`
 - selected sample seed: `155`
-- docs: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DISTINCT_SAMPLE_SEED_DEAD_AIR_ADJACENT_REPAIR_2026-05-29.md`
+- docs: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_COVERAGE_AWARE_ADJACENT_CONSTRAINED_REPAIR_2026-05-29.md`
 - repair sweep reports: `2`
-- repair sweep candidates: `96`
+- repair sweep candidates: `48`
 - target-qualified candidate count: `0`
-- partial candidate: `margin_recovered_phrase_vocab_seed_311_topk_7_temp_078_n48_sample_31`
-- partial sample seed: `341`
-- partial focused unique pitch count: `7`
-- partial dead-air ratio: `0.3889`
-- partial adjacent pitch repeats: `1`
+- partial candidate: `margin_recovered_phrase_vocab_seed_353_topk_7_temp_082_n24_sample_3`
+- partial sample seed: `355`
+- partial focused unique pitch count: `9`
+- partial dead-air ratio: `0.5714`
+- partial adjacent pitch repeats: `0`
 - partial focused max interval: `7`
-- remaining flags: `dead_air_not_repaired`, `adjacent_repetition_not_repaired`
+- remaining flags: `dead_air_not_repaired`
 
 판단:
 
-- lower-temperature/top_k 조정도 target-qualified 후보를 찾지 못했다.
-- best partial candidate는 max interval guardrail을 회복했지만 dead-air와 adjacent repeat가 남아 있다.
-- 같은 checkpoint sampling 반복만으로는 dead-air와 adjacent repeat 동시 해결 가능성이 낮다.
+- constrained decoding은 adjacent repeat와 pitch variety를 개선했다.
+- dead-air가 `0.5714`로 악화되어 target-qualified 후보는 없다.
+- 남은 병목은 pitch/repeat sampling이 아니라 duration/coverage fill이다.
 - broad trained-model quality, human listening preference, Brad style adaptation은 아직 미검증이다.
 
 다음 작업:
 
-- 다음 issue는 `Stage B margin-recovered phrase/vocabulary coverage-aware adjacent-repeat constrained repair`로 잡는다.
-- post-sampling 후보 선택이 아니라 generation/decoding 단계에서 coverage와 adjacent repeat를 직접 제어한다.
+- 다음 issue는 `Stage B margin-recovered phrase/vocabulary duration coverage fill repair`로 잡는다.
+- adjacent repeat와 pitch variety guardrail을 유지하면서 dead-air를 낮추는 duration/coverage repair를 검토한다.
 - broad training은 focused context/listening boundary를 먼저 본 뒤 결정한다.
 
 ## 10. 한 문장 요약

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #310, Stage B margin-recovered phrase/vocabulary distinct sample-seed dead-air adjacent-repeat targeted repair
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary coverage-aware adjacent-repeat constrained repair`
+- latest functional result: Issue #312, Stage B margin-recovered phrase/vocabulary coverage-aware adjacent-repeat constrained repair
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill repair`
 
 현재 범위가 아닌 것:
 
@@ -1998,6 +1998,56 @@ Issue #310은 Issue #308 partial candidate에서 남은 dead-air와 adjacent rep
 Docs:
 
 - `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DISTINCT_SAMPLE_SEED_DEAD_AIR_ADJACENT_REPAIR_2026-05-29.md`
+
+## Current Margin-Recovered Phrase/Vocabulary Coverage-Aware Adjacent Constrained Repair Result
+
+Issue #312는 sampling 반복 대신 constrained decoding에서 coverage와 adjacent pitch repeat를 직접 제어한 작업이다.
+
+변경:
+
+- coverage-aware adjacent constrained repair harness 추가
+- seed `353`, `397`, constrained decoding 조건으로 checkpoint reuse generation 실행
+- seed `353`: coverage-aware positions, chord-aware pitches, repeat window `4`, groups per bar `8`
+- seed `397`: 위 조건에 jazz duration tokens와 groups per bar `10` 추가
+- Issue #306 target threshold로 repair summary 재평가
+- README와 handoff docs 업데이트
+
+검증:
+
+- `bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-coverage-aware-adjacent-constrained-repair`
+
+결과:
+
+| 항목 | 값 |
+|---|---|
+| report count | `2` |
+| candidate count | `48` |
+| target-qualified candidate count | `0` |
+| selected partial candidate | `margin_recovered_phrase_vocab_seed_353_topk_7_temp_082_n24_sample_3` |
+| selected source seed | `353` |
+| selected sample index | `3` |
+| selected sample seed | `355` |
+| selected focused note count | `12` |
+| selected focused unique pitch count | `9` |
+| selected dead-air ratio | `0.5714` |
+| selected onset coverage | `0.4375` |
+| selected sustained coverage | `0.59375` |
+| selected adjacent pitch repeats | `0` |
+| selected focused max interval | `7` |
+| qualified | `false` |
+| remaining flags | `dead_air_not_repaired` |
+
+해석:
+
+- constrained decoding은 adjacent repeat를 `1 -> 0`으로 낮췄다.
+- pitch variety도 `6 -> 9`로 개선됐다.
+- 그러나 dead-air가 `0.5714`로 악화되어 target-qualified 후보는 없다.
+- dead-air blocker는 단순 sampling/top_k 조정이나 pitch repeat window만으로 해결되지 않는다.
+- 다음 경계는 duration/coverage postprocess 또는 constrained duration/onset fill을 별도 repair로 검토하는 것이다.
+
+Docs:
+
+- `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_COVERAGE_AWARE_ADJACENT_CONSTRAINED_REPAIR_2026-05-29.md`
 
 ## Latest README Footer Section Removal Result
 

--- a/docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_COVERAGE_AWARE_ADJACENT_CONSTRAINED_REPAIR_2026-05-29.md
+++ b/docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_COVERAGE_AWARE_ADJACENT_CONSTRAINED_REPAIR_2026-05-29.md
@@ -1,0 +1,62 @@
+# Stage B Margin-Recovered Phrase/Vocabulary Coverage-Aware Adjacent Constrained Repair
+
+## 요약
+
+Issue #312는 sampling 반복 대신 constrained decoding에서 coverage와 adjacent pitch repeat를 직접 제어한 작업이다.
+
+이 단계는 coverage-aware positions, chord-aware pitches, repeat window를 적용해 adjacent repeat blocker를 줄이면서 target-qualified 후보가 나오는지 확인하기 위한 경계다.
+
+## 변경
+
+- coverage-aware adjacent constrained repair harness 추가
+- seed `353`, `397`, constrained decoding 조건으로 checkpoint reuse generation 실행
+- seed `353`: coverage-aware positions, chord-aware pitches, repeat window `4`, groups per bar `8`
+- seed `397`: 위 조건에 jazz duration tokens와 groups per bar `10` 추가
+- Issue #306 target threshold로 repair summary 재평가
+- README, CORE_PLAN, CURRENT_STATUS_AND_PLAN, AGENTS handoff 업데이트
+
+## 결과
+
+| 항목 | 값 |
+|---|---|
+| report count | `2` |
+| candidate count | `48` |
+| target-qualified candidate count | `0` |
+| selected partial candidate | `margin_recovered_phrase_vocab_seed_353_topk_7_temp_082_n24_sample_3` |
+| selected source seed | `353` |
+| selected sample index | `3` |
+| selected sample seed | `355` |
+| selected focused note count | `12` |
+| selected focused unique pitch count | `9` |
+| selected dead-air ratio | `0.5714` |
+| selected onset coverage | `0.4375` |
+| selected sustained coverage | `0.59375` |
+| selected adjacent pitch repeats | `0` |
+| selected focused max interval | `7` |
+| qualified | `false` |
+| remaining flags | `dead_air_not_repaired` |
+
+## 해석
+
+- constrained decoding은 adjacent repeat를 `1 -> 0`으로 낮췄다.
+- pitch variety도 `6 -> 9`로 개선됐다.
+- 그러나 dead-air가 `0.5714`로 악화되어 target-qualified 후보는 없다.
+- dead-air blocker는 단순 sampling/top_k 조정이나 pitch repeat window만으로 해결되지 않는다.
+- 다음 경계는 duration/coverage postprocess 또는 constrained duration/onset fill을 별도 repair로 검토하는 것이다.
+
+## 검증
+
+```bash
+bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-coverage-aware-adjacent-constrained-repair
+```
+
+## 산출물
+
+- seed353 report: `outputs/stage_b_generation_probe/harness_stage_b_margin_recovered_phrase_vocab_coverage_adjacent_seed353_groups8/report.json`
+- seed397 report: `outputs/stage_b_generation_probe/harness_stage_b_margin_recovered_phrase_vocab_coverage_adjacent_seed397_groups10_duration/report.json`
+- repair summary: `outputs/stage_b_margin_recovered_phrase_vocabulary_repair/harness_stage_b_margin_recovered_phrase_vocabulary_coverage_aware_adjacent_constrained_repair/phrase_vocabulary_repair_summary.json`
+
+## 다음 경계
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill repair`
+- 목표: adjacent repeat와 pitch variety guardrail을 유지하면서 dead-air를 낮추는 duration/coverage repair

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -106,6 +106,8 @@ Modes:
                 Run a target sweep for the distinct sample-seed remaining blockers.
   stage-b-margin-recovered-phrase-vocabulary-distinct-sample-seed-dead-air-adjacent-repair
                 Run a targeted sweep for distinct sample-seed dead-air and adjacent-repeat blockers.
+  stage-b-margin-recovered-phrase-vocabulary-coverage-aware-adjacent-constrained-repair
+                Run coverage-aware constrained decoding for adjacent-repeat repair.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -1351,6 +1353,86 @@ run_stage_b_margin_recovered_phrase_vocabulary_distinct_sample_seed_dead_air_adj
     --max_interval_exclusive 12
 }
 
+run_stage_b_margin_recovered_phrase_vocabulary_coverage_aware_adjacent_constrained_repair() {
+  local seed353_run_id="${SEED353_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocab_coverage_adjacent_seed353_groups8}"
+  local seed397_run_id="${SEED397_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocab_coverage_adjacent_seed397_groups10_duration}"
+  local repair_run_id="${RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_coverage_aware_adjacent_constrained_repair}"
+  local checkpoint_dir="${CHECKPOINT_DIR:-outputs/stage_b_generation_probe/issue_238_stage_b_candidate_count_margin_recovery_seed31_files6/checkpoints}"
+  if [[ ! -f "outputs/stage_b_generation_probe/${seed353_run_id}/report.json" ]]; then
+    print_header "Stage B coverage-aware adjacent constrained seed 353"
+    "$PYTHON_BIN" scripts/run_stage_b_generation_probe.py \
+      --run_id "$seed353_run_id" \
+      --checkpoint_dir "$checkpoint_dir" \
+      --skip_prepare \
+      --skip_train \
+      --seed 353 \
+      --max_files 6 \
+      --max_sequence 96 \
+      --num_samples 24 \
+      --temperature 0.82 \
+      --top_k 7 \
+      --generation_mode constrained \
+      --coverage_aware_positions \
+      --coverage_position_window 1 \
+      --chord_aware_pitches \
+      --chord_pitch_mode tones_tensions \
+      --chord_pitch_repeat_window 4 \
+      --constrained_note_groups_per_bar 8 \
+      --postprocess_overlap \
+      --max_simultaneous_notes 2 \
+      --require_valid_sample \
+      --require_strict_valid_sample \
+      --require_note_groups \
+      --issue_number 312
+  fi
+  if [[ ! -f "outputs/stage_b_generation_probe/${seed397_run_id}/report.json" ]]; then
+    print_header "Stage B coverage-aware adjacent constrained seed 397"
+    "$PYTHON_BIN" scripts/run_stage_b_generation_probe.py \
+      --run_id "$seed397_run_id" \
+      --checkpoint_dir "$checkpoint_dir" \
+      --skip_prepare \
+      --skip_train \
+      --seed 397 \
+      --max_files 6 \
+      --max_sequence 96 \
+      --num_samples 24 \
+      --temperature 0.82 \
+      --top_k 7 \
+      --generation_mode constrained \
+      --coverage_aware_positions \
+      --coverage_position_window 1 \
+      --chord_aware_pitches \
+      --chord_pitch_mode tones_tensions \
+      --chord_pitch_repeat_window 4 \
+      --jazz_duration_tokens \
+      --constrained_note_groups_per_bar 10 \
+      --postprocess_overlap \
+      --max_simultaneous_notes 2 \
+      --require_valid_sample \
+      --require_strict_valid_sample \
+      --require_note_groups \
+      --issue_number 312
+  fi
+  print_header "Stage B coverage-aware adjacent constrained repair summary"
+  "$PYTHON_BIN" scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_repair.py \
+    --run_id "$repair_run_id" \
+    --report_path "outputs/stage_b_generation_probe/${seed353_run_id}/report.json" \
+    --report_path "outputs/stage_b_generation_probe/${seed397_run_id}/report.json" \
+    --previous_candidate_id margin_recovered_phrase_vocab_seed_109_topk_7_temp_082_n48_sample_47 \
+    --previous_dead_air 0.375 \
+    --previous_unique_pitch_count 6 \
+    --previous_note_count 13 \
+    --previous_adjacent_pitch_repeats 1 \
+    --previous_max_interval 3 \
+    --min_unique_pitch_count 7 \
+    --max_dead_air_ratio_exclusive 0.376 \
+    --min_note_count 12 \
+    --max_simultaneous_notes 1 \
+    --max_duplicated_3_note_chunks 0 \
+    --max_adjacent_pitch_repeats_exclusive 1 \
+    --max_interval_exclusive 12
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -2581,6 +2663,9 @@ case "$MODE" in
     ;;
   stage-b-margin-recovered-phrase-vocabulary-distinct-sample-seed-dead-air-adjacent-repair)
     run_stage_b_margin_recovered_phrase_vocabulary_distinct_sample_seed_dead_air_adjacent_repair
+    ;;
+  stage-b-margin-recovered-phrase-vocabulary-coverage-aware-adjacent-constrained-repair)
+    run_stage_b_margin_recovered_phrase_vocabulary_coverage_aware_adjacent_constrained_repair
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe


### PR DESCRIPTION
## Summary
- Run coverage-aware constrained decoding with chord-aware repeat window for adjacent-repeat repair.
- Add a harness mode for the constrained repair sweep.
- Update README, CORE_PLAN, CURRENT_STATUS_AND_PLAN, and AGENTS handoff state to Issue #312.

## Context
Closes #312. Issue #310 showed lower-temperature sampling still could not repair dead-air and adjacent repeat together.

## Result
- report count: `2`
- candidate count: `48`
- target-qualified candidate count: `0`
- selected partial candidate: `margin_recovered_phrase_vocab_seed_353_topk_7_temp_082_n24_sample_3`
- selected source seed: `353`
- selected sample index: `3`
- selected sample seed: `355`
- selected focused note count: `12`
- selected focused unique pitch count: `9`
- selected dead-air ratio: `0.5714`
- selected onset coverage: `0.4375`
- selected sustained coverage: `0.59375`
- selected adjacent pitch repeats: `0`
- selected focused max interval: `7`
- qualified: `false`
- remaining flags: `dead_air_not_repaired`

## Validation
- `bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-coverage-aware-adjacent-constrained-repair`
- `bash scripts/agent_harness.sh quick`
- `rg -n "codex|Codex|코덱스" <changed files>`

## Risk
- This PR records a constrained decoding boundary, not a keep candidate.
- adjacent repeat improved, but dead-air worsened.

## Follow-up
- Stage B margin-recovered phrase/vocabulary duration coverage fill repair.