### PR TITLE
Stage B duration coverage fill outside-soloing repair decision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #359, Stage B duration coverage fill repeatability user listening review fill.
+- Latest functional issue completed: Issue #361, Stage B duration coverage fill outside-soloing repair decision.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair decision.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair sweep.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -794,6 +794,14 @@ bash scripts/agent_harness.sh stage-b-duration-coverage-repeatability-user-liste
 ```
 
 This harness records user listening feedback for repeatability WAV files and keeps human/audio keep claims false when candidates need follow-up.
+
+For Stage B duration coverage fill outside-soloing repair decision changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-decision
+```
+
+This harness converts repeatability user listening follow-up into pitch-role and phrase-clarity repair targets.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -124,6 +124,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - duration coverage fill repeatability consolidation 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_REPEATABILITY_CONSOLIDATION_2026-05-29.md`
 - duration coverage fill repeatability audio review package 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_REPEATABILITY_AUDIO_REVIEW_PACKAGE_2026-05-29.md`
 - duration coverage fill repeatability user listening review fill 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_REPEATABILITY_USER_LISTENING_REVIEW_FILL_2026-05-29.md`
+- duration coverage fill outside-soloing repair decision 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_DECISION_2026-05-29.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -186,6 +187,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - duration coverage fill repeatability consolidation: current keep single-user preference `true`, distinct source MIDI/dead-air gain support `true`, boundary `current_keep_and_distinct_source_dead_air_gain_midi_support`
 - duration coverage fill repeatability audio review package: repeatability source WAV `2`, sample rate `44100`, status `ready_for_user_listening_review`, quality/preference claim `false`
 - duration coverage fill repeatability user listening review fill: overall decision `reject_all`, candidate decision `needs_followup`, timing/phrase/vocabulary `outside_or_unclear`, boundary `repeatability_audio_review_needs_followup`
+- duration coverage fill outside-soloing repair decision: next boundary `outside_soloing_pitch_role_phrase_clarity_repair`, repair targets `5`, critical user input `false`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #359, Stage B duration coverage fill repeatability user listening review fill
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair decision`
+- latest functional result: Issue #361, Stage B duration coverage fill outside-soloing repair decision
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair sweep`
 
 현재 범위가 아닌 것:
 
@@ -65,6 +65,46 @@ Issue #220은 현재 작업이 core인지, MVP 완료로 볼 수 있는지를 �
 Docs:
 
 - `docs/STAGE_B_MODEL_CORE_MVP_COMPLETION_AUDIT_2026-05-28.md`
+
+## Current Duration Coverage Fill Outside-Soloing Repair Decision Result
+
+Issue #361은 repeatability source 청취 리뷰의 `needs_followup` 결과를 다음 repair target으로 변환한 작업이다.
+
+변경:
+
+- outside-soloing repair decision script 추가
+- user review boundary를 repair target으로 변환
+- auto progress 가능 여부와 critical user input 필요 여부 분리
+
+결과:
+
+- input boundary: `repeatability_audio_review_needs_followup`
+- next boundary: `outside_soloing_pitch_role_phrase_clarity_repair`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- repair target count: `5`
+- human/audio keep claimed: `false`
+- broad model quality claimed: `false`
+
+repair targets:
+
+- `reduce_outside_sounding_pitch_choices`
+- `increase_chord_tone_or_guide_tone_landing`
+- `limit_non_chord_tone_run_length`
+- `penalize_large_interval_after_fill`
+- `prefer_phrase_contour_resolution_over_density`
+
+판단:
+
+- MIDI/dead-air repeatability는 유지
+- 청취 기준 문제는 density 자체보다 pitch-role / chord-fit / phrase clarity 축으로 분리
+- 다음 repair는 dead-air gain과 monophonic gate를 유지하면서 outside-sounding pitch 선택을 제한
+- repair 후 audio review 필요
+- broad trained-model quality, Brad style adaptation, production-ready improviser claim 금지
+
+다음:
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair sweep`
 
 ## Current Duration Coverage Fill Repeatability User Listening Review Fill Result
 

--- a/docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_DECISION_2026-05-29.md
+++ b/docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_DECISION_2026-05-29.md
@@ -1,0 +1,65 @@
+# Stage B Duration Coverage Fill Outside-Soloing Repair Decision
+
+Issue #361은 repeatability source 청취 리뷰의 `needs_followup` 결과를 다음 repair target으로 변환한 작업이다.
+
+## Context
+
+- Issue #359 boundary: `repeatability_audio_review_needs_followup`
+- overall decision: `reject_all`
+- candidate decision: `needs_followup`
+- timing / phrase / vocabulary: `outside_or_unclear`
+- user review: both candidates sound difficult and outside-soloing-like
+- human/audio keep claimed: `false`
+- broad model quality claimed: `false`
+
+## Change
+
+- outside-soloing repair decision script 추가
+- user review boundary를 repair target으로 변환
+- auto progress 가능 여부와 critical user input 필요 여부 분리
+- 전용 harness와 unit test 추가
+
+## Result
+
+| item | value |
+|---|---:|
+| input boundary | `repeatability_audio_review_needs_followup` |
+| next boundary | `outside_soloing_pitch_role_phrase_clarity_repair` |
+| auto progress allowed | `true` |
+| critical user input required | `false` |
+| repair target count | `5` |
+| human/audio keep claimed | `false` |
+| broad model quality claimed | `false` |
+
+## Repair Targets
+
+- `reduce_outside_sounding_pitch_choices`
+- `increase_chord_tone_or_guide_tone_landing`
+- `limit_non_chord_tone_run_length`
+- `penalize_large_interval_after_fill`
+- `prefer_phrase_contour_resolution_over_density`
+
+## Judgment
+
+- MIDI/dead-air repeatability는 유지
+- 청취 기준 문제는 density 자체보다 pitch-role / chord-fit / phrase clarity 축으로 분리
+- 다음 repair는 dead-air gain과 monophonic gate를 유지하면서 outside-sounding pitch 선택을 제한
+- repair 후 audio review 필요
+- broad trained-model quality, Brad style adaptation, production-ready improviser claim 금지
+
+## Validation
+
+```bash
+.venv/bin/python -m unittest tests/test_stage_b_duration_coverage_outside_soloing_repair_decision.py
+bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-decision
+```
+
+## Output
+
+- script: `scripts/decide_stage_b_duration_coverage_outside_soloing_repair.py`
+- test: `tests/test_stage_b_duration_coverage_outside_soloing_repair_decision.py`
+- summary: `outputs/stage_b_duration_coverage_fill_outside_soloing_repair_decision/harness_stage_b_duration_coverage_fill_outside_soloing_repair_decision/stage_b_duration_coverage_fill_outside_soloing_repair_decision.json`
+
+## Next
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair sweep`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -138,6 +138,8 @@ Modes:
                 Render repeatability source candidates for user listening review.
   stage-b-duration-coverage-repeatability-user-listening-review
                 Fill user listening review for repeatability source WAV files.
+  stage-b-duration-coverage-outside-soloing-repair-decision
+                Decide next repair boundary after outside-soloing user review.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -1977,6 +1979,24 @@ run_stage_b_duration_coverage_repeatability_user_listening_review() {
     --require_no_broad_quality_claim
 }
 
+run_stage_b_duration_coverage_outside_soloing_repair_decision() {
+  local user_review_run_id="${USER_REVIEW_RUN_ID:-harness_stage_b_duration_coverage_fill_repeatability_user_listening_review_fill}"
+  local run_id="${RUN_ID:-harness_stage_b_duration_coverage_fill_outside_soloing_repair_decision}"
+  local user_review="outputs/stage_b_duration_coverage_fill_repeatability_user_listening_review_fill/${user_review_run_id}/stage_b_duration_coverage_fill_repeatability_user_listening_review_fill.json"
+  if [[ ! -f "$user_review" ]]; then
+    print_header "Stage B duration/coverage fill repeatability user listening review"
+    RUN_ID="$user_review_run_id" run_stage_b_duration_coverage_repeatability_user_listening_review
+  fi
+  print_header "Stage B duration/coverage fill outside-soloing repair decision"
+  "$PYTHON_BIN" scripts/decide_stage_b_duration_coverage_outside_soloing_repair.py \
+    --run_id "$run_id" \
+    --user_listening_review "$user_review" \
+    --expected_next_boundary outside_soloing_pitch_role_phrase_clarity_repair \
+    --require_auto_progress_allowed \
+    --require_no_critical_user_input \
+    --require_no_broad_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -3279,6 +3299,9 @@ case "$MODE" in
     ;;
   stage-b-duration-coverage-repeatability-user-listening-review)
     run_stage_b_duration_coverage_repeatability_user_listening_review
+    ;;
+  stage-b-duration-coverage-outside-soloing-repair-decision)
+    run_stage_b_duration_coverage_outside_soloing_repair_decision
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/decide_stage_b_duration_coverage_outside_soloing_repair.py
+++ b/scripts/decide_stage_b_duration_coverage_outside_soloing_repair.py
@@ -1,0 +1,227 @@
+"""Decide next repair boundary after outside-soloing user review."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class StageBDurationCoverageOutsideSoloingRepairDecisionError(ValueError):
+    pass
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def build_outside_soloing_repair_decision(
+    user_listening_review: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> dict[str, Any]:
+    review = _dict(user_listening_review.get("user_listening_review"))
+    claim = _dict(user_listening_review.get("claim_boundary"))
+    if str(claim.get("boundary") or "") != "repeatability_audio_review_needs_followup":
+        raise StageBDurationCoverageOutsideSoloingRepairDecisionError("needs-followup audio boundary is required")
+    if str(review.get("overall_decision") or "") != "reject_all":
+        raise StageBDurationCoverageOutsideSoloingRepairDecisionError("overall reject_all decision is required")
+    if bool(claim.get("repeatability_human_audio_keep_claimed", True)):
+        raise StageBDurationCoverageOutsideSoloingRepairDecisionError("human/audio keep must not be claimed")
+    if bool(claim.get("broad_model_quality_claimed", True)):
+        raise StageBDurationCoverageOutsideSoloingRepairDecisionError("broad model quality must not be claimed")
+    candidate_reviews = _list(review.get("candidate_reviews"))
+    if len(candidate_reviews) != 2:
+        raise StageBDurationCoverageOutsideSoloingRepairDecisionError("expected two candidate reviews")
+    if any(str(item.get("decision") or "") != "needs_followup" for item in candidate_reviews if isinstance(item, dict)):
+        raise StageBDurationCoverageOutsideSoloingRepairDecisionError("all candidate reviews must need follow-up")
+
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_outside_soloing_repair_decision_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_user_listening_review_schema": str(user_listening_review.get("schema_version") or ""),
+        "candidate_id": str(user_listening_review.get("candidate_id") or ""),
+        "input_boundary": str(claim.get("boundary") or ""),
+        "user_review_summary": {
+            "overall_decision": str(review.get("overall_decision") or ""),
+            "candidate_decision": str(review.get("candidate_decision") or ""),
+            "timing": str(review.get("timing") or ""),
+            "phrase": str(review.get("phrase") or ""),
+            "vocabulary": str(review.get("vocabulary") or ""),
+            "assessment": str(review.get("assessment") or ""),
+            "reviewed_audio_file_count": len(_list(user_listening_review.get("reviewed_audio_files"))),
+        },
+        "decision": {
+            "next_boundary": "outside_soloing_pitch_role_phrase_clarity_repair",
+            "reason": "MIDI/dead-air repeatability passed, but user listening rejected both repeatability WAVs as difficult and outside-soloing-like",
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "blocked_reason": "",
+        },
+        "repair_targets": [
+            "reduce_outside_sounding_pitch_choices",
+            "increase_chord_tone_or_guide_tone_landing",
+            "limit_non_chord_tone_run_length",
+            "penalize_large_interval_after_fill",
+            "prefer_phrase_contour_resolution_over_density",
+        ],
+        "selection_constraints": {
+            "keep_dead_air_gain_gate": True,
+            "keep_monophonic_gate": True,
+            "require_audio_review_after_repair": True,
+            "do_not_claim_broad_model_quality": True,
+        },
+        "claim_boundary": {
+            "boundary": "outside_soloing_repair_decision",
+            "human_audio_keep_claimed": False,
+            "broad_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_improviser_claimed": False,
+        },
+        "not_proven": [
+            "human_audio_keep",
+            "multi_reviewer_preference",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "production_ready_improviser",
+        ],
+        "next_recommended_issue": (
+            "Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair sweep"
+        ),
+    }
+
+
+def validate_outside_soloing_repair_decision(
+    report: dict[str, Any],
+    *,
+    expected_next_boundary: str | None,
+    require_auto_progress_allowed: bool,
+    require_no_critical_user_input: bool,
+    require_no_broad_quality_claim: bool,
+) -> dict[str, Any]:
+    decision = _dict(report.get("decision"))
+    claim = _dict(report.get("claim_boundary"))
+    next_boundary = str(decision.get("next_boundary") or "")
+    if expected_next_boundary and next_boundary != expected_next_boundary:
+        raise StageBDurationCoverageOutsideSoloingRepairDecisionError(
+            f"expected next boundary {expected_next_boundary}, got {next_boundary}"
+        )
+    if require_auto_progress_allowed and not bool(decision.get("auto_progress_allowed", False)):
+        raise StageBDurationCoverageOutsideSoloingRepairDecisionError("auto progress must be allowed")
+    if require_no_critical_user_input and bool(decision.get("critical_user_input_required", True)):
+        raise StageBDurationCoverageOutsideSoloingRepairDecisionError("critical user input must not be required")
+    if require_no_broad_quality_claim and bool(claim.get("broad_model_quality_claimed", True)):
+        raise StageBDurationCoverageOutsideSoloingRepairDecisionError("broad model quality must not be claimed")
+    return {
+        "candidate_id": str(report.get("candidate_id") or ""),
+        "input_boundary": str(report.get("input_boundary") or ""),
+        "next_boundary": next_boundary,
+        "auto_progress_allowed": bool(decision.get("auto_progress_allowed", False)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "repair_target_count": len(_list(report.get("repair_targets"))),
+        "human_audio_keep_claimed": bool(claim.get("human_audio_keep_claimed", True)),
+        "broad_model_quality_claimed": bool(claim.get("broad_model_quality_claimed", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    decision = report["decision"]
+    review = report["user_review_summary"]
+    claim = report["claim_boundary"]
+    lines = [
+        "# Stage B Duration Coverage Fill Outside-Soloing Repair Decision",
+        "",
+        f"- candidate: `{report['candidate_id']}`",
+        f"- input boundary: `{report['input_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- auto progress allowed: `{decision['auto_progress_allowed']}`",
+        f"- critical user input required: `{decision['critical_user_input_required']}`",
+        f"- human/audio keep claimed: `{claim['human_audio_keep_claimed']}`",
+        f"- broad model quality claimed: `{claim['broad_model_quality_claimed']}`",
+        "",
+        "## User Review",
+        "",
+        f"- overall decision: `{review['overall_decision']}`",
+        f"- candidate decision: `{review['candidate_decision']}`",
+        f"- timing: `{review['timing']}`",
+        f"- phrase: `{review['phrase']}`",
+        f"- vocabulary: `{review['vocabulary']}`",
+        f"- assessment: {review['assessment']}",
+        "",
+        "## Repair Targets",
+        "",
+    ]
+    for item in report.get("repair_targets", []):
+        lines.append(f"- `{item}`")
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Decide outside-soloing repair boundary")
+    parser.add_argument(
+        "--user_listening_review",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_repeatability_user_listening_review_fill/"
+        "harness_stage_b_duration_coverage_fill_repeatability_user_listening_review_fill/"
+        "stage_b_duration_coverage_fill_repeatability_user_listening_review_fill.json",
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_decision",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_auto_progress_allowed", action="store_true")
+    parser.add_argument("--require_no_critical_user_input", action="store_true")
+    parser.add_argument("--require_no_broad_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_outside_soloing_repair_decision(
+        read_json(Path(args.user_listening_review)),
+        output_dir=output_dir,
+    )
+    summary = validate_outside_soloing_repair_decision(
+        report,
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_auto_progress_allowed=bool(args.require_auto_progress_allowed),
+        require_no_critical_user_input=bool(args.require_no_critical_user_input),
+        require_no_broad_quality_claim=bool(args.require_no_broad_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "stage_b_duration_coverage_fill_outside_soloing_repair_decision.json"
+    markdown_path = output_dir / "stage_b_duration_coverage_fill_outside_soloing_repair_decision.md"
+    write_json(report_path, report)
+    write_json(output_dir / "stage_b_duration_coverage_fill_outside_soloing_repair_decision_validation_summary.json", summary)
+    markdown_path.write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps({**summary, "report_path": str(report_path), "markdown_path": str(markdown_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_duration_coverage_outside_soloing_repair_decision.py
+++ b/tests/test_stage_b_duration_coverage_outside_soloing_repair_decision.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.decide_stage_b_duration_coverage_outside_soloing_repair import (
+    StageBDurationCoverageOutsideSoloingRepairDecisionError,
+    build_outside_soloing_repair_decision,
+    validate_outside_soloing_repair_decision,
+)
+
+
+def user_listening_review(*, keep_claim: bool = False, boundary: str = "repeatability_audio_review_needs_followup") -> dict:
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_repeatability_user_listening_review_fill_v1",
+        "candidate_id": "duration_coverage_fill_repeatability_sources",
+        "reviewed_audio_files": [{}, {}],
+        "user_listening_review": {
+            "overall_decision": "reject_all",
+            "candidate_decision": "needs_followup",
+            "timing": "outside_or_unclear",
+            "phrase": "outside_or_unclear",
+            "vocabulary": "outside_or_unclear",
+            "assessment": "both candidates sound difficult and outside-soloing-like",
+            "candidate_reviews": [
+                {"decision": "needs_followup"},
+                {"decision": "needs_followup"},
+            ],
+        },
+        "claim_boundary": {
+            "boundary": boundary,
+            "repeatability_human_audio_keep_claimed": keep_claim,
+            "broad_model_quality_claimed": False,
+        },
+    }
+
+
+class StageBDurationCoverageOutsideSoloingRepairDecisionTest(unittest.TestCase):
+    def test_selects_pitch_role_phrase_clarity_repair_boundary(self) -> None:
+        report = build_outside_soloing_repair_decision(
+            user_listening_review(),
+            output_dir=Path("outputs/outside_soloing_decision"),
+        )
+        summary = validate_outside_soloing_repair_decision(
+            report,
+            expected_next_boundary="outside_soloing_pitch_role_phrase_clarity_repair",
+            require_auto_progress_allowed=True,
+            require_no_critical_user_input=True,
+            require_no_broad_quality_claim=True,
+        )
+
+        self.assertEqual(summary["input_boundary"], "repeatability_audio_review_needs_followup")
+        self.assertTrue(summary["auto_progress_allowed"])
+        self.assertFalse(summary["critical_user_input_required"])
+        self.assertFalse(summary["human_audio_keep_claimed"])
+        self.assertGreaterEqual(summary["repair_target_count"], 5)
+        self.assertIn("reduce_outside_sounding_pitch_choices", report["repair_targets"])
+
+    def test_rejects_keep_claim(self) -> None:
+        with self.assertRaises(StageBDurationCoverageOutsideSoloingRepairDecisionError):
+            build_outside_soloing_repair_decision(
+                user_listening_review(keep_claim=True),
+                output_dir=Path("outputs/outside_soloing_decision"),
+            )
+
+    def test_rejects_unexpected_boundary(self) -> None:
+        with self.assertRaises(StageBDurationCoverageOutsideSoloingRepairDecisionError):
+            build_outside_soloing_repair_decision(
+                user_listening_review(boundary="other_boundary"),
+                output_dir=Path("outputs/outside_soloing_decision"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- repeatability user listening follow-up을 repair decision으로 전환
- next boundary: `outside_soloing_pitch_role_phrase_clarity_repair`
- repair targets `5`개 정의
- broad model quality / human-audio keep claim 금지 유지

## Context

- Issue #359 boundary: `repeatability_audio_review_needs_followup`
- overall decision: `reject_all`
- candidate decision: `needs_followup`
- timing / phrase / vocabulary: `outside_or_unclear`
- user review: both candidates sound difficult and outside-soloing-like

## Repair Targets

- `reduce_outside_sounding_pitch_choices`
- `increase_chord_tone_or_guide_tone_landing`
- `limit_non_chord_tone_run_length`
- `penalize_large_interval_after_fill`
- `prefer_phrase_contour_resolution_over_density`

## Validation

- `.venv/bin/python -m unittest tests/test_stage_b_duration_coverage_outside_soloing_repair_decision.py`
- `bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-decision`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- `rg -n "codex|Codex|코덱스" changed files`: no output

## Risk

- MIDI/dead-air repeatability는 유지되지만 청취 keep은 미검증
- repair 후 audio review 필요
- broad trained-model quality 미검증

Closes #361