### PR TITLE
Stage B local audio render tooling setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #337, Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render package.
+- Latest functional issue completed: Issue #339, Stage B local audio render tooling setup.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render tooling setup.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill renderer path decision.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -706,6 +706,14 @@ bash scripts/agent_harness.sh stage-b-margin-recovered-phrase-vocabulary-duratio
 ```
 
 This harness packages local audio render readiness without claiming rendered audio quality.
+
+For Stage B local audio render tooling setup changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-local-audio-render-tooling
+```
+
+This harness checks renderer/soundfont readiness without installing packages or rendering audio.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@
 | MIDI evidence claim boundary 필요 | MIDI 기반 우세와 human/audio proof를 혼동할 가능성 | MIDI evidence consolidation 추가 | boundary `midi_evidence_preference_support`, human/audio preference claimed `false` |
 | human/audio claim 경계 필요 | MIDI evidence preference가 외부 청감 선호로 오해될 수 있음 | external human/audio boundary 추가 | boundary `external_human_audio_review_required_for_human_preference_claim`, status `pending_external_review_input` |
 | local audio render 준비 상태 불명확 | source/fill MIDI는 준비됐지만 WAV render tooling과 audio quality claim이 분리되지 않음 | local audio render package 추가 | planned outputs `2`, render attempted `false`, audio quality claim `false` |
+| renderer/soundfont 준비 상태 불명확 | local render package는 준비됐지만 renderer가 없는 환경에서 render attempt를 진행할 위험 | tooling readiness check 추가 | `fluidsynth`/`timidity` 미탐지, system modification `false`, render attempted `false` |
 
 ## 파이프라인 구조
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -113,6 +113,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered phrase/vocabulary duration coverage fill MIDI evidence consolidation 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_MIDI_EVIDENCE_CONSOLIDATION_2026-05-29.md`
 - margin-recovered phrase/vocabulary duration coverage fill external human/audio boundary 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_EXTERNAL_HUMAN_AUDIO_BOUNDARY_2026-05-29.md`
 - margin-recovered phrase/vocabulary duration coverage fill local audio render package 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_LOCAL_AUDIO_RENDER_PACKAGE_2026-05-29.md`
+- local audio render tooling setup 문서: `docs/STAGE_B_LOCAL_AUDIO_RENDER_TOOLING_SETUP_2026-05-29.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -164,6 +165,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered phrase/vocabulary duration coverage fill MIDI evidence consolidation: boundary `midi_evidence_preference_support`, human/audio proof 미검증
 - margin-recovered phrase/vocabulary duration coverage fill external human/audio boundary: external review status `pending_external_review_input`, human/audio preference claimed `false`
 - margin-recovered phrase/vocabulary duration coverage fill local audio render package: planned audio outputs `2`, render attempted `false`, audio quality claim `false`
+- local audio render tooling setup: renderer `unavailable`, system modification `false`, audio render attempted `false`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #337, Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render package
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render tooling setup`
+- latest functional result: Issue #339, Stage B local audio render tooling setup
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill renderer path decision`
 
 현재 범위가 아닌 것:
 
@@ -65,6 +65,38 @@ Issue #220은 현재 작업이 core인지, MVP 완료로 볼 수 있는지를 �
 Docs:
 
 - `docs/STAGE_B_MODEL_CORE_MVP_COMPLETION_AUDIT_2026-05-28.md`
+
+## Current Local Audio Render Tooling Setup Result
+
+Issue #339는 local audio render attempt 전 renderer/soundfont readiness를 점검한 작업이다.
+
+변경:
+
+- local audio render tooling readiness script 추가
+- renderer/soundfont probe summary 추가
+- system modification, package install, download, audio render attempt를 모두 `false`로 검증
+
+결과:
+
+- tooling status: current local probe `renderer_unavailable`
+- fluidsynth available: `false`
+- timidity available: `false`
+- soundfont exists: `false`
+- system modified: `false`
+- package install executed: `false`
+- download executed: `false`
+- audio render attempted: `false`
+
+판단:
+
+- renderer/soundfont 준비 전 audio render attempt 금지
+- package manager install 자동 실행 제외
+- audio rendered quality와 human/audio preference는 미검증 유지
+
+다음:
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill renderer path decision`
+- renderer/soundfont 준비 후 `Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render attempt`
 
 ## Current Duration Coverage Fill Local Audio Render Package Result
 

--- a/docs/STAGE_B_LOCAL_AUDIO_RENDER_TOOLING_SETUP_2026-05-29.md
+++ b/docs/STAGE_B_LOCAL_AUDIO_RENDER_TOOLING_SETUP_2026-05-29.md
@@ -1,0 +1,57 @@
+# Stage B Local Audio Render Tooling Setup
+
+Issue #339는 local audio render attempt 전 renderer/soundfont readiness를 점검한 작업이다.
+
+## Context
+
+- Issue #337 local audio render package 완료
+- current local render status: `renderer_unavailable`
+- planned audio outputs: `2`
+- render attempted: `false`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+
+## Change
+
+- local audio render tooling readiness script 추가
+- renderer/soundfont probe summary 추가
+- system modification, package install, download, audio render attempt를 모두 `false`로 검증
+- 전용 harness와 unit test 추가
+
+## Result
+
+| item | value |
+|---|---:|
+| tooling status | current local probe `renderer_unavailable` |
+| fluidsynth available | `false` |
+| timidity available | `false` |
+| soundfont exists | `false` |
+| system modified | `false` |
+| package install executed | `false` |
+| download executed | `false` |
+| audio render attempted | `false` |
+
+## Boundary
+
+- renderer/soundfont 준비 전 audio render attempt 금지
+- package manager install 자동 실행 제외
+- generated audio artifact commit 제외
+- audio rendered quality와 human/audio preference 미검증 유지
+
+## Validation
+
+```bash
+.venv/bin/python -m unittest tests/test_stage_b_local_audio_render_tooling.py
+bash scripts/agent_harness.sh stage-b-local-audio-render-tooling
+```
+
+## Output
+
+- script: `scripts/check_stage_b_local_audio_render_tooling.py`
+- test: `tests/test_stage_b_local_audio_render_tooling.py`
+- summary: `outputs/stage_b_local_audio_render_tooling/harness_stage_b_local_audio_render_tooling/stage_b_local_audio_render_tooling.json`
+
+## Next
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill renderer path decision`
+- renderer/soundfont 준비 후 `Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render attempt`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -1718,6 +1718,14 @@ run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_local_audi
     --require_no_audio_claim
 }
 
+run_stage_b_local_audio_render_tooling() {
+  local run_id="${RUN_ID:-harness_stage_b_local_audio_render_tooling}"
+  print_header "Stage B local audio render tooling"
+  "$PYTHON_BIN" scripts/check_stage_b_local_audio_render_tooling.py \
+    --run_id "$run_id" \
+    --require_no_system_modification
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -2987,6 +2995,9 @@ case "$MODE" in
     ;;
   stage-b-margin-recovered-phrase-vocabulary-duration-coverage-fill-local-audio-render-package)
     run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_local_audio_render_package
+    ;;
+  stage-b-local-audio-render-tooling)
+    run_stage_b_local_audio_render_tooling
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/check_stage_b_local_audio_render_tooling.py
+++ b/scripts/check_stage_b_local_audio_render_tooling.py
@@ -1,0 +1,174 @@
+"""Check local audio render tooling readiness without modifying the system."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.build_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_local_audio_render_package import (
+    renderer_probe,
+)
+
+
+class StageBLocalAudioRenderToolingError(ValueError):
+    pass
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def install_guidance(status: str) -> list[str]:
+    if status == "ready_for_local_render":
+        return []
+    if status == "soundfont_missing":
+        return [
+            "provide an existing .sf2/.sf3 path with --soundfont",
+            "verify the soundfont license before committing any derived audio",
+        ]
+    return [
+        "install or provide a local renderer path outside this script",
+        "supported renderer options: fluidsynth with soundfont, or timidity",
+        "rerun readiness check before render attempt",
+    ]
+
+
+def build_tooling_report(
+    *,
+    output_dir: Path,
+    requested_renderer: str = "",
+    soundfont_path: str = "",
+    renderer_paths: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    probe = renderer_probe(
+        requested_renderer=requested_renderer,
+        soundfont_path=soundfont_path,
+        renderer_paths=renderer_paths,
+    )
+    status = str(probe.get("status") or "")
+    return {
+        "schema_version": "stage_b_local_audio_render_tooling_readiness_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "tooling_status": status,
+        "renderer_probe": probe,
+        "setup_boundary": {
+            "system_modified": False,
+            "package_install_executed": False,
+            "download_executed": False,
+            "generated_audio_created": False,
+            "audio_render_attempted": False,
+        },
+        "install_guidance": install_guidance(status),
+        "next_recommended_issue": "Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render attempt"
+        if status == "ready_for_local_render"
+        else "Stage B margin-recovered phrase/vocabulary duration coverage fill renderer path decision",
+    }
+
+
+def validate_tooling_report(
+    report: dict[str, Any],
+    *,
+    expected_status: str | None,
+    require_no_system_modification: bool,
+) -> dict[str, Any]:
+    status = str(report.get("tooling_status") or "")
+    if expected_status and status != expected_status:
+        raise StageBLocalAudioRenderToolingError(f"expected status {expected_status}, got {status}")
+    boundary = report.get("setup_boundary") if isinstance(report.get("setup_boundary"), dict) else {}
+    if require_no_system_modification:
+        changed = [
+            bool(boundary.get("system_modified", True)),
+            bool(boundary.get("package_install_executed", True)),
+            bool(boundary.get("download_executed", True)),
+            bool(boundary.get("generated_audio_created", True)),
+            bool(boundary.get("audio_render_attempted", True)),
+        ]
+        if any(changed):
+            raise StageBLocalAudioRenderToolingError("tooling check must not modify system or render audio")
+    probe = report.get("renderer_probe") if isinstance(report.get("renderer_probe"), dict) else {}
+    return {
+        "tooling_status": status,
+        "selected_renderer_name": str(probe.get("selected_renderer_name") or ""),
+        "fluidsynth_available": bool(probe.get("fluidsynth_path")),
+        "timidity_available": bool(probe.get("timidity_path")),
+        "soundfont_exists": bool(probe.get("soundfont_exists", False)),
+        "system_modified": bool(boundary.get("system_modified", True)),
+        "audio_render_attempted": bool(boundary.get("audio_render_attempted", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    probe = report["renderer_probe"]
+    boundary = report["setup_boundary"]
+    lines = [
+        "# Stage B Local Audio Render Tooling Readiness",
+        "",
+        f"- tooling status: `{report['tooling_status']}`",
+        f"- selected renderer: `{probe['selected_renderer_name']}`",
+        f"- fluidsynth path: `{probe['fluidsynth_path']}`",
+        f"- timidity path: `{probe['timidity_path']}`",
+        f"- soundfont path: `{probe['soundfont_path']}`",
+        f"- soundfont exists: `{probe['soundfont_exists']}`",
+        f"- system modified: `{boundary['system_modified']}`",
+        f"- audio render attempted: `{boundary['audio_render_attempted']}`",
+        "",
+        "## Guidance",
+        "",
+    ]
+    for item in report.get("install_guidance", []):
+        lines.append(f"- {item}")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Check Stage B local audio render tooling")
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_local_audio_render_tooling",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--renderer", type=str, default="")
+    parser.add_argument("--soundfont", type=str, default="")
+    parser.add_argument("--expected_status", type=str, default="")
+    parser.add_argument("--require_no_system_modification", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_tooling_report(
+        output_dir=output_dir,
+        requested_renderer=str(args.renderer or ""),
+        soundfont_path=str(args.soundfont or ""),
+    )
+    summary = validate_tooling_report(
+        report,
+        expected_status=str(args.expected_status or ""),
+        require_no_system_modification=bool(args.require_no_system_modification),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "stage_b_local_audio_render_tooling.json"
+    markdown_path = output_dir / "stage_b_local_audio_render_tooling.md"
+    write_json(report_path, report)
+    write_json(output_dir / "stage_b_local_audio_render_tooling_validation_summary.json", summary)
+    markdown_path.write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps({**summary, "report_path": str(report_path), "markdown_path": str(markdown_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_local_audio_render_tooling.py
+++ b/tests/test_stage_b_local_audio_render_tooling.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import stat
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from scripts.check_stage_b_local_audio_render_tooling import (
+    StageBLocalAudioRenderToolingError,
+    build_tooling_report,
+    validate_tooling_report,
+)
+
+
+def fake_executable(path: Path) -> None:
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+class StageBLocalAudioRenderToolingTest(unittest.TestCase):
+    def test_reports_renderer_unavailable_without_system_changes(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            report = build_tooling_report(
+                output_dir=Path(temp_dir) / "tooling",
+                renderer_paths={"fluidsynth": "", "timidity": ""},
+            )
+            summary = validate_tooling_report(
+                report,
+                expected_status="renderer_unavailable",
+                require_no_system_modification=True,
+            )
+
+            self.assertEqual(summary["tooling_status"], "renderer_unavailable")
+            self.assertFalse(summary["system_modified"])
+            self.assertFalse(summary["audio_render_attempted"])
+            self.assertTrue(report["install_guidance"])
+
+    def test_reports_soundfont_missing_for_fluidsynth_without_soundfont(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            renderer = Path(temp_dir) / "fluidsynth"
+            fake_executable(renderer)
+            report = build_tooling_report(
+                output_dir=Path(temp_dir) / "tooling",
+                requested_renderer="fluidsynth",
+                renderer_paths={"fluidsynth": str(renderer), "timidity": ""},
+            )
+            summary = validate_tooling_report(
+                report,
+                expected_status="soundfont_missing",
+                require_no_system_modification=True,
+            )
+
+            self.assertEqual(summary["selected_renderer_name"], "fluidsynth")
+            self.assertFalse(summary["soundfont_exists"])
+
+    def test_reports_ready_when_renderer_and_soundfont_exist(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            soundfont = root / "piano.sf2"
+            fake_executable(renderer)
+            soundfont.write_bytes(b"sf2")
+            report = build_tooling_report(
+                output_dir=root / "tooling",
+                requested_renderer="fluidsynth",
+                soundfont_path=str(soundfont),
+                renderer_paths={"fluidsynth": str(renderer), "timidity": ""},
+            )
+            summary = validate_tooling_report(
+                report,
+                expected_status="ready_for_local_render",
+                require_no_system_modification=True,
+            )
+
+            self.assertEqual(summary["tooling_status"], "ready_for_local_render")
+            self.assertTrue(summary["soundfont_exists"])
+
+    def test_rejects_system_modification_claim(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            report = build_tooling_report(output_dir=Path(temp_dir) / "tooling")
+            report["setup_boundary"]["system_modified"] = True
+
+            with self.assertRaises(StageBLocalAudioRenderToolingError):
+                validate_tooling_report(
+                    report,
+                    expected_status=None,
+                    require_no_system_modification=True,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- local audio render attempt 전 renderer/soundfont readiness check 추가
- package install, download, render attempt 미수행 guard 기록
- renderer 미준비 상태에서 audio quality와 human/audio preference claim 차단

## Context

- Issue #337 local audio render package result: `renderer_unavailable`
- planned audio outputs: `2`
- render attempted: `false`
- audio rendered quality claimed: `false`
- human/audio preference claimed: `false`

## Scope

- tooling readiness script: `scripts/check_stage_b_local_audio_render_tooling.py`
- renderer probe: fluidsynth, timidity, optional soundfont
- setup boundary: system_modified/package_install/download/render_attempt all false
- harness mode: `stage-b-local-audio-render-tooling`
- README, CORE_PLAN, CURRENT_STATUS_AND_PLAN, AGENTS handoff 갱신

## Validation

- `.venv/bin/python -m unittest tests/test_stage_b_local_audio_render_tooling.py`
- `bash scripts/agent_harness.sh stage-b-local-audio-render-tooling`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- `rg -n 'codex|Codex|코덱스' ...` no output

## Risk

- current local status: `renderer_unavailable`
- no package manager install executed
- no audio render attempted
- generated audio artifacts remain excluded from commit scope

## Follow-up

- next primary boundary: `Stage B margin-recovered phrase/vocabulary duration coverage fill renderer path decision`
- renderer/soundfont 준비 후 local audio render attempt

Closes #339