### PR TITLE
Stage B generic split duration-explicit window preparation smoke

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #387, Stage B generic base manifest contract.
+- Latest functional issue completed: Issue #389, Stage B generic split duration-explicit window preparation smoke.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B generic split duration-explicit window preparation smoke.
+- Recommended next issue: Stage B generic base tiny training smoke.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -882,6 +882,14 @@ bash scripts/agent_harness.sh stage-b-generic-base-manifest-contract
 ```
 
 This harness verifies generic/Brad manifest split counts and leakage guards before Stage B duration-explicit window preparation, without claiming broad trained-model quality or Brad style adaptation.
+
+For Stage B generic split duration-explicit window preparation smoke changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-generic-manifest-window-smoke
+```
+
+This harness prepares a small generic manifest prefix as `stage_b_v1` duration-explicit windows and verifies train/val token records plus vocab fit without running broad training.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -138,6 +138,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - Muzig application resume wording 문서: `docs/MUZIG_APPLICATION_RESUME_WORDING_2026-05-29.md`
 - generic base readiness audit 문서: `docs/STAGE_B_GENERIC_BASE_READINESS_AUDIT_2026-05-29.md`
 - generic base manifest contract 문서: `docs/STAGE_B_GENERIC_BASE_MANIFEST_CONTRACT_2026-05-29.md`
+- generic manifest window smoke 문서: `docs/STAGE_B_GENERIC_MANIFEST_WINDOW_SMOKE_2026-05-29.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -214,6 +215,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
 - generic base readiness audit: phase4 prep ready `true`, broad training execution ready `false`, broad quality/Brad adaptation claim `false`
 - generic base manifest contract: generic split `2433/270`, Brad split `47/11/14`, leakage/overlap `0`, broad training execution ready `false`
+- generic manifest window smoke: selected files `6/3`, tokenized train/val `556/191`, max token id `544 < 547`, broad training execution ready `false`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -1128,6 +1130,16 @@ Issue #312는 constrained decoding으로 adjacent repeat를 줄였지만 dead-ai
 - manifest contract ready: `true`
 - broad training execution ready: `false`
 - 다음 작업은 generic split manifest를 사용한 Stage B duration-explicit window preparation smoke다.
+
+현재 generic window smoke:
+
+- Issue #389 result: selected train/val files `6/3`
+- tokenized train/val records: `556/191`
+- max token id / vocab size: `544/547`
+- fits vocab: `true`
+- Stage B window prepare smoke ready: `true`
+- generic base training execution ready: `false`
+- 다음 작업은 generic base tiny training smoke다.
 
 ### Phase 5. Brad Style Adaptation
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #387, Stage B generic base manifest contract
-- 다음 권장 이슈: `Stage B generic split duration-explicit window preparation smoke`
+- latest functional result: Issue #389, Stage B generic split duration-explicit window preparation smoke
+- 다음 권장 이슈: `Stage B generic base tiny training smoke`
 
 현재 범위가 아닌 것:
 
@@ -141,6 +141,43 @@ Issue #387은 Phase 4 준비용 generic/Brad manifest split 계약을 검증한 
 다음:
 
 - `Stage B generic split duration-explicit window preparation smoke`
+
+## Current Generic Split Window Preparation Smoke Result
+
+Issue #389는 Issue #387 generic manifest contract 결과를 사용해 작은 generic train/val prefix를 `stage_b_v1` duration-explicit window records로 준비한 smoke 작업이다.
+
+변경:
+
+- generic manifest window smoke script 추가
+- generic_jazz_train/val prefix를 smoke manifest로 복사
+- `prepare_role_dataset.py`를 `stage_b_v1`, 2-bar window, 2-bar stride로 실행
+- tokenized train/val record, max token id, vocab fit 검증
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_GENERIC_MANIFEST_WINDOW_SMOKE_2026-05-29.md`
+- selected train files: `6`
+- selected val files: `3`
+- tokenized train files: `556`
+- tokenized val files: `191`
+- max token id: `544`
+- vocab size: `547`
+- fits vocab: `true`
+- stage_b window prepare smoke ready: `true`
+- generic base training execution ready: `false`
+- broad trained-model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+
+판단:
+
+- generic manifest split이 Stage B duration-explicit window preparation 경로와 호환됨
+- 아직 generic-base training run, multi-seed quality, Brad style adaptation은 미실행
+- 다음 작업은 broad training이 아니라 generic base tiny training smoke
+
+다음:
+
+- `Stage B generic base tiny training smoke`
 
 ## Current Muzig Application Resume Wording Result
 

--- a/docs/STAGE_B_GENERIC_MANIFEST_WINDOW_SMOKE_2026-05-29.md
+++ b/docs/STAGE_B_GENERIC_MANIFEST_WINDOW_SMOKE_2026-05-29.md
@@ -1,0 +1,35 @@
+# Stage B Generic Split Window Preparation Smoke
+
+## Summary
+
+- boundary: `stage_b_generic_stage_b_window_prepare_smoke`
+- next boundary: `stage_b_generic_base_tiny_training_smoke`
+- stage_b window prepare smoke ready: `true`
+- generic base training execution ready: `false`
+- broad trained-model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+
+## Input
+
+- selected train files: `6`
+- selected val files: `3`
+- window bars: `2`
+- window stride bars: `2`
+- min window target notes: `4`
+
+## Tokenized Records
+
+- tokenized train files: `556`
+- tokenized val files: `191`
+- max token id: `544`
+- vocab size: `547`
+- fits vocab: `true`
+- dataset train samples: `556`
+- dataset val samples: `191`
+
+## Not Proven
+
+- `generic_base_training_run`
+- `generic_base_multi_seed_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -160,6 +160,8 @@ Modes:
                 Assess Stage B readiness before generic jazz base preparation.
   stage-b-generic-base-manifest-contract
                 Build and validate generic/Brad split manifest contract before Stage B window preparation.
+  stage-b-generic-manifest-window-smoke
+                Prepare Stage B duration-explicit windows from generic split manifest prefix.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -314,6 +316,7 @@ run_quick() {
     scripts/summarize_stage_b_duration_coverage_fill_outside_soloing_repair_broader_repeatability_sweep.py \
     scripts/assess_stage_b_generic_base_readiness.py \
     scripts/check_stage_b_generic_base_manifest_contract.py \
+    scripts/run_stage_b_generic_manifest_window_smoke.py \
     scripts/build_stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison.py \
     scripts/audit_stage_b_margin_recovered_phrase_vocabulary_duplicate_source_divergence.py \
     scripts/repair_stage_b_margin_recovered_phrase_vocabulary_sample_seed_diversity.py \
@@ -2240,6 +2243,25 @@ run_stage_b_generic_base_manifest_contract() {
     --require_no_brad_style_claim
 }
 
+run_stage_b_generic_manifest_window_smoke() {
+  local manifest_contract_run_id="${MANIFEST_CONTRACT_RUN_ID:-harness_stage_b_generic_base_manifest_contract}"
+  local run_id="${RUN_ID:-harness_stage_b_generic_manifest_window_smoke}"
+  local manifests_dir="outputs/stage_b_generic_base_manifest_contract/${manifest_contract_run_id}/manifests"
+  if [[ ! -f "${manifests_dir}/generic_jazz_train.txt" || ! -f "${manifests_dir}/generic_jazz_val.txt" ]]; then
+    print_header "Stage B generic base manifest contract"
+    RUN_ID="$manifest_contract_run_id" run_stage_b_generic_base_manifest_contract
+  fi
+  print_header "Stage B generic manifest window smoke"
+  "$PYTHON_BIN" scripts/run_stage_b_generic_manifest_window_smoke.py \
+    --run_id "$run_id" \
+    --manifests_dir "$manifests_dir" \
+    --expected_boundary stage_b_generic_stage_b_window_prepare_smoke \
+    --expected_next_boundary stage_b_generic_base_tiny_training_smoke \
+    --require_smoke_ready \
+    --require_no_broad_quality_claim \
+    --require_no_brad_style_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -3575,6 +3597,9 @@ case "$MODE" in
     ;;
   stage-b-generic-base-manifest-contract)
     run_stage_b_generic_base_manifest_contract
+    ;;
+  stage-b-generic-manifest-window-smoke)
+    run_stage_b_generic_manifest_window_smoke
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/run_stage_b_generic_manifest_window_smoke.py
+++ b/scripts/run_stage_b_generic_manifest_window_smoke.py
@@ -1,0 +1,327 @@
+"""Run Stage B duration-explicit window preparation smoke from generic manifests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text
+from scripts.run_manifest_prepare_smoke import read_manifest_paths, write_limited_manifest
+from scripts.run_stage_b_window_tiny_overfit import token_stats
+
+
+class StageBGenericManifestWindowSmokeError(ValueError):
+    pass
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def run_command(command: Sequence[str]) -> None:
+    print("+ " + " ".join(str(part) for part in command))
+    subprocess.run(command, cwd=ROOT_DIR, check=True)
+
+
+def count_npy_files(path: Path) -> int:
+    return len(sorted(path.glob("*.npy")))
+
+
+def build_smoke_report(
+    *,
+    run_dir: Path,
+    source_manifests_dir: Path,
+    train_manifest: Path,
+    val_manifest: Path,
+    roles_dir: Path,
+    selected_train_files: int,
+    selected_val_files: int,
+    window_bars: int,
+    window_stride_bars: int,
+    min_window_target_notes: int,
+) -> dict[str, Any]:
+    role_root = roles_dir / "lead"
+    summary_path = role_root / "dataset_summary.json"
+    dataset_summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    tokenized_dir = role_root / "tokenized"
+    stats = token_stats(tokenized_dir)
+    tokenized_train = count_npy_files(tokenized_dir / "train")
+    tokenized_val = count_npy_files(tokenized_dir / "val")
+    smoke_ready = (
+        selected_train_files > 0
+        and selected_val_files > 0
+        and tokenized_train > 0
+        and tokenized_val > 0
+        and bool(stats.get("fits_vocab", False))
+        and str(dataset_summary.get("sequence_format") or "") == "stage_b_v1"
+        and _int(dataset_summary.get("stage_b_window_bars")) == int(window_bars)
+        and _int(dataset_summary.get("stage_b_window_stride_bars")) == int(window_stride_bars)
+    )
+    boundary = "stage_b_generic_stage_b_window_prepare_smoke"
+    next_boundary = "stage_b_generic_base_tiny_training_smoke"
+    return {
+        "schema_version": "stage_b_generic_manifest_window_smoke_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "run_dir": str(run_dir),
+        "source_manifests_dir": str(source_manifests_dir),
+        "smoke_train_manifest": str(train_manifest),
+        "smoke_val_manifest": str(val_manifest),
+        "roles_dir": str(roles_dir),
+        "input": {
+            "selected_train_files": int(selected_train_files),
+            "selected_val_files": int(selected_val_files),
+            "window_bars": int(window_bars),
+            "window_stride_bars": int(window_stride_bars),
+            "min_window_target_notes": int(min_window_target_notes),
+        },
+        "dataset_summary": dataset_summary,
+        "token_stats": {
+            **stats,
+            "tokenized_train_files": int(tokenized_train),
+            "tokenized_val_files": int(tokenized_val),
+        },
+        "readiness": {
+            "boundary": boundary,
+            "stage_b_window_prepare_smoke_ready": smoke_ready,
+            "generic_base_training_execution_ready": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_improviser_claimed": False,
+        },
+        "decision": {
+            "current_boundary": boundary,
+            "next_boundary": next_boundary,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": (
+                "generic manifest prefix produced stage_b_v1 duration-explicit train/val windows; "
+                "next step is a tiny training smoke, not broad quality claim"
+            ),
+        },
+        "not_proven": [
+            "generic_base_training_run",
+            "generic_base_multi_seed_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": "Stage B generic base tiny training smoke",
+    }
+
+
+def validate_smoke_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_smoke_ready: bool,
+    require_no_broad_quality_claim: bool,
+    require_no_brad_style_claim: bool,
+) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    token = _dict(report.get("token_stats"))
+    boundary = str(readiness.get("boundary") or "")
+    next_boundary = str(decision.get("next_boundary") or "")
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBGenericManifestWindowSmokeError(f"expected boundary {expected_boundary}, got {boundary}")
+    if expected_next_boundary and next_boundary != expected_next_boundary:
+        raise StageBGenericManifestWindowSmokeError(f"expected next boundary {expected_next_boundary}, got {next_boundary}")
+    if require_smoke_ready and not bool(readiness.get("stage_b_window_prepare_smoke_ready", False)):
+        raise StageBGenericManifestWindowSmokeError("Stage B generic window preparation smoke should be ready")
+    if require_no_broad_quality_claim and bool(readiness.get("broad_trained_model_quality_claimed", True)):
+        raise StageBGenericManifestWindowSmokeError("broad trained-model quality must not be claimed")
+    if require_no_brad_style_claim and bool(readiness.get("brad_style_adaptation_claimed", True)):
+        raise StageBGenericManifestWindowSmokeError("Brad style adaptation must not be claimed")
+    if not bool(token.get("fits_vocab", False)):
+        raise StageBGenericManifestWindowSmokeError("token ids must fit the model vocab")
+    if _int(token.get("tokenized_train_files")) <= 0:
+        raise StageBGenericManifestWindowSmokeError("tokenized train records required")
+    if _int(token.get("tokenized_val_files")) <= 0:
+        raise StageBGenericManifestWindowSmokeError("tokenized val records required")
+    return {
+        "boundary": boundary,
+        "next_boundary": next_boundary,
+        "stage_b_window_prepare_smoke_ready": bool(
+            readiness.get("stage_b_window_prepare_smoke_ready", False)
+        ),
+        "tokenized_train_files": _int(token.get("tokenized_train_files")),
+        "tokenized_val_files": _int(token.get("tokenized_val_files")),
+        "fits_vocab": bool(token.get("fits_vocab", False)),
+        "generic_base_training_execution_ready": bool(
+            readiness.get("generic_base_training_execution_ready", True)
+        ),
+        "broad_trained_model_quality_claimed": bool(
+            readiness.get("broad_trained_model_quality_claimed", True)
+        ),
+        "brad_style_adaptation_claimed": bool(readiness.get("brad_style_adaptation_claimed", True)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    inputs = report["input"]
+    token = report["token_stats"]
+    summary = report["dataset_summary"]
+    lines = [
+        "# Stage B Generic Split Window Preparation Smoke",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{readiness['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- stage_b window prepare smoke ready: `{_bool_token(readiness['stage_b_window_prepare_smoke_ready'])}`",
+        f"- generic base training execution ready: `{_bool_token(readiness['generic_base_training_execution_ready'])}`",
+        f"- broad trained-model quality claimed: `{_bool_token(readiness['broad_trained_model_quality_claimed'])}`",
+        f"- Brad style adaptation claimed: `{_bool_token(readiness['brad_style_adaptation_claimed'])}`",
+        "",
+        "## Input",
+        "",
+        f"- selected train files: `{inputs['selected_train_files']}`",
+        f"- selected val files: `{inputs['selected_val_files']}`",
+        f"- window bars: `{inputs['window_bars']}`",
+        f"- window stride bars: `{inputs['window_stride_bars']}`",
+        f"- min window target notes: `{inputs['min_window_target_notes']}`",
+        "",
+        "## Tokenized Records",
+        "",
+        f"- tokenized train files: `{token['tokenized_train_files']}`",
+        f"- tokenized val files: `{token['tokenized_val_files']}`",
+        f"- max token id: `{token['max_token_id']}`",
+        f"- vocab size: `{token['vocab_size']}`",
+        f"- fits vocab: `{_bool_token(token['fits_vocab'])}`",
+        f"- dataset train samples: `{summary.get('train_samples')}`",
+        f"- dataset val samples: `{summary.get('val_samples')}`",
+        "",
+        "## Not Proven",
+        "",
+    ]
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run Stage B generic manifest window preparation smoke")
+    parser.add_argument(
+        "--manifests_dir",
+        type=str,
+        default="outputs/stage_b_generic_base_manifest_contract/"
+        "harness_stage_b_generic_base_manifest_contract/manifests",
+    )
+    parser.add_argument("--output_root", type=str, default="outputs/stage_b_generic_manifest_window_smoke")
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--train_files", type=int, default=6)
+    parser.add_argument("--val_files", type=int, default=3)
+    parser.add_argument("--window_bars", type=int, default=2)
+    parser.add_argument("--window_stride_bars", type=int, default=2)
+    parser.add_argument("--min_window_target_notes", type=int, default=4)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_smoke_ready", action="store_true")
+    parser.add_argument("--require_no_broad_quality_claim", action="store_true")
+    parser.add_argument("--require_no_brad_style_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    run_dir = Path(args.output_root) / run_id
+    if run_dir.exists():
+        shutil.rmtree(run_dir)
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    manifests_dir = Path(args.manifests_dir)
+    train_manifest = run_dir / "smoke_manifests" / "generic_jazz_train.txt"
+    val_manifest = run_dir / "smoke_manifests" / "generic_jazz_val.txt"
+    selected_train = write_limited_manifest(manifests_dir / "generic_jazz_train.txt", train_manifest, args.train_files)
+    selected_val = write_limited_manifest(manifests_dir / "generic_jazz_val.txt", val_manifest, args.val_files)
+    if selected_train <= 0:
+        raise StageBGenericManifestWindowSmokeError("generic smoke train manifest is empty")
+    if selected_val <= 0:
+        raise StageBGenericManifestWindowSmokeError("generic smoke val manifest is empty")
+
+    # Explicit read validates the generated manifest files are parseable after the prefix copy.
+    read_manifest_paths(train_manifest)
+    read_manifest_paths(val_manifest)
+
+    roles_dir = run_dir / "roles"
+    run_command(
+        [
+            sys.executable,
+            "scripts/prepare_role_dataset.py",
+            "--train_manifest",
+            str(train_manifest),
+            "--val_manifest",
+            str(val_manifest),
+            "--output_dir",
+            str(roles_dir),
+            "--role",
+            "lead",
+            "--sequence_format",
+            "stage_b_v1",
+            "--stage_b_window_bars",
+            str(args.window_bars),
+            "--stage_b_window_stride_bars",
+            str(args.window_stride_bars),
+            "--stage_b_min_window_target_notes",
+            str(args.min_window_target_notes),
+            "--overwrite",
+        ]
+    )
+    report = build_smoke_report(
+        run_dir=run_dir,
+        source_manifests_dir=manifests_dir,
+        train_manifest=train_manifest,
+        val_manifest=val_manifest,
+        roles_dir=roles_dir,
+        selected_train_files=selected_train,
+        selected_val_files=selected_val,
+        window_bars=args.window_bars,
+        window_stride_bars=args.window_stride_bars,
+        min_window_target_notes=args.min_window_target_notes,
+    )
+    summary = validate_smoke_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_smoke_ready=bool(args.require_smoke_ready),
+        require_no_broad_quality_claim=bool(args.require_no_broad_quality_claim),
+        require_no_brad_style_claim=bool(args.require_no_brad_style_claim),
+    )
+    write_json(run_dir / "stage_b_generic_manifest_window_smoke.json", report)
+    write_json(run_dir / "stage_b_generic_manifest_window_smoke_validation_summary.json", summary)
+    markdown = markdown_report(report)
+    write_text(run_dir / "stage_b_generic_manifest_window_smoke.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_generic_manifest_window_smoke.py
+++ b/tests/test_stage_b_generic_manifest_window_smoke.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.run_stage_b_generic_manifest_window_smoke import (
+    StageBGenericManifestWindowSmokeError,
+    validate_smoke_report,
+)
+
+
+def smoke_report(*, fits_vocab: bool = True, broad_claim: bool = False) -> dict:
+    return {
+        "readiness": {
+            "boundary": "stage_b_generic_stage_b_window_prepare_smoke",
+            "stage_b_window_prepare_smoke_ready": True,
+            "generic_base_training_execution_ready": False,
+            "broad_trained_model_quality_claimed": broad_claim,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "next_boundary": "stage_b_generic_base_tiny_training_smoke",
+            "critical_user_input_required": False,
+        },
+        "token_stats": {
+            "tokenized_train_files": 12,
+            "tokenized_val_files": 4,
+            "fits_vocab": fits_vocab,
+        },
+        "next_recommended_issue": "Stage B generic base tiny training smoke",
+    }
+
+
+class StageBGenericManifestWindowSmokeTest(unittest.TestCase):
+    def test_accepts_ready_window_smoke_without_quality_claim(self) -> None:
+        summary = validate_smoke_report(
+            smoke_report(),
+            expected_boundary="stage_b_generic_stage_b_window_prepare_smoke",
+            expected_next_boundary="stage_b_generic_base_tiny_training_smoke",
+            require_smoke_ready=True,
+            require_no_broad_quality_claim=True,
+            require_no_brad_style_claim=True,
+        )
+
+        self.assertTrue(summary["stage_b_window_prepare_smoke_ready"])
+        self.assertEqual(summary["tokenized_train_files"], 12)
+        self.assertEqual(summary["tokenized_val_files"], 4)
+        self.assertTrue(summary["fits_vocab"])
+        self.assertFalse(summary["generic_base_training_execution_ready"])
+        self.assertFalse(summary["broad_trained_model_quality_claimed"])
+
+    def test_rejects_broad_quality_claim(self) -> None:
+        with self.assertRaises(StageBGenericManifestWindowSmokeError):
+            validate_smoke_report(
+                smoke_report(broad_claim=True),
+                expected_boundary="stage_b_generic_stage_b_window_prepare_smoke",
+                expected_next_boundary="stage_b_generic_base_tiny_training_smoke",
+                require_smoke_ready=True,
+                require_no_broad_quality_claim=True,
+                require_no_brad_style_claim=True,
+            )
+
+    def test_rejects_vocab_overflow(self) -> None:
+        with self.assertRaises(StageBGenericManifestWindowSmokeError):
+            validate_smoke_report(
+                smoke_report(fits_vocab=False),
+                expected_boundary="stage_b_generic_stage_b_window_prepare_smoke",
+                expected_next_boundary="stage_b_generic_base_tiny_training_smoke",
+                require_smoke_ready=True,
+                require_no_broad_quality_claim=True,
+                require_no_brad_style_claim=True,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- generic split manifest prefix 기반 Stage B window preparation smoke 추가
- `stage_b_v1` duration-explicit train/val token records 생성 검증
- max token id / vocab fit guard 기록
- 다음 경계: Stage B generic base tiny training smoke

## Context

- Issue #387 manifest contract ready: `true`
- generic_jazz_train `2433`, generic_jazz_val `270`
- leakage/overlap `0`
- broad training execution ready: `false`

## Scope

- `scripts/run_stage_b_generic_manifest_window_smoke.py`
- `tests/test_stage_b_generic_manifest_window_smoke.py`
- `stage-b-generic-manifest-window-smoke` harness mode
- `docs/STAGE_B_GENERIC_MANIFEST_WINDOW_SMOKE_2026-05-29.md`
- `CURRENT_STATUS`, `CORE_PLAN`, `AGENTS` handoff 갱신

## Validation

- `.venv/bin/python -m unittest tests/test_stage_b_generic_manifest_window_smoke.py`
- `bash scripts/agent_harness.sh stage-b-generic-manifest-window-smoke`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- smoke는 broad training 실행이 아님
- generated MIDI quality, broad trained-model quality, Brad style adaptation claim 금지
- raw dataset/checkpoint upload 없음

Closes #389
