### PR TITLE
Stage B generic base readiness audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #383, Muzig application resume wording.
+- Latest functional issue completed: Issue #385, Stage B generic base readiness audit.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Application resume HTML/content insertion outside this repository if requested.
+- Recommended next issue: Stage B generic base manifest contract.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -866,6 +866,14 @@ bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-f
 ```
 
 This harness records the objective-only final boundary and routes the next automatic task to model-core evidence README refresh without claiming human/audio preference.
+
+For Stage B generic jazz base readiness audit changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-generic-base-readiness-audit
+```
+
+This harness verifies that dataset pool evidence and Stage B objective-path evidence support Phase 4 preparation without claiming broad trained-model quality or Brad style adaptation.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -136,6 +136,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - model-core evidence README refresh: `README.md`
 - model-core portfolio bullet draft 문서: `docs/STAGE_B_MODEL_CORE_PORTFOLIO_BULLET_DRAFT_2026-05-29.md`
 - Muzig application resume wording 문서: `docs/MUZIG_APPLICATION_RESUME_WORDING_2026-05-29.md`
+- generic base readiness audit 문서: `docs/STAGE_B_GENERIC_BASE_READINESS_AUDIT_2026-05-29.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -210,6 +211,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - model-core evidence README refresh: 구현 범위, 문제/해결/결과, 검증 결과, claim boundary 중심으로 README 재정리
 - model-core portfolio bullet draft: resume bullet `6`, metric 근거와 unsupported claim guard 분리
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
+- generic base readiness audit: phase4 prep ready `true`, broad training execution ready `false`, broad quality/Brad adaptation claim `false`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -1105,6 +1107,15 @@ Issue #312는 constrained decoding으로 adjacent repeat를 줄였지만 dead-ai
 - generic split에서 train/val leakage가 없다.
 - broad training 결과가 Brad-only tiny probe보다 안정적이다.
 - generated MIDI가 여러 sample에서 review gate를 통과한다.
+
+현재 readiness audit:
+
+- Issue #385 result: dataset readable `2777`, non-Brad candidate `2703`, Brad holdout `72`, duplicate exact hash groups `0`
+- Stage B objective path: `outside_soloing_repair_objective_path_complete`
+- phase4 prep ready: `true`
+- broad training execution ready: `false`
+- broad trained-model quality / Brad style adaptation claim: `false`
+- 다음 작업은 broad training 실행이 아니라 Stage B generic train/val manifest contract 갱신이다.
 
 ### Phase 5. Brad Style Adaptation
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #383, Muzig application resume wording
-- 다음 권장 이슈: `Application resume HTML/content insertion outside this repository if requested`
+- latest functional result: Issue #385, Stage B generic base readiness audit
+- 다음 권장 이슈: `Stage B generic base manifest contract`
 
 현재 범위가 아닌 것:
 
@@ -66,6 +66,44 @@ Docs:
 
 - `docs/STAGE_B_MODEL_CORE_MVP_COMPLETION_AUDIT_2026-05-28.md`
 
+## Current Generic Base Readiness Audit Result
+
+Issue #385는 portfolio/application 정리 이후 Phase 4 generic jazz base 준비로 넘어갈 수 있는지 dataset evidence와 Stage B objective evidence를 분리한 audit이다.
+
+변경:
+
+- generic base readiness audit script 추가
+- dataset audit summary와 outside-soloing repair final decision 결과 연결
+- Phase 4 preparation readiness와 broad training execution readiness 분리
+- broad trained-model quality, Brad style adaptation, production-ready improviser claim guard 유지
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_GENERIC_BASE_READINESS_AUDIT_2026-05-29.md`
+- dataset readable: `2777`
+- candidate non-Brad files: `2703`
+- Brad holdout candidates: `72`
+- duplicate exact hash groups: `0`
+- Stage B objective path: `outside_soloing_repair_objective_path_complete`
+- objective source candidates: `2/2`
+- supported repair policies: `3`
+- qualified variants: `6`
+- phase4 prep ready: `true`
+- broad training execution ready: `false`
+- broad trained-model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+
+판단:
+
+- generic jazz base 준비 단계로 넘어갈 dataset pool과 Stage B objective path 근거는 있음
+- 실제 generic-base training run, multi-seed quality, Brad style adaptation은 아직 미실행
+- 다음 작업은 broad training 실행이 아니라 Stage B generic train/val manifest contract 갱신
+
+다음:
+
+- `Stage B generic base manifest contract`
+
 ## Current Muzig Application Resume Wording Result
 
 Issue #383은 Muzig 지원 맥락에 맞춘 이력서/자기소개 문장을 정리한 작업이다.
@@ -89,11 +127,11 @@ Issue #383은 Muzig 지원 맥락에 맞춘 이력서/자기소개 문장을 정
 
 - 지원 공고 맞춤 이력서 문장 초안 작성 완료
 - repository 내부 claim boundary는 model-core validation pipeline으로 유지
-- 실제 이력서 HTML/개인 문서 반영은 별도 workspace 작업으로 분리
+- 실제 이력서 HTML/개인 문서 반영은 별도 workspace 작업으로 완료
 
 다음:
 
-- `Application resume HTML/content insertion outside this repository if requested`
+- `Stage B generic base readiness audit`
 
 ## Current Model-Core Portfolio Bullet Draft Result
 

--- a/docs/STAGE_B_GENERIC_BASE_READINESS_AUDIT_2026-05-29.md
+++ b/docs/STAGE_B_GENERIC_BASE_READINESS_AUDIT_2026-05-29.md
@@ -1,0 +1,48 @@
+# Stage B Generic Base Readiness Audit
+
+## Summary
+
+- boundary: `stage_b_generic_base_readiness_audit`
+- next boundary: `stage_b_generic_base_manifest_contract`
+- phase4 prep ready: `true`
+- broad training execution ready: `false`
+- broad trained-model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+
+## Dataset Pool
+
+- readable files: `2777`
+- candidate files: `2775`
+- non-Brad candidate files: `2703`
+- Brad holdout candidates: `72`
+- duplicate exact hash groups: `0`
+- generic candidate pool ready: `true`
+
+## Stage B Objective Path
+
+- final boundary: `outside_soloing_repair_objective_path_complete`
+- objective path ready: `true`
+- source candidates: `2`
+- qualified source candidates: `2`
+- supported repair policies: `3`
+- qualified variants: `6`
+
+## Missing For Broad Training Execution
+
+- Stage B generic train/val manifest contract refresh
+- generic split duration-explicit window preparation smoke
+- generic-base training run and multi-sample review gate
+
+## Missing For Brad Style Adaptation
+
+- generic base review-gate pass-rate
+- Brad adaptation or retrieval path experiment
+- Brad holdout evaluation boundary
+
+## Not Proven
+
+- `generic_base_training_run`
+- `generic_base_multi_seed_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`
+- `production_ready_improviser`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -156,6 +156,8 @@ Modes:
                 Consolidate outside-soloing repair objective repeatability boundaries.
   stage-b-duration-coverage-outside-soloing-repair-final-decision
                 Decide final objective-only boundary after outside-soloing repair repeatability.
+  stage-b-generic-base-readiness-audit
+                Assess Stage B readiness before generic jazz base preparation.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -308,6 +310,7 @@ run_quick() {
     scripts/summarize_stage_b_duration_coverage_fill_outside_soloing_repair_objective_evidence_consolidation.py \
     scripts/decide_stage_b_duration_coverage_outside_soloing_repair_next_step.py \
     scripts/summarize_stage_b_duration_coverage_fill_outside_soloing_repair_broader_repeatability_sweep.py \
+    scripts/assess_stage_b_generic_base_readiness.py \
     scripts/build_stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison.py \
     scripts/audit_stage_b_margin_recovered_phrase_vocabulary_duplicate_source_divergence.py \
     scripts/repair_stage_b_margin_recovered_phrase_vocabulary_sample_seed_diversity.py \
@@ -2196,6 +2199,25 @@ run_stage_b_duration_coverage_outside_soloing_repair_final_decision() {
     --require_no_broad_quality_claim
 }
 
+run_stage_b_generic_base_readiness_audit() {
+  local final_decision_run_id="${FINAL_DECISION_RUN_ID:-harness_stage_b_duration_coverage_fill_outside_soloing_repair_final_decision}"
+  local run_id="${RUN_ID:-harness_stage_b_generic_base_readiness_audit}"
+  local final_decision="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_final_decision/${final_decision_run_id}/stage_b_duration_coverage_fill_outside_soloing_repair_final_decision.json"
+  if [[ ! -f "$final_decision" ]]; then
+    print_header "Stage B duration/coverage fill outside-soloing repair final decision"
+    RUN_ID="$final_decision_run_id" run_stage_b_duration_coverage_outside_soloing_repair_final_decision
+  fi
+  print_header "Stage B generic base readiness audit"
+  "$PYTHON_BIN" scripts/assess_stage_b_generic_base_readiness.py \
+    --run_id "$run_id" \
+    --final_decision "$final_decision" \
+    --expected_boundary stage_b_generic_base_readiness_audit \
+    --expected_next_boundary stage_b_generic_base_manifest_contract \
+    --require_phase4_prep_ready \
+    --require_no_broad_quality_claim \
+    --require_no_brad_style_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -3525,6 +3547,9 @@ case "$MODE" in
     ;;
   stage-b-duration-coverage-outside-soloing-repair-final-decision)
     run_stage_b_duration_coverage_outside_soloing_repair_final_decision
+    ;;
+  stage-b-generic-base-readiness-audit)
+    run_stage_b_generic_base_readiness_audit
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/assess_stage_b_generic_base_readiness.py
+++ b/scripts/assess_stage_b_generic_base_readiness.py
@@ -1,0 +1,340 @@
+"""Assess Stage B readiness before moving toward a generic jazz base."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class StageBGenericBaseReadinessError(ValueError):
+    pass
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def validate_inputs(dataset_audit: dict[str, Any], final_decision: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    dataset_summary = _dict(dataset_audit.get("summary"))
+    decision = _dict(final_decision.get("decision"))
+    claim = _dict(final_decision.get("claim_boundary"))
+
+    if not dataset_summary:
+        raise StageBGenericBaseReadinessError("dataset audit summary required")
+    if str(decision.get("final_boundary") or "") != "outside_soloing_repair_objective_path_complete":
+        raise StageBGenericBaseReadinessError("outside-soloing repair final objective boundary required")
+
+    blocked_claims = [
+        "human_audio_preference_claimed",
+        "multi_reviewer_preference_claimed",
+        "broad_model_quality_claimed",
+        "brad_style_adaptation_claimed",
+        "production_ready_improviser_claimed",
+    ]
+    claimed = [name for name in blocked_claims if bool(claim.get(name, True))]
+    if claimed:
+        raise StageBGenericBaseReadinessError(f"unexpected claim for readiness audit: {claimed}")
+    return dataset_summary, claim
+
+
+def build_readiness_report(
+    dataset_audit: dict[str, Any],
+    final_decision: dict[str, Any],
+    *,
+    output_dir: Path,
+    min_non_brad_candidates: int,
+    min_brad_holdout_candidates: int,
+) -> dict[str, Any]:
+    dataset_summary, final_claim = validate_inputs(dataset_audit, final_decision)
+    final_decision_payload = _dict(final_decision.get("decision"))
+    objective = _dict(final_decision.get("objective_repeatability"))
+
+    readable = _int(dataset_summary.get("readable_file_count"))
+    unreadable = _int(dataset_summary.get("unreadable_file_count"))
+    candidate = _int(dataset_summary.get("candidate_file_count"))
+    non_brad = _int(dataset_summary.get("candidate_non_brad_file_count"))
+    brad = _int(dataset_summary.get("candidate_brad_file_count"))
+    duplicate_groups = _int(dataset_summary.get("duplicate_exact_hash_group_count"))
+    duplicate_files = _int(dataset_summary.get("duplicate_exact_file_count"))
+
+    dataset_pool_ready = (
+        readable > 0
+        and unreadable == 0
+        and candidate > 0
+        and non_brad >= min_non_brad_candidates
+        and brad >= min_brad_holdout_candidates
+        and duplicate_groups == 0
+        and duplicate_files == 0
+    )
+    objective_path_ready = bool(final_claim.get("outside_soloing_repair_objective_path_claimed", False))
+    phase4_prep_ready = dataset_pool_ready and objective_path_ready
+
+    missing_for_training_run = [
+        "Stage B generic train/val manifest contract refresh",
+        "generic split duration-explicit window preparation smoke",
+        "generic-base training run and multi-sample review gate",
+    ]
+    missing_for_style_adaptation = [
+        "generic base review-gate pass-rate",
+        "Brad adaptation or retrieval path experiment",
+        "Brad holdout evaluation boundary",
+    ]
+
+    boundary = "stage_b_generic_base_readiness_audit"
+    next_boundary = "stage_b_generic_base_manifest_contract"
+    return {
+        "schema_version": "stage_b_generic_base_readiness_audit_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_dataset_audit": str(dataset_audit.get("input_dir") or ""),
+        "source_final_decision_schema": str(final_decision.get("schema_version") or ""),
+        "dataset_pool": {
+            "readable_file_count": readable,
+            "unreadable_file_count": unreadable,
+            "candidate_file_count": candidate,
+            "candidate_non_brad_file_count": non_brad,
+            "candidate_brad_file_count": brad,
+            "duplicate_exact_hash_group_count": duplicate_groups,
+            "duplicate_exact_file_count": duplicate_files,
+            "min_non_brad_candidates": int(min_non_brad_candidates),
+            "min_brad_holdout_candidates": int(min_brad_holdout_candidates),
+            "generic_candidate_pool_ready": dataset_pool_ready,
+            "brad_holdout_available": brad >= min_brad_holdout_candidates,
+        },
+        "stage_b_objective_path": {
+            "final_boundary": str(final_decision_payload.get("final_boundary") or ""),
+            "objective_path_ready": objective_path_ready,
+            "source_candidate_count": _int(objective.get("source_candidate_count")),
+            "qualified_source_candidate_count": _int(objective.get("qualified_source_candidate_count")),
+            "supported_repair_policy_count": _int(objective.get("supported_repair_policy_count")),
+            "total_qualified_variant_count": _int(objective.get("total_qualified_variant_count")),
+        },
+        "readiness": {
+            "boundary": boundary,
+            "phase4_prep_ready": phase4_prep_ready,
+            "broad_training_execution_ready": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_ready": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_improviser_claimed": False,
+        },
+        "decision": {
+            "current_boundary": boundary,
+            "next_boundary": next_boundary,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": (
+                "dataset pool and Stage B objective path support Phase 4 preparation; "
+                "actual generic-base training and Brad adaptation remain unrun"
+            ),
+        },
+        "missing_for_broad_training_execution": missing_for_training_run,
+        "missing_for_brad_style_adaptation": missing_for_style_adaptation,
+        "proven": [
+            "dataset_audit_readable_candidate_pool",
+            "non_brad_generic_candidate_pool_available",
+            "brad_holdout_pool_available",
+            "stage_b_objective_repair_path_complete",
+        ],
+        "not_proven": [
+            "generic_base_training_run",
+            "generic_base_multi_seed_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "production_ready_improviser",
+        ],
+        "next_recommended_issue": "Stage B generic base manifest contract",
+    }
+
+
+def validate_readiness_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_phase4_prep_ready: bool,
+    require_no_broad_quality_claim: bool,
+    require_no_brad_style_claim: bool,
+) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    dataset = _dict(report.get("dataset_pool"))
+    stage_b = _dict(report.get("stage_b_objective_path"))
+
+    boundary = str(readiness.get("boundary") or "")
+    next_boundary = str(decision.get("next_boundary") or "")
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBGenericBaseReadinessError(f"expected boundary {expected_boundary}, got {boundary}")
+    if expected_next_boundary and next_boundary != expected_next_boundary:
+        raise StageBGenericBaseReadinessError(f"expected next boundary {expected_next_boundary}, got {next_boundary}")
+    if require_phase4_prep_ready and not bool(readiness.get("phase4_prep_ready", False)):
+        raise StageBGenericBaseReadinessError("Phase 4 preparation should be ready")
+    if require_no_broad_quality_claim and bool(readiness.get("broad_trained_model_quality_claimed", True)):
+        raise StageBGenericBaseReadinessError("broad trained-model quality must not be claimed")
+    if require_no_brad_style_claim and bool(readiness.get("brad_style_adaptation_claimed", True)):
+        raise StageBGenericBaseReadinessError("Brad style adaptation must not be claimed")
+
+    return {
+        "boundary": boundary,
+        "next_boundary": next_boundary,
+        "phase4_prep_ready": bool(readiness.get("phase4_prep_ready", False)),
+        "generic_candidate_pool_ready": bool(dataset.get("generic_candidate_pool_ready", False)),
+        "brad_holdout_available": bool(dataset.get("brad_holdout_available", False)),
+        "stage_b_objective_path_ready": bool(stage_b.get("objective_path_ready", False)),
+        "broad_training_execution_ready": bool(readiness.get("broad_training_execution_ready", True)),
+        "broad_trained_model_quality_claimed": bool(
+            readiness.get("broad_trained_model_quality_claimed", True)
+        ),
+        "brad_style_adaptation_claimed": bool(readiness.get("brad_style_adaptation_claimed", True)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    dataset = report["dataset_pool"]
+    stage_b = report["stage_b_objective_path"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    lines = [
+        "# Stage B Generic Base Readiness Audit",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{readiness['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- phase4 prep ready: `{_bool_token(readiness['phase4_prep_ready'])}`",
+        f"- broad training execution ready: `{_bool_token(readiness['broad_training_execution_ready'])}`",
+        f"- broad trained-model quality claimed: `{_bool_token(readiness['broad_trained_model_quality_claimed'])}`",
+        f"- Brad style adaptation claimed: `{_bool_token(readiness['brad_style_adaptation_claimed'])}`",
+        "",
+        "## Dataset Pool",
+        "",
+        f"- readable files: `{dataset['readable_file_count']}`",
+        f"- candidate files: `{dataset['candidate_file_count']}`",
+        f"- non-Brad candidate files: `{dataset['candidate_non_brad_file_count']}`",
+        f"- Brad holdout candidates: `{dataset['candidate_brad_file_count']}`",
+        f"- duplicate exact hash groups: `{dataset['duplicate_exact_hash_group_count']}`",
+        f"- generic candidate pool ready: `{_bool_token(dataset['generic_candidate_pool_ready'])}`",
+        "",
+        "## Stage B Objective Path",
+        "",
+        f"- final boundary: `{stage_b['final_boundary']}`",
+        f"- objective path ready: `{_bool_token(stage_b['objective_path_ready'])}`",
+        f"- source candidates: `{stage_b['source_candidate_count']}`",
+        f"- qualified source candidates: `{stage_b['qualified_source_candidate_count']}`",
+        f"- supported repair policies: `{stage_b['supported_repair_policy_count']}`",
+        f"- qualified variants: `{stage_b['total_qualified_variant_count']}`",
+        "",
+        "## Missing For Broad Training Execution",
+        "",
+    ]
+    for item in report["missing_for_broad_training_execution"]:
+        lines.append(f"- {item}")
+    lines.extend(
+        [
+            "",
+            "## Missing For Brad Style Adaptation",
+            "",
+        ]
+    )
+    for item in report["missing_for_brad_style_adaptation"]:
+        lines.append(f"- {item}")
+    lines.extend(
+        [
+            "",
+            "## Not Proven",
+            "",
+        ]
+    )
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Assess Stage B generic base readiness")
+    parser.add_argument(
+        "--dataset_audit",
+        type=str,
+        default="outputs/dataset_audit/jazz_piano_dataset_audit.json",
+    )
+    parser.add_argument(
+        "--final_decision",
+        type=str,
+        default="outputs/stage_b_duration_coverage_fill_outside_soloing_repair_final_decision/"
+        "harness_stage_b_duration_coverage_fill_outside_soloing_repair_final_decision/"
+        "stage_b_duration_coverage_fill_outside_soloing_repair_final_decision.json",
+    )
+    parser.add_argument("--output_root", type=str, default="outputs/stage_b_generic_base_readiness_audit")
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--min_non_brad_candidates", type=int, default=1000)
+    parser.add_argument("--min_brad_holdout_candidates", type=int, default=20)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_phase4_prep_ready", action="store_true")
+    parser.add_argument("--require_no_broad_quality_claim", action="store_true")
+    parser.add_argument("--require_no_brad_style_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_readiness_report(
+        read_json(Path(args.dataset_audit)),
+        read_json(Path(args.final_decision)),
+        output_dir=output_dir,
+        min_non_brad_candidates=args.min_non_brad_candidates,
+        min_brad_holdout_candidates=args.min_brad_holdout_candidates,
+    )
+    summary = validate_readiness_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_phase4_prep_ready=bool(args.require_phase4_prep_ready),
+        require_no_broad_quality_claim=bool(args.require_no_broad_quality_claim),
+        require_no_brad_style_claim=bool(args.require_no_brad_style_claim),
+    )
+    write_json(output_dir / "stage_b_generic_base_readiness_audit.json", report)
+    write_json(output_dir / "stage_b_generic_base_readiness_audit_validation_summary.json", summary)
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_generic_base_readiness_audit.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_generic_base_readiness_audit.py
+++ b/tests/test_stage_b_generic_base_readiness_audit.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.assess_stage_b_generic_base_readiness import (
+    StageBGenericBaseReadinessError,
+    build_readiness_report,
+    validate_readiness_report,
+)
+
+
+def dataset_audit(*, non_brad: int = 2703, brad: int = 72, duplicate_groups: int = 0) -> dict:
+    return {
+        "input_dir": "midi_dataset/midi",
+        "summary": {
+            "readable_file_count": 2777,
+            "unreadable_file_count": 0,
+            "candidate_file_count": 2775,
+            "candidate_non_brad_file_count": non_brad,
+            "candidate_brad_file_count": brad,
+            "duplicate_exact_hash_group_count": duplicate_groups,
+            "duplicate_exact_file_count": 0,
+        },
+    }
+
+
+def final_decision(*, broad_claim: bool = False, brad_claim: bool = False, boundary: str = "") -> dict:
+    return {
+        "schema_version": "stage_b_duration_coverage_fill_outside_soloing_repair_final_decision_v1",
+        "decision": {
+            "final_boundary": boundary or "outside_soloing_repair_objective_path_complete",
+            "next_boundary": "stage_b_model_core_evidence_readme_refresh",
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+        },
+        "objective_repeatability": {
+            "source_candidate_count": 2,
+            "qualified_source_candidate_count": 2,
+            "supported_repair_policy_count": 3,
+            "total_qualified_variant_count": 6,
+        },
+        "claim_boundary": {
+            "outside_soloing_repair_objective_path_claimed": True,
+            "human_audio_preference_claimed": False,
+            "multi_reviewer_preference_claimed": False,
+            "broad_model_quality_claimed": broad_claim,
+            "brad_style_adaptation_claimed": brad_claim,
+            "production_ready_improviser_claimed": False,
+        },
+    }
+
+
+class StageBGenericBaseReadinessAuditTest(unittest.TestCase):
+    def test_marks_phase4_prep_ready_without_claiming_broad_quality(self) -> None:
+        report = build_readiness_report(
+            dataset_audit(),
+            final_decision(),
+            output_dir=Path("outputs/readiness"),
+            min_non_brad_candidates=1000,
+            min_brad_holdout_candidates=20,
+        )
+        summary = validate_readiness_report(
+            report,
+            expected_boundary="stage_b_generic_base_readiness_audit",
+            expected_next_boundary="stage_b_generic_base_manifest_contract",
+            require_phase4_prep_ready=True,
+            require_no_broad_quality_claim=True,
+            require_no_brad_style_claim=True,
+        )
+
+        self.assertTrue(summary["phase4_prep_ready"])
+        self.assertTrue(summary["generic_candidate_pool_ready"])
+        self.assertTrue(summary["brad_holdout_available"])
+        self.assertTrue(summary["stage_b_objective_path_ready"])
+        self.assertFalse(summary["broad_training_execution_ready"])
+        self.assertFalse(summary["broad_trained_model_quality_claimed"])
+        self.assertFalse(summary["brad_style_adaptation_claimed"])
+
+    def test_rejects_broad_quality_claim(self) -> None:
+        with self.assertRaises(StageBGenericBaseReadinessError):
+            build_readiness_report(
+                dataset_audit(),
+                final_decision(broad_claim=True),
+                output_dir=Path("outputs/readiness"),
+                min_non_brad_candidates=1000,
+                min_brad_holdout_candidates=20,
+            )
+
+    def test_rejects_brad_style_claim(self) -> None:
+        with self.assertRaises(StageBGenericBaseReadinessError):
+            build_readiness_report(
+                dataset_audit(),
+                final_decision(brad_claim=True),
+                output_dir=Path("outputs/readiness"),
+                min_non_brad_candidates=1000,
+                min_brad_holdout_candidates=20,
+            )
+
+    def test_requires_objective_final_boundary(self) -> None:
+        with self.assertRaises(StageBGenericBaseReadinessError):
+            build_readiness_report(
+                dataset_audit(),
+                final_decision(boundary="stage_b_model_core_evidence_readme_refresh"),
+                output_dir=Path("outputs/readiness"),
+                min_non_brad_candidates=1000,
+                min_brad_holdout_candidates=20,
+            )
+
+    def test_phase4_prep_not_ready_when_generic_pool_is_too_small(self) -> None:
+        report = build_readiness_report(
+            dataset_audit(non_brad=20),
+            final_decision(),
+            output_dir=Path("outputs/readiness"),
+            min_non_brad_candidates=1000,
+            min_brad_holdout_candidates=20,
+        )
+
+        self.assertFalse(report["dataset_pool"]["generic_candidate_pool_ready"])
+        self.assertFalse(report["readiness"]["phase4_prep_ready"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Stage B generic base readiness audit 추가
- dataset audit 결과와 outside-soloing repair final decision evidence 연결
- Phase 4 preparation readiness와 broad training execution readiness 분리
- claim guard 유지: broad trained-model quality, Brad style adaptation, production-ready improviser

## Context

- Issue #383 이후 README/portfolio/application 문장 정리 완료
- 현재 claim boundary: symbolic MIDI 생성 검증 파이프라인
- dataset audit: readable `2777`, non-Brad candidate `2703`, Brad holdout `72`, duplicate exact hash groups `0`
- Stage B objective path: `outside_soloing_repair_objective_path_complete`
- objective source candidates: `2/2`
- supported repair policies: `3`
- qualified variants: `6`

## Scope

- `scripts/assess_stage_b_generic_base_readiness.py`
- `tests/test_stage_b_generic_base_readiness_audit.py`
- `stage-b-generic-base-readiness-audit` harness mode
- `docs/STAGE_B_GENERIC_BASE_READINESS_AUDIT_2026-05-29.md`
- `CURRENT_STATUS`, `CORE_PLAN`, `AGENTS` handoff 갱신

## Validation

- `.venv/bin/python -m unittest tests/test_stage_b_generic_base_readiness_audit.py`
- `bash scripts/agent_harness.sh stage-b-generic-base-readiness-audit`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- broad training execution ready: `false`
- broad trained-model quality claimed: `false`
- Brad style adaptation claimed: `false`
- 다음 작업은 broad training 실행이 아니라 Stage B generic train/val manifest contract 갱신

Closes #385


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Stage B generic base readiness audit assessment and validation capabilities with comprehensive reporting.

* **Documentation**
  * Updated project roadmap and status with completion of Stage B generic base readiness audit.
  * Documented readiness metrics, dataset evidence, and next phase requirements.

* **Tests**
  * Added test suite for readiness audit validation and report generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohhalim/fine_tuning_art-tatum_midi_solo/pull/386?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->