### PR TITLE
Stage B duration coverage fill repeatability consolidation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #353, Stage B duration coverage fill dead-air gain repeatability repair.
+- Latest functional issue completed: Issue #355, Stage B duration coverage fill repeatability consolidation.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill repeatability consolidation.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill repeatability audio review package.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -770,6 +770,14 @@ bash scripts/agent_harness.sh stage-b-duration-coverage-dead-air-gain-repeatabil
 ```
 
 This harness requires selected distinct source candidates to keep the MIDI gate while reducing dead-air.
+
+For Stage B duration coverage fill repeatability consolidation changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-duration-coverage-repeatability-consolidation
+```
+
+This harness consolidates current keep listening support and distinct-source MIDI/dead-air gain evidence.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -121,6 +121,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - duration coverage fill next decision 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_NEXT_DECISION_2026-05-29.md`
 - duration coverage fill broader repeatability sweep 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_BROADER_REPEATABILITY_SWEEP_2026-05-29.md`
 - duration coverage fill dead-air gain repeatability repair 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_DEAD_AIR_GAIN_REPEATABILITY_REPAIR_2026-05-29.md`
+- duration coverage fill repeatability consolidation 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_REPEATABILITY_CONSOLIDATION_2026-05-29.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -180,6 +181,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - duration coverage fill next decision: next boundary `broader_repeatability_sweep`, critical user input `false`
 - duration coverage fill broader repeatability sweep: distinct sample-seed source `2`, qualified source `2`, variants `7/8`, dead-air improved source `1/2`, boundary `qualified_gate_repeatability_with_partial_dead_air_gain`
 - duration coverage fill dead-air gain repeatability repair: selection rule `qualified_dead_air_gain_then_min_fill_additions`, dead-air gain source `2/2`, dead-air gain variants `6/8`, boundary `qualified_gate_repeatability_with_dead_air_gain`
+- duration coverage fill repeatability consolidation: current keep single-user preference `true`, distinct source MIDI/dead-air gain support `true`, boundary `current_keep_and_distinct_source_dead_air_gain_midi_support`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #353, Stage B duration coverage fill dead-air gain repeatability repair
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill repeatability consolidation`
+- latest functional result: Issue #355, Stage B duration coverage fill repeatability consolidation
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill repeatability audio review package`
 
 현재 범위가 아닌 것:
 
@@ -65,6 +65,42 @@ Issue #220은 현재 작업이 core인지, MVP 완료로 볼 수 있는지를 �
 Docs:
 
 - `docs/STAGE_B_MODEL_CORE_MVP_COMPLETION_AUDIT_2026-05-28.md`
+
+## Current Duration Coverage Fill Repeatability Consolidation Result
+
+Issue #355는 current keep anchor의 single-user listening support와 distinct source repeatability evidence를 하나의 claim boundary로 정리한 작업이다.
+
+변경:
+
+- repeatability consolidation summary script 추가
+- current keep anchor와 distinct source repeatability evidence 조인
+- proven / not proven claim boundary 분리
+
+결과:
+
+- boundary: `current_keep_and_distinct_source_dead_air_gain_midi_support`
+- current keep single-user preference: `true`
+- distinct source MIDI repeatability: `true`
+- distinct source dead-air gain: `true`
+- source candidates: `2`
+- qualified source candidates: `2`
+- dead-air gain source candidates: `2`
+- total variants: `8`
+- qualified variants: `7`
+- dead-air gain variants: `6`
+- new source human/audio preference claimed: `false`
+- broad model quality claimed: `false`
+
+판단:
+
+- current keep 후보는 MIDI evidence와 single-user listening review에서 지지
+- distinct source 후보 `2/2`는 MIDI gate와 selected dead-air gain 통과
+- 이 결과는 source 확장 MIDI evidence이며 broad trained-model quality proof가 아님
+- new source human/audio preference, multi-reviewer preference, Brad style adaptation은 미검증
+
+다음:
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill repeatability audio review package`
 
 ## Current Duration Coverage Fill Dead-Air Gain Repeatability Repair Result
 

--- a/docs/STAGE_B_DURATION_COVERAGE_FILL_REPEATABILITY_CONSOLIDATION_2026-05-29.md
+++ b/docs/STAGE_B_DURATION_COVERAGE_FILL_REPEATABILITY_CONSOLIDATION_2026-05-29.md
@@ -1,0 +1,61 @@
+# Stage B Duration Coverage Fill Repeatability Consolidation
+
+Issue #355는 current keep anchor의 single-user listening support와 distinct source repeatability evidence를 하나의 claim boundary로 정리한 작업이다.
+
+## Context
+
+- Issue #353 boundary: `qualified_gate_repeatability_with_dead_air_gain`
+- current keep anchor: `margin_recovered_phrase_vocab_seed_353_topk_7_temp_082_n24_sample_3_duration_fill_maxadd_6`
+- current keep MIDI/user preference aligned: `true`
+- current keep rendered audio file count: `2`
+- distinct source candidates: `2`
+- dead-air gain source candidates: `2`
+- broad model quality claimed: `false`
+
+## Change
+
+- repeatability consolidation summary script 추가
+- current keep anchor와 distinct source repeatability evidence 조인
+- proven / not proven claim boundary 분리
+- 전용 harness와 unit test 추가
+
+## Result
+
+| item | value |
+|---|---:|
+| boundary | `current_keep_and_distinct_source_dead_air_gain_midi_support` |
+| current keep single-user preference | `true` |
+| distinct source MIDI repeatability | `true` |
+| distinct source dead-air gain | `true` |
+| source candidates | `2` |
+| qualified source candidates | `2` |
+| dead-air gain source candidates | `2` |
+| total variants | `8` |
+| qualified variants | `7` |
+| dead-air gain variants | `6` |
+| new source human/audio preference claimed | `false` |
+| broad model quality claimed | `false` |
+
+## Judgment
+
+- current keep 후보는 MIDI evidence와 single-user listening review에서 지지
+- distinct source 후보 `2/2`는 MIDI gate와 selected dead-air gain 통과
+- 이 결과는 source 확장 MIDI evidence이며 broad trained-model quality proof가 아님
+- new source human/audio preference, multi-reviewer preference, Brad style adaptation은 미검증
+
+## Validation
+
+```bash
+.venv/bin/python -m unittest tests/test_stage_b_duration_coverage_fill_repeatability_consolidation.py
+bash scripts/agent_harness.sh stage-b-duration-coverage-repeatability-consolidation
+```
+
+## Output
+
+- script: `scripts/summarize_stage_b_duration_coverage_fill_repeatability_consolidation.py`
+- test: `tests/test_stage_b_duration_coverage_fill_repeatability_consolidation.py`
+- summary: `outputs/stage_b_duration_coverage_fill_repeatability_consolidation/harness_stage_b_duration_coverage_fill_repeatability_consolidation/stage_b_duration_coverage_fill_repeatability_consolidation.json`
+
+## Next
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill repeatability audio review package`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -132,6 +132,8 @@ Modes:
                 Run broader duration/coverage fill repeatability over distinct source candidates.
   stage-b-duration-coverage-dead-air-gain-repeatability-repair
                 Repair duration/coverage fill repeatability selection to require dead-air gain.
+  stage-b-duration-coverage-repeatability-consolidation
+                Consolidate current keep and distinct-source repeatability evidence.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -1897,6 +1899,29 @@ run_stage_b_duration_coverage_dead_air_gain_repeatability_repair() {
     --require_no_broad_quality_claim
 }
 
+run_stage_b_duration_coverage_repeatability_consolidation() {
+  local user_consolidation_run_id="${USER_CONSOLIDATION_RUN_ID:-harness_stage_b_duration_coverage_fill_user_listening_review_consolidation}"
+  local dead_air_repair_run_id="${DEAD_AIR_REPAIR_RUN_ID:-harness_stage_b_duration_coverage_fill_dead_air_gain_repeatability_repair}"
+  local run_id="${RUN_ID:-harness_stage_b_duration_coverage_fill_repeatability_consolidation}"
+  local user_consolidation="outputs/stage_b_duration_coverage_fill_user_listening_review_consolidation/${user_consolidation_run_id}/stage_b_duration_coverage_fill_user_listening_review_consolidation.json"
+  local dead_air_repair="outputs/stage_b_duration_coverage_fill_dead_air_gain_repeatability_repair/${dead_air_repair_run_id}/stage_b_duration_coverage_fill_dead_air_gain_repeatability_repair.json"
+  if [[ ! -f "$user_consolidation" ]]; then
+    print_header "Stage B duration/coverage fill user listening review consolidation"
+    RUN_ID="$user_consolidation_run_id" run_stage_b_user_listening_review_consolidation
+  fi
+  if [[ ! -f "$dead_air_repair" ]]; then
+    print_header "Stage B duration/coverage fill dead-air gain repeatability repair"
+    RUN_ID="$dead_air_repair_run_id" run_stage_b_duration_coverage_dead_air_gain_repeatability_repair
+  fi
+  print_header "Stage B duration/coverage fill repeatability consolidation"
+  "$PYTHON_BIN" scripts/summarize_stage_b_duration_coverage_fill_repeatability_consolidation.py \
+    --run_id "$run_id" \
+    --user_listening_consolidation "$user_consolidation" \
+    --dead_air_gain_repair "$dead_air_repair" \
+    --expected_boundary current_keep_and_distinct_source_dead_air_gain_midi_support \
+    --require_no_broad_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -3190,6 +3215,9 @@ case "$MODE" in
     ;;
   stage-b-duration-coverage-dead-air-gain-repeatability-repair)
     run_stage_b_duration_coverage_dead_air_gain_repeatability_repair
+    ;;
+  stage-b-duration-coverage-repeatability-consolidation)
+    run_stage_b_duration_coverage_repeatability_consolidation
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/summarize_stage_b_duration_coverage_fill_repeatability_consolidation.py
+++ b/scripts/summarize_stage_b_duration_coverage_fill_repeatability_consolidation.py
@@ -1,0 +1,243 @@
+"""Consolidate duration/coverage fill repeatability evidence boundaries."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class StageBDurationCoverageRepeatabilityConsolidationError(ValueError):
+    pass
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def build_repeatability_consolidation_report(
+    *,
+    user_listening_consolidation: dict[str, Any],
+    dead_air_gain_repair: dict[str, Any],
+    output_dir: Path,
+) -> dict[str, Any]:
+    user_boundary = _dict(user_listening_consolidation.get("consolidated_claim_boundary"))
+    user_alignment = _dict(user_listening_consolidation.get("evidence_alignment"))
+    repair_summary = _dict(dead_air_gain_repair.get("repair_summary"))
+    repair_claim = _dict(dead_air_gain_repair.get("claim_boundary"))
+
+    if str(user_boundary.get("preferred_candidate") or "") != "duration_coverage_fill_keep":
+        raise StageBDurationCoverageRepeatabilityConsolidationError("unexpected user preferred candidate")
+    if not bool(user_boundary.get("single_user_human_audio_preference_claimed", False)):
+        raise StageBDurationCoverageRepeatabilityConsolidationError("single-user preference is required")
+    if bool(user_boundary.get("broad_model_quality_claimed", True)):
+        raise StageBDurationCoverageRepeatabilityConsolidationError("user consolidation must not claim broad quality")
+    if str(repair_summary.get("boundary") or "") != "qualified_gate_repeatability_with_dead_air_gain":
+        raise StageBDurationCoverageRepeatabilityConsolidationError("dead-air gain repeatability boundary is required")
+    if not bool(repair_claim.get("selected_distinct_source_dead_air_gain_claimed", False)):
+        raise StageBDurationCoverageRepeatabilityConsolidationError("dead-air gain claim is required")
+    if bool(repair_claim.get("broad_model_quality_claimed", True)):
+        raise StageBDurationCoverageRepeatabilityConsolidationError("repair report must not claim broad quality")
+
+    boundary = "current_keep_and_distinct_source_dead_air_gain_midi_support"
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_repeatability_consolidation_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_schemas": {
+            "user_listening_consolidation": str(user_listening_consolidation.get("schema_version") or ""),
+            "dead_air_gain_repair": str(dead_air_gain_repair.get("schema_version") or ""),
+        },
+        "current_keep_anchor": {
+            "candidate_id": str(user_listening_consolidation.get("candidate_id") or ""),
+            "preferred_candidate": str(user_boundary.get("preferred_candidate") or ""),
+            "midi_and_user_preference_aligned": bool(user_alignment.get("same_preferred_candidate", False)),
+            "single_user_human_audio_preference_claimed": True,
+            "rendered_audio_file_count": int(user_alignment.get("rendered_audio_file_count", 0) or 0),
+        },
+        "distinct_source_repeatability": {
+            "boundary": str(repair_summary.get("boundary") or ""),
+            "source_candidate_count": int(repair_summary.get("source_candidate_count", 0) or 0),
+            "qualified_source_candidate_count": int(repair_summary.get("qualified_source_candidate_count", 0) or 0),
+            "dead_air_gain_source_candidate_count": int(
+                repair_summary.get("dead_air_gain_source_candidate_count", 0) or 0
+            ),
+            "total_variant_count": int(repair_summary.get("total_variant_count", 0) or 0),
+            "total_qualified_variant_count": int(repair_summary.get("total_qualified_variant_count", 0) or 0),
+            "total_dead_air_gain_variant_count": int(
+                repair_summary.get("total_dead_air_gain_variant_count", 0) or 0
+            ),
+            "selected_fill_additions": list(repair_summary.get("selected_fill_additions") or []),
+        },
+        "consolidated_claim_boundary": {
+            "boundary": boundary,
+            "current_keep_single_user_preference_claimed": True,
+            "distinct_source_midi_gate_repeatability_claimed": True,
+            "distinct_source_dead_air_gain_claimed": True,
+            "new_source_human_audio_preference_claimed": False,
+            "multi_reviewer_preference_claimed": False,
+            "broad_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_improviser_claimed": False,
+        },
+        "proven": [
+            "current_keep_midi_and_single_user_listening_preference",
+            "distinct_source_qualified_midi_gate_repeatability",
+            "distinct_source_selected_dead_air_gain",
+        ],
+        "not_proven": [
+            "new_source_human_audio_preference",
+            "multi_reviewer_preference",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "production_ready_improviser",
+        ],
+        "next_recommended_issue": (
+            "Stage B margin-recovered phrase/vocabulary duration coverage fill repeatability audio review package"
+        ),
+    }
+
+
+def validate_repeatability_consolidation(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    require_no_broad_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = _dict(report.get("consolidated_claim_boundary"))
+    repeatability = _dict(report.get("distinct_source_repeatability"))
+    boundary_name = str(boundary.get("boundary") or "")
+    if expected_boundary and boundary_name != expected_boundary:
+        raise StageBDurationCoverageRepeatabilityConsolidationError(
+            f"expected boundary {expected_boundary}, got {boundary_name}"
+        )
+    if int(repeatability.get("dead_air_gain_source_candidate_count", 0) or 0) < 2:
+        raise StageBDurationCoverageRepeatabilityConsolidationError("dead-air gain source count is too low")
+    if require_no_broad_quality_claim:
+        blocked = [
+            "new_source_human_audio_preference_claimed",
+            "multi_reviewer_preference_claimed",
+            "broad_model_quality_claimed",
+            "brad_style_adaptation_claimed",
+            "production_ready_improviser_claimed",
+        ]
+        claimed = [name for name in blocked if bool(boundary.get(name, True))]
+        if claimed:
+            raise StageBDurationCoverageRepeatabilityConsolidationError(f"unexpected broad claim: {claimed}")
+    return {
+        "boundary": boundary_name,
+        "current_keep_single_user_preference_claimed": bool(
+            boundary.get("current_keep_single_user_preference_claimed", False)
+        ),
+        "distinct_source_midi_gate_repeatability_claimed": bool(
+            boundary.get("distinct_source_midi_gate_repeatability_claimed", False)
+        ),
+        "distinct_source_dead_air_gain_claimed": bool(
+            boundary.get("distinct_source_dead_air_gain_claimed", False)
+        ),
+        "source_candidate_count": int(repeatability.get("source_candidate_count", 0) or 0),
+        "dead_air_gain_source_candidate_count": int(
+            repeatability.get("dead_air_gain_source_candidate_count", 0) or 0
+        ),
+        "broad_model_quality_claimed": bool(boundary.get("broad_model_quality_claimed", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    boundary = report["consolidated_claim_boundary"]
+    anchor = report["current_keep_anchor"]
+    repeatability = report["distinct_source_repeatability"]
+    lines = [
+        "# Stage B Duration Coverage Fill Repeatability Consolidation",
+        "",
+        f"- boundary: `{boundary['boundary']}`",
+        f"- current keep anchor: `{anchor['candidate_id']}`",
+        f"- current keep single-user preference: `{boundary['current_keep_single_user_preference_claimed']}`",
+        f"- distinct source MIDI repeatability: `{boundary['distinct_source_midi_gate_repeatability_claimed']}`",
+        f"- distinct source dead-air gain: `{boundary['distinct_source_dead_air_gain_claimed']}`",
+        f"- new source human/audio preference claimed: `{boundary['new_source_human_audio_preference_claimed']}`",
+        f"- broad model quality claimed: `{boundary['broad_model_quality_claimed']}`",
+        "",
+        "## Repeatability Evidence",
+        "",
+        f"- source candidates: `{repeatability['source_candidate_count']}`",
+        f"- qualified source candidates: `{repeatability['qualified_source_candidate_count']}`",
+        f"- dead-air gain source candidates: `{repeatability['dead_air_gain_source_candidate_count']}`",
+        f"- total variants: `{repeatability['total_variant_count']}`",
+        f"- qualified variants: `{repeatability['total_qualified_variant_count']}`",
+        f"- dead-air gain variants: `{repeatability['total_dead_air_gain_variant_count']}`",
+        f"- selected fill additions: `{repeatability['selected_fill_additions']}`",
+        "",
+        "## Not Proven",
+        "",
+    ]
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Consolidate duration coverage fill repeatability evidence")
+    parser.add_argument(
+        "--user_listening_consolidation",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_user_listening_review_consolidation/"
+        "harness_stage_b_duration_coverage_fill_user_listening_review_consolidation/"
+        "stage_b_duration_coverage_fill_user_listening_review_consolidation.json",
+    )
+    parser.add_argument(
+        "--dead_air_gain_repair",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_dead_air_gain_repeatability_repair/"
+        "harness_stage_b_duration_coverage_fill_dead_air_gain_repeatability_repair/"
+        "stage_b_duration_coverage_fill_dead_air_gain_repeatability_repair.json",
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_repeatability_consolidation",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--require_no_broad_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_repeatability_consolidation_report(
+        user_listening_consolidation=read_json(Path(args.user_listening_consolidation)),
+        dead_air_gain_repair=read_json(Path(args.dead_air_gain_repair)),
+        output_dir=output_dir,
+    )
+    summary = validate_repeatability_consolidation(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        require_no_broad_quality_claim=bool(args.require_no_broad_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "stage_b_duration_coverage_fill_repeatability_consolidation.json"
+    markdown_path = output_dir / "stage_b_duration_coverage_fill_repeatability_consolidation.md"
+    write_json(report_path, report)
+    write_json(output_dir / "stage_b_duration_coverage_fill_repeatability_consolidation_validation_summary.json", summary)
+    markdown_path.write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps({**summary, "report_path": str(report_path), "markdown_path": str(markdown_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_duration_coverage_fill_repeatability_consolidation.py
+++ b/tests/test_stage_b_duration_coverage_fill_repeatability_consolidation.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.summarize_stage_b_duration_coverage_fill_repeatability_consolidation import (
+    StageBDurationCoverageRepeatabilityConsolidationError,
+    build_repeatability_consolidation_report,
+    validate_repeatability_consolidation,
+)
+
+
+def user_listening_consolidation(*, broad_claim: bool = False) -> dict:
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_user_listening_consolidation_v1",
+        "candidate_id": "current_duration_fill_keep",
+        "evidence_alignment": {
+            "same_preferred_candidate": True,
+            "rendered_audio_file_count": 2,
+        },
+        "consolidated_claim_boundary": {
+            "preferred_candidate": "duration_coverage_fill_keep",
+            "single_user_human_audio_preference_claimed": True,
+            "broad_model_quality_claimed": broad_claim,
+        },
+    }
+
+
+def dead_air_gain_repair(*, boundary: str = "qualified_gate_repeatability_with_dead_air_gain") -> dict:
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_dead_air_gain_repeatability_repair_v1",
+        "repair_summary": {
+            "boundary": boundary,
+            "source_candidate_count": 2,
+            "qualified_source_candidate_count": 2,
+            "dead_air_gain_source_candidate_count": 2,
+            "total_variant_count": 8,
+            "total_qualified_variant_count": 7,
+            "total_dead_air_gain_variant_count": 6,
+            "selected_fill_additions": [6],
+            "broad_model_quality_claimed": False,
+        },
+        "claim_boundary": {
+            "selected_distinct_source_dead_air_gain_claimed": True,
+            "broad_model_quality_claimed": False,
+        },
+    }
+
+
+class StageBDurationCoverageFillRepeatabilityConsolidationTest(unittest.TestCase):
+    def test_consolidates_current_keep_and_distinct_source_repeatability(self) -> None:
+        report = build_repeatability_consolidation_report(
+            user_listening_consolidation=user_listening_consolidation(),
+            dead_air_gain_repair=dead_air_gain_repair(),
+            output_dir=Path("outputs/repeatability_consolidation"),
+        )
+        summary = validate_repeatability_consolidation(
+            report,
+            expected_boundary="current_keep_and_distinct_source_dead_air_gain_midi_support",
+            require_no_broad_quality_claim=True,
+        )
+
+        self.assertTrue(summary["current_keep_single_user_preference_claimed"])
+        self.assertTrue(summary["distinct_source_midi_gate_repeatability_claimed"])
+        self.assertTrue(summary["distinct_source_dead_air_gain_claimed"])
+        self.assertEqual(summary["source_candidate_count"], 2)
+        self.assertEqual(summary["dead_air_gain_source_candidate_count"], 2)
+        self.assertFalse(summary["broad_model_quality_claimed"])
+        self.assertIn("new_source_human_audio_preference", report["not_proven"])
+
+    def test_rejects_broad_quality_claim(self) -> None:
+        with self.assertRaises(StageBDurationCoverageRepeatabilityConsolidationError):
+            build_repeatability_consolidation_report(
+                user_listening_consolidation=user_listening_consolidation(broad_claim=True),
+                dead_air_gain_repair=dead_air_gain_repair(),
+                output_dir=Path("outputs/repeatability_consolidation"),
+            )
+
+    def test_rejects_missing_dead_air_gain_boundary(self) -> None:
+        with self.assertRaises(StageBDurationCoverageRepeatabilityConsolidationError):
+            build_repeatability_consolidation_report(
+                user_listening_consolidation=user_listening_consolidation(),
+                dead_air_gain_repair=dead_air_gain_repair(boundary="dead_air_gain_repeatability_not_repaired"),
+                output_dir=Path("outputs/repeatability_consolidation"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- current keep anchor와 distinct source repeatability evidence 조인
- `current_keep_and_distinct_source_dead_air_gain_midi_support` boundary 정의
- proven / not proven claim boundary 분리
- 전용 harness, unit test, 문서, handoff 갱신

## Context

- Issue #353 boundary: `qualified_gate_repeatability_with_dead_air_gain`
- current keep single-user preference: `true`
- distinct source candidates: `2`
- dead-air gain source candidates: `2`
- broad model quality claim: `false`

## Result

- current keep MIDI/user preference support 유지
- distinct source MIDI gate repeatability claim: `true`
- distinct source dead-air gain claim: `true`
- new source human/audio preference: not claimed
- broad trained-model quality: not claimed

## Validation

- `.venv/bin/python -m unittest tests/test_stage_b_duration_coverage_fill_repeatability_consolidation.py`
- `bash scripts/agent_harness.sh stage-b-duration-coverage-repeatability-consolidation`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- `rg -n "codex|Codex|코덱스" changed files`: no output

## Risk

- new source human/audio preference 미검증
- multi-reviewer preference 미검증
- broad trained-model quality 미검증

Closes #355