### PR TITLE
Stage B duration coverage fill keep consolidation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #320, Stage B margin-recovered phrase/vocabulary duration coverage fill focused listening fill.
+- Latest functional issue completed: Issue #322, Stage B margin-recovered phrase/vocabulary duration coverage fill keep consolidation.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill keep consolidation.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill human/audio comparison boundary.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -642,6 +642,14 @@ bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-duratio
 ```
 
 This harness fills the selected duration/coverage fill focused listening review notes from MIDI/context evidence.
+
+For Stage B margin-recovered phrase/vocabulary duration coverage fill keep consolidation changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-keep-consolidation
+```
+
+This harness consolidates the selected duration/coverage fill keep candidate and records the single postprocess-candidate claim boundary.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@
 | target-qualified 후보 미발견 | 추가 sampling에서도 pitch variety와 adjacent/dead-air target 동시 충족 실패 | seed `181/223`, top_k8, temp `0.90/0.86` sweep 실행 | target-qualified `0/96`, partial 후보 unique `9`, dead-air `0.3889`, adjacent repeat `1` |
 | sampling 조정 한계 | lower temperature/top_k에서도 dead-air와 adjacent repeat 동시 해결 실패 | seed `269/311`, top_k7, temp `0.80/0.78` sweep 실행 | target-qualified `0/96`, partial 후보 unique `7`, max interval `7`, dead-air `0.3889`, adjacent repeat `1` |
 | adjacent repeat 직접 제어 후 dead-air 악화 | constrained decoding으로 repeat는 줄었지만 duration/coverage 공백이 남음 | coverage-aware positions + chord-aware repeat window 적용 | adjacent repeat `0`, unique `9`, dead-air `0.5714`, target-qualified `0/48` |
+| constrained partial 후보의 coverage 공백 | adjacent repeat는 제거됐지만 dead-air `0.5714`로 target 미달 | duration/coverage fill variant 생성 | qualified `2/4`, selected fill additions `6`, dead-air `0.2941` |
+| duration fill keep 과장 위험 | focused listening fill decision `keep`은 단일 postprocess 후보 증거 | keep consolidation으로 claim boundary 분리 | boundary `single_postprocess_candidate_keep_support`, human/audio proof 미검증 |
 
 ## 파이프라인 구조
 
@@ -81,7 +83,7 @@ flowchart LR
 
 ## 핵심 결과
 
-Issue #320 기준 model-core MVP:
+Issue #322 기준 model-core MVP:
 
 | 항목 | 결과 |
 |---|---|
@@ -199,6 +201,7 @@ MVP 근거:
 - duration/coverage fill focused context에서 decision `keep_for_focused_listening`, flags `{}`, final `F4` over `Fm7` chord tone 확인
 - duration/coverage fill focused listening notes에서 pending `1`, review risk `sustained_coverage_review`로 다음 evidence fill 경계 분리
 - duration/coverage fill focused listening fill에서 MIDI-derived coverage 반영 후 decision `keep`, review risks `{}` 확인
+- duration/coverage fill keep consolidation에서 single postprocess candidate boundary `single_postprocess_candidate_keep_support`로 정리
 - constrained/postprocessed generation의 strict review gate 통과
 - objective-clean focused candidates `6/6`
 - listening review pending `6`
@@ -210,10 +213,10 @@ MVP 근거:
 | 만든 것 | symbolic MIDI 생성 모델의 dataset, tokenization, training, generation, decode, objective review, proxy review pipeline |
 | 겪은 문제 | `.mid` 파일 존재만으로 성공 판단 불가, one-note collapse, long sustain block, chord block, dead-air outlier, seed-level margin 부족 |
 | 해결 방식 | duration-explicit token 구조, grammar/coverage/chord-aware probe, overlap-free postprocess, repeatability sweep, dead-air diagnostics, proxy review scoring, repair candidate selection |
-| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab focused context `keep_for_focused_listening`, timing/repetition repair qualified `2/96`, phrase/vocabulary focused fill `keep`, selected/peer duplicate output, constrained adjacent repair target-qualified `0/48`, duration/coverage fill qualified `2/4`, duration/coverage fill focused context `keep_for_focused_listening`, duration/coverage fill evidence decision `keep` |
+| 검증 결과 | raw generation local gate 통과, 6-file 5-sample recovery strict `12/15`, margin-recovered fallback focused keep `0/3`, pitch-vocab focused context `keep_for_focused_listening`, timing/repetition repair qualified `2/96`, phrase/vocabulary focused fill `keep`, selected/peer duplicate output, constrained adjacent repair target-qualified `0/48`, duration/coverage fill qualified `2/4`, duration/coverage fill focused context `keep_for_focused_listening`, duration/coverage fill evidence decision `keep`, duration/coverage fill keep boundary `single_postprocess_candidate_keep_support` |
 | 주장 경계 | reviewable MIDI 후보 생성 검증 파이프라인까지 가능, human listening preference / Brad style adaptation / broad production quality는 미검증 |
 
-Issue #320 기준 current margin-recovered evidence boundary:
+Issue #322 기준 current margin-recovered evidence boundary:
 
 | 항목 | 결과 |
 |---|---|
@@ -272,6 +275,9 @@ Issue #320 기준 current margin-recovered evidence boundary:
 | duration coverage focused listening fill | reviewed `1`, decision `keep`, risks `{}` |
 | duration coverage grid coverage | onset `0.5625`, sustained `0.6250` |
 | duration coverage filled fields | timing `acceptable`, chord fit `strong`, phrase `acceptable`, landing `strong`, vocabulary `acceptable` |
+| duration coverage keep consolidation | boundary `single_postprocess_candidate_keep_support` |
+| duration coverage proven boundary | MIDI/context evidence keep, dead-air repair, adjacent repeat repair, wide interval repair |
+| duration coverage not proven boundary | human/audio preference, broad trained-model quality, Brad style adaptation, broad repeatability |
 
 Issue #210 기준 current best focused review candidate:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -101,6 +101,11 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered phrase/vocabulary distinct sample-seed remaining blocker repair sweep 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DISTINCT_SAMPLE_SEED_REMAINING_BLOCKER_REPAIR_SWEEP_2026-05-29.md`
 - margin-recovered phrase/vocabulary distinct sample-seed dead-air adjacent repair 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DISTINCT_SAMPLE_SEED_DEAD_AIR_ADJACENT_REPAIR_2026-05-29.md`
 - margin-recovered phrase/vocabulary coverage-aware adjacent constrained repair 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_COVERAGE_AWARE_ADJACENT_CONSTRAINED_REPAIR_2026-05-29.md`
+- margin-recovered phrase/vocabulary duration coverage fill repair 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_REPAIR_2026-05-29.md`
+- margin-recovered phrase/vocabulary duration coverage fill focused context 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_FOCUSED_CONTEXT_2026-05-29.md`
+- margin-recovered phrase/vocabulary duration coverage fill focused listening notes 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_FOCUSED_LISTENING_NOTES_2026-05-29.md`
+- margin-recovered phrase/vocabulary duration coverage fill focused listening fill 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_FOCUSED_LISTENING_FILL_2026-05-29.md`
+- margin-recovered phrase/vocabulary duration coverage fill keep consolidation 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_KEEP_CONSOLIDATION_2026-05-29.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -140,6 +145,11 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered phrase/vocabulary duplicate source divergence: source seed diff `true`, shared sample seed `85`, output diversity `absent`
 - margin-recovered phrase/vocabulary sample-seed diversity repair: qualified sample seed `1`, distinct peer `0`, boundary `single_distinct_sample_seed_keep_support`
 - margin-recovered phrase/vocabulary distinct sample-seed repair sweep: blocked seed `85` 제외, distinct qualified `2`, selected sample seed `155`
+- margin-recovered phrase/vocabulary coverage-aware adjacent constrained repair: target-qualified `0/48`, adjacent repeat `0`, dead-air `0.5714`
+- margin-recovered phrase/vocabulary duration coverage fill repair: qualified `2/4`, fill additions `6`, dead-air `0.5714 -> 0.2941`
+- margin-recovered phrase/vocabulary duration coverage fill focused context: decision `keep_for_focused_listening`, flags `{}`, final `F4` over `Fm7` chord tone
+- margin-recovered phrase/vocabulary duration coverage fill focused listening fill: reviewed `1`, decision `keep`, review risks `{}`
+- margin-recovered phrase/vocabulary duration coverage fill keep consolidation: boundary `single_postprocess_candidate_keep_support`, human/audio proof 미검증
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -1147,16 +1157,51 @@ Stage B margin-recovered phrase/vocabulary duration coverage fill focused listen
 
 - MIDI/context evidence fill 기준 keep.
 - source coverage metric 부재 시 solo MIDI 기반 coverage를 산출하도록 보정.
-- adjacent repeat, wide interval blocker 유지.
+- adjacent repeat, wide interval blocker repair 유지.
 - human/audio listening proof는 아직 아니다.
 - claim boundary: `postprocess_duration_coverage_fill_candidate`.
 - broad trained-model quality, human listening preference, Brad style adaptation은 아직 미검증이다.
 
 다음 작업:
 
-- 다음 issue는 `Stage B margin-recovered phrase/vocabulary duration coverage fill keep consolidation`로 잡는다.
+- 다음 issue는 `Stage B margin-recovered phrase/vocabulary duration coverage fill human/audio comparison boundary`로 잡는다.
 - postprocess candidate boundary, human review boundary, broad training boundary를 분리한다.
 - broad training은 focused context/listening boundary를 먼저 본 뒤 결정한다.
+
+## 9.1 Stage B margin-recovered phrase/vocabulary duration coverage fill keep consolidation
+
+Issue #322는 Issue #320의 `keep` 결과를 claim boundary 기준으로 정리한 작업이다.
+
+결과:
+
+- candidate: `margin_recovered_phrase_vocab_seed_353_topk_7_temp_082_n24_sample_3_duration_fill_maxadd_6`
+- decision: `keep`
+- evidence boundary: `single_postprocess_candidate_keep_support`
+- postprocess claim boundary: `postprocess_duration_coverage_fill_candidate`
+- variant count: `4`
+- qualified variant count: `2`
+- fill additions: `6`
+- dead-air ratio: `0.5714 -> 0.2941`
+- onset coverage: `0.5625`
+- sustained coverage: `0.6250`
+- note count: `18`
+- unique pitch count: `15`
+- final note: `F4` over `Fm7`, chord tone
+
+판단:
+
+- MIDI/context evidence keep은 확인했다.
+- adjacent repeat blocker와 wide interval blocker는 repair 상태다.
+- single postprocess candidate support이므로 broad repeatability는 아직 아니다.
+- human/audio preference, broad trained-model quality, Brad style adaptation은 아직 미검증이다.
+
+검증:
+
+- `bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-keep-consolidation`
+
+다음 작업:
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill human/audio comparison boundary`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #320, Stage B margin-recovered phrase/vocabulary duration coverage fill focused listening fill
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill keep consolidation`
+- latest functional result: Issue #322, Stage B margin-recovered phrase/vocabulary duration coverage fill keep consolidation
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill human/audio comparison boundary`
 
 현재 범위가 아닌 것:
 
@@ -66,6 +66,44 @@ Docs:
 
 - `docs/STAGE_B_MODEL_CORE_MVP_COMPLETION_AUDIT_2026-05-28.md`
 
+## Current Duration Coverage Fill Keep Consolidation Result
+
+Issue #322는 Issue #320의 duration/coverage fill `keep` 결과를 claim boundary 기준으로 정리한 작업이다.
+
+변경:
+
+- duration fill repair summary와 focused listening filled notes 조인
+- single keep candidate 검증
+- postprocess claim boundary 검증
+- proven / not proven boundary 분리
+
+결과:
+
+- candidate: `margin_recovered_phrase_vocab_seed_353_topk_7_temp_082_n24_sample_3_duration_fill_maxadd_6`
+- decision: `keep`
+- boundary: `single_postprocess_candidate_keep_support`
+- postprocess claim boundary: `postprocess_duration_coverage_fill_candidate`
+- variant count: `4`
+- qualified variant count: `2`
+- fill additions: `6`
+- dead-air ratio: `0.5714 -> 0.2941`
+- onset coverage: `0.5625`
+- sustained coverage: `0.6250`
+- note count: `18`
+- unique pitch count: `15`
+- final note: `F4` over `Fm7`, chord tone
+
+판단:
+
+- MIDI/context evidence 기준 keep
+- adjacent repeat, wide interval blocker repair 유지
+- single postprocess candidate support로 claim boundary 제한
+- human/audio listening proof와 broad trained-model quality는 아직 미검증
+
+다음:
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill human/audio comparison boundary`
+
 ## Current Duration Coverage Fill Focused Listening Fill Result
 
 Issue #320은 duration/coverage fill candidate의 focused listening notes를 MIDI/context evidence로 채운 작업이다.
@@ -99,12 +137,12 @@ Issue #320은 duration/coverage fill candidate의 focused listening notes를 MID
 판단:
 
 - MIDI/context evidence fill 기준 keep
-- adjacent repeat, wide interval blocker 유지
+- adjacent repeat, wide interval blocker repair 유지
 - human/audio listening proof는 아직 아님
 
-다음:
+후속:
 
-- `Stage B margin-recovered phrase/vocabulary duration coverage fill keep consolidation`
+- Issue #322 `Stage B margin-recovered phrase/vocabulary duration coverage fill keep consolidation` 완료
 
 ## Current Duration Coverage Fill Focused Listening Notes Result
 

--- a/docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_KEEP_CONSOLIDATION_2026-05-29.md
+++ b/docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_KEEP_CONSOLIDATION_2026-05-29.md
@@ -1,0 +1,83 @@
+# Stage B Margin-Recovered Phrase/Vocabulary Duration Coverage Fill Keep Consolidation
+
+Issue #322는 Issue #320의 duration/coverage fill `keep` 결과를 claim boundary 기준으로 정리한 작업이다.
+
+## Context
+
+- source candidate: `margin_recovered_phrase_vocab_seed_353_topk_7_temp_082_n24_sample_3`
+- selected candidate: `margin_recovered_phrase_vocab_seed_353_topk_7_temp_082_n24_sample_3_duration_fill_maxadd_6`
+- previous issue: focused listening fill decision `keep`
+- review boundary: MIDI/context evidence fill
+- claim risk: 단일 postprocess 후보의 `keep`을 broad model quality로 과장할 가능성
+
+## Change
+
+- duration fill repair summary와 focused listening filled notes 조인
+- single keep candidate 검증
+- postprocess claim boundary 검증
+- proven / not proven boundary 분리
+- harness mode 추가
+
+## Result
+
+| item | value |
+|---|---:|
+| decision | `keep` |
+| boundary | `single_postprocess_candidate_keep_support` |
+| postprocess claim boundary | `postprocess_duration_coverage_fill_candidate` |
+| variant count | `4` |
+| qualified variant count | `2` |
+| fill additions | `6` |
+| dead-air | `0.5714 -> 0.2941` |
+| onset coverage | `0.5625` |
+| sustained coverage | `0.6250` |
+
+Focused metrics:
+
+| item | value |
+|---|---:|
+| note count | `18` |
+| unique pitch count | `15` |
+| range | `D#4-G#5` |
+| phrase span | `7.000` beats |
+| max active notes | `1` |
+| adjacent pitch repeats | `0` |
+| duplicated 3-note pitch-class chunks | `0` |
+| max interval | `7` |
+| final note | `F4` over `Fm7`, chord tone |
+| review risks | `[]` |
+
+## Proven
+
+- MIDI/context evidence 기준 `keep`
+- constrained partial 후보 대비 dead-air 감소
+- adjacent repeat blocker repair
+- wide interval blocker repair
+- solo/context review artifact 확보
+- final landing chord tone
+
+## Not Proven
+
+- human/audio preference
+- broad trained-model quality
+- Brad style adaptation
+- broad repeatability
+- production-ready improviser
+
+## Validation
+
+```bash
+.venv/bin/python -m unittest tests/test_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_keep_consolidation.py
+bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-keep-consolidation
+```
+
+## Output
+
+- script: `scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_keep_consolidation.py`
+- test: `tests/test_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_keep_consolidation.py`
+- summary: `outputs/stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_keep_consolidation/harness_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_keep_consolidation/duration_coverage_fill_keep_consolidation.json`
+
+## Next
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill human/audio comparison boundary`
+- MIDI/context evidence keep과 human/audio review boundary 분리

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -116,6 +116,8 @@ Modes:
                 Build focused listening notes for the duration/coverage fill candidate.
   stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-focused-listening-fill
                 Fill focused listening notes for the duration/coverage fill candidate.
+  stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-keep-consolidation
+                Consolidate the duration/coverage fill keep candidate boundary.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -1530,6 +1532,32 @@ run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_focused_li
     --expected_decision keep
 }
 
+run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_keep_consolidation() {
+  local repair_run_id="${REPAIR_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_repair}"
+  local fill_run_id="${FILL_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_focused_listening_fill}"
+  local run_id="${RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_keep_consolidation}"
+  local candidate_id="margin_recovered_phrase_vocab_seed_353_topk_7_temp_082_n24_sample_3_duration_fill_maxadd_6"
+  local duration_fill_summary="outputs/stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_repair/${repair_run_id}/duration_coverage_fill_repair_summary.json"
+  local filled_notes="outputs/stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill/${fill_run_id}/focused_listening_review_notes_filled.json"
+  if [[ ! -f "$duration_fill_summary" ]]; then
+    print_header "Stage B duration/coverage fill repair"
+    RUN_ID="$repair_run_id" run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_repair
+  fi
+  if [[ ! -f "$filled_notes" ]]; then
+    print_header "Stage B duration/coverage fill focused listening fill"
+    RUN_ID="$fill_run_id" run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_focused_listening_fill
+  fi
+  print_header "Stage B duration/coverage fill keep consolidation"
+  "$PYTHON_BIN" scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_keep_consolidation.py \
+    --run_id "$run_id" \
+    --duration_fill_summary "$duration_fill_summary" \
+    --filled_notes "$filled_notes" \
+    --expected_candidate_id "$candidate_id" \
+    --expected_boundary single_postprocess_candidate_keep_support \
+    --require_not_human_audio_review \
+    --require_postprocess_claim_boundary postprocess_duration_coverage_fill_candidate
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -2775,6 +2803,9 @@ case "$MODE" in
     ;;
   stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-focused-listening-fill)
     run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_focused_listening_fill
+    ;;
+  stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-keep-consolidation)
+    run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_keep_consolidation
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_keep_consolidation.py
+++ b/scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_keep_consolidation.py
@@ -1,0 +1,345 @@
+"""Consolidate the duration/coverage fill keep candidate boundary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class DurationCoverageFillKeepConsolidationError(ValueError):
+    pass
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def single_keep_candidate(filled_notes: dict[str, Any]) -> dict[str, Any]:
+    candidates = filled_notes.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise DurationCoverageFillKeepConsolidationError("filled notes must contain candidates")
+    keep_candidates = [
+        candidate
+        for candidate in candidates
+        if str(candidate.get("listening", {}).get("decision") or "") == "keep"
+    ]
+    if len(keep_candidates) != 1:
+        raise DurationCoverageFillKeepConsolidationError(
+            f"expected exactly one keep candidate, got {len(keep_candidates)}"
+        )
+    return keep_candidates[0]
+
+
+def compact_keep_candidate(candidate: dict[str, Any]) -> dict[str, Any]:
+    metadata = candidate.get("review_metadata") if isinstance(candidate.get("review_metadata"), dict) else {}
+    listening = candidate.get("listening") if isinstance(candidate.get("listening"), dict) else {}
+    metrics = candidate.get("focused_context_metrics") if isinstance(candidate.get("focused_context_metrics"), dict) else {}
+    evidence = candidate.get("listening_fill_evidence") if isinstance(candidate.get("listening_fill_evidence"), dict) else {}
+    files = candidate.get("review_files") if isinstance(candidate.get("review_files"), dict) else {}
+    return {
+        "candidate_id": str(candidate.get("candidate_id") or ""),
+        "mode": str(metadata.get("mode") or ""),
+        "decision": str(listening.get("decision") or ""),
+        "timing": str(listening.get("timing") or ""),
+        "chord_fit": str(listening.get("chord_fit") or ""),
+        "phrase_continuation": str(listening.get("phrase_continuation") or ""),
+        "landing": str(listening.get("landing") or ""),
+        "jazz_vocabulary": str(listening.get("jazz_vocabulary") or ""),
+        "note_count": int(metrics.get("note_count", 0) or 0),
+        "unique_pitch_count": int(metrics.get("unique_pitch_count", 0) or 0),
+        "range": str(metrics.get("range") or ""),
+        "phrase_span_beats": float(metrics.get("phrase_span_beats", 0.0) or 0.0),
+        "max_active_notes": int(metrics.get("max_simultaneous_notes", 0) or 0),
+        "dead_air_ratio": float(metrics.get("dead_air_ratio", 0.0) or 0.0),
+        "onset_coverage_ratio": float(metrics.get("onset_coverage_ratio", 0.0) or 0.0),
+        "sustained_coverage_ratio": float(metrics.get("sustained_coverage_ratio", 0.0) or 0.0),
+        "adjacent_pitch_repeats": int(metrics.get("adjacent_pitch_repeats", 0) or 0),
+        "duplicated_3_note_pitch_class_chunks": int(
+            metrics.get("duplicated_3_note_pitch_class_chunks", 0) or 0
+        ),
+        "max_interval": int(metrics.get("max_interval", 0) or 0),
+        "final_note": str(metrics.get("final_note") or ""),
+        "final_chord": str(metrics.get("final_chord") or ""),
+        "final_note_role": str(metrics.get("final_note_role") or ""),
+        "review_risks": list(candidate.get("review_risks") or []),
+        "not_human_audio_review": bool(evidence.get("not_human_audio_review", False)),
+        "midi_path": str(files.get("midi_path") or ""),
+        "context_midi_path": str(files.get("context_midi_path") or ""),
+        "source_midi_path": str(files.get("source_midi_path") or ""),
+    }
+
+
+def compact_duration_repair(duration_fill_summary: dict[str, Any]) -> dict[str, Any]:
+    repair = duration_fill_summary.get("repair_summary")
+    selected = duration_fill_summary.get("selected_candidate")
+    source = duration_fill_summary.get("source_candidate")
+    if not isinstance(repair, dict) or not isinstance(selected, dict) or not isinstance(source, dict):
+        raise DurationCoverageFillKeepConsolidationError("duration fill summary is missing repair/source data")
+    fill_repair = selected.get("fill_repair") if isinstance(selected.get("fill_repair"), dict) else {}
+    gate = selected.get("duration_coverage_gate") if isinstance(selected.get("duration_coverage_gate"), dict) else {}
+    selected_metrics = selected.get("metrics") if isinstance(selected.get("metrics"), dict) else {}
+    source_metrics = source.get("metrics") if isinstance(source.get("metrics"), dict) else {}
+    selected_focused = (
+        selected.get("focused_solo_metrics") if isinstance(selected.get("focused_solo_metrics"), dict) else {}
+    )
+    source_focused = source.get("focused_solo_metrics") if isinstance(source.get("focused_solo_metrics"), dict) else {}
+    return {
+        "source_candidate_id": str(source.get("candidate_id") or ""),
+        "selected_candidate_id": str(repair.get("selected_candidate_id") or selected.get("candidate_id") or ""),
+        "variant_count": int(duration_fill_summary.get("variant_count", 0) or 0),
+        "qualified_variant_count": int(duration_fill_summary.get("qualified_variant_count", 0) or 0),
+        "qualified": bool(repair.get("qualified", False)),
+        "remaining_flags": list(repair.get("remaining_flags") or gate.get("flags") or []),
+        "fill_addition_count": int(repair.get("selected_fill_addition_count", 0) or 0),
+        "max_additions": int(fill_repair.get("max_additions", 0) or 0),
+        "baseline_dead_air_ratio": float(repair.get("baseline_dead_air_ratio", 0.0) or 0.0),
+        "selected_dead_air_ratio": float(repair.get("selected_dead_air_ratio", 0.0) or 0.0),
+        "dead_air_delta_from_baseline": float(repair.get("dead_air_delta_from_baseline", 0.0) or 0.0),
+        "source_note_count": int(source_focused.get("focused_note_count", 0) or source_metrics.get("note_count", 0) or 0),
+        "source_unique_pitch_count": int(
+            source_focused.get("focused_unique_pitch_count", 0) or source_metrics.get("unique_pitch_count", 0) or 0
+        ),
+        "selected_note_count": int(
+            selected_focused.get("focused_note_count", 0) or selected_metrics.get("note_count", 0) or 0
+        ),
+        "selected_unique_pitch_count": int(
+            selected_focused.get("focused_unique_pitch_count", 0)
+            or selected_metrics.get("unique_pitch_count", 0)
+            or 0
+        ),
+        "selected_adjacent_pitch_repeats": int(
+            repair.get("selected_adjacent_pitch_repeats", 0)
+            or selected_focused.get("focused_adjacent_pitch_repeats", 0)
+            or 0
+        ),
+        "selected_duplicated_3_note_pitch_class_chunks": int(
+            repair.get("selected_duplicated_3_note_pitch_class_chunks", 0)
+            or selected_focused.get("focused_duplicated_3_note_pitch_class_chunks", 0)
+            or 0
+        ),
+        "selected_max_interval": int(
+            repair.get("selected_max_interval", 0) or selected_focused.get("focused_max_interval", 0) or 0
+        ),
+        "duration_coverage_fill_improved": bool(repair.get("duration_coverage_fill_improved", False)),
+        "claim_boundary": str(repair.get("claim_boundary") or ""),
+    }
+
+
+def build_keep_consolidation_report(
+    filled_notes: dict[str, Any],
+    duration_fill_summary: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> dict[str, Any]:
+    keep = compact_keep_candidate(single_keep_candidate(filled_notes))
+    duration = compact_duration_repair(duration_fill_summary)
+    if keep["candidate_id"] != duration["selected_candidate_id"]:
+        raise DurationCoverageFillKeepConsolidationError(
+            f"filled keep candidate does not match duration fill selected candidate: {keep['candidate_id']}"
+        )
+
+    boundary = (
+        "single_postprocess_candidate_keep_support"
+        if keep["decision"] == "keep"
+        and duration["qualified"]
+        and duration["duration_coverage_fill_improved"]
+        and keep["not_human_audio_review"]
+        else "insufficient_keep_support"
+    )
+    return {
+        "schema_version": "stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_keep_consolidation_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_filled_notes_schema": str(filled_notes.get("schema_version") or ""),
+        "source_duration_fill_schema": str(duration_fill_summary.get("schema_version") or ""),
+        "decision_path": [
+            "duration_coverage_fill_repair",
+            "focused_context_package",
+            "focused_listening_notes",
+            "midi_context_evidence_fill",
+            "keep_consolidation",
+        ],
+        "candidate": keep,
+        "duration_coverage_repair": duration,
+        "evidence_boundary": {
+            "boundary": boundary,
+            "claim": "single_postprocess_candidate_midi_context_keep",
+            "postprocess_claim_boundary": duration["claim_boundary"],
+            "selected_candidate_is_keep": keep["decision"] == "keep",
+            "duration_fill_qualified": duration["qualified"],
+            "duration_fill_improved_dead_air": duration["duration_coverage_fill_improved"],
+            "not_human_audio_review": keep["not_human_audio_review"],
+        },
+        "proven": [
+            "midi_context_evidence_keep",
+            "dead_air_reduced_from_constrained_partial_candidate",
+            "adjacent_repeat_blocker_repaired",
+            "wide_interval_blocker_repaired",
+            "solo_context_review_artifact_available",
+            "final_landing_chord_tone",
+        ],
+        "not_proven": [
+            "human_audio_preference",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "broad_repeatability",
+            "production_ready_improviser",
+        ],
+        "next_recommended_issue": (
+            "Stage B margin-recovered phrase/vocabulary duration coverage fill human/audio comparison boundary"
+        ),
+    }
+
+
+def validate_keep_consolidation(
+    report: dict[str, Any],
+    *,
+    expected_candidate_id: str | None,
+    expected_boundary: str | None,
+    require_not_human_audio_review: bool,
+    require_postprocess_claim_boundary: str | None,
+) -> dict[str, Any]:
+    candidate = report.get("candidate") if isinstance(report.get("candidate"), dict) else {}
+    boundary = report.get("evidence_boundary") if isinstance(report.get("evidence_boundary"), dict) else {}
+    candidate_id = str(candidate.get("candidate_id") or "")
+    if expected_candidate_id and candidate_id != expected_candidate_id:
+        raise DurationCoverageFillKeepConsolidationError(
+            f"expected candidate {expected_candidate_id}, got {candidate_id}"
+        )
+    if candidate.get("decision") != "keep":
+        raise DurationCoverageFillKeepConsolidationError("candidate decision must be keep")
+    if expected_boundary and str(boundary.get("boundary") or "") != expected_boundary:
+        raise DurationCoverageFillKeepConsolidationError(
+            f"expected boundary {expected_boundary}, got {boundary.get('boundary')}"
+        )
+    if require_not_human_audio_review and not bool(boundary.get("not_human_audio_review", False)):
+        raise DurationCoverageFillKeepConsolidationError("expected not_human_audio_review boundary")
+    if require_postprocess_claim_boundary and str(boundary.get("postprocess_claim_boundary") or "") != (
+        require_postprocess_claim_boundary
+    ):
+        raise DurationCoverageFillKeepConsolidationError(
+            "expected postprocess claim boundary "
+            f"{require_postprocess_claim_boundary}, got {boundary.get('postprocess_claim_boundary')}"
+        )
+    return {
+        "candidate_id": candidate_id,
+        "decision": str(candidate.get("decision") or ""),
+        "boundary": str(boundary.get("boundary") or ""),
+        "postprocess_claim_boundary": str(boundary.get("postprocess_claim_boundary") or ""),
+        "not_human_audio_review": bool(boundary.get("not_human_audio_review", False)),
+        "note_count": int(candidate.get("note_count", 0) or 0),
+        "unique_pitch_count": int(candidate.get("unique_pitch_count", 0) or 0),
+        "dead_air_ratio": float(candidate.get("dead_air_ratio", 0.0) or 0.0),
+        "onset_coverage_ratio": float(candidate.get("onset_coverage_ratio", 0.0) or 0.0),
+        "sustained_coverage_ratio": float(candidate.get("sustained_coverage_ratio", 0.0) or 0.0),
+        "adjacent_pitch_repeats": int(candidate.get("adjacent_pitch_repeats", 0) or 0),
+        "max_interval": int(candidate.get("max_interval", 0) or 0),
+        "fill_addition_count": int(report.get("duration_coverage_repair", {}).get("fill_addition_count", 0) or 0),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    candidate = report["candidate"]
+    repair = report["duration_coverage_repair"]
+    boundary = report["evidence_boundary"]
+    lines = [
+        "# Stage B Margin-Recovered Phrase/Vocabulary Duration Coverage Fill Keep Consolidation",
+        "",
+        f"- candidate: `{candidate['candidate_id']}`",
+        f"- source candidate: `{repair['source_candidate_id']}`",
+        f"- decision: `{candidate['decision']}`",
+        f"- boundary: `{boundary['boundary']}`",
+        f"- postprocess claim boundary: `{boundary['postprocess_claim_boundary']}`",
+        f"- fill additions: `{repair['fill_addition_count']}`",
+        f"- dead-air: `{repair['baseline_dead_air_ratio']:.4f}` -> `{repair['selected_dead_air_ratio']:.4f}`",
+        f"- grid coverage: onset `{candidate['onset_coverage_ratio']:.4f}`, sustained `{candidate['sustained_coverage_ratio']:.4f}`",
+        "",
+        "This is single postprocess candidate MIDI/context evidence, not human audio proof or broad model quality.",
+        "",
+        "| notes | unique | range | phrase span | max active | dead-air | adj repeat | dup3 | max interval | final landing | risks |",
+        "|---:|---:|---|---:|---:|---:|---:|---:|---:|---|---|",
+    ]
+    risks = ",".join(candidate["review_risks"]) if candidate["review_risks"] else "none"
+    final_landing = f"{candidate['final_note']} over {candidate['final_chord']} ({candidate['final_note_role']})"
+    lines.append(
+        "| "
+        + " | ".join(
+            [
+                str(candidate["note_count"]),
+                str(candidate["unique_pitch_count"]),
+                str(candidate["range"]),
+                f"{float(candidate['phrase_span_beats']):.3f}",
+                str(candidate["max_active_notes"]),
+                f"{float(candidate['dead_air_ratio']):.4f}",
+                str(candidate["adjacent_pitch_repeats"]),
+                str(candidate["duplicated_3_note_pitch_class_chunks"]),
+                str(candidate["max_interval"]),
+                final_landing,
+                risks,
+            ]
+        )
+        + " |"
+    )
+    lines.extend(["", "## Proven", ""])
+    for item in report.get("proven", []):
+        lines.append(f"- `{item}`")
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Consolidate duration/coverage fill keep candidate evidence")
+    parser.add_argument("--filled_notes", type=str, required=True)
+    parser.add_argument("--duration_fill_summary", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_keep_consolidation",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--expected_candidate_id", type=str, default="")
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--require_not_human_audio_review", action="store_true")
+    parser.add_argument("--require_postprocess_claim_boundary", type=str, default="")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_keep_consolidation_report(
+        read_json(Path(args.filled_notes)),
+        read_json(Path(args.duration_fill_summary)),
+        output_dir=output_dir,
+    )
+    summary = validate_keep_consolidation(
+        report,
+        expected_candidate_id=str(args.expected_candidate_id or ""),
+        expected_boundary=str(args.expected_boundary or ""),
+        require_not_human_audio_review=bool(args.require_not_human_audio_review),
+        require_postprocess_claim_boundary=str(args.require_postprocess_claim_boundary or ""),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "duration_coverage_fill_keep_consolidation.json"
+    markdown_path = output_dir / "duration_coverage_fill_keep_consolidation.md"
+    write_json(report_path, report)
+    write_json(output_dir / "duration_coverage_fill_keep_consolidation_validation_summary.json", summary)
+    markdown_path.write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps({**summary, "report_path": str(report_path), "markdown_path": str(markdown_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_keep_consolidation.py
+++ b/tests/test_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_keep_consolidation.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.summarize_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_keep_consolidation import (
+    DurationCoverageFillKeepConsolidationError,
+    build_keep_consolidation_report,
+    validate_keep_consolidation,
+)
+
+
+def filled_notes(*, decision: str = "keep") -> dict:
+    return {
+        "schema_version": "stage_b_margin_recovered_phrase_vocabulary_focused_listening_fill_v1",
+        "candidates": [
+            {
+                "candidate_id": "duration_fill_candidate",
+                "review_metadata": {
+                    "mode": "margin_recovered_phrase_vocabulary_duration_coverage_fill_repair",
+                },
+                "review_files": {
+                    "midi_path": "outputs/solo.mid",
+                    "context_midi_path": "outputs/context.mid",
+                    "source_midi_path": "outputs/source.mid",
+                },
+                "listening": {
+                    "status": "reviewed",
+                    "timing": "acceptable",
+                    "chord_fit": "strong",
+                    "phrase_continuation": "acceptable",
+                    "landing": "strong",
+                    "jazz_vocabulary": "acceptable",
+                    "decision": decision,
+                },
+                "focused_context_metrics": {
+                    "note_count": 18,
+                    "unique_pitch_count": 15,
+                    "range": "D#4-G#5",
+                    "phrase_span_beats": 7.0,
+                    "dead_air_ratio": 0.29411764705882354,
+                    "onset_coverage_ratio": 0.5625,
+                    "sustained_coverage_ratio": 0.625,
+                    "adjacent_pitch_repeats": 0,
+                    "duplicated_3_note_pitch_class_chunks": 0,
+                    "max_simultaneous_notes": 1,
+                    "max_interval": 7,
+                    "final_note": "F4",
+                    "final_chord": "Fm7",
+                    "final_note_role": "chord_tone",
+                },
+                "review_risks": [],
+                "listening_fill_evidence": {
+                    "not_human_audio_review": True,
+                },
+            }
+        ],
+    }
+
+
+def duration_fill_summary() -> dict:
+    return {
+        "schema_version": "stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_repair_v1",
+        "variant_count": 4,
+        "qualified_variant_count": 2,
+        "source_candidate": {
+            "candidate_id": "source_candidate",
+            "metrics": {
+                "note_count": 15,
+                "dead_air_ratio": 0.5714285714285714,
+            },
+            "focused_solo_metrics": {
+                "focused_note_count": 12,
+                "focused_unique_pitch_count": 9,
+            },
+        },
+        "selected_candidate": {
+            "candidate_id": "duration_fill_candidate",
+            "metrics": {
+                "note_count": 18,
+                "dead_air_ratio": 0.29411764705882354,
+            },
+            "focused_solo_metrics": {
+                "focused_note_count": 18,
+                "focused_unique_pitch_count": 15,
+                "focused_adjacent_pitch_repeats": 0,
+                "focused_duplicated_3_note_pitch_class_chunks": 0,
+                "focused_max_interval": 7,
+            },
+            "fill_repair": {
+                "max_additions": 6,
+                "fill_addition_count": 6,
+            },
+            "duration_coverage_gate": {
+                "qualified": True,
+                "flags": [],
+            },
+        },
+        "repair_summary": {
+            "selected_candidate_id": "duration_fill_candidate",
+            "selected_fill_addition_count": 6,
+            "qualified": True,
+            "remaining_flags": [],
+            "baseline_dead_air_ratio": 0.5714285714285714,
+            "selected_dead_air_ratio": 0.29411764705882354,
+            "dead_air_delta_from_baseline": 0.277311,
+            "selected_adjacent_pitch_repeats": 0,
+            "selected_duplicated_3_note_pitch_class_chunks": 0,
+            "selected_max_interval": 7,
+            "duration_coverage_fill_improved": True,
+            "claim_boundary": "postprocess_duration_coverage_fill_candidate",
+        },
+    }
+
+
+class StageBMarginRecoveredPhraseVocabularyDurationCoverageFillKeepConsolidationTest(unittest.TestCase):
+    def test_builds_single_postprocess_keep_boundary(self) -> None:
+        report = build_keep_consolidation_report(
+            filled_notes(),
+            duration_fill_summary(),
+            output_dir=Path("outputs/keep_consolidation"),
+        )
+        summary = validate_keep_consolidation(
+            report,
+            expected_candidate_id="duration_fill_candidate",
+            expected_boundary="single_postprocess_candidate_keep_support",
+            require_not_human_audio_review=True,
+            require_postprocess_claim_boundary="postprocess_duration_coverage_fill_candidate",
+        )
+
+        self.assertEqual(summary["decision"], "keep")
+        self.assertEqual(summary["boundary"], "single_postprocess_candidate_keep_support")
+        self.assertEqual(summary["fill_addition_count"], 6)
+        self.assertEqual(summary["note_count"], 18)
+        self.assertEqual(summary["unique_pitch_count"], 15)
+        self.assertEqual(summary["adjacent_pitch_repeats"], 0)
+        self.assertEqual(summary["max_interval"], 7)
+        self.assertIn("human_audio_preference", report["not_proven"])
+
+    def test_rejects_non_matching_duration_candidate(self) -> None:
+        summary = duration_fill_summary()
+        summary["repair_summary"]["selected_candidate_id"] = "other_candidate"
+
+        with self.assertRaises(DurationCoverageFillKeepConsolidationError):
+            build_keep_consolidation_report(
+                filled_notes(),
+                summary,
+                output_dir=Path("outputs/keep_consolidation"),
+            )
+
+    def test_requires_keep_decision(self) -> None:
+        with self.assertRaises(DurationCoverageFillKeepConsolidationError):
+            build_keep_consolidation_report(
+                filled_notes(decision="needs_followup"),
+                duration_fill_summary(),
+                output_dir=Path("outputs/keep_consolidation"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- duration/coverage fill `keep` result consolidation
- single postprocess candidate evidence boundary 기록
- README, CORE_PLAN, CURRENT_STATUS handoff 갱신

## Context
- Issue #320 duration/coverage fill focused listening fill result: decision `keep`
- selected candidate: `margin_recovered_phrase_vocab_seed_353_topk_7_temp_082_n24_sample_3_duration_fill_maxadd_6`
- fill additions: `6`
- dead-air ratio: `0.5714 -> 0.2941`
- onset/sustained coverage: `0.5625` / `0.6250`
- claim boundary 필요: single postprocess candidate, not human/audio proof

## Scope
- keep consolidation summary script 추가
- unit test 추가
- harness mode `stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-keep-consolidation` 추가
- docs/README status 갱신

## Validation
- `.venv/bin/python -m unittest tests/test_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_keep_consolidation.py`
- `bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-keep-consolidation`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- human/audio preference 미검증
- broad trained-model quality 미검증
- Brad style adaptation 미검증
- broad repeatability 미검증

## Follow-up
- Stage B margin-recovered phrase/vocabulary duration coverage fill human/audio comparison boundary

Closes #322