### PR TITLE
Stage B outside-soloing repair repeatability consolidation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #373, Stage B duration coverage fill outside-soloing repair broader repeatability sweep.
+- Latest functional issue completed: Issue #375, Stage B duration coverage fill outside-soloing repair repeatability consolidation.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair repeatability consolidation.
+- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair final decision.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -850,6 +850,14 @@ bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-b
 ```
 
 This harness aggregates policy-level objective repeatability across selected outside-soloing repair sources.
+
+For Stage B duration coverage fill outside-soloing repair repeatability consolidation changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-repeatability-consolidation
+```
+
+This harness consolidates selected-source objective support, policy repeatability support, and the pending review boundary without claiming human/audio preference.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -131,6 +131,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - duration coverage fill outside-soloing repair objective evidence consolidation 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_OBJECTIVE_EVIDENCE_CONSOLIDATION_2026-05-29.md`
 - duration coverage fill outside-soloing repair next decision 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_NEXT_DECISION_2026-05-29.md`
 - duration coverage fill outside-soloing repair broader repeatability sweep 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_BROADER_REPEATABILITY_SWEEP_2026-05-29.md`
+- duration coverage fill outside-soloing repair repeatability consolidation 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_REPEATABILITY_CONSOLIDATION_2026-05-29.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -200,6 +201,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - duration coverage fill outside-soloing repair objective evidence consolidation: objective support source `2/2`, chord-tone pass `2/2`, non-chord run pass `2/2`, interval pass `2/2`, preference claim `false`
 - duration coverage fill outside-soloing repair next decision: next boundary `outside_soloing_repair_broader_repeatability_sweep`, auto progress `true`, critical user input `false`
 - duration coverage fill outside-soloing repair broader repeatability sweep: policy support `3/3`, variants qualified `6/6`, chord-tone min `1.000`, non-chord max `0`, preference claim `false`
+- duration coverage fill outside-soloing repair repeatability consolidation: objective source support `2/2`, policy support `3/3`, variants qualified `6/6`, pending review preserved, preference claim `false`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #373, Stage B duration coverage fill outside-soloing repair broader repeatability sweep
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair repeatability consolidation`
+- latest functional result: Issue #375, Stage B duration coverage fill outside-soloing repair repeatability consolidation
+- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair final decision`
 
 현재 범위가 아닌 것:
 
@@ -65,6 +65,43 @@ Issue #220은 현재 작업이 core인지, MVP 완료로 볼 수 있는지를 �
 Docs:
 
 - `docs/STAGE_B_MODEL_CORE_MVP_COMPLETION_AUDIT_2026-05-28.md`
+
+## Current Duration Coverage Fill Outside-Soloing Repair Repeatability Consolidation Result
+
+Issue #375는 outside-soloing repair objective evidence와 policy repeatability를 하나의 objective-only claim boundary로 정리한 작업이다.
+
+변경:
+
+- outside-soloing repair repeatability consolidation script 추가
+- selected-source objective support와 policy repeatability support 조인
+- pending user listening review boundary 보존
+- human/audio preference claim false 유지
+
+결과:
+
+- boundary: `outside_soloing_repair_objective_repeatability_support`
+- objective source candidates: `2`
+- qualified source candidates: `2`
+- dead-air preserved source candidates: `2`
+- chord-tone pass source candidates: `2`
+- non-chord run pass source candidates: `2`
+- interval pass source candidates: `2`
+- supported repair policies: `3`
+- total variants: `6`
+- qualified variants: `6`
+- review input present: `false`
+- human/audio preference claimed: `false`
+- broad model quality claimed: `false`
+
+판단:
+
+- outside-soloing repair는 objective selected-source support와 policy repeatability support를 동시에 만족
+- 청취 선호는 아직 미검증
+- broad trained-model quality는 아직 미검증
+
+다음:
+
+- `Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair final decision`
 
 ## Current Duration Coverage Fill Outside-Soloing Repair Broader Repeatability Sweep Result
 

--- a/docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_REPEATABILITY_CONSOLIDATION_2026-05-29.md
+++ b/docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_REPEATABILITY_CONSOLIDATION_2026-05-29.md
@@ -1,0 +1,56 @@
+# Stage B Duration Coverage Fill Outside-Soloing Repair Repeatability Consolidation
+
+## Context
+
+- Previous result: Issue #373 broader repeatability sweep
+- Objective evidence boundary: `outside_soloing_repair_objective_evidence_support`
+- Policy repeatability boundary: `outside_soloing_repair_policy_repeatability_support`
+- Pending review boundary: `outside_soloing_repair_audio_review_pending`
+- Human/audio preference claim: `false`
+
+## Scope
+
+- selected-source objective repair support consolidation
+- policy-level objective repeatability support consolidation
+- pending user listening review boundary preservation
+- proven / not-proven claim boundary 정리
+
+## Result
+
+- boundary: `outside_soloing_repair_objective_repeatability_support`
+- objective source candidates: `2`
+- qualified source candidates: `2`
+- dead-air preserved source candidates: `2`
+- chord-tone pass source candidates: `2`
+- non-chord run pass source candidates: `2`
+- interval pass source candidates: `2`
+- supported repair policies: `3`
+- total variants: `6`
+- qualified variants: `6`
+- selected min chord-tone ratio: `1.000`
+- selected max non-chord run: `0`
+- selected max interval: `7`
+- review input present: `false`
+- human/audio preference claimed: `false`
+- broad model quality claimed: `false`
+
+## Claim Boundary
+
+- objective repair repeatability: `true`
+- selected-source objective support: `true`
+- policy repeatability: `true`
+- human/audio preference: `false`
+- multi-reviewer preference: `false`
+- broad trained-model quality: `false`
+- Brad style adaptation: `false`
+- production-ready improviser: `false`
+
+## Validation
+
+- `.venv/bin/python -m unittest tests/test_stage_b_duration_coverage_fill_outside_soloing_repair_repeatability_consolidation.py`
+- `bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-repeatability-consolidation`
+- `bash scripts/agent_harness.sh quick`
+
+## Follow-up
+
+- Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair final decision

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -152,6 +152,8 @@ Modes:
                 Decide next objective-only step after outside-soloing repair evidence.
   stage-b-duration-coverage-outside-soloing-repair-broader-repeatability
                 Aggregate outside-soloing repair policy repeatability across sources.
+  stage-b-duration-coverage-outside-soloing-repair-repeatability-consolidation
+                Consolidate outside-soloing repair objective repeatability boundaries.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -2140,6 +2142,38 @@ run_stage_b_duration_coverage_outside_soloing_repair_broader_repeatability() {
     --require_no_broad_quality_claim
 }
 
+run_stage_b_duration_coverage_outside_soloing_repair_repeatability_consolidation() {
+  local objective_run_id="${OBJECTIVE_RUN_ID:-harness_stage_b_duration_coverage_fill_outside_soloing_repair_objective_evidence_consolidation}"
+  local repeatability_run_id="${REPEATABILITY_RUN_ID:-harness_stage_b_duration_coverage_fill_outside_soloing_repair_broader_repeatability_sweep}"
+  local review_fill_run_id="${REVIEW_FILL_RUN_ID:-harness_stage_b_duration_coverage_fill_outside_soloing_repair_user_listening_review_fill}"
+  local run_id="${RUN_ID:-harness_stage_b_duration_coverage_fill_outside_soloing_repair_repeatability_consolidation}"
+  local objective_evidence="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_objective_evidence_consolidation/${objective_run_id}/stage_b_duration_coverage_fill_outside_soloing_repair_objective_evidence_consolidation.json"
+  local broader_repeatability="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_broader_repeatability_sweep/${repeatability_run_id}/stage_b_duration_coverage_fill_outside_soloing_repair_broader_repeatability_sweep.json"
+  local review_fill="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_user_listening_review_fill/${review_fill_run_id}/stage_b_duration_coverage_fill_outside_soloing_repair_user_listening_review_fill.json"
+  if [[ ! -f "$objective_evidence" ]]; then
+    print_header "Stage B duration/coverage fill outside-soloing repair objective evidence"
+    RUN_ID="$objective_run_id" run_stage_b_duration_coverage_outside_soloing_repair_objective_evidence
+  fi
+  if [[ ! -f "$broader_repeatability" ]]; then
+    print_header "Stage B duration/coverage fill outside-soloing repair broader repeatability"
+    RUN_ID="$repeatability_run_id" run_stage_b_duration_coverage_outside_soloing_repair_broader_repeatability
+  fi
+  if [[ ! -f "$review_fill" ]]; then
+    print_header "Stage B duration/coverage fill outside-soloing repair user listening review"
+    RUN_ID="$review_fill_run_id" run_stage_b_duration_coverage_outside_soloing_repair_user_listening_review
+  fi
+  print_header "Stage B duration/coverage fill outside-soloing repair repeatability consolidation"
+  "$PYTHON_BIN" scripts/summarize_stage_b_duration_coverage_fill_outside_soloing_repair_repeatability_consolidation.py \
+    --run_id "$run_id" \
+    --objective_evidence "$objective_evidence" \
+    --broader_repeatability "$broader_repeatability" \
+    --user_review_fill "$review_fill" \
+    --expected_boundary outside_soloing_repair_objective_repeatability_support \
+    --require_pending_review_guard \
+    --require_no_preference_claim \
+    --require_no_broad_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -3463,6 +3497,9 @@ case "$MODE" in
     ;;
   stage-b-duration-coverage-outside-soloing-repair-broader-repeatability)
     run_stage_b_duration_coverage_outside_soloing_repair_broader_repeatability
+    ;;
+  stage-b-duration-coverage-outside-soloing-repair-repeatability-consolidation)
+    run_stage_b_duration_coverage_outside_soloing_repair_repeatability_consolidation
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/summarize_stage_b_duration_coverage_fill_outside_soloing_repair_repeatability_consolidation.py
+++ b/scripts/summarize_stage_b_duration_coverage_fill_outside_soloing_repair_repeatability_consolidation.py
@@ -1,0 +1,420 @@
+"""Consolidate outside-soloing repair objective and repeatability boundaries."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError(ValueError):
+    pass
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def validate_inputs(
+    *,
+    objective_evidence: dict[str, Any],
+    broader_repeatability: dict[str, Any],
+    user_review_fill: dict[str, Any],
+) -> None:
+    objective_summary = _dict(objective_evidence.get("objective_evidence_summary"))
+    objective_claim = _dict(objective_evidence.get("claim_boundary"))
+    repeatability_summary = _dict(broader_repeatability.get("repeatability_summary"))
+    repeatability_claim = _dict(broader_repeatability.get("claim_boundary"))
+    review_claim = _dict(user_review_fill.get("claim_boundary"))
+    review_decision = _dict(user_review_fill.get("decision"))
+
+    if str(objective_summary.get("boundary") or "") != "outside_soloing_repair_objective_evidence_support":
+        raise StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError(
+            "objective evidence support boundary required"
+        )
+    if not bool(objective_claim.get("objective_midi_evidence_claimed", False)):
+        raise StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError(
+            "objective MIDI evidence claim required"
+        )
+    if bool(objective_claim.get("human_audio_preference_claimed", True)):
+        raise StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError(
+            "objective evidence must not claim human/audio preference"
+        )
+    if bool(objective_claim.get("broad_model_quality_claimed", True)):
+        raise StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError(
+            "objective evidence must not claim broad model quality"
+        )
+
+    if str(repeatability_summary.get("boundary") or "") != "outside_soloing_repair_policy_repeatability_support":
+        raise StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError(
+            "policy repeatability support boundary required"
+        )
+    if not bool(repeatability_claim.get("policy_repeatability_claimed", False)):
+        raise StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError(
+            "policy repeatability claim required"
+        )
+    if bool(repeatability_claim.get("human_audio_preference_claimed", True)):
+        raise StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError(
+            "repeatability sweep must not claim human/audio preference"
+        )
+    if bool(repeatability_claim.get("broad_model_quality_claimed", True)):
+        raise StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError(
+            "repeatability sweep must not claim broad model quality"
+        )
+
+    if str(review_claim.get("boundary") or "") != "outside_soloing_repair_audio_review_pending":
+        raise StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError(
+            "pending audio review boundary required"
+        )
+    if bool(user_review_fill.get("review_input_present", True)):
+        raise StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError(
+            "review input must remain absent for objective-only consolidation"
+        )
+    if bool(review_claim.get("human_audio_preference_claimed", True)):
+        raise StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError(
+            "pending review must not claim human/audio preference"
+        )
+    if not bool(review_decision.get("objective_auto_progress_allowed", False)):
+        raise StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError(
+            "objective auto progress must be allowed"
+        )
+
+
+def build_repeatability_consolidation_report(
+    *,
+    objective_evidence: dict[str, Any],
+    broader_repeatability: dict[str, Any],
+    user_review_fill: dict[str, Any],
+    output_dir: Path,
+    min_source_candidates: int,
+    min_policy_repeatability_count: int,
+) -> dict[str, Any]:
+    validate_inputs(
+        objective_evidence=objective_evidence,
+        broader_repeatability=broader_repeatability,
+        user_review_fill=user_review_fill,
+    )
+
+    objective_summary = _dict(objective_evidence.get("objective_evidence_summary"))
+    repeatability_summary = _dict(broader_repeatability.get("repeatability_summary"))
+    review_claim = _dict(user_review_fill.get("claim_boundary"))
+
+    objective_source_count = int(objective_summary.get("source_candidate_count", 0) or 0)
+    objective_qualified_count = int(objective_summary.get("qualified_source_candidate_count", 0) or 0)
+    objective_dead_air_count = int(objective_summary.get("dead_air_preserved_source_candidate_count", 0) or 0)
+    objective_chord_count = int(objective_summary.get("chord_tone_pass_source_candidate_count", 0) or 0)
+    objective_non_chord_count = int(objective_summary.get("non_chord_run_pass_source_candidate_count", 0) or 0)
+    objective_interval_count = int(objective_summary.get("interval_pass_source_candidate_count", 0) or 0)
+    supported_policy_count = int(repeatability_summary.get("supported_repair_policy_count", 0) or 0)
+    total_variant_count = int(repeatability_summary.get("total_variant_count", 0) or 0)
+    total_qualified_variant_count = int(repeatability_summary.get("total_qualified_variant_count", 0) or 0)
+
+    selected_source_support = (
+        objective_source_count >= int(min_source_candidates)
+        and objective_qualified_count >= int(min_source_candidates)
+        and objective_dead_air_count >= int(min_source_candidates)
+        and objective_chord_count >= int(min_source_candidates)
+        and objective_non_chord_count >= int(min_source_candidates)
+        and objective_interval_count >= int(min_source_candidates)
+    )
+    policy_repeatability_support = supported_policy_count >= int(min_policy_repeatability_count)
+    objective_repeatability_support = selected_source_support and policy_repeatability_support
+    boundary = (
+        "outside_soloing_repair_objective_repeatability_support"
+        if objective_repeatability_support
+        else "outside_soloing_repair_objective_repeatability_incomplete"
+    )
+
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_outside_soloing_repair_repeatability_consolidation_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_schemas": {
+            "objective_evidence": str(objective_evidence.get("schema_version") or ""),
+            "broader_repeatability": str(broader_repeatability.get("schema_version") or ""),
+            "user_review_fill": str(user_review_fill.get("schema_version") or ""),
+        },
+        "thresholds": {
+            "min_source_candidates": int(min_source_candidates),
+            "min_policy_repeatability_count": int(min_policy_repeatability_count),
+        },
+        "input_boundaries": {
+            "objective_evidence": str(objective_summary.get("boundary") or ""),
+            "broader_repeatability": str(repeatability_summary.get("boundary") or ""),
+            "user_review": str(review_claim.get("boundary") or ""),
+        },
+        "selected_source_objective_support": {
+            "source_candidate_count": objective_source_count,
+            "qualified_source_candidate_count": objective_qualified_count,
+            "dead_air_preserved_source_candidate_count": objective_dead_air_count,
+            "chord_tone_pass_source_candidate_count": objective_chord_count,
+            "non_chord_run_pass_source_candidate_count": objective_non_chord_count,
+            "interval_pass_source_candidate_count": objective_interval_count,
+            "selected_min_chord_tone_ratio": float(
+                objective_summary.get("selected_min_chord_tone_ratio", 0.0) or 0.0
+            ),
+            "selected_max_non_chord_tone_run": int(
+                objective_summary.get("selected_max_non_chord_tone_run", 0) or 0
+            ),
+            "selected_max_interval": int(objective_summary.get("selected_max_interval", 0) or 0),
+            "support_claimed": bool(selected_source_support),
+        },
+        "policy_repeatability_support": {
+            "source_candidate_count": int(repeatability_summary.get("source_candidate_count", 0) or 0),
+            "repair_policy_count": int(repeatability_summary.get("repair_policy_count", 0) or 0),
+            "supported_repair_policy_count": supported_policy_count,
+            "total_variant_count": total_variant_count,
+            "total_qualified_variant_count": total_qualified_variant_count,
+            "selected_min_chord_tone_ratio": float(
+                repeatability_summary.get("selected_min_chord_tone_ratio", 0.0) or 0.0
+            ),
+            "selected_max_non_chord_tone_run": int(
+                repeatability_summary.get("selected_max_non_chord_tone_run", 0) or 0
+            ),
+            "selected_max_interval": int(repeatability_summary.get("selected_max_interval", 0) or 0),
+            "support_claimed": bool(policy_repeatability_support),
+        },
+        "pending_user_review": {
+            "review_input_present": bool(user_review_fill.get("review_input_present", False)),
+            "fill_status": str(user_review_fill.get("fill_status") or ""),
+            "boundary": str(review_claim.get("boundary") or ""),
+            "human_audio_preference_claimed": False,
+        },
+        "consolidated_claim_boundary": {
+            "boundary": boundary,
+            "objective_repair_repeatability_claimed": bool(objective_repeatability_support),
+            "selected_source_objective_support_claimed": bool(selected_source_support),
+            "policy_repeatability_claimed": bool(policy_repeatability_support),
+            "human_audio_preference_claimed": False,
+            "multi_reviewer_preference_claimed": False,
+            "broad_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_improviser_claimed": False,
+        },
+        "proven": [
+            "selected_source_objective_repair_support",
+            "policy_level_objective_repeatability_support",
+            "pending_review_boundary_preserved",
+        ]
+        if objective_repeatability_support
+        else [],
+        "not_proven": [
+            "human_audio_preference",
+            "multi_reviewer_preference",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "production_ready_improviser",
+        ],
+        "next_recommended_issue": (
+            "Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair final decision"
+        ),
+    }
+
+
+def validate_repeatability_consolidation(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    min_source_candidates: int,
+    min_policy_repeatability_count: int,
+    require_pending_review_guard: bool,
+    require_no_preference_claim: bool,
+    require_no_broad_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = _dict(report.get("consolidated_claim_boundary"))
+    objective = _dict(report.get("selected_source_objective_support"))
+    repeatability = _dict(report.get("policy_repeatability_support"))
+    review = _dict(report.get("pending_user_review"))
+    boundary_name = str(boundary.get("boundary") or "")
+
+    if expected_boundary and boundary_name != expected_boundary:
+        raise StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError(
+            f"expected boundary {expected_boundary}, got {boundary_name}"
+        )
+    if int(objective.get("source_candidate_count", 0) or 0) < int(min_source_candidates):
+        raise StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError(
+            "not enough objective source candidates"
+        )
+    if int(repeatability.get("supported_repair_policy_count", 0) or 0) < int(min_policy_repeatability_count):
+        raise StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError(
+            "not enough supported repair policies"
+        )
+    if require_pending_review_guard:
+        if bool(review.get("review_input_present", True)):
+            raise StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError(
+                "review input must remain absent"
+            )
+        if str(review.get("boundary") or "") != "outside_soloing_repair_audio_review_pending":
+            raise StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError(
+                "pending review boundary required"
+            )
+    if require_no_preference_claim:
+        blocked = ["human_audio_preference_claimed", "multi_reviewer_preference_claimed"]
+        claimed = [name for name in blocked if bool(boundary.get(name, True))]
+        if claimed:
+            raise StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError(
+                f"unexpected preference claim: {claimed}"
+            )
+    if require_no_broad_quality_claim:
+        blocked = [
+            "broad_model_quality_claimed",
+            "brad_style_adaptation_claimed",
+            "production_ready_improviser_claimed",
+        ]
+        claimed = [name for name in blocked if bool(boundary.get(name, True))]
+        if claimed:
+            raise StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError(
+                f"unexpected broad claim: {claimed}"
+            )
+
+    return {
+        "boundary": boundary_name,
+        "objective_repair_repeatability_claimed": bool(
+            boundary.get("objective_repair_repeatability_claimed", False)
+        ),
+        "objective_source_candidate_count": int(objective.get("source_candidate_count", 0) or 0),
+        "qualified_source_candidate_count": int(objective.get("qualified_source_candidate_count", 0) or 0),
+        "dead_air_preserved_source_candidate_count": int(
+            objective.get("dead_air_preserved_source_candidate_count", 0) or 0
+        ),
+        "supported_repair_policy_count": int(repeatability.get("supported_repair_policy_count", 0) or 0),
+        "total_variant_count": int(repeatability.get("total_variant_count", 0) or 0),
+        "total_qualified_variant_count": int(repeatability.get("total_qualified_variant_count", 0) or 0),
+        "review_input_present": bool(review.get("review_input_present", False)),
+        "human_audio_preference_claimed": bool(boundary.get("human_audio_preference_claimed", True)),
+        "broad_model_quality_claimed": bool(boundary.get("broad_model_quality_claimed", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    boundary = report["consolidated_claim_boundary"]
+    objective = report["selected_source_objective_support"]
+    repeatability = report["policy_repeatability_support"]
+    review = report["pending_user_review"]
+    lines = [
+        "# Stage B Duration Coverage Fill Outside-Soloing Repair Repeatability Consolidation",
+        "",
+        f"- boundary: `{boundary['boundary']}`",
+        f"- objective repair repeatability claimed: `{boundary['objective_repair_repeatability_claimed']}`",
+        f"- human/audio preference claimed: `{boundary['human_audio_preference_claimed']}`",
+        f"- broad model quality claimed: `{boundary['broad_model_quality_claimed']}`",
+        "",
+        "## Selected Source Objective Support",
+        "",
+        f"- source candidates: `{objective['source_candidate_count']}`",
+        f"- qualified source candidates: `{objective['qualified_source_candidate_count']}`",
+        f"- dead-air preserved source candidates: `{objective['dead_air_preserved_source_candidate_count']}`",
+        f"- chord-tone pass source candidates: `{objective['chord_tone_pass_source_candidate_count']}`",
+        f"- non-chord run pass source candidates: `{objective['non_chord_run_pass_source_candidate_count']}`",
+        f"- interval pass source candidates: `{objective['interval_pass_source_candidate_count']}`",
+        "",
+        "## Policy Repeatability Support",
+        "",
+        f"- repair policies supported: `{repeatability['supported_repair_policy_count']}`",
+        f"- total variants: `{repeatability['total_variant_count']}`",
+        f"- qualified variants: `{repeatability['total_qualified_variant_count']}`",
+        f"- selected min chord-tone ratio: `{repeatability['selected_min_chord_tone_ratio']:.3f}`",
+        f"- selected max non-chord run: `{repeatability['selected_max_non_chord_tone_run']}`",
+        f"- selected max interval: `{repeatability['selected_max_interval']}`",
+        "",
+        "## Pending Review Boundary",
+        "",
+        f"- review input present: `{review['review_input_present']}`",
+        f"- boundary: `{review['boundary']}`",
+        f"- human/audio preference claimed: `{review['human_audio_preference_claimed']}`",
+        "",
+        "## Not Proven",
+        "",
+    ]
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Consolidate outside-soloing repair repeatability evidence")
+    parser.add_argument(
+        "--objective_evidence",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_objective_evidence_consolidation/"
+        "harness_stage_b_duration_coverage_fill_outside_soloing_repair_objective_evidence_consolidation/"
+        "stage_b_duration_coverage_fill_outside_soloing_repair_objective_evidence_consolidation.json",
+    )
+    parser.add_argument(
+        "--broader_repeatability",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_broader_repeatability_sweep/"
+        "harness_stage_b_duration_coverage_fill_outside_soloing_repair_broader_repeatability_sweep/"
+        "stage_b_duration_coverage_fill_outside_soloing_repair_broader_repeatability_sweep.json",
+    )
+    parser.add_argument(
+        "--user_review_fill",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_user_listening_review_fill/"
+        "harness_stage_b_duration_coverage_fill_outside_soloing_repair_user_listening_review_fill/"
+        "stage_b_duration_coverage_fill_outside_soloing_repair_user_listening_review_fill.json",
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_repeatability_consolidation",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--min_source_candidates", type=int, default=2)
+    parser.add_argument("--min_policy_repeatability_count", type=int, default=3)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--require_pending_review_guard", action="store_true")
+    parser.add_argument("--require_no_preference_claim", action="store_true")
+    parser.add_argument("--require_no_broad_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_repeatability_consolidation_report(
+        objective_evidence=read_json(Path(args.objective_evidence)),
+        broader_repeatability=read_json(Path(args.broader_repeatability)),
+        user_review_fill=read_json(Path(args.user_review_fill)),
+        output_dir=output_dir,
+        min_source_candidates=int(args.min_source_candidates),
+        min_policy_repeatability_count=int(args.min_policy_repeatability_count),
+    )
+    summary = validate_repeatability_consolidation(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        min_source_candidates=int(args.min_source_candidates),
+        min_policy_repeatability_count=int(args.min_policy_repeatability_count),
+        require_pending_review_guard=bool(args.require_pending_review_guard),
+        require_no_preference_claim=bool(args.require_no_preference_claim),
+        require_no_broad_quality_claim=bool(args.require_no_broad_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "stage_b_duration_coverage_fill_outside_soloing_repair_repeatability_consolidation.json"
+    markdown_path = output_dir / "stage_b_duration_coverage_fill_outside_soloing_repair_repeatability_consolidation.md"
+    write_json(report_path, report)
+    write_json(
+        output_dir
+        / "stage_b_duration_coverage_fill_outside_soloing_repair_repeatability_consolidation_validation_summary.json",
+        summary,
+    )
+    markdown_path.write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps({**summary, "report_path": str(report_path), "markdown_path": str(markdown_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_duration_coverage_fill_outside_soloing_repair_repeatability_consolidation.py
+++ b/tests/test_stage_b_duration_coverage_fill_outside_soloing_repair_repeatability_consolidation.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.summarize_stage_b_duration_coverage_fill_outside_soloing_repair_repeatability_consolidation import (
+    StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError,
+    build_repeatability_consolidation_report,
+    validate_repeatability_consolidation,
+)
+
+
+def objective_evidence(*, broad_claim: bool = False) -> dict:
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_outside_soloing_repair_objective_evidence_consolidation_v1",
+        "objective_evidence_summary": {
+            "boundary": "outside_soloing_repair_objective_evidence_support",
+            "source_candidate_count": 2,
+            "qualified_source_candidate_count": 2,
+            "dead_air_preserved_source_candidate_count": 2,
+            "chord_tone_pass_source_candidate_count": 2,
+            "non_chord_run_pass_source_candidate_count": 2,
+            "interval_pass_source_candidate_count": 2,
+            "selected_min_chord_tone_ratio": 1.0,
+            "selected_max_non_chord_tone_run": 0,
+            "selected_max_interval": 7,
+            "human_audio_preference_claimed": False,
+            "broad_model_quality_claimed": False,
+        },
+        "claim_boundary": {
+            "boundary": "outside_soloing_repair_objective_evidence_support",
+            "objective_midi_evidence_claimed": True,
+            "human_audio_preference_claimed": False,
+            "broad_model_quality_claimed": broad_claim,
+        },
+    }
+
+
+def broader_repeatability(*, supported_policy_count: int = 3) -> dict:
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_outside_soloing_repair_broader_repeatability_sweep_v1",
+        "repeatability_summary": {
+            "boundary": "outside_soloing_repair_policy_repeatability_support",
+            "source_candidate_count": 2,
+            "repair_policy_count": 3,
+            "supported_repair_policy_count": supported_policy_count,
+            "total_variant_count": 6,
+            "total_qualified_variant_count": 6,
+            "selected_min_chord_tone_ratio": 1.0,
+            "selected_max_non_chord_tone_run": 0,
+            "selected_max_interval": 7,
+            "human_audio_preference_claimed": False,
+            "broad_model_quality_claimed": False,
+        },
+        "claim_boundary": {
+            "boundary": "outside_soloing_repair_policy_repeatability_support",
+            "policy_repeatability_claimed": True,
+            "human_audio_preference_claimed": False,
+            "broad_model_quality_claimed": False,
+        },
+    }
+
+
+def user_review_fill(*, review_input_present: bool = False, preference_claimed: bool = False) -> dict:
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_outside_soloing_repair_user_listening_review_fill_v1",
+        "review_input_present": review_input_present,
+        "fill_status": "pending_review_input",
+        "decision": {
+            "objective_auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "next_boundary": "outside_soloing_repair_audio_review_pending",
+        },
+        "claim_boundary": {
+            "boundary": "outside_soloing_repair_audio_review_pending",
+            "human_audio_preference_claimed": preference_claimed,
+            "pending_without_review_input": True,
+            "objective_only_followup_allowed": True,
+            "broad_model_quality_claimed": False,
+        },
+    }
+
+
+class StageBDurationCoverageFillOutsideSoloingRepairRepeatabilityConsolidationTest(unittest.TestCase):
+    def test_consolidates_objective_repeatability_support(self) -> None:
+        report = build_repeatability_consolidation_report(
+            objective_evidence=objective_evidence(),
+            broader_repeatability=broader_repeatability(),
+            user_review_fill=user_review_fill(),
+            output_dir=Path("outputs/repeatability_consolidation"),
+            min_source_candidates=2,
+            min_policy_repeatability_count=3,
+        )
+        summary = validate_repeatability_consolidation(
+            report,
+            expected_boundary="outside_soloing_repair_objective_repeatability_support",
+            min_source_candidates=2,
+            min_policy_repeatability_count=3,
+            require_pending_review_guard=True,
+            require_no_preference_claim=True,
+            require_no_broad_quality_claim=True,
+        )
+
+        self.assertTrue(summary["objective_repair_repeatability_claimed"])
+        self.assertEqual(summary["objective_source_candidate_count"], 2)
+        self.assertEqual(summary["supported_repair_policy_count"], 3)
+        self.assertEqual(summary["total_qualified_variant_count"], 6)
+        self.assertFalse(summary["review_input_present"])
+        self.assertFalse(summary["human_audio_preference_claimed"])
+        self.assertFalse(summary["broad_model_quality_claimed"])
+
+    def test_rejects_preference_claim_without_review_boundary(self) -> None:
+        with self.assertRaises(StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError):
+            build_repeatability_consolidation_report(
+                objective_evidence=objective_evidence(),
+                broader_repeatability=broader_repeatability(),
+                user_review_fill=user_review_fill(preference_claimed=True),
+                output_dir=Path("outputs/repeatability_consolidation"),
+                min_source_candidates=2,
+                min_policy_repeatability_count=3,
+            )
+
+    def test_rejects_present_review_input_for_objective_only_consolidation(self) -> None:
+        with self.assertRaises(StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError):
+            build_repeatability_consolidation_report(
+                objective_evidence=objective_evidence(),
+                broader_repeatability=broader_repeatability(),
+                user_review_fill=user_review_fill(review_input_present=True),
+                output_dir=Path("outputs/repeatability_consolidation"),
+                min_source_candidates=2,
+                min_policy_repeatability_count=3,
+            )
+
+    def test_rejects_broad_quality_claim(self) -> None:
+        with self.assertRaises(StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError):
+            build_repeatability_consolidation_report(
+                objective_evidence=objective_evidence(broad_claim=True),
+                broader_repeatability=broader_repeatability(),
+                user_review_fill=user_review_fill(),
+                output_dir=Path("outputs/repeatability_consolidation"),
+                min_source_candidates=2,
+                min_policy_repeatability_count=3,
+            )
+
+    def test_validation_rejects_insufficient_policy_support(self) -> None:
+        report = build_repeatability_consolidation_report(
+            objective_evidence=objective_evidence(),
+            broader_repeatability=broader_repeatability(supported_policy_count=2),
+            user_review_fill=user_review_fill(),
+            output_dir=Path("outputs/repeatability_consolidation"),
+            min_source_candidates=2,
+            min_policy_repeatability_count=3,
+        )
+
+        with self.assertRaises(StageBDurationCoverageOutsideSoloingRepairRepeatabilityConsolidationError):
+            validate_repeatability_consolidation(
+                report,
+                expected_boundary="outside_soloing_repair_objective_repeatability_support",
+                min_source_candidates=2,
+                min_policy_repeatability_count=3,
+                require_pending_review_guard=True,
+                require_no_preference_claim=True,
+                require_no_broad_quality_claim=True,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- outside-soloing repair objective evidence와 policy repeatability support 통합
- pending user listening review boundary 보존
- human/audio preference 및 broad model quality claim 차단 유지

## Context

- Issue #373 broader repeatability sweep 결과: policy support `3/3`, qualified variants `6/6`
- Issue #369 objective evidence 결과: selected-source objective support `2/2`
- Issue #367 review guard 결과: review input `false`, preference claim `false`

## Scope

- repeatability consolidation script 추가
- focused unit test 추가
- harness mode 추가
- status/core/handoff docs 갱신

## Validation

- `.venv/bin/python -m unittest tests/test_stage_b_duration_coverage_fill_outside_soloing_repair_repeatability_consolidation.py`
- `bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-repeatability-consolidation`
- `bash scripts/agent_harness.sh quick`

## Risk

- human/audio preference 미검증
- broad trained-model quality 미검증
- generated artifact 미커밋

## Follow-up

- Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair final decision

Closes #375