### PR TITLE
Stage B outside-soloing repair final decision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #375, Stage B duration coverage fill outside-soloing repair repeatability consolidation.
+- Latest functional issue completed: Issue #377, Stage B duration coverage fill outside-soloing repair final decision.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair final decision.
+- Recommended next issue: Stage B model-core evidence README refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -858,6 +858,14 @@ bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-r
 ```
 
 This harness consolidates selected-source objective support, policy repeatability support, and the pending review boundary without claiming human/audio preference.
+
+For Stage B duration coverage fill outside-soloing repair final decision changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-final-decision
+```
+
+This harness records the objective-only final boundary and routes the next automatic task to model-core evidence README refresh without claiming human/audio preference.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -132,6 +132,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - duration coverage fill outside-soloing repair next decision 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_NEXT_DECISION_2026-05-29.md`
 - duration coverage fill outside-soloing repair broader repeatability sweep 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_BROADER_REPEATABILITY_SWEEP_2026-05-29.md`
 - duration coverage fill outside-soloing repair repeatability consolidation 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_REPEATABILITY_CONSOLIDATION_2026-05-29.md`
+- duration coverage fill outside-soloing repair final decision 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_FINAL_DECISION_2026-05-29.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -202,6 +203,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - duration coverage fill outside-soloing repair next decision: next boundary `outside_soloing_repair_broader_repeatability_sweep`, auto progress `true`, critical user input `false`
 - duration coverage fill outside-soloing repair broader repeatability sweep: policy support `3/3`, variants qualified `6/6`, chord-tone min `1.000`, non-chord max `0`, preference claim `false`
 - duration coverage fill outside-soloing repair repeatability consolidation: objective source support `2/2`, policy support `3/3`, variants qualified `6/6`, pending review preserved, preference claim `false`
+- duration coverage fill outside-soloing repair final decision: final boundary `outside_soloing_repair_objective_path_complete`, next boundary `stage_b_model_core_evidence_readme_refresh`, preference claim `false`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #375, Stage B duration coverage fill outside-soloing repair repeatability consolidation
-- 다음 권장 이슈: `Stage B margin-recovered phrase/vocabulary duration coverage fill outside-soloing repair final decision`
+- latest functional result: Issue #377, Stage B duration coverage fill outside-soloing repair final decision
+- 다음 권장 이슈: `Stage B model-core evidence README refresh`
 
 현재 범위가 아닌 것:
 
@@ -65,6 +65,40 @@ Issue #220은 현재 작업이 core인지, MVP 완료로 볼 수 있는지를 �
 Docs:
 
 - `docs/STAGE_B_MODEL_CORE_MVP_COMPLETION_AUDIT_2026-05-28.md`
+
+## Current Duration Coverage Fill Outside-Soloing Repair Final Decision Result
+
+Issue #377은 outside-soloing repair path를 objective-only boundary로 닫고 다음 자동 작업 경계를 정리한 작업이다.
+
+변경:
+
+- outside-soloing repair final decision script 추가
+- repeatability consolidation 결과 검증
+- human/audio preference claim 금지 유지
+- 다음 자동 작업 boundary 정의
+
+결과:
+
+- input boundary: `outside_soloing_repair_objective_repeatability_support`
+- final boundary: `outside_soloing_repair_objective_path_complete`
+- next boundary: `stage_b_model_core_evidence_readme_refresh`
+- objective source support: `2/2`
+- policy repeatability support: `3/3`
+- qualified variants: `6/6`
+- review input present: `false`
+- human/audio preference claimed: `false`
+- broad model quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- outside-soloing repair objective path는 selected-source support와 policy repeatability support 기준 완료
+- 청취 선호는 review input 부재로 미인정
+- 다음 작업은 README의 model-core evidence claim boundary 갱신
+
+다음:
+
+- `Stage B model-core evidence README refresh`
 
 ## Current Duration Coverage Fill Outside-Soloing Repair Repeatability Consolidation Result
 

--- a/docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_FINAL_DECISION_2026-05-29.md
+++ b/docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_FINAL_DECISION_2026-05-29.md
@@ -1,0 +1,46 @@
+# Stage B Duration Coverage Fill Outside-Soloing Repair Final Decision
+
+## Context
+
+- Previous result: Issue #375 repeatability consolidation
+- Input boundary: `outside_soloing_repair_objective_repeatability_support`
+- Objective source support: `2/2`
+- Policy repeatability support: `3/3`
+- Qualified variants: `6/6`
+- Review input present: `false`
+- Human/audio preference claim: `false`
+- Broad model quality claim: `false`
+
+## Scope
+
+- outside-soloing repair objective-only final boundary 정의
+- human/audio preference pending boundary 보존
+- next automatic work boundary 정의
+- broad trained-model quality claim 차단
+
+## Result
+
+- final boundary: `outside_soloing_repair_objective_path_complete`
+- next boundary: `stage_b_model_core_evidence_readme_refresh`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- review input present: `false`
+- human/audio preference claimed: `false`
+- broad model quality claimed: `false`
+
+## Decision
+
+- objective selected-source support와 policy repeatability support는 outside-soloing repair path의 objective boundary로 인정
+- 청취 선호는 review input 부재로 미인정
+- broad trained-model quality와 Brad style adaptation은 미인정
+- 다음 자동 작업: model-core evidence README refresh
+
+## Validation
+
+- `.venv/bin/python -m unittest tests/test_stage_b_duration_coverage_outside_soloing_repair_final_decision.py`
+- `bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-final-decision`
+- `bash scripts/agent_harness.sh quick`
+
+## Follow-up
+
+- Stage B model-core evidence README refresh

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -154,6 +154,8 @@ Modes:
                 Aggregate outside-soloing repair policy repeatability across sources.
   stage-b-duration-coverage-outside-soloing-repair-repeatability-consolidation
                 Consolidate outside-soloing repair objective repeatability boundaries.
+  stage-b-duration-coverage-outside-soloing-repair-final-decision
+                Decide final objective-only boundary after outside-soloing repair repeatability.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -2174,6 +2176,26 @@ run_stage_b_duration_coverage_outside_soloing_repair_repeatability_consolidation
     --require_no_broad_quality_claim
 }
 
+run_stage_b_duration_coverage_outside_soloing_repair_final_decision() {
+  local repeatability_run_id="${REPEATABILITY_RUN_ID:-harness_stage_b_duration_coverage_fill_outside_soloing_repair_repeatability_consolidation}"
+  local run_id="${RUN_ID:-harness_stage_b_duration_coverage_fill_outside_soloing_repair_final_decision}"
+  local repeatability_consolidation="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_repeatability_consolidation/${repeatability_run_id}/stage_b_duration_coverage_fill_outside_soloing_repair_repeatability_consolidation.json"
+  if [[ ! -f "$repeatability_consolidation" ]]; then
+    print_header "Stage B duration/coverage fill outside-soloing repair repeatability consolidation"
+    RUN_ID="$repeatability_run_id" run_stage_b_duration_coverage_outside_soloing_repair_repeatability_consolidation
+  fi
+  print_header "Stage B duration/coverage fill outside-soloing repair final decision"
+  "$PYTHON_BIN" scripts/decide_stage_b_duration_coverage_outside_soloing_repair_final_decision.py \
+    --run_id "$run_id" \
+    --repeatability_consolidation "$repeatability_consolidation" \
+    --expected_final_boundary outside_soloing_repair_objective_path_complete \
+    --expected_next_boundary stage_b_model_core_evidence_readme_refresh \
+    --require_auto_progress_allowed \
+    --require_no_critical_user_input \
+    --require_no_preference_claim \
+    --require_no_broad_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -3500,6 +3522,9 @@ case "$MODE" in
     ;;
   stage-b-duration-coverage-outside-soloing-repair-repeatability-consolidation)
     run_stage_b_duration_coverage_outside_soloing_repair_repeatability_consolidation
+    ;;
+  stage-b-duration-coverage-outside-soloing-repair-final-decision)
+    run_stage_b_duration_coverage_outside_soloing_repair_final_decision
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/decide_stage_b_duration_coverage_outside_soloing_repair_final_decision.py
+++ b/scripts/decide_stage_b_duration_coverage_outside_soloing_repair_final_decision.py
@@ -1,0 +1,280 @@
+"""Decide final objective-only boundary after outside-soloing repair repeatability consolidation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class StageBDurationCoverageOutsideSoloingRepairFinalDecisionError(ValueError):
+    pass
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def validate_inputs(repeatability_consolidation: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    boundary = _dict(repeatability_consolidation.get("consolidated_claim_boundary"))
+    objective = _dict(repeatability_consolidation.get("selected_source_objective_support"))
+    repeatability = _dict(repeatability_consolidation.get("policy_repeatability_support"))
+    review = _dict(repeatability_consolidation.get("pending_user_review"))
+
+    if str(boundary.get("boundary") or "") != "outside_soloing_repair_objective_repeatability_support":
+        raise StageBDurationCoverageOutsideSoloingRepairFinalDecisionError(
+            "objective repeatability support boundary required"
+        )
+    if not bool(boundary.get("objective_repair_repeatability_claimed", False)):
+        raise StageBDurationCoverageOutsideSoloingRepairFinalDecisionError(
+            "objective repair repeatability claim required"
+        )
+    if int(objective.get("source_candidate_count", 0) or 0) < 2:
+        raise StageBDurationCoverageOutsideSoloingRepairFinalDecisionError("two objective source candidates required")
+    if int(repeatability.get("supported_repair_policy_count", 0) or 0) < 3:
+        raise StageBDurationCoverageOutsideSoloingRepairFinalDecisionError("three supported repair policies required")
+    if bool(review.get("review_input_present", True)):
+        raise StageBDurationCoverageOutsideSoloingRepairFinalDecisionError(
+            "review input must remain absent for objective-only final decision"
+        )
+    blocked_claims = [
+        "human_audio_preference_claimed",
+        "multi_reviewer_preference_claimed",
+        "broad_model_quality_claimed",
+        "brad_style_adaptation_claimed",
+        "production_ready_improviser_claimed",
+    ]
+    claimed = [name for name in blocked_claims if bool(boundary.get(name, True))]
+    if claimed:
+        raise StageBDurationCoverageOutsideSoloingRepairFinalDecisionError(f"unexpected claim: {claimed}")
+    return objective, repeatability, review
+
+
+def build_final_decision(
+    repeatability_consolidation: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> dict[str, Any]:
+    objective, repeatability, review = validate_inputs(repeatability_consolidation)
+    final_boundary = "outside_soloing_repair_objective_path_complete"
+    next_boundary = "stage_b_model_core_evidence_readme_refresh"
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_outside_soloing_repair_final_decision_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_repeatability_consolidation_schema": str(repeatability_consolidation.get("schema_version") or ""),
+        "input_boundary": "outside_soloing_repair_objective_repeatability_support",
+        "objective_repeatability": {
+            "source_candidate_count": int(objective.get("source_candidate_count", 0) or 0),
+            "qualified_source_candidate_count": int(objective.get("qualified_source_candidate_count", 0) or 0),
+            "dead_air_preserved_source_candidate_count": int(
+                objective.get("dead_air_preserved_source_candidate_count", 0) or 0
+            ),
+            "supported_repair_policy_count": int(repeatability.get("supported_repair_policy_count", 0) or 0),
+            "total_variant_count": int(repeatability.get("total_variant_count", 0) or 0),
+            "total_qualified_variant_count": int(repeatability.get("total_qualified_variant_count", 0) or 0),
+            "selected_min_chord_tone_ratio": float(
+                repeatability.get("selected_min_chord_tone_ratio", 0.0) or 0.0
+            ),
+            "selected_max_non_chord_tone_run": int(
+                repeatability.get("selected_max_non_chord_tone_run", 0) or 0
+            ),
+            "selected_max_interval": int(repeatability.get("selected_max_interval", 0) or 0),
+        },
+        "review_boundary": {
+            "boundary": str(review.get("boundary") or ""),
+            "review_input_present": bool(review.get("review_input_present", False)),
+            "human_audio_preference_claimed": False,
+            "preference_claim_requires_user_review": True,
+        },
+        "decision": {
+            "final_boundary": final_boundary,
+            "next_boundary": next_boundary,
+            "reason": (
+                "outside-soloing repair has objective selected-source and policy repeatability support; "
+                "human/audio preference remains pending and must not be inferred from MIDI metrics"
+            ),
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "blocked_reason": "",
+        },
+        "claim_boundary": {
+            "boundary": final_boundary,
+            "outside_soloing_repair_objective_path_claimed": True,
+            "human_audio_preference_claimed": False,
+            "multi_reviewer_preference_claimed": False,
+            "broad_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_improviser_claimed": False,
+        },
+        "proven": [
+            "outside_soloing_repair_selected_source_objective_support",
+            "outside_soloing_repair_policy_repeatability_support",
+            "human_audio_preference_claim_blocked_without_review_input",
+        ],
+        "not_proven": [
+            "human_audio_preference",
+            "multi_reviewer_preference",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "production_ready_improviser",
+        ],
+        "next_recommended_issue": "Stage B model-core evidence README refresh",
+    }
+
+
+def validate_final_decision(
+    report: dict[str, Any],
+    *,
+    expected_final_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_auto_progress_allowed: bool,
+    require_no_critical_user_input: bool,
+    require_no_preference_claim: bool,
+    require_no_broad_quality_claim: bool,
+) -> dict[str, Any]:
+    decision = _dict(report.get("decision"))
+    claim = _dict(report.get("claim_boundary"))
+    review = _dict(report.get("review_boundary"))
+    final_boundary = str(decision.get("final_boundary") or "")
+    next_boundary = str(decision.get("next_boundary") or "")
+
+    if expected_final_boundary and final_boundary != expected_final_boundary:
+        raise StageBDurationCoverageOutsideSoloingRepairFinalDecisionError(
+            f"expected final boundary {expected_final_boundary}, got {final_boundary}"
+        )
+    if expected_next_boundary and next_boundary != expected_next_boundary:
+        raise StageBDurationCoverageOutsideSoloingRepairFinalDecisionError(
+            f"expected next boundary {expected_next_boundary}, got {next_boundary}"
+        )
+    if require_auto_progress_allowed and not bool(decision.get("auto_progress_allowed", False)):
+        raise StageBDurationCoverageOutsideSoloingRepairFinalDecisionError("auto progress must be allowed")
+    if require_no_critical_user_input and bool(decision.get("critical_user_input_required", True)):
+        raise StageBDurationCoverageOutsideSoloingRepairFinalDecisionError("critical user input must not be required")
+    if require_no_preference_claim:
+        if bool(claim.get("human_audio_preference_claimed", True)):
+            raise StageBDurationCoverageOutsideSoloingRepairFinalDecisionError(
+                "human/audio preference must not be claimed"
+            )
+        if bool(review.get("review_input_present", True)):
+            raise StageBDurationCoverageOutsideSoloingRepairFinalDecisionError("review input must remain absent")
+    if require_no_broad_quality_claim and bool(claim.get("broad_model_quality_claimed", True)):
+        raise StageBDurationCoverageOutsideSoloingRepairFinalDecisionError("broad model quality must not be claimed")
+    return {
+        "input_boundary": str(report.get("input_boundary") or ""),
+        "final_boundary": final_boundary,
+        "next_boundary": next_boundary,
+        "auto_progress_allowed": bool(decision.get("auto_progress_allowed", False)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "review_input_present": bool(review.get("review_input_present", False)),
+        "human_audio_preference_claimed": bool(claim.get("human_audio_preference_claimed", True)),
+        "broad_model_quality_claimed": bool(claim.get("broad_model_quality_claimed", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    decision = report["decision"]
+    objective = report["objective_repeatability"]
+    review = report["review_boundary"]
+    claim = report["claim_boundary"]
+    lines = [
+        "# Stage B Duration Coverage Fill Outside-Soloing Repair Final Decision",
+        "",
+        f"- input boundary: `{report['input_boundary']}`",
+        f"- final boundary: `{decision['final_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- auto progress allowed: `{decision['auto_progress_allowed']}`",
+        f"- critical user input required: `{decision['critical_user_input_required']}`",
+        f"- human/audio preference claimed: `{claim['human_audio_preference_claimed']}`",
+        f"- broad model quality claimed: `{claim['broad_model_quality_claimed']}`",
+        "",
+        "## Objective Repeatability",
+        "",
+        f"- source candidates: `{objective['source_candidate_count']}`",
+        f"- qualified source candidates: `{objective['qualified_source_candidate_count']}`",
+        f"- dead-air preserved source candidates: `{objective['dead_air_preserved_source_candidate_count']}`",
+        f"- supported repair policies: `{objective['supported_repair_policy_count']}`",
+        f"- total variants: `{objective['total_variant_count']}`",
+        f"- qualified variants: `{objective['total_qualified_variant_count']}`",
+        "",
+        "## Review Boundary",
+        "",
+        f"- review input present: `{review['review_input_present']}`",
+        f"- preference claim requires user review: `{review['preference_claim_requires_user_review']}`",
+        "",
+        "## Not Proven",
+        "",
+    ]
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Decide final boundary after outside-soloing repair repeatability")
+    parser.add_argument(
+        "--repeatability_consolidation",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_repeatability_consolidation/"
+        "harness_stage_b_duration_coverage_fill_outside_soloing_repair_repeatability_consolidation/"
+        "stage_b_duration_coverage_fill_outside_soloing_repair_repeatability_consolidation.json",
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_final_decision",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--expected_final_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_auto_progress_allowed", action="store_true")
+    parser.add_argument("--require_no_critical_user_input", action="store_true")
+    parser.add_argument("--require_no_preference_claim", action="store_true")
+    parser.add_argument("--require_no_broad_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_final_decision(
+        read_json(Path(args.repeatability_consolidation)),
+        output_dir=output_dir,
+    )
+    summary = validate_final_decision(
+        report,
+        expected_final_boundary=str(args.expected_final_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_auto_progress_allowed=bool(args.require_auto_progress_allowed),
+        require_no_critical_user_input=bool(args.require_no_critical_user_input),
+        require_no_preference_claim=bool(args.require_no_preference_claim),
+        require_no_broad_quality_claim=bool(args.require_no_broad_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "stage_b_duration_coverage_fill_outside_soloing_repair_final_decision.json"
+    markdown_path = output_dir / "stage_b_duration_coverage_fill_outside_soloing_repair_final_decision.md"
+    write_json(report_path, report)
+    write_json(
+        output_dir / "stage_b_duration_coverage_fill_outside_soloing_repair_final_decision_validation_summary.json",
+        summary,
+    )
+    markdown_path.write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps({**summary, "report_path": str(report_path), "markdown_path": str(markdown_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_duration_coverage_outside_soloing_repair_final_decision.py
+++ b/tests/test_stage_b_duration_coverage_outside_soloing_repair_final_decision.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.decide_stage_b_duration_coverage_outside_soloing_repair_final_decision import (
+    StageBDurationCoverageOutsideSoloingRepairFinalDecisionError,
+    build_final_decision,
+    validate_final_decision,
+)
+
+
+def repeatability_consolidation(
+    *,
+    boundary: str = "outside_soloing_repair_objective_repeatability_support",
+    review_input_present: bool = False,
+    broad_claim: bool = False,
+) -> dict:
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_outside_soloing_repair_repeatability_consolidation_v1",
+        "selected_source_objective_support": {
+            "source_candidate_count": 2,
+            "qualified_source_candidate_count": 2,
+            "dead_air_preserved_source_candidate_count": 2,
+        },
+        "policy_repeatability_support": {
+            "supported_repair_policy_count": 3,
+            "total_variant_count": 6,
+            "total_qualified_variant_count": 6,
+            "selected_min_chord_tone_ratio": 1.0,
+            "selected_max_non_chord_tone_run": 0,
+            "selected_max_interval": 7,
+        },
+        "pending_user_review": {
+            "boundary": "outside_soloing_repair_audio_review_pending",
+            "review_input_present": review_input_present,
+            "human_audio_preference_claimed": False,
+        },
+        "consolidated_claim_boundary": {
+            "boundary": boundary,
+            "objective_repair_repeatability_claimed": True,
+            "human_audio_preference_claimed": False,
+            "multi_reviewer_preference_claimed": False,
+            "broad_model_quality_claimed": broad_claim,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_improviser_claimed": False,
+        },
+    }
+
+
+class StageBDurationCoverageOutsideSoloingRepairFinalDecisionTest(unittest.TestCase):
+    def test_records_objective_path_complete_and_next_readme_boundary(self) -> None:
+        report = build_final_decision(
+            repeatability_consolidation(),
+            output_dir=Path("outputs/final_decision"),
+        )
+        summary = validate_final_decision(
+            report,
+            expected_final_boundary="outside_soloing_repair_objective_path_complete",
+            expected_next_boundary="stage_b_model_core_evidence_readme_refresh",
+            require_auto_progress_allowed=True,
+            require_no_critical_user_input=True,
+            require_no_preference_claim=True,
+            require_no_broad_quality_claim=True,
+        )
+
+        self.assertEqual(summary["input_boundary"], "outside_soloing_repair_objective_repeatability_support")
+        self.assertEqual(summary["next_boundary"], "stage_b_model_core_evidence_readme_refresh")
+        self.assertTrue(summary["auto_progress_allowed"])
+        self.assertFalse(summary["critical_user_input_required"])
+        self.assertFalse(summary["review_input_present"])
+        self.assertFalse(summary["human_audio_preference_claimed"])
+        self.assertFalse(summary["broad_model_quality_claimed"])
+
+    def test_rejects_incomplete_repeatability_boundary(self) -> None:
+        with self.assertRaises(StageBDurationCoverageOutsideSoloingRepairFinalDecisionError):
+            build_final_decision(
+                repeatability_consolidation(boundary="outside_soloing_repair_objective_repeatability_incomplete"),
+                output_dir=Path("outputs/final_decision"),
+            )
+
+    def test_rejects_review_input_for_objective_only_final_decision(self) -> None:
+        with self.assertRaises(StageBDurationCoverageOutsideSoloingRepairFinalDecisionError):
+            build_final_decision(
+                repeatability_consolidation(review_input_present=True),
+                output_dir=Path("outputs/final_decision"),
+            )
+
+    def test_rejects_broad_quality_claim(self) -> None:
+        with self.assertRaises(StageBDurationCoverageOutsideSoloingRepairFinalDecisionError):
+            build_final_decision(
+                repeatability_consolidation(broad_claim=True),
+                output_dir=Path("outputs/final_decision"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- outside-soloing repair objective path final boundary 기록
- human/audio preference pending boundary 보존
- next boundary를 model-core evidence README refresh로 정의

## Context

- Issue #375 repeatability consolidation 결과: objective source support `2/2`, policy support `3/3`, qualified variants `6/6`
- Review input present: `false`
- Human/audio preference claimed: `false`
- Broad model quality claimed: `false`

## Scope

- final decision script 추가
- focused unit test 추가
- harness mode 추가
- status/core/handoff docs 갱신

## Validation

- `.venv/bin/python -m unittest tests/test_stage_b_duration_coverage_outside_soloing_repair_final_decision.py`
- `bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-final-decision`
- `bash scripts/agent_harness.sh quick`

## Risk

- human/audio preference 미검증
- broad trained-model quality 미검증
- next boundary는 README evidence refresh이며 모델 품질 확장 claim 아님

## Follow-up

- Stage B model-core evidence README refresh

Closes #377