### PR TITLE
Stage B duration coverage fill user listening review fill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #343, Stage B duration coverage fill local audio render attempt.
+- Latest functional issue completed: Issue #345, Stage B duration coverage fill user listening review fill.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill user listening review fill.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill user listening review consolidation.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -730,6 +730,14 @@ bash scripts/agent_harness.sh stage-b-local-audio-render-attempt
 ```
 
 This harness renders source/fill MIDI to local WAV files and validates technical WAV metadata without claiming listening preference.
+
+For Stage B duration coverage fill user listening review fill changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-user-listening-review-fill
+```
+
+This harness applies a validated user listening review from rendered WAV files and keeps broad model quality unclaimed.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@
 | renderer/soundfont 준비 상태 불명확 | local render package는 준비됐지만 renderer가 없는 환경에서 render attempt를 진행할 위험 | tooling readiness check 추가 | `fluidsynth`/`timidity` 미탐지, system modification `false`, render attempted `false` |
 | renderer path decision 필요 | renderer unavailable 상태에서 설치/다운로드 없이 render attempt로 넘어갈 위험 | renderer path decision 추가 | decision `renderer_path_or_install_approval_required`, critical user input `true` |
 | user listening review artifact 필요 | MIDI evidence는 있지만 사용자가 직접 들을 WAV가 없음 | FluidSynth + GeneralUser GS로 source/fill WAV 렌더 | rendered files `2`, duration `6.474s`, technical WAV validation `true`, preference claim `false` |
+| user listening preference 기록 필요 | WAV 리뷰 후에도 선호와 claim boundary가 문서화되지 않으면 다음 판단 근거가 분리됨 | user listening review fill 추가 | preference `duration_coverage_fill_keep`, source random-like, fill jazz-like soloing, broad quality claim `false` |
 
 ## 파이프라인 구조
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -116,6 +116,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - local audio render tooling setup 문서: `docs/STAGE_B_LOCAL_AUDIO_RENDER_TOOLING_SETUP_2026-05-29.md`
 - renderer path decision 문서: `docs/STAGE_B_RENDERER_PATH_DECISION_2026-05-29.md`
 - duration coverage fill local audio render attempt 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_LOCAL_AUDIO_RENDER_ATTEMPT_2026-05-29.md`
+- duration coverage fill user listening review fill 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_USER_LISTENING_REVIEW_FILL_2026-05-29.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -170,6 +171,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - local audio render tooling setup: renderer `unavailable`, system modification `false`, audio render attempted `false`
 - renderer path decision: decision `renderer_path_or_install_approval_required`, critical user input `true`
 - duration coverage fill local audio render attempt: rendered WAV files `2`, sample rate `44100`, duration `6.474s`, preference claim `false`
+- duration coverage fill user listening review fill: preference `duration_coverage_fill_keep`, human/audio preference claim `true`, broad model quality claim `false`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #343, Stage B duration coverage fill local audio render attempt
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill user listening review fill`
+- latest functional result: Issue #345, Stage B duration coverage fill user listening review fill
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill user listening review consolidation`
 
 현재 범위가 아닌 것:
 
@@ -65,6 +65,43 @@ Issue #220은 현재 작업이 core인지, MVP 완료로 볼 수 있는지를 �
 Docs:
 
 - `docs/STAGE_B_MODEL_CORE_MVP_COMPLETION_AUDIT_2026-05-28.md`
+
+## Current Duration Coverage Fill User Listening Review Fill Result
+
+Issue #345는 rendered source/fill WAV에 대한 user listening review 입력을 반영한 작업이다.
+
+변경:
+
+- user listening review fill script 추가
+- audio render report와 review input schema 검증
+- single-user human/audio preference claim 기록
+- source assessment / fill assessment 분리
+- broad model quality claim guard 유지
+
+결과:
+
+- review status: `reviewed`
+- preference: `duration_coverage_fill_keep`
+- timing: `duration_coverage_fill_keep`
+- phrase: `duration_coverage_fill_keep`
+- vocabulary: `duration_coverage_fill_keep`
+- source assessment: source 후보는 이해하기 어렵고 random notes처럼 들림
+- fill assessment: fill 후보가 훨씬 jazz-like soloing으로 들림
+- human/audio preference claimed: `true`
+- single user review: `true`
+- broad model quality claimed: `false`
+- audio rendered quality claimed: `false`
+
+판단:
+
+- MIDI evidence preference와 user listening preference가 같은 fill 후보를 지지
+- 단일 사용자 리뷰이므로 broad trained-model quality claim 금지
+- Brad style adaptation과 production-ready improviser claim 금지
+
+다음:
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill user listening review consolidation`
+- MIDI evidence, technical WAV validation, user listening preference를 하나의 claim boundary로 정리
 
 ## Current Duration Coverage Fill Local Audio Render Attempt Result
 

--- a/docs/STAGE_B_DURATION_COVERAGE_FILL_USER_LISTENING_REVIEW_FILL_2026-05-29.md
+++ b/docs/STAGE_B_DURATION_COVERAGE_FILL_USER_LISTENING_REVIEW_FILL_2026-05-29.md
@@ -1,0 +1,66 @@
+# Stage B Duration Coverage Fill User Listening Review Fill
+
+Issue #345는 rendered source/fill WAV에 대한 user listening review 입력을 반영한 작업이다.
+
+## Context
+
+- Issue #343 local audio render attempt 완료
+- rendered audio file count: `2`
+- source WAV: `source_constrained_partial.wav`
+- fill WAV: `duration_coverage_fill_keep.wav`
+- technical WAV validation: `true`
+- prior MIDI evidence preference: `duration_coverage_fill_keep`
+
+## User Review Input
+
+- preference: `duration_coverage_fill_keep`
+- source assessment: source 후보는 이해하기 어렵고 random notes처럼 들림
+- fill assessment: fill 후보가 훨씬 jazz-like soloing으로 들림
+
+## Change
+
+- user listening review fill script 추가
+- audio render report와 review input schema 검증
+- single-user human/audio preference claim 기록
+- source assessment / fill assessment 분리
+- broad model quality claim guard 유지
+
+## Result
+
+| item | value |
+|---|---:|
+| review status | `reviewed` |
+| preference | `duration_coverage_fill_keep` |
+| timing | `duration_coverage_fill_keep` |
+| phrase | `duration_coverage_fill_keep` |
+| vocabulary | `duration_coverage_fill_keep` |
+| human/audio preference claimed | `true` |
+| single user review | `true` |
+| broad model quality claimed | `false` |
+| audio rendered quality claimed | `false` |
+
+## Not Proven
+
+- multi-reviewer preference
+- audio rendered quality
+- broad trained-model quality
+- Brad style adaptation
+- production-ready improviser
+
+## Validation
+
+```bash
+.venv/bin/python -m unittest tests/test_stage_b_user_listening_review_fill.py
+bash scripts/agent_harness.sh stage-b-user-listening-review-fill
+```
+
+## Output
+
+- script: `scripts/fill_stage_b_duration_coverage_user_listening_review.py`
+- test: `tests/test_stage_b_user_listening_review_fill.py`
+- summary: `outputs/stage_b_duration_coverage_fill_user_listening_review_fill/harness_stage_b_duration_coverage_fill_user_listening_review_fill/stage_b_duration_coverage_fill_user_listening_review_fill.json`
+
+## Next
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill user listening review consolidation`
+- MIDI evidence, technical WAV validation, user listening preference를 하나의 claim boundary로 정리

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -1760,6 +1760,31 @@ run_stage_b_local_audio_render_attempt() {
     --require_no_quality_claim
 }
 
+run_stage_b_user_listening_review_fill() {
+  local audio_render_run_id="${AUDIO_RENDER_RUN_ID:-harness_stage_b_duration_coverage_fill_local_audio_render_attempt}"
+  local run_id="${RUN_ID:-harness_stage_b_duration_coverage_fill_user_listening_review_fill}"
+  local audio_render_report="outputs/stage_b_duration_coverage_fill_local_audio_render_attempt/${audio_render_run_id}/stage_b_duration_coverage_fill_local_audio_render_attempt.json"
+  if [[ ! -f "$audio_render_report" ]]; then
+    print_header "Stage B duration/coverage fill local audio render attempt"
+    RUN_ID="$audio_render_run_id" run_stage_b_local_audio_render_attempt
+  fi
+  print_header "Stage B duration/coverage fill user listening review fill"
+  "$PYTHON_BIN" scripts/fill_stage_b_duration_coverage_user_listening_review.py \
+    --run_id "$run_id" \
+    --audio_render_report "$audio_render_report" \
+    --reviewer "user" \
+    --preference duration_coverage_fill_keep \
+    --timing duration_coverage_fill_keep \
+    --phrase duration_coverage_fill_keep \
+    --vocabulary duration_coverage_fill_keep \
+    --source_assessment "source sounds like random notes and is hard to understand" \
+    --fill_assessment "fill sounds much more jazz-like as soloing" \
+    --notes "user listened to rendered WAV files and preferred the duration coverage fill candidate" \
+    --expected_preference duration_coverage_fill_keep \
+    --require_human_audio_preference \
+    --require_no_broad_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -3038,6 +3063,9 @@ case "$MODE" in
     ;;
   stage-b-local-audio-render-attempt)
     run_stage_b_local_audio_render_attempt
+    ;;
+  stage-b-user-listening-review-fill)
+    run_stage_b_user_listening_review_fill
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/fill_stage_b_duration_coverage_user_listening_review.py
+++ b/scripts/fill_stage_b_duration_coverage_user_listening_review.py
@@ -1,0 +1,260 @@
+"""Fill user listening review from rendered duration/coverage fill WAV evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class StageBDurationCoverageUserListeningReviewFillError(ValueError):
+    pass
+
+
+PREFERENCE_VALUES = {
+    "source_constrained_partial",
+    "duration_coverage_fill_keep",
+    "tie",
+    "reject_both",
+}
+
+ATTRIBUTE_VALUES = {
+    "source_constrained_partial",
+    "duration_coverage_fill_keep",
+    "tie",
+    "unclear",
+}
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def validate_audio_render_report(audio_render_report: dict[str, Any]) -> list[dict[str, Any]]:
+    boundary = (
+        audio_render_report.get("audio_render_boundary")
+        if isinstance(audio_render_report.get("audio_render_boundary"), dict)
+        else {}
+    )
+    if not bool(boundary.get("render_attempted", False)):
+        raise StageBDurationCoverageUserListeningReviewFillError("audio render must be attempted")
+    if not bool(boundary.get("technical_wav_validation", False)):
+        raise StageBDurationCoverageUserListeningReviewFillError("technical WAV validation is required")
+    if bool(boundary.get("human_audio_preference_claimed", True)):
+        raise StageBDurationCoverageUserListeningReviewFillError("source audio render report must not claim preference")
+    rendered_files = audio_render_report.get("rendered_audio_files")
+    if not isinstance(rendered_files, list) or len(rendered_files) != 2:
+        raise StageBDurationCoverageUserListeningReviewFillError("audio render report must contain two WAV files")
+    compacted = []
+    for item in rendered_files:
+        wav_file = item.get("wav_file") if isinstance(item.get("wav_file"), dict) else {}
+        if not bool(wav_file.get("exists", False)):
+            raise StageBDurationCoverageUserListeningReviewFillError(f"missing WAV for {item.get('role')}")
+        compacted.append(
+            {
+                "role": str(item.get("role") or ""),
+                "candidate_id": str(item.get("candidate_id") or ""),
+                "source_midi_path": str(item.get("source_midi_path") or ""),
+                "wav_path": str(wav_file.get("path") or ""),
+                "duration_seconds": float(wav_file.get("duration_seconds", 0.0) or 0.0),
+                "sample_rate": int(wav_file.get("sample_rate", 0) or 0),
+                "sha256": str(wav_file.get("sha256") or ""),
+            }
+        )
+    return compacted
+
+
+def build_user_listening_review_fill(
+    audio_render_report: dict[str, Any],
+    *,
+    output_dir: Path,
+    reviewer: str,
+    preference: str,
+    timing: str,
+    phrase: str,
+    vocabulary: str,
+    source_assessment: str,
+    fill_assessment: str,
+    notes: str,
+) -> dict[str, Any]:
+    rendered_files = validate_audio_render_report(audio_render_report)
+    if not reviewer.strip():
+        raise StageBDurationCoverageUserListeningReviewFillError("reviewer is required")
+    if preference not in PREFERENCE_VALUES:
+        raise StageBDurationCoverageUserListeningReviewFillError(f"invalid preference: {preference}")
+    for field, value in (("timing", timing), ("phrase", phrase), ("vocabulary", vocabulary)):
+        if value not in ATTRIBUTE_VALUES:
+            raise StageBDurationCoverageUserListeningReviewFillError(f"invalid {field}: {value}")
+    candidate_id = str(audio_render_report.get("candidate_id") or "")
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_user_listening_review_fill_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_audio_render_schema": str(audio_render_report.get("schema_version") or ""),
+        "candidate_id": candidate_id,
+        "rendered_audio_files": rendered_files,
+        "user_listening_review": {
+            "status": "reviewed",
+            "reviewer": reviewer.strip(),
+            "audio_render_used": True,
+            "review_basis": "user_listening_review_of_rendered_wav",
+            "preference": preference,
+            "timing": timing,
+            "phrase": phrase,
+            "vocabulary": vocabulary,
+            "source_assessment": source_assessment.strip(),
+            "fill_assessment": fill_assessment.strip(),
+            "notes": notes.strip(),
+        },
+        "claim_boundary": {
+            "human_audio_preference_claimed": True,
+            "single_user_review": True,
+            "audio_render_used": True,
+            "audio_rendered_quality_claimed": False,
+            "broad_model_quality_claimed": False,
+        },
+        "proven": [
+            "single_user_preference_for_duration_coverage_fill_keep",
+            "source_fill_audio_review_completed",
+        ],
+        "not_proven": [
+            "multi_reviewer_preference",
+            "audio_rendered_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "production_ready_improviser",
+        ],
+        "next_recommended_issue": "Stage B margin-recovered phrase/vocabulary duration coverage fill user listening review consolidation",
+    }
+
+
+def validate_user_listening_review_fill(
+    report: dict[str, Any],
+    *,
+    expected_preference: str | None,
+    require_human_audio_preference: bool,
+    require_no_broad_quality_claim: bool,
+) -> dict[str, Any]:
+    review = report.get("user_listening_review") if isinstance(report.get("user_listening_review"), dict) else {}
+    preference = str(review.get("preference") or "")
+    if expected_preference and preference != expected_preference:
+        raise StageBDurationCoverageUserListeningReviewFillError(
+            f"expected preference {expected_preference}, got {preference}"
+        )
+    claim = report.get("claim_boundary") if isinstance(report.get("claim_boundary"), dict) else {}
+    if require_human_audio_preference and not bool(claim.get("human_audio_preference_claimed", False)):
+        raise StageBDurationCoverageUserListeningReviewFillError("human/audio preference must be claimed")
+    if require_no_broad_quality_claim and bool(claim.get("broad_model_quality_claimed", True)):
+        raise StageBDurationCoverageUserListeningReviewFillError("broad model quality must not be claimed")
+    if require_no_broad_quality_claim and bool(claim.get("audio_rendered_quality_claimed", True)):
+        raise StageBDurationCoverageUserListeningReviewFillError("audio rendered quality must not be claimed")
+    return {
+        "candidate_id": str(report.get("candidate_id") or ""),
+        "review_status": str(review.get("status") or ""),
+        "preference": preference,
+        "timing": str(review.get("timing") or ""),
+        "phrase": str(review.get("phrase") or ""),
+        "vocabulary": str(review.get("vocabulary") or ""),
+        "human_audio_preference_claimed": bool(claim.get("human_audio_preference_claimed", False)),
+        "broad_model_quality_claimed": bool(claim.get("broad_model_quality_claimed", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    review = report["user_listening_review"]
+    claim = report["claim_boundary"]
+    lines = [
+        "# Stage B Duration Coverage Fill User Listening Review Fill",
+        "",
+        f"- candidate: `{report['candidate_id']}`",
+        f"- review status: `{review['status']}`",
+        f"- reviewer: `{review['reviewer']}`",
+        f"- preference: `{review['preference']}`",
+        f"- timing: `{review['timing']}`",
+        f"- phrase: `{review['phrase']}`",
+        f"- vocabulary: `{review['vocabulary']}`",
+        f"- human/audio preference claimed: `{claim['human_audio_preference_claimed']}`",
+        f"- broad model quality claimed: `{claim['broad_model_quality_claimed']}`",
+        "",
+        "## Assessment",
+        "",
+        f"- source: {review['source_assessment']}",
+        f"- fill: {review['fill_assessment']}",
+        f"- notes: {review['notes']}",
+        "",
+        "## Rendered Files",
+        "",
+    ]
+    for item in report.get("rendered_audio_files", []):
+        lines.append(f"- `{item['role']}`: `{item['wav_path']}`")
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Fill Stage B duration coverage user listening review")
+    parser.add_argument("--audio_render_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_user_listening_review_fill",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--reviewer", type=str, required=True)
+    parser.add_argument("--preference", type=str, required=True)
+    parser.add_argument("--timing", type=str, required=True)
+    parser.add_argument("--phrase", type=str, required=True)
+    parser.add_argument("--vocabulary", type=str, required=True)
+    parser.add_argument("--source_assessment", type=str, required=True)
+    parser.add_argument("--fill_assessment", type=str, required=True)
+    parser.add_argument("--notes", type=str, default="")
+    parser.add_argument("--expected_preference", type=str, default="")
+    parser.add_argument("--require_human_audio_preference", action="store_true")
+    parser.add_argument("--require_no_broad_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_user_listening_review_fill(
+        read_json(Path(args.audio_render_report)),
+        output_dir=output_dir,
+        reviewer=str(args.reviewer),
+        preference=str(args.preference),
+        timing=str(args.timing),
+        phrase=str(args.phrase),
+        vocabulary=str(args.vocabulary),
+        source_assessment=str(args.source_assessment),
+        fill_assessment=str(args.fill_assessment),
+        notes=str(args.notes or ""),
+    )
+    summary = validate_user_listening_review_fill(
+        report,
+        expected_preference=str(args.expected_preference or ""),
+        require_human_audio_preference=bool(args.require_human_audio_preference),
+        require_no_broad_quality_claim=bool(args.require_no_broad_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "stage_b_duration_coverage_fill_user_listening_review_fill.json"
+    markdown_path = output_dir / "stage_b_duration_coverage_fill_user_listening_review_fill.md"
+    write_json(report_path, report)
+    write_json(output_dir / "stage_b_duration_coverage_fill_user_listening_review_fill_validation_summary.json", summary)
+    markdown_path.write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps({**summary, "report_path": str(report_path), "markdown_path": str(markdown_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_user_listening_review_fill.py
+++ b/tests/test_stage_b_user_listening_review_fill.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.fill_stage_b_duration_coverage_user_listening_review import (
+    StageBDurationCoverageUserListeningReviewFillError,
+    build_user_listening_review_fill,
+    validate_user_listening_review_fill,
+)
+
+
+def audio_render_report(*, preference_claimed: bool = False) -> dict:
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_local_audio_render_attempt_v1",
+        "candidate_id": "duration_fill_candidate",
+        "audio_render_boundary": {
+            "render_attempted": True,
+            "technical_wav_validation": True,
+            "human_audio_preference_claimed": preference_claimed,
+        },
+        "rendered_audio_files": [
+            {
+                "role": "source_constrained_partial",
+                "candidate_id": "source_candidate",
+                "source_midi_path": "source.mid",
+                "wav_file": {
+                    "path": "source.wav",
+                    "exists": True,
+                    "duration_seconds": 6.474,
+                    "sample_rate": 44100,
+                    "sha256": "a" * 64,
+                },
+            },
+            {
+                "role": "duration_coverage_fill_keep",
+                "candidate_id": "duration_fill_candidate",
+                "source_midi_path": "fill.mid",
+                "wav_file": {
+                    "path": "fill.wav",
+                    "exists": True,
+                    "duration_seconds": 6.474,
+                    "sample_rate": 44100,
+                    "sha256": "b" * 64,
+                },
+            },
+        ],
+    }
+
+
+class StageBDurationCoverageFillUserListeningReviewFillTest(unittest.TestCase):
+    def test_records_fill_preference_without_broad_quality_claim(self) -> None:
+        report = build_user_listening_review_fill(
+            audio_render_report(),
+            output_dir=Path("outputs/user_review"),
+            reviewer="user",
+            preference="duration_coverage_fill_keep",
+            timing="duration_coverage_fill_keep",
+            phrase="duration_coverage_fill_keep",
+            vocabulary="duration_coverage_fill_keep",
+            source_assessment="source sounds like random notes and is hard to understand",
+            fill_assessment="fill sounds much more jazz-like as soloing",
+            notes="single user listening review after WAV render",
+        )
+        summary = validate_user_listening_review_fill(
+            report,
+            expected_preference="duration_coverage_fill_keep",
+            require_human_audio_preference=True,
+            require_no_broad_quality_claim=True,
+        )
+
+        self.assertEqual(summary["review_status"], "reviewed")
+        self.assertEqual(summary["preference"], "duration_coverage_fill_keep")
+        self.assertTrue(summary["human_audio_preference_claimed"])
+        self.assertFalse(summary["broad_model_quality_claimed"])
+        self.assertIn("multi_reviewer_preference", report["not_proven"])
+
+    def test_rejects_already_claimed_source_report(self) -> None:
+        with self.assertRaises(StageBDurationCoverageUserListeningReviewFillError):
+            build_user_listening_review_fill(
+                audio_render_report(preference_claimed=True),
+                output_dir=Path("outputs/user_review"),
+                reviewer="user",
+                preference="duration_coverage_fill_keep",
+                timing="duration_coverage_fill_keep",
+                phrase="duration_coverage_fill_keep",
+                vocabulary="duration_coverage_fill_keep",
+                source_assessment="source rejected",
+                fill_assessment="fill preferred",
+                notes="",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- rendered source/fill WAV에 대한 user listening review 입력 반영
- fill 후보 human/audio preference claim 기록
- source assessment와 fill assessment 분리
- broad model quality claim guard 유지

## Context

- Issue #343 local audio render attempt 완료
- rendered WAV files: `2`
- source WAV: `source_constrained_partial.wav`
- fill WAV: `duration_coverage_fill_keep.wav`
- user review: fill 후보가 훨씬 jazz-like soloing, source 후보는 random notes처럼 인식
- prior MIDI evidence preference: `duration_coverage_fill_keep`

## Scope

- user listening review fill script: `scripts/fill_stage_b_duration_coverage_user_listening_review.py`
- audio render report and review input validation
- preference: `duration_coverage_fill_keep`
- timing/phrase/vocabulary: `duration_coverage_fill_keep`
- claim boundary: single-user human/audio preference only
- harness mode: `stage-b-user-listening-review-fill`
- README, CORE_PLAN, CURRENT_STATUS_AND_PLAN, AGENTS handoff 갱신

## Validation

- `.venv/bin/python -m unittest tests/test_stage_b_user_listening_review_fill.py`
- `bash scripts/agent_harness.sh stage-b-user-listening-review-fill`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- `rg -n 'codex|Codex|코덱스' ...` no output

## Result

- review status: `reviewed`
- preference: `duration_coverage_fill_keep`
- human/audio preference claimed: `true`
- single user review: `true`
- broad model quality claimed: `false`
- audio rendered quality claimed: `false`

## Risk

- single-user preference is not multi-reviewer proof
- Brad style adaptation and production-ready improviser claims remain not proven
- rendered WAV files remain local artifacts

## Follow-up

- next primary boundary: `Stage B margin-recovered phrase/vocabulary duration coverage fill user listening review consolidation`

Closes #345