### PR TITLE
Stage B outside-soloing repair listening review input guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #365, Stage B duration coverage fill outside-soloing repair audio review package.
+- Latest functional issue completed: Issue #367, Stage B duration coverage fill outside-soloing repair user listening review input guard.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair user listening review fill.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair objective evidence consolidation.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -818,6 +818,14 @@ bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-a
 ```
 
 This harness renders selected outside-soloing repair candidates to WAV files and validates technical audio metadata without claiming preference.
+
+For Stage B duration coverage fill outside-soloing repair user listening review changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-user-listening-review
+```
+
+This harness records missing listening review input as pending while allowing objective-only follow-up without claiming human preference.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -127,6 +127,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - duration coverage fill outside-soloing repair decision 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_DECISION_2026-05-29.md`
 - duration coverage fill outside-soloing repair sweep 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_SWEEP_2026-05-29.md`
 - duration coverage fill outside-soloing repair audio review package 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_AUDIO_REVIEW_PACKAGE_2026-05-29.md`
+- duration coverage fill outside-soloing repair user listening review guard 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_USER_LISTENING_REVIEW_GUARD_2026-05-29.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -192,6 +193,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - duration coverage fill outside-soloing repair decision: next boundary `outside_soloing_pitch_role_phrase_clarity_repair`, repair targets `5`, critical user input `false`
 - duration coverage fill outside-soloing repair sweep: repaired source `2/2`, qualified variants `6/6`, selected chord-tone ratio `1.000`, max non-chord run `0`, boundary `outside_soloing_pitch_role_repair_candidates`
 - duration coverage fill outside-soloing repair audio review package: repaired candidate WAV `2`, sample rate `44100`, status `ready_for_user_listening_review`, quality/preference claim `false`
+- duration coverage fill outside-soloing repair user listening review guard: review input `false`, preference claim `false`, objective auto progress `true`, boundary `outside_soloing_repair_audio_review_pending`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #365, Stage B duration coverage fill outside-soloing repair audio review package
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair user listening review fill`
+- latest functional result: Issue #367, Stage B duration coverage fill outside-soloing repair user listening review input guard
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair objective evidence consolidation`
 
 현재 범위가 아닌 것:
 
@@ -65,6 +65,39 @@ Issue #220은 현재 작업이 core인지, MVP 완료로 볼 수 있는지를 �
 Docs:
 
 - `docs/STAGE_B_MODEL_CORE_MVP_COMPLETION_AUDIT_2026-05-28.md`
+
+## Current Duration Coverage Fill Outside-Soloing Repair User Listening Review Guard Result
+
+Issue #367은 outside-soloing repair WAV 후보 `2`개에 대한 청취 입력 부재 상태를 preference claim 없이 기록한 작업이다.
+
+변경:
+
+- outside-soloing repair user listening review fill script 추가
+- review input absent 상태를 `pending_review_input`으로 기록
+- human/audio preference claim guard 유지
+- objective-only 후속 진행 가능 여부와 human preference claim 필요 조건 분리
+
+결과:
+
+- boundary: `outside_soloing_repair_audio_review_pending`
+- review input present: `false`
+- fill status: `pending_review_input`
+- user listening status: `pending_review_input`
+- overall decision: `pending`
+- human/audio preference claimed: `false`
+- objective auto progress allowed: `true`
+- critical user input required: `false`
+
+판단:
+
+- 청취 선호는 아직 미검증
+- 사용자 청취 입력 없이 human/audio preference claim 금지
+- objective-only evidence consolidation은 계속 진행 가능
+- broad trained-model quality, Brad style adaptation, production-ready improviser claim 금지
+
+다음:
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair objective evidence consolidation`
 
 ## Current Duration Coverage Fill Outside-Soloing Repair Audio Review Package Result
 

--- a/docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_USER_LISTENING_REVIEW_GUARD_2026-05-29.md
+++ b/docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_USER_LISTENING_REVIEW_GUARD_2026-05-29.md
@@ -1,0 +1,65 @@
+# Stage B Duration Coverage Fill Outside-Soloing Repair User Listening Review Guard
+
+Issue #367은 outside-soloing repair WAV 후보 `2`개에 대한 청취 입력 부재 상태를 preference claim 없이 기록한 작업이다.
+
+## Context
+
+- Issue #365 status: `ready_for_user_listening_review`
+- rendered WAV files: `2`
+- technical WAV validation: `true`
+- current missing input: user listening preference
+- required boundary: no human/audio preference claim without validated review input
+
+## Change
+
+- outside-soloing repair user listening review fill script 추가
+- review input absent 상태를 `pending_review_input`으로 기록
+- candidate별 WAV path와 objective metrics 유지
+- human/audio preference claim guard 유지
+- objective-only follow-up 가능 여부와 preference claim 조건 분리
+- 전용 harness와 unit test 추가
+
+## Result
+
+| item | value |
+|---|---:|
+| boundary | `outside_soloing_repair_audio_review_pending` |
+| review input present | `false` |
+| fill status | `pending_review_input` |
+| user listening status | `pending_review_input` |
+| overall decision | `pending` |
+| human/audio preference claimed | `false` |
+| objective auto progress allowed | `true` |
+| critical user input required | `false` |
+
+## Reviewed Audio Files
+
+| sample seed | role | wav |
+|---:|---|---|
+| `155` | `outside_repair_sample_seed_155_contour_resolution` | `outputs/stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package/harness_stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package/audio/outside_repair_sample_seed_155_contour_resolution.wav` |
+| `131` | `outside_repair_sample_seed_131_contour_resolution` | `outputs/stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package/harness_stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package/audio/outside_repair_sample_seed_131_contour_resolution.wav` |
+
+## Judgment
+
+- 청취 선호는 아직 미검증
+- human/audio preference, multi-reviewer preference claim 금지
+- objective-only evidence consolidation은 계속 진행 가능
+- broad trained-model quality, Brad style adaptation, production-ready improviser claim 금지
+
+## Validation
+
+```bash
+.venv/bin/python -m unittest tests/test_stage_b_duration_coverage_fill_outside_soloing_repair_user_listening_review.py
+bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-user-listening-review
+```
+
+## Output
+
+- script: `scripts/fill_stage_b_duration_coverage_outside_soloing_repair_user_listening_review.py`
+- test: `tests/test_stage_b_duration_coverage_fill_outside_soloing_repair_user_listening_review.py`
+- summary: `outputs/stage_b_duration_coverage_fill_outside_soloing_repair_user_listening_review_fill/harness_stage_b_duration_coverage_fill_outside_soloing_repair_user_listening_review_fill/stage_b_duration_coverage_fill_outside_soloing_repair_user_listening_review_fill.json`
+- markdown: `outputs/stage_b_duration_coverage_fill_outside_soloing_repair_user_listening_review_fill/harness_stage_b_duration_coverage_fill_outside_soloing_repair_user_listening_review_fill/stage_b_duration_coverage_fill_outside_soloing_repair_user_listening_review_fill.md`
+
+## Next
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair objective evidence consolidation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -144,6 +144,8 @@ Modes:
                 Build pitch-role repair candidates for outside-soloing repeatability sources.
   stage-b-duration-coverage-outside-soloing-repair-audio-review-package
                 Render outside-soloing repair candidates for user listening review.
+  stage-b-duration-coverage-outside-soloing-repair-user-listening-review
+                Guard outside-soloing repair listening review when user input is absent.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -292,6 +294,7 @@ run_quick() {
     scripts/summarize_stage_b_margin_recovered_phrase_vocabulary_two_candidate_keep.py \
     scripts/summarize_stage_b_duration_coverage_fill_outside_soloing_repair_sweep.py \
     scripts/render_stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package.py \
+    scripts/fill_stage_b_duration_coverage_outside_soloing_repair_user_listening_review.py \
     scripts/build_stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison.py \
     scripts/audit_stage_b_margin_recovered_phrase_vocabulary_duplicate_source_divergence.py \
     scripts/repair_stage_b_margin_recovered_phrase_vocabulary_sample_seed_diversity.py \
@@ -2044,6 +2047,24 @@ run_stage_b_duration_coverage_outside_soloing_repair_audio_review_package() {
     --require_no_quality_claim
 }
 
+run_stage_b_duration_coverage_outside_soloing_repair_user_listening_review() {
+  local audio_review_run_id="${AUDIO_REVIEW_RUN_ID:-harness_stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package}"
+  local run_id="${RUN_ID:-harness_stage_b_duration_coverage_fill_outside_soloing_repair_user_listening_review_fill}"
+  local audio_review_package="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package/${audio_review_run_id}/stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package.json"
+  if [[ ! -f "$audio_review_package" ]]; then
+    print_header "Stage B duration/coverage fill outside-soloing repair audio review package"
+    RUN_ID="$audio_review_run_id" run_stage_b_duration_coverage_outside_soloing_repair_audio_review_package
+  fi
+  print_header "Stage B duration/coverage fill outside-soloing repair user listening review"
+  "$PYTHON_BIN" scripts/fill_stage_b_duration_coverage_outside_soloing_repair_user_listening_review.py \
+    --run_id "$run_id" \
+    --audio_review_package "$audio_review_package" \
+    --expected_boundary outside_soloing_repair_audio_review_pending \
+    --require_pending_without_input \
+    --require_no_preference_without_input \
+    --require_objective_auto_progress_allowed
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -3355,6 +3376,9 @@ case "$MODE" in
     ;;
   stage-b-duration-coverage-outside-soloing-repair-audio-review-package)
     run_stage_b_duration_coverage_outside_soloing_repair_audio_review_package
+    ;;
+  stage-b-duration-coverage-outside-soloing-repair-user-listening-review)
+    run_stage_b_duration_coverage_outside_soloing_repair_user_listening_review
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/fill_stage_b_duration_coverage_outside_soloing_repair_user_listening_review.py
+++ b/scripts/fill_stage_b_duration_coverage_outside_soloing_repair_user_listening_review.py
@@ -1,0 +1,383 @@
+"""Fill or guard outside-soloing repair user listening review state."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class StageBDurationCoverageOutsideSoloingRepairUserListeningReviewError(ValueError):
+    pass
+
+
+OVERALL_DECISIONS = {
+    "keep_both",
+    "prefer_sample_seed_155",
+    "prefer_sample_seed_131",
+    "reject_all",
+    "unclear",
+}
+ATTRIBUTE_VALUES = {
+    "improved",
+    "acceptable",
+    "outside_or_unclear",
+    "needs_followup",
+    "unclear",
+}
+CANDIDATE_DECISIONS = {"keep", "needs_followup", "reject", "unclear"}
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def review_items(audio_review_package: dict[str, Any]) -> list[dict[str, Any]]:
+    boundary = _dict(audio_review_package.get("audio_review_boundary"))
+    if str(boundary.get("status") or "") != "ready_for_user_listening_review":
+        raise StageBDurationCoverageOutsideSoloingRepairUserListeningReviewError(
+            "audio review package must be ready for user listening review"
+        )
+    if bool(boundary.get("audio_rendered_quality_claimed", True)):
+        raise StageBDurationCoverageOutsideSoloingRepairUserListeningReviewError(
+            "audio rendered quality must not be claimed before review"
+        )
+    if bool(boundary.get("human_audio_preference_claimed", True)):
+        raise StageBDurationCoverageOutsideSoloingRepairUserListeningReviewError(
+            "human/audio preference must not be claimed before review"
+        )
+    items = [dict(item) for item in _list(audio_review_package.get("review_items")) if isinstance(item, dict)]
+    if len(items) != 2:
+        raise StageBDurationCoverageOutsideSoloingRepairUserListeningReviewError(
+            f"expected 2 review items, got {len(items)}"
+        )
+    for item in items:
+        wav_file = _dict(item.get("wav_file"))
+        if not bool(wav_file.get("exists", False)):
+            raise StageBDurationCoverageOutsideSoloingRepairUserListeningReviewError(
+                f"missing wav for {item.get('role')}"
+            )
+    return items
+
+
+def pending_candidate_reviews(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "role": str(item.get("role") or ""),
+            "candidate_id": str(item.get("candidate_id") or ""),
+            "sample_seed": int(item.get("sample_seed", 0) or 0),
+            "decision": "pending",
+            "notes": "",
+        }
+        for item in items
+    ]
+
+
+def validate_review_input(review_input: dict[str, Any], *, expected_candidate_id: str, items: list[dict[str, Any]]) -> dict[str, Any]:
+    candidate_id = str(review_input.get("candidate_id") or "")
+    if candidate_id != expected_candidate_id:
+        raise StageBDurationCoverageOutsideSoloingRepairUserListeningReviewError(
+            f"expected review candidate {expected_candidate_id}, got {candidate_id}"
+        )
+    reviewer = str(review_input.get("reviewer") or "").strip()
+    if not reviewer:
+        raise StageBDurationCoverageOutsideSoloingRepairUserListeningReviewError("reviewer is required")
+    if not bool(review_input.get("audio_render_used", False)):
+        raise StageBDurationCoverageOutsideSoloingRepairUserListeningReviewError("audio_render_used must be true")
+    overall_decision = str(review_input.get("overall_decision") or "")
+    if overall_decision not in OVERALL_DECISIONS:
+        raise StageBDurationCoverageOutsideSoloingRepairUserListeningReviewError(
+            f"invalid overall decision: {overall_decision}"
+        )
+    timing = str(review_input.get("timing") or "")
+    phrase = str(review_input.get("phrase") or "")
+    vocabulary = str(review_input.get("vocabulary") or "")
+    for field, value in (("timing", timing), ("phrase", phrase), ("vocabulary", vocabulary)):
+        if value not in ATTRIBUTE_VALUES:
+            raise StageBDurationCoverageOutsideSoloingRepairUserListeningReviewError(
+                f"invalid {field}: {value}"
+            )
+    candidate_reviews = _list(review_input.get("candidate_reviews"))
+    expected_roles = {str(item.get("role") or "") for item in items}
+    if len(candidate_reviews) != len(items):
+        raise StageBDurationCoverageOutsideSoloingRepairUserListeningReviewError("candidate review count mismatch")
+    compact_reviews: list[dict[str, Any]] = []
+    for review in candidate_reviews:
+        if not isinstance(review, dict):
+            raise StageBDurationCoverageOutsideSoloingRepairUserListeningReviewError("candidate review must be an object")
+        role = str(review.get("role") or "")
+        decision = str(review.get("decision") or "")
+        if role not in expected_roles:
+            raise StageBDurationCoverageOutsideSoloingRepairUserListeningReviewError(f"unexpected review role: {role}")
+        if decision not in CANDIDATE_DECISIONS:
+            raise StageBDurationCoverageOutsideSoloingRepairUserListeningReviewError(
+                f"invalid candidate decision: {decision}"
+            )
+        compact_reviews.append(
+            {
+                "role": role,
+                "decision": decision,
+                "notes": str(review.get("notes") or ""),
+            }
+        )
+    return {
+        "status": "reviewed",
+        "reviewer": reviewer,
+        "audio_render_used": True,
+        "overall_decision": overall_decision,
+        "timing": timing,
+        "phrase": phrase,
+        "vocabulary": vocabulary,
+        "assessment": str(review_input.get("assessment") or ""),
+        "candidate_reviews": compact_reviews,
+    }
+
+
+def pending_review(items: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "status": "pending_review_input",
+        "reviewer": "",
+        "audio_render_used": False,
+        "overall_decision": "pending",
+        "timing": "pending",
+        "phrase": "pending",
+        "vocabulary": "pending",
+        "assessment": "",
+        "candidate_reviews": pending_candidate_reviews(items),
+    }
+
+
+def build_user_listening_review_fill(
+    audio_review_package: dict[str, Any],
+    review_input: dict[str, Any] | None,
+    *,
+    output_dir: Path,
+) -> dict[str, Any]:
+    items = review_items(audio_review_package)
+    candidate_id = str(audio_review_package.get("candidate_id") or "")
+    if candidate_id != "outside_soloing_repair_candidates":
+        raise StageBDurationCoverageOutsideSoloingRepairUserListeningReviewError(
+            f"unexpected candidate id: {candidate_id}"
+        )
+    if review_input is None:
+        fill_status = "pending_review_input"
+        review = pending_review(items)
+        preference_claimed = False
+    else:
+        fill_status = "review_input_applied"
+        review = validate_review_input(review_input, expected_candidate_id=candidate_id, items=items)
+        preference_claimed = True
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_outside_soloing_repair_user_listening_review_fill_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_audio_review_package_schema": str(audio_review_package.get("schema_version") or ""),
+        "candidate_id": candidate_id,
+        "review_input_present": review_input is not None,
+        "fill_status": fill_status,
+        "reviewed_audio_files": [
+            {
+                "role": str(item.get("role") or ""),
+                "candidate_id": str(item.get("candidate_id") or ""),
+                "sample_seed": int(item.get("sample_seed", 0) or 0),
+                "wav_path": str(_dict(item.get("wav_file")).get("path") or ""),
+                "metrics": _dict(item.get("metrics")),
+            }
+            for item in items
+        ],
+        "user_listening_review": review,
+        "decision": {
+            "objective_auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "human_preference_input_required_for_preference_claim": review_input is None,
+            "next_boundary": (
+                "outside_soloing_repair_audio_review_pending"
+                if review_input is None
+                else "outside_soloing_repair_audio_review_applied"
+            ),
+        },
+        "claim_boundary": {
+            "boundary": (
+                "outside_soloing_repair_audio_review_pending"
+                if review_input is None
+                else "outside_soloing_repair_audio_review_applied"
+            ),
+            "human_audio_preference_claimed": preference_claimed,
+            "pending_without_review_input": review_input is None,
+            "objective_only_followup_allowed": True,
+            "broad_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_improviser_claimed": False,
+        },
+        "not_proven": []
+        if review_input is not None
+        else [
+            "human_audio_preference",
+            "multi_reviewer_preference",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "production_ready_improviser",
+        ],
+        "next_recommended_issue": (
+            "Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair "
+            "objective evidence consolidation"
+            if review_input is None
+            else "Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair "
+            "listening review consolidation"
+        ),
+    }
+
+
+def validate_user_listening_review_fill(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    require_pending_without_input: bool,
+    require_no_preference_without_input: bool,
+    require_objective_auto_progress_allowed: bool,
+) -> dict[str, Any]:
+    claim = _dict(report.get("claim_boundary"))
+    decision = _dict(report.get("decision"))
+    review = _dict(report.get("user_listening_review"))
+    boundary = str(claim.get("boundary") or "")
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBDurationCoverageOutsideSoloingRepairUserListeningReviewError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if require_objective_auto_progress_allowed and not bool(decision.get("objective_auto_progress_allowed", False)):
+        raise StageBDurationCoverageOutsideSoloingRepairUserListeningReviewError(
+            "objective auto progress must be allowed"
+        )
+    review_input_present = bool(report.get("review_input_present", False))
+    if require_pending_without_input and not review_input_present:
+        if str(report.get("fill_status") or "") != "pending_review_input":
+            raise StageBDurationCoverageOutsideSoloingRepairUserListeningReviewError("expected pending fill status")
+        if str(review.get("status") or "") != "pending_review_input":
+            raise StageBDurationCoverageOutsideSoloingRepairUserListeningReviewError("expected pending review status")
+    if require_no_preference_without_input and not review_input_present:
+        if bool(claim.get("human_audio_preference_claimed", True)):
+            raise StageBDurationCoverageOutsideSoloingRepairUserListeningReviewError(
+                "preference must not be claimed without input"
+            )
+    return {
+        "candidate_id": str(report.get("candidate_id") or ""),
+        "boundary": boundary,
+        "review_input_present": review_input_present,
+        "fill_status": str(report.get("fill_status") or ""),
+        "user_listening_status": str(review.get("status") or ""),
+        "overall_decision": str(review.get("overall_decision") or ""),
+        "human_audio_preference_claimed": bool(claim.get("human_audio_preference_claimed", True)),
+        "objective_auto_progress_allowed": bool(decision.get("objective_auto_progress_allowed", False)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    review = report["user_listening_review"]
+    claim = report["claim_boundary"]
+    decision = report["decision"]
+    lines = [
+        "# Stage B Duration Coverage Fill Outside-Soloing Repair User Listening Review Fill",
+        "",
+        f"- candidate: `{report['candidate_id']}`",
+        f"- review input present: `{report['review_input_present']}`",
+        f"- fill status: `{report['fill_status']}`",
+        f"- boundary: `{claim['boundary']}`",
+        f"- user listening status: `{review['status']}`",
+        f"- overall decision: `{review['overall_decision']}`",
+        f"- human/audio preference claimed: `{claim['human_audio_preference_claimed']}`",
+        f"- objective auto progress allowed: `{decision['objective_auto_progress_allowed']}`",
+        f"- critical user input required: `{decision['critical_user_input_required']}`",
+        "",
+        "Human/audio preference is not claimed unless validated listening input is provided.",
+        "",
+        "## Reviewed Audio Files",
+        "",
+        "| role | sample seed | wav path |",
+        "|---|---:|---|",
+    ]
+    for item in report.get("reviewed_audio_files", []):
+        lines.append(
+            "| {role} | {sample_seed} | `{wav}` |".format(
+                role=item["role"],
+                sample_seed=int(item["sample_seed"]),
+                wav=item["wav_path"],
+            )
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Fill or guard outside-soloing repair user listening review")
+    parser.add_argument(
+        "--audio_review_package",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package/"
+        "harness_stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package/"
+        "stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package.json",
+    )
+    parser.add_argument("--review_input", type=str, default="")
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_user_listening_review_fill",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--require_pending_without_input", action="store_true")
+    parser.add_argument("--require_no_preference_without_input", action="store_true")
+    parser.add_argument("--require_objective_auto_progress_allowed", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    review_input = read_json(Path(args.review_input)) if args.review_input else None
+    report = build_user_listening_review_fill(
+        read_json(Path(args.audio_review_package)),
+        review_input,
+        output_dir=output_dir,
+    )
+    summary = validate_user_listening_review_fill(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        require_pending_without_input=bool(args.require_pending_without_input),
+        require_no_preference_without_input=bool(args.require_no_preference_without_input),
+        require_objective_auto_progress_allowed=bool(args.require_objective_auto_progress_allowed),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "stage_b_duration_coverage_fill_outside_soloing_repair_user_listening_review_fill.json"
+    markdown_path = output_dir / "stage_b_duration_coverage_fill_outside_soloing_repair_user_listening_review_fill.md"
+    write_json(report_path, report)
+    write_json(
+        output_dir / "stage_b_duration_coverage_fill_outside_soloing_repair_user_listening_review_fill_validation_summary.json",
+        summary,
+    )
+    markdown_path.write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps({**summary, "report_path": str(report_path), "markdown_path": str(markdown_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_duration_coverage_fill_outside_soloing_repair_user_listening_review.py
+++ b/tests/test_stage_b_duration_coverage_fill_outside_soloing_repair_user_listening_review.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.fill_stage_b_duration_coverage_outside_soloing_repair_user_listening_review import (
+    StageBDurationCoverageOutsideSoloingRepairUserListeningReviewError,
+    build_user_listening_review_fill,
+    validate_user_listening_review_fill,
+)
+
+
+def audio_review_package(*, preference_claim: bool = False) -> dict:
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package_v1",
+        "candidate_id": "outside_soloing_repair_candidates",
+        "audio_review_boundary": {
+            "status": "ready_for_user_listening_review",
+            "render_attempted": True,
+            "rendered_audio_file_count": 2,
+            "technical_wav_validation": True,
+            "audio_rendered_quality_claimed": False,
+            "human_audio_preference_claimed": preference_claim,
+            "broad_model_quality_claimed": False,
+        },
+        "review_items": [
+            {
+                "role": "outside_repair_sample_seed_155_contour_resolution",
+                "candidate_id": "outside_155",
+                "sample_seed": 155,
+                "wav_file": {"path": "outputs/audio_155.wav", "exists": True},
+                "metrics": {
+                    "repaired_chord_tone_ratio": 1.0,
+                    "repaired_max_non_chord_tone_run": 0,
+                },
+            },
+            {
+                "role": "outside_repair_sample_seed_131_contour_resolution",
+                "candidate_id": "outside_131",
+                "sample_seed": 131,
+                "wav_file": {"path": "outputs/audio_131.wav", "exists": True},
+                "metrics": {
+                    "repaired_chord_tone_ratio": 1.0,
+                    "repaired_max_non_chord_tone_run": 0,
+                },
+            },
+        ],
+    }
+
+
+class StageBDurationCoverageFillOutsideSoloingRepairUserListeningReviewTest(unittest.TestCase):
+    def test_keeps_pending_without_review_input_and_allows_objective_followup(self) -> None:
+        report = build_user_listening_review_fill(
+            audio_review_package(),
+            None,
+            output_dir=Path("outputs/review_fill"),
+        )
+        summary = validate_user_listening_review_fill(
+            report,
+            expected_boundary="outside_soloing_repair_audio_review_pending",
+            require_pending_without_input=True,
+            require_no_preference_without_input=True,
+            require_objective_auto_progress_allowed=True,
+        )
+
+        self.assertFalse(summary["review_input_present"])
+        self.assertEqual(summary["fill_status"], "pending_review_input")
+        self.assertEqual(summary["user_listening_status"], "pending_review_input")
+        self.assertEqual(summary["overall_decision"], "pending")
+        self.assertFalse(summary["human_audio_preference_claimed"])
+        self.assertTrue(summary["objective_auto_progress_allowed"])
+        self.assertFalse(summary["critical_user_input_required"])
+        self.assertIn("human_audio_preference", report["not_proven"])
+
+    def test_accepts_valid_review_input(self) -> None:
+        report = build_user_listening_review_fill(
+            audio_review_package(),
+            {
+                "candidate_id": "outside_soloing_repair_candidates",
+                "reviewer": "user",
+                "audio_render_used": True,
+                "overall_decision": "keep_both",
+                "timing": "improved",
+                "phrase": "acceptable",
+                "vocabulary": "improved",
+                "assessment": "both repaired candidates are easier to follow",
+                "candidate_reviews": [
+                    {
+                        "role": "outside_repair_sample_seed_155_contour_resolution",
+                        "decision": "keep",
+                    },
+                    {
+                        "role": "outside_repair_sample_seed_131_contour_resolution",
+                        "decision": "keep",
+                    },
+                ],
+            },
+            output_dir=Path("outputs/review_fill"),
+        )
+        summary = validate_user_listening_review_fill(
+            report,
+            expected_boundary="outside_soloing_repair_audio_review_applied",
+            require_pending_without_input=True,
+            require_no_preference_without_input=True,
+            require_objective_auto_progress_allowed=True,
+        )
+
+        self.assertTrue(summary["review_input_present"])
+        self.assertEqual(summary["fill_status"], "review_input_applied")
+        self.assertEqual(summary["user_listening_status"], "reviewed")
+        self.assertEqual(summary["overall_decision"], "keep_both")
+        self.assertTrue(summary["human_audio_preference_claimed"])
+
+    def test_rejects_existing_preference_claim(self) -> None:
+        with self.assertRaises(StageBDurationCoverageOutsideSoloingRepairUserListeningReviewError):
+            build_user_listening_review_fill(
+                audio_review_package(preference_claim=True),
+                None,
+                output_dir=Path("outputs/review_fill"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Record missing listening review input as pending
- Keep human/audio preference claims false without validated review input
- Allow objective-only follow-up path for repaired candidates

## Context

- Issue #365 status: `ready_for_user_listening_review`
- Rendered WAV files: `2`
- Technical WAV validation: `true`
- Current missing input: user listening preference

## Scope

- Added user listening review fill guard script
- Added pending review state and objective auto-progress decision fields
- Added harness mode and focused unit coverage
- Updated current status, core plan, and handoff notes

## Result

- boundary: `outside_soloing_repair_audio_review_pending`
- review input present: `false`
- fill status: `pending_review_input`
- overall decision: `pending`
- human/audio preference claimed: `false`
- objective auto progress allowed: `true`
- critical user input required: `false`

## Validation

```bash
.venv/bin/python -m unittest tests/test_stage_b_duration_coverage_fill_outside_soloing_repair_user_listening_review.py
bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-user-listening-review
bash scripts/agent_harness.sh quick
```

## Risk

- Human preference remains unproven until listening input exists
- Follow-up must stay objective-only unless review input is provided

## Follow-up

- Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair objective evidence consolidation

Closes #367
