### PR TITLE
Stage B outside-soloing repair audio review package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #363, Stage B duration coverage fill outside-soloing repair sweep.
+- Latest functional issue completed: Issue #365, Stage B duration coverage fill outside-soloing repair audio review package.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair audio review package.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair user listening review fill.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -810,6 +810,14 @@ bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-s
 ```
 
 This harness builds pitch-role repair candidates for repeatability sources while preserving dead-air gain and monophonic gates.
+
+For Stage B duration coverage fill outside-soloing repair audio review package changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-audio-review-package
+```
+
+This harness renders selected outside-soloing repair candidates to WAV files and validates technical audio metadata without claiming preference.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -126,6 +126,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - duration coverage fill repeatability user listening review fill 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_REPEATABILITY_USER_LISTENING_REVIEW_FILL_2026-05-29.md`
 - duration coverage fill outside-soloing repair decision 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_DECISION_2026-05-29.md`
 - duration coverage fill outside-soloing repair sweep 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_SWEEP_2026-05-29.md`
+- duration coverage fill outside-soloing repair audio review package 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_AUDIO_REVIEW_PACKAGE_2026-05-29.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -190,6 +191,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - duration coverage fill repeatability user listening review fill: overall decision `reject_all`, candidate decision `needs_followup`, timing/phrase/vocabulary `outside_or_unclear`, boundary `repeatability_audio_review_needs_followup`
 - duration coverage fill outside-soloing repair decision: next boundary `outside_soloing_pitch_role_phrase_clarity_repair`, repair targets `5`, critical user input `false`
 - duration coverage fill outside-soloing repair sweep: repaired source `2/2`, qualified variants `6/6`, selected chord-tone ratio `1.000`, max non-chord run `0`, boundary `outside_soloing_pitch_role_repair_candidates`
+- duration coverage fill outside-soloing repair audio review package: repaired candidate WAV `2`, sample rate `44100`, status `ready_for_user_listening_review`, quality/preference claim `false`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #363, Stage B duration coverage fill outside-soloing repair sweep
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair audio review package`
+- latest functional result: Issue #365, Stage B duration coverage fill outside-soloing repair audio review package
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair user listening review fill`
 
 현재 범위가 아닌 것:
 
@@ -65,6 +65,43 @@ Issue #220은 현재 작업이 core인지, MVP 완료로 볼 수 있는지를 �
 Docs:
 
 - `docs/STAGE_B_MODEL_CORE_MVP_COMPLETION_AUDIT_2026-05-28.md`
+
+## Current Duration Coverage Fill Outside-Soloing Repair Audio Review Package Result
+
+Issue #365는 outside-soloing repair 후보 `2`개를 WAV로 렌더하고 청취 리뷰 준비 상태를 검증한 작업이다.
+
+변경:
+
+- outside-soloing repair audio review package script 추가
+- Issue #363 selected repaired MIDI `2`개 WAV 렌더
+- WAV sample rate, duration, size, checksum 검증
+- audio quality / human preference claim guard 유지
+
+결과:
+
+- status: `ready_for_user_listening_review`
+- rendered audio file count: `2`
+- technical WAV validation: `true`
+- sample rate: `44100`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- broad model quality claimed: `false`
+
+rendered WAV:
+
+- sample seed `155`: `outputs/stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package/harness_stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package/audio/outside_repair_sample_seed_155_contour_resolution.wav`
+- sample seed `131`: `outputs/stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package/harness_stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package/audio/outside_repair_sample_seed_131_contour_resolution.wav`
+
+판단:
+
+- repaired 후보 `2`개는 청취 가능한 WAV artifact로 준비 완료
+- 이 결과는 기술적 렌더 검증이며 음악적 선호 proof가 아님
+- 다음 단계는 사용자 청취 리뷰 입력 기록
+- generated WAV files는 commit 대상에서 제외
+
+다음:
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair user listening review fill`
 
 ## Current Duration Coverage Fill Outside-Soloing Repair Sweep Result
 

--- a/docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_AUDIO_REVIEW_PACKAGE_2026-05-29.md
+++ b/docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_AUDIO_REVIEW_PACKAGE_2026-05-29.md
@@ -1,0 +1,65 @@
+# Stage B Duration Coverage Fill Outside-Soloing Repair Audio Review Package
+
+Issue #365는 outside-soloing repair 후보 `2`개를 WAV로 렌더하고 청취 리뷰 준비 상태를 검증한 작업이다.
+
+## Context
+
+- Issue #363 boundary: `outside_soloing_pitch_role_repair_candidates`
+- repaired source candidates: `2/2`
+- qualified variants: `6/6`
+- selected policy: `contour_resolution`
+- selected min chord-tone ratio: `1.000`
+- selected max non-chord run: `0`
+- 남은 검증: audio review / human preference
+
+## Change
+
+- outside-soloing repair audio review package script 추가
+- selected repaired MIDI `2`개 WAV 렌더
+- file count, sample rate, frame count, duration, size, checksum 검증
+- audio quality / human preference claim guard 유지
+- 전용 harness와 unit test 추가
+
+## Result
+
+| item | value |
+|---|---:|
+| status | `ready_for_user_listening_review` |
+| rendered audio file count | `2` |
+| technical WAV validation | `true` |
+| sample rate | `44100` |
+| audio rendered quality claimed | `false` |
+| human/audio preference claimed | `false` |
+| broad model quality claimed | `false` |
+
+## Rendered WAV
+
+| sample seed | duration | size | chord-tone ratio | non-chord run | wav |
+|---:|---:|---:|---:|---:|---|
+| `155` | `6.621s` | `1167916` | `1.000` | `0` | `outputs/stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package/harness_stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package/audio/outside_repair_sample_seed_155_contour_resolution.wav` |
+| `131` | `6.866s` | `1211180` | `1.000` | `0` | `outputs/stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package/harness_stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package/audio/outside_repair_sample_seed_131_contour_resolution.wav` |
+
+## Judgment
+
+- WAV `2`개 생성 및 technical validation 완료
+- 이 결과는 청취 가능한 artifact 준비이며 음악적 품질 proof가 아님
+- human/audio preference, multi-reviewer preference, broad trained-model quality는 미검증
+- generated WAV files는 commit 대상에서 제외
+
+## Validation
+
+```bash
+.venv/bin/python -m unittest tests/test_stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package.py
+bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-audio-review-package
+```
+
+## Output
+
+- script: `scripts/render_stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package.py`
+- test: `tests/test_stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package.py`
+- summary: `outputs/stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package/harness_stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package/stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package.json`
+- markdown: `outputs/stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package/harness_stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package/stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package.md`
+
+## Next
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair user listening review fill`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -142,6 +142,8 @@ Modes:
                 Decide next repair boundary after outside-soloing user review.
   stage-b-duration-coverage-outside-soloing-repair-sweep
                 Build pitch-role repair candidates for outside-soloing repeatability sources.
+  stage-b-duration-coverage-outside-soloing-repair-audio-review-package
+                Render outside-soloing repair candidates for user listening review.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -289,6 +291,7 @@ run_quick() {
     scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_keep_stability.py \
     scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_two_candidate_keep.py \
     scripts/summarize_stage_b_duration_coverage_fill_outside_soloing_repair_sweep.py \
+    scripts/render_stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package.py \
     scripts/build_stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison.py \
     scripts/audit_stage_b_margin_recovered_phrase_vocabulary_duplicate_source_divergence.py \
     scripts/repair_stage_b_margin_recovered_phrase_vocabulary_sample_seed_diversity.py \
@@ -2023,6 +2026,24 @@ run_stage_b_duration_coverage_outside_soloing_repair_sweep() {
     --require_no_broad_quality_claim
 }
 
+run_stage_b_duration_coverage_outside_soloing_repair_audio_review_package() {
+  local repair_sweep_run_id="${REPAIR_SWEEP_RUN_ID:-harness_stage_b_duration_coverage_fill_outside_soloing_repair_sweep}"
+  local run_id="${RUN_ID:-harness_stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package}"
+  local repair_sweep="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_sweep/${repair_sweep_run_id}/stage_b_duration_coverage_fill_outside_soloing_repair_sweep.json"
+  local soundfont="${SOUNDFONT_PATH:-$HOME/.local/share/soundfonts/generaluser-gs/v1.471.sf2}"
+  if [[ ! -f "$repair_sweep" ]]; then
+    print_header "Stage B duration/coverage fill outside-soloing repair sweep"
+    RUN_ID="$repair_sweep_run_id" run_stage_b_duration_coverage_outside_soloing_repair_sweep
+  fi
+  print_header "Stage B duration/coverage fill outside-soloing repair audio review package"
+  "$PYTHON_BIN" scripts/render_stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package.py \
+    --run_id "$run_id" \
+    --outside_soloing_repair_sweep "$repair_sweep" \
+    --soundfont "$soundfont" \
+    --expected_file_count 2 \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -3331,6 +3352,9 @@ case "$MODE" in
     ;;
   stage-b-duration-coverage-outside-soloing-repair-sweep)
     run_stage_b_duration_coverage_outside_soloing_repair_sweep
+    ;;
+  stage-b-duration-coverage-outside-soloing-repair-audio-review-package)
+    run_stage_b_duration_coverage_outside_soloing_repair_audio_review_package
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/render_stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package.py
+++ b/scripts/render_stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package.py
@@ -1,0 +1,351 @@
+"""Render outside-soloing repair candidates for audio review."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.render_stage_b_duration_coverage_fill_audio import (  # noqa: E402
+    build_audio_render_report,
+    validate_audio_render_report,
+)
+
+
+class StageBDurationCoverageOutsideSoloingRepairAudioReviewPackageError(ValueError):
+    pass
+
+
+CommandRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def review_items_from_repair_sweep(outside_soloing_repair_sweep: dict[str, Any]) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for result in _list(outside_soloing_repair_sweep.get("source_repair_results")):
+        if not isinstance(result, dict):
+            continue
+        selected = _dict(result.get("selected_candidate"))
+        midi_path = str(selected.get("midi_path") or "")
+        if not midi_path or not Path(midi_path).exists():
+            raise StageBDurationCoverageOutsideSoloingRepairAudioReviewPackageError(
+                f"selected repaired MIDI not found: {midi_path}"
+            )
+        gate = _dict(selected.get("outside_soloing_gate"))
+        if not bool(gate.get("qualified", False)):
+            raise StageBDurationCoverageOutsideSoloingRepairAudioReviewPackageError(
+                f"selected repaired candidate is not qualified: {selected.get('candidate_id')}"
+            )
+        sample_seed = int(result.get("sample_seed", 0) or 0)
+        role = f"outside_repair_sample_seed_{sample_seed}_{selected.get('repair_policy')}"
+        metrics = _dict(selected.get("metrics"))
+        focused = _dict(selected.get("focused_solo_metrics"))
+        pitch_role = _dict(selected.get("pitch_role_metrics"))
+        items.append(
+            {
+                "role": role,
+                "candidate_id": str(selected.get("candidate_id") or ""),
+                "source_candidate_id": str(result.get("source_candidate_id") or ""),
+                "sample_seed": sample_seed,
+                "repair_policy": str(selected.get("repair_policy") or ""),
+                "midi_file": {
+                    "path": midi_path,
+                    "required": True,
+                },
+                "metrics": {
+                    "source_selected_dead_air_ratio": float(
+                        result.get("source_selected_dead_air_ratio", 0.0) or 0.0
+                    ),
+                    "repaired_dead_air_ratio": float(metrics.get("dead_air_ratio", 0.0) or 0.0),
+                    "repaired_chord_tone_ratio": float(metrics.get("chord_tone_ratio", 0.0) or 0.0),
+                    "repaired_focused_note_count": int(focused.get("focused_note_count", 0) or 0),
+                    "repaired_focused_unique_pitch_count": int(
+                        focused.get("focused_unique_pitch_count", 0) or 0
+                    ),
+                    "repaired_max_interval": int(focused.get("focused_max_interval", 0) or 0),
+                    "repaired_max_non_chord_tone_run": int(
+                        pitch_role.get("max_non_chord_tone_run", 0) or 0
+                    ),
+                },
+            }
+        )
+    if len(items) != 2:
+        raise StageBDurationCoverageOutsideSoloingRepairAudioReviewPackageError(
+            f"expected 2 outside-soloing repair review items, got {len(items)}"
+        )
+    return items
+
+
+def build_local_audio_render_package(outside_soloing_repair_sweep: dict[str, Any]) -> dict[str, Any]:
+    summary = _dict(outside_soloing_repair_sweep.get("repair_summary"))
+    claim = _dict(outside_soloing_repair_sweep.get("claim_boundary"))
+    if str(summary.get("boundary") or "") != "outside_soloing_pitch_role_repair_candidates":
+        raise StageBDurationCoverageOutsideSoloingRepairAudioReviewPackageError(
+            "outside-soloing repair candidate boundary required"
+        )
+    if int(summary.get("repaired_source_candidate_count", 0) or 0) < 2:
+        raise StageBDurationCoverageOutsideSoloingRepairAudioReviewPackageError(
+            "two repaired source candidates required"
+        )
+    if bool(claim.get("broad_model_quality_claimed", True)):
+        raise StageBDurationCoverageOutsideSoloingRepairAudioReviewPackageError(
+            "broad model quality must not be claimed"
+        )
+    if bool(claim.get("human_audio_preference_claimed", True)):
+        raise StageBDurationCoverageOutsideSoloingRepairAudioReviewPackageError(
+            "human/audio preference must not be claimed before review"
+        )
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_outside_soloing_repair_audio_local_package_v1",
+        "candidate_id": "outside_soloing_repair_candidates",
+        "review_items": review_items_from_repair_sweep(outside_soloing_repair_sweep),
+    }
+
+
+def build_outside_soloing_repair_audio_review_package(
+    *,
+    outside_soloing_repair_sweep: dict[str, Any],
+    output_dir: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+    runner: CommandRunner | None = None,
+) -> dict[str, Any]:
+    local_package = build_local_audio_render_package(outside_soloing_repair_sweep)
+    render_kwargs: dict[str, Any] = {}
+    if runner is not None:
+        render_kwargs["runner"] = runner
+    render_report = build_audio_render_report(
+        local_package,
+        output_dir=output_dir,
+        renderer_path=renderer_path,
+        soundfont_path=soundfont_path,
+        sample_rate=int(sample_rate),
+        **render_kwargs,
+    )
+    render_summary = validate_audio_render_report(
+        render_report,
+        expected_file_count=2,
+        expected_sample_rate=int(sample_rate),
+        require_no_quality_claim=True,
+    )
+    rendered_by_role = {
+        str(item.get("role") or ""): item for item in _list(render_report.get("rendered_audio_files"))
+    }
+    review_items = []
+    for item in local_package["review_items"]:
+        rendered = _dict(rendered_by_role.get(item["role"]))
+        review_items.append(
+            {
+                "role": item["role"],
+                "candidate_id": item["candidate_id"],
+                "source_candidate_id": item["source_candidate_id"],
+                "sample_seed": item["sample_seed"],
+                "repair_policy": item["repair_policy"],
+                "midi_file": item["midi_file"],
+                "wav_file": _dict(rendered.get("wav_file")),
+                "metrics": item["metrics"],
+            }
+        )
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_schemas": {
+            "outside_soloing_repair_sweep": str(outside_soloing_repair_sweep.get("schema_version") or ""),
+            "render_report": str(render_report.get("schema_version") or ""),
+        },
+        "candidate_id": "outside_soloing_repair_candidates",
+        "review_items": review_items,
+        "audio_render_summary": render_summary,
+        "audio_review_boundary": {
+            "status": "ready_for_user_listening_review",
+            "render_attempted": True,
+            "rendered_audio_file_count": int(render_summary["rendered_audio_file_count"]),
+            "technical_wav_validation": True,
+            "audio_rendered_quality_claimed": False,
+            "human_audio_preference_claimed": False,
+            "broad_model_quality_claimed": False,
+        },
+        "not_proven": [
+            "audio_rendered_quality",
+            "human_audio_preference",
+            "multi_reviewer_preference",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "production_ready_improviser",
+        ],
+        "next_recommended_issue": (
+            "Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair "
+            "user listening review fill"
+        ),
+    }
+
+
+def validate_outside_soloing_repair_audio_review_package(
+    report: dict[str, Any],
+    *,
+    expected_file_count: int,
+    expected_sample_rate: int,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = _dict(report.get("audio_review_boundary"))
+    items = _list(report.get("review_items"))
+    if len(items) != int(expected_file_count):
+        raise StageBDurationCoverageOutsideSoloingRepairAudioReviewPackageError(
+            f"expected {int(expected_file_count)} review items"
+        )
+    for item in items:
+        wav_file = _dict(item.get("wav_file"))
+        if not bool(wav_file.get("exists", False)):
+            raise StageBDurationCoverageOutsideSoloingRepairAudioReviewPackageError(
+                f"missing wav for {item.get('role')}"
+            )
+        if int(wav_file.get("sample_rate", 0) or 0) != int(expected_sample_rate):
+            raise StageBDurationCoverageOutsideSoloingRepairAudioReviewPackageError(
+                f"unexpected sample rate for {item.get('role')}"
+            )
+    if require_no_quality_claim:
+        blocked = [
+            "audio_rendered_quality_claimed",
+            "human_audio_preference_claimed",
+            "broad_model_quality_claimed",
+        ]
+        claimed = [name for name in blocked if bool(boundary.get(name, True))]
+        if claimed:
+            raise StageBDurationCoverageOutsideSoloingRepairAudioReviewPackageError(
+                f"unexpected audio claim: {claimed}"
+            )
+    return {
+        "candidate_id": str(report.get("candidate_id") or ""),
+        "status": str(boundary.get("status") or ""),
+        "render_attempted": bool(boundary.get("render_attempted", False)),
+        "rendered_audio_file_count": int(boundary.get("rendered_audio_file_count", 0) or 0),
+        "technical_wav_validation": bool(boundary.get("technical_wav_validation", False)),
+        "audio_rendered_quality_claimed": bool(boundary.get("audio_rendered_quality_claimed", True)),
+        "human_audio_preference_claimed": bool(boundary.get("human_audio_preference_claimed", True)),
+        "wav_paths": [str(_dict(item.get("wav_file")).get("path") or "") for item in items],
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    boundary = report["audio_review_boundary"]
+    lines = [
+        "# Stage B Duration Coverage Fill Outside-Soloing Repair Audio Review Package",
+        "",
+        f"- candidate: `{report['candidate_id']}`",
+        f"- status: `{boundary['status']}`",
+        f"- rendered audio file count: `{boundary['rendered_audio_file_count']}`",
+        f"- technical WAV validation: `{boundary['technical_wav_validation']}`",
+        f"- audio rendered quality claimed: `{boundary['audio_rendered_quality_claimed']}`",
+        f"- human/audio preference claimed: `{boundary['human_audio_preference_claimed']}`",
+        "",
+        "| role | sample seed | policy | wav path | duration | sample rate | chord-tone | non-chord run |",
+        "|---|---:|---|---|---:|---:|---:|---:|",
+    ]
+    for item in report.get("review_items", []):
+        wav_file = item["wav_file"]
+        metrics = item["metrics"]
+        lines.append(
+            "| {role} | {sample_seed} | `{policy}` | `{wav}` | {duration:.3f} | {sample_rate} | "
+            "{chord_tone:.3f} | {non_chord_run} |".format(
+                role=item["role"],
+                sample_seed=int(item["sample_seed"]),
+                policy=item["repair_policy"],
+                wav=wav_file["path"],
+                duration=float(wav_file["duration_seconds"]),
+                sample_rate=int(wav_file["sample_rate"]),
+                chord_tone=float(metrics["repaired_chord_tone_ratio"]),
+                non_chord_run=int(metrics["repaired_max_non_chord_tone_run"]),
+            )
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Render outside-soloing repair candidates for audio review")
+    parser.add_argument(
+        "--outside_soloing_repair_sweep",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_sweep/"
+        "harness_stage_b_duration_coverage_fill_outside_soloing_repair_sweep/"
+        "stage_b_duration_coverage_fill_outside_soloing_repair_sweep.json",
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--renderer_path", type=str, default=shutil.which("fluidsynth") or "/opt/homebrew/bin/fluidsynth")
+    parser.add_argument(
+        "--soundfont",
+        type=str,
+        default=str(Path.home() / ".local/share/soundfonts/generaluser-gs/v1.471.sf2"),
+    )
+    parser.add_argument("--sample_rate", type=int, default=44100)
+    parser.add_argument("--expected_file_count", type=int, default=2)
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_outside_soloing_repair_audio_review_package(
+        outside_soloing_repair_sweep=read_json(Path(args.outside_soloing_repair_sweep)),
+        output_dir=output_dir,
+        renderer_path=str(args.renderer_path),
+        soundfont_path=str(args.soundfont),
+        sample_rate=int(args.sample_rate),
+    )
+    summary = validate_outside_soloing_repair_audio_review_package(
+        report,
+        expected_file_count=int(args.expected_file_count),
+        expected_sample_rate=int(args.sample_rate),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package.json"
+    markdown_path = output_dir / "stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package.md"
+    write_json(report_path, report)
+    write_json(
+        output_dir / "stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package_validation_summary.json",
+        summary,
+    )
+    markdown_path.write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps({**summary, "report_path": str(report_path), "markdown_path": str(markdown_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package.py
+++ b/tests/test_stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from scripts.render_stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package import (
+    StageBDurationCoverageOutsideSoloingRepairAudioReviewPackageError,
+    build_outside_soloing_repair_audio_review_package,
+    validate_outside_soloing_repair_audio_review_package,
+)
+from tests.test_stage_b_local_audio_render_attempt import fake_runner, write_midi
+
+
+def outside_soloing_repair_sweep(root: Path, *, broad_claim: bool = False) -> dict:
+    first = root / "outside_155.mid"
+    second = root / "outside_131.mid"
+    write_midi(first, 67)
+    write_midi(second, 71)
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_outside_soloing_repair_sweep_v1",
+        "repair_summary": {
+            "boundary": "outside_soloing_pitch_role_repair_candidates",
+            "source_candidate_count": 2,
+            "repaired_source_candidate_count": 2,
+            "dead_air_preserved_source_candidate_count": 2,
+            "total_variant_count": 6,
+            "total_qualified_variant_count": 6,
+            "broad_model_quality_claimed": False,
+        },
+        "claim_boundary": {
+            "boundary": "outside_soloing_pitch_role_repair_candidates",
+            "human_audio_preference_claimed": False,
+            "broad_model_quality_claimed": broad_claim,
+        },
+        "source_repair_results": [
+            {
+                "source_candidate_id": "source_155",
+                "sample_seed": 155,
+                "source_selected_dead_air_ratio": 0.3333333333333333,
+                "selected_candidate": {
+                    "candidate_id": "source_155_outside_repair",
+                    "repair_policy": "contour_resolution",
+                    "midi_path": str(first),
+                    "outside_soloing_gate": {"qualified": True, "flags": []},
+                    "metrics": {
+                        "dead_air_ratio": 0.3333333333333333,
+                        "chord_tone_ratio": 1.0,
+                    },
+                    "focused_solo_metrics": {
+                        "focused_note_count": 18,
+                        "focused_unique_pitch_count": 10,
+                        "focused_max_interval": 7,
+                    },
+                    "pitch_role_metrics": {
+                        "max_non_chord_tone_run": 0,
+                    },
+                },
+            },
+            {
+                "source_candidate_id": "source_131",
+                "sample_seed": 131,
+                "source_selected_dead_air_ratio": 0.35294117647058826,
+                "selected_candidate": {
+                    "candidate_id": "source_131_outside_repair",
+                    "repair_policy": "contour_resolution",
+                    "midi_path": str(second),
+                    "outside_soloing_gate": {"qualified": True, "flags": []},
+                    "metrics": {
+                        "dead_air_ratio": 0.35294117647058826,
+                        "chord_tone_ratio": 1.0,
+                    },
+                    "focused_solo_metrics": {
+                        "focused_note_count": 18,
+                        "focused_unique_pitch_count": 9,
+                        "focused_max_interval": 5,
+                    },
+                    "pitch_role_metrics": {
+                        "max_non_chord_tone_run": 0,
+                    },
+                },
+            },
+        ],
+    }
+
+
+class StageBDurationCoverageFillOutsideSoloingRepairAudioReviewPackageTest(unittest.TestCase):
+    def test_renders_repaired_candidates_without_quality_claim(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            soundfont = root / "piano.sf2"
+            renderer.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            report = build_outside_soloing_repair_audio_review_package(
+                outside_soloing_repair_sweep=outside_soloing_repair_sweep(root),
+                output_dir=root / "audio_review",
+                renderer_path=str(renderer),
+                soundfont_path=str(soundfont),
+                sample_rate=44100,
+                runner=fake_runner,
+            )
+            summary = validate_outside_soloing_repair_audio_review_package(
+                report,
+                expected_file_count=2,
+                expected_sample_rate=44100,
+                require_no_quality_claim=True,
+            )
+
+            self.assertEqual(summary["status"], "ready_for_user_listening_review")
+            self.assertEqual(summary["rendered_audio_file_count"], 2)
+            self.assertTrue(summary["technical_wav_validation"])
+            self.assertFalse(summary["audio_rendered_quality_claimed"])
+            self.assertFalse(summary["human_audio_preference_claimed"])
+            self.assertEqual(len(summary["wav_paths"]), 2)
+
+    def test_rejects_broad_quality_claim(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with self.assertRaises(StageBDurationCoverageOutsideSoloingRepairAudioReviewPackageError):
+                build_outside_soloing_repair_audio_review_package(
+                    outside_soloing_repair_sweep=outside_soloing_repair_sweep(root, broad_claim=True),
+                    output_dir=root / "audio_review",
+                    renderer_path=str(root / "fluidsynth"),
+                    soundfont_path=str(root / "piano.sf2"),
+                    sample_rate=44100,
+                    runner=fake_runner,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Render selected outside-soloing repair candidates to WAV
- Validate technical WAV metadata for user listening review
- Update current status and next review-fill boundary

## Context

- Issue #363 boundary: `outside_soloing_pitch_role_repair_candidates`
- Repaired source candidates: `2/2`
- Qualified variants: `6/6`
- Selected policy: `contour_resolution`
- Remaining proof boundary: audio review / human preference

## Scope

- Added repaired-candidate audio review package script
- Added file count, sample rate, duration, size, checksum validation
- Added harness mode and focused unit coverage
- Updated current status, core plan, and handoff notes

## Result

- status: `ready_for_user_listening_review`
- rendered audio file count: `2`
- sample rate: `44100`
- technical WAV validation: `true`
- audio rendered quality claimed: `false`
- human/audio preference claimed: `false`
- broad model quality claimed: `false`

## Validation

```bash
.venv/bin/python -m unittest tests/test_stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package.py
bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-audio-review-package
bash scripts/agent_harness.sh quick
```

## Risk

- WAV files are generated artifacts and not committed
- Musical preference remains unproven until user listening input

## Follow-up

- Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair user listening review fill

Closes #365
