### PR TITLE
Stage B outside-soloing repair next decision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #369, Stage B duration coverage fill outside-soloing repair objective evidence consolidation.
+- Latest functional issue completed: Issue #371, Stage B duration coverage fill outside-soloing repair next decision.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair next decision.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair broader repeatability sweep.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -834,6 +834,14 @@ bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-o
 ```
 
 This harness consolidates repaired candidate objective evidence while keeping human/audio preference claims false.
+
+For Stage B duration coverage fill outside-soloing repair next decision changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-next-decision
+```
+
+This harness converts objective evidence support into the next repeatability sweep boundary.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -129,6 +129,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - duration coverage fill outside-soloing repair audio review package 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_AUDIO_REVIEW_PACKAGE_2026-05-29.md`
 - duration coverage fill outside-soloing repair user listening review guard 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_USER_LISTENING_REVIEW_GUARD_2026-05-29.md`
 - duration coverage fill outside-soloing repair objective evidence consolidation 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_OBJECTIVE_EVIDENCE_CONSOLIDATION_2026-05-29.md`
+- duration coverage fill outside-soloing repair next decision 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_NEXT_DECISION_2026-05-29.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -196,6 +197,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - duration coverage fill outside-soloing repair audio review package: repaired candidate WAV `2`, sample rate `44100`, status `ready_for_user_listening_review`, quality/preference claim `false`
 - duration coverage fill outside-soloing repair user listening review guard: review input `false`, preference claim `false`, objective auto progress `true`, boundary `outside_soloing_repair_audio_review_pending`
 - duration coverage fill outside-soloing repair objective evidence consolidation: objective support source `2/2`, chord-tone pass `2/2`, non-chord run pass `2/2`, interval pass `2/2`, preference claim `false`
+- duration coverage fill outside-soloing repair next decision: next boundary `outside_soloing_repair_broader_repeatability_sweep`, auto progress `true`, critical user input `false`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #369, Stage B duration coverage fill outside-soloing repair objective evidence consolidation
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair next decision`
+- latest functional result: Issue #371, Stage B duration coverage fill outside-soloing repair next decision
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair broader repeatability sweep`
 
 현재 범위가 아닌 것:
 
@@ -65,6 +65,46 @@ Issue #220은 현재 작업이 core인지, MVP 완료로 볼 수 있는지를 �
 Docs:
 
 - `docs/STAGE_B_MODEL_CORE_MVP_COMPLETION_AUDIT_2026-05-28.md`
+
+## Current Duration Coverage Fill Outside-Soloing Repair Next Decision Result
+
+Issue #371은 outside-soloing repair objective evidence support를 다음 자동 작업 경계로 변환한 작업이다.
+
+변경:
+
+- outside-soloing repair next decision script 추가
+- objective support와 pending listening preference 경계 분리
+- broader repeatability sweep 자동 진행 여부 기록
+- human/audio preference claim false 유지
+
+결과:
+
+- input boundary: `outside_soloing_repair_objective_evidence_support`
+- next boundary: `outside_soloing_repair_broader_repeatability_sweep`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- human/audio preference claimed: `false`
+- broad model quality claimed: `false`
+
+objective evidence:
+
+- source candidates: `2`
+- qualified source candidates: `2`
+- dead-air preserved source candidates: `2`
+- chord-tone pass source candidates: `2`
+- non-chord run pass source candidates: `2`
+- interval pass source candidates: `2`
+
+판단:
+
+- selected repaired source `2/2` objective support 확보
+- 청취 preference는 pending 상태 유지
+- 다음 작업은 broader repeatability sweep
+- preference 또는 broad model quality claim 금지
+
+다음:
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair broader repeatability sweep`
 
 ## Current Duration Coverage Fill Outside-Soloing Repair Objective Evidence Consolidation Result
 

--- a/docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_NEXT_DECISION_2026-05-29.md
+++ b/docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_NEXT_DECISION_2026-05-29.md
@@ -1,0 +1,69 @@
+# Stage B Duration Coverage Fill Outside-Soloing Repair Next Decision
+
+Issue #371은 outside-soloing repair objective evidence support를 다음 자동 작업 경계로 변환한 작업이다.
+
+## Context
+
+- Issue #369 boundary: `outside_soloing_repair_objective_evidence_support`
+- objective support source candidates: `2/2`
+- human/audio preference claimed: `false`
+- broad model quality claimed: `false`
+- listening preference status: pending
+
+## Change
+
+- outside-soloing repair next decision script 추가
+- objective evidence support와 pending listening preference 경계 분리
+- broader repeatability sweep 자동 진행 여부 기록
+- 다음 issue selection constraints 기록
+- 전용 harness와 unit test 추가
+
+## Result
+
+| item | value |
+|---|---:|
+| input boundary | `outside_soloing_repair_objective_evidence_support` |
+| next boundary | `outside_soloing_repair_broader_repeatability_sweep` |
+| auto progress allowed | `true` |
+| critical user input required | `false` |
+| human/audio preference claimed | `false` |
+| broad model quality claimed | `false` |
+
+## Objective Evidence
+
+| item | value |
+|---|---:|
+| source candidates | `2` |
+| qualified source candidates | `2` |
+| dead-air preserved source candidates | `2` |
+| chord-tone pass source candidates | `2` |
+| non-chord run pass source candidates | `2` |
+| interval pass source candidates | `2` |
+| selected min chord-tone ratio | `1.000` |
+| selected max non-chord run | `0` |
+| selected max interval | `7` |
+
+## Judgment
+
+- selected repaired source `2/2` objective support 확보
+- 청취 preference는 pending 상태 유지
+- broader repeatability sweep으로 objective evidence 확장
+- human/audio preference, multi-reviewer preference, broad trained-model quality는 미검증
+
+## Validation
+
+```bash
+.venv/bin/python -m unittest tests/test_stage_b_duration_coverage_outside_soloing_repair_next_decision.py
+bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-next-decision
+```
+
+## Output
+
+- script: `scripts/decide_stage_b_duration_coverage_outside_soloing_repair_next_step.py`
+- test: `tests/test_stage_b_duration_coverage_outside_soloing_repair_next_decision.py`
+- summary: `outputs/stage_b_duration_coverage_fill_outside_soloing_repair_next_decision/harness_stage_b_duration_coverage_fill_outside_soloing_repair_next_decision/stage_b_duration_coverage_fill_outside_soloing_repair_next_decision.json`
+- markdown: `outputs/stage_b_duration_coverage_fill_outside_soloing_repair_next_decision/harness_stage_b_duration_coverage_fill_outside_soloing_repair_next_decision/stage_b_duration_coverage_fill_outside_soloing_repair_next_decision.md`
+
+## Next
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair broader repeatability sweep`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -148,6 +148,8 @@ Modes:
                 Guard outside-soloing repair listening review when user input is absent.
   stage-b-duration-coverage-outside-soloing-repair-objective-evidence
                 Consolidate objective evidence for outside-soloing repair candidates.
+  stage-b-duration-coverage-outside-soloing-repair-next-decision
+                Decide next objective-only step after outside-soloing repair evidence.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -298,6 +300,7 @@ run_quick() {
     scripts/render_stage_b_duration_coverage_fill_outside_soloing_repair_audio_review_package.py \
     scripts/fill_stage_b_duration_coverage_outside_soloing_repair_user_listening_review.py \
     scripts/summarize_stage_b_duration_coverage_fill_outside_soloing_repair_objective_evidence_consolidation.py \
+    scripts/decide_stage_b_duration_coverage_outside_soloing_repair_next_step.py \
     scripts/build_stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison.py \
     scripts/audit_stage_b_margin_recovered_phrase_vocabulary_duplicate_source_divergence.py \
     scripts/repair_stage_b_margin_recovered_phrase_vocabulary_sample_seed_diversity.py \
@@ -2092,6 +2095,24 @@ run_stage_b_duration_coverage_outside_soloing_repair_objective_evidence() {
     --require_no_broad_quality_claim
 }
 
+run_stage_b_duration_coverage_outside_soloing_repair_next_decision() {
+  local objective_run_id="${OBJECTIVE_RUN_ID:-harness_stage_b_duration_coverage_fill_outside_soloing_repair_objective_evidence_consolidation}"
+  local run_id="${RUN_ID:-harness_stage_b_duration_coverage_fill_outside_soloing_repair_next_decision}"
+  local objective_evidence="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_objective_evidence_consolidation/${objective_run_id}/stage_b_duration_coverage_fill_outside_soloing_repair_objective_evidence_consolidation.json"
+  if [[ ! -f "$objective_evidence" ]]; then
+    print_header "Stage B duration/coverage fill outside-soloing repair objective evidence"
+    RUN_ID="$objective_run_id" run_stage_b_duration_coverage_outside_soloing_repair_objective_evidence
+  fi
+  print_header "Stage B duration/coverage fill outside-soloing repair next decision"
+  "$PYTHON_BIN" scripts/decide_stage_b_duration_coverage_outside_soloing_repair_next_step.py \
+    --run_id "$run_id" \
+    --objective_evidence "$objective_evidence" \
+    --expected_next_boundary outside_soloing_repair_broader_repeatability_sweep \
+    --require_auto_progress_allowed \
+    --require_no_critical_user_input \
+    --require_no_broad_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -3409,6 +3430,9 @@ case "$MODE" in
     ;;
   stage-b-duration-coverage-outside-soloing-repair-objective-evidence)
     run_stage_b_duration_coverage_outside_soloing_repair_objective_evidence
+    ;;
+  stage-b-duration-coverage-outside-soloing-repair-next-decision)
+    run_stage_b_duration_coverage_outside_soloing_repair_next_decision
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/decide_stage_b_duration_coverage_outside_soloing_repair_next_step.py
+++ b/scripts/decide_stage_b_duration_coverage_outside_soloing_repair_next_step.py
@@ -1,0 +1,231 @@
+"""Decide next step after outside-soloing repair objective evidence consolidation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class StageBDurationCoverageOutsideSoloingRepairNextDecisionError(ValueError):
+    pass
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def validate_inputs(objective_evidence: dict[str, Any]) -> dict[str, Any]:
+    summary = _dict(objective_evidence.get("objective_evidence_summary"))
+    claim = _dict(objective_evidence.get("claim_boundary"))
+    boundary = str(summary.get("boundary") or "")
+    if boundary != "outside_soloing_repair_objective_evidence_support":
+        raise StageBDurationCoverageOutsideSoloingRepairNextDecisionError(
+            f"objective support boundary required, got {boundary}"
+        )
+    if int(summary.get("source_candidate_count", 0) or 0) < 2:
+        raise StageBDurationCoverageOutsideSoloingRepairNextDecisionError("two source candidates required")
+    if int(summary.get("qualified_source_candidate_count", 0) or 0) < 2:
+        raise StageBDurationCoverageOutsideSoloingRepairNextDecisionError("two qualified source candidates required")
+    if bool(claim.get("human_audio_preference_claimed", True)):
+        raise StageBDurationCoverageOutsideSoloingRepairNextDecisionError(
+            "human/audio preference must not be claimed"
+        )
+    if bool(claim.get("broad_model_quality_claimed", True)):
+        raise StageBDurationCoverageOutsideSoloingRepairNextDecisionError(
+            "broad model quality must not be claimed"
+        )
+    return summary
+
+
+def build_outside_soloing_repair_next_decision(
+    objective_evidence: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> dict[str, Any]:
+    summary = validate_inputs(objective_evidence)
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_outside_soloing_repair_next_decision_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_objective_evidence_schema": str(objective_evidence.get("schema_version") or ""),
+        "input_boundary": str(summary.get("boundary") or ""),
+        "objective_evidence": {
+            "source_candidate_count": int(summary.get("source_candidate_count", 0) or 0),
+            "qualified_source_candidate_count": int(summary.get("qualified_source_candidate_count", 0) or 0),
+            "dead_air_preserved_source_candidate_count": int(
+                summary.get("dead_air_preserved_source_candidate_count", 0) or 0
+            ),
+            "chord_tone_pass_source_candidate_count": int(
+                summary.get("chord_tone_pass_source_candidate_count", 0) or 0
+            ),
+            "non_chord_run_pass_source_candidate_count": int(
+                summary.get("non_chord_run_pass_source_candidate_count", 0) or 0
+            ),
+            "interval_pass_source_candidate_count": int(summary.get("interval_pass_source_candidate_count", 0) or 0),
+            "selected_min_chord_tone_ratio": float(summary.get("selected_min_chord_tone_ratio", 0.0) or 0.0),
+            "selected_max_non_chord_tone_run": int(summary.get("selected_max_non_chord_tone_run", 0) or 0),
+            "selected_max_interval": int(summary.get("selected_max_interval", 0) or 0),
+        },
+        "decision": {
+            "next_boundary": "outside_soloing_repair_broader_repeatability_sweep",
+            "reason": (
+                "selected repaired sources have objective pitch-role support, but listening preference remains "
+                "pending; broaden objective repeatability before any preference or broad quality claim"
+            ),
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "blocked_reason": "",
+        },
+        "selection_constraints": {
+            "require_dead_air_preservation": True,
+            "require_chord_tone_ratio_gate": True,
+            "require_non_chord_run_gate": True,
+            "require_interval_gate": True,
+            "do_not_claim_human_audio_preference": True,
+            "do_not_claim_broad_model_quality": True,
+        },
+        "claim_boundary": {
+            "boundary": "outside_soloing_repair_next_decision",
+            "human_audio_preference_claimed": False,
+            "broad_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_improviser_claimed": False,
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "multi_reviewer_preference",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "production_ready_improviser",
+        ],
+        "next_recommended_issue": (
+            "Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair "
+            "broader repeatability sweep"
+        ),
+    }
+
+
+def validate_outside_soloing_repair_next_decision(
+    report: dict[str, Any],
+    *,
+    expected_next_boundary: str | None,
+    require_auto_progress_allowed: bool,
+    require_no_critical_user_input: bool,
+    require_no_broad_quality_claim: bool,
+) -> dict[str, Any]:
+    decision = _dict(report.get("decision"))
+    claim = _dict(report.get("claim_boundary"))
+    next_boundary = str(decision.get("next_boundary") or "")
+    if expected_next_boundary and next_boundary != expected_next_boundary:
+        raise StageBDurationCoverageOutsideSoloingRepairNextDecisionError(
+            f"expected next boundary {expected_next_boundary}, got {next_boundary}"
+        )
+    if require_auto_progress_allowed and not bool(decision.get("auto_progress_allowed", False)):
+        raise StageBDurationCoverageOutsideSoloingRepairNextDecisionError("auto progress must be allowed")
+    if require_no_critical_user_input and bool(decision.get("critical_user_input_required", True)):
+        raise StageBDurationCoverageOutsideSoloingRepairNextDecisionError("critical user input must not be required")
+    if require_no_broad_quality_claim and bool(claim.get("broad_model_quality_claimed", True)):
+        raise StageBDurationCoverageOutsideSoloingRepairNextDecisionError("broad model quality must not be claimed")
+    return {
+        "input_boundary": str(report.get("input_boundary") or ""),
+        "next_boundary": next_boundary,
+        "auto_progress_allowed": bool(decision.get("auto_progress_allowed", False)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "human_audio_preference_claimed": bool(claim.get("human_audio_preference_claimed", True)),
+        "broad_model_quality_claimed": bool(claim.get("broad_model_quality_claimed", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    decision = report["decision"]
+    claim = report["claim_boundary"]
+    objective = report["objective_evidence"]
+    lines = [
+        "# Stage B Duration Coverage Fill Outside-Soloing Repair Next Decision",
+        "",
+        f"- input boundary: `{report['input_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- auto progress allowed: `{decision['auto_progress_allowed']}`",
+        f"- critical user input required: `{decision['critical_user_input_required']}`",
+        f"- human/audio preference claimed: `{claim['human_audio_preference_claimed']}`",
+        f"- broad model quality claimed: `{claim['broad_model_quality_claimed']}`",
+        "",
+        "## Objective Evidence",
+        "",
+        f"- source candidates: `{objective['source_candidate_count']}`",
+        f"- qualified source candidates: `{objective['qualified_source_candidate_count']}`",
+        f"- dead-air preserved source candidates: `{objective['dead_air_preserved_source_candidate_count']}`",
+        f"- chord-tone pass source candidates: `{objective['chord_tone_pass_source_candidate_count']}`",
+        f"- non-chord run pass source candidates: `{objective['non_chord_run_pass_source_candidate_count']}`",
+        f"- interval pass source candidates: `{objective['interval_pass_source_candidate_count']}`",
+        "",
+        "## Not Proven",
+        "",
+    ]
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Decide next step after outside-soloing repair objective evidence")
+    parser.add_argument(
+        "--objective_evidence",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_objective_evidence_consolidation/"
+        "harness_stage_b_duration_coverage_fill_outside_soloing_repair_objective_evidence_consolidation/"
+        "stage_b_duration_coverage_fill_outside_soloing_repair_objective_evidence_consolidation.json",
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_next_decision",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_auto_progress_allowed", action="store_true")
+    parser.add_argument("--require_no_critical_user_input", action="store_true")
+    parser.add_argument("--require_no_broad_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_outside_soloing_repair_next_decision(
+        read_json(Path(args.objective_evidence)),
+        output_dir=output_dir,
+    )
+    summary = validate_outside_soloing_repair_next_decision(
+        report,
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_auto_progress_allowed=bool(args.require_auto_progress_allowed),
+        require_no_critical_user_input=bool(args.require_no_critical_user_input),
+        require_no_broad_quality_claim=bool(args.require_no_broad_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "stage_b_duration_coverage_fill_outside_soloing_repair_next_decision.json"
+    markdown_path = output_dir / "stage_b_duration_coverage_fill_outside_soloing_repair_next_decision.md"
+    write_json(report_path, report)
+    write_json(output_dir / "stage_b_duration_coverage_fill_outside_soloing_repair_next_decision_validation_summary.json", summary)
+    markdown_path.write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps({**summary, "report_path": str(report_path), "markdown_path": str(markdown_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_duration_coverage_outside_soloing_repair_next_decision.py
+++ b/tests/test_stage_b_duration_coverage_outside_soloing_repair_next_decision.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.decide_stage_b_duration_coverage_outside_soloing_repair_next_step import (
+    StageBDurationCoverageOutsideSoloingRepairNextDecisionError,
+    build_outside_soloing_repair_next_decision,
+    validate_outside_soloing_repair_next_decision,
+)
+
+
+def objective_evidence(*, boundary: str = "outside_soloing_repair_objective_evidence_support", broad_claim: bool = False) -> dict:
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_outside_soloing_repair_objective_evidence_consolidation_v1",
+        "objective_evidence_summary": {
+            "boundary": boundary,
+            "source_candidate_count": 2,
+            "qualified_source_candidate_count": 2,
+            "dead_air_preserved_source_candidate_count": 2,
+            "chord_tone_pass_source_candidate_count": 2,
+            "non_chord_run_pass_source_candidate_count": 2,
+            "interval_pass_source_candidate_count": 2,
+            "selected_min_chord_tone_ratio": 1.0,
+            "selected_max_non_chord_tone_run": 0,
+            "selected_max_interval": 7,
+        },
+        "claim_boundary": {
+            "boundary": boundary,
+            "human_audio_preference_claimed": False,
+            "broad_model_quality_claimed": broad_claim,
+        },
+    }
+
+
+class StageBDurationCoverageOutsideSoloingRepairNextDecisionTest(unittest.TestCase):
+    def test_selects_broader_repeatability_sweep_boundary(self) -> None:
+        report = build_outside_soloing_repair_next_decision(
+            objective_evidence(),
+            output_dir=Path("outputs/next_decision"),
+        )
+        summary = validate_outside_soloing_repair_next_decision(
+            report,
+            expected_next_boundary="outside_soloing_repair_broader_repeatability_sweep",
+            require_auto_progress_allowed=True,
+            require_no_critical_user_input=True,
+            require_no_broad_quality_claim=True,
+        )
+
+        self.assertEqual(summary["input_boundary"], "outside_soloing_repair_objective_evidence_support")
+        self.assertEqual(summary["next_boundary"], "outside_soloing_repair_broader_repeatability_sweep")
+        self.assertTrue(summary["auto_progress_allowed"])
+        self.assertFalse(summary["critical_user_input_required"])
+        self.assertFalse(summary["human_audio_preference_claimed"])
+        self.assertFalse(summary["broad_model_quality_claimed"])
+
+    def test_rejects_incomplete_objective_boundary(self) -> None:
+        with self.assertRaises(StageBDurationCoverageOutsideSoloingRepairNextDecisionError):
+            build_outside_soloing_repair_next_decision(
+                objective_evidence(boundary="outside_soloing_repair_objective_evidence_incomplete"),
+                output_dir=Path("outputs/next_decision"),
+            )
+
+    def test_rejects_broad_quality_claim(self) -> None:
+        with self.assertRaises(StageBDurationCoverageOutsideSoloingRepairNextDecisionError):
+            build_outside_soloing_repair_next_decision(
+                objective_evidence(broad_claim=True),
+                output_dir=Path("outputs/next_decision"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Convert objective evidence support into next automatic repair boundary
- Select broader repeatability sweep as next objective-only step
- Keep listening preference and broad quality claims false

## Context

- Issue #369 boundary: `outside_soloing_repair_objective_evidence_support`
- Source candidates: `2`
- Objective support source candidates: `2/2`
- Human/audio preference remains pending

## Scope

- Added next decision script
- Added selection constraints for broader repeatability sweep
- Added harness mode and focused unit coverage
- Updated current status, core plan, and handoff notes

## Result

- input boundary: `outside_soloing_repair_objective_evidence_support`
- next boundary: `outside_soloing_repair_broader_repeatability_sweep`
- auto progress allowed: `true`
- critical user input required: `false`
- human/audio preference claimed: `false`
- broad model quality claimed: `false`

## Validation

```bash
.venv/bin/python -m unittest tests/test_stage_b_duration_coverage_outside_soloing_repair_next_decision.py
bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-next-decision
bash scripts/agent_harness.sh quick
```

## Risk

- Human preference remains unproven until listening input exists
- Broader sweep must remain objective-only

## Follow-up

- Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair broader repeatability sweep

Closes #371
