### PR TITLE
Stage B duration coverage fill user listening review consolidation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #345, Stage B duration coverage fill user listening review fill.
+- Latest functional issue completed: Issue #347, Stage B duration coverage fill user listening review consolidation.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill user listening review consolidation.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill next repair or repeatability decision.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -738,6 +738,14 @@ bash scripts/agent_harness.sh stage-b-user-listening-review-fill
 ```
 
 This harness applies a validated user listening review from rendered WAV files and keeps broad model quality unclaimed.
+
+For Stage B duration coverage fill user listening review consolidation changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-user-listening-review-consolidation
+```
+
+This harness consolidates MIDI evidence, technical WAV validation, and single-user listening preference.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@
 | renderer path decision 필요 | renderer unavailable 상태에서 설치/다운로드 없이 render attempt로 넘어갈 위험 | renderer path decision 추가 | decision `renderer_path_or_install_approval_required`, critical user input `true` |
 | user listening review artifact 필요 | MIDI evidence는 있지만 사용자가 직접 들을 WAV가 없음 | FluidSynth + GeneralUser GS로 source/fill WAV 렌더 | rendered files `2`, duration `6.474s`, technical WAV validation `true`, preference claim `false` |
 | user listening preference 기록 필요 | WAV 리뷰 후에도 선호와 claim boundary가 문서화되지 않으면 다음 판단 근거가 분리됨 | user listening review fill 추가 | preference `duration_coverage_fill_keep`, source random-like, fill jazz-like soloing, broad quality claim `false` |
+| evidence consolidation 필요 | MIDI evidence, WAV render, user review가 분리돼 다음 판단 경계가 불명확함 | user listening review consolidation 추가 | boundary `midi_evidence_and_single_user_listening_support_duration_coverage_fill_keep`, broad quality claim `false` |
 
 ## 파이프라인 구조
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -117,6 +117,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - renderer path decision 문서: `docs/STAGE_B_RENDERER_PATH_DECISION_2026-05-29.md`
 - duration coverage fill local audio render attempt 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_LOCAL_AUDIO_RENDER_ATTEMPT_2026-05-29.md`
 - duration coverage fill user listening review fill 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_USER_LISTENING_REVIEW_FILL_2026-05-29.md`
+- duration coverage fill user listening review consolidation 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_USER_LISTENING_REVIEW_CONSOLIDATION_2026-05-29.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -172,6 +173,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - renderer path decision: decision `renderer_path_or_install_approval_required`, critical user input `true`
 - duration coverage fill local audio render attempt: rendered WAV files `2`, sample rate `44100`, duration `6.474s`, preference claim `false`
 - duration coverage fill user listening review fill: preference `duration_coverage_fill_keep`, human/audio preference claim `true`, broad model quality claim `false`
+- duration coverage fill user listening review consolidation: MIDI evidence and single-user listening both support `duration_coverage_fill_keep`, broad model quality claim `false`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #345, Stage B duration coverage fill user listening review fill
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill user listening review consolidation`
+- latest functional result: Issue #347, Stage B duration coverage fill user listening review consolidation
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill next repair or repeatability decision`
 
 현재 범위가 아닌 것:
 
@@ -65,6 +65,40 @@ Issue #220은 현재 작업이 core인지, MVP 완료로 볼 수 있는지를 �
 Docs:
 
 - `docs/STAGE_B_MODEL_CORE_MVP_COMPLETION_AUDIT_2026-05-28.md`
+
+## Current Duration Coverage Fill User Listening Review Consolidation Result
+
+Issue #347은 MIDI evidence, WAV render validation, user listening review를 하나의 claim boundary로 정리한 작업이다.
+
+변경:
+
+- user listening review consolidation script 추가
+- MIDI evidence / audio render / user review reports 조인
+- consolidated claim boundary 정의
+- proven / not proven / next decision 정리
+
+결과:
+
+- boundary: `midi_evidence_and_single_user_listening_support_duration_coverage_fill_keep`
+- preferred candidate: `duration_coverage_fill_keep`
+- MIDI evidence preference: `duration_coverage_fill_keep`
+- user listening preference: `duration_coverage_fill_keep`
+- same preferred candidate: `true`
+- rendered audio file count: `2`
+- technical WAV validation: `true`
+- single user review: `true`
+- broad model quality claimed: `false`
+
+판단:
+
+- MIDI metric, rendered WAV technical validation, single-user listening review가 같은 fill 후보를 지지
+- multi-reviewer preference, broad trained-model quality, Brad style adaptation은 미검증
+- production-ready improviser claim 금지
+
+다음:
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill next repair or repeatability decision`
+- consolidated fill evidence를 기준으로 broader repeatability 또는 다음 repair target 분리
 
 ## Current Duration Coverage Fill User Listening Review Fill Result
 

--- a/docs/STAGE_B_DURATION_COVERAGE_FILL_USER_LISTENING_REVIEW_CONSOLIDATION_2026-05-29.md
+++ b/docs/STAGE_B_DURATION_COVERAGE_FILL_USER_LISTENING_REVIEW_CONSOLIDATION_2026-05-29.md
@@ -1,0 +1,64 @@
+# Stage B Duration Coverage Fill User Listening Review Consolidation
+
+Issue #347은 MIDI evidence, WAV render validation, user listening review를 하나의 claim boundary로 정리한 작업이다.
+
+## Context
+
+- Issue #332 MIDI evidence consolidation: `midi_evidence_preference_support`
+- Issue #343 local audio render attempt: rendered WAV files `2`, technical WAV validation `true`
+- Issue #345 user listening review fill: preference `duration_coverage_fill_keep`
+- user assessment: source 후보는 random-like, fill 후보는 jazz-like soloing
+
+## Change
+
+- user listening review consolidation script 추가
+- MIDI evidence / audio render / user review reports 조인
+- consolidated claim boundary 정의
+- proven / not proven / next decision 정리
+- 전용 harness와 unit test 추가
+
+## Result
+
+| item | value |
+|---|---:|
+| boundary | `midi_evidence_and_single_user_listening_support_duration_coverage_fill_keep` |
+| preferred candidate | `duration_coverage_fill_keep` |
+| MIDI evidence preference | `duration_coverage_fill_keep` |
+| user listening preference | `duration_coverage_fill_keep` |
+| same preferred candidate | `true` |
+| rendered audio file count | `2` |
+| technical WAV validation | `true` |
+| single user review | `true` |
+| broad model quality claimed | `false` |
+
+## Proven
+
+- MIDI metric preference for duration/coverage fill keep
+- technical WAV render validation completed
+- single-user listening preference for duration/coverage fill keep
+
+## Not Proven
+
+- multi-reviewer preference
+- audio rendered quality
+- broad trained-model quality
+- Brad style adaptation
+- production-ready improviser
+
+## Validation
+
+```bash
+.venv/bin/python -m unittest tests/test_stage_b_user_listening_review_consolidation.py
+bash scripts/agent_harness.sh stage-b-user-listening-review-consolidation
+```
+
+## Output
+
+- script: `scripts/summarize_stage_b_duration_coverage_user_listening_consolidation.py`
+- test: `tests/test_stage_b_user_listening_review_consolidation.py`
+- summary: `outputs/stage_b_duration_coverage_fill_user_listening_review_consolidation/harness_stage_b_duration_coverage_fill_user_listening_review_consolidation/stage_b_duration_coverage_fill_user_listening_review_consolidation.json`
+
+## Next
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill next repair or repeatability decision`
+- consolidated fill evidence를 기준으로 broader repeatability 또는 다음 repair target 분리

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -1785,6 +1785,37 @@ run_stage_b_user_listening_review_fill() {
     --require_no_broad_quality_claim
 }
 
+run_stage_b_user_listening_review_consolidation() {
+  local midi_evidence_run_id="${MIDI_EVIDENCE_RUN_ID:-harness_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_midi_evidence_consolidation}"
+  local audio_render_run_id="${AUDIO_RENDER_RUN_ID:-harness_stage_b_duration_coverage_fill_local_audio_render_attempt}"
+  local user_review_run_id="${USER_REVIEW_RUN_ID:-harness_stage_b_duration_coverage_fill_user_listening_review_fill}"
+  local run_id="${RUN_ID:-harness_stage_b_duration_coverage_fill_user_listening_review_consolidation}"
+  local midi_evidence="outputs/stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_midi_evidence_consolidation/${midi_evidence_run_id}/duration_coverage_fill_midi_evidence_consolidation.json"
+  local audio_render_report="outputs/stage_b_duration_coverage_fill_local_audio_render_attempt/${audio_render_run_id}/stage_b_duration_coverage_fill_local_audio_render_attempt.json"
+  local user_review="outputs/stage_b_duration_coverage_fill_user_listening_review_fill/${user_review_run_id}/stage_b_duration_coverage_fill_user_listening_review_fill.json"
+  if [[ ! -f "$midi_evidence" ]]; then
+    print_header "Stage B duration/coverage fill MIDI evidence consolidation"
+    RUN_ID="$midi_evidence_run_id" run_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_midi_evidence_consolidation
+  fi
+  if [[ ! -f "$audio_render_report" ]]; then
+    print_header "Stage B duration/coverage fill local audio render attempt"
+    RUN_ID="$audio_render_run_id" run_stage_b_local_audio_render_attempt
+  fi
+  if [[ ! -f "$user_review" ]]; then
+    print_header "Stage B duration/coverage fill user listening review fill"
+    RUN_ID="$user_review_run_id" run_stage_b_user_listening_review_fill
+  fi
+  print_header "Stage B duration/coverage fill user listening review consolidation"
+  "$PYTHON_BIN" scripts/summarize_stage_b_duration_coverage_user_listening_consolidation.py \
+    --run_id "$run_id" \
+    --midi_evidence_consolidation "$midi_evidence" \
+    --audio_render_attempt "$audio_render_report" \
+    --user_listening_review_fill "$user_review" \
+    --expected_boundary midi_evidence_and_single_user_listening_support_duration_coverage_fill_keep \
+    --expected_preferred_candidate duration_coverage_fill_keep \
+    --require_no_broad_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -3066,6 +3097,9 @@ case "$MODE" in
     ;;
   stage-b-user-listening-review-fill)
     run_stage_b_user_listening_review_fill
+    ;;
+  stage-b-user-listening-review-consolidation)
+    run_stage_b_user_listening_review_consolidation
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/summarize_stage_b_duration_coverage_user_listening_consolidation.py
+++ b/scripts/summarize_stage_b_duration_coverage_user_listening_consolidation.py
@@ -1,0 +1,306 @@
+"""Consolidate MIDI evidence, WAV render validation, and user listening review."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class StageBDurationCoverageUserListeningConsolidationError(ValueError):
+    pass
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def require_candidate_match(*reports: dict[str, Any]) -> str:
+    candidate_ids = [str(report.get("candidate_id") or "") for report in reports]
+    unique_ids = {candidate_id for candidate_id in candidate_ids if candidate_id}
+    if len(unique_ids) != 1:
+        raise StageBDurationCoverageUserListeningConsolidationError(
+            f"candidate mismatch: {candidate_ids}"
+        )
+    return next(iter(unique_ids))
+
+
+def build_consolidation_report(
+    midi_evidence_consolidation: dict[str, Any],
+    audio_render_attempt: dict[str, Any],
+    user_listening_review_fill: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> dict[str, Any]:
+    candidate_id = require_candidate_match(
+        midi_evidence_consolidation,
+        audio_render_attempt,
+        user_listening_review_fill,
+    )
+    midi_summary = (
+        midi_evidence_consolidation.get("midi_evidence_summary")
+        if isinstance(midi_evidence_consolidation.get("midi_evidence_summary"), dict)
+        else {}
+    )
+    midi_claim = (
+        midi_evidence_consolidation.get("claim_boundary")
+        if isinstance(midi_evidence_consolidation.get("claim_boundary"), dict)
+        else {}
+    )
+    audio_boundary = (
+        audio_render_attempt.get("audio_render_boundary")
+        if isinstance(audio_render_attempt.get("audio_render_boundary"), dict)
+        else {}
+    )
+    user_review = (
+        user_listening_review_fill.get("user_listening_review")
+        if isinstance(user_listening_review_fill.get("user_listening_review"), dict)
+        else {}
+    )
+    user_claim = (
+        user_listening_review_fill.get("claim_boundary")
+        if isinstance(user_listening_review_fill.get("claim_boundary"), dict)
+        else {}
+    )
+    midi_preference = str(midi_summary.get("preference") or "")
+    user_preference = str(user_review.get("preference") or "")
+    if midi_preference != "duration_coverage_fill_keep":
+        raise StageBDurationCoverageUserListeningConsolidationError(
+            f"unexpected MIDI evidence preference: {midi_preference}"
+        )
+    if user_preference != "duration_coverage_fill_keep":
+        raise StageBDurationCoverageUserListeningConsolidationError(
+            f"unexpected user listening preference: {user_preference}"
+        )
+    if not bool(midi_claim.get("midi_evidence_preference_claimed", False)):
+        raise StageBDurationCoverageUserListeningConsolidationError("MIDI evidence preference is not claimed")
+    if not bool(audio_boundary.get("technical_wav_validation", False)):
+        raise StageBDurationCoverageUserListeningConsolidationError("technical WAV validation is required")
+    if not bool(user_claim.get("human_audio_preference_claimed", False)):
+        raise StageBDurationCoverageUserListeningConsolidationError("user listening preference is not claimed")
+    rendered_files = audio_render_attempt.get("rendered_audio_files")
+    if not isinstance(rendered_files, list) or len(rendered_files) != 2:
+        raise StageBDurationCoverageUserListeningConsolidationError("expected two rendered WAV files")
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_user_listening_consolidation_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "candidate_id": candidate_id,
+        "source_schemas": {
+            "midi_evidence_consolidation": str(midi_evidence_consolidation.get("schema_version") or ""),
+            "audio_render_attempt": str(audio_render_attempt.get("schema_version") or ""),
+            "user_listening_review_fill": str(user_listening_review_fill.get("schema_version") or ""),
+        },
+        "evidence_alignment": {
+            "midi_evidence_preference": midi_preference,
+            "user_listening_preference": user_preference,
+            "same_preferred_candidate": midi_preference == user_preference,
+            "technical_wav_validation": True,
+            "rendered_audio_file_count": int(audio_boundary.get("rendered_audio_file_count", 0) or 0),
+            "single_user_review": bool(user_claim.get("single_user_review", False)),
+        },
+        "midi_evidence_summary": {
+            "review_basis": str(midi_summary.get("review_basis") or ""),
+            "source_score": float(midi_summary.get("source_score", 0.0) or 0.0),
+            "fill_score": float(midi_summary.get("fill_score", 0.0) or 0.0),
+            "score_delta_fill_minus_source": float(midi_summary.get("score_delta_fill_minus_source", 0.0) or 0.0),
+            "dead_air_delta_fill_minus_source": float(midi_summary.get("dead_air_delta_fill_minus_source", 0.0) or 0.0),
+            "focused_note_count_delta_fill_minus_source": int(
+                midi_summary.get("focused_note_count_delta_fill_minus_source", 0) or 0
+            ),
+            "focused_unique_pitch_count_delta_fill_minus_source": int(
+                midi_summary.get("focused_unique_pitch_count_delta_fill_minus_source", 0) or 0
+            ),
+            "max_simultaneous_notes_delta_fill_minus_source": int(
+                midi_summary.get("max_simultaneous_notes_delta_fill_minus_source", 0) or 0
+            ),
+        },
+        "audio_render_summary": {
+            "render_attempted": bool(audio_boundary.get("render_attempted", False)),
+            "technical_wav_validation": bool(audio_boundary.get("technical_wav_validation", False)),
+            "rendered_audio_file_count": int(audio_boundary.get("rendered_audio_file_count", 0) or 0),
+            "sample_rates": sorted(
+                {
+                    int(item.get("wav_file", {}).get("sample_rate", 0) or 0)
+                    for item in rendered_files
+                    if isinstance(item, dict)
+                }
+            ),
+            "durations_seconds": {
+                str(item.get("role") or ""): float(item.get("wav_file", {}).get("duration_seconds", 0.0) or 0.0)
+                for item in rendered_files
+                if isinstance(item, dict)
+            },
+        },
+        "user_listening_summary": {
+            "review_basis": str(user_review.get("review_basis") or ""),
+            "preference": user_preference,
+            "timing": str(user_review.get("timing") or ""),
+            "phrase": str(user_review.get("phrase") or ""),
+            "vocabulary": str(user_review.get("vocabulary") or ""),
+            "source_assessment": str(user_review.get("source_assessment") or ""),
+            "fill_assessment": str(user_review.get("fill_assessment") or ""),
+            "notes": str(user_review.get("notes") or ""),
+        },
+        "consolidated_claim_boundary": {
+            "boundary": "midi_evidence_and_single_user_listening_support_duration_coverage_fill_keep",
+            "preferred_candidate": "duration_coverage_fill_keep",
+            "midi_evidence_preference_claimed": True,
+            "technical_wav_validation_claimed": True,
+            "single_user_human_audio_preference_claimed": True,
+            "multi_reviewer_preference_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "broad_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_improviser_claimed": False,
+        },
+        "proven": [
+            "midi_metric_preference_for_duration_coverage_fill_keep",
+            "technical_wav_render_validation_completed",
+            "single_user_listening_preference_for_duration_coverage_fill_keep",
+        ],
+        "not_proven": [
+            "multi_reviewer_preference",
+            "audio_rendered_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "production_ready_improviser",
+        ],
+        "next_recommended_issue": "Stage B margin-recovered phrase/vocabulary duration coverage fill next repair or repeatability decision",
+    }
+
+
+def validate_consolidation_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_preferred_candidate: str | None,
+    require_no_broad_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = (
+        report.get("consolidated_claim_boundary")
+        if isinstance(report.get("consolidated_claim_boundary"), dict)
+        else {}
+    )
+    boundary_name = str(boundary.get("boundary") or "")
+    preferred = str(boundary.get("preferred_candidate") or "")
+    if expected_boundary and boundary_name != expected_boundary:
+        raise StageBDurationCoverageUserListeningConsolidationError(
+            f"expected boundary {expected_boundary}, got {boundary_name}"
+        )
+    if expected_preferred_candidate and preferred != expected_preferred_candidate:
+        raise StageBDurationCoverageUserListeningConsolidationError(
+            f"expected preferred candidate {expected_preferred_candidate}, got {preferred}"
+        )
+    if require_no_broad_quality_claim:
+        blocked = [
+            "multi_reviewer_preference_claimed",
+            "audio_rendered_quality_claimed",
+            "broad_model_quality_claimed",
+            "brad_style_adaptation_claimed",
+            "production_ready_improviser_claimed",
+        ]
+        claimed = [name for name in blocked if bool(boundary.get(name, True))]
+        if claimed:
+            raise StageBDurationCoverageUserListeningConsolidationError(
+                f"unexpected broad claim: {claimed}"
+            )
+    alignment = report.get("evidence_alignment") if isinstance(report.get("evidence_alignment"), dict) else {}
+    if not bool(alignment.get("same_preferred_candidate", False)):
+        raise StageBDurationCoverageUserListeningConsolidationError("evidence preference mismatch")
+    return {
+        "candidate_id": str(report.get("candidate_id") or ""),
+        "boundary": boundary_name,
+        "preferred_candidate": preferred,
+        "same_preferred_candidate": bool(alignment.get("same_preferred_candidate", False)),
+        "rendered_audio_file_count": int(alignment.get("rendered_audio_file_count", 0) or 0),
+        "single_user_review": bool(alignment.get("single_user_review", False)),
+        "broad_model_quality_claimed": bool(boundary.get("broad_model_quality_claimed", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    boundary = report["consolidated_claim_boundary"]
+    midi = report["midi_evidence_summary"]
+    user = report["user_listening_summary"]
+    audio = report["audio_render_summary"]
+    lines = [
+        "# Stage B Duration Coverage Fill User Listening Review Consolidation",
+        "",
+        f"- candidate: `{report['candidate_id']}`",
+        f"- boundary: `{boundary['boundary']}`",
+        f"- preferred candidate: `{boundary['preferred_candidate']}`",
+        f"- MIDI score delta fill-source: `{midi['score_delta_fill_minus_source']:.3f}`",
+        f"- rendered audio file count: `{audio['rendered_audio_file_count']}`",
+        f"- user listening preference: `{user['preference']}`",
+        f"- broad model quality claimed: `{boundary['broad_model_quality_claimed']}`",
+        "",
+        "## User Assessment",
+        "",
+        f"- source: {user['source_assessment']}",
+        f"- fill: {user['fill_assessment']}",
+        "",
+        "## Proven",
+        "",
+    ]
+    for item in report.get("proven", []):
+        lines.append(f"- `{item}`")
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Consolidate Stage B duration coverage user listening review")
+    parser.add_argument("--midi_evidence_consolidation", type=str, required=True)
+    parser.add_argument("--audio_render_attempt", type=str, required=True)
+    parser.add_argument("--user_listening_review_fill", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_user_listening_review_consolidation",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_preferred_candidate", type=str, default="")
+    parser.add_argument("--require_no_broad_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_consolidation_report(
+        read_json(Path(args.midi_evidence_consolidation)),
+        read_json(Path(args.audio_render_attempt)),
+        read_json(Path(args.user_listening_review_fill)),
+        output_dir=output_dir,
+    )
+    summary = validate_consolidation_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_preferred_candidate=str(args.expected_preferred_candidate or ""),
+        require_no_broad_quality_claim=bool(args.require_no_broad_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "stage_b_duration_coverage_fill_user_listening_review_consolidation.json"
+    markdown_path = output_dir / "stage_b_duration_coverage_fill_user_listening_review_consolidation.md"
+    write_json(report_path, report)
+    write_json(output_dir / "stage_b_duration_coverage_fill_user_listening_review_consolidation_validation_summary.json", summary)
+    markdown_path.write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps({**summary, "report_path": str(report_path), "markdown_path": str(markdown_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_user_listening_review_consolidation.py
+++ b/tests/test_stage_b_user_listening_review_consolidation.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.summarize_stage_b_duration_coverage_user_listening_consolidation import (
+    StageBDurationCoverageUserListeningConsolidationError,
+    build_consolidation_report,
+    validate_consolidation_report,
+)
+
+
+def midi_evidence_consolidation() -> dict:
+    return {
+        "schema_version": "stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_midi_evidence_consolidation_v1",
+        "candidate_id": "duration_fill_candidate",
+        "midi_evidence_summary": {
+            "preference": "duration_coverage_fill_keep",
+            "review_basis": "midi_metric_and_note_structure",
+            "source_score": 91.857143,
+            "fill_score": 171.588235,
+            "score_delta_fill_minus_source": 79.731092,
+            "dead_air_delta_fill_minus_source": -0.277311,
+            "focused_note_count_delta_fill_minus_source": 6,
+            "focused_unique_pitch_count_delta_fill_minus_source": 6,
+            "max_simultaneous_notes_delta_fill_minus_source": -1,
+        },
+        "claim_boundary": {
+            "boundary": "midi_evidence_preference_support",
+            "midi_evidence_preference_claimed": True,
+            "human_audio_preference_claimed": False,
+        },
+    }
+
+
+def audio_render_attempt() -> dict:
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_local_audio_render_attempt_v1",
+        "candidate_id": "duration_fill_candidate",
+        "audio_render_boundary": {
+            "render_attempted": True,
+            "technical_wav_validation": True,
+            "rendered_audio_file_count": 2,
+        },
+        "rendered_audio_files": [
+            {
+                "role": "source_constrained_partial",
+                "wav_file": {
+                    "sample_rate": 44100,
+                    "duration_seconds": 6.474,
+                },
+            },
+            {
+                "role": "duration_coverage_fill_keep",
+                "wav_file": {
+                    "sample_rate": 44100,
+                    "duration_seconds": 6.474,
+                },
+            },
+        ],
+    }
+
+
+def user_listening_review_fill(*, preference: str = "duration_coverage_fill_keep") -> dict:
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_user_listening_review_fill_v1",
+        "candidate_id": "duration_fill_candidate",
+        "user_listening_review": {
+            "review_basis": "user_listening_review_of_rendered_wav",
+            "preference": preference,
+            "timing": "duration_coverage_fill_keep",
+            "phrase": "duration_coverage_fill_keep",
+            "vocabulary": "duration_coverage_fill_keep",
+            "source_assessment": "source sounds like random notes and is hard to understand",
+            "fill_assessment": "fill sounds much more jazz-like as soloing",
+            "notes": "single user listening review",
+        },
+        "claim_boundary": {
+            "human_audio_preference_claimed": True,
+            "single_user_review": True,
+            "audio_rendered_quality_claimed": False,
+            "broad_model_quality_claimed": False,
+        },
+    }
+
+
+class StageBDurationCoverageFillUserListeningConsolidationTest(unittest.TestCase):
+    def test_consolidates_aligned_midi_audio_and_user_evidence(self) -> None:
+        report = build_consolidation_report(
+            midi_evidence_consolidation(),
+            audio_render_attempt(),
+            user_listening_review_fill(),
+            output_dir=Path("outputs/consolidation"),
+        )
+        summary = validate_consolidation_report(
+            report,
+            expected_boundary="midi_evidence_and_single_user_listening_support_duration_coverage_fill_keep",
+            expected_preferred_candidate="duration_coverage_fill_keep",
+            require_no_broad_quality_claim=True,
+        )
+
+        self.assertTrue(summary["same_preferred_candidate"])
+        self.assertTrue(summary["single_user_review"])
+        self.assertEqual(summary["rendered_audio_file_count"], 2)
+        self.assertFalse(summary["broad_model_quality_claimed"])
+        self.assertIn("multi_reviewer_preference", report["not_proven"])
+
+    def test_rejects_mismatched_user_preference(self) -> None:
+        with self.assertRaises(StageBDurationCoverageUserListeningConsolidationError):
+            build_consolidation_report(
+                midi_evidence_consolidation(),
+                audio_render_attempt(),
+                user_listening_review_fill(preference="source_constrained_partial"),
+                output_dir=Path("outputs/consolidation"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- MIDI evidence, technical WAV validation, user listening preference를 하나의 claim boundary로 정리
- duration/coverage fill 후보 지지 근거와 not-proven 범위 분리
- broad model quality, Brad style adaptation, production-ready claim guard 유지

## Context

- Issue #332 MIDI evidence preference: `duration_coverage_fill_keep`
- Issue #343 rendered WAV files: `2`, technical WAV validation: `true`
- Issue #345 user listening preference: `duration_coverage_fill_keep`
- user assessment: source random-like, fill jazz-like soloing

## Scope

- consolidation script: `scripts/summarize_stage_b_duration_coverage_user_listening_consolidation.py`
- inputs: MIDI evidence consolidation, local audio render attempt, user listening review fill
- consolidated boundary: `midi_evidence_and_single_user_listening_support_duration_coverage_fill_keep`
- harness mode: `stage-b-user-listening-review-consolidation`
- README, CORE_PLAN, CURRENT_STATUS_AND_PLAN, AGENTS handoff 갱신

## Validation

- `.venv/bin/python -m unittest tests/test_stage_b_user_listening_review_consolidation.py`
- `bash scripts/agent_harness.sh stage-b-user-listening-review-consolidation`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- `rg -n 'codex|Codex|코덱스' ...` no output

## Result

- preferred candidate: `duration_coverage_fill_keep`
- same preferred candidate across MIDI and user review: `true`
- rendered audio file count: `2`
- single user review: `true`
- broad model quality claimed: `false`

## Risk

- single user preference is not multi-reviewer proof
- audio rendered quality, broad trained-model quality, Brad style adaptation remain not proven
- generated WAV files remain local artifacts

## Follow-up

- next primary boundary: `Stage B margin-recovered phrase/vocabulary duration coverage fill next repair or repeatability decision`

Closes #347