### PR TITLE
Stage B generic tiny checkpoint repair listening notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #399, Stage B generic tiny checkpoint repair review package.
+- Latest functional issue completed: Issue #401, Stage B generic tiny checkpoint repair listening notes.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B generic tiny checkpoint repair listening notes.
+- Recommended next issue: Stage B generic tiny checkpoint repair listening fill.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -930,6 +930,14 @@ bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-review-pack
 ```
 
 This harness packages strict-valid repair candidates for review and records MIDI paths without claiming musical quality.
+
+For Stage B generic tiny checkpoint repair listening notes changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-listening-notes
+```
+
+This harness builds pending human-review listening notes for packaged repair candidates without filling or claiming musical quality.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -144,6 +144,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint grammar repair 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_GRAMMAR_REPAIR_2026-05-30.md`
 - generic tiny checkpoint repair repeatability 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_REPEATABILITY_2026-05-30.md`
 - generic tiny checkpoint repair review package 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_REVIEW_PACKAGE_2026-05-30.md`
+- generic tiny checkpoint repair listening notes 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_LISTENING_NOTES_2026-05-30.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -226,6 +227,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint grammar repair: baseline valid/strict/grammar `0/0/0`, repair `2/2/2`, constrained quality claim `false`
 - generic tiny checkpoint repair repeatability: sample `6`, valid/strict/grammar `5/5/6`, constrained quality claim `false`
 - generic tiny checkpoint repair review package: strict-valid candidates `5`, failed rows `1`, musical quality claim `false`
+- generic tiny checkpoint repair listening notes: candidate notes `5`, status `pending_human_review`, musical quality claim `false`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -1210,6 +1212,15 @@ Issue #312는 constrained decoding으로 adjacent repeat를 줄였지만 dead-ai
 - failed row: seed `44`, sample `3`, reason `dead-air ratio too high: 1.000 >= 0.800`
 - musical quality / broad trained-model quality / Brad style adaptation claim: `false/false/false`
 - 다음 작업은 repair listening notes다.
+
+현재 generic tiny checkpoint repair listening notes:
+
+- Issue #401 result: source candidate count `5`
+- notes candidate count: `5`
+- notes status: `pending_human_review`
+- human review filled: `false`
+- musical quality / broad trained-model quality / Brad style adaptation claim: `false/false/false`
+- 다음 작업은 repair listening fill이다.
 
 ### Phase 5. Brad Style Adaptation
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #399, Stage B generic tiny checkpoint repair review package
-- 다음 권장 이슈: `Stage B generic tiny checkpoint repair listening notes`
+- latest functional result: Issue #401, Stage B generic tiny checkpoint repair listening notes
+- 다음 권장 이슈: `Stage B generic tiny checkpoint repair listening fill`
 
 현재 범위가 아닌 것:
 
@@ -380,6 +380,40 @@ Issue #399는 Issue #397 repeatability 결과의 strict-valid repair candidates�
 다음:
 
 - `Stage B generic tiny checkpoint repair listening notes`
+
+## Current Generic Tiny Checkpoint Repair Listening Notes Result
+
+Issue #401은 Issue #399 review package 후보 `5`개를 pending listening notes로 정리한 작업이다.
+
+변경:
+
+- generic tiny checkpoint repair listening notes script 추가
+- 후보별 MIDI path와 objective context를 listening note에 연결
+- human review fields를 pending 상태로 생성
+- musical quality, broad trained-model quality, Brad style adaptation claim guard 유지
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_LISTENING_NOTES_2026-05-30.md`
+- source candidate count: `5`
+- source failed candidate count: `1`
+- notes candidate count: `5`
+- notes status: `pending_human_review`
+- human review filled: `false`
+- musical quality claimed: `false`
+- broad trained-model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+
+판단:
+
+- review package 후보 `5`개에 대한 listening notes template 생성 완료
+- 현재 결과는 청취 입력 대기 상태이며, musical quality 판정은 아님
+- 다음 작업은 listening fill이나 WAV render package
+
+다음:
+
+- `Stage B generic tiny checkpoint repair listening fill`
 
 ## Current Muzig Application Resume Wording Result
 

--- a/docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_LISTENING_NOTES_2026-05-30.md
+++ b/docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_LISTENING_NOTES_2026-05-30.md
@@ -1,0 +1,100 @@
+# Stage B Generic Tiny Checkpoint Repair Listening Notes
+
+## Summary
+
+- boundary: `stage_b_generic_tiny_checkpoint_repair_listening_notes`
+- next boundary: `stage_b_generic_tiny_checkpoint_repair_listening_fill`
+- listening notes ready: `true`
+- human review filled: `false`
+- musical quality claimed: `false`
+- broad trained-model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+
+## Source
+
+- candidate count: `5`
+- failed candidate count: `1`
+- midi dir: `outputs/stage_b_generic_tiny_checkpoint_repair_review_package/issue_399_stage_b_generic_tiny_checkpoint_repair_review_package/midi`
+
+## Notes
+
+- notes status: `pending_human_review`
+- notes candidate count: `5`
+
+### Candidate 1
+
+- midi: `outputs/stage_b_generic_tiny_checkpoint_repair_review_package/issue_399_stage_b_generic_tiny_checkpoint_repair_review_package/midi/rank_01_seed_47_sample_6.mid`
+- seed / sample: `47/6`
+- dead-air / coverage / chord-tone: `0.5/0.6562486875/0.5714285714285714`
+- unique pitch / max simultaneous: `6/2`
+- status: `pending`
+- phrase naturalness: ``
+- time feel: ``
+- inside/outside balance: ``
+- repetition or liveliness: ``
+- keep decision: ``
+- notes: ``
+
+### Candidate 2
+
+- midi: `outputs/stage_b_generic_tiny_checkpoint_repair_review_package/issue_399_stage_b_generic_tiny_checkpoint_repair_review_package/midi/rank_02_seed_45_sample_4.mid`
+- seed / sample: `45/4`
+- dead-air / coverage / chord-tone: `0.5714285714285714/0.8437483124999999/0.5`
+- unique pitch / max simultaneous: `7/2`
+- status: `pending`
+- phrase naturalness: ``
+- time feel: ``
+- inside/outside balance: ``
+- repetition or liveliness: ``
+- keep decision: ``
+- notes: ``
+
+### Candidate 3
+
+- midi: `outputs/stage_b_generic_tiny_checkpoint_repair_review_package/issue_399_stage_b_generic_tiny_checkpoint_repair_review_package/midi/rank_03_seed_42_sample_1.mid`
+- seed / sample: `42/1`
+- dead-air / coverage / chord-tone: `0.6666666666666666/0.9062481875/0.42857142857142855`
+- unique pitch / max simultaneous: `6/2`
+- status: `pending`
+- phrase naturalness: ``
+- time feel: ``
+- inside/outside balance: ``
+- repetition or liveliness: ``
+- keep decision: ``
+- notes: ``
+
+### Candidate 4
+
+- midi: `outputs/stage_b_generic_tiny_checkpoint_repair_review_package/issue_399_stage_b_generic_tiny_checkpoint_repair_review_package/midi/rank_04_seed_43_sample_2.mid`
+- seed / sample: `43/2`
+- dead-air / coverage / chord-tone: `0.6666666666666666/0.7812484375/0.42857142857142855`
+- unique pitch / max simultaneous: `6/2`
+- status: `pending`
+- phrase naturalness: ``
+- time feel: ``
+- inside/outside balance: ``
+- repetition or liveliness: ``
+- keep decision: ``
+- notes: ``
+
+### Candidate 5
+
+- midi: `outputs/stage_b_generic_tiny_checkpoint_repair_review_package/issue_399_stage_b_generic_tiny_checkpoint_repair_review_package/midi/rank_05_seed_46_sample_5.mid`
+- seed / sample: `46/5`
+- dead-air / coverage / chord-tone: `0.7142857142857143/0.7812484375/0.375`
+- unique pitch / max simultaneous: `5/2`
+- status: `pending`
+- phrase naturalness: ``
+- time feel: ``
+- inside/outside balance: ``
+- repetition or liveliness: ``
+- keep decision: ``
+- notes: ``
+
+## Not Proven
+
+- `human_listening_result`
+- `musical_quality`
+- `unconstrained_raw_generation_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -172,6 +172,8 @@ Modes:
                 Run a seed-expanded repeatability probe for the generic tiny checkpoint repair.
   stage-b-generic-tiny-checkpoint-repair-review-package
                 Package strict-valid generic tiny checkpoint repair candidates for review.
+  stage-b-generic-tiny-checkpoint-repair-listening-notes
+                Build pending listening notes for generic tiny checkpoint repair candidates.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -2365,6 +2367,26 @@ run_stage_b_generic_tiny_checkpoint_repair_review_package() {
     --require_no_brad_style_claim
 }
 
+run_stage_b_generic_tiny_checkpoint_repair_listening_notes() {
+  local review_package_run_id="${REVIEW_PACKAGE_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_review_package}"
+  local run_id="${RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_listening_notes}"
+  local review_package_report="outputs/stage_b_generic_tiny_checkpoint_repair_review_package/${review_package_run_id}/stage_b_generic_tiny_checkpoint_repair_review_package.json"
+  if [[ ! -f "$review_package_report" ]]; then
+    print_header "Stage B generic tiny checkpoint repair review package"
+    RUN_ID="$review_package_run_id" run_stage_b_generic_tiny_checkpoint_repair_review_package
+  fi
+  print_header "Stage B generic tiny checkpoint repair listening notes"
+  "$PYTHON_BIN" scripts/build_stage_b_generic_tiny_checkpoint_repair_listening_notes.py \
+    --run_id "$run_id" \
+    --review_package_report "$review_package_report" \
+    --expected_boundary stage_b_generic_tiny_checkpoint_repair_listening_notes \
+    --require_listening_notes_ready \
+    --require_pending_human_review \
+    --require_no_musical_quality_claim \
+    --require_no_broad_quality_claim \
+    --require_no_brad_style_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -3718,6 +3740,9 @@ case "$MODE" in
     ;;
   stage-b-generic-tiny-checkpoint-repair-review-package)
     run_stage_b_generic_tiny_checkpoint_repair_review_package
+    ;;
+  stage-b-generic-tiny-checkpoint-repair-listening-notes)
+    run_stage_b_generic_tiny_checkpoint_repair_listening_notes
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/build_stage_b_generic_tiny_checkpoint_repair_listening_notes.py
+++ b/scripts/build_stage_b_generic_tiny_checkpoint_repair_listening_notes.py
@@ -1,0 +1,300 @@
+"""Build pending listening notes for generic tiny checkpoint repair candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.run_stage_b_generic_tiny_checkpoint_generation_probe import (  # noqa: E402
+    _bool_token,
+    _dict,
+    _float,
+    _int,
+)
+
+
+class StageBGenericTinyCheckpointRepairListeningNotesError(ValueError):
+    pass
+
+
+def build_listening_note(candidate: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "review_rank": _int(candidate.get("review_rank")),
+        "sample_seed": _int(candidate.get("sample_seed")),
+        "sample_index": _int(candidate.get("sample_index")),
+        "midi_path": str(candidate.get("package_midi_path") or candidate.get("source_midi_path") or ""),
+        "objective_context": {
+            "dead_air_ratio": _float(candidate.get("dead_air_ratio")),
+            "phrase_coverage_ratio": _float(candidate.get("phrase_coverage_ratio")),
+            "chord_tone_ratio": _float(candidate.get("chord_tone_ratio")),
+            "unique_pitch_count": _int(candidate.get("unique_pitch_count")),
+            "max_simultaneous_notes": _int(candidate.get("max_simultaneous_notes")),
+            "adjacent_repeated_pitch_ratio": _float(candidate.get("adjacent_repeated_pitch_ratio")),
+            "direction_change_ratio": _float(candidate.get("direction_change_ratio")),
+            "root_tone_ratio": _float(candidate.get("root_tone_ratio")),
+            "tension_ratio": _float(candidate.get("tension_ratio")),
+        },
+        "human_review": {
+            "status": "pending",
+            "phrase_naturalness": "",
+            "time_feel": "",
+            "inside_outside_balance": "",
+            "repetition_or_liveliness": "",
+            "keep_decision": "",
+            "notes": "",
+        },
+    }
+
+
+def build_notes_report(
+    *,
+    run_dir: Path,
+    review_package_report_path: Path,
+    review_package_report: dict[str, Any],
+    notes: list[dict[str, Any]],
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    package = _dict(review_package_report.get("review_package"))
+    candidate_count = len(notes)
+    notes_ready = candidate_count >= int(args.min_candidate_count)
+    return {
+        "schema_version": "stage_b_generic_tiny_checkpoint_repair_listening_notes_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "run_dir": str(run_dir),
+        "review_package_report_path": str(review_package_report_path),
+        "input": {
+            "issue_number": int(args.issue_number),
+            "min_candidate_count": int(args.min_candidate_count),
+        },
+        "source_summary": {
+            "candidate_count": _int(package.get("candidate_count")),
+            "failed_candidate_count": _int(package.get("failed_candidate_count")),
+            "midi_dir": str(package.get("midi_dir") or ""),
+        },
+        "listening_notes": {
+            "candidate_count": candidate_count,
+            "status": "pending_human_review",
+            "notes": notes,
+        },
+        "readiness": {
+            "boundary": "stage_b_generic_tiny_checkpoint_repair_listening_notes",
+            "listening_notes_ready": notes_ready,
+            "human_review_filled": False,
+            "musical_quality_claimed": False,
+            "raw_generation_quality_claimed": False,
+            "constrained_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "current_boundary": "stage_b_generic_tiny_checkpoint_repair_listening_notes",
+            "next_boundary": (
+                "stage_b_generic_tiny_checkpoint_repair_listening_fill"
+                if notes_ready
+                else "stage_b_generic_tiny_checkpoint_repair_listening_notes_rebuild"
+            ),
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "listening notes are prepared as pending human-review inputs without quality claims",
+        },
+        "not_proven": [
+            "human_listening_result",
+            "musical_quality",
+            "unconstrained_raw_generation_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B generic tiny checkpoint repair listening fill"
+            if notes_ready
+            else "Stage B generic tiny checkpoint repair listening notes rebuild"
+        ),
+    }
+
+
+def validate_notes_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    require_listening_notes_ready: bool,
+    require_pending_human_review: bool,
+    require_no_musical_quality_claim: bool,
+    require_no_broad_quality_claim: bool,
+    require_no_brad_style_claim: bool,
+) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    notes = _dict(report.get("listening_notes"))
+    source = _dict(report.get("source_summary"))
+    boundary = str(readiness.get("boundary") or "")
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBGenericTinyCheckpointRepairListeningNotesError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if require_listening_notes_ready and not bool(readiness.get("listening_notes_ready", False)):
+        raise StageBGenericTinyCheckpointRepairListeningNotesError("listening notes should be ready")
+    if require_pending_human_review and notes.get("status") != "pending_human_review":
+        raise StageBGenericTinyCheckpointRepairListeningNotesError("listening notes must stay pending")
+    if require_pending_human_review and bool(readiness.get("human_review_filled", True)):
+        raise StageBGenericTinyCheckpointRepairListeningNotesError("human review must not be marked filled")
+    if require_no_musical_quality_claim and bool(readiness.get("musical_quality_claimed", True)):
+        raise StageBGenericTinyCheckpointRepairListeningNotesError("musical quality must not be claimed")
+    if require_no_broad_quality_claim and bool(readiness.get("broad_trained_model_quality_claimed", True)):
+        raise StageBGenericTinyCheckpointRepairListeningNotesError("broad trained-model quality must not be claimed")
+    if require_no_brad_style_claim and bool(readiness.get("brad_style_adaptation_claimed", True)):
+        raise StageBGenericTinyCheckpointRepairListeningNotesError("Brad style adaptation must not be claimed")
+    if _int(notes.get("candidate_count")) <= 0:
+        raise StageBGenericTinyCheckpointRepairListeningNotesError("candidate notes count must be positive")
+    return {
+        "boundary": boundary,
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "source_candidate_count": _int(source.get("candidate_count")),
+        "source_failed_candidate_count": _int(source.get("failed_candidate_count")),
+        "notes_candidate_count": _int(notes.get("candidate_count")),
+        "notes_status": str(notes.get("status") or ""),
+        "listening_notes_ready": bool(readiness.get("listening_notes_ready", False)),
+        "human_review_filled": bool(readiness.get("human_review_filled", True)),
+        "musical_quality_claimed": bool(readiness.get("musical_quality_claimed", True)),
+        "raw_generation_quality_claimed": bool(readiness.get("raw_generation_quality_claimed", True)),
+        "constrained_generation_quality_claimed": bool(
+            readiness.get("constrained_generation_quality_claimed", True)
+        ),
+        "broad_trained_model_quality_claimed": bool(
+            readiness.get("broad_trained_model_quality_claimed", True)
+        ),
+        "brad_style_adaptation_claimed": bool(readiness.get("brad_style_adaptation_claimed", True)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    notes = report["listening_notes"]
+    source = report["source_summary"]
+    lines = [
+        "# Stage B Generic Tiny Checkpoint Repair Listening Notes",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{readiness['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- listening notes ready: `{_bool_token(readiness['listening_notes_ready'])}`",
+        f"- human review filled: `{_bool_token(readiness['human_review_filled'])}`",
+        f"- musical quality claimed: `{_bool_token(readiness['musical_quality_claimed'])}`",
+        f"- broad trained-model quality claimed: `{_bool_token(readiness['broad_trained_model_quality_claimed'])}`",
+        f"- Brad style adaptation claimed: `{_bool_token(readiness['brad_style_adaptation_claimed'])}`",
+        "",
+        "## Source",
+        "",
+        f"- candidate count: `{source['candidate_count']}`",
+        f"- failed candidate count: `{source['failed_candidate_count']}`",
+        f"- midi dir: `{source['midi_dir']}`",
+        "",
+        "## Notes",
+        "",
+        f"- notes status: `{notes['status']}`",
+        f"- notes candidate count: `{notes['candidate_count']}`",
+        "",
+    ]
+    for note in notes["notes"]:
+        context = note["objective_context"]
+        review = note["human_review"]
+        lines.extend(
+            [
+                f"### Candidate {note['review_rank']}",
+                "",
+                f"- midi: `{note['midi_path']}`",
+                f"- seed / sample: `{note['sample_seed']}/{note['sample_index']}`",
+                f"- dead-air / coverage / chord-tone: `{context['dead_air_ratio']}/"
+                f"{context['phrase_coverage_ratio']}/{context['chord_tone_ratio']}`",
+                f"- unique pitch / max simultaneous: `{context['unique_pitch_count']}/"
+                f"{context['max_simultaneous_notes']}`",
+                f"- status: `{review['status']}`",
+                f"- phrase naturalness: `{review['phrase_naturalness']}`",
+                f"- time feel: `{review['time_feel']}`",
+                f"- inside/outside balance: `{review['inside_outside_balance']}`",
+                f"- repetition or liveliness: `{review['repetition_or_liveliness']}`",
+                f"- keep decision: `{review['keep_decision']}`",
+                f"- notes: `{review['notes']}`",
+                "",
+            ]
+        )
+    lines.extend(["## Not Proven", ""])
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build pending listening notes for repair review candidates")
+    parser.add_argument(
+        "--review_package_report",
+        type=str,
+        default="outputs/stage_b_generic_tiny_checkpoint_repair_review_package/"
+        "harness_stage_b_generic_tiny_checkpoint_repair_review_package/"
+        "stage_b_generic_tiny_checkpoint_repair_review_package.json",
+    )
+    parser.add_argument("--output_root", type=str, default="outputs/stage_b_generic_tiny_checkpoint_repair_listening_notes")
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=401)
+    parser.add_argument("--min_candidate_count", type=int, default=5)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--require_listening_notes_ready", action="store_true")
+    parser.add_argument("--require_pending_human_review", action="store_true")
+    parser.add_argument("--require_no_musical_quality_claim", action="store_true")
+    parser.add_argument("--require_no_broad_quality_claim", action="store_true")
+    parser.add_argument("--require_no_brad_style_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    run_dir = Path(args.output_root) / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    review_package_report_path = Path(args.review_package_report)
+    if not review_package_report_path.exists():
+        raise StageBGenericTinyCheckpointRepairListeningNotesError("review package report required")
+    review_package_report = read_json(review_package_report_path)
+    candidates = _dict(review_package_report.get("review_package")).get("candidates") or []
+    notes = [build_listening_note(candidate) for candidate in candidates]
+    report = build_notes_report(
+        run_dir=run_dir,
+        review_package_report_path=review_package_report_path,
+        review_package_report=review_package_report,
+        notes=notes,
+        args=args,
+    )
+    summary = validate_notes_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        require_listening_notes_ready=bool(args.require_listening_notes_ready),
+        require_pending_human_review=bool(args.require_pending_human_review),
+        require_no_musical_quality_claim=bool(args.require_no_musical_quality_claim),
+        require_no_broad_quality_claim=bool(args.require_no_broad_quality_claim),
+        require_no_brad_style_claim=bool(args.require_no_brad_style_claim),
+    )
+    write_json(run_dir / "stage_b_generic_tiny_checkpoint_repair_listening_notes.json", report)
+    write_json(run_dir / "stage_b_generic_tiny_checkpoint_repair_listening_notes_validation_summary.json", summary)
+    markdown = markdown_report(report)
+    write_text(run_dir / "stage_b_generic_tiny_checkpoint_repair_listening_notes.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_generic_tiny_checkpoint_repair_listening_notes.py
+++ b/tests/test_stage_b_generic_tiny_checkpoint_repair_listening_notes.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import argparse
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.build_stage_b_generic_tiny_checkpoint_repair_listening_notes import (
+    StageBGenericTinyCheckpointRepairListeningNotesError,
+    build_listening_note,
+    build_notes_report,
+    validate_notes_report,
+)
+
+
+def candidate(rank: int = 1) -> dict:
+    return {
+        "review_rank": rank,
+        "sample_seed": 42 + rank,
+        "sample_index": rank,
+        "package_midi_path": f"outputs/review/rank_{rank:02d}.mid",
+        "dead_air_ratio": 0.5,
+        "phrase_coverage_ratio": 0.8,
+        "chord_tone_ratio": 0.4,
+        "unique_pitch_count": 6,
+        "max_simultaneous_notes": 2,
+        "adjacent_repeated_pitch_ratio": 0.0,
+        "direction_change_ratio": 0.8,
+        "root_tone_ratio": 0.1,
+        "tension_ratio": 0.2,
+    }
+
+
+def notes_report(*, ready: bool = True, filled: bool = False, musical_claim: bool = False) -> dict:
+    return {
+        "readiness": {
+            "boundary": "stage_b_generic_tiny_checkpoint_repair_listening_notes",
+            "listening_notes_ready": ready,
+            "human_review_filled": filled,
+            "musical_quality_claimed": musical_claim,
+            "raw_generation_quality_claimed": False,
+            "constrained_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "next_boundary": "stage_b_generic_tiny_checkpoint_repair_listening_fill",
+            "critical_user_input_required": False,
+        },
+        "source_summary": {
+            "candidate_count": 5,
+            "failed_candidate_count": 1,
+        },
+        "listening_notes": {
+            "candidate_count": 5,
+            "status": "pending_human_review",
+        },
+        "next_recommended_issue": "Stage B generic tiny checkpoint repair listening fill",
+    }
+
+
+class StageBGenericTinyCheckpointRepairListeningNotesTest(unittest.TestCase):
+    def test_builds_pending_note_fields(self) -> None:
+        note = build_listening_note(candidate())
+
+        self.assertEqual(note["human_review"]["status"], "pending")
+        self.assertEqual(note["human_review"]["keep_decision"], "")
+        self.assertEqual(note["objective_context"]["dead_air_ratio"], 0.5)
+        self.assertIn("rank_01.mid", note["midi_path"])
+
+    def test_accepts_ready_pending_notes_without_quality_claim(self) -> None:
+        summary = validate_notes_report(
+            notes_report(),
+            expected_boundary="stage_b_generic_tiny_checkpoint_repair_listening_notes",
+            require_listening_notes_ready=True,
+            require_pending_human_review=True,
+            require_no_musical_quality_claim=True,
+            require_no_broad_quality_claim=True,
+            require_no_brad_style_claim=True,
+        )
+
+        self.assertEqual(summary["notes_candidate_count"], 5)
+        self.assertEqual(summary["notes_status"], "pending_human_review")
+        self.assertFalse(summary["human_review_filled"])
+        self.assertFalse(summary["musical_quality_claimed"])
+
+    def test_rejects_filled_human_review(self) -> None:
+        with self.assertRaises(StageBGenericTinyCheckpointRepairListeningNotesError):
+            validate_notes_report(
+                notes_report(filled=True),
+                expected_boundary="stage_b_generic_tiny_checkpoint_repair_listening_notes",
+                require_listening_notes_ready=True,
+                require_pending_human_review=True,
+                require_no_musical_quality_claim=True,
+                require_no_broad_quality_claim=True,
+                require_no_brad_style_claim=True,
+            )
+
+    def test_rejects_musical_quality_claim(self) -> None:
+        with self.assertRaises(StageBGenericTinyCheckpointRepairListeningNotesError):
+            validate_notes_report(
+                notes_report(musical_claim=True),
+                expected_boundary="stage_b_generic_tiny_checkpoint_repair_listening_notes",
+                require_listening_notes_ready=True,
+                require_pending_human_review=True,
+                require_no_musical_quality_claim=True,
+                require_no_broad_quality_claim=True,
+                require_no_brad_style_claim=True,
+            )
+
+    def test_build_report_routes_ready_notes_to_fill(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            args = argparse.Namespace(issue_number=401, min_candidate_count=5)
+            report = build_notes_report(
+                run_dir=root,
+                review_package_report_path=root / "review_package.json",
+                review_package_report={
+                    "review_package": {
+                        "candidate_count": 5,
+                        "failed_candidate_count": 1,
+                        "midi_dir": "outputs/review/midi",
+                    }
+                },
+                notes=[build_listening_note(candidate(index)) for index in range(1, 6)],
+                args=args,
+            )
+
+        self.assertTrue(report["readiness"]["listening_notes_ready"])
+        self.assertFalse(report["readiness"]["musical_quality_claimed"])
+        self.assertEqual(report["decision"]["next_boundary"], "stage_b_generic_tiny_checkpoint_repair_listening_fill")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- #399 review package 후보 `5`개 기반 pending listening notes 추가
- 후보별 MIDI path, objective metrics, human review fields 기록
- musical quality claim 없이 청취 입력 대기 상태 유지

## Context

- #399 candidate count: `5`
- failed candidate count: `1`
- MIDI review package path 기록 완료
- 미정리 지점: 후보별 청취 기록 양식과 objective context
- 제외 범위: musical quality pass/fail, broad trained-model quality, Brad style adaptation

## Scope

- `scripts/build_stage_b_generic_tiny_checkpoint_repair_listening_notes.py` 추가
- `stage-b-generic-tiny-checkpoint-repair-listening-notes` harness mode 추가
- focused unit test 추가
- `CURRENT_STATUS_AND_PLAN`, `CORE_PLAN`, `AGENTS` handoff 갱신
- 결과 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_LISTENING_NOTES_2026-05-30.md`

## Result

- source candidate count: `5`
- source failed candidate count: `1`
- notes candidate count: `5`
- notes status: `pending_human_review`
- human review filled: `false`
- musical quality claimed: `false`
- next boundary: `Stage B generic tiny checkpoint repair listening fill`

## Validation

- `./.venv/bin/python -m unittest tests/test_stage_b_generic_tiny_checkpoint_repair_listening_notes.py`
- `./.venv/bin/python -m compileall scripts/build_stage_b_generic_tiny_checkpoint_repair_listening_notes.py tests/test_stage_b_generic_tiny_checkpoint_repair_listening_notes.py`
- `RUN_ID=issue_401_stage_b_generic_tiny_checkpoint_repair_listening_notes_harness REVIEW_PACKAGE_RUN_ID=harness_stage_b_generic_tiny_checkpoint_repair_review_package bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-listening-notes`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- listening notes는 청취 입력 대기 상태
- musical quality 판정 아님
- raw generated artifact upload 없음

Closes #401