### PR TITLE
Stage B duration coverage fill repeatability audio review package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #355, Stage B duration coverage fill repeatability consolidation.
+- Latest functional issue completed: Issue #357, Stage B duration coverage fill repeatability audio review package.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill repeatability audio review package.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill repeatability user listening review fill.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -778,6 +778,14 @@ bash scripts/agent_harness.sh stage-b-duration-coverage-repeatability-consolidat
 ```
 
 This harness consolidates current keep listening support and distinct-source MIDI/dead-air gain evidence.
+
+For Stage B duration coverage fill repeatability audio review package changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-duration-coverage-repeatability-audio-review-package
+```
+
+This harness renders repeatability source candidates to local WAV files and validates technical WAV metadata without claiming listening preference.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -122,6 +122,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - duration coverage fill broader repeatability sweep 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_BROADER_REPEATABILITY_SWEEP_2026-05-29.md`
 - duration coverage fill dead-air gain repeatability repair 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_DEAD_AIR_GAIN_REPEATABILITY_REPAIR_2026-05-29.md`
 - duration coverage fill repeatability consolidation 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_REPEATABILITY_CONSOLIDATION_2026-05-29.md`
+- duration coverage fill repeatability audio review package 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_REPEATABILITY_AUDIO_REVIEW_PACKAGE_2026-05-29.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -182,6 +183,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - duration coverage fill broader repeatability sweep: distinct sample-seed source `2`, qualified source `2`, variants `7/8`, dead-air improved source `1/2`, boundary `qualified_gate_repeatability_with_partial_dead_air_gain`
 - duration coverage fill dead-air gain repeatability repair: selection rule `qualified_dead_air_gain_then_min_fill_additions`, dead-air gain source `2/2`, dead-air gain variants `6/8`, boundary `qualified_gate_repeatability_with_dead_air_gain`
 - duration coverage fill repeatability consolidation: current keep single-user preference `true`, distinct source MIDI/dead-air gain support `true`, boundary `current_keep_and_distinct_source_dead_air_gain_midi_support`
+- duration coverage fill repeatability audio review package: repeatability source WAV `2`, sample rate `44100`, status `ready_for_user_listening_review`, quality/preference claim `false`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #355, Stage B duration coverage fill repeatability consolidation
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill repeatability audio review package`
+- latest functional result: Issue #357, Stage B duration coverage fill repeatability audio review package
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill repeatability user listening review fill`
 
 현재 범위가 아닌 것:
 
@@ -65,6 +65,40 @@ Issue #220은 현재 작업이 core인지, MVP 완료로 볼 수 있는지를 �
 Docs:
 
 - `docs/STAGE_B_MODEL_CORE_MVP_COMPLETION_AUDIT_2026-05-28.md`
+
+## Current Duration Coverage Fill Repeatability Audio Review Package Result
+
+Issue #357은 repeatability source 후보 `2`개를 WAV로 렌더하고 사용자 청취 review 입력 전 기술 검증 경계를 정리한 작업이다.
+
+변경:
+
+- repeatability audio review package render script 추가
+- distinct source selected fill MIDI `2`개 WAV 렌더
+- WAV sample rate, duration, size, sha256 검증
+- audio quality/preference claim guard 유지
+
+결과:
+
+- candidate: `duration_coverage_fill_repeatability_sources`
+- status: `ready_for_user_listening_review`
+- rendered audio file count: `2`
+- technical WAV validation: `true`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- broad model quality claimed: `false`
+- sample seed `155` WAV: `outputs/stage_b_duration_coverage_fill_repeatability_audio_review_package/harness_stage_b_duration_coverage_fill_repeatability_audio_review_package/audio/repeatability_sample_seed_155_duration_fill.wav`
+- sample seed `131` WAV: `outputs/stage_b_duration_coverage_fill_repeatability_audio_review_package/harness_stage_b_duration_coverage_fill_repeatability_audio_review_package/audio/repeatability_sample_seed_131_duration_fill.wav`
+
+판단:
+
+- WAV 파일 `2`개 생성 및 technical validation 완료
+- 이 결과는 청취 가능한 artifact 준비이며 음악적 품질 proof가 아님
+- human/audio preference, multi-reviewer preference, broad trained-model quality는 미검증
+- generated WAV files는 commit 대상에서 제외
+
+다음:
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill repeatability user listening review fill`
 
 ## Current Duration Coverage Fill Repeatability Consolidation Result
 

--- a/docs/STAGE_B_DURATION_COVERAGE_FILL_REPEATABILITY_AUDIO_REVIEW_PACKAGE_2026-05-29.md
+++ b/docs/STAGE_B_DURATION_COVERAGE_FILL_REPEATABILITY_AUDIO_REVIEW_PACKAGE_2026-05-29.md
@@ -1,0 +1,63 @@
+# Stage B Duration Coverage Fill Repeatability Audio Review Package
+
+Issue #357은 repeatability source 후보 `2`개를 WAV로 렌더하고 사용자 청취 review 입력 전 기술 검증 경계를 정리한 작업이다.
+
+## Context
+
+- Issue #355 boundary: `current_keep_and_distinct_source_dead_air_gain_midi_support`
+- distinct source MIDI/dead-air gain support: `true`
+- new source human/audio preference claimed: `false`
+- broad model quality claimed: `false`
+- renderer: FluidSynth
+- soundfont: GeneralUser GS `v1.471.sf2`
+
+## Change
+
+- repeatability audio review package render script 추가
+- distinct source selected fill MIDI `2`개 WAV 렌더
+- WAV sample rate, duration, size, sha256 검증
+- audio quality/preference claim guard 유지
+- 전용 harness와 unit test 추가
+
+## Result
+
+| item | value |
+|---|---:|
+| candidate | `duration_coverage_fill_repeatability_sources` |
+| status | `ready_for_user_listening_review` |
+| rendered audio file count | `2` |
+| technical WAV validation | `true` |
+| audio rendered quality claimed | `false` |
+| human/audio preference claimed | `false` |
+| broad model quality claimed | `false` |
+
+## Review Files
+
+| role | sample seed | WAV | duration | sample rate | size | dead-air | unique |
+|---|---:|---|---:|---:|---:|---:|---:|
+| `repeatability_sample_seed_155_duration_fill` | `155` | `outputs/stage_b_duration_coverage_fill_repeatability_audio_review_package/harness_stage_b_duration_coverage_fill_repeatability_audio_review_package/audio/repeatability_sample_seed_155_duration_fill.wav` | `6.622s` | `44100` | `1168172` | `0.3333` | `12` |
+| `repeatability_sample_seed_131_duration_fill` | `131` | `outputs/stage_b_duration_coverage_fill_repeatability_audio_review_package/harness_stage_b_duration_coverage_fill_repeatability_audio_review_package/audio/repeatability_sample_seed_131_duration_fill.wav` | `6.866s` | `44100` | `1211180` | `0.3529` | `13` |
+
+## Judgment
+
+- WAV 파일 `2`개 생성 및 technical validation 완료
+- 이 결과는 청취 가능한 artifact 준비이며 음악적 품질 proof가 아님
+- human/audio preference, multi-reviewer preference, broad trained-model quality는 미검증
+- generated WAV files는 commit 대상에서 제외
+
+## Validation
+
+```bash
+.venv/bin/python -m unittest tests/test_stage_b_duration_coverage_fill_repeatability_audio_review_package.py
+bash scripts/agent_harness.sh stage-b-duration-coverage-repeatability-audio-review-package
+```
+
+## Output
+
+- script: `scripts/render_stage_b_duration_coverage_fill_repeatability_audio_review_package.py`
+- test: `tests/test_stage_b_duration_coverage_fill_repeatability_audio_review_package.py`
+- summary: `outputs/stage_b_duration_coverage_fill_repeatability_audio_review_package/harness_stage_b_duration_coverage_fill_repeatability_audio_review_package/stage_b_duration_coverage_fill_repeatability_audio_review_package.json`
+
+## Next
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill repeatability user listening review fill`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -134,6 +134,8 @@ Modes:
                 Repair duration/coverage fill repeatability selection to require dead-air gain.
   stage-b-duration-coverage-repeatability-consolidation
                 Consolidate current keep and distinct-source repeatability evidence.
+  stage-b-duration-coverage-repeatability-audio-review-package
+                Render repeatability source candidates for user listening review.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -1922,6 +1924,31 @@ run_stage_b_duration_coverage_repeatability_consolidation() {
     --require_no_broad_quality_claim
 }
 
+run_stage_b_duration_coverage_repeatability_audio_review_package() {
+  local repeatability_consolidation_run_id="${REPEATABILITY_CONSOLIDATION_RUN_ID:-harness_stage_b_duration_coverage_fill_repeatability_consolidation}"
+  local dead_air_repair_run_id="${DEAD_AIR_REPAIR_RUN_ID:-harness_stage_b_duration_coverage_fill_dead_air_gain_repeatability_repair}"
+  local run_id="${RUN_ID:-harness_stage_b_duration_coverage_fill_repeatability_audio_review_package}"
+  local repeatability_consolidation="outputs/stage_b_duration_coverage_fill_repeatability_consolidation/${repeatability_consolidation_run_id}/stage_b_duration_coverage_fill_repeatability_consolidation.json"
+  local dead_air_repair="outputs/stage_b_duration_coverage_fill_dead_air_gain_repeatability_repair/${dead_air_repair_run_id}/stage_b_duration_coverage_fill_dead_air_gain_repeatability_repair.json"
+  local soundfont="${SOUNDFONT_PATH:-$HOME/.local/share/soundfonts/generaluser-gs/v1.471.sf2}"
+  if [[ ! -f "$repeatability_consolidation" ]]; then
+    print_header "Stage B duration/coverage fill repeatability consolidation"
+    RUN_ID="$repeatability_consolidation_run_id" run_stage_b_duration_coverage_repeatability_consolidation
+  fi
+  if [[ ! -f "$dead_air_repair" ]]; then
+    print_header "Stage B duration/coverage fill dead-air gain repeatability repair"
+    RUN_ID="$dead_air_repair_run_id" run_stage_b_duration_coverage_dead_air_gain_repeatability_repair
+  fi
+  print_header "Stage B duration/coverage fill repeatability audio review package"
+  "$PYTHON_BIN" scripts/render_stage_b_duration_coverage_fill_repeatability_audio_review_package.py \
+    --run_id "$run_id" \
+    --repeatability_consolidation "$repeatability_consolidation" \
+    --dead_air_gain_repair "$dead_air_repair" \
+    --soundfont "$soundfont" \
+    --expected_file_count 2 \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -3218,6 +3245,9 @@ case "$MODE" in
     ;;
   stage-b-duration-coverage-repeatability-consolidation)
     run_stage_b_duration_coverage_repeatability_consolidation
+    ;;
+  stage-b-duration-coverage-repeatability-audio-review-package)
+    run_stage_b_duration_coverage_repeatability_audio_review_package
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/render_stage_b_duration_coverage_fill_repeatability_audio_review_package.py
+++ b/scripts/render_stage_b_duration_coverage_fill_repeatability_audio_review_package.py
@@ -1,0 +1,333 @@
+"""Render repeatability source candidates for duration/coverage fill audio review."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.render_stage_b_duration_coverage_fill_audio import (
+    build_audio_render_report,
+    validate_audio_render_report,
+)
+
+
+class StageBDurationCoverageRepeatabilityAudioReviewPackageError(ValueError):
+    pass
+
+
+CommandRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def review_items_from_repair(dead_air_gain_repair: dict[str, Any]) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for result in _list(dead_air_gain_repair.get("source_repeatability_results")):
+        if not isinstance(result, dict):
+            continue
+        midi_path = str(result.get("selected_midi_path") or "")
+        if not midi_path or not Path(midi_path).exists():
+            raise StageBDurationCoverageRepeatabilityAudioReviewPackageError(
+                f"selected MIDI not found: {midi_path}"
+            )
+        sample_seed = int(result.get("sample_seed", 0) or 0)
+        items.append(
+            {
+                "role": f"repeatability_sample_seed_{sample_seed}_duration_fill",
+                "candidate_id": str(result.get("selected_candidate_id") or ""),
+                "source_candidate_id": str(result.get("source_candidate_id") or ""),
+                "sample_seed": sample_seed,
+                "midi_file": {
+                    "path": midi_path,
+                    "required": True,
+                },
+                "metrics": {
+                    "baseline_dead_air_ratio": float(result.get("baseline_dead_air_ratio", 0.0) or 0.0),
+                    "selected_dead_air_ratio": float(result.get("selected_dead_air_ratio", 0.0) or 0.0),
+                    "dead_air_delta_from_baseline": float(result.get("dead_air_delta_from_baseline", 0.0) or 0.0),
+                    "selected_focused_note_count": int(result.get("selected_focused_note_count", 0) or 0),
+                    "selected_focused_unique_pitch_count": int(
+                        result.get("selected_focused_unique_pitch_count", 0) or 0
+                    ),
+                    "selected_adjacent_pitch_repeats": int(
+                        result.get("selected_adjacent_pitch_repeats", 0) or 0
+                    ),
+                    "selected_max_interval": int(result.get("selected_max_interval", 0) or 0),
+                },
+            }
+        )
+    if len(items) != 2:
+        raise StageBDurationCoverageRepeatabilityAudioReviewPackageError(
+            f"expected 2 repeatability review items, got {len(items)}"
+        )
+    return items
+
+
+def build_local_audio_render_package(
+    repeatability_consolidation: dict[str, Any],
+    dead_air_gain_repair: dict[str, Any],
+) -> dict[str, Any]:
+    consolidation_boundary = _dict(repeatability_consolidation.get("consolidated_claim_boundary"))
+    repair_summary = _dict(dead_air_gain_repair.get("repair_summary"))
+    if str(consolidation_boundary.get("boundary") or "") != (
+        "current_keep_and_distinct_source_dead_air_gain_midi_support"
+    ):
+        raise StageBDurationCoverageRepeatabilityAudioReviewPackageError("repeatability consolidation boundary required")
+    if bool(consolidation_boundary.get("broad_model_quality_claimed", True)):
+        raise StageBDurationCoverageRepeatabilityAudioReviewPackageError("broad model quality must not be claimed")
+    if str(repair_summary.get("boundary") or "") != "qualified_gate_repeatability_with_dead_air_gain":
+        raise StageBDurationCoverageRepeatabilityAudioReviewPackageError("dead-air gain repair boundary required")
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_repeatability_audio_review_local_package_v1",
+        "candidate_id": "duration_coverage_fill_repeatability_sources",
+        "review_items": review_items_from_repair(dead_air_gain_repair),
+    }
+
+
+def build_repeatability_audio_review_package(
+    *,
+    repeatability_consolidation: dict[str, Any],
+    dead_air_gain_repair: dict[str, Any],
+    output_dir: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+    runner: CommandRunner | None = None,
+) -> dict[str, Any]:
+    local_package = build_local_audio_render_package(repeatability_consolidation, dead_air_gain_repair)
+    render_kwargs: dict[str, Any] = {}
+    if runner is not None:
+        render_kwargs["runner"] = runner
+    render_report = build_audio_render_report(
+        local_package,
+        output_dir=output_dir,
+        renderer_path=renderer_path,
+        soundfont_path=soundfont_path,
+        sample_rate=int(sample_rate),
+        **render_kwargs,
+    )
+    render_summary = validate_audio_render_report(
+        render_report,
+        expected_file_count=2,
+        expected_sample_rate=int(sample_rate),
+        require_no_quality_claim=True,
+    )
+    rendered_by_role = {
+        str(item.get("role") or ""): item for item in _list(render_report.get("rendered_audio_files"))
+    }
+    review_items = []
+    for item in local_package["review_items"]:
+        rendered = _dict(rendered_by_role.get(item["role"]))
+        review_items.append(
+            {
+                "role": item["role"],
+                "candidate_id": item["candidate_id"],
+                "source_candidate_id": item["source_candidate_id"],
+                "sample_seed": item["sample_seed"],
+                "midi_file": item["midi_file"],
+                "wav_file": _dict(rendered.get("wav_file")),
+                "metrics": item["metrics"],
+            }
+        )
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_repeatability_audio_review_package_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_schemas": {
+            "repeatability_consolidation": str(repeatability_consolidation.get("schema_version") or ""),
+            "dead_air_gain_repair": str(dead_air_gain_repair.get("schema_version") or ""),
+            "render_report": str(render_report.get("schema_version") or ""),
+        },
+        "candidate_id": "duration_coverage_fill_repeatability_sources",
+        "review_items": review_items,
+        "audio_render_summary": render_summary,
+        "audio_review_boundary": {
+            "status": "ready_for_user_listening_review",
+            "render_attempted": True,
+            "rendered_audio_file_count": int(render_summary["rendered_audio_file_count"]),
+            "technical_wav_validation": True,
+            "audio_rendered_quality_claimed": False,
+            "human_audio_preference_claimed": False,
+            "broad_model_quality_claimed": False,
+        },
+        "not_proven": [
+            "audio_rendered_quality",
+            "human_audio_preference",
+            "multi_reviewer_preference",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "production_ready_improviser",
+        ],
+        "next_recommended_issue": (
+            "Stage B margin-recovered phrase/vocabulary duration coverage fill repeatability user listening review fill"
+        ),
+    }
+
+
+def validate_repeatability_audio_review_package(
+    report: dict[str, Any],
+    *,
+    expected_file_count: int,
+    expected_sample_rate: int,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = _dict(report.get("audio_review_boundary"))
+    items = _list(report.get("review_items"))
+    if len(items) != int(expected_file_count):
+        raise StageBDurationCoverageRepeatabilityAudioReviewPackageError(
+            f"expected {int(expected_file_count)} review items"
+        )
+    for item in items:
+        wav_file = _dict(item.get("wav_file"))
+        if not bool(wav_file.get("exists", False)):
+            raise StageBDurationCoverageRepeatabilityAudioReviewPackageError(f"missing wav for {item.get('role')}")
+        if int(wav_file.get("sample_rate", 0) or 0) != int(expected_sample_rate):
+            raise StageBDurationCoverageRepeatabilityAudioReviewPackageError(
+                f"unexpected sample rate for {item.get('role')}"
+            )
+    if require_no_quality_claim:
+        blocked = [
+            "audio_rendered_quality_claimed",
+            "human_audio_preference_claimed",
+            "broad_model_quality_claimed",
+        ]
+        claimed = [name for name in blocked if bool(boundary.get(name, True))]
+        if claimed:
+            raise StageBDurationCoverageRepeatabilityAudioReviewPackageError(f"unexpected audio claim: {claimed}")
+    return {
+        "candidate_id": str(report.get("candidate_id") or ""),
+        "status": str(boundary.get("status") or ""),
+        "render_attempted": bool(boundary.get("render_attempted", False)),
+        "rendered_audio_file_count": int(boundary.get("rendered_audio_file_count", 0) or 0),
+        "technical_wav_validation": bool(boundary.get("technical_wav_validation", False)),
+        "audio_rendered_quality_claimed": bool(boundary.get("audio_rendered_quality_claimed", True)),
+        "human_audio_preference_claimed": bool(boundary.get("human_audio_preference_claimed", True)),
+        "wav_paths": [str(_dict(item.get("wav_file")).get("path") or "") for item in items],
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    boundary = report["audio_review_boundary"]
+    lines = [
+        "# Stage B Duration Coverage Fill Repeatability Audio Review Package",
+        "",
+        f"- candidate: `{report['candidate_id']}`",
+        f"- status: `{boundary['status']}`",
+        f"- rendered audio file count: `{boundary['rendered_audio_file_count']}`",
+        f"- technical WAV validation: `{boundary['technical_wav_validation']}`",
+        f"- audio rendered quality claimed: `{boundary['audio_rendered_quality_claimed']}`",
+        f"- human/audio preference claimed: `{boundary['human_audio_preference_claimed']}`",
+        "",
+        "| role | sample seed | wav path | duration | sample rate | dead-air | unique |",
+        "|---|---:|---|---:|---:|---:|---:|",
+    ]
+    for item in report.get("review_items", []):
+        wav_file = item["wav_file"]
+        metrics = item["metrics"]
+        lines.append(
+            "| {role} | {sample_seed} | `{wav}` | {duration:.3f} | {sample_rate} | "
+            "{dead_air:.4f} | {unique} |".format(
+                role=item["role"],
+                sample_seed=int(item["sample_seed"]),
+                wav=wav_file["path"],
+                duration=float(wav_file["duration_seconds"]),
+                sample_rate=int(wav_file["sample_rate"]),
+                dead_air=float(metrics["selected_dead_air_ratio"]),
+                unique=int(metrics["selected_focused_unique_pitch_count"]),
+            )
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Render repeatability source candidates for audio review")
+    parser.add_argument(
+        "--repeatability_consolidation",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_repeatability_consolidation/"
+        "harness_stage_b_duration_coverage_fill_repeatability_consolidation/"
+        "stage_b_duration_coverage_fill_repeatability_consolidation.json",
+    )
+    parser.add_argument(
+        "--dead_air_gain_repair",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_dead_air_gain_repeatability_repair/"
+        "harness_stage_b_duration_coverage_fill_dead_air_gain_repeatability_repair/"
+        "stage_b_duration_coverage_fill_dead_air_gain_repeatability_repair.json",
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_repeatability_audio_review_package",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--renderer_path", type=str, default=shutil.which("fluidsynth") or "/opt/homebrew/bin/fluidsynth")
+    parser.add_argument(
+        "--soundfont",
+        type=str,
+        default=str(Path.home() / ".local/share/soundfonts/generaluser-gs/v1.471.sf2"),
+    )
+    parser.add_argument("--sample_rate", type=int, default=44100)
+    parser.add_argument("--expected_file_count", type=int, default=2)
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_repeatability_audio_review_package(
+        repeatability_consolidation=read_json(Path(args.repeatability_consolidation)),
+        dead_air_gain_repair=read_json(Path(args.dead_air_gain_repair)),
+        output_dir=output_dir,
+        renderer_path=str(args.renderer_path),
+        soundfont_path=str(args.soundfont),
+        sample_rate=int(args.sample_rate),
+    )
+    summary = validate_repeatability_audio_review_package(
+        report,
+        expected_file_count=int(args.expected_file_count),
+        expected_sample_rate=int(args.sample_rate),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "stage_b_duration_coverage_fill_repeatability_audio_review_package.json"
+    markdown_path = output_dir / "stage_b_duration_coverage_fill_repeatability_audio_review_package.md"
+    write_json(report_path, report)
+    write_json(output_dir / "stage_b_duration_coverage_fill_repeatability_audio_review_package_validation_summary.json", summary)
+    markdown_path.write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps({**summary, "report_path": str(report_path), "markdown_path": str(markdown_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_duration_coverage_fill_repeatability_audio_review_package.py
+++ b/tests/test_stage_b_duration_coverage_fill_repeatability_audio_review_package.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from scripts.render_stage_b_duration_coverage_fill_repeatability_audio_review_package import (
+    StageBDurationCoverageRepeatabilityAudioReviewPackageError,
+    build_repeatability_audio_review_package,
+    validate_repeatability_audio_review_package,
+)
+from tests.test_stage_b_local_audio_render_attempt import fake_runner, write_midi
+
+
+def repeatability_consolidation(*, broad_claim: bool = False) -> dict:
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_repeatability_consolidation_v1",
+        "consolidated_claim_boundary": {
+            "boundary": "current_keep_and_distinct_source_dead_air_gain_midi_support",
+            "broad_model_quality_claimed": broad_claim,
+        },
+    }
+
+
+def dead_air_gain_repair(root: Path) -> dict:
+    first = root / "sample_155.mid"
+    second = root / "sample_131.mid"
+    write_midi(first, 67)
+    write_midi(second, 71)
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_dead_air_gain_repeatability_repair_v1",
+        "repair_summary": {
+            "boundary": "qualified_gate_repeatability_with_dead_air_gain",
+        },
+        "source_repeatability_results": [
+            {
+                "source_candidate_id": "source_155",
+                "selected_candidate_id": "source_155_fill",
+                "selected_midi_path": str(first),
+                "sample_seed": 155,
+                "baseline_dead_air_ratio": 0.375,
+                "selected_dead_air_ratio": 0.3333333333333333,
+                "dead_air_delta_from_baseline": 0.041667,
+                "selected_focused_note_count": 19,
+                "selected_focused_unique_pitch_count": 12,
+                "selected_adjacent_pitch_repeats": 0,
+                "selected_max_interval": 6,
+            },
+            {
+                "source_candidate_id": "source_131",
+                "selected_candidate_id": "source_131_fill",
+                "selected_midi_path": str(second),
+                "sample_seed": 131,
+                "baseline_dead_air_ratio": 0.375,
+                "selected_dead_air_ratio": 0.35294117647058826,
+                "dead_air_delta_from_baseline": 0.022059,
+                "selected_focused_note_count": 18,
+                "selected_focused_unique_pitch_count": 13,
+                "selected_adjacent_pitch_repeats": 0,
+                "selected_max_interval": 11,
+            },
+        ],
+    }
+
+
+class StageBDurationCoverageFillRepeatabilityAudioReviewPackageTest(unittest.TestCase):
+    def test_renders_repeatability_review_wavs_without_quality_claim(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            soundfont = root / "piano.sf2"
+            renderer.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            report = build_repeatability_audio_review_package(
+                repeatability_consolidation=repeatability_consolidation(),
+                dead_air_gain_repair=dead_air_gain_repair(root),
+                output_dir=root / "audio_review",
+                renderer_path=str(renderer),
+                soundfont_path=str(soundfont),
+                sample_rate=44100,
+                runner=fake_runner,
+            )
+            summary = validate_repeatability_audio_review_package(
+                report,
+                expected_file_count=2,
+                expected_sample_rate=44100,
+                require_no_quality_claim=True,
+            )
+
+            self.assertEqual(summary["status"], "ready_for_user_listening_review")
+            self.assertEqual(summary["rendered_audio_file_count"], 2)
+            self.assertTrue(summary["technical_wav_validation"])
+            self.assertFalse(summary["audio_rendered_quality_claimed"])
+            self.assertFalse(summary["human_audio_preference_claimed"])
+            self.assertEqual(len(summary["wav_paths"]), 2)
+
+    def test_rejects_broad_quality_claim(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with self.assertRaises(StageBDurationCoverageRepeatabilityAudioReviewPackageError):
+                build_repeatability_audio_review_package(
+                    repeatability_consolidation=repeatability_consolidation(broad_claim=True),
+                    dead_air_gain_repair=dead_air_gain_repair(root),
+                    output_dir=root / "audio_review",
+                    renderer_path=str(root / "fluidsynth"),
+                    soundfont_path=str(root / "piano.sf2"),
+                    sample_rate=44100,
+                    runner=fake_runner,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- repeatability source selected fill MIDI `2`개 WAV 렌더
- technical WAV metadata 검증 추가
- audio quality/preference claim guard 유지
- 전용 harness, unit test, 문서, handoff 갱신

## Context

- Issue #355 boundary: `current_keep_and_distinct_source_dead_air_gain_midi_support`
- distinct source MIDI/dead-air gain support: `true`
- new source human/audio preference: not claimed
- broad model quality: not claimed

## Result

- status: `ready_for_user_listening_review`
- rendered audio file count: `2`
- sample rate: `44100`
- sample seed `155` WAV: `outputs/stage_b_duration_coverage_fill_repeatability_audio_review_package/harness_stage_b_duration_coverage_fill_repeatability_audio_review_package/audio/repeatability_sample_seed_155_duration_fill.wav`
- sample seed `131` WAV: `outputs/stage_b_duration_coverage_fill_repeatability_audio_review_package/harness_stage_b_duration_coverage_fill_repeatability_audio_review_package/audio/repeatability_sample_seed_131_duration_fill.wav`
- audio rendered quality: not claimed
- human/audio preference: not claimed

## Validation

- `.venv/bin/python -m unittest tests/test_stage_b_duration_coverage_fill_repeatability_audio_review_package.py`
- `bash scripts/agent_harness.sh stage-b-duration-coverage-repeatability-audio-review-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- `rg -n "codex|Codex|코덱스" changed files`: no output

## Risk

- generated WAV files are local artifacts and not committed
- human/audio preference 미검증
- broad trained-model quality 미검증

Closes #357