### PR TITLE
Stage B duration coverage fill local audio render attempt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #341, Stage B renderer path decision.
+- Latest functional issue completed: Issue #343, Stage B duration coverage fill local audio render attempt.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render attempt after renderer path is available.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill user listening review fill.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -722,6 +722,14 @@ bash scripts/agent_harness.sh stage-b-renderer-path-decision
 ```
 
 This harness records whether renderer path or install approval is required before local audio render attempt.
+
+For Stage B duration coverage fill local audio render attempt changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-local-audio-render-attempt
+```
+
+This harness renders source/fill MIDI to local WAV files and validates technical WAV metadata without claiming listening preference.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@
 | local audio render 준비 상태 불명확 | source/fill MIDI는 준비됐지만 WAV render tooling과 audio quality claim이 분리되지 않음 | local audio render package 추가 | planned outputs `2`, render attempted `false`, audio quality claim `false` |
 | renderer/soundfont 준비 상태 불명확 | local render package는 준비됐지만 renderer가 없는 환경에서 render attempt를 진행할 위험 | tooling readiness check 추가 | `fluidsynth`/`timidity` 미탐지, system modification `false`, render attempted `false` |
 | renderer path decision 필요 | renderer unavailable 상태에서 설치/다운로드 없이 render attempt로 넘어갈 위험 | renderer path decision 추가 | decision `renderer_path_or_install_approval_required`, critical user input `true` |
+| user listening review artifact 필요 | MIDI evidence는 있지만 사용자가 직접 들을 WAV가 없음 | FluidSynth + GeneralUser GS로 source/fill WAV 렌더 | rendered files `2`, duration `6.474s`, technical WAV validation `true`, preference claim `false` |
 
 ## 파이프라인 구조
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -115,6 +115,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered phrase/vocabulary duration coverage fill local audio render package 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_DURATION_COVERAGE_FILL_LOCAL_AUDIO_RENDER_PACKAGE_2026-05-29.md`
 - local audio render tooling setup 문서: `docs/STAGE_B_LOCAL_AUDIO_RENDER_TOOLING_SETUP_2026-05-29.md`
 - renderer path decision 문서: `docs/STAGE_B_RENDERER_PATH_DECISION_2026-05-29.md`
+- duration coverage fill local audio render attempt 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_LOCAL_AUDIO_RENDER_ATTEMPT_2026-05-29.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -168,6 +169,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - margin-recovered phrase/vocabulary duration coverage fill local audio render package: planned audio outputs `2`, render attempted `false`, audio quality claim `false`
 - local audio render tooling setup: renderer `unavailable`, system modification `false`, audio render attempted `false`
 - renderer path decision: decision `renderer_path_or_install_approval_required`, critical user input `true`
+- duration coverage fill local audio render attempt: rendered WAV files `2`, sample rate `44100`, duration `6.474s`, preference claim `false`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #341, Stage B renderer path decision
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill local audio render attempt after renderer path is available`
+- latest functional result: Issue #343, Stage B duration coverage fill local audio render attempt
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill user listening review fill`
 
 현재 범위가 아닌 것:
 
@@ -65,6 +65,45 @@ Issue #220은 현재 작업이 core인지, MVP 완료로 볼 수 있는지를 �
 Docs:
 
 - `docs/STAGE_B_MODEL_CORE_MVP_COMPLETION_AUDIT_2026-05-28.md`
+
+## Current Duration Coverage Fill Local Audio Render Attempt Result
+
+Issue #343은 source/fill MIDI를 FluidSynth와 GeneralUser GS soundfont로 WAV 렌더한 작업이다.
+
+변경:
+
+- local audio render attempt script 추가
+- source/fill WAV 생성
+- WAV sample rate, channel count, duration, size, sha256 검증
+- rendered audio file path summary 기록
+- audio quality/human preference claim guard 유지
+
+결과:
+
+- render attempted: `true`
+- rendered audio file count: `2`
+- technical WAV validation: `true`
+- sample rate: `44100`
+- source duration seconds: `6.474`
+- fill duration seconds: `6.474`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+
+로컬 WAV:
+
+- source: `outputs/stage_b_duration_coverage_fill_local_audio_render_attempt/harness_stage_b_duration_coverage_fill_local_audio_render_attempt/audio/source_constrained_partial.wav`
+- fill: `outputs/stage_b_duration_coverage_fill_local_audio_render_attempt/harness_stage_b_duration_coverage_fill_local_audio_render_attempt/audio/duration_coverage_fill_keep.wav`
+
+판단:
+
+- user listening review 입력 전까지 preference claim 금지
+- technical WAV validation은 음악적 품질 proof가 아님
+- generated WAV files는 commit 대상에서 제외
+
+다음:
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill user listening review fill`
+- user review input 필요: source/fill preference, timing, phrase, vocabulary, notes
 
 ## Current Renderer Path Decision Result
 

--- a/docs/STAGE_B_DURATION_COVERAGE_FILL_LOCAL_AUDIO_RENDER_ATTEMPT_2026-05-29.md
+++ b/docs/STAGE_B_DURATION_COVERAGE_FILL_LOCAL_AUDIO_RENDER_ATTEMPT_2026-05-29.md
@@ -1,0 +1,65 @@
+# Stage B Duration Coverage Fill Local Audio Render Attempt
+
+Issue #343은 source/fill MIDI를 FluidSynth와 GeneralUser GS soundfont로 WAV 렌더한 작업이다.
+
+## Context
+
+- Issue #341 decision: `renderer_path_or_install_approval_required`
+- user approval: FluidSynth install and soundfont download 허용
+- renderer: `/opt/homebrew/bin/fluidsynth`
+- soundfont: `~/.local/share/soundfonts/generaluser-gs/v1.471.sf2`
+- soundfont source: `https://github.com/ropensci/fluidsynth/releases/download/generaluser-gs-v1.471/generaluser-gs-v1.471.zip`
+- soundfont license reference: `https://github.com/mrbumpy409/GeneralUser-GS/blob/main/documentation/LICENSE.txt`
+- render target: duration/coverage fill source vs keep MIDI package
+
+## Change
+
+- local audio render attempt script 추가
+- source/fill WAV 생성
+- WAV sample rate, channel count, duration, size, sha256 검증
+- rendered audio file path summary 기록
+- audio quality/human preference claim guard 유지
+
+## Result
+
+| item | value |
+|---|---:|
+| render attempted | `true` |
+| rendered audio file count | `2` |
+| technical WAV validation | `true` |
+| sample rate | `44100` |
+| source duration seconds | `6.474` |
+| fill duration seconds | `6.474` |
+| audio rendered quality claimed | `false` |
+| human/audio preference claimed | `false` |
+
+## Rendered Files
+
+- source: `outputs/stage_b_duration_coverage_fill_local_audio_render_attempt/harness_stage_b_duration_coverage_fill_local_audio_render_attempt/audio/source_constrained_partial.wav`
+- fill: `outputs/stage_b_duration_coverage_fill_local_audio_render_attempt/harness_stage_b_duration_coverage_fill_local_audio_render_attempt/audio/duration_coverage_fill_keep.wav`
+
+## Not Proven
+
+- audio rendered quality
+- human/audio preference
+- broad trained-model quality
+- Brad style adaptation
+- production-ready improviser
+
+## Validation
+
+```bash
+.venv/bin/python -m unittest tests/test_stage_b_local_audio_render_attempt.py
+bash scripts/agent_harness.sh stage-b-local-audio-render-attempt
+```
+
+## Output
+
+- script: `scripts/render_stage_b_duration_coverage_fill_audio.py`
+- test: `tests/test_stage_b_local_audio_render_attempt.py`
+- summary: `outputs/stage_b_duration_coverage_fill_local_audio_render_attempt/harness_stage_b_duration_coverage_fill_local_audio_render_attempt/stage_b_duration_coverage_fill_local_audio_render_attempt.json`
+
+## Next
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill user listening review fill`
+- user review input 필요: source/fill preference, timing, phrase, vocabulary, notes

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -1742,6 +1742,24 @@ run_stage_b_renderer_path_decision() {
     --require_no_execution
 }
 
+run_stage_b_local_audio_render_attempt() {
+  local local_package_run_id="${LOCAL_AUDIO_PACKAGE_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_local_audio_render_package}"
+  local run_id="${RUN_ID:-harness_stage_b_duration_coverage_fill_local_audio_render_attempt}"
+  local local_audio_render_package="outputs/stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_local_audio_render_package/${local_package_run_id}/duration_coverage_fill_local_audio_render_package.json"
+  local soundfont="${SOUNDFONT_PATH:-$HOME/.local/share/soundfonts/generaluser-gs/v1.471.sf2}"
+  if [[ ! -f "$local_audio_render_package" ]]; then
+    print_header "Stage B duration/coverage fill local audio render package"
+    RUN_ID="$local_package_run_id" run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_local_audio_render_package
+  fi
+  print_header "Stage B duration/coverage fill local audio render attempt"
+  "$PYTHON_BIN" scripts/render_stage_b_duration_coverage_fill_audio.py \
+    --run_id "$run_id" \
+    --local_audio_render_package "$local_audio_render_package" \
+    --soundfont "$soundfont" \
+    --expected_file_count 2 \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -3017,6 +3035,9 @@ case "$MODE" in
     ;;
   stage-b-renderer-path-decision)
     run_stage_b_renderer_path_decision
+    ;;
+  stage-b-local-audio-render-attempt)
+    run_stage_b_local_audio_render_attempt
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/render_stage_b_duration_coverage_fill_audio.py
+++ b/scripts/render_stage_b_duration_coverage_fill_audio.py
@@ -1,0 +1,324 @@
+"""Render duration/coverage fill review MIDI files to local WAV files."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+import wave
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+
+class StageBDurationCoverageFillAudioRenderError(ValueError):
+    pass
+
+
+CommandRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def wav_meta(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise StageBDurationCoverageFillAudioRenderError(f"WAV not found: {path}")
+    with wave.open(str(path), "rb") as handle:
+        channels = handle.getnchannels()
+        sample_width = handle.getsampwidth()
+        sample_rate = handle.getframerate()
+        frame_count = handle.getnframes()
+    return {
+        "path": str(path),
+        "exists": True,
+        "size_bytes": int(path.stat().st_size),
+        "sha256": sha256_file(path),
+        "channels": int(channels),
+        "sample_width_bytes": int(sample_width),
+        "sample_rate": int(sample_rate),
+        "frame_count": int(frame_count),
+        "duration_seconds": float(frame_count / sample_rate) if sample_rate else 0.0,
+    }
+
+
+def required_review_items(local_audio_render_package: dict[str, Any]) -> list[dict[str, Any]]:
+    items = local_audio_render_package.get("review_items")
+    if not isinstance(items, list) or len(items) != 2:
+        raise StageBDurationCoverageFillAudioRenderError("local audio render package must contain two review items")
+    compacted: list[dict[str, Any]] = []
+    for item in items:
+        midi_file = item.get("midi_file") if isinstance(item.get("midi_file"), dict) else {}
+        midi_path = str(midi_file.get("path") or "")
+        if bool(midi_file.get("required", False)) and not Path(midi_path).exists():
+            raise StageBDurationCoverageFillAudioRenderError(f"required MIDI not found: {midi_path}")
+        compacted.append(
+            {
+                "role": str(item.get("role") or ""),
+                "candidate_id": str(item.get("candidate_id") or ""),
+                "midi_path": midi_path,
+            }
+        )
+    return compacted
+
+
+def build_render_plan(
+    local_audio_render_package: dict[str, Any],
+    *,
+    output_dir: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+) -> list[dict[str, Any]]:
+    renderer = Path(renderer_path)
+    soundfont = Path(soundfont_path)
+    if not renderer.exists():
+        raise StageBDurationCoverageFillAudioRenderError(f"renderer not found: {renderer}")
+    if not soundfont.exists():
+        raise StageBDurationCoverageFillAudioRenderError(f"soundfont not found: {soundfont}")
+    plan = []
+    for item in required_review_items(local_audio_render_package):
+        wav_path = output_dir / "audio" / f"{item['role']}.wav"
+        plan.append(
+            {
+                "role": item["role"],
+                "candidate_id": item["candidate_id"],
+                "midi_path": item["midi_path"],
+                "wav_path": str(wav_path),
+                "command": [
+                    str(renderer),
+                    "-ni",
+                    "-F",
+                    str(wav_path),
+                    "-r",
+                    str(sample_rate),
+                    str(soundfont),
+                    item["midi_path"],
+                ],
+            }
+        )
+    return plan
+
+
+def default_runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(list(command), check=False, text=True, capture_output=True)
+
+
+def execute_render_plan(
+    plan: list[dict[str, Any]],
+    *,
+    runner: CommandRunner = default_runner,
+) -> list[dict[str, Any]]:
+    rendered = []
+    for item in plan:
+        wav_path = Path(str(item["wav_path"]))
+        wav_path.parent.mkdir(parents=True, exist_ok=True)
+        completed = runner(item["command"])
+        if completed.returncode != 0:
+            raise StageBDurationCoverageFillAudioRenderError(
+                f"render failed for {item['role']}: {completed.stderr or completed.stdout}"
+            )
+        meta = wav_meta(wav_path)
+        rendered.append(
+            {
+                "role": item["role"],
+                "candidate_id": item["candidate_id"],
+                "source_midi_path": item["midi_path"],
+                "wav_file": meta,
+                "command": list(item["command"]),
+                "stdout_tail": (completed.stdout or "")[-1000:],
+                "stderr_tail": (completed.stderr or "")[-1000:],
+            }
+        )
+    return rendered
+
+
+def build_audio_render_report(
+    local_audio_render_package: dict[str, Any],
+    *,
+    output_dir: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+    runner: CommandRunner = default_runner,
+) -> dict[str, Any]:
+    plan = build_render_plan(
+        local_audio_render_package,
+        output_dir=output_dir,
+        renderer_path=renderer_path,
+        soundfont_path=soundfont_path,
+        sample_rate=sample_rate,
+    )
+    rendered = execute_render_plan(plan, runner=runner)
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_local_audio_render_attempt_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_local_audio_render_package_schema": str(local_audio_render_package.get("schema_version") or ""),
+        "candidate_id": str(local_audio_render_package.get("candidate_id") or ""),
+        "renderer": {
+            "name": "fluidsynth",
+            "path": renderer_path,
+            "version": "",
+        },
+        "soundfont": {
+            "path": soundfont_path,
+            "sha256": sha256_file(Path(soundfont_path)),
+        },
+        "rendered_audio_files": rendered,
+        "audio_render_boundary": {
+            "render_attempted": True,
+            "rendered_audio_file_count": len(rendered),
+            "audio_output_claimed": True,
+            "technical_wav_validation": True,
+            "audio_rendered_quality_claimed": False,
+            "human_audio_preference_claimed": False,
+        },
+        "not_proven": [
+            "audio_rendered_quality",
+            "human_audio_preference",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "production_ready_improviser",
+        ],
+        "next_recommended_issue": "Stage B margin-recovered phrase/vocabulary duration coverage fill user listening review fill",
+    }
+
+
+def validate_audio_render_report(
+    report: dict[str, Any],
+    *,
+    expected_file_count: int,
+    expected_sample_rate: int,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    files = report.get("rendered_audio_files")
+    if not isinstance(files, list) or len(files) != expected_file_count:
+        raise StageBDurationCoverageFillAudioRenderError(f"expected {expected_file_count} rendered files")
+    for item in files:
+        wav_file = item.get("wav_file") if isinstance(item.get("wav_file"), dict) else {}
+        if not bool(wav_file.get("exists", False)):
+            raise StageBDurationCoverageFillAudioRenderError(f"missing rendered wav for {item.get('role')}")
+        if int(wav_file.get("sample_rate", 0) or 0) != expected_sample_rate:
+            raise StageBDurationCoverageFillAudioRenderError(f"unexpected sample rate for {item.get('role')}")
+        if int(wav_file.get("frame_count", 0) or 0) <= 0:
+            raise StageBDurationCoverageFillAudioRenderError(f"empty wav for {item.get('role')}")
+        if int(wav_file.get("size_bytes", 0) or 0) <= 44:
+            raise StageBDurationCoverageFillAudioRenderError(f"invalid wav size for {item.get('role')}")
+    boundary = report.get("audio_render_boundary") if isinstance(report.get("audio_render_boundary"), dict) else {}
+    if require_no_quality_claim:
+        if bool(boundary.get("audio_rendered_quality_claimed", True)):
+            raise StageBDurationCoverageFillAudioRenderError("audio rendered quality must not be claimed")
+        if bool(boundary.get("human_audio_preference_claimed", True)):
+            raise StageBDurationCoverageFillAudioRenderError("human/audio preference must not be claimed")
+    return {
+        "candidate_id": str(report.get("candidate_id") or ""),
+        "render_attempted": bool(boundary.get("render_attempted", False)),
+        "rendered_audio_file_count": int(boundary.get("rendered_audio_file_count", 0) or 0),
+        "technical_wav_validation": bool(boundary.get("technical_wav_validation", False)),
+        "audio_rendered_quality_claimed": bool(boundary.get("audio_rendered_quality_claimed", True)),
+        "human_audio_preference_claimed": bool(boundary.get("human_audio_preference_claimed", True)),
+        "wav_paths": [str(item.get("wav_file", {}).get("path") or "") for item in files],
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    boundary = report["audio_render_boundary"]
+    lines = [
+        "# Stage B Duration Coverage Fill Local Audio Render Attempt",
+        "",
+        f"- candidate: `{report['candidate_id']}`",
+        f"- render attempted: `{boundary['render_attempted']}`",
+        f"- rendered audio file count: `{boundary['rendered_audio_file_count']}`",
+        f"- technical WAV validation: `{boundary['technical_wav_validation']}`",
+        f"- audio rendered quality claimed: `{boundary['audio_rendered_quality_claimed']}`",
+        f"- human/audio preference claimed: `{boundary['human_audio_preference_claimed']}`",
+        "",
+        "| role | wav path | duration | sample rate | size | sha256 |",
+        "|---|---|---:|---:|---:|---|",
+    ]
+    for item in report.get("rendered_audio_files", []):
+        wav_file = item["wav_file"]
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(item["role"]),
+                    str(wav_file["path"]),
+                    f"{float(wav_file['duration_seconds']):.3f}",
+                    str(wav_file["sample_rate"]),
+                    str(wav_file["size_bytes"]),
+                    str(wav_file["sha256"][:12]),
+                ]
+            )
+            + " |"
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Render Stage B duration/coverage fill audio")
+    parser.add_argument("--local_audio_render_package", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_local_audio_render_attempt",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--renderer", type=str, default=shutil.which("fluidsynth") or "")
+    parser.add_argument("--soundfont", type=str, required=True)
+    parser.add_argument("--sample_rate", type=int, default=44100)
+    parser.add_argument("--expected_file_count", type=int, default=2)
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_audio_render_report(
+        read_json(Path(args.local_audio_render_package)),
+        output_dir=output_dir,
+        renderer_path=str(args.renderer or ""),
+        soundfont_path=str(args.soundfont or ""),
+        sample_rate=int(args.sample_rate),
+    )
+    summary = validate_audio_render_report(
+        report,
+        expected_file_count=int(args.expected_file_count),
+        expected_sample_rate=int(args.sample_rate),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "stage_b_duration_coverage_fill_local_audio_render_attempt.json"
+    markdown_path = output_dir / "stage_b_duration_coverage_fill_local_audio_render_attempt.md"
+    write_json(report_path, report)
+    write_json(output_dir / "stage_b_duration_coverage_fill_local_audio_render_attempt_validation_summary.json", summary)
+    markdown_path.write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps({**summary, "report_path": str(report_path), "markdown_path": str(markdown_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_local_audio_render_attempt.py
+++ b/tests/test_stage_b_local_audio_render_attempt.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import subprocess
+import unittest
+import wave
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Sequence
+
+import pretty_midi
+
+from scripts.render_stage_b_duration_coverage_fill_audio import (
+    StageBDurationCoverageFillAudioRenderError,
+    build_audio_render_report,
+    validate_audio_render_report,
+)
+
+
+def write_midi(path: Path, pitch: int) -> None:
+    midi = pretty_midi.PrettyMIDI(initial_tempo=124)
+    piano = pretty_midi.Instrument(program=0, is_drum=False, name="solo")
+    piano.notes.append(pretty_midi.Note(velocity=76, pitch=pitch, start=0.0, end=0.2))
+    midi.instruments.append(piano)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    midi.write(str(path))
+
+
+def write_wav(path: Path, sample_rate: int = 44100) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(2)
+        handle.setsampwidth(2)
+        handle.setframerate(sample_rate)
+        handle.writeframes(b"\x00\x00\x00\x00" * sample_rate)
+
+
+def local_audio_render_package(root: Path) -> dict:
+    source_path = root / "source.mid"
+    fill_path = root / "fill.mid"
+    write_midi(source_path, 60)
+    write_midi(fill_path, 64)
+    return {
+        "schema_version": "stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_local_audio_render_package_v1",
+        "candidate_id": "duration_fill_candidate",
+        "review_items": [
+            {
+                "role": "source_constrained_partial",
+                "candidate_id": "source_candidate",
+                "midi_file": {"path": str(source_path), "required": True},
+            },
+            {
+                "role": "duration_coverage_fill_keep",
+                "candidate_id": "duration_fill_candidate",
+                "midi_file": {"path": str(fill_path), "required": True},
+            },
+        ],
+    }
+
+
+def fake_runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    wav_path = Path(command[3])
+    write_wav(wav_path)
+    return subprocess.CompletedProcess(list(command), 0, stdout="rendered", stderr="")
+
+
+class StageBDurationCoverageFillAudioRenderAttemptTest(unittest.TestCase):
+    def test_renders_two_wav_files_without_quality_claim(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            soundfont = root / "piano.sf2"
+            renderer.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            report = build_audio_render_report(
+                local_audio_render_package(root),
+                output_dir=root / "rendered",
+                renderer_path=str(renderer),
+                soundfont_path=str(soundfont),
+                sample_rate=44100,
+                runner=fake_runner,
+            )
+            summary = validate_audio_render_report(
+                report,
+                expected_file_count=2,
+                expected_sample_rate=44100,
+                require_no_quality_claim=True,
+            )
+
+            self.assertTrue(summary["render_attempted"])
+            self.assertEqual(summary["rendered_audio_file_count"], 2)
+            self.assertTrue(summary["technical_wav_validation"])
+            self.assertFalse(summary["audio_rendered_quality_claimed"])
+            self.assertFalse(summary["human_audio_preference_claimed"])
+            self.assertEqual(len(summary["wav_paths"]), 2)
+
+    def test_rejects_missing_soundfont(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            renderer.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+
+            with self.assertRaises(StageBDurationCoverageFillAudioRenderError):
+                build_audio_render_report(
+                    local_audio_render_package(root),
+                    output_dir=root / "rendered",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(root / "missing.sf2"),
+                    sample_rate=44100,
+                    runner=fake_runner,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- source/fill MIDI를 FluidSynth + GeneralUser GS soundfont로 WAV 렌더
- WAV sample rate, duration, file size, sha256 기술 검증 추가
- audio quality와 human/audio preference claim guard 유지

## Context

- Issue #341 decision: `renderer_path_or_install_approval_required`
- user approval: FluidSynth install and GeneralUser GS soundfont download
- renderer: `/opt/homebrew/bin/fluidsynth`
- soundfont: `~/.local/share/soundfonts/generaluser-gs/v1.471.sf2`
- render target: duration/coverage fill source vs keep MIDI package

## Scope

- render script: `scripts/render_stage_b_duration_coverage_fill_audio.py`
- rendered files: source/fill WAV under `outputs/stage_b_duration_coverage_fill_local_audio_render_attempt/.../audio/`
- technical validation: WAV existence, sample rate, frame count, size, sha256
- harness mode: `stage-b-local-audio-render-attempt`
- README, CORE_PLAN, CURRENT_STATUS_AND_PLAN, AGENTS handoff 갱신

## Validation

- `.venv/bin/python -m unittest tests/test_stage_b_local_audio_render_attempt.py`
- `bash scripts/agent_harness.sh stage-b-local-audio-render-attempt`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- `rg -n 'codex|Codex|코덱스' ...` no output

## Result

- rendered audio file count: `2`
- sample rate: `44100`
- source duration: `6.474s`
- fill duration: `6.474s`
- audio rendered quality claimed: `false`
- human/audio preference claimed: `false`

## Risk

- generated WAV files are local artifacts and not committed
- technical WAV validation does not prove musical quality
- user listening review input required before preference claim

## Follow-up

- next primary boundary: `Stage B margin-recovered phrase/vocabulary duration coverage fill user listening review fill`

Closes #343