### PR TITLE
Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #335, Stage B margin-recovered phrase/vocabulary duration coverage fill external human/audio review boundary.
+- Latest functional issue completed: Issue #337, Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render package.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render package.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render tooling setup.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -698,6 +698,14 @@ bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-duratio
 ```
 
 This harness records the external review input requirement before any human/audio preference claim.
+
+For Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render package changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-local-audio-render-package
+```
+
+This harness packages local audio render readiness without claiming rendered audio quality.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
 | MIDI evidence 기반 보고 필요 | source/fill MIDI를 사람이 듣기 전에도 구조 차이를 판단해야 함 | MIDI metric and note-structure review 실행 | preference `duration_coverage_fill_keep`, score delta `+79.731`, human/audio preference 미주장 |
 | MIDI evidence claim boundary 필요 | MIDI 기반 우세와 human/audio proof를 혼동할 가능성 | MIDI evidence consolidation 추가 | boundary `midi_evidence_preference_support`, human/audio preference claimed `false` |
 | human/audio claim 경계 필요 | MIDI evidence preference가 외부 청감 선호로 오해될 수 있음 | external human/audio boundary 추가 | boundary `external_human_audio_review_required_for_human_preference_claim`, status `pending_external_review_input` |
+| local audio render 준비 상태 불명확 | source/fill MIDI는 준비됐지만 WAV render tooling과 audio quality claim이 분리되지 않음 | local audio render package 추가 | planned outputs `2`, render attempted `false`, audio quality claim `false` |
 
 ## 파이프라인 구조
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -112,6 +112,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered phrase/vocabulary duration coverage fill MIDI evidence review 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_MIDI_EVIDENCE_REVIEW_2026-05-29.md`
 - margin-recovered phrase/vocabulary duration coverage fill MIDI evidence consolidation 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_MIDI_EVIDENCE_CONSOLIDATION_2026-05-29.md`
 - margin-recovered phrase/vocabulary duration coverage fill external human/audio boundary 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_EXTERNAL_HUMAN_AUDIO_BOUNDARY_2026-05-29.md`
+- margin-recovered phrase/vocabulary duration coverage fill local audio render package 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_LOCAL_AUDIO_RENDER_PACKAGE_2026-05-29.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -162,6 +163,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered phrase/vocabulary duration coverage fill MIDI evidence review: preference `duration_coverage_fill_keep`, score delta `+79.731`, human/audio preference claimed `false`
 - margin-recovered phrase/vocabulary duration coverage fill MIDI evidence consolidation: boundary `midi_evidence_preference_support`, human/audio proof 미검증
 - margin-recovered phrase/vocabulary duration coverage fill external human/audio boundary: external review status `pending_external_review_input`, human/audio preference claimed `false`
+- margin-recovered phrase/vocabulary duration coverage fill local audio render package: planned audio outputs `2`, render attempted `false`, audio quality claim `false`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #335, Stage B margin-recovered phrase/vocabulary duration coverage fill external human/audio review boundary
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render package`
+- latest functional result: Issue #337, Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render package
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render tooling setup`
 
 현재 범위가 아닌 것:
 
@@ -65,6 +65,39 @@ Issue #220은 현재 작업이 core인지, MVP 완료로 볼 수 있는지를 �
 Docs:
 
 - `docs/STAGE_B_MODEL_CORE_MVP_COMPLETION_AUDIT_2026-05-28.md`
+
+## Current Duration Coverage Fill Local Audio Render Package Result
+
+Issue #337은 Issue #335 external human/audio boundary 이후 local audio render 준비 상태를 정리한 작업이다.
+
+변경:
+
+- local audio render package script 추가
+- source/fill MIDI와 planned WAV output path 정리
+- renderer/soundfont availability probe 기록
+- render attempt와 audio quality claim 분리
+
+결과:
+
+- package boundary: local audio render package
+- render status: environment-dependent, current local probe `renderer_unavailable`
+- planned audio outputs: `2`
+- render attempted: `false`
+- rendered audio file count: `0`
+- audio output claimed: `false`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+
+판단:
+
+- audio render 대상 MIDI와 planned WAV path는 정리됨
+- renderer/soundfont 준비 전까지 audio quality와 human/audio preference는 미검증
+- generated audio artifact는 commit 대상에서 제외
+
+다음:
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render tooling setup`
+- renderer/soundfont 준비 후 `Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render attempt`
 
 ## Current Duration Coverage Fill External Human/Audio Boundary Result
 

--- a/docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_LOCAL_AUDIO_RENDER_PACKAGE_2026-05-29.md
+++ b/docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_LOCAL_AUDIO_RENDER_PACKAGE_2026-05-29.md
@@ -1,0 +1,60 @@
+# Stage B Margin-Recovered Phrase/Vocabulary Duration Coverage Fill Local Audio Render Package
+
+Issue #337은 Issue #335 external human/audio boundary 이후 local audio render 준비 상태를 정리한 작업이다.
+
+## Context
+
+- Issue #335 external boundary: `external_human_audio_review_required_for_human_preference_claim`
+- external review status: `pending_external_review_input`
+- MIDI evidence preference: `duration_coverage_fill_keep`
+- human/audio preference claimed: `false`
+- audio rendered quality: 미검증
+- local environment probe: `fluidsynth` 미탐지, `timidity` 미탐지
+
+## Change
+
+- local audio render package script 추가
+- source/fill MIDI와 planned WAV output path 정리
+- renderer/soundfont availability probe 기록
+- render attempt와 audio quality claim 분리
+- 전용 harness와 unit test 추가
+
+## Result
+
+| item | value |
+|---|---:|
+| package boundary | local audio render package |
+| render status | environment-dependent, current local probe `renderer_unavailable` |
+| planned audio outputs | `2` |
+| render attempted | `false` |
+| rendered audio file count | `0` |
+| audio output claimed | `false` |
+| audio rendered quality claimed | `false` |
+| human/audio preference claimed | `false` |
+
+## Not Proven
+
+- audio rendered quality
+- human/audio preference
+- broad trained-model quality
+- Brad style adaptation
+- production-ready improviser
+
+## Validation
+
+```bash
+.venv/bin/python -m unittest tests/test_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_local_audio_render_package.py
+bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-local-audio-render-package
+```
+
+## Output
+
+- script: `scripts/build_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_local_audio_render_package.py`
+- test: `tests/test_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_local_audio_render_package.py`
+- summary: `outputs/stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_local_audio_render_package/harness_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_local_audio_render_package/duration_coverage_fill_local_audio_render_package.json`
+
+## Next
+
+- renderer/soundfont 준비 전: `Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render tooling setup`
+- renderer/soundfont 준비 후: `Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render attempt`
+- audio render 확보 후: `Stage B margin-recovered phrase/vocabulary duration coverage fill external review input fill`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -1693,6 +1693,31 @@ run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_external_h
     --require_pending_external_review
 }
 
+run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_local_audio_render_package() {
+  local external_boundary_run_id="${EXTERNAL_BOUNDARY_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_external_human_audio_boundary}"
+  local audio_package_run_id="${AUDIO_PACKAGE_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_audio_review_package}"
+  local run_id="${RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_local_audio_render_package}"
+  local candidate_id="margin_recovered_phrase_vocab_seed_353_topk_7_temp_082_n24_sample_3_duration_fill_maxadd_6"
+  local external_boundary="outputs/stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_external_human_audio_boundary/${external_boundary_run_id}/duration_coverage_fill_external_human_audio_boundary.json"
+  local audio_review_package="outputs/stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_audio_review_package/${audio_package_run_id}/duration_coverage_fill_audio_review_package.json"
+  if [[ ! -f "$external_boundary" ]]; then
+    print_header "Stage B duration/coverage fill external human/audio boundary"
+    RUN_ID="$external_boundary_run_id" run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_external_human_audio_boundary
+  fi
+  if [[ ! -f "$audio_review_package" ]]; then
+    print_header "Stage B duration/coverage fill audio review package"
+    RUN_ID="$audio_package_run_id" run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_audio_review_package
+  fi
+  print_header "Stage B duration/coverage fill local audio render package"
+  "$PYTHON_BIN" scripts/build_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_local_audio_render_package.py \
+    --run_id "$run_id" \
+    --external_human_audio_boundary "$external_boundary" \
+    --audio_review_package "$audio_review_package" \
+    --expected_candidate_id "$candidate_id" \
+    --require_required_midi_exists \
+    --require_no_audio_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -2959,6 +2984,9 @@ case "$MODE" in
     ;;
   stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-external-human-audio-boundary)
     run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_external_human_audio_boundary
+    ;;
+  stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-local-audio-render-package)
+    run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_local_audio_render_package
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/build_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_local_audio_render_package.py
+++ b/scripts/build_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_local_audio_render_package.py
@@ -1,0 +1,355 @@
+"""Build local audio render package metadata for duration coverage fill review."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class DurationCoverageFillLocalAudioRenderPackageError(ValueError):
+    pass
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def file_meta(path: str, *, required: bool) -> dict[str, Any]:
+    if not path:
+        return {
+            "path": "",
+            "required": required,
+            "exists": False,
+            "size_bytes": 0,
+        }
+    target = Path(path)
+    exists = target.exists()
+    if required and not exists:
+        raise DurationCoverageFillLocalAudioRenderPackageError(f"required file not found: {path}")
+    return {
+        "path": path,
+        "required": required,
+        "exists": exists,
+        "size_bytes": int(target.stat().st_size) if exists else 0,
+    }
+
+
+def resolve_tool(name: str, renderer_paths: dict[str, str] | None) -> str:
+    if renderer_paths and name in renderer_paths:
+        return str(renderer_paths.get(name) or "")
+    return shutil.which(name) or ""
+
+
+def renderer_probe(
+    *,
+    requested_renderer: str,
+    soundfont_path: str,
+    renderer_paths: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    fluidsynth_path = resolve_tool("fluidsynth", renderer_paths)
+    timidity_path = resolve_tool("timidity", renderer_paths)
+    selected = ""
+    status = "renderer_unavailable"
+    soundfont = Path(soundfont_path) if soundfont_path else None
+    soundfont_exists = bool(soundfont and soundfont.exists())
+    if requested_renderer:
+        if requested_renderer == "fluidsynth":
+            selected = fluidsynth_path
+            status = "ready_for_local_render" if selected and soundfont_exists else "soundfont_missing"
+        elif requested_renderer == "timidity":
+            selected = timidity_path
+            status = "ready_for_local_render" if selected else "renderer_unavailable"
+        else:
+            raise DurationCoverageFillLocalAudioRenderPackageError(f"unsupported renderer: {requested_renderer}")
+    elif fluidsynth_path:
+        selected = fluidsynth_path
+        status = "ready_for_local_render" if soundfont_exists else "soundfont_missing"
+    elif timidity_path:
+        selected = timidity_path
+        status = "ready_for_local_render"
+    return {
+        "requested_renderer": requested_renderer,
+        "selected_renderer": selected,
+        "selected_renderer_name": "fluidsynth" if selected == fluidsynth_path and fluidsynth_path else "timidity"
+        if selected == timidity_path and timidity_path
+        else "",
+        "fluidsynth_path": fluidsynth_path,
+        "timidity_path": timidity_path,
+        "soundfont_path": str(soundfont_path or ""),
+        "soundfont_exists": soundfont_exists,
+        "status": status,
+    }
+
+
+def validate_external_boundary(external_boundary: dict[str, Any]) -> None:
+    boundary = (
+        external_boundary.get("external_review_boundary")
+        if isinstance(external_boundary.get("external_review_boundary"), dict)
+        else {}
+    )
+    if str(boundary.get("boundary") or "") != "external_human_audio_review_required_for_human_preference_claim":
+        raise DurationCoverageFillLocalAudioRenderPackageError("unexpected external review boundary")
+    if str(boundary.get("status") or "") != "pending_external_review_input":
+        raise DurationCoverageFillLocalAudioRenderPackageError("external review input must remain pending")
+    if bool(boundary.get("human_audio_preference_claimed", True)):
+        raise DurationCoverageFillLocalAudioRenderPackageError("human/audio preference must not be claimed")
+
+
+def validate_audio_review_package(audio_review_package: dict[str, Any]) -> None:
+    boundary = (
+        audio_review_package.get("package_boundary")
+        if isinstance(audio_review_package.get("package_boundary"), dict)
+        else {}
+    )
+    if str(boundary.get("status") or "") != "ready_for_external_review_input":
+        raise DurationCoverageFillLocalAudioRenderPackageError("audio review package must be ready")
+    if bool(boundary.get("preference_claimed", True)):
+        raise DurationCoverageFillLocalAudioRenderPackageError("preference must not be claimed")
+    items = audio_review_package.get("review_items")
+    if not isinstance(items, list) or len(items) != 2:
+        raise DurationCoverageFillLocalAudioRenderPackageError("audio review package must contain two review items")
+
+
+def compact_review_item(item: dict[str, Any]) -> dict[str, Any]:
+    role = str(item.get("role") or "")
+    midi_file = item.get("midi_file") if isinstance(item.get("midi_file"), dict) else {}
+    context_file = item.get("context_midi_file") if isinstance(item.get("context_midi_file"), dict) else {}
+    return {
+        "role": role,
+        "candidate_id": str(item.get("candidate_id") or ""),
+        "midi_file": file_meta(str(midi_file.get("path") or ""), required=bool(midi_file.get("required", False))),
+        "context_midi_file": file_meta(
+            str(context_file.get("path") or ""), required=bool(context_file.get("required", False))
+        ),
+        "metric_summary": dict(item.get("metric_summary") or {}),
+    }
+
+
+def render_command(probe: dict[str, Any], midi_path: str, output_wav_path: str) -> list[str]:
+    renderer_name = str(probe.get("selected_renderer_name") or "")
+    renderer = str(probe.get("selected_renderer") or "")
+    if str(probe.get("status") or "") != "ready_for_local_render" or not renderer:
+        return []
+    if renderer_name == "fluidsynth":
+        return [
+            renderer,
+            "-ni",
+            str(probe.get("soundfont_path") or ""),
+            midi_path,
+            "-F",
+            output_wav_path,
+            "-r",
+            "44100",
+        ]
+    if renderer_name == "timidity":
+        return [renderer, midi_path, "-Ow", "-o", output_wav_path]
+    return []
+
+
+def build_local_audio_render_package(
+    external_boundary: dict[str, Any],
+    audio_review_package: dict[str, Any],
+    *,
+    output_dir: Path,
+    requested_renderer: str = "",
+    soundfont_path: str = "",
+    renderer_paths: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    validate_external_boundary(external_boundary)
+    validate_audio_review_package(audio_review_package)
+    candidate_id = str(audio_review_package.get("candidate_id") or "")
+    probe = renderer_probe(
+        requested_renderer=requested_renderer,
+        soundfont_path=soundfont_path,
+        renderer_paths=renderer_paths,
+    )
+    items = [compact_review_item(item) for item in audio_review_package["review_items"]]
+    planned_outputs = []
+    for item in items:
+        output_wav_path = output_dir / "audio" / f"{item['role']}.wav"
+        planned_outputs.append(
+            {
+                "role": item["role"],
+                "candidate_id": item["candidate_id"],
+                "source_midi_path": item["midi_file"]["path"],
+                "planned_wav_path": str(output_wav_path),
+                "planned_wav_exists": output_wav_path.exists(),
+                "render_command": render_command(probe, item["midi_file"]["path"], str(output_wav_path)),
+            }
+        )
+    return {
+        "schema_version": "stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_local_audio_render_package_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_external_boundary_schema": str(external_boundary.get("schema_version") or ""),
+        "source_audio_review_package_schema": str(audio_review_package.get("schema_version") or ""),
+        "candidate_id": candidate_id,
+        "review_items": items,
+        "renderer_probe": probe,
+        "planned_audio_outputs": planned_outputs,
+        "local_audio_render_boundary": {
+            "status": str(probe["status"]),
+            "render_attempted": False,
+            "rendered_audio_file_count": 0,
+            "audio_output_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "human_audio_preference_claimed": False,
+        },
+        "not_proven": [
+            "audio_rendered_quality",
+            "human_audio_preference",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "production_ready_improviser",
+        ],
+        "next_recommended_issue": "Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render attempt"
+        if str(probe["status"]) == "ready_for_local_render"
+        else "Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render tooling setup",
+    }
+
+
+def validate_local_audio_render_package(
+    report: dict[str, Any],
+    *,
+    expected_candidate_id: str | None,
+    expected_status: str | None,
+    require_required_midi_exists: bool,
+    require_no_audio_claim: bool,
+) -> dict[str, Any]:
+    candidate_id = str(report.get("candidate_id") or "")
+    if expected_candidate_id and candidate_id != expected_candidate_id:
+        raise DurationCoverageFillLocalAudioRenderPackageError(
+            f"expected candidate {expected_candidate_id}, got {candidate_id}"
+        )
+    boundary = (
+        report.get("local_audio_render_boundary")
+        if isinstance(report.get("local_audio_render_boundary"), dict)
+        else {}
+    )
+    status = str(boundary.get("status") or "")
+    if expected_status and status != expected_status:
+        raise DurationCoverageFillLocalAudioRenderPackageError(f"expected status {expected_status}, got {status}")
+    if require_no_audio_claim:
+        claimed = [
+            bool(boundary.get("audio_output_claimed", True)),
+            bool(boundary.get("audio_rendered_quality_claimed", True)),
+            bool(boundary.get("human_audio_preference_claimed", True)),
+        ]
+        if any(claimed):
+            raise DurationCoverageFillLocalAudioRenderPackageError("audio or human preference must not be claimed")
+    if require_required_midi_exists:
+        missing = []
+        for item in report.get("review_items", []):
+            for key in ("midi_file", "context_midi_file"):
+                file_info = item.get(key) if isinstance(item.get(key), dict) else {}
+                if bool(file_info.get("required", False)) and not bool(file_info.get("exists", False)):
+                    missing.append(str(file_info.get("path") or key))
+        if missing:
+            raise DurationCoverageFillLocalAudioRenderPackageError(f"missing required MIDI files: {missing}")
+    return {
+        "candidate_id": candidate_id,
+        "render_status": status,
+        "selected_renderer_name": str(report.get("renderer_probe", {}).get("selected_renderer_name") or ""),
+        "planned_audio_output_count": len(report.get("planned_audio_outputs", [])),
+        "render_attempted": bool(boundary.get("render_attempted", True)),
+        "audio_rendered_quality_claimed": bool(boundary.get("audio_rendered_quality_claimed", True)),
+        "human_audio_preference_claimed": bool(boundary.get("human_audio_preference_claimed", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    boundary = report["local_audio_render_boundary"]
+    probe = report["renderer_probe"]
+    lines = [
+        "# Stage B Margin-Recovered Phrase/Vocabulary Duration Coverage Fill Local Audio Render Package",
+        "",
+        f"- candidate: `{report['candidate_id']}`",
+        f"- render status: `{boundary['status']}`",
+        f"- selected renderer: `{probe['selected_renderer_name']}`",
+        f"- soundfont exists: `{probe['soundfont_exists']}`",
+        f"- render attempted: `{boundary['render_attempted']}`",
+        f"- audio rendered quality claimed: `{boundary['audio_rendered_quality_claimed']}`",
+        f"- human/audio preference claimed: `{boundary['human_audio_preference_claimed']}`",
+        "",
+        "| role | MIDI exists | planned WAV | command ready |",
+        "|---|:---:|---|:---:|",
+    ]
+    for item in report.get("planned_audio_outputs", []):
+        command_ready = bool(item.get("render_command"))
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(item.get("role") or ""),
+                    str(Path(str(item.get("source_midi_path") or "")).exists()),
+                    str(item.get("planned_wav_path") or ""),
+                    str(command_ready),
+                ]
+            )
+            + " |"
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build local audio render package metadata")
+    parser.add_argument("--external_human_audio_boundary", type=str, required=True)
+    parser.add_argument("--audio_review_package", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_local_audio_render_package",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--renderer", type=str, default="")
+    parser.add_argument("--soundfont", type=str, default="")
+    parser.add_argument("--expected_candidate_id", type=str, default="")
+    parser.add_argument("--expected_status", type=str, default="")
+    parser.add_argument("--require_required_midi_exists", action="store_true")
+    parser.add_argument("--require_no_audio_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_local_audio_render_package(
+        read_json(Path(args.external_human_audio_boundary)),
+        read_json(Path(args.audio_review_package)),
+        output_dir=output_dir,
+        requested_renderer=str(args.renderer or ""),
+        soundfont_path=str(args.soundfont or ""),
+    )
+    summary = validate_local_audio_render_package(
+        report,
+        expected_candidate_id=str(args.expected_candidate_id or ""),
+        expected_status=str(args.expected_status or ""),
+        require_required_midi_exists=bool(args.require_required_midi_exists),
+        require_no_audio_claim=bool(args.require_no_audio_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "duration_coverage_fill_local_audio_render_package.json"
+    markdown_path = output_dir / "duration_coverage_fill_local_audio_render_package.md"
+    write_json(report_path, report)
+    write_json(output_dir / "duration_coverage_fill_local_audio_render_package_validation_summary.json", summary)
+    markdown_path.write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps({**summary, "report_path": str(report_path), "markdown_path": str(markdown_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_local_audio_render_package.py
+++ b/tests/test_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_local_audio_render_package.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import stat
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pretty_midi
+
+from scripts.build_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_local_audio_render_package import (
+    DurationCoverageFillLocalAudioRenderPackageError,
+    build_local_audio_render_package,
+    validate_local_audio_render_package,
+)
+
+
+def write_midi(path: Path, pitch: int) -> None:
+    midi = pretty_midi.PrettyMIDI(initial_tempo=124)
+    piano = pretty_midi.Instrument(program=0, is_drum=False, name="solo")
+    piano.notes.append(pretty_midi.Note(velocity=76, pitch=pitch, start=0.0, end=0.2))
+    midi.instruments.append(piano)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    midi.write(str(path))
+
+
+def external_boundary() -> dict:
+    return {
+        "schema_version": "stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_external_human_audio_boundary_v1",
+        "external_review_boundary": {
+            "boundary": "external_human_audio_review_required_for_human_preference_claim",
+            "status": "pending_external_review_input",
+            "human_audio_preference_claimed": False,
+        },
+    }
+
+
+def audio_review_package(root: Path) -> dict:
+    source_path = root / "source.mid"
+    fill_path = root / "fill.mid"
+    context_path = root / "fill_context.mid"
+    write_midi(source_path, 60)
+    write_midi(fill_path, 64)
+    write_midi(context_path, 67)
+    return {
+        "schema_version": "stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_audio_review_package_v1",
+        "candidate_id": "duration_fill_candidate",
+        "review_items": [
+            {
+                "role": "source_constrained_partial",
+                "candidate_id": "source_candidate",
+                "midi_file": {"path": str(source_path), "required": True},
+                "context_midi_file": {"path": "", "required": False},
+                "metric_summary": {"note_count": 1},
+            },
+            {
+                "role": "duration_coverage_fill_keep",
+                "candidate_id": "duration_fill_candidate",
+                "midi_file": {"path": str(fill_path), "required": True},
+                "context_midi_file": {"path": str(context_path), "required": True},
+                "metric_summary": {"note_count": 1},
+            },
+        ],
+        "package_boundary": {
+            "status": "ready_for_external_review_input",
+            "preference_claimed": False,
+        },
+    }
+
+
+def fake_executable(path: Path) -> None:
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+class StageBMarginRecoveredPhraseVocabularyDurationCoverageFillLocalAudioRenderPackageTest(unittest.TestCase):
+    def test_records_renderer_unavailable_without_audio_claim(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            report = build_local_audio_render_package(
+                external_boundary(),
+                audio_review_package(root),
+                output_dir=root / "render_package",
+                renderer_paths={"fluidsynth": "", "timidity": ""},
+            )
+            summary = validate_local_audio_render_package(
+                report,
+                expected_candidate_id="duration_fill_candidate",
+                expected_status="renderer_unavailable",
+                require_required_midi_exists=True,
+                require_no_audio_claim=True,
+            )
+
+            self.assertEqual(summary["render_status"], "renderer_unavailable")
+            self.assertEqual(summary["planned_audio_output_count"], 2)
+            self.assertFalse(summary["render_attempted"])
+            self.assertFalse(summary["audio_rendered_quality_claimed"])
+            self.assertFalse(summary["human_audio_preference_claimed"])
+            self.assertEqual(report["planned_audio_outputs"][0]["render_command"], [])
+
+    def test_records_ready_command_when_renderer_and_soundfont_exist(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            soundfont = root / "piano.sf2"
+            fake_executable(renderer)
+            soundfont.write_bytes(b"sf2")
+            report = build_local_audio_render_package(
+                external_boundary(),
+                audio_review_package(root),
+                output_dir=root / "render_package",
+                requested_renderer="fluidsynth",
+                soundfont_path=str(soundfont),
+                renderer_paths={"fluidsynth": str(renderer), "timidity": ""},
+            )
+            summary = validate_local_audio_render_package(
+                report,
+                expected_candidate_id="duration_fill_candidate",
+                expected_status="ready_for_local_render",
+                require_required_midi_exists=True,
+                require_no_audio_claim=True,
+            )
+
+            self.assertEqual(summary["selected_renderer_name"], "fluidsynth")
+            self.assertTrue(report["planned_audio_outputs"][0]["render_command"])
+            self.assertIn(str(soundfont), report["planned_audio_outputs"][0]["render_command"])
+
+    def test_rejects_external_human_audio_preference_claim(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            boundary = external_boundary()
+            boundary["external_review_boundary"]["human_audio_preference_claimed"] = True
+            with self.assertRaises(DurationCoverageFillLocalAudioRenderPackageError):
+                build_local_audio_render_package(
+                    boundary,
+                    audio_review_package(Path(temp_dir)),
+                    output_dir=Path(temp_dir) / "render_package",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- duration/coverage fill source/fill MIDI의 local audio render package 추가
- planned WAV output path와 renderer/soundfont availability 기록
- render attempt, audio quality claim, human/audio preference claim 분리

## Context

- Issue #335 external boundary: `external_human_audio_review_required_for_human_preference_claim`
- external review status: `pending_external_review_input`
- MIDI evidence preference: `duration_coverage_fill_keep`
- human/audio preference claimed: `false`
- local probe: `fluidsynth` unavailable, `timidity` unavailable

## Scope

- local audio render package script
- source/fill MIDI manifest and planned WAV outputs
- renderer availability detection: fluidsynth, timidity, optional soundfont
- no-audio-claim validation guard
- harness mode: `stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-local-audio-render-package`
- README, CORE_PLAN, CURRENT_STATUS_AND_PLAN, AGENTS handoff 갱신

## Validation

- `.venv/bin/python -m unittest tests/test_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_local_audio_render_package.py`
- `bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-local-audio-render-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- `rg -n 'codex|Codex|코덱스' ...` no output

## Risk

- current local render status: `renderer_unavailable`
- render attempted: `false`
- audio rendered quality claimed: `false`
- human/audio preference claimed: `false`
- generated audio artifacts remain excluded from commit scope

## Follow-up

- next primary boundary: `Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render tooling setup`
- renderer/soundfont 준비 후 local audio render attempt
- audio render 확보 후 external review input fill

Closes #337