### PR TITLE
Stage B generic base tiny training smoke

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #389, Stage B generic split duration-explicit window preparation smoke.
+- Latest functional issue completed: Issue #391, Stage B generic base tiny training smoke.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B generic base tiny training smoke.
+- Recommended next issue: Stage B generic tiny checkpoint generation probe.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -890,6 +890,14 @@ bash scripts/agent_harness.sh stage-b-generic-manifest-window-smoke
 ```
 
 This harness prepares a small generic manifest prefix as `stage_b_v1` duration-explicit windows and verifies train/val token records plus vocab fit without running broad training.
+
+For Stage B generic base tiny training smoke changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-generic-base-tiny-training-smoke
+```
+
+This harness copies a small generic Stage B window token subset into the training path and verifies the training command succeeds without claiming broad model quality.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -139,6 +139,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic base readiness audit 문서: `docs/STAGE_B_GENERIC_BASE_READINESS_AUDIT_2026-05-29.md`
 - generic base manifest contract 문서: `docs/STAGE_B_GENERIC_BASE_MANIFEST_CONTRACT_2026-05-29.md`
 - generic manifest window smoke 문서: `docs/STAGE_B_GENERIC_MANIFEST_WINDOW_SMOKE_2026-05-29.md`
+- generic base tiny training smoke 문서: `docs/STAGE_B_GENERIC_BASE_TINY_TRAINING_SMOKE_2026-05-29.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -216,6 +217,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic base readiness audit: phase4 prep ready `true`, broad training execution ready `false`, broad quality/Brad adaptation claim `false`
 - generic base manifest contract: generic split `2433/270`, Brad split `47/11/14`, leakage/overlap `0`, broad training execution ready `false`
 - generic manifest window smoke: selected files `6/3`, tokenized train/val `556/191`, max token id `544 < 547`, broad training execution ready `false`
+- generic base tiny training smoke: selected records `32/8`, best validation loss `6.1427`, training returncode `0`, broad quality claim `false`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -1140,6 +1142,17 @@ Issue #312는 constrained decoding으로 adjacent repeat를 줄였지만 dead-ai
 - Stage B window prepare smoke ready: `true`
 - generic base training execution ready: `false`
 - 다음 작업은 generic base tiny training smoke다.
+
+현재 generic tiny training smoke:
+
+- Issue #391 result: selected train/val records `32/8`
+- token files: `40`
+- max token id / vocab size: `544/547`
+- training returncode: `0`
+- best validation loss: `6.1427`
+- tiny training smoke passed: `true`
+- broad trained-model quality / Brad style adaptation claim: `false`
+- 다음 작업은 tiny checkpoint generation probe다.
 
 ### Phase 5. Brad Style Adaptation
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #389, Stage B generic split duration-explicit window preparation smoke
-- 다음 권장 이슈: `Stage B generic base tiny training smoke`
+- latest functional result: Issue #391, Stage B generic base tiny training smoke
+- 다음 권장 이슈: `Stage B generic tiny checkpoint generation probe`
 
 현재 범위가 아닌 것:
 
@@ -178,6 +178,44 @@ Issue #389는 Issue #387 generic manifest contract 결과를 사용해 작은 ge
 다음:
 
 - `Stage B generic base tiny training smoke`
+
+## Current Generic Base Tiny Training Smoke Result
+
+Issue #391은 Issue #389에서 만든 Stage B generic window token records 일부를 사용해 training path가 실제로 도는지 확인한 smoke 작업이다.
+
+변경:
+
+- generic base tiny training smoke script 추가
+- window smoke tokenized train/val 일부를 별도 smoke dataset으로 복사
+- `train_qlora.py` 1 epoch full-model tiny training path 실행
+- training returncode, best validation loss, vocab fit, claim guard 검증
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_GENERIC_BASE_TINY_TRAINING_SMOKE_2026-05-29.md`
+- selected train records: `32`
+- selected val records: `8`
+- token files: `40`
+- max token id: `544`
+- vocab size: `547`
+- fits vocab: `true`
+- training returncode: `0`
+- best validation loss: `6.1427`
+- tiny training smoke passed: `true`
+- broad training execution ready: `false`
+- broad trained-model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+
+판단:
+
+- generic Stage B window records가 tiny training path에 들어갈 수 있음
+- 아직 generation quality, multi-seed quality, broad trained-model quality는 미검증
+- 다음 작업은 tiny checkpoint generation probe
+
+다음:
+
+- `Stage B generic tiny checkpoint generation probe`
 
 ## Current Muzig Application Resume Wording Result
 

--- a/docs/STAGE_B_GENERIC_BASE_TINY_TRAINING_SMOKE_2026-05-29.md
+++ b/docs/STAGE_B_GENERIC_BASE_TINY_TRAINING_SMOKE_2026-05-29.md
@@ -1,0 +1,31 @@
+# Stage B Generic Base Tiny Training Smoke
+
+## Summary
+
+- boundary: `stage_b_generic_base_tiny_training_smoke`
+- next boundary: `stage_b_generic_tiny_checkpoint_generation_probe`
+- tiny training smoke passed: `true`
+- broad training execution ready: `false`
+- broad trained-model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+
+## Input
+
+- selected train records: `32`
+- selected val records: `8`
+- token files: `40`
+- max token id: `544`
+- vocab size: `547`
+- fits vocab: `true`
+
+## Training
+
+- returncode: `0`
+- best validation loss: `6.1427`
+
+## Not Proven
+
+- `generic_base_generation_quality`
+- `generic_base_multi_seed_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -162,6 +162,8 @@ Modes:
                 Build and validate generic/Brad split manifest contract before Stage B window preparation.
   stage-b-generic-manifest-window-smoke
                 Prepare Stage B duration-explicit windows from generic split manifest prefix.
+  stage-b-generic-base-tiny-training-smoke
+                Run a tiny training smoke from generic Stage B window records.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -317,6 +319,7 @@ run_quick() {
     scripts/assess_stage_b_generic_base_readiness.py \
     scripts/check_stage_b_generic_base_manifest_contract.py \
     scripts/run_stage_b_generic_manifest_window_smoke.py \
+    scripts/run_stage_b_generic_base_tiny_training_smoke.py \
     scripts/build_stage_b_margin_recovered_phrase_vocabulary_human_listening_comparison.py \
     scripts/audit_stage_b_margin_recovered_phrase_vocabulary_duplicate_source_divergence.py \
     scripts/repair_stage_b_margin_recovered_phrase_vocabulary_sample_seed_diversity.py \
@@ -2262,6 +2265,25 @@ run_stage_b_generic_manifest_window_smoke() {
     --require_no_brad_style_claim
 }
 
+run_stage_b_generic_base_tiny_training_smoke() {
+  local window_smoke_run_id="${WINDOW_SMOKE_RUN_ID:-harness_stage_b_generic_manifest_window_smoke}"
+  local run_id="${RUN_ID:-harness_stage_b_generic_base_tiny_training_smoke}"
+  local source_tokenized_dir="outputs/stage_b_generic_manifest_window_smoke/${window_smoke_run_id}/roles/lead/tokenized"
+  if [[ ! -d "${source_tokenized_dir}/train" || ! -d "${source_tokenized_dir}/val" ]]; then
+    print_header "Stage B generic manifest window smoke"
+    RUN_ID="$window_smoke_run_id" run_stage_b_generic_manifest_window_smoke
+  fi
+  print_header "Stage B generic base tiny training smoke"
+  "$PYTHON_BIN" scripts/run_stage_b_generic_base_tiny_training_smoke.py \
+    --run_id "$run_id" \
+    --source_tokenized_dir "$source_tokenized_dir" \
+    --expected_boundary stage_b_generic_base_tiny_training_smoke \
+    --expected_next_boundary stage_b_generic_tiny_checkpoint_generation_probe \
+    --require_training_smoke_passed \
+    --require_no_broad_quality_claim \
+    --require_no_brad_style_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -3600,6 +3622,9 @@ case "$MODE" in
     ;;
   stage-b-generic-manifest-window-smoke)
     run_stage_b_generic_manifest_window_smoke
+    ;;
+  stage-b-generic-base-tiny-training-smoke)
+    run_stage_b_generic_base_tiny_training_smoke
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/run_stage_b_generic_base_tiny_training_smoke.py
+++ b/scripts/run_stage_b_generic_base_tiny_training_smoke.py
@@ -1,0 +1,372 @@
+"""Run a tiny Stage B generic-base training smoke from prepared window records."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+sys.path.insert(0, str(ROOT_DIR / "music_transformer"))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text
+from utilities.constants import VOCAB_SIZE
+
+
+class StageBGenericBaseTinyTrainingSmokeError(ValueError):
+    pass
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def run_command(command: Sequence[str]) -> dict[str, Any]:
+    completed = subprocess.run(
+        list(command),
+        cwd=str(ROOT_DIR),
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    return {
+        "cmd": list(command),
+        "returncode": int(completed.returncode),
+        "stdout_tail": completed.stdout[-4000:],
+        "stderr_tail": completed.stderr[-4000:],
+    }
+
+
+def parse_best_validation_loss(text: str) -> float | None:
+    matches = re.findall(r"Best validation loss:\s*([0-9]+(?:\.[0-9]+)?)", text)
+    return float(matches[-1]) if matches else None
+
+
+def copy_limited_records(source_split_dir: Path, target_split_dir: Path, limit: int) -> int:
+    files = sorted(source_split_dir.glob("*.npy"))[: max(0, int(limit))]
+    target_split_dir.mkdir(parents=True, exist_ok=True)
+    for index, source in enumerate(files):
+        shutil.copy2(source, target_split_dir / f"{index:05d}.npy")
+    return len(files)
+
+
+def token_subset_stats(tokenized_dir: Path) -> dict[str, Any]:
+    files = sorted(tokenized_dir.glob("*/*.npy"))
+    lengths: list[int] = []
+    max_token_id = -1
+    for path in files:
+        tokens = np.load(path)
+        if len(tokens) <= 0:
+            continue
+        lengths.append(int(len(tokens)))
+        max_token_id = max(max_token_id, int(tokens.max()))
+    return {
+        "files": len(files),
+        "non_empty_files": len(lengths),
+        "max_token_id": int(max_token_id),
+        "vocab_size": int(VOCAB_SIZE),
+        "fits_vocab": bool(lengths and max_token_id < VOCAB_SIZE),
+        "min_length": min(lengths) if lengths else 0,
+        "max_length": max(lengths) if lengths else 0,
+    }
+
+
+def build_train_command(args: argparse.Namespace, tokenized_dir: Path, checkpoint_dir: Path) -> list[str]:
+    return [
+        sys.executable,
+        "scripts/train_qlora.py",
+        "--data_dir",
+        str(tokenized_dir),
+        "--output_dir",
+        str(checkpoint_dir),
+        "--epochs",
+        str(args.epochs),
+        "--batch_size",
+        str(args.batch_size),
+        "--gradient_accumulation",
+        "1",
+        "--num_workers",
+        "0",
+        "--label_smoothing",
+        "0.0",
+        "--lr",
+        str(args.lr),
+        "--seed",
+        str(args.seed),
+        "--max_sequence",
+        str(args.max_sequence),
+        "--n_layers",
+        str(args.n_layers),
+        "--num_heads",
+        str(args.num_heads),
+        "--d_model",
+        str(args.d_model),
+        "--dim_feedforward",
+        str(args.dim_feedforward),
+        "--lora_r",
+        str(args.lora_r),
+        "--lora_alpha",
+        str(args.lora_alpha),
+        "--lora_dropout",
+        "0.0",
+        "--train_full_model",
+    ]
+
+
+def build_training_smoke_report(
+    *,
+    run_dir: Path,
+    source_tokenized_dir: Path,
+    tokenized_dir: Path,
+    checkpoint_dir: Path,
+    selected_train_records: int,
+    selected_val_records: int,
+    train_result: dict[str, Any],
+    token_stats: dict[str, Any],
+) -> dict[str, Any]:
+    best_validation_loss = parse_best_validation_loss(
+        str(train_result.get("stdout_tail") or "") + "\n" + str(train_result.get("stderr_tail") or "")
+    )
+    training_smoke_passed = (
+        selected_train_records > 0
+        and selected_val_records > 0
+        and bool(token_stats.get("fits_vocab", False))
+        and int(train_result.get("returncode", 1)) == 0
+        and best_validation_loss is not None
+    )
+    boundary = "stage_b_generic_base_tiny_training_smoke"
+    next_boundary = "stage_b_generic_tiny_checkpoint_generation_probe"
+    return {
+        "schema_version": "stage_b_generic_base_tiny_training_smoke_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "run_dir": str(run_dir),
+        "source_tokenized_dir": str(source_tokenized_dir),
+        "tokenized_dir": str(tokenized_dir),
+        "checkpoint_dir": str(checkpoint_dir),
+        "input": {
+            "selected_train_records": int(selected_train_records),
+            "selected_val_records": int(selected_val_records),
+        },
+        "token_stats": token_stats,
+        "training": {
+            "returncode": int(train_result.get("returncode", 1)),
+            "best_validation_loss": best_validation_loss,
+            "stdout_tail": str(train_result.get("stdout_tail") or ""),
+            "stderr_tail": str(train_result.get("stderr_tail") or ""),
+        },
+        "readiness": {
+            "boundary": boundary,
+            "tiny_training_smoke_passed": training_smoke_passed,
+            "generic_base_training_path_smoked": training_smoke_passed,
+            "broad_training_execution_ready": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_improviser_claimed": False,
+        },
+        "decision": {
+            "current_boundary": boundary,
+            "next_boundary": next_boundary,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": (
+                "generic Stage B window records can enter the tiny training path; "
+                "this is a training contract smoke, not broad model quality evidence"
+            ),
+        },
+        "not_proven": [
+            "generic_base_generation_quality",
+            "generic_base_multi_seed_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": "Stage B generic tiny checkpoint generation probe",
+    }
+
+
+def validate_training_smoke_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_training_smoke_passed: bool,
+    require_no_broad_quality_claim: bool,
+    require_no_brad_style_claim: bool,
+) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    training = _dict(report.get("training"))
+    token = _dict(report.get("token_stats"))
+    boundary = str(readiness.get("boundary") or "")
+    next_boundary = str(decision.get("next_boundary") or "")
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBGenericBaseTinyTrainingSmokeError(f"expected boundary {expected_boundary}, got {boundary}")
+    if expected_next_boundary and next_boundary != expected_next_boundary:
+        raise StageBGenericBaseTinyTrainingSmokeError(f"expected next boundary {expected_next_boundary}, got {next_boundary}")
+    if require_training_smoke_passed and not bool(readiness.get("tiny_training_smoke_passed", False)):
+        raise StageBGenericBaseTinyTrainingSmokeError("tiny training smoke should pass")
+    if require_no_broad_quality_claim and bool(readiness.get("broad_trained_model_quality_claimed", True)):
+        raise StageBGenericBaseTinyTrainingSmokeError("broad trained-model quality must not be claimed")
+    if require_no_brad_style_claim and bool(readiness.get("brad_style_adaptation_claimed", True)):
+        raise StageBGenericBaseTinyTrainingSmokeError("Brad style adaptation must not be claimed")
+    if not bool(token.get("fits_vocab", False)):
+        raise StageBGenericBaseTinyTrainingSmokeError("token ids must fit vocab")
+    if _int(training.get("returncode")) != 0:
+        raise StageBGenericBaseTinyTrainingSmokeError("training command must succeed")
+    return {
+        "boundary": boundary,
+        "next_boundary": next_boundary,
+        "tiny_training_smoke_passed": bool(readiness.get("tiny_training_smoke_passed", False)),
+        "generic_base_training_path_smoked": bool(readiness.get("generic_base_training_path_smoked", False)),
+        "best_validation_loss": training.get("best_validation_loss"),
+        "fits_vocab": bool(token.get("fits_vocab", False)),
+        "broad_training_execution_ready": bool(readiness.get("broad_training_execution_ready", True)),
+        "broad_trained_model_quality_claimed": bool(
+            readiness.get("broad_trained_model_quality_claimed", True)
+        ),
+        "brad_style_adaptation_claimed": bool(readiness.get("brad_style_adaptation_claimed", True)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    inputs = report["input"]
+    token = report["token_stats"]
+    training = report["training"]
+    lines = [
+        "# Stage B Generic Base Tiny Training Smoke",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{readiness['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- tiny training smoke passed: `{_bool_token(readiness['tiny_training_smoke_passed'])}`",
+        f"- broad training execution ready: `{_bool_token(readiness['broad_training_execution_ready'])}`",
+        f"- broad trained-model quality claimed: `{_bool_token(readiness['broad_trained_model_quality_claimed'])}`",
+        f"- Brad style adaptation claimed: `{_bool_token(readiness['brad_style_adaptation_claimed'])}`",
+        "",
+        "## Input",
+        "",
+        f"- selected train records: `{inputs['selected_train_records']}`",
+        f"- selected val records: `{inputs['selected_val_records']}`",
+        f"- token files: `{token['files']}`",
+        f"- max token id: `{token['max_token_id']}`",
+        f"- vocab size: `{token['vocab_size']}`",
+        f"- fits vocab: `{_bool_token(token['fits_vocab'])}`",
+        "",
+        "## Training",
+        "",
+        f"- returncode: `{training['returncode']}`",
+        f"- best validation loss: `{training['best_validation_loss']}`",
+        "",
+        "## Not Proven",
+        "",
+    ]
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run Stage B generic base tiny training smoke")
+    parser.add_argument(
+        "--source_tokenized_dir",
+        type=str,
+        default="outputs/stage_b_generic_manifest_window_smoke/"
+        "harness_stage_b_generic_manifest_window_smoke/roles/lead/tokenized",
+    )
+    parser.add_argument("--output_root", type=str, default="outputs/stage_b_generic_base_tiny_training_smoke")
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--train_records", type=int, default=32)
+    parser.add_argument("--val_records", type=int, default=8)
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--batch_size", type=int, default=8)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--max_sequence", type=int, default=96)
+    parser.add_argument("--n_layers", type=int, default=1)
+    parser.add_argument("--num_heads", type=int, default=4)
+    parser.add_argument("--d_model", type=int, default=64)
+    parser.add_argument("--dim_feedforward", type=int, default=128)
+    parser.add_argument("--lora_r", type=int, default=4)
+    parser.add_argument("--lora_alpha", type=int, default=8)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_training_smoke_passed", action="store_true")
+    parser.add_argument("--require_no_broad_quality_claim", action="store_true")
+    parser.add_argument("--require_no_brad_style_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    run_dir = Path(args.output_root) / run_id
+    if run_dir.exists():
+        shutil.rmtree(run_dir)
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    source_tokenized_dir = Path(args.source_tokenized_dir)
+    tokenized_dir = run_dir / "tokenized"
+    selected_train = copy_limited_records(source_tokenized_dir / "train", tokenized_dir / "train", args.train_records)
+    selected_val = copy_limited_records(source_tokenized_dir / "val", tokenized_dir / "val", args.val_records)
+    if selected_train <= 0:
+        raise StageBGenericBaseTinyTrainingSmokeError("selected train token records required")
+    if selected_val <= 0:
+        raise StageBGenericBaseTinyTrainingSmokeError("selected val token records required")
+    stats = token_subset_stats(tokenized_dir)
+    checkpoint_dir = run_dir / "checkpoints"
+    train_result = run_command(build_train_command(args, tokenized_dir, checkpoint_dir))
+    report = build_training_smoke_report(
+        run_dir=run_dir,
+        source_tokenized_dir=source_tokenized_dir,
+        tokenized_dir=tokenized_dir,
+        checkpoint_dir=checkpoint_dir,
+        selected_train_records=selected_train,
+        selected_val_records=selected_val,
+        train_result=train_result,
+        token_stats=stats,
+    )
+    summary = validate_training_smoke_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_training_smoke_passed=bool(args.require_training_smoke_passed),
+        require_no_broad_quality_claim=bool(args.require_no_broad_quality_claim),
+        require_no_brad_style_claim=bool(args.require_no_brad_style_claim),
+    )
+    write_json(run_dir / "stage_b_generic_base_tiny_training_smoke.json", report)
+    write_json(run_dir / "stage_b_generic_base_tiny_training_smoke_validation_summary.json", summary)
+    markdown = markdown_report(report)
+    write_text(run_dir / "stage_b_generic_base_tiny_training_smoke.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_generic_base_tiny_training_smoke.py
+++ b/tests/test_stage_b_generic_base_tiny_training_smoke.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.run_stage_b_generic_base_tiny_training_smoke import (
+    StageBGenericBaseTinyTrainingSmokeError,
+    parse_best_validation_loss,
+    validate_training_smoke_report,
+)
+
+
+def training_report(*, returncode: int = 0, fits_vocab: bool = True, broad_claim: bool = False) -> dict:
+    return {
+        "readiness": {
+            "boundary": "stage_b_generic_base_tiny_training_smoke",
+            "tiny_training_smoke_passed": returncode == 0 and fits_vocab,
+            "generic_base_training_path_smoked": returncode == 0 and fits_vocab,
+            "broad_training_execution_ready": False,
+            "broad_trained_model_quality_claimed": broad_claim,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "next_boundary": "stage_b_generic_tiny_checkpoint_generation_probe",
+            "critical_user_input_required": False,
+        },
+        "training": {
+            "returncode": returncode,
+            "best_validation_loss": 1.234,
+        },
+        "token_stats": {
+            "fits_vocab": fits_vocab,
+        },
+        "next_recommended_issue": "Stage B generic tiny checkpoint generation probe",
+    }
+
+
+class StageBGenericBaseTinyTrainingSmokeTest(unittest.TestCase):
+    def test_parses_best_validation_loss(self) -> None:
+        self.assertEqual(parse_best_validation_loss("Best validation loss: 1.2345"), 1.2345)
+
+    def test_accepts_passed_training_smoke_without_quality_claim(self) -> None:
+        summary = validate_training_smoke_report(
+            training_report(),
+            expected_boundary="stage_b_generic_base_tiny_training_smoke",
+            expected_next_boundary="stage_b_generic_tiny_checkpoint_generation_probe",
+            require_training_smoke_passed=True,
+            require_no_broad_quality_claim=True,
+            require_no_brad_style_claim=True,
+        )
+
+        self.assertTrue(summary["tiny_training_smoke_passed"])
+        self.assertTrue(summary["generic_base_training_path_smoked"])
+        self.assertEqual(summary["best_validation_loss"], 1.234)
+        self.assertFalse(summary["broad_training_execution_ready"])
+        self.assertFalse(summary["broad_trained_model_quality_claimed"])
+
+    def test_rejects_training_failure(self) -> None:
+        with self.assertRaises(StageBGenericBaseTinyTrainingSmokeError):
+            validate_training_smoke_report(
+                training_report(returncode=1),
+                expected_boundary="stage_b_generic_base_tiny_training_smoke",
+                expected_next_boundary="stage_b_generic_tiny_checkpoint_generation_probe",
+                require_training_smoke_passed=True,
+                require_no_broad_quality_claim=True,
+                require_no_brad_style_claim=True,
+            )
+
+    def test_rejects_broad_quality_claim(self) -> None:
+        with self.assertRaises(StageBGenericBaseTinyTrainingSmokeError):
+            validate_training_smoke_report(
+                training_report(broad_claim=True),
+                expected_boundary="stage_b_generic_base_tiny_training_smoke",
+                expected_next_boundary="stage_b_generic_tiny_checkpoint_generation_probe",
+                require_training_smoke_passed=True,
+                require_no_broad_quality_claim=True,
+                require_no_brad_style_claim=True,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Stage B generic base tiny training smoke 추가
- generic window token subset `32/8`로 `train_qlora.py` 1 epoch training path 검증
- vocab fit, returncode, best validation loss 기록
- 다음 경계: Stage B generic tiny checkpoint generation probe

## Context

- Issue #389 window preparation smoke ready: `true`
- tokenized train/val records: `556/191`
- max token id / vocab size: `544/547`
- broad training execution ready: `false`

## Scope

- `scripts/run_stage_b_generic_base_tiny_training_smoke.py`
- `tests/test_stage_b_generic_base_tiny_training_smoke.py`
- `stage-b-generic-base-tiny-training-smoke` harness mode
- `docs/STAGE_B_GENERIC_BASE_TINY_TRAINING_SMOKE_2026-05-29.md`
- `CURRENT_STATUS`, `CORE_PLAN`, `AGENTS` handoff 갱신

## Validation

- `.venv/bin/python -m unittest tests/test_stage_b_generic_base_tiny_training_smoke.py`
- `bash scripts/agent_harness.sh stage-b-generic-base-tiny-training-smoke`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- tiny smoke는 broad training result가 아님
- generated MIDI quality, broad trained-model quality, Brad style adaptation claim 금지
- raw dataset/checkpoint upload 없음

Closes #391
