### PR TITLE
Stage B margin-recovered phrase/vocabulary duration coverage fill external human/audio review boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #332, Stage B margin-recovered phrase/vocabulary duration coverage fill MIDI evidence review consolidation.
+- Latest functional issue completed: Issue #335, Stage B margin-recovered phrase/vocabulary duration coverage fill external human/audio review boundary.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill external human/audio review boundary.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render package.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -690,6 +690,14 @@ bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-duratio
 ```
 
 This harness consolidates MIDI evidence preference and keeps human/audio preference unclaimed.
+
+For Stage B margin-recovered phrase/vocabulary duration coverage fill external human/audio boundary changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-external-human-audio-boundary
+```
+
+This harness records the external review input requirement before any human/audio preference claim.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@
 | 외부 review 입력 준비 부족 | reviewer가 확인할 source/fill MIDI와 입력 schema가 분리됨 | audio review package 생성 | package status `ready_for_external_review_input`, required files `3`, preference claimed `false` |
 | MIDI evidence 기반 보고 필요 | source/fill MIDI를 사람이 듣기 전에도 구조 차이를 판단해야 함 | MIDI metric and note-structure review 실행 | preference `duration_coverage_fill_keep`, score delta `+79.731`, human/audio preference 미주장 |
 | MIDI evidence claim boundary 필요 | MIDI 기반 우세와 human/audio proof를 혼동할 가능성 | MIDI evidence consolidation 추가 | boundary `midi_evidence_preference_support`, human/audio preference claimed `false` |
+| human/audio claim 경계 필요 | MIDI evidence preference가 외부 청감 선호로 오해될 수 있음 | external human/audio boundary 추가 | boundary `external_human_audio_review_required_for_human_preference_claim`, status `pending_external_review_input` |
 
 ## 파이프라인 구조
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -111,6 +111,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered phrase/vocabulary duration coverage fill audio review package 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_AUDIO_REVIEW_PACKAGE_2026-05-29.md`
 - margin-recovered phrase/vocabulary duration coverage fill MIDI evidence review 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_MIDI_EVIDENCE_REVIEW_2026-05-29.md`
 - margin-recovered phrase/vocabulary duration coverage fill MIDI evidence consolidation 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_MIDI_EVIDENCE_CONSOLIDATION_2026-05-29.md`
+- margin-recovered phrase/vocabulary duration coverage fill external human/audio boundary 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_EXTERNAL_HUMAN_AUDIO_BOUNDARY_2026-05-29.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -160,6 +161,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered phrase/vocabulary duration coverage fill audio review package: status `ready_for_external_review_input`, required files `3`, preference claimed `false`
 - margin-recovered phrase/vocabulary duration coverage fill MIDI evidence review: preference `duration_coverage_fill_keep`, score delta `+79.731`, human/audio preference claimed `false`
 - margin-recovered phrase/vocabulary duration coverage fill MIDI evidence consolidation: boundary `midi_evidence_preference_support`, human/audio proof 미검증
+- margin-recovered phrase/vocabulary duration coverage fill external human/audio boundary: external review status `pending_external_review_input`, human/audio preference claimed `false`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #332, Stage B margin-recovered phrase/vocabulary duration coverage fill MIDI evidence review consolidation
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill external human/audio review boundary`
+- latest functional result: Issue #335, Stage B margin-recovered phrase/vocabulary duration coverage fill external human/audio review boundary
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render package`
 
 현재 범위가 아닌 것:
 
@@ -65,6 +65,38 @@ Issue #220은 현재 작업이 core인지, MVP 완료로 볼 수 있는지를 �
 Docs:
 
 - `docs/STAGE_B_MODEL_CORE_MVP_COMPLETION_AUDIT_2026-05-28.md`
+
+## Current Duration Coverage Fill External Human/Audio Boundary Result
+
+Issue #335는 Issue #332 MIDI evidence consolidation 이후 human/audio review claim 경계를 정리한 작업이다.
+
+변경:
+
+- external human/audio review boundary summary 추가
+- required external review input schema 정리
+- MIDI evidence preference와 human/audio preference claim 분리
+- pending external review 상태 검증
+
+결과:
+
+- source boundary: `midi_evidence_preference_support`
+- external boundary: `external_human_audio_review_required_for_human_preference_claim`
+- external review status: `pending_external_review_input`
+- MIDI evidence preference: `duration_coverage_fill_keep`
+- score delta fill-source: `+79.7311`
+- human/audio preference claimed: `false`
+- audio render used: `false`
+
+판단:
+
+- MIDI evidence preference는 review prioritization 근거로 한정
+- human/audio preference와 audio rendered quality는 external review input 전까지 미검증
+- broad trained-model quality와 Brad style adaptation은 아직 미검증
+
+다음:
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render package`
+- 외부 review input 확보 시 `Stage B margin-recovered phrase/vocabulary duration coverage fill external review input fill`
 
 ## Current Duration Coverage Fill MIDI Evidence Consolidation Result
 

--- a/docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_EXTERNAL_HUMAN_AUDIO_BOUNDARY_2026-05-29.md
+++ b/docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_EXTERNAL_HUMAN_AUDIO_BOUNDARY_2026-05-29.md
@@ -1,0 +1,71 @@
+# Stage B Margin-Recovered Phrase/Vocabulary Duration Coverage Fill External Human/Audio Boundary
+
+Issue #335는 Issue #332 MIDI evidence consolidation 이후 human/audio review claim 경계를 정리한 작업이다.
+
+## Context
+
+- Issue #332 boundary: `midi_evidence_preference_support`
+- MIDI evidence preference: `duration_coverage_fill_keep`
+- score delta fill-source: `+79.7311`
+- dead-air delta fill-source: `-0.2773`
+- focused note count delta: `+6`
+- focused unique pitch count delta: `+6`
+- max simultaneous notes delta: `-1`
+- human/audio preference claimed: `false`
+- audio rendered quality: 미검증
+
+## Change
+
+- external human/audio review boundary summary 추가
+- required external review input schema 정리
+- MIDI evidence preference와 human/audio preference claim 분리
+- pending external review 상태 검증
+- 전용 harness와 unit test 추가
+
+## Result
+
+| item | value |
+|---|---:|
+| source boundary | `midi_evidence_preference_support` |
+| external boundary | `external_human_audio_review_required_for_human_preference_claim` |
+| external review status | `pending_external_review_input` |
+| MIDI evidence preference | `duration_coverage_fill_keep` |
+| score delta fill-source | `+79.7311` |
+| human/audio preference claimed | `false` |
+| audio render used | `false` |
+
+## Required External Review Input
+
+- `reviewer`
+- `audio_render_used`
+- `preference`
+- `timing`
+- `phrase`
+- `vocabulary`
+- `notes`
+
+## Not Proven
+
+- human/audio preference
+- audio rendered quality
+- broad trained-model quality
+- Brad style adaptation
+- production-ready improviser
+
+## Validation
+
+```bash
+.venv/bin/python -m unittest tests/test_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_external_human_audio_boundary.py
+bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-external-human-audio-boundary
+```
+
+## Output
+
+- script: `scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_external_human_audio_boundary.py`
+- test: `tests/test_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_external_human_audio_boundary.py`
+- summary: `outputs/stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_external_human_audio_boundary/harness_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_external_human_audio_boundary/duration_coverage_fill_external_human_audio_boundary.json`
+
+## Next
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render package`
+- 외부 review input 확보 시 `Stage B margin-recovered phrase/vocabulary duration coverage fill external review input fill`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -1674,6 +1674,25 @@ run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_midi_evide
     --require_no_human_audio_preference
 }
 
+run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_external_human_audio_boundary() {
+  local consolidation_run_id="${CONSOLIDATION_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_midi_evidence_consolidation}"
+  local run_id="${RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_external_human_audio_boundary}"
+  local candidate_id="margin_recovered_phrase_vocab_seed_353_topk_7_temp_082_n24_sample_3_duration_fill_maxadd_6"
+  local midi_evidence_consolidation="outputs/stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_midi_evidence_consolidation/${consolidation_run_id}/duration_coverage_fill_midi_evidence_consolidation.json"
+  if [[ ! -f "$midi_evidence_consolidation" ]]; then
+    print_header "Stage B duration/coverage fill MIDI evidence consolidation"
+    RUN_ID="$consolidation_run_id" run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_midi_evidence_consolidation
+  fi
+  print_header "Stage B duration/coverage fill external human/audio boundary"
+  "$PYTHON_BIN" scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_external_human_audio_boundary.py \
+    --run_id "$run_id" \
+    --midi_evidence_consolidation "$midi_evidence_consolidation" \
+    --expected_candidate_id "$candidate_id" \
+    --expected_boundary external_human_audio_review_required_for_human_preference_claim \
+    --require_no_human_audio_preference \
+    --require_pending_external_review
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -2937,6 +2956,9 @@ case "$MODE" in
     ;;
   stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-midi-evidence-consolidation)
     run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_midi_evidence_consolidation
+    ;;
+  stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-external-human-audio-boundary)
+    run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_external_human_audio_boundary
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_external_human_audio_boundary.py
+++ b/scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_external_human_audio_boundary.py
@@ -1,0 +1,242 @@
+"""Summarize external human/audio review boundary for duration coverage fill evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class DurationCoverageFillExternalHumanAudioBoundaryError(ValueError):
+    pass
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def build_external_boundary_report(
+    midi_evidence_consolidation: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> dict[str, Any]:
+    source_claim = (
+        midi_evidence_consolidation.get("claim_boundary")
+        if isinstance(midi_evidence_consolidation.get("claim_boundary"), dict)
+        else {}
+    )
+    midi_summary = (
+        midi_evidence_consolidation.get("midi_evidence_summary")
+        if isinstance(midi_evidence_consolidation.get("midi_evidence_summary"), dict)
+        else {}
+    )
+    source_boundary = str(source_claim.get("boundary") or "")
+    preference = str(midi_summary.get("preference") or "")
+    if source_boundary != "midi_evidence_preference_support":
+        raise DurationCoverageFillExternalHumanAudioBoundaryError(f"unexpected source boundary: {source_boundary}")
+    if preference != "duration_coverage_fill_keep":
+        raise DurationCoverageFillExternalHumanAudioBoundaryError(f"unexpected MIDI evidence preference: {preference}")
+    if not bool(source_claim.get("midi_evidence_preference_claimed", False)):
+        raise DurationCoverageFillExternalHumanAudioBoundaryError("MIDI evidence preference must be claimed first")
+    if bool(source_claim.get("human_audio_preference_claimed", True)):
+        raise DurationCoverageFillExternalHumanAudioBoundaryError("human/audio preference must not be claimed")
+    return {
+        "schema_version": "stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_external_human_audio_boundary_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_midi_evidence_consolidation_schema": str(midi_evidence_consolidation.get("schema_version") or ""),
+        "candidate_id": str(midi_evidence_consolidation.get("candidate_id") or ""),
+        "decision_path": [
+            "duration_coverage_fill_repair",
+            "focused_context",
+            "focused_listening_fill",
+            "keep_consolidation",
+            "audio_review_package",
+            "midi_evidence_review",
+            "midi_evidence_consolidation",
+            "external_human_audio_boundary",
+        ],
+        "source_boundary": {
+            "boundary": source_boundary,
+            "preference": preference,
+            "midi_evidence_preference_claimed": bool(source_claim.get("midi_evidence_preference_claimed", False)),
+            "human_audio_preference_claimed": False,
+            "audio_render_used": bool(source_claim.get("audio_render_used", False)),
+        },
+        "midi_evidence_summary": {
+            "preference": preference,
+            "source_score": float(midi_summary.get("source_score", 0.0) or 0.0),
+            "fill_score": float(midi_summary.get("fill_score", 0.0) or 0.0),
+            "score_delta_fill_minus_source": float(midi_summary.get("score_delta_fill_minus_source", 0.0) or 0.0),
+            "dead_air_delta_fill_minus_source": float(midi_summary.get("dead_air_delta_fill_minus_source", 0.0) or 0.0),
+            "focused_note_count_delta_fill_minus_source": int(
+                midi_summary.get("focused_note_count_delta_fill_minus_source", 0) or 0
+            ),
+            "focused_unique_pitch_count_delta_fill_minus_source": int(
+                midi_summary.get("focused_unique_pitch_count_delta_fill_minus_source", 0) or 0
+            ),
+            "max_simultaneous_notes_delta_fill_minus_source": int(
+                midi_summary.get("max_simultaneous_notes_delta_fill_minus_source", 0) or 0
+            ),
+        },
+        "external_review_boundary": {
+            "boundary": "external_human_audio_review_required_for_human_preference_claim",
+            "status": "pending_external_review_input",
+            "reviewer_input_present": False,
+            "midi_evidence_preference_claimed": True,
+            "human_audio_preference_claimed": False,
+            "audio_render_used": False,
+            "requires_external_human_or_audio_review": True,
+        },
+        "required_review_input": {
+            "reviewer": {"required": True},
+            "audio_render_used": {"required": True, "allowed_values": [True]},
+            "preference": {
+                "required": True,
+                "allowed_values": [
+                    "source_constrained_partial",
+                    "duration_coverage_fill_keep",
+                    "no_preference",
+                    "needs_followup",
+                ],
+            },
+            "timing": {"required": True, "allowed_values": ["weak", "acceptable", "strong"]},
+            "phrase": {"required": True, "allowed_values": ["weak", "acceptable", "strong"]},
+            "vocabulary": {"required": True, "allowed_values": ["thin", "acceptable", "strong"]},
+            "notes": {"required": True},
+        },
+        "claim_policy": [
+            "MIDI evidence preference can support review prioritization only",
+            "human/audio preference requires validated external review input",
+            "audio rendered quality requires an audio render and reviewer notes",
+            "broad trained-model quality remains out of scope",
+        ],
+        "not_proven": [
+            "human_audio_preference",
+            "audio_rendered_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "production_ready_improviser",
+        ],
+        "next_recommended_issue": "Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render package",
+        "external_review_input_followup": "Stage B margin-recovered phrase/vocabulary duration coverage fill external review input fill",
+    }
+
+
+def validate_external_boundary(
+    report: dict[str, Any],
+    *,
+    expected_candidate_id: str | None,
+    expected_boundary: str | None,
+    require_no_human_audio_preference: bool,
+    require_pending_external_review: bool,
+) -> dict[str, Any]:
+    candidate_id = str(report.get("candidate_id") or "")
+    if expected_candidate_id and candidate_id != expected_candidate_id:
+        raise DurationCoverageFillExternalHumanAudioBoundaryError(
+            f"expected candidate {expected_candidate_id}, got {candidate_id}"
+        )
+    boundary = (
+        report.get("external_review_boundary")
+        if isinstance(report.get("external_review_boundary"), dict)
+        else {}
+    )
+    boundary_name = str(boundary.get("boundary") or "")
+    if expected_boundary and boundary_name != expected_boundary:
+        raise DurationCoverageFillExternalHumanAudioBoundaryError(
+            f"expected boundary {expected_boundary}, got {boundary_name}"
+        )
+    if require_no_human_audio_preference and bool(boundary.get("human_audio_preference_claimed", True)):
+        raise DurationCoverageFillExternalHumanAudioBoundaryError("human/audio preference must not be claimed")
+    if require_pending_external_review and str(boundary.get("status") or "") != "pending_external_review_input":
+        raise DurationCoverageFillExternalHumanAudioBoundaryError("external review input must remain pending")
+    summary = report.get("midi_evidence_summary") if isinstance(report.get("midi_evidence_summary"), dict) else {}
+    return {
+        "candidate_id": candidate_id,
+        "source_boundary": str(report.get("source_boundary", {}).get("boundary") or ""),
+        "external_boundary": boundary_name,
+        "external_review_status": str(boundary.get("status") or ""),
+        "midi_evidence_preference": str(summary.get("preference") or ""),
+        "score_delta_fill_minus_source": float(summary.get("score_delta_fill_minus_source", 0.0) or 0.0),
+        "human_audio_preference_claimed": bool(boundary.get("human_audio_preference_claimed", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["midi_evidence_summary"]
+    boundary = report["external_review_boundary"]
+    lines = [
+        "# Stage B Margin-Recovered Phrase/Vocabulary Duration Coverage Fill External Human/Audio Boundary",
+        "",
+        f"- candidate: `{report['candidate_id']}`",
+        f"- source boundary: `{report['source_boundary']['boundary']}`",
+        f"- external boundary: `{boundary['boundary']}`",
+        f"- external review status: `{boundary['status']}`",
+        f"- MIDI evidence preference: `{summary['preference']}`",
+        f"- score delta fill-source: `{summary['score_delta_fill_minus_source']:.3f}`",
+        f"- human/audio preference claimed: `{boundary['human_audio_preference_claimed']}`",
+        "",
+        "## Required Review Input",
+        "",
+    ]
+    for field, config in report.get("required_review_input", {}).items():
+        allowed = config.get("allowed_values") if isinstance(config, dict) else None
+        suffix = f", allowed `{allowed}`" if allowed else ""
+        lines.append(f"- `{field}`: required `{bool(config.get('required', False))}`{suffix}")
+    lines.extend(["", "## Claim Policy", ""])
+    for item in report.get("claim_policy", []):
+        lines.append(f"- {item}")
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Summarize external human/audio review boundary")
+    parser.add_argument("--midi_evidence_consolidation", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_external_human_audio_boundary",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--expected_candidate_id", type=str, default="")
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--require_no_human_audio_preference", action="store_true")
+    parser.add_argument("--require_pending_external_review", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_external_boundary_report(read_json(Path(args.midi_evidence_consolidation)), output_dir=output_dir)
+    summary = validate_external_boundary(
+        report,
+        expected_candidate_id=str(args.expected_candidate_id or ""),
+        expected_boundary=str(args.expected_boundary or ""),
+        require_no_human_audio_preference=bool(args.require_no_human_audio_preference),
+        require_pending_external_review=bool(args.require_pending_external_review),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "duration_coverage_fill_external_human_audio_boundary.json"
+    markdown_path = output_dir / "duration_coverage_fill_external_human_audio_boundary.md"
+    write_json(report_path, report)
+    write_json(output_dir / "duration_coverage_fill_external_human_audio_boundary_validation_summary.json", summary)
+    markdown_path.write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps({**summary, "report_path": str(report_path), "markdown_path": str(markdown_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_external_human_audio_boundary.py
+++ b/tests/test_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_external_human_audio_boundary.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.summarize_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_external_human_audio_boundary import (
+    DurationCoverageFillExternalHumanAudioBoundaryError,
+    build_external_boundary_report,
+    validate_external_boundary,
+)
+
+
+def midi_evidence_consolidation(
+    *,
+    source_boundary: str = "midi_evidence_preference_support",
+    human_audio_preference_claimed: bool = False,
+) -> dict:
+    return {
+        "schema_version": "stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_midi_evidence_consolidation_v1",
+        "candidate_id": "duration_fill_candidate",
+        "midi_evidence_summary": {
+            "preference": "duration_coverage_fill_keep",
+            "source_score": 91.857143,
+            "fill_score": 171.588235,
+            "score_delta_fill_minus_source": 79.731092,
+            "dead_air_delta_fill_minus_source": -0.277311,
+            "focused_note_count_delta_fill_minus_source": 6,
+            "focused_unique_pitch_count_delta_fill_minus_source": 6,
+            "max_simultaneous_notes_delta_fill_minus_source": -1,
+        },
+        "claim_boundary": {
+            "boundary": source_boundary,
+            "midi_evidence_preference_claimed": True,
+            "human_audio_preference_claimed": human_audio_preference_claimed,
+            "audio_render_used": False,
+        },
+    }
+
+
+class StageBMarginRecoveredPhraseVocabularyDurationCoverageFillExternalHumanAudioBoundaryTest(unittest.TestCase):
+    def test_summarizes_external_boundary_without_human_audio_claim(self) -> None:
+        report = build_external_boundary_report(
+            midi_evidence_consolidation(),
+            output_dir=Path("outputs/external_boundary"),
+        )
+        summary = validate_external_boundary(
+            report,
+            expected_candidate_id="duration_fill_candidate",
+            expected_boundary="external_human_audio_review_required_for_human_preference_claim",
+            require_no_human_audio_preference=True,
+            require_pending_external_review=True,
+        )
+
+        self.assertEqual(summary["source_boundary"], "midi_evidence_preference_support")
+        self.assertEqual(
+            summary["external_boundary"],
+            "external_human_audio_review_required_for_human_preference_claim",
+        )
+        self.assertEqual(summary["external_review_status"], "pending_external_review_input")
+        self.assertEqual(summary["midi_evidence_preference"], "duration_coverage_fill_keep")
+        self.assertFalse(summary["human_audio_preference_claimed"])
+        self.assertGreater(summary["score_delta_fill_minus_source"], 0.0)
+        self.assertIn("human_audio_preference", report["not_proven"])
+        self.assertTrue(report["required_review_input"]["audio_render_used"]["required"])
+
+    def test_rejects_source_human_audio_preference_claim(self) -> None:
+        with self.assertRaises(DurationCoverageFillExternalHumanAudioBoundaryError):
+            build_external_boundary_report(
+                midi_evidence_consolidation(human_audio_preference_claimed=True),
+                output_dir=Path("outputs/external_boundary"),
+            )
+
+    def test_rejects_unexpected_source_boundary(self) -> None:
+        with self.assertRaises(DurationCoverageFillExternalHumanAudioBoundaryError):
+            build_external_boundary_report(
+                midi_evidence_consolidation(source_boundary="pending_human_audio_review"),
+                output_dir=Path("outputs/external_boundary"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- duration/coverage fill 후보의 external human/audio review claim boundary 추가
- MIDI evidence preference와 human/audio preference claim 분리
- pending external review input guard 및 전용 harness 추가

## Context

- Issue #332 boundary: `midi_evidence_preference_support`
- MIDI evidence preference: `duration_coverage_fill_keep`
- score delta fill-source: `+79.7311`
- dead-air delta fill-source: `-0.2773`
- human/audio preference claimed: `false`
- audio rendered quality: 미검증

## Scope

- external human/audio boundary report script
- required review input schema: reviewer, audio_render_used, preference, timing, phrase, vocabulary, notes
- source boundary validation and human/audio preference claim rejection test
- harness mode: `stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-external-human-audio-boundary`
- README, CORE_PLAN, CURRENT_STATUS_AND_PLAN, AGENTS handoff 갱신

## Validation

- `.venv/bin/python -m unittest tests/test_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_external_human_audio_boundary.py`
- `bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-external-human-audio-boundary`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- `rg -n 'codex|Codex|코덱스' ...` no output

## Risk

- human/audio preference remains unclaimed without external review input
- audio rendered quality, broad trained-model quality, Brad style adaptation remain not proven

## Follow-up

- next primary boundary: `Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render package`
- external review input fill only after validated review input exists

Closes #335