### PR TITLE
Stage B duration fill focused listening notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #316, Stage B margin-recovered phrase/vocabulary duration coverage fill focused context review.
+- Latest functional issue completed: Issue #318, Stage B margin-recovered phrase/vocabulary duration coverage fill focused listening notes.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill focused listening notes.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill focused listening fill.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -626,6 +626,14 @@ bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-duratio
 ```
 
 This harness packages the selected duration/coverage fill candidate with chord/bass context and verifies focused context decision readiness.
+
+For Stage B margin-recovered phrase/vocabulary duration coverage fill focused listening notes changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-focused-listening-notes
+```
+
+This harness writes the focused listening review notes template for the selected duration/coverage fill candidate.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ flowchart LR
 
 ## 핵심 결과
 
-Issue #316 기준 model-core MVP:
+Issue #318 기준 model-core MVP:
 
 | 항목 | 결과 |
 |---|---|
@@ -197,6 +197,7 @@ MVP 근거:
 - coverage-aware constrained decoding에서 adjacent repeat와 pitch variety는 개선됐지만 dead-air가 악화되어 duration/coverage fill repair 필요성 분리
 - duration/coverage fill repair에서 selected fill additions `6`, dead-air `0.5714 -> 0.2941`, focused unique pitch `15`, adjacent repeat `0`, duplicated 3-note pitch-class chunks `0`
 - duration/coverage fill focused context에서 decision `keep_for_focused_listening`, flags `{}`, final `F4` over `Fm7` chord tone 확인
+- duration/coverage fill focused listening notes에서 pending `1`, review risk `sustained_coverage_review`로 다음 evidence fill 경계 분리
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`
@@ -208,10 +209,10 @@ MVP 근거:
 | 만든 것 | symbolic MIDI 생성 모델의 dataset, tokenization, training, generation, decode, objective review, proxy review pipeline |
 | 겪은 문제 | `.mid` 파일 존재만으로 성공 판단 불가, one-note collapse, long sustain block, chord block, dead-air outlier, seed-level margin 부족 |
 | 해결 방식 | duration-explicit token 구조, grammar/coverage/chord-aware probe, overlap-free postprocess, repeatability sweep, dead-air diagnostics, proxy review scoring, repair candidate selection |
-| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab focused context `keep_for_focused_listening`, timing/repetition repair qualified `2/96`, phrase/vocabulary focused fill `keep`, selected/peer duplicate output, constrained adjacent repair target-qualified `0/48`, duration/coverage fill qualified `2/4`, duration/coverage fill focused context `keep_for_focused_listening` |
+| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab focused context `keep_for_focused_listening`, timing/repetition repair qualified `2/96`, phrase/vocabulary focused fill `keep`, selected/peer duplicate output, constrained adjacent repair target-qualified `0/48`, duration/coverage fill qualified `2/4`, duration/coverage fill focused context `keep_for_focused_listening`, duration/coverage fill listening notes pending `1` |
 | 주장 경계 | reviewable MIDI 후보 생성 검증 파이프라인까지 가능, human listening preference / Brad style adaptation / broad production quality는 미검증 |
 
-Issue #316 기준 current margin-recovered evidence boundary:
+Issue #318 기준 current margin-recovered evidence boundary:
 
 | 항목 | 결과 |
 |---|---|
@@ -265,6 +266,8 @@ Issue #316 기준 current margin-recovered evidence boundary:
 | duration coverage focused context flags | `{}` |
 | duration coverage focused context range | `D#4-G#5`, phrase span `7.000` beats, max active `1` |
 | duration coverage focused context final | `F4` over `Fm7`, chord tone |
+| duration coverage focused listening notes | pending `1`, reviewed `0` |
+| duration coverage focused listening risk | `sustained_coverage_review` |
 
 Issue #210 기준 current best focused review candidate:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -1112,16 +1112,19 @@ Issue #312는 constrained decoding으로 adjacent repeat를 줄였지만 dead-ai
 완료된 바로 전 작업:
 
 ```text
-Stage B margin-recovered phrase/vocabulary duration coverage fill focused context review
+Stage B margin-recovered phrase/vocabulary duration coverage fill focused listening notes
 ```
 
 결과:
 
 - selected candidate: `margin_recovered_phrase_vocab_seed_353_topk_7_temp_082_n24_sample_3_duration_fill_maxadd_6`
-- docs: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_FOCUSED_CONTEXT_2026-05-29.md`
+- docs: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_FOCUSED_LISTENING_NOTES_2026-05-29.md`
 - candidate count: `1`
-- focused context decision: `keep_for_focused_listening`
-- decision flags: `[]`
+- prior decision: `keep_for_focused_listening`
+- listening decision: `pending`
+- reviewed count: `0`
+- pending count: `1`
+- review risks: `sustained_coverage_review`
 - note count: `18`
 - unique pitch count: `15`
 - range: `D#4-G#5`
@@ -1135,16 +1138,17 @@ Stage B margin-recovered phrase/vocabulary duration coverage fill focused contex
 
 판단:
 
-- focused context blocker는 관측되지 않았다.
-- chord guide, bass guide, solo track context MIDI 생성 확인.
-- selected candidate는 focused listening notes로 넘길 수 있다.
+- focused listening review template 생성 완료.
+- listening fields는 pending 상태로 유지한다.
+- notes template은 human/audio listening proof가 아니다.
+- 남은 review risk는 `sustained_coverage_review`다.
 - claim boundary: `postprocess_duration_coverage_fill_candidate`.
 - broad trained-model quality, human listening preference, Brad style adaptation은 아직 미검증이다.
 
 다음 작업:
 
-- 다음 issue는 `Stage B margin-recovered phrase/vocabulary duration coverage fill focused listening notes`로 잡는다.
-- focused listening fields를 pending 상태로 만들고 evidence fill 또는 human review 경계를 분리한다.
+- 다음 issue는 `Stage B margin-recovered phrase/vocabulary duration coverage fill focused listening fill`로 잡는다.
+- evidence fill에서 timing, phrase continuation, landing, vocabulary decision을 기록한다.
 - broad training은 focused context/listening boundary를 먼저 본 뒤 결정한다.
 
 ## 10. 한 문장 요약

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #316, Stage B margin-recovered phrase/vocabulary duration coverage fill focused context review
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill focused listening notes`
+- latest functional result: Issue #318, Stage B margin-recovered phrase/vocabulary duration coverage fill focused listening notes
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill focused listening fill`
 
 현재 범위가 아닌 것:
 
@@ -65,6 +65,42 @@ Issue #220은 현재 작업이 core인지, MVP 완료로 볼 수 있는지를 �
 Docs:
 
 - `docs/STAGE_B_MODEL_CORE_MVP_COMPLETION_AUDIT_2026-05-28.md`
+
+## Current Duration Coverage Fill Focused Listening Notes Result
+
+Issue #318은 Issue #316 focused context keep candidate의 focused listening notes template을 생성한 작업이다.
+
+변경:
+
+- focused listening notes template 생성
+- prior decision `keep_for_focused_listening` 연결
+- listening fields pending 유지
+
+결과:
+
+- candidate count: `1`
+- reviewed count: `0`
+- pending count: `1`
+- prior decision: `keep_for_focused_listening`
+- listening decision: `pending`
+- review risks: `sustained_coverage_review`
+- note count: `18`
+- unique pitch count: `15`
+- phrase span: `7.000` beats
+- dead-air ratio: `0.2941`
+- adjacent pitch repeats: `0`
+- max interval: `7`
+- final note: `F4` over `Fm7`, chord tone
+
+판단:
+
+- focused listening review template 생성 완료
+- pending 상태 유지
+- notes template은 human/audio listening proof가 아님
+
+다음:
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill focused listening fill`
 
 ## Current Duration Coverage Fill Focused Context Result
 

--- a/docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_FOCUSED_LISTENING_NOTES_2026-05-29.md
+++ b/docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_FOCUSED_LISTENING_NOTES_2026-05-29.md
@@ -1,0 +1,67 @@
+# Stage B Margin-Recovered Phrase/Vocabulary Duration Coverage Fill Focused Listening Notes
+
+Issue #318은 Issue #316 focused context keep candidate의 focused listening notes template을 생성한 작업이다.
+
+## Context
+
+- candidate: `margin_recovered_phrase_vocab_seed_353_topk_7_temp_082_n24_sample_3_duration_fill_maxadd_6`
+- prior decision: `keep_for_focused_listening`
+- context flags: `[]`
+- note count: `18`
+- unique pitch count: `15`
+- range: `D#4-G#5`
+- phrase span: `7.000` beats
+- dead-air ratio: `0.2941`
+- adjacent pitch repeats: `0`
+- max interval: `7`
+- final note: `F4` over `Fm7`, chord tone
+
+## Change
+
+- duration/coverage fill focused listening notes harness 추가
+- focused package/context decision dependency check 추가
+- focused listening notes template 생성
+- listening fields pending 유지
+
+## Result
+
+| item | value |
+|---|---:|
+| candidate count | `1` |
+| reviewed count | `0` |
+| pending count | `1` |
+| prior decision | `keep_for_focused_listening` |
+| listening decision | `pending` |
+| review risks | `sustained_coverage_review` |
+
+Focused context metrics:
+
+| item | value |
+|---|---:|
+| note count | `18` |
+| unique pitch count | `15` |
+| phrase span | `7.000` beats |
+| dead-air ratio | `0.2941` |
+| adjacent pitch repeats | `0` |
+| duplicated 3-note pitch-class chunks | `0` |
+| max active notes | `1` |
+| max interval | `7` |
+| final note role | `chord_tone` |
+
+## Judgment
+
+- focused listening review template 생성 완료.
+- pending 상태 유지.
+- notes template은 human/audio listening proof가 아님.
+- 남은 review risk: `sustained_coverage_review`.
+
+## Validation
+
+```bash
+bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-focused-listening-notes
+```
+
+## Next
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill focused listening fill`
+- evidence fill에서 timing, phrase continuation, landing, vocabulary decision 기록

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -112,6 +112,8 @@ Modes:
                 Build duration/coverage fill repair variants for the constrained partial candidate.
   stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-focused-context
                 Package and review the duration/coverage fill candidate in context.
+  stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-focused-listening-notes
+                Build focused listening notes for the duration/coverage fill candidate.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -1486,6 +1488,26 @@ run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_focused_co
     --expected_decision keep_for_focused_listening
 }
 
+run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_focused_listening_notes() {
+  local package_run_id="${PACKAGE_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_focused_package}"
+  local decision_run_id="${DECISION_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_focused_context_decision}"
+  local run_id="${RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_focused_listening_notes}"
+  local candidate_id="margin_recovered_phrase_vocab_seed_353_topk_7_temp_082_n24_sample_3_duration_fill_maxadd_6"
+  local package_path="outputs/stage_b_margin_recovered_phrase_vocabulary_focused_package/${package_run_id}/focused_review_package.json"
+  local decision_path="outputs/stage_b_margin_recovered_focused_context_decision/${decision_run_id}/focused_context_decision.json"
+  if [[ ! -f "$package_path" || ! -f "$decision_path" ]]; then
+    print_header "Stage B duration/coverage fill focused context"
+    PACKAGE_RUN_ID="$package_run_id" RUN_ID="$decision_run_id" run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_focused_context
+  fi
+  print_header "Stage B duration/coverage fill focused listening notes"
+  "$PYTHON_BIN" scripts/build_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes.py \
+    --run_id "$run_id" \
+    --focused_package "$package_path" \
+    --focused_context_decision "$decision_path" \
+    --expected_candidate_id "$candidate_id" \
+    --expected_prior_decision keep_for_focused_listening
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -2725,6 +2747,9 @@ case "$MODE" in
     ;;
   stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-focused-context)
     run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_focused_context
+    ;;
+  stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-focused-listening-notes)
+    run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_focused_listening_notes
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe


### PR DESCRIPTION
## Summary

- duration/coverage fill candidate focused listening notes harness 추가
- focused listening notes template 생성 결과 문서화
- current status, core plan, README 최신 경계 갱신

## Context

- Issue #316 focused context decision: `keep_for_focused_listening`
- candidate: `margin_recovered_phrase_vocab_seed_353_topk_7_temp_082_n24_sample_3_duration_fill_maxadd_6`
- context flags: `[]`
- final: `F4` over `Fm7`, chord tone

## Result

- candidate count: `1`
- reviewed count: `0`
- pending count: `1`
- prior decision: `keep_for_focused_listening`
- listening decision: `pending`
- review risk: `sustained_coverage_review`
- dead-air ratio: `0.2941`
- adjacent pitch repeats: `0`
- max interval: `7`

## Validation

- `bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-focused-listening-notes`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- notes template is not human/audio listening proof
- evidence fill and Brad style adaptation remain unverified

Closes #318
