### PR TITLE
Stage B duration coverage fill outside-soloing repair sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #361, Stage B duration coverage fill outside-soloing repair decision.
+- Latest functional issue completed: Issue #363, Stage B duration coverage fill outside-soloing repair sweep.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair sweep.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair audio review package.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -802,6 +802,14 @@ bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-d
 ```
 
 This harness converts repeatability user listening follow-up into pitch-role and phrase-clarity repair targets.
+
+For Stage B duration coverage fill outside-soloing repair sweep changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-sweep
+```
+
+This harness builds pitch-role repair candidates for repeatability sources while preserving dead-air gain and monophonic gates.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -125,6 +125,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - duration coverage fill repeatability audio review package 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_REPEATABILITY_AUDIO_REVIEW_PACKAGE_2026-05-29.md`
 - duration coverage fill repeatability user listening review fill 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_REPEATABILITY_USER_LISTENING_REVIEW_FILL_2026-05-29.md`
 - duration coverage fill outside-soloing repair decision 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_DECISION_2026-05-29.md`
+- duration coverage fill outside-soloing repair sweep 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_SWEEP_2026-05-29.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -188,6 +189,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - duration coverage fill repeatability audio review package: repeatability source WAV `2`, sample rate `44100`, status `ready_for_user_listening_review`, quality/preference claim `false`
 - duration coverage fill repeatability user listening review fill: overall decision `reject_all`, candidate decision `needs_followup`, timing/phrase/vocabulary `outside_or_unclear`, boundary `repeatability_audio_review_needs_followup`
 - duration coverage fill outside-soloing repair decision: next boundary `outside_soloing_pitch_role_phrase_clarity_repair`, repair targets `5`, critical user input `false`
+- duration coverage fill outside-soloing repair sweep: repaired source `2/2`, qualified variants `6/6`, selected chord-tone ratio `1.000`, max non-chord run `0`, boundary `outside_soloing_pitch_role_repair_candidates`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #361, Stage B duration coverage fill outside-soloing repair decision
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair sweep`
+- latest functional result: Issue #363, Stage B duration coverage fill outside-soloing repair sweep
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair audio review package`
 
 현재 범위가 아닌 것:
 
@@ -65,6 +65,47 @@ Issue #220은 현재 작업이 core인지, MVP 완료로 볼 수 있는지를 �
 Docs:
 
 - `docs/STAGE_B_MODEL_CORE_MVP_COMPLETION_AUDIT_2026-05-28.md`
+
+## Current Duration Coverage Fill Outside-Soloing Repair Sweep Result
+
+Issue #363은 repeatability source 후보 `2`개에 pitch-role / chord-fit 보정 sweep을 적용한 작업이다.
+
+변경:
+
+- outside-soloing repair sweep script 추가
+- chord tone / guide tone 중심 pitch 보정 variant 생성
+- dead-air gain, monophonic, chord-tone ratio, non-chord run, max interval gate 분리
+- 전용 harness와 unit test 추가
+
+결과:
+
+- boundary: `outside_soloing_pitch_role_repair_candidates`
+- source candidates: `2`
+- repaired source candidates: `2`
+- dead-air preserved source candidates: `2`
+- total variants: `6`
+- qualified variants: `6`
+- selected policy: `contour_resolution`
+- selected min chord-tone ratio: `1.000`
+- selected max non-chord run: `0`
+- selected max interval: `7`
+- broad model quality claimed: `false`
+
+source별 selected 결과:
+
+- sample seed `155`: dead-air `0.3333`, unique pitch `10`, max interval `7`, chord-tone ratio `1.000`
+- sample seed `131`: dead-air `0.3529`, unique pitch `9`, max interval `5`, chord-tone ratio `1.000`
+
+판단:
+
+- 사용자 청취에서 지적된 outside-soloing 문제를 pitch-role objective boundary로 1차 보정
+- 기존 dead-air gain과 monophonic gate 유지
+- 이 결과는 MIDI objective repair 후보이며 청취 선호 proof가 아님
+- human/audio preference, multi-reviewer preference, broad trained-model quality claim 금지
+
+다음:
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair audio review package`
 
 ## Current Duration Coverage Fill Outside-Soloing Repair Decision Result
 

--- a/docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_SWEEP_2026-05-29.md
+++ b/docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_SWEEP_2026-05-29.md
@@ -1,0 +1,70 @@
+# Stage B Duration Coverage Fill Outside-Soloing Repair Sweep
+
+Issue #363은 repeatability source 후보 `2`개에 pitch-role / chord-fit 보정 sweep을 적용한 작업이다.
+
+## Context
+
+- Issue #361 next boundary: `outside_soloing_pitch_role_phrase_clarity_repair`
+- Issue #353 source boundary: `qualified_gate_repeatability_with_dead_air_gain`
+- user listening review: repeatability WAV 후보 `2`개 모두 difficult / outside-soloing-like
+- 기존 유지 조건: dead-air gain, monophonic gate
+- 제외 claim: human/audio preference, broad trained-model quality, Brad style adaptation, production-ready improviser
+
+## Change
+
+- outside-soloing repair sweep script 추가
+- `chord_tone_snap`, `guide_tone_landing`, `contour_resolution` policy 비교
+- chord-tone ratio, guide-tone landing, max non-chord run, max interval 측정
+- source별 selected repaired MIDI 후보 기록
+- 전용 harness와 unit test 추가
+
+## Result
+
+| item | value |
+|---|---:|
+| boundary | `outside_soloing_pitch_role_repair_candidates` |
+| source candidates | `2` |
+| repaired source candidates | `2` |
+| dead-air preserved source candidates | `2` |
+| total variants | `6` |
+| qualified variants | `6` |
+| selected policy | `contour_resolution` |
+| selected min chord-tone ratio | `1.000` |
+| selected max non-chord run | `0` |
+| selected max interval | `7` |
+| broad model quality claimed | `false` |
+
+## Selected Sources
+
+| sample seed | dead-air | unique pitch | max interval | chord-tone ratio | selected |
+|---:|---:|---:|---:|---:|---|
+| `155` | `0.3333` | `10` | `7` | `1.000` | `margin_recovered_phrase_vocab_seed_109_topk_7_temp_082_n48_sample_47_duration_fill_maxadd_6_outside_repair_contour_resolution` |
+| `131` | `0.3529` | `9` | `5` | `1.000` | `margin_recovered_phrase_vocab_seed_109_topk_7_temp_082_n48_sample_23_duration_fill_maxadd_6_outside_repair_contour_resolution` |
+
+## Judgment
+
+- outside-soloing 청취 문제를 pitch-role objective repair 후보로 1차 보정
+- dead-air gain preserved source candidates: `2/2`
+- selected candidates: chord-tone ratio `1.000`, max non-chord run `0`
+- sample seed `131` max interval: `11 -> 5`
+- sample seed `155` max interval: `6 -> 7`
+- 이번 결과는 MIDI objective repair 후보이며 청취 선호 proof가 아님
+- audio review 필요
+
+## Validation
+
+```bash
+.venv/bin/python -m unittest tests/test_stage_b_duration_coverage_fill_outside_soloing_repair_sweep.py
+bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-sweep
+```
+
+## Output
+
+- script: `scripts/summarize_stage_b_duration_coverage_fill_outside_soloing_repair_sweep.py`
+- test: `tests/test_stage_b_duration_coverage_fill_outside_soloing_repair_sweep.py`
+- summary: `outputs/stage_b_duration_coverage_fill_outside_soloing_repair_sweep/harness_stage_b_duration_coverage_fill_outside_soloing_repair_sweep/stage_b_duration_coverage_fill_outside_soloing_repair_sweep.json`
+- markdown: `outputs/stage_b_duration_coverage_fill_outside_soloing_repair_sweep/harness_stage_b_duration_coverage_fill_outside_soloing_repair_sweep/stage_b_duration_coverage_fill_outside_soloing_repair_sweep.md`
+
+## Next
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair audio review package`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -140,6 +140,8 @@ Modes:
                 Fill user listening review for repeatability source WAV files.
   stage-b-duration-coverage-outside-soloing-repair-decision
                 Decide next repair boundary after outside-soloing user review.
+  stage-b-duration-coverage-outside-soloing-repair-sweep
+                Build pitch-role repair candidates for outside-soloing repeatability sources.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -286,6 +288,7 @@ run_quick() {
     scripts/fill_stage_b_margin_recovered_phrase_vocabulary_focused_listening_notes.py \
     scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_keep_stability.py \
     scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_two_candidate_keep.py \
+    scripts/summarize_stage_b_duration_coverage_fill_outside_soloing_repair_sweep.py \
     scripts/build_stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison.py \
     scripts/audit_stage_b_margin_recovered_phrase_vocabulary_duplicate_source_divergence.py \
     scripts/repair_stage_b_margin_recovered_phrase_vocabulary_sample_seed_diversity.py \
@@ -1997,6 +2000,29 @@ run_stage_b_duration_coverage_outside_soloing_repair_decision() {
     --require_no_broad_quality_claim
 }
 
+run_stage_b_duration_coverage_outside_soloing_repair_sweep() {
+  local outside_decision_run_id="${OUTSIDE_DECISION_RUN_ID:-harness_stage_b_duration_coverage_fill_outside_soloing_repair_decision}"
+  local dead_air_repair_run_id="${DEAD_AIR_REPAIR_RUN_ID:-harness_stage_b_duration_coverage_fill_dead_air_gain_repeatability_repair}"
+  local run_id="${RUN_ID:-harness_stage_b_duration_coverage_fill_outside_soloing_repair_sweep}"
+  local outside_decision="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_decision/${outside_decision_run_id}/stage_b_duration_coverage_fill_outside_soloing_repair_decision.json"
+  local dead_air_repair="outputs/stage_b_duration_coverage_fill_dead_air_gain_repeatability_repair/${dead_air_repair_run_id}/stage_b_duration_coverage_fill_dead_air_gain_repeatability_repair.json"
+  if [[ ! -f "$outside_decision" ]]; then
+    print_header "Stage B duration/coverage fill outside-soloing repair decision"
+    RUN_ID="$outside_decision_run_id" run_stage_b_duration_coverage_outside_soloing_repair_decision
+  fi
+  if [[ ! -f "$dead_air_repair" ]]; then
+    print_header "Stage B duration/coverage fill dead-air gain repeatability repair"
+    RUN_ID="$dead_air_repair_run_id" run_stage_b_duration_coverage_dead_air_gain_repeatability_repair
+  fi
+  print_header "Stage B duration/coverage fill outside-soloing repair sweep"
+  "$PYTHON_BIN" scripts/summarize_stage_b_duration_coverage_fill_outside_soloing_repair_sweep.py \
+    --run_id "$run_id" \
+    --outside_soloing_decision "$outside_decision" \
+    --dead_air_gain_repair "$dead_air_repair" \
+    --expected_boundary outside_soloing_pitch_role_repair_candidates \
+    --require_no_broad_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -3302,6 +3328,9 @@ case "$MODE" in
     ;;
   stage-b-duration-coverage-outside-soloing-repair-decision)
     run_stage_b_duration_coverage_outside_soloing_repair_decision
+    ;;
+  stage-b-duration-coverage-outside-soloing-repair-sweep)
+    run_stage_b_duration_coverage_outside_soloing_repair_sweep
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/summarize_stage_b_duration_coverage_fill_outside_soloing_repair_sweep.py
+++ b/scripts/summarize_stage_b_duration_coverage_fill_outside_soloing_repair_sweep.py
@@ -1,0 +1,823 @@
+"""Build outside-soloing repair variants for duration/coverage repeatability sources."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import numbers
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+import pretty_midi
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from inference.app.fallback import (  # noqa: E402
+    chord_for_time,
+    chord_pitches_in_range,
+    parse_chord,
+    phrase_duration_sec,
+)
+from inference.app.metrics import compute_midi_metrics  # noqa: E402
+from inference.app.schemas import GenerationRequest  # noqa: E402
+from scripts.select_stage_b_margin_recovered_repair_candidate import (  # noqa: E402
+    focused_solo_metrics,
+    non_drum_notes,
+)
+from scripts.summarize_stage_b_margin_recovered_phrase_vocabulary_duration_coverage_fill_repair import (  # noqa: E402
+    copy_note,
+    enforce_monophonic_note_ends,
+    request_from_report,
+    write_midi,
+)
+from scripts.summarize_stage_b_margin_recovered_phrase_vocabulary_repair import (  # noqa: E402
+    focused_max_interval,
+    float_value,
+)
+
+
+PREFERRED_SOLO_MIN = 48
+PREFERRED_SOLO_MAX = 88
+DEFAULT_REPAIR_POLICIES = (
+    "chord_tone_snap",
+    "guide_tone_landing",
+    "contour_resolution",
+)
+GUIDE_INTERVALS = {3, 4, 10, 11}
+
+
+class StageBDurationCoverageOutsideSoloingRepairSweepError(ValueError):
+    pass
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, tuple):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, bool) or value is None or isinstance(value, str):
+        return value
+    if isinstance(value, numbers.Integral):
+        return int(value)
+    if isinstance(value, numbers.Real):
+        return float(value)
+    return value
+
+
+def safe_label(value: Any) -> str:
+    text = str(value).lower().replace(".", "_").replace("-", "m")
+    return "".join(char for char in text if char.isalnum() or char == "_") or "na"
+
+
+def load_source_notes(midi_path: Path) -> list[pretty_midi.Note]:
+    midi = pretty_midi.PrettyMIDI(str(midi_path))
+    notes = [copy_note(note) for note in non_drum_notes(midi)]
+    if not notes:
+        raise StageBDurationCoverageOutsideSoloingRepairSweepError(f"source MIDI has no notes: {midi_path}")
+    return sorted(notes, key=lambda note: (float(note.start), int(note.pitch), float(note.end)))
+
+
+def chord_pitch_classes(request: GenerationRequest, start_sec: float) -> set[int]:
+    root_pc, intervals = parse_chord(chord_for_time(request, start_sec))
+    return {(root_pc + interval) % 12 for interval in intervals}
+
+
+def guide_pitch_classes(request: GenerationRequest, start_sec: float) -> set[int]:
+    root_pc, intervals = parse_chord(chord_for_time(request, start_sec))
+    guide_intervals = [interval for interval in intervals if interval % 12 in GUIDE_INTERVALS]
+    if not guide_intervals:
+        guide_intervals = intervals[:1]
+    return {(root_pc + interval) % 12 for interval in guide_intervals}
+
+
+def pitches_for_time(
+    request: GenerationRequest,
+    start_sec: float,
+    *,
+    guide_only: bool,
+) -> list[int]:
+    root_pc, intervals = parse_chord(chord_for_time(request, start_sec))
+    if guide_only:
+        intervals = [interval for interval in intervals if interval % 12 in GUIDE_INTERVALS] or intervals[:1]
+    pitches = chord_pitches_in_range(root_pc, intervals, PREFERRED_SOLO_MIN, PREFERRED_SOLO_MAX)
+    if not pitches:
+        pitches = chord_pitches_in_range(root_pc, [0], PREFERRED_SOLO_MIN, PREFERRED_SOLO_MAX)
+    return sorted(set(int(pitch) for pitch in pitches))
+
+
+def landing_note_indexes(notes: Sequence[pretty_midi.Note], request: GenerationRequest) -> set[int]:
+    if not notes:
+        return set()
+    phrase_duration = phrase_duration_sec(request)
+    segment_duration = phrase_duration / max(1, len(request.chord_progression))
+    indexes: set[int] = {len(notes) - 1}
+    for segment_index in range(len(request.chord_progression)):
+        segment_start = segment_index * segment_duration
+        segment_end = (segment_index + 1) * segment_duration
+        candidates = [
+            index
+            for index, note in enumerate(notes)
+            if float(note.start) >= segment_start and float(note.start) < segment_end
+        ]
+        if candidates:
+            indexes.add(max(candidates, key=lambda index: float(notes[index].start)))
+    return indexes
+
+
+def choose_repair_pitch(
+    *,
+    original_pitch: int,
+    pool: Sequence[int],
+    previous_pitch: int | None,
+    max_interval: int,
+    force_move: bool,
+) -> int:
+    if not pool:
+        return int(original_pitch)
+    scored: list[tuple[bool, int, int, int, int, int]] = []
+    for pitch in pool:
+        interval = abs(int(pitch) - int(previous_pitch)) if previous_pitch is not None else 0
+        overflow = max(0, interval - int(max_interval))
+        repeat_penalty = 1 if previous_pitch is not None and int(pitch) == int(previous_pitch) else 0
+        original_distance = abs(int(pitch) - int(original_pitch))
+        if force_move and int(pitch) == int(original_pitch):
+            original_distance += 4
+        scored.append(
+            (
+                overflow > 0,
+                overflow,
+                repeat_penalty,
+                original_distance,
+                interval,
+                int(pitch),
+            )
+        )
+    scored.sort()
+    return int(scored[0][-1])
+
+
+def build_repaired_notes(
+    source_notes: Sequence[pretty_midi.Note],
+    *,
+    request: GenerationRequest,
+    policy: str,
+    max_interval: int,
+) -> list[pretty_midi.Note]:
+    ordered = [copy_note(note) for note in sorted(source_notes, key=lambda note: (float(note.start), int(note.pitch)))]
+    phrase_duration = phrase_duration_sec(request)
+    landing_indexes = landing_note_indexes(ordered, request)
+    repaired: list[pretty_midi.Note] = []
+    previous_pitch: int | None = None
+
+    for index, note in enumerate(ordered):
+        original_pitch = int(note.pitch)
+        is_landing = index in landing_indexes
+        original_is_chord_tone = original_pitch % 12 in chord_pitch_classes(request, float(note.start))
+        force_guide = policy in {"guide_tone_landing", "contour_resolution"} and is_landing
+        guide_only = bool(force_guide)
+        pool = pitches_for_time(request, float(note.start), guide_only=guide_only)
+        keep_original = (
+            original_is_chord_tone
+            and not force_guide
+            and (
+                previous_pitch is None
+                or abs(int(original_pitch) - int(previous_pitch)) <= int(max_interval)
+            )
+            and not (
+                previous_pitch is not None
+                and int(original_pitch) == int(previous_pitch)
+                and policy == "contour_resolution"
+            )
+        )
+        if keep_original:
+            pitch = original_pitch
+        else:
+            pitch = choose_repair_pitch(
+                original_pitch=original_pitch,
+                pool=pool,
+                previous_pitch=previous_pitch,
+                max_interval=int(max_interval),
+                force_move=policy == "contour_resolution",
+            )
+        repaired.append(
+            pretty_midi.Note(
+                velocity=int(note.velocity),
+                pitch=int(pitch),
+                start=float(note.start),
+                end=min(float(phrase_duration), float(note.end)),
+            )
+        )
+        previous_pitch = int(pitch)
+
+    return enforce_monophonic_note_ends(repaired, max_duration_sec=phrase_duration)
+
+
+def max_non_chord_run(notes: Sequence[pretty_midi.Note], request: GenerationRequest) -> int:
+    longest = 0
+    current = 0
+    for note in sorted(notes, key=lambda item: (float(item.start), int(item.pitch))):
+        if int(note.pitch) % 12 in chord_pitch_classes(request, float(note.start)):
+            current = 0
+        else:
+            current += 1
+            longest = max(longest, current)
+    return int(longest)
+
+
+def landing_metrics(notes: Sequence[pretty_midi.Note], request: GenerationRequest) -> dict[str, Any]:
+    ordered = sorted(notes, key=lambda item: (float(item.start), int(item.pitch)))
+    indexes = landing_note_indexes(ordered, request)
+    landing_notes = [ordered[index] for index in sorted(indexes)]
+    guide_count = sum(
+        1
+        for note in landing_notes
+        if int(note.pitch) % 12 in guide_pitch_classes(request, float(note.start))
+    )
+    chord_count = sum(
+        1
+        for note in landing_notes
+        if int(note.pitch) % 12 in chord_pitch_classes(request, float(note.start))
+    )
+    total = len(landing_notes)
+    return {
+        "landing_note_count": int(total),
+        "guide_tone_landing_count": int(guide_count),
+        "chord_tone_landing_count": int(chord_count),
+        "guide_tone_landing_ratio": float(guide_count / total) if total else 0.0,
+        "chord_tone_landing_ratio": float(chord_count / total) if total else 0.0,
+    }
+
+
+def pitch_role_metrics(midi_path: Path, request: GenerationRequest) -> dict[str, Any]:
+    midi = pretty_midi.PrettyMIDI(str(midi_path))
+    notes = non_drum_notes(midi)
+    return {
+        "max_non_chord_tone_run": max_non_chord_run(notes, request),
+        **landing_metrics(notes, request),
+    }
+
+
+def outside_soloing_gate_flags(
+    variant: dict[str, Any],
+    source_result: dict[str, Any],
+    *,
+    min_chord_tone_ratio: float,
+    max_non_chord_run_length: int,
+    max_interval: int,
+    min_unique_pitch_count: int,
+    min_note_count: int,
+    max_dead_air_ratio_exclusive: float,
+    max_simultaneous_notes: int,
+) -> list[str]:
+    metrics = _dict(variant.get("metrics"))
+    focused = _dict(variant.get("focused_solo_metrics"))
+    pitch_role = _dict(variant.get("pitch_role_metrics"))
+    source_selected_dead_air = float(source_result.get("selected_dead_air_ratio", 1.0) or 1.0)
+    source_baseline_dead_air = float(source_result.get("baseline_dead_air_ratio", 1.0) or 1.0)
+    repaired_dead_air = float_value(metrics.get("dead_air_ratio"), 1.0)
+    flags: list[str] = []
+
+    if repaired_dead_air > source_selected_dead_air + 1e-9:
+        flags.append("dead_air_gain_not_preserved")
+    if repaired_dead_air >= source_baseline_dead_air:
+        flags.append("dead_air_gain_boundary_lost")
+    if repaired_dead_air >= float(max_dead_air_ratio_exclusive):
+        flags.append("dead_air_gate_failed")
+    if int(focused.get("focused_max_simultaneous_notes", 0) or 0) > int(max_simultaneous_notes):
+        flags.append("focused_polyphony")
+    if int(focused.get("focused_note_count", 0) or 0) < int(min_note_count):
+        flags.append("too_sparse_for_context_review")
+    if int(focused.get("focused_unique_pitch_count", 0) or 0) < int(min_unique_pitch_count):
+        flags.append("low_pitch_variety")
+    if int(focused.get("focused_max_interval", 0) or 0) > int(max_interval):
+        flags.append("wide_interval_after_repair")
+    if float_value(metrics.get("chord_tone_ratio"), 0.0) < float(min_chord_tone_ratio):
+        flags.append("low_chord_tone_ratio")
+    if int(pitch_role.get("max_non_chord_tone_run", 0) or 0) > int(max_non_chord_run_length):
+        flags.append("non_chord_run_not_repaired")
+    return flags
+
+
+def outside_soloing_score(variant: dict[str, Any], *, qualified: bool) -> float:
+    metrics = _dict(variant.get("metrics"))
+    focused = _dict(variant.get("focused_solo_metrics"))
+    pitch_role = _dict(variant.get("pitch_role_metrics"))
+    score = 1000.0 if qualified else 0.0
+    score += float_value(metrics.get("chord_tone_ratio"), 0.0) * 240.0
+    score += float_value(pitch_role.get("guide_tone_landing_ratio"), 0.0) * 90.0
+    score += (1.0 - min(1.0, float_value(metrics.get("dead_air_ratio"), 1.0))) * 80.0
+    score += min(12, int(focused.get("focused_unique_pitch_count", 0) or 0)) * 7.0
+    score -= int(pitch_role.get("max_non_chord_tone_run", 0) or 0) * 60.0
+    score -= max(0, int(focused.get("focused_max_interval", 0) or 0) - 5) * 14.0
+    score -= int(focused.get("focused_adjacent_pitch_repeats", 0) or 0) * 8.0
+    score -= int(focused.get("focused_duplicated_3_note_pitch_class_chunks", 0) or 0) * 12.0
+    return round(float(score), 6)
+
+
+def build_variant(
+    *,
+    source_result: dict[str, Any],
+    source_notes: Sequence[pretty_midi.Note],
+    source_report: dict[str, Any],
+    output_dir: Path,
+    policy: str,
+    max_interval: int,
+    min_chord_tone_ratio: float,
+    max_non_chord_run_length: int,
+    min_unique_pitch_count: int,
+    min_note_count: int,
+    max_dead_air_ratio_exclusive: float,
+    max_simultaneous_notes: int,
+) -> dict[str, Any]:
+    request = request_from_report(source_report)
+    selected_id = str(source_result.get("selected_candidate_id") or source_result.get("source_candidate_id") or "source")
+    candidate_id = f"{selected_id}_outside_repair_{safe_label(policy)}"
+    repaired_notes = build_repaired_notes(
+        source_notes,
+        request=request,
+        policy=policy,
+        max_interval=int(max_interval),
+    )
+    midi_path = write_midi(
+        repaired_notes,
+        output_dir / "midi" / f"{candidate_id}.mid",
+        bpm=int(request.bpm),
+    )
+    focused = focused_solo_metrics(midi_path)
+    focused["focused_max_interval"] = focused_max_interval(midi_path)
+    row: dict[str, Any] = {
+        "candidate_id": candidate_id,
+        "source_candidate_id": str(source_result.get("source_candidate_id") or ""),
+        "source_selected_candidate_id": str(source_result.get("selected_candidate_id") or ""),
+        "source_run_id": str(source_result.get("source_run_id") or ""),
+        "sample_seed": int(source_result.get("sample_seed", 0) or 0),
+        "repair_policy": str(policy),
+        "midi_path": str(midi_path),
+        "metrics": compute_midi_metrics(midi_path, 0, False, request=request).to_dict(),
+        "focused_solo_metrics": focused,
+        "pitch_role_metrics": pitch_role_metrics(midi_path, request),
+    }
+    flags = outside_soloing_gate_flags(
+        row,
+        source_result,
+        min_chord_tone_ratio=float(min_chord_tone_ratio),
+        max_non_chord_run_length=int(max_non_chord_run_length),
+        max_interval=int(max_interval),
+        min_unique_pitch_count=int(min_unique_pitch_count),
+        min_note_count=int(min_note_count),
+        max_dead_air_ratio_exclusive=float(max_dead_air_ratio_exclusive),
+        max_simultaneous_notes=int(max_simultaneous_notes),
+    )
+    row["outside_soloing_gate"] = {
+        "qualified": not flags,
+        "flags": flags,
+    }
+    row["outside_soloing_score"] = outside_soloing_score(row, qualified=not flags)
+    return _json_safe(row)
+
+
+def select_variant(variants: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    rows = [dict(row) for row in variants]
+    if not rows:
+        raise StageBDurationCoverageOutsideSoloingRepairSweepError("no outside-soloing repair variants found")
+    rows.sort(
+        key=lambda row: (
+            not bool(_dict(row.get("outside_soloing_gate")).get("qualified", False)),
+            -float(row.get("outside_soloing_score", 0.0) or 0.0),
+            -float_value(_dict(row.get("metrics")).get("chord_tone_ratio"), 0.0),
+            int(_dict(row.get("pitch_role_metrics")).get("max_non_chord_tone_run", 99) or 99),
+            int(_dict(row.get("focused_solo_metrics")).get("focused_max_interval", 99) or 99),
+            str(row.get("repair_policy") or ""),
+        )
+    )
+    return rows[0]
+
+
+def validate_inputs(
+    *,
+    outside_soloing_decision: dict[str, Any],
+    dead_air_gain_repair: dict[str, Any],
+) -> None:
+    decision = _dict(outside_soloing_decision.get("decision"))
+    constraints = _dict(outside_soloing_decision.get("selection_constraints"))
+    decision_claim = _dict(outside_soloing_decision.get("claim_boundary"))
+    if str(decision.get("next_boundary") or "") != "outside_soloing_pitch_role_phrase_clarity_repair":
+        raise StageBDurationCoverageOutsideSoloingRepairSweepError("outside-soloing repair decision boundary required")
+    if not bool(decision.get("auto_progress_allowed", False)):
+        raise StageBDurationCoverageOutsideSoloingRepairSweepError("auto progress is not allowed")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBDurationCoverageOutsideSoloingRepairSweepError("critical user input is still required")
+    if not bool(constraints.get("keep_dead_air_gain_gate", False)):
+        raise StageBDurationCoverageOutsideSoloingRepairSweepError("dead-air gain gate preservation is required")
+    if not bool(constraints.get("keep_monophonic_gate", False)):
+        raise StageBDurationCoverageOutsideSoloingRepairSweepError("monophonic gate preservation is required")
+    if bool(decision_claim.get("broad_model_quality_claimed", True)):
+        raise StageBDurationCoverageOutsideSoloingRepairSweepError("broad model quality must not be claimed")
+
+    summary = _dict(dead_air_gain_repair.get("repair_summary"))
+    claim = _dict(dead_air_gain_repair.get("claim_boundary"))
+    if str(summary.get("boundary") or "") != "qualified_gate_repeatability_with_dead_air_gain":
+        raise StageBDurationCoverageOutsideSoloingRepairSweepError("dead-air gain repeatability boundary required")
+    if bool(claim.get("broad_model_quality_claimed", True)):
+        raise StageBDurationCoverageOutsideSoloingRepairSweepError("broad model quality must not be claimed")
+
+
+def build_outside_soloing_repair_sweep_report(
+    *,
+    outside_soloing_decision: dict[str, Any],
+    dead_air_gain_repair: dict[str, Any],
+    output_dir: Path,
+    generation_output_root: Path,
+    repair_policies: Sequence[str],
+    min_source_candidates: int,
+    min_repaired_source_candidates: int,
+    min_chord_tone_ratio: float,
+    max_non_chord_run_length: int,
+    max_interval: int,
+    min_unique_pitch_count: int,
+    min_note_count: int,
+    max_dead_air_ratio_exclusive: float,
+    max_simultaneous_notes: int,
+) -> dict[str, Any]:
+    validate_inputs(
+        outside_soloing_decision=outside_soloing_decision,
+        dead_air_gain_repair=dead_air_gain_repair,
+    )
+    unknown_policies = sorted(set(repair_policies) - set(DEFAULT_REPAIR_POLICIES))
+    if unknown_policies:
+        raise StageBDurationCoverageOutsideSoloingRepairSweepError(
+            f"unknown repair policies: {unknown_policies}"
+        )
+    source_results = [
+        dict(row)
+        for row in _list(dead_air_gain_repair.get("source_repeatability_results"))
+        if isinstance(row, dict)
+    ]
+    if len(source_results) < int(min_source_candidates):
+        raise StageBDurationCoverageOutsideSoloingRepairSweepError(
+            f"expected at least {int(min_source_candidates)} source candidates, got {len(source_results)}"
+        )
+
+    repaired_results: list[dict[str, Any]] = []
+    all_variants: list[dict[str, Any]] = []
+    for index, source_result in enumerate(source_results, start=1):
+        source_midi_path = Path(str(source_result.get("selected_midi_path") or ""))
+        if not source_midi_path.exists():
+            raise StageBDurationCoverageOutsideSoloingRepairSweepError(f"selected MIDI not found: {source_midi_path}")
+        source_run_id = str(source_result.get("source_run_id") or "")
+        source_report_path = generation_output_root / source_run_id / "report.json"
+        if not source_report_path.exists():
+            raise StageBDurationCoverageOutsideSoloingRepairSweepError(f"source report not found: {source_report_path}")
+        if not bool(source_result.get("dead_air_gain_repaired", False)):
+            raise StageBDurationCoverageOutsideSoloingRepairSweepError("source result must preserve dead-air gain")
+
+        source_report = read_json(source_report_path)
+        source_notes = load_source_notes(source_midi_path)
+        source_output_dir = output_dir / "source_sweeps" / f"{index:02d}_{source_result.get('sample_seed', 0)}"
+        variants = [
+            build_variant(
+                source_result=source_result,
+                source_notes=source_notes,
+                source_report=source_report,
+                output_dir=source_output_dir,
+                policy=policy,
+                max_interval=int(max_interval),
+                min_chord_tone_ratio=float(min_chord_tone_ratio),
+                max_non_chord_run_length=int(max_non_chord_run_length),
+                min_unique_pitch_count=int(min_unique_pitch_count),
+                min_note_count=int(min_note_count),
+                max_dead_air_ratio_exclusive=float(max_dead_air_ratio_exclusive),
+                max_simultaneous_notes=int(max_simultaneous_notes),
+            )
+            for policy in repair_policies
+        ]
+        for rank, row in enumerate(
+            sorted(
+                variants,
+                key=lambda item: (
+                    not bool(_dict(item.get("outside_soloing_gate")).get("qualified", False)),
+                    -float(item.get("outside_soloing_score", 0.0) or 0.0),
+                    str(item.get("repair_policy") or ""),
+                ),
+            ),
+            start=1,
+        ):
+            row["outside_soloing_rank"] = int(rank)
+        selected = select_variant(variants)
+        selected["outside_soloing_rank"] = min(
+            int(row.get("outside_soloing_rank", 0) or 0)
+            for row in variants
+            if str(row.get("candidate_id") or "") == str(selected.get("candidate_id") or "")
+        )
+        all_variants.extend(variants)
+        repaired_results.append(
+            {
+                "source_candidate_id": str(source_result.get("source_candidate_id") or ""),
+                "source_selected_candidate_id": str(source_result.get("selected_candidate_id") or ""),
+                "source_run_id": source_run_id,
+                "source_seed": int(source_result.get("source_seed", 0) or 0),
+                "sample_index": int(source_result.get("sample_index", 0) or 0),
+                "sample_seed": int(source_result.get("sample_seed", 0) or 0),
+                "source_selected_midi_path": str(source_midi_path),
+                "source_report_path": str(source_report_path),
+                "baseline_dead_air_ratio": float(source_result.get("baseline_dead_air_ratio", 1.0) or 1.0),
+                "source_selected_dead_air_ratio": float(source_result.get("selected_dead_air_ratio", 1.0) or 1.0),
+                "source_selected_max_interval": int(source_result.get("selected_max_interval", 0) or 0),
+                "variant_count": int(len(variants)),
+                "qualified_variant_count": sum(
+                    1 for row in variants if bool(_dict(row.get("outside_soloing_gate")).get("qualified", False))
+                ),
+                "selected_candidate": selected,
+                "variants": variants,
+            }
+        )
+
+    selected_rows = [result["selected_candidate"] for result in repaired_results]
+    repaired_source_count = sum(
+        1 for row in selected_rows if bool(_dict(row.get("outside_soloing_gate")).get("qualified", False))
+    )
+    dead_air_preserved_source_count = sum(
+        1
+        for result in repaired_results
+        if float_value(_dict(result["selected_candidate"].get("metrics")).get("dead_air_ratio"), 1.0)
+        <= float(result.get("source_selected_dead_air_ratio", 1.0) or 1.0) + 1e-9
+    )
+    total_variant_count = len(all_variants)
+    qualified_variant_count = sum(
+        1 for row in all_variants if bool(_dict(row.get("outside_soloing_gate")).get("qualified", False))
+    )
+    boundary = (
+        "outside_soloing_pitch_role_repair_candidates"
+        if repaired_source_count >= int(min_repaired_source_candidates)
+        else "outside_soloing_pitch_role_repair_not_recovered"
+    )
+
+    return _json_safe(
+        {
+            "schema_version": "stage_b_duration_coverage_fill_outside_soloing_repair_sweep_v1",
+            "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+            "output_dir": str(output_dir),
+            "previous_boundary": str(_dict(outside_soloing_decision.get("decision")).get("next_boundary") or ""),
+            "source_dead_air_boundary": str(_dict(dead_air_gain_repair.get("repair_summary")).get("boundary") or ""),
+            "repair_targets": list(outside_soloing_decision.get("repair_targets") or []),
+            "repair_policies": list(repair_policies),
+            "thresholds": {
+                "min_source_candidates": int(min_source_candidates),
+                "min_repaired_source_candidates": int(min_repaired_source_candidates),
+                "min_chord_tone_ratio": float(min_chord_tone_ratio),
+                "max_non_chord_run_length": int(max_non_chord_run_length),
+                "max_interval": int(max_interval),
+                "min_focused_unique_pitch_count": int(min_unique_pitch_count),
+                "min_focused_note_count": int(min_note_count),
+                "max_dead_air_ratio_exclusive": float(max_dead_air_ratio_exclusive),
+                "max_focused_simultaneous_notes": int(max_simultaneous_notes),
+            },
+            "source_repair_results": repaired_results,
+            "repair_summary": {
+                "boundary": boundary,
+                "source_candidate_count": int(len(repaired_results)),
+                "repaired_source_candidate_count": int(repaired_source_count),
+                "dead_air_preserved_source_candidate_count": int(dead_air_preserved_source_count),
+                "total_variant_count": int(total_variant_count),
+                "total_qualified_variant_count": int(qualified_variant_count),
+                "selected_repair_policies": sorted(
+                    {str(row.get("repair_policy") or "") for row in selected_rows}
+                ),
+                "selected_min_chord_tone_ratio": min(
+                    float_value(_dict(row.get("metrics")).get("chord_tone_ratio"), 0.0) for row in selected_rows
+                ),
+                "selected_max_non_chord_tone_run": max(
+                    int(_dict(row.get("pitch_role_metrics")).get("max_non_chord_tone_run", 0) or 0)
+                    for row in selected_rows
+                ),
+                "selected_max_interval": max(
+                    int(_dict(row.get("focused_solo_metrics")).get("focused_max_interval", 0) or 0)
+                    for row in selected_rows
+                ),
+                "broad_model_quality_claimed": False,
+            },
+            "claim_boundary": {
+                "boundary": boundary,
+                "midi_pitch_role_repair_candidate_claimed": repaired_source_count
+                >= int(min_repaired_source_candidates),
+                "dead_air_gain_preserved_claimed": dead_air_preserved_source_count
+                >= int(min_repaired_source_candidates),
+                "human_audio_preference_claimed": False,
+                "multi_reviewer_preference_claimed": False,
+                "broad_model_quality_claimed": False,
+                "brad_style_adaptation_claimed": False,
+                "production_ready_improviser_claimed": False,
+            },
+            "not_proven": [
+                "human_audio_preference",
+                "multi_reviewer_preference",
+                "broad_trained_model_quality",
+                "brad_style_adaptation",
+                "production_ready_improviser",
+            ],
+            "next_recommended_issue": (
+                "Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair "
+                "audio review package"
+            ),
+        }
+    )
+
+
+def validate_outside_soloing_repair_sweep(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    min_source_candidates: int,
+    min_repaired_source_candidates: int,
+    require_no_broad_quality_claim: bool,
+) -> dict[str, Any]:
+    summary = _dict(report.get("repair_summary"))
+    claim = _dict(report.get("claim_boundary"))
+    boundary = str(summary.get("boundary") or "")
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBDurationCoverageOutsideSoloingRepairSweepError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if int(summary.get("source_candidate_count", 0) or 0) < int(min_source_candidates):
+        raise StageBDurationCoverageOutsideSoloingRepairSweepError("not enough source candidates")
+    if int(summary.get("repaired_source_candidate_count", 0) or 0) < int(min_repaired_source_candidates):
+        raise StageBDurationCoverageOutsideSoloingRepairSweepError("not enough repaired source candidates")
+    if require_no_broad_quality_claim:
+        blocked = [
+            "human_audio_preference_claimed",
+            "multi_reviewer_preference_claimed",
+            "broad_model_quality_claimed",
+            "brad_style_adaptation_claimed",
+            "production_ready_improviser_claimed",
+        ]
+        claimed = [name for name in blocked if bool(claim.get(name, True))]
+        if claimed:
+            raise StageBDurationCoverageOutsideSoloingRepairSweepError(f"unexpected broad claim: {claimed}")
+    return {
+        "boundary": boundary,
+        "source_candidate_count": int(summary.get("source_candidate_count", 0) or 0),
+        "repaired_source_candidate_count": int(summary.get("repaired_source_candidate_count", 0) or 0),
+        "dead_air_preserved_source_candidate_count": int(
+            summary.get("dead_air_preserved_source_candidate_count", 0) or 0
+        ),
+        "total_variant_count": int(summary.get("total_variant_count", 0) or 0),
+        "total_qualified_variant_count": int(summary.get("total_qualified_variant_count", 0) or 0),
+        "selected_repair_policies": list(summary.get("selected_repair_policies") or []),
+        "selected_min_chord_tone_ratio": float(summary.get("selected_min_chord_tone_ratio", 0.0) or 0.0),
+        "selected_max_non_chord_tone_run": int(summary.get("selected_max_non_chord_tone_run", 0) or 0),
+        "selected_max_interval": int(summary.get("selected_max_interval", 0) or 0),
+        "broad_model_quality_claimed": bool(summary.get("broad_model_quality_claimed", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["repair_summary"]
+    lines = [
+        "# Stage B Duration Coverage Fill Outside-Soloing Repair Sweep",
+        "",
+        f"- previous boundary: `{report['previous_boundary']}`",
+        f"- source dead-air boundary: `{report['source_dead_air_boundary']}`",
+        f"- boundary: `{summary['boundary']}`",
+        f"- source candidates: `{summary['source_candidate_count']}`",
+        f"- repaired source candidates: `{summary['repaired_source_candidate_count']}`",
+        f"- dead-air preserved source candidates: `{summary['dead_air_preserved_source_candidate_count']}`",
+        f"- total variants: `{summary['total_variant_count']}`",
+        f"- qualified variants: `{summary['total_qualified_variant_count']}`",
+        f"- selected policies: `{summary['selected_repair_policies']}`",
+        f"- selected min chord-tone ratio: `{summary['selected_min_chord_tone_ratio']:.3f}`",
+        f"- selected max non-chord run: `{summary['selected_max_non_chord_tone_run']}`",
+        f"- selected max interval: `{summary['selected_max_interval']}`",
+        f"- broad model quality claimed: `{summary['broad_model_quality_claimed']}`",
+        "",
+        "| source | sample seed | selected | policy | qualified | chord-tone | non-chord run | "
+        "dead-air | unique | max interval | flags |",
+        "|---|---:|---|---|:---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for result in report["source_repair_results"]:
+        selected = result["selected_candidate"]
+        metrics = selected["metrics"]
+        focused = selected["focused_solo_metrics"]
+        pitch_role = selected["pitch_role_metrics"]
+        gate = selected["outside_soloing_gate"]
+        lines.append(
+            "| `{source}` | {sample_seed} | `{selected_id}` | `{policy}` | {qualified} | "
+            "{chord_tone:.3f} | {non_chord_run} | {dead_air:.4f} | {unique} | {interval} | `{flags}` |".format(
+                source=result["source_candidate_id"],
+                sample_seed=int(result["sample_seed"]),
+                selected_id=selected["candidate_id"],
+                policy=selected["repair_policy"],
+                qualified=bool(gate["qualified"]),
+                chord_tone=float_value(metrics.get("chord_tone_ratio"), 0.0),
+                non_chord_run=int(pitch_role["max_non_chord_tone_run"]),
+                dead_air=float_value(metrics.get("dead_air_ratio"), 1.0),
+                unique=int(focused["focused_unique_pitch_count"]),
+                interval=int(focused["focused_max_interval"]),
+                flags=list(gate["flags"]),
+            )
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build Stage B outside-soloing repair sweep")
+    parser.add_argument(
+        "--outside_soloing_decision",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_decision/"
+        "harness_stage_b_duration_coverage_fill_outside_soloing_repair_decision/"
+        "stage_b_duration_coverage_fill_outside_soloing_repair_decision.json",
+    )
+    parser.add_argument(
+        "--dead_air_gain_repair",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_dead_air_gain_repeatability_repair/"
+        "harness_stage_b_duration_coverage_fill_dead_air_gain_repeatability_repair/"
+        "stage_b_duration_coverage_fill_dead_air_gain_repeatability_repair.json",
+    )
+    parser.add_argument("--generation_output_root", type=str, default="outputs/stage_b_generation_probe")
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_sweep",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--repair_policy", action="append", type=str, default=None)
+    parser.add_argument("--min_source_candidates", type=int, default=2)
+    parser.add_argument("--min_repaired_source_candidates", type=int, default=2)
+    parser.add_argument("--min_chord_tone_ratio", type=float, default=0.72)
+    parser.add_argument("--max_non_chord_run_length", type=int, default=1)
+    parser.add_argument("--max_interval", type=int, default=7)
+    parser.add_argument("--min_unique_pitch_count", type=int, default=6)
+    parser.add_argument("--min_note_count", type=int, default=12)
+    parser.add_argument("--max_dead_air_ratio_exclusive", type=float, default=0.376)
+    parser.add_argument("--max_simultaneous_notes", type=int, default=1)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--require_no_broad_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_outside_soloing_repair_sweep_report(
+        outside_soloing_decision=read_json(Path(args.outside_soloing_decision)),
+        dead_air_gain_repair=read_json(Path(args.dead_air_gain_repair)),
+        output_dir=output_dir,
+        generation_output_root=Path(args.generation_output_root),
+        repair_policies=args.repair_policy or list(DEFAULT_REPAIR_POLICIES),
+        min_source_candidates=int(args.min_source_candidates),
+        min_repaired_source_candidates=int(args.min_repaired_source_candidates),
+        min_chord_tone_ratio=float(args.min_chord_tone_ratio),
+        max_non_chord_run_length=int(args.max_non_chord_run_length),
+        max_interval=int(args.max_interval),
+        min_unique_pitch_count=int(args.min_unique_pitch_count),
+        min_note_count=int(args.min_note_count),
+        max_dead_air_ratio_exclusive=float(args.max_dead_air_ratio_exclusive),
+        max_simultaneous_notes=int(args.max_simultaneous_notes),
+    )
+    summary = validate_outside_soloing_repair_sweep(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        min_source_candidates=int(args.min_source_candidates),
+        min_repaired_source_candidates=int(args.min_repaired_source_candidates),
+        require_no_broad_quality_claim=bool(args.require_no_broad_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "stage_b_duration_coverage_fill_outside_soloing_repair_sweep.json"
+    markdown_path = output_dir / "stage_b_duration_coverage_fill_outside_soloing_repair_sweep.md"
+    write_json(report_path, report)
+    write_json(output_dir / "stage_b_duration_coverage_fill_outside_soloing_repair_sweep_validation_summary.json", summary)
+    markdown_path.write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps({**summary, "report_path": str(report_path), "markdown_path": str(markdown_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_duration_coverage_fill_outside_soloing_repair_sweep.py
+++ b/tests/test_stage_b_duration_coverage_fill_outside_soloing_repair_sweep.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pretty_midi
+
+from scripts.summarize_stage_b_duration_coverage_fill_outside_soloing_repair_sweep import (
+    StageBDurationCoverageOutsideSoloingRepairSweepError,
+    build_outside_soloing_repair_sweep_report,
+    validate_outside_soloing_repair_sweep,
+)
+
+
+def outside_soloing_decision(*, boundary: str = "outside_soloing_pitch_role_phrase_clarity_repair") -> dict:
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_outside_soloing_repair_decision_v1",
+        "decision": {
+            "next_boundary": boundary,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+        },
+        "repair_targets": [
+            "reduce_outside_sounding_pitch_choices",
+            "increase_chord_tone_or_guide_tone_landing",
+            "limit_non_chord_tone_run_length",
+            "penalize_large_interval_after_fill",
+            "prefer_phrase_contour_resolution_over_density",
+        ],
+        "selection_constraints": {
+            "keep_dead_air_gain_gate": True,
+            "keep_monophonic_gate": True,
+            "require_audio_review_after_repair": True,
+            "do_not_claim_broad_model_quality": True,
+        },
+        "claim_boundary": {
+            "boundary": "outside_soloing_repair_decision",
+            "human_audio_keep_claimed": False,
+            "broad_model_quality_claimed": False,
+        },
+    }
+
+
+def write_source_report(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "request": {
+                    "bpm": 124,
+                    "chord_progression": ["Cm7", "Fm7", "Bb7", "Ebmaj7"],
+                    "bars": 2,
+                    "density": "medium",
+                    "energy": "mid",
+                    "temperature": 0.82,
+                    "top_k": 7,
+                    "top_p": None,
+                    "seed": 109,
+                }
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def write_outside_source_midi(path: Path, *, transpose: int = 0) -> None:
+    midi = pretty_midi.PrettyMIDI(initial_tempo=124)
+    piano = pretty_midi.Instrument(program=0, is_drum=False, name="outside_source")
+    starts = [index * 0.16 for index in range(14)]
+    pitches = [61, 75, 62, 76, 64, 78, 65, 79, 66, 80, 68, 82, 69, 83]
+    for start, pitch in zip(starts, pitches):
+        piano.notes.append(
+            pretty_midi.Note(
+                velocity=84,
+                pitch=int(pitch + transpose),
+                start=float(start),
+                end=float(start + 0.09),
+            )
+        )
+    midi.instruments.append(piano)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    midi.write(str(path))
+
+
+def dead_air_gain_repair(root: Path) -> dict:
+    generation_root = root / "outputs" / "stage_b_generation_probe"
+    write_source_report(generation_root / "run_a" / "report.json")
+    write_source_report(generation_root / "run_b" / "report.json")
+    midi_a = root / "selected" / "source_a.mid"
+    midi_b = root / "selected" / "source_b.mid"
+    write_outside_source_midi(midi_a, transpose=0)
+    write_outside_source_midi(midi_b, transpose=1)
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_dead_air_gain_repeatability_repair_v1",
+        "repair_summary": {
+            "boundary": "qualified_gate_repeatability_with_dead_air_gain",
+            "source_candidate_count": 2,
+            "dead_air_gain_source_candidate_count": 2,
+            "broad_model_quality_claimed": False,
+        },
+        "claim_boundary": {
+            "boundary": "qualified_gate_repeatability_with_dead_air_gain",
+            "broad_model_quality_claimed": False,
+        },
+        "source_repeatability_results": [
+            {
+                "source_candidate_id": "source_a",
+                "source_run_id": "run_a",
+                "source_seed": 109,
+                "sample_index": 1,
+                "sample_seed": 155,
+                "selected_candidate_id": "source_a_duration_fill",
+                "selected_midi_path": str(midi_a),
+                "baseline_dead_air_ratio": 0.375,
+                "selected_dead_air_ratio": 0.0,
+                "dead_air_gain_repaired": True,
+                "selected_max_interval": 14,
+            },
+            {
+                "source_candidate_id": "source_b",
+                "source_run_id": "run_b",
+                "source_seed": 109,
+                "sample_index": 2,
+                "sample_seed": 131,
+                "selected_candidate_id": "source_b_duration_fill",
+                "selected_midi_path": str(midi_b),
+                "baseline_dead_air_ratio": 0.375,
+                "selected_dead_air_ratio": 0.0,
+                "dead_air_gain_repaired": True,
+                "selected_max_interval": 14,
+            },
+        ],
+    }
+
+
+class StageBDurationCoverageFillOutsideSoloingRepairSweepTest(unittest.TestCase):
+    def test_builds_pitch_role_repair_candidates(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            report = build_outside_soloing_repair_sweep_report(
+                outside_soloing_decision=outside_soloing_decision(),
+                dead_air_gain_repair=dead_air_gain_repair(root),
+                output_dir=root / "outside_repair",
+                generation_output_root=root / "outputs" / "stage_b_generation_probe",
+                repair_policies=["chord_tone_snap", "guide_tone_landing", "contour_resolution"],
+                min_source_candidates=2,
+                min_repaired_source_candidates=2,
+                min_chord_tone_ratio=0.72,
+                max_non_chord_run_length=1,
+                max_interval=7,
+                min_unique_pitch_count=6,
+                min_note_count=12,
+                max_dead_air_ratio_exclusive=0.376,
+                max_simultaneous_notes=1,
+            )
+            summary = validate_outside_soloing_repair_sweep(
+                report,
+                expected_boundary="outside_soloing_pitch_role_repair_candidates",
+                min_source_candidates=2,
+                min_repaired_source_candidates=2,
+                require_no_broad_quality_claim=True,
+            )
+
+            self.assertEqual(summary["source_candidate_count"], 2)
+            self.assertEqual(summary["repaired_source_candidate_count"], 2)
+            self.assertEqual(summary["dead_air_preserved_source_candidate_count"], 2)
+            self.assertEqual(summary["total_variant_count"], 6)
+            self.assertFalse(summary["broad_model_quality_claimed"])
+            self.assertGreaterEqual(summary["selected_min_chord_tone_ratio"], 0.72)
+            self.assertLessEqual(summary["selected_max_non_chord_tone_run"], 1)
+            self.assertLessEqual(summary["selected_max_interval"], 7)
+            for result in report["source_repair_results"]:
+                selected = result["selected_candidate"]
+                self.assertTrue(selected["outside_soloing_gate"]["qualified"])
+                self.assertFalse(selected["outside_soloing_gate"]["flags"])
+
+    def test_rejects_unexpected_decision_boundary(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with self.assertRaises(StageBDurationCoverageOutsideSoloingRepairSweepError):
+                build_outside_soloing_repair_sweep_report(
+                    outside_soloing_decision=outside_soloing_decision(boundary="other_boundary"),
+                    dead_air_gain_repair=dead_air_gain_repair(root),
+                    output_dir=root / "outside_repair",
+                    generation_output_root=root / "outputs" / "stage_b_generation_probe",
+                    repair_policies=["chord_tone_snap"],
+                    min_source_candidates=2,
+                    min_repaired_source_candidates=2,
+                    min_chord_tone_ratio=0.72,
+                    max_non_chord_run_length=1,
+                    max_interval=7,
+                    min_unique_pitch_count=6,
+                    min_note_count=12,
+                    max_dead_air_ratio_exclusive=0.376,
+                    max_simultaneous_notes=1,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Pitch-role repair sweep for repeatability source candidates
- Dead-air gain and monophonic gate preservation check
- Issue #363 result and next audio review boundary documentation

## Context

- Issue #361 boundary: `outside_soloing_pitch_role_phrase_clarity_repair`
- Issue #353 boundary: `qualified_gate_repeatability_with_dead_air_gain`
- User listening review: repeatability WAV candidates rejected as difficult / outside-soloing-like
- Remaining proof boundary: objective MIDI repair candidate only

## Scope

- Added `chord_tone_snap`, `guide_tone_landing`, `contour_resolution` repair policy comparison
- Added chord-tone ratio, non-chord run, guide-tone landing, max interval gate summary
- Added harness mode and focused unit coverage
- Updated current status, core plan, and handoff notes

## Result

- boundary: `outside_soloing_pitch_role_repair_candidates`
- repaired source candidates: `2/2`
- qualified variants: `6/6`
- selected policy: `contour_resolution`
- selected min chord-tone ratio: `1.000`
- selected max non-chord run: `0`
- selected max interval: `7`
- broad model quality claimed: `false`

## Validation

```bash
.venv/bin/python -m unittest tests/test_stage_b_duration_coverage_fill_outside_soloing_repair_sweep.py
bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-sweep
bash scripts/agent_harness.sh quick
```

## Risk

- Musical preference not proven by objective metrics
- Repaired candidates require audio render and listening review

## Follow-up

- Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair audio review package

Closes #363
