### PR TITLE
Stage B duration fill listening evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #318, Stage B margin-recovered phrase/vocabulary duration coverage fill focused listening notes.
+- Latest functional issue completed: Issue #320, Stage B margin-recovered phrase/vocabulary duration coverage fill focused listening fill.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill focused listening fill.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill keep consolidation.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -634,6 +634,14 @@ bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-duratio
 ```
 
 This harness writes the focused listening review notes template for the selected duration/coverage fill candidate.
+
+For Stage B margin-recovered phrase/vocabulary duration coverage fill focused listening fill changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-focused-listening-fill
+```
+
+This harness fills the selected duration/coverage fill focused listening review notes from MIDI/context evidence.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ flowchart LR
 
 ## 핵심 결과
 
-Issue #318 기준 model-core MVP:
+Issue #320 기준 model-core MVP:
 
 | 항목 | 결과 |
 |---|---|
@@ -198,6 +198,7 @@ MVP 근거:
 - duration/coverage fill repair에서 selected fill additions `6`, dead-air `0.5714 -> 0.2941`, focused unique pitch `15`, adjacent repeat `0`, duplicated 3-note pitch-class chunks `0`
 - duration/coverage fill focused context에서 decision `keep_for_focused_listening`, flags `{}`, final `F4` over `Fm7` chord tone 확인
 - duration/coverage fill focused listening notes에서 pending `1`, review risk `sustained_coverage_review`로 다음 evidence fill 경계 분리
+- duration/coverage fill focused listening fill에서 MIDI-derived coverage 반영 후 decision `keep`, review risks `{}` 확인
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`
@@ -209,10 +210,10 @@ MVP 근거:
 | 만든 것 | symbolic MIDI 생성 모델의 dataset, tokenization, training, generation, decode, objective review, proxy review pipeline |
 | 겪은 문제 | `.mid` 파일 존재만으로 성공 판단 불가, one-note collapse, long sustain block, chord block, dead-air outlier, seed-level margin 부족 |
 | 해결 방식 | duration-explicit token 구조, grammar/coverage/chord-aware probe, overlap-free postprocess, repeatability sweep, dead-air diagnostics, proxy review scoring, repair candidate selection |
-| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab focused context `keep_for_focused_listening`, timing/repetition repair qualified `2/96`, phrase/vocabulary focused fill `keep`, selected/peer duplicate output, constrained adjacent repair target-qualified `0/48`, duration/coverage fill qualified `2/4`, duration/coverage fill focused context `keep_for_focused_listening`, duration/coverage fill listening notes pending `1` |
+| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab focused context `keep_for_focused_listening`, timing/repetition repair qualified `2/96`, phrase/vocabulary focused fill `keep`, selected/peer duplicate output, constrained adjacent repair target-qualified `0/48`, duration/coverage fill qualified `2/4`, duration/coverage fill focused context `keep_for_focused_listening`, duration/coverage fill evidence decision `keep` |
 | 주장 경계 | reviewable MIDI 후보 생성 검증 파이프라인까지 가능, human listening preference / Brad style adaptation / broad production quality는 미검증 |
 
-Issue #318 기준 current margin-recovered evidence boundary:
+Issue #320 기준 current margin-recovered evidence boundary:
 
 | 항목 | 결과 |
 |---|---|
@@ -268,6 +269,9 @@ Issue #318 기준 current margin-recovered evidence boundary:
 | duration coverage focused context final | `F4` over `Fm7`, chord tone |
 | duration coverage focused listening notes | pending `1`, reviewed `0` |
 | duration coverage focused listening risk | `sustained_coverage_review` |
+| duration coverage focused listening fill | reviewed `1`, decision `keep`, risks `{}` |
+| duration coverage grid coverage | onset `0.5625`, sustained `0.6250` |
+| duration coverage filled fields | timing `acceptable`, chord fit `strong`, phrase `acceptable`, landing `strong`, vocabulary `acceptable` |
 
 Issue #210 기준 current best focused review candidate:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -1112,25 +1112,32 @@ Issue #312는 constrained decoding으로 adjacent repeat를 줄였지만 dead-ai
 완료된 바로 전 작업:
 
 ```text
-Stage B margin-recovered phrase/vocabulary duration coverage fill focused listening notes
+Stage B margin-recovered phrase/vocabulary duration coverage fill focused listening fill
 ```
 
 결과:
 
 - selected candidate: `margin_recovered_phrase_vocab_seed_353_topk_7_temp_082_n24_sample_3_duration_fill_maxadd_6`
-- docs: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_FOCUSED_LISTENING_NOTES_2026-05-29.md`
+- docs: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_FOCUSED_LISTENING_FILL_2026-05-29.md`
 - candidate count: `1`
 - prior decision: `keep_for_focused_listening`
-- listening decision: `pending`
-- reviewed count: `0`
-- pending count: `1`
-- review risks: `sustained_coverage_review`
+- listening decision: `keep`
+- reviewed count: `1`
+- pending count: `0`
+- review risks: `[]`
+- timing: `acceptable`
+- chord fit: `strong`
+- phrase continuation: `acceptable`
+- landing: `strong`
+- jazz vocabulary: `acceptable`
 - note count: `18`
 - unique pitch count: `15`
 - range: `D#4-G#5`
 - phrase span: `7.000` beats
 - max active notes: `1`
 - dead-air ratio: `0.2941`
+- onset coverage: `0.5625`
+- sustained coverage: `0.6250`
 - adjacent pitch repeats: `0`
 - duplicated 3-note pitch-class chunks: `0`
 - max interval: `7`
@@ -1138,17 +1145,17 @@ Stage B margin-recovered phrase/vocabulary duration coverage fill focused listen
 
 판단:
 
-- focused listening review template 생성 완료.
-- listening fields는 pending 상태로 유지한다.
-- notes template은 human/audio listening proof가 아니다.
-- 남은 review risk는 `sustained_coverage_review`다.
+- MIDI/context evidence fill 기준 keep.
+- source coverage metric 부재 시 solo MIDI 기반 coverage를 산출하도록 보정.
+- adjacent repeat, wide interval blocker 유지.
+- human/audio listening proof는 아직 아니다.
 - claim boundary: `postprocess_duration_coverage_fill_candidate`.
 - broad trained-model quality, human listening preference, Brad style adaptation은 아직 미검증이다.
 
 다음 작업:
 
-- 다음 issue는 `Stage B margin-recovered phrase/vocabulary duration coverage fill focused listening fill`로 잡는다.
-- evidence fill에서 timing, phrase continuation, landing, vocabulary decision을 기록한다.
+- 다음 issue는 `Stage B margin-recovered phrase/vocabulary duration coverage fill keep consolidation`로 잡는다.
+- postprocess candidate boundary, human review boundary, broad training boundary를 분리한다.
 - broad training은 focused context/listening boundary를 먼저 본 뒤 결정한다.
 
 ## 10. 한 문장 요약

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #318, Stage B margin-recovered phrase/vocabulary duration coverage fill focused listening notes
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill focused listening fill`
+- latest functional result: Issue #320, Stage B margin-recovered phrase/vocabulary duration coverage fill focused listening fill
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill keep consolidation`
 
 현재 범위가 아닌 것:
 
@@ -65,6 +65,46 @@ Issue #220은 현재 작업이 core인지, MVP 완료로 볼 수 있는지를 �
 Docs:
 
 - `docs/STAGE_B_MODEL_CORE_MVP_COMPLETION_AUDIT_2026-05-28.md`
+
+## Current Duration Coverage Fill Focused Listening Fill Result
+
+Issue #320은 duration/coverage fill candidate의 focused listening notes를 MIDI/context evidence로 채운 작업이다.
+
+변경:
+
+- source coverage metric 부재 시 solo MIDI grid 기반 coverage 산출
+- focused context decision 재생성
+- focused listening notes 재생성
+- focused listening evidence fill 실행
+
+결과:
+
+- candidate count: `1`
+- reviewed count: `1`
+- pending count: `0`
+- decision: `keep`
+- review risks: `[]`
+- timing: `acceptable`
+- chord fit: `strong`
+- phrase continuation: `acceptable`
+- landing: `strong`
+- jazz vocabulary: `acceptable`
+- onset coverage: `0.5625`
+- sustained coverage: `0.6250`
+- dead-air ratio: `0.2941`
+- adjacent pitch repeats: `0`
+- max interval: `7`
+- final note: `F4` over `Fm7`, chord tone
+
+판단:
+
+- MIDI/context evidence fill 기준 keep
+- adjacent repeat, wide interval blocker 유지
+- human/audio listening proof는 아직 아님
+
+다음:
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill keep consolidation`
 
 ## Current Duration Coverage Fill Focused Listening Notes Result
 

--- a/docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_FOCUSED_LISTENING_FILL_2026-05-29.md
+++ b/docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_FOCUSED_LISTENING_FILL_2026-05-29.md
@@ -1,0 +1,70 @@
+# Stage B Margin-Recovered Phrase/Vocabulary Duration Coverage Fill Focused Listening Fill
+
+Issue #320은 duration/coverage fill candidate의 focused listening notes를 MIDI/context evidence로 채운 작업이다.
+
+## Context
+
+- Issue #318 notes result: pending `1`
+- candidate: `margin_recovered_phrase_vocab_seed_353_topk_7_temp_082_n24_sample_3_duration_fill_maxadd_6`
+- prior decision: `keep_for_focused_listening`
+- notes risk before fix: `sustained_coverage_review`
+- source issue: token-derived onset/sustained coverage metric absent
+
+## Change
+
+- source coverage metric 부재 시 solo MIDI grid 기반 coverage 산출
+- focused context decision 재생성
+- focused listening notes 재생성
+- focused listening evidence fill 실행
+
+## Result
+
+| item | value |
+|---|---:|
+| candidate count | `1` |
+| reviewed count | `1` |
+| pending count | `0` |
+| decision | `keep` |
+| review risks | `[]` |
+| timing | `acceptable` |
+| chord fit | `strong` |
+| phrase continuation | `acceptable` |
+| landing | `strong` |
+| jazz vocabulary | `acceptable` |
+
+Focused context metrics:
+
+| item | value |
+|---|---:|
+| note count | `18` |
+| unique pitch count | `15` |
+| range | `D#4-G#5` |
+| phrase span | `7.000` beats |
+| dead-air ratio | `0.2941` |
+| onset coverage | `0.5625` |
+| sustained coverage | `0.6250` |
+| adjacent pitch repeats | `0` |
+| duplicated 3-note pitch-class chunks | `0` |
+| max active notes | `1` |
+| max interval | `7` |
+| final note | `F4` over `Fm7`, chord tone |
+
+## Judgment
+
+- duration/coverage fill candidate remains keep under MIDI/context evidence fill.
+- adjacent repeat and wide interval blockers remain repaired.
+- review risk list cleared after MIDI-derived coverage metric.
+- claim boundary: MIDI/context evidence fill, not human audio proof.
+- broad trained-model quality and Brad style adaptation remain unverified.
+
+## Validation
+
+```bash
+.venv/bin/python -m unittest tests/test_stage_b_margin_recovered_focused_context_decision.py tests/test_stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill.py
+bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-focused-listening-fill
+```
+
+## Next
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill keep consolidation`
+- postprocess candidate boundary, human review boundary, broad training boundary 분리

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -114,6 +114,8 @@ Modes:
                 Package and review the duration/coverage fill candidate in context.
   stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-focused-listening-notes
                 Build focused listening notes for the duration/coverage fill candidate.
+  stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-focused-listening-fill
+                Fill focused listening notes for the duration/coverage fill candidate.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -1508,6 +1510,26 @@ run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_focused_li
     --expected_prior_decision keep_for_focused_listening
 }
 
+run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_focused_listening_fill() {
+  local package_run_id="${PACKAGE_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_focused_package}"
+  local decision_run_id="${DECISION_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_focused_context_decision_with_midi_coverage}"
+  local notes_run_id="${NOTES_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_focused_listening_notes_with_midi_coverage}"
+  local run_id="${RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_focused_listening_fill}"
+  local candidate_id="margin_recovered_phrase_vocab_seed_353_topk_7_temp_082_n24_sample_3_duration_fill_maxadd_6"
+  local review_notes="outputs/stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes/${notes_run_id}/focused_listening_review_notes_template.json"
+  if [[ ! -f "$review_notes" ]]; then
+    print_header "Stage B duration/coverage fill focused listening notes"
+    PACKAGE_RUN_ID="$package_run_id" DECISION_RUN_ID="$decision_run_id" RUN_ID="$notes_run_id" \
+      run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_focused_listening_notes
+  fi
+  print_header "Stage B duration/coverage fill focused listening fill"
+  "$PYTHON_BIN" scripts/fill_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes.py \
+    --run_id "$run_id" \
+    --review_notes "$review_notes" \
+    --expected_candidate_id "$candidate_id" \
+    --expected_decision keep
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -2750,6 +2772,9 @@ case "$MODE" in
     ;;
   stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-focused-listening-notes)
     run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_focused_listening_notes
+    ;;
+  stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-focused-listening-fill)
+    run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_focused_listening_fill
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/review_stage_b_margin_recovered_focused_context.py
+++ b/scripts/review_stage_b_margin_recovered_focused_context.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import sys
 from collections import Counter
 from datetime import datetime, timezone
@@ -83,6 +84,31 @@ def infer_bpm(midi_path: Path, fallback_bpm: float = 124.0) -> float:
 
 def seconds_to_beats(seconds: float, bpm: float) -> float:
     return float(seconds) * float(bpm) / 60.0
+
+
+def grid_coverage_metrics(notes: list[pretty_midi.Note], *, bpm: float, bars: int) -> dict[str, Any]:
+    total_steps = max(1, int(bars) * 16)
+    onset_occupied = [False] * total_steps
+    sustained_occupied = [False] * total_steps
+    for note in notes:
+        start_beat = seconds_to_beats(float(note.start), bpm)
+        end_beat = seconds_to_beats(float(note.end), bpm)
+        start_step = int(round(start_beat * 4.0))
+        end_step = max(start_step + 1, int(math.ceil(end_beat * 4.0)))
+        if 0 <= start_step < total_steps:
+            onset_occupied[start_step] = True
+        for step in range(max(0, start_step), min(total_steps, end_step)):
+            sustained_occupied[step] = True
+    return {
+        "onset_coverage_ratio": float(sum(1 for value in onset_occupied if value) / total_steps),
+        "sustained_coverage_ratio": float(sum(1 for value in sustained_occupied if value) / total_steps),
+    }
+
+
+def metric_or_default(source_metrics: dict[str, Any], key: str, default: float) -> float:
+    if key in source_metrics and source_metrics.get(key) is not None:
+        return float(source_metrics.get(key) or 0.0)
+    return float(default)
 
 
 def parse_chord(chord: str) -> tuple[str, str]:
@@ -202,6 +228,7 @@ def analyze_candidate(candidate: dict[str, Any]) -> dict[str, Any]:
     final_chord = chord_at_beat(final_start_beats, chords[:bars] or chords)
     final_role = pitch_role(int(final_note.pitch), final_chord)
     source_metrics = candidate.get("source_metrics") if isinstance(candidate.get("source_metrics"), dict) else {}
+    coverage = grid_coverage_metrics(notes, bpm=bpm, bars=bars)
     metrics = {
         "note_count": int(len(notes)),
         "unique_pitch_count": int(len(set(pitches))),
@@ -217,8 +244,16 @@ def analyze_candidate(candidate: dict[str, Any]) -> dict[str, Any]:
         "duplicated_3_note_pitch_class_chunks": duplicated_pitch_class_chunks(pitches, 3),
         "max_simultaneous_notes": max_simultaneous_notes(notes),
         "dead_air_ratio": float(source_metrics.get("dead_air_ratio", 0.0) or 0.0),
-        "onset_coverage_ratio": float(source_metrics.get("onset_coverage_ratio", 0.0) or 0.0),
-        "sustained_coverage_ratio": float(source_metrics.get("sustained_coverage_ratio", 0.0) or 0.0),
+        "onset_coverage_ratio": metric_or_default(
+            source_metrics,
+            "onset_coverage_ratio",
+            coverage["onset_coverage_ratio"],
+        ),
+        "sustained_coverage_ratio": metric_or_default(
+            source_metrics,
+            "sustained_coverage_ratio",
+            coverage["sustained_coverage_ratio"],
+        ),
         "final_note": pitch_name(int(final_note.pitch)),
         "final_start_beats": round(float(final_start_beats), 3),
         "final_chord": final_chord,

--- a/tests/test_stage_b_margin_recovered_focused_context_decision.py
+++ b/tests/test_stage_b_margin_recovered_focused_context_decision.py
@@ -68,6 +68,52 @@ def sample_package(root: Path, *, pitches: list[int], dead_air: float) -> dict:
     }
 
 
+def package_without_source_coverage(root: Path) -> dict:
+    solo_path = root / "midi" / "coverage_candidate.mid"
+    context_path = root / "context" / "coverage_candidate_context.mid"
+    midi = pretty_midi.PrettyMIDI(initial_tempo=124)
+    solo = pretty_midi.Instrument(program=0, is_drum=False, name="Solo")
+    rows = [
+        (70, 0.120967, 0.241935),
+        (71, 0.241935, 0.362903),
+        (73, 0.362903, 0.483871),
+        (74, 0.483871, 0.604838),
+        (76, 0.604838, 0.725805),
+        (77, 0.725805, 0.846773),
+        (78, 0.846773, 0.967740),
+        (75, 0.967740, 1.088708),
+        (80, 1.088708, 1.209675),
+        (79, 1.209675, 1.572578),
+    ]
+    for pitch, start, end in rows:
+        solo.notes.append(pretty_midi.Note(velocity=84, pitch=pitch, start=start, end=end))
+    midi.instruments.append(solo)
+    solo_path.parent.mkdir(parents=True, exist_ok=True)
+    midi.write(str(solo_path))
+    write_context(context_path, solo_path)
+    return {
+        "output_dir": str(root),
+        "candidates": [
+            {
+                "candidate_id": "coverage_candidate",
+                "review_files": {
+                    "midi_path": str(solo_path),
+                    "context_midi_path": str(context_path),
+                },
+                "source_metrics": {
+                    "dead_air_ratio": 0.29411764705882354,
+                },
+                "listening": {"decision": "keep_for_focused_listening"},
+                "focused_package_transform": {
+                    "context_chords": ["Cm7", "Fm7"],
+                    "context_bpm": 124,
+                    "context_bars": 2,
+                },
+            }
+        ],
+    }
+
+
 class MarginRecoveredFocusedContextDecisionTest(unittest.TestCase):
     def test_low_pitch_variety_candidate_needs_followup(self) -> None:
         with TemporaryDirectory() as temp_dir:
@@ -101,6 +147,18 @@ class MarginRecoveredFocusedContextDecisionTest(unittest.TestCase):
             )
 
             self.assertEqual(summary["decisions"], ["keep_for_focused_listening"])
+
+    def test_derives_grid_coverage_when_source_metrics_are_missing(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            report = build_focused_context_decision(
+                package_without_source_coverage(root),
+                output_dir=root / "decision",
+            )
+
+            metrics = report["candidates"][0]["metrics"]
+            self.assertGreater(metrics["onset_coverage_ratio"], 0.0)
+            self.assertGreater(metrics["sustained_coverage_ratio"], 0.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- focused context decision에서 source coverage metric 부재 시 solo MIDI grid coverage 산출
- duration/coverage fill focused listening evidence fill harness 추가
- evidence fill 결과와 current boundary 문서 갱신

## Context

- Issue #318 focused listening notes risk: `sustained_coverage_review`
- source issue: duration fill candidate에는 token-derived onset/sustained coverage metric 부재
- actual solo MIDI grid coverage: onset `0.5625`, sustained `0.6250`

## Result

- candidate count: `1`
- reviewed count: `1`
- pending count: `0`
- decision: `keep`
- review risks: `[]`
- timing: `acceptable`
- chord fit: `strong`
- phrase continuation: `acceptable`
- landing: `strong`
- jazz vocabulary: `acceptable`
- final: `F4` over `Fm7`, chord tone

## Validation

- `.venv/bin/python -m unittest tests/test_stage_b_margin_recovered_focused_context_decision.py tests/test_stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill.py`
- `bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-focused-listening-fill`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- evidence fill is MIDI/context evidence, not human audio proof
- broad trained-model quality and Brad style adaptation remain unverified

Closes #320
