### PR TITLE
Stage B duration coverage fill next decision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #347, Stage B duration coverage fill user listening review consolidation.
+- Latest functional issue completed: Issue #349, Stage B duration coverage fill next decision.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill next repair or repeatability decision.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill broader repeatability sweep.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -746,6 +746,14 @@ bash scripts/agent_harness.sh stage-b-user-listening-review-consolidation
 ```
 
 This harness consolidates MIDI evidence, technical WAV validation, and single-user listening preference.
+
+For Stage B duration coverage fill next decision changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-duration-coverage-next-decision
+```
+
+This harness selects the next auto-progress boundary after consolidated fill evidence.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@
 | user listening review artifact 필요 | MIDI evidence는 있지만 사용자가 직접 들을 WAV가 없음 | FluidSynth + GeneralUser GS로 source/fill WAV 렌더 | rendered files `2`, duration `6.474s`, technical WAV validation `true`, preference claim `false` |
 | user listening preference 기록 필요 | WAV 리뷰 후에도 선호와 claim boundary가 문서화되지 않으면 다음 판단 근거가 분리됨 | user listening review fill 추가 | preference `duration_coverage_fill_keep`, source random-like, fill jazz-like soloing, broad quality claim `false` |
 | evidence consolidation 필요 | MIDI evidence, WAV render, user review가 분리돼 다음 판단 경계가 불명확함 | user listening review consolidation 추가 | boundary `midi_evidence_and_single_user_listening_support_duration_coverage_fill_keep`, broad quality claim `false` |
+| 다음 경계 결정 필요 | fill 후보 지지는 확인됐지만 multi-seed repeatability는 미검증 | next decision 추가 | next boundary `broader_repeatability_sweep`, critical user input `false` |
 
 ## 파이프라인 구조
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -118,6 +118,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - duration coverage fill local audio render attempt 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_LOCAL_AUDIO_RENDER_ATTEMPT_2026-05-29.md`
 - duration coverage fill user listening review fill 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_USER_LISTENING_REVIEW_FILL_2026-05-29.md`
 - duration coverage fill user listening review consolidation 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_USER_LISTENING_REVIEW_CONSOLIDATION_2026-05-29.md`
+- duration coverage fill next decision 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_NEXT_DECISION_2026-05-29.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -174,6 +175,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - duration coverage fill local audio render attempt: rendered WAV files `2`, sample rate `44100`, duration `6.474s`, preference claim `false`
 - duration coverage fill user listening review fill: preference `duration_coverage_fill_keep`, human/audio preference claim `true`, broad model quality claim `false`
 - duration coverage fill user listening review consolidation: MIDI evidence and single-user listening both support `duration_coverage_fill_keep`, broad model quality claim `false`
+- duration coverage fill next decision: next boundary `broader_repeatability_sweep`, critical user input `false`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #347, Stage B duration coverage fill user listening review consolidation
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill next repair or repeatability decision`
+- latest functional result: Issue #349, Stage B duration coverage fill next decision
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill broader repeatability sweep`
 
 현재 범위가 아닌 것:
 
@@ -65,6 +65,34 @@ Issue #220은 현재 작업이 core인지, MVP 완료로 볼 수 있는지를 �
 Docs:
 
 - `docs/STAGE_B_MODEL_CORE_MVP_COMPLETION_AUDIT_2026-05-28.md`
+
+## Current Duration Coverage Fill Next Decision Result
+
+Issue #349는 user listening review consolidation 이후 다음 작업 경계를 정리한 작업이다.
+
+변경:
+
+- next decision summary script 추가
+- repeatability vs repair decision rule 정의
+- single-candidate support와 broad-quality not-proven boundary 유지
+
+결과:
+
+- preferred candidate: `duration_coverage_fill_keep`
+- next boundary: `broader_repeatability_sweep`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- broad model quality claimed: `false`
+
+판단:
+
+- fill candidate는 MIDI evidence와 single-user listening review에서 같은 방향으로 지지됨
+- 아직 multi-seed repeatability가 미검증
+- 다음 자동 작업은 broader repeatability sweep
+
+다음:
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill broader repeatability sweep`
 
 ## Current Duration Coverage Fill User Listening Review Consolidation Result
 

--- a/docs/STAGE_B_DURATION_COVERAGE_FILL_NEXT_DECISION_2026-05-29.md
+++ b/docs/STAGE_B_DURATION_COVERAGE_FILL_NEXT_DECISION_2026-05-29.md
@@ -1,0 +1,61 @@
+# Stage B Duration Coverage Fill Next Decision
+
+Issue #349는 user listening review consolidation 이후 다음 작업 경계를 정리한 작업이다.
+
+## Context
+
+- Issue #347 boundary: `midi_evidence_and_single_user_listening_support_duration_coverage_fill_keep`
+- preferred candidate: `duration_coverage_fill_keep`
+- MIDI/user preference aligned: `true`
+- rendered audio file count: `2`
+- single user review: `true`
+- broad model quality claimed: `false`
+
+## Change
+
+- next decision summary script 추가
+- repeatability vs repair decision rule 정의
+- single-candidate support와 broad-quality not-proven boundary 유지
+- 전용 harness와 unit test 추가
+
+## Result
+
+| item | value |
+|---|---:|
+| preferred candidate | `duration_coverage_fill_keep` |
+| next boundary | `broader_repeatability_sweep` |
+| auto progress allowed | `true` |
+| critical user input required | `false` |
+| broad model quality claimed | `false` |
+
+## Decision
+
+- fill candidate는 MIDI evidence와 single-user listening review에서 같은 방향으로 지지됨
+- 아직 multi-seed repeatability가 미검증
+- 다음 경계: broader repeatability sweep
+
+## Not Proven
+
+- multi-seed repeatability
+- multi-reviewer preference
+- audio rendered quality
+- broad trained-model quality
+- Brad style adaptation
+- production-ready improviser
+
+## Validation
+
+```bash
+.venv/bin/python -m unittest tests/test_stage_b_duration_coverage_next_decision.py
+bash scripts/agent_harness.sh stage-b-duration-coverage-next-decision
+```
+
+## Output
+
+- script: `scripts/decide_stage_b_duration_coverage_next_step.py`
+- test: `tests/test_stage_b_duration_coverage_next_decision.py`
+- summary: `outputs/stage_b_duration_coverage_fill_next_decision/harness_stage_b_duration_coverage_fill_next_decision/stage_b_duration_coverage_fill_next_decision.json`
+
+## Next
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill broader repeatability sweep`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -1816,6 +1816,23 @@ run_stage_b_user_listening_review_consolidation() {
     --require_no_broad_quality_claim
 }
 
+run_stage_b_duration_coverage_next_decision() {
+  local consolidation_run_id="${CONSOLIDATION_RUN_ID:-harness_stage_b_duration_coverage_fill_user_listening_review_consolidation}"
+  local run_id="${RUN_ID:-harness_stage_b_duration_coverage_fill_next_decision}"
+  local consolidation="outputs/stage_b_duration_coverage_fill_user_listening_review_consolidation/${consolidation_run_id}/stage_b_duration_coverage_fill_user_listening_review_consolidation.json"
+  if [[ ! -f "$consolidation" ]]; then
+    print_header "Stage B duration/coverage fill user listening review consolidation"
+    RUN_ID="$consolidation_run_id" run_stage_b_user_listening_review_consolidation
+  fi
+  print_header "Stage B duration/coverage fill next decision"
+  "$PYTHON_BIN" scripts/decide_stage_b_duration_coverage_next_step.py \
+    --run_id "$run_id" \
+    --consolidation "$consolidation" \
+    --expected_next_boundary broader_repeatability_sweep \
+    --require_auto_progress_allowed \
+    --require_no_critical_user_input
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -3100,6 +3117,9 @@ case "$MODE" in
     ;;
   stage-b-user-listening-review-consolidation)
     run_stage_b_user_listening_review_consolidation
+    ;;
+  stage-b-duration-coverage-next-decision)
+    run_stage_b_duration_coverage_next_decision
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/decide_stage_b_duration_coverage_next_step.py
+++ b/scripts/decide_stage_b_duration_coverage_next_step.py
@@ -1,0 +1,181 @@
+"""Decide next Stage B duration/coverage fill boundary after user review consolidation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class StageBDurationCoverageNextDecisionError(ValueError):
+    pass
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def build_next_decision(
+    consolidation: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> dict[str, Any]:
+    boundary = (
+        consolidation.get("consolidated_claim_boundary")
+        if isinstance(consolidation.get("consolidated_claim_boundary"), dict)
+        else {}
+    )
+    alignment = (
+        consolidation.get("evidence_alignment")
+        if isinstance(consolidation.get("evidence_alignment"), dict)
+        else {}
+    )
+    preferred = str(boundary.get("preferred_candidate") or "")
+    if preferred != "duration_coverage_fill_keep":
+        raise StageBDurationCoverageNextDecisionError(f"unexpected preferred candidate: {preferred}")
+    if not bool(alignment.get("same_preferred_candidate", False)):
+        raise StageBDurationCoverageNextDecisionError("MIDI/user evidence must prefer the same candidate")
+    if bool(boundary.get("broad_model_quality_claimed", True)):
+        raise StageBDurationCoverageNextDecisionError("broad model quality must not be claimed")
+    if not bool(boundary.get("single_user_human_audio_preference_claimed", False)):
+        raise StageBDurationCoverageNextDecisionError("single-user human/audio preference is required")
+    decision = "broader_repeatability_sweep"
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_next_decision_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_consolidation_schema": str(consolidation.get("schema_version") or ""),
+        "candidate_id": str(consolidation.get("candidate_id") or ""),
+        "current_evidence": {
+            "preferred_candidate": preferred,
+            "midi_and_user_preference_aligned": True,
+            "rendered_audio_file_count": int(alignment.get("rendered_audio_file_count", 0) or 0),
+            "single_user_review": bool(alignment.get("single_user_review", False)),
+            "broad_model_quality_claimed": False,
+        },
+        "decision": {
+            "next_boundary": decision,
+            "reason": "fill candidate has aligned MIDI evidence and single-user listening support, but repeatability is not proven",
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "blocked_reason": "",
+        },
+        "repeatability_requirements": {
+            "compare_against_current_keep": True,
+            "require_midi_evidence_gate": True,
+            "require_no_broad_quality_claim": True,
+            "requires_new_user_review": False,
+            "suggested_scope": "duration_coverage_fill_broader_repeatability_sweep",
+        },
+        "not_proven": [
+            "multi_seed_repeatability",
+            "multi_reviewer_preference",
+            "audio_rendered_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "production_ready_improviser",
+        ],
+        "next_recommended_issue": "Stage B margin-recovered phrase/vocabulary duration coverage fill broader repeatability sweep",
+    }
+
+
+def validate_next_decision(
+    report: dict[str, Any],
+    *,
+    expected_next_boundary: str | None,
+    require_auto_progress_allowed: bool,
+    require_no_critical_user_input: bool,
+) -> dict[str, Any]:
+    decision = report.get("decision") if isinstance(report.get("decision"), dict) else {}
+    next_boundary = str(decision.get("next_boundary") or "")
+    if expected_next_boundary and next_boundary != expected_next_boundary:
+        raise StageBDurationCoverageNextDecisionError(
+            f"expected next boundary {expected_next_boundary}, got {next_boundary}"
+        )
+    if require_auto_progress_allowed and not bool(decision.get("auto_progress_allowed", False)):
+        raise StageBDurationCoverageNextDecisionError("auto progress must be allowed")
+    if require_no_critical_user_input and bool(decision.get("critical_user_input_required", True)):
+        raise StageBDurationCoverageNextDecisionError("critical user input must not be required")
+    current = report.get("current_evidence") if isinstance(report.get("current_evidence"), dict) else {}
+    if bool(current.get("broad_model_quality_claimed", True)):
+        raise StageBDurationCoverageNextDecisionError("broad model quality must not be claimed")
+    return {
+        "candidate_id": str(report.get("candidate_id") or ""),
+        "next_boundary": next_boundary,
+        "auto_progress_allowed": bool(decision.get("auto_progress_allowed", False)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "preferred_candidate": str(current.get("preferred_candidate") or ""),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    current = report["current_evidence"]
+    decision = report["decision"]
+    lines = [
+        "# Stage B Duration Coverage Fill Next Decision",
+        "",
+        f"- candidate: `{report['candidate_id']}`",
+        f"- preferred candidate: `{current['preferred_candidate']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- auto progress allowed: `{decision['auto_progress_allowed']}`",
+        f"- critical user input required: `{decision['critical_user_input_required']}`",
+        f"- broad model quality claimed: `{current['broad_model_quality_claimed']}`",
+        "",
+        "## Reason",
+        "",
+        f"- {decision['reason']}",
+        "",
+        "## Not Proven",
+        "",
+    ]
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Decide next Stage B duration coverage boundary")
+    parser.add_argument("--consolidation", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_next_decision",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_auto_progress_allowed", action="store_true")
+    parser.add_argument("--require_no_critical_user_input", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_next_decision(read_json(Path(args.consolidation)), output_dir=output_dir)
+    summary = validate_next_decision(
+        report,
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_auto_progress_allowed=bool(args.require_auto_progress_allowed),
+        require_no_critical_user_input=bool(args.require_no_critical_user_input),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "stage_b_duration_coverage_fill_next_decision.json"
+    markdown_path = output_dir / "stage_b_duration_coverage_fill_next_decision.md"
+    write_json(report_path, report)
+    write_json(output_dir / "stage_b_duration_coverage_fill_next_decision_validation_summary.json", summary)
+    markdown_path.write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps({**summary, "report_path": str(report_path), "markdown_path": str(markdown_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_duration_coverage_next_decision.py
+++ b/tests/test_stage_b_duration_coverage_next_decision.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.decide_stage_b_duration_coverage_next_step import (
+    StageBDurationCoverageNextDecisionError,
+    build_next_decision,
+    validate_next_decision,
+)
+
+
+def consolidation(*, same_preference: bool = True, broad_claim: bool = False) -> dict:
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_user_listening_consolidation_v1",
+        "candidate_id": "duration_fill_candidate",
+        "evidence_alignment": {
+            "same_preferred_candidate": same_preference,
+            "rendered_audio_file_count": 2,
+            "single_user_review": True,
+        },
+        "consolidated_claim_boundary": {
+            "preferred_candidate": "duration_coverage_fill_keep",
+            "single_user_human_audio_preference_claimed": True,
+            "broad_model_quality_claimed": broad_claim,
+        },
+    }
+
+
+class StageBDurationCoverageNextDecisionTest(unittest.TestCase):
+    def test_selects_broader_repeatability_without_critical_user_input(self) -> None:
+        report = build_next_decision(consolidation(), output_dir=Path("outputs/next_decision"))
+        summary = validate_next_decision(
+            report,
+            expected_next_boundary="broader_repeatability_sweep",
+            require_auto_progress_allowed=True,
+            require_no_critical_user_input=True,
+        )
+
+        self.assertEqual(summary["preferred_candidate"], "duration_coverage_fill_keep")
+        self.assertTrue(summary["auto_progress_allowed"])
+        self.assertFalse(summary["critical_user_input_required"])
+        self.assertIn("multi_seed_repeatability", report["not_proven"])
+
+    def test_rejects_misaligned_evidence(self) -> None:
+        with self.assertRaises(StageBDurationCoverageNextDecisionError):
+            build_next_decision(consolidation(same_preference=False), output_dir=Path("outputs/next_decision"))
+
+    def test_rejects_broad_quality_claim(self) -> None:
+        with self.assertRaises(StageBDurationCoverageNextDecisionError):
+            build_next_decision(consolidation(broad_claim=True), output_dir=Path("outputs/next_decision"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- consolidated fill evidence 이후 다음 검증 경계 결정
- broader repeatability sweep을 다음 자동 경계로 선택
- single-candidate/single-user support와 broad quality not-proven 범위 분리

## Context

- Issue #347 boundary: `midi_evidence_and_single_user_listening_support_duration_coverage_fill_keep`
- preferred candidate: `duration_coverage_fill_keep`
- MIDI/user preference aligned: `true`
- rendered audio file count: `2`
- single user review: `true`
- broad model quality claimed: `false`

## Scope

- next decision script: `scripts/decide_stage_b_duration_coverage_next_step.py`
- decision: `broader_repeatability_sweep`
- auto progress allowed: `true`
- critical user input required: `false`
- harness mode: `stage-b-duration-coverage-next-decision`
- README, CORE_PLAN, CURRENT_STATUS_AND_PLAN, AGENTS handoff 갱신

## Validation

- `.venv/bin/python -m unittest tests/test_stage_b_duration_coverage_next_decision.py`
- `bash scripts/agent_harness.sh stage-b-duration-coverage-next-decision`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- `rg -n 'codex|Codex|코덱스' ...` no output

## Risk

- multi-seed repeatability remains not proven
- multi-reviewer preference remains not proven
- broad trained-model quality and Brad style adaptation claims remain blocked

## Follow-up

- next primary boundary: `Stage B margin-recovered phrase/vocabulary duration coverage fill broader repeatability sweep`

Closes #349