### PR TITLE
Stage B generic tiny checkpoint repair listening fill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #401, Stage B generic tiny checkpoint repair listening notes.
+- Latest functional issue completed: Issue #403, Stage B generic tiny checkpoint repair listening fill.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B generic tiny checkpoint repair listening fill.
+- Recommended next issue: Stage B generic tiny checkpoint repair audio render package.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -938,6 +938,14 @@ bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-listening-n
 ```
 
 This harness builds pending human-review listening notes for packaged repair candidates without filling or claiming musical quality.
+
+For Stage B generic tiny checkpoint repair listening fill changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-listening-fill
+```
+
+This harness guards listening-note fill when human review input is absent and keeps musical quality claims blocked.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -145,6 +145,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint repair repeatability 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_REPEATABILITY_2026-05-30.md`
 - generic tiny checkpoint repair review package 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_REVIEW_PACKAGE_2026-05-30.md`
 - generic tiny checkpoint repair listening notes 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_LISTENING_NOTES_2026-05-30.md`
+- generic tiny checkpoint repair listening fill 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_LISTENING_FILL_2026-05-30.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -228,6 +229,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint repair repeatability: sample `6`, valid/strict/grammar `5/5/6`, constrained quality claim `false`
 - generic tiny checkpoint repair review package: strict-valid candidates `5`, failed rows `1`, musical quality claim `false`
 - generic tiny checkpoint repair listening notes: candidate notes `5`, status `pending_human_review`, musical quality claim `false`
+- generic tiny checkpoint repair listening fill: review input `false`, fill status `pending_review_input`, candidate `5`, auto progress `true`, musical quality claim `false`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -1221,6 +1223,17 @@ Issue #312는 constrained decoding으로 adjacent repeat를 줄였지만 dead-ai
 - human review filled: `false`
 - musical quality / broad trained-model quality / Brad style adaptation claim: `false/false/false`
 - 다음 작업은 repair listening fill이다.
+
+현재 generic tiny checkpoint repair listening fill:
+
+- Issue #403 result: review input present `false`
+- fill status: `pending_review_input`
+- listening fill status: `pending_review_input`
+- candidate count / keep count: `5/0`
+- human review filled: `false`
+- musical quality / broad trained-model quality / Brad style adaptation claim: `false/false/false`
+- objective-only auto progress allowed: `true`
+- 다음 작업은 repair audio render package다.
 
 ### Phase 5. Brad Style Adaptation
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #401, Stage B generic tiny checkpoint repair listening notes
-- 다음 권장 이슈: `Stage B generic tiny checkpoint repair listening fill`
+- latest functional result: Issue #403, Stage B generic tiny checkpoint repair listening fill
+- 다음 권장 이슈: `Stage B generic tiny checkpoint repair audio render package`
 
 현재 범위가 아닌 것:
 
@@ -414,6 +414,42 @@ Issue #401은 Issue #399 review package 후보 `5`개를 pending listening notes
 다음:
 
 - `Stage B generic tiny checkpoint repair listening fill`
+
+## Current Generic Tiny Checkpoint Repair Listening Fill Result
+
+Issue #403은 Issue #401 pending listening notes에 대해 review input 부재 시 품질 판정을 차단하고 다음 자동 진행 경계를 정리한 작업이다.
+
+변경:
+
+- generic tiny checkpoint repair listening fill script 추가
+- review input schema와 후보별 fill row 검증 추가
+- review input absent 상태에서 pending fill, no musical quality claim, no broad quality claim guard 유지
+- objective-only auto progress boundary를 audio render package로 기록
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_LISTENING_FILL_2026-05-30.md`
+- review input present: `false`
+- fill status: `pending_review_input`
+- listening fill status: `pending_review_input`
+- candidate count: `5`
+- keep count: `0`
+- human review filled: `false`
+- musical quality claimed: `false`
+- broad trained-model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+- auto progress allowed: `true`
+
+판단:
+
+- listening notes 후보 `5`개는 아직 human review input 미반영 상태
+- 현재 결과는 품질 판정이 아니라 review input guard와 다음 자동 진행 경계
+- WAV render package 준비는 critical user input 없이 진행 가능
+
+다음:
+
+- `Stage B generic tiny checkpoint repair audio render package`
 
 ## Current Muzig Application Resume Wording Result
 

--- a/docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_LISTENING_FILL_2026-05-30.md
+++ b/docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_LISTENING_FILL_2026-05-30.md
@@ -1,0 +1,33 @@
+# Stage B Generic Tiny Checkpoint Repair Listening Fill
+
+## Summary
+
+- boundary: `stage_b_generic_tiny_checkpoint_repair_listening_fill`
+- next boundary: `stage_b_generic_tiny_checkpoint_repair_audio_render_package`
+- review input present: `false`
+- fill status: `pending_review_input`
+- listening fill status: `pending_review_input`
+- human review filled: `false`
+- musical quality claimed: `false`
+- broad trained-model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+- auto progress allowed: `true`
+
+## Candidate Reviews
+
+- candidate count: `5`
+- keep count: `0`
+
+- rank `1` seed `47` sample `6` status `pending_review_input` keep `pending`
+- rank `2` seed `45` sample `4` status `pending_review_input` keep `pending`
+- rank `3` seed `42` sample `1` status `pending_review_input` keep `pending`
+- rank `4` seed `43` sample `2` status `pending_review_input` keep `pending`
+- rank `5` seed `46` sample `5` status `pending_review_input` keep `pending`
+
+## Not Proven
+
+- `human_listening_result`
+- `musical_quality`
+- `unconstrained_raw_generation_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -174,6 +174,8 @@ Modes:
                 Package strict-valid generic tiny checkpoint repair candidates for review.
   stage-b-generic-tiny-checkpoint-repair-listening-notes
                 Build pending listening notes for generic tiny checkpoint repair candidates.
+  stage-b-generic-tiny-checkpoint-repair-listening-fill
+                Guard or fill generic tiny checkpoint repair listening notes.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -2387,6 +2389,26 @@ run_stage_b_generic_tiny_checkpoint_repair_listening_notes() {
     --require_no_brad_style_claim
 }
 
+run_stage_b_generic_tiny_checkpoint_repair_listening_fill() {
+  local listening_notes_run_id="${LISTENING_NOTES_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_listening_notes}"
+  local run_id="${RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_listening_fill}"
+  local listening_notes_report="outputs/stage_b_generic_tiny_checkpoint_repair_listening_notes/${listening_notes_run_id}/stage_b_generic_tiny_checkpoint_repair_listening_notes.json"
+  if [[ ! -f "$listening_notes_report" ]]; then
+    print_header "Stage B generic tiny checkpoint repair listening notes"
+    RUN_ID="$listening_notes_run_id" run_stage_b_generic_tiny_checkpoint_repair_listening_notes
+  fi
+  print_header "Stage B generic tiny checkpoint repair listening fill"
+  "$PYTHON_BIN" scripts/fill_stage_b_generic_tiny_checkpoint_repair_listening_notes.py \
+    --run_id "$run_id" \
+    --listening_notes_report "$listening_notes_report" \
+    --expected_boundary stage_b_generic_tiny_checkpoint_repair_listening_fill \
+    --require_pending_without_input \
+    --require_no_quality_without_input \
+    --require_objective_auto_progress_allowed \
+    --require_no_broad_quality_claim \
+    --require_no_brad_style_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -3743,6 +3765,9 @@ case "$MODE" in
     ;;
   stage-b-generic-tiny-checkpoint-repair-listening-notes)
     run_stage_b_generic_tiny_checkpoint_repair_listening_notes
+    ;;
+  stage-b-generic-tiny-checkpoint-repair-listening-fill)
+    run_stage_b_generic_tiny_checkpoint_repair_listening_fill
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/fill_stage_b_generic_tiny_checkpoint_repair_listening_notes.py
+++ b/scripts/fill_stage_b_generic_tiny_checkpoint_repair_listening_notes.py
@@ -1,0 +1,386 @@
+"""Fill or guard generic tiny checkpoint repair listening notes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.run_stage_b_generic_tiny_checkpoint_generation_probe import (  # noqa: E402
+    _bool_token,
+    _dict,
+    _int,
+)
+
+
+class StageBGenericTinyCheckpointRepairListeningFillError(ValueError):
+    pass
+
+
+PHRASE_VALUES = {"natural", "acceptable", "stiff", "unclear"}
+TIME_FEEL_VALUES = {"swinging", "acceptable", "stiff", "unclear"}
+INSIDE_OUTSIDE_VALUES = {"inside", "outside_but_usable", "too_outside", "unclear"}
+REPETITION_VALUES = {"lively", "acceptable", "repetitive", "unclear"}
+KEEP_VALUES = {"keep", "needs_followup", "reject", "unclear"}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def note_items(listening_notes_report: dict[str, Any]) -> list[dict[str, Any]]:
+    readiness = _dict(listening_notes_report.get("readiness"))
+    notes = _dict(listening_notes_report.get("listening_notes"))
+    if str(readiness.get("boundary") or "") != "stage_b_generic_tiny_checkpoint_repair_listening_notes":
+        raise StageBGenericTinyCheckpointRepairListeningFillError("unexpected listening notes boundary")
+    if bool(readiness.get("musical_quality_claimed", True)):
+        raise StageBGenericTinyCheckpointRepairListeningFillError("musical quality must not be claimed before fill")
+    if bool(readiness.get("human_review_filled", True)):
+        raise StageBGenericTinyCheckpointRepairListeningFillError("source notes must not already be filled")
+    if str(notes.get("status") or "") != "pending_human_review":
+        raise StageBGenericTinyCheckpointRepairListeningFillError("source notes must be pending human review")
+    items = [dict(item) for item in _list(notes.get("notes")) if isinstance(item, dict)]
+    if not items:
+        raise StageBGenericTinyCheckpointRepairListeningFillError("listening notes must contain candidates")
+    return items
+
+
+def pending_review_for_note(note: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "review_rank": _int(note.get("review_rank")),
+        "sample_seed": _int(note.get("sample_seed")),
+        "sample_index": _int(note.get("sample_index")),
+        "midi_path": str(note.get("midi_path") or ""),
+        "status": "pending_review_input",
+        "phrase_naturalness": "pending",
+        "time_feel": "pending",
+        "inside_outside_balance": "pending",
+        "repetition_or_liveliness": "pending",
+        "keep_decision": "pending",
+        "notes": "",
+    }
+
+
+def validate_review_input(review_input: dict[str, Any], *, notes: list[dict[str, Any]]) -> dict[str, Any]:
+    reviewer = str(review_input.get("reviewer") or "").strip()
+    if not reviewer:
+        raise StageBGenericTinyCheckpointRepairListeningFillError("reviewer is required")
+    reviews = _list(review_input.get("candidate_reviews"))
+    expected_ranks = {_int(note.get("review_rank")) for note in notes}
+    if len(reviews) != len(notes):
+        raise StageBGenericTinyCheckpointRepairListeningFillError("candidate review count mismatch")
+    compact_reviews: list[dict[str, Any]] = []
+    seen_ranks: set[int] = set()
+    for review in reviews:
+        if not isinstance(review, dict):
+            raise StageBGenericTinyCheckpointRepairListeningFillError("candidate review must be an object")
+        rank = _int(review.get("review_rank"))
+        if rank not in expected_ranks:
+            raise StageBGenericTinyCheckpointRepairListeningFillError(f"unexpected review rank: {rank}")
+        if rank in seen_ranks:
+            raise StageBGenericTinyCheckpointRepairListeningFillError(f"duplicate review rank: {rank}")
+        seen_ranks.add(rank)
+        phrase = str(review.get("phrase_naturalness") or "")
+        time_feel = str(review.get("time_feel") or "")
+        inside_outside = str(review.get("inside_outside_balance") or "")
+        repetition = str(review.get("repetition_or_liveliness") or "")
+        keep = str(review.get("keep_decision") or "")
+        if phrase not in PHRASE_VALUES:
+            raise StageBGenericTinyCheckpointRepairListeningFillError(f"invalid phrase_naturalness: {phrase}")
+        if time_feel not in TIME_FEEL_VALUES:
+            raise StageBGenericTinyCheckpointRepairListeningFillError(f"invalid time_feel: {time_feel}")
+        if inside_outside not in INSIDE_OUTSIDE_VALUES:
+            raise StageBGenericTinyCheckpointRepairListeningFillError(
+                f"invalid inside_outside_balance: {inside_outside}"
+            )
+        if repetition not in REPETITION_VALUES:
+            raise StageBGenericTinyCheckpointRepairListeningFillError(
+                f"invalid repetition_or_liveliness: {repetition}"
+            )
+        if keep not in KEEP_VALUES:
+            raise StageBGenericTinyCheckpointRepairListeningFillError(f"invalid keep_decision: {keep}")
+        compact_reviews.append(
+            {
+                "review_rank": rank,
+                "status": "reviewed",
+                "phrase_naturalness": phrase,
+                "time_feel": time_feel,
+                "inside_outside_balance": inside_outside,
+                "repetition_or_liveliness": repetition,
+                "keep_decision": keep,
+                "notes": str(review.get("notes") or ""),
+            }
+        )
+    return {
+        "reviewer": reviewer,
+        "overall_notes": str(review_input.get("overall_notes") or ""),
+        "candidate_reviews": sorted(compact_reviews, key=lambda item: item["review_rank"]),
+    }
+
+
+def build_review_rows(notes: list[dict[str, Any]], review_input: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if review_input is None:
+        return [pending_review_for_note(note) for note in notes]
+    validated = validate_review_input(review_input, notes=notes)
+    review_by_rank = {review["review_rank"]: review for review in validated["candidate_reviews"]}
+    rows: list[dict[str, Any]] = []
+    for note in notes:
+        rank = _int(note.get("review_rank"))
+        rows.append(
+            {
+                "review_rank": rank,
+                "sample_seed": _int(note.get("sample_seed")),
+                "sample_index": _int(note.get("sample_index")),
+                "midi_path": str(note.get("midi_path") or ""),
+                **review_by_rank[rank],
+            }
+        )
+    return rows
+
+
+def build_listening_fill_report(
+    *,
+    run_dir: Path,
+    listening_notes_report_path: Path,
+    listening_notes_report: dict[str, Any],
+    review_input: dict[str, Any] | None,
+    review_rows: list[dict[str, Any]],
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    review_input_present = review_input is not None
+    keep_count = sum(1 for row in review_rows if row.get("keep_decision") == "keep")
+    fill_status = "review_input_applied" if review_input_present else "pending_review_input"
+    return {
+        "schema_version": "stage_b_generic_tiny_checkpoint_repair_listening_fill_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "run_dir": str(run_dir),
+        "listening_notes_report_path": str(listening_notes_report_path),
+        "input": {
+            "issue_number": int(args.issue_number),
+            "review_input_present": review_input_present,
+        },
+        "source_summary": {
+            "candidate_count": _int(_dict(listening_notes_report.get("listening_notes")).get("candidate_count")),
+            "notes_status": str(_dict(listening_notes_report.get("listening_notes")).get("status") or ""),
+        },
+        "review_input_present": review_input_present,
+        "fill_status": fill_status,
+        "listening_fill": {
+            "status": "reviewed" if review_input_present else "pending_review_input",
+            "reviewer": str(review_input.get("reviewer") or "") if review_input_present else "",
+            "candidate_count": len(review_rows),
+            "keep_count": keep_count,
+            "candidate_reviews": review_rows,
+        },
+        "readiness": {
+            "boundary": "stage_b_generic_tiny_checkpoint_repair_listening_fill",
+            "human_review_filled": review_input_present,
+            "pending_without_review_input": not review_input_present,
+            "musical_quality_claimed": review_input_present and keep_count > 0,
+            "raw_generation_quality_claimed": False,
+            "constrained_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "current_boundary": "stage_b_generic_tiny_checkpoint_repair_listening_fill",
+            "next_boundary": (
+                "stage_b_generic_tiny_checkpoint_repair_listening_consolidation"
+                if review_input_present
+                else "stage_b_generic_tiny_checkpoint_repair_audio_render_package"
+            ),
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "human_review_input_required_for_quality_claim": not review_input_present,
+            "reason": (
+                "human review input is required before musical quality or keep decisions are claimed"
+                if not review_input_present
+                else "validated human review input was applied to listening notes"
+            ),
+        },
+        "not_proven": []
+        if review_input_present
+        else [
+            "human_listening_result",
+            "musical_quality",
+            "unconstrained_raw_generation_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B generic tiny checkpoint repair listening consolidation"
+            if review_input_present
+            else "Stage B generic tiny checkpoint repair audio render package"
+        ),
+    }
+
+
+def validate_listening_fill_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    require_pending_without_input: bool,
+    require_no_quality_without_input: bool,
+    require_objective_auto_progress_allowed: bool,
+    require_no_broad_quality_claim: bool,
+    require_no_brad_style_claim: bool,
+) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    fill = _dict(report.get("listening_fill"))
+    boundary = str(readiness.get("boundary") or "")
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBGenericTinyCheckpointRepairListeningFillError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    review_input_present = bool(report.get("review_input_present", False))
+    if require_pending_without_input and not review_input_present:
+        if str(report.get("fill_status") or "") != "pending_review_input":
+            raise StageBGenericTinyCheckpointRepairListeningFillError("expected pending fill status")
+        if str(fill.get("status") or "") != "pending_review_input":
+            raise StageBGenericTinyCheckpointRepairListeningFillError("expected pending review status")
+    if require_no_quality_without_input and not review_input_present:
+        if bool(readiness.get("musical_quality_claimed", True)):
+            raise StageBGenericTinyCheckpointRepairListeningFillError(
+                "musical quality must not be claimed without input"
+            )
+    if require_objective_auto_progress_allowed and not bool(decision.get("auto_progress_allowed", False)):
+        raise StageBGenericTinyCheckpointRepairListeningFillError("objective auto progress must be allowed")
+    if require_no_broad_quality_claim and bool(readiness.get("broad_trained_model_quality_claimed", True)):
+        raise StageBGenericTinyCheckpointRepairListeningFillError("broad trained-model quality must not be claimed")
+    if require_no_brad_style_claim and bool(readiness.get("brad_style_adaptation_claimed", True)):
+        raise StageBGenericTinyCheckpointRepairListeningFillError("Brad style adaptation must not be claimed")
+    return {
+        "boundary": boundary,
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "review_input_present": review_input_present,
+        "fill_status": str(report.get("fill_status") or ""),
+        "listening_fill_status": str(fill.get("status") or ""),
+        "candidate_count": _int(fill.get("candidate_count")),
+        "keep_count": _int(fill.get("keep_count")),
+        "human_review_filled": bool(readiness.get("human_review_filled", True)),
+        "pending_without_review_input": bool(readiness.get("pending_without_review_input", False)),
+        "musical_quality_claimed": bool(readiness.get("musical_quality_claimed", True)),
+        "broad_trained_model_quality_claimed": bool(
+            readiness.get("broad_trained_model_quality_claimed", True)
+        ),
+        "brad_style_adaptation_claimed": bool(readiness.get("brad_style_adaptation_claimed", True)),
+        "auto_progress_allowed": bool(decision.get("auto_progress_allowed", False)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    fill = report["listening_fill"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    lines = [
+        "# Stage B Generic Tiny Checkpoint Repair Listening Fill",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{readiness['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- review input present: `{_bool_token(report['review_input_present'])}`",
+        f"- fill status: `{report['fill_status']}`",
+        f"- listening fill status: `{fill['status']}`",
+        f"- human review filled: `{_bool_token(readiness['human_review_filled'])}`",
+        f"- musical quality claimed: `{_bool_token(readiness['musical_quality_claimed'])}`",
+        f"- broad trained-model quality claimed: `{_bool_token(readiness['broad_trained_model_quality_claimed'])}`",
+        f"- Brad style adaptation claimed: `{_bool_token(readiness['brad_style_adaptation_claimed'])}`",
+        f"- auto progress allowed: `{_bool_token(decision['auto_progress_allowed'])}`",
+        "",
+        "## Candidate Reviews",
+        "",
+        f"- candidate count: `{fill['candidate_count']}`",
+        f"- keep count: `{fill['keep_count']}`",
+        "",
+    ]
+    for row in fill["candidate_reviews"]:
+        lines.append(
+            "- "
+            f"rank `{row['review_rank']}` "
+            f"seed `{row['sample_seed']}` "
+            f"sample `{row['sample_index']}` "
+            f"status `{row['status']}` "
+            f"keep `{row['keep_decision']}`"
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Fill or guard generic tiny checkpoint repair listening notes")
+    parser.add_argument(
+        "--listening_notes_report",
+        type=str,
+        default="outputs/stage_b_generic_tiny_checkpoint_repair_listening_notes/"
+        "harness_stage_b_generic_tiny_checkpoint_repair_listening_notes/"
+        "stage_b_generic_tiny_checkpoint_repair_listening_notes.json",
+    )
+    parser.add_argument("--review_input", type=str, default="")
+    parser.add_argument("--output_root", type=str, default="outputs/stage_b_generic_tiny_checkpoint_repair_listening_fill")
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=403)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--require_pending_without_input", action="store_true")
+    parser.add_argument("--require_no_quality_without_input", action="store_true")
+    parser.add_argument("--require_objective_auto_progress_allowed", action="store_true")
+    parser.add_argument("--require_no_broad_quality_claim", action="store_true")
+    parser.add_argument("--require_no_brad_style_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    run_dir = Path(args.output_root) / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    listening_notes_report_path = Path(args.listening_notes_report)
+    if not listening_notes_report_path.exists():
+        raise StageBGenericTinyCheckpointRepairListeningFillError("listening notes report required")
+    listening_notes_report = read_json(listening_notes_report_path)
+    review_input = read_json(Path(args.review_input)) if args.review_input else None
+    notes = note_items(listening_notes_report)
+    review_rows = build_review_rows(notes, review_input)
+    report = build_listening_fill_report(
+        run_dir=run_dir,
+        listening_notes_report_path=listening_notes_report_path,
+        listening_notes_report=listening_notes_report,
+        review_input=review_input,
+        review_rows=review_rows,
+        args=args,
+    )
+    summary = validate_listening_fill_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        require_pending_without_input=bool(args.require_pending_without_input),
+        require_no_quality_without_input=bool(args.require_no_quality_without_input),
+        require_objective_auto_progress_allowed=bool(args.require_objective_auto_progress_allowed),
+        require_no_broad_quality_claim=bool(args.require_no_broad_quality_claim),
+        require_no_brad_style_claim=bool(args.require_no_brad_style_claim),
+    )
+    write_json(run_dir / "stage_b_generic_tiny_checkpoint_repair_listening_fill.json", report)
+    write_json(run_dir / "stage_b_generic_tiny_checkpoint_repair_listening_fill_validation_summary.json", summary)
+    markdown = markdown_report(report)
+    write_text(run_dir / "stage_b_generic_tiny_checkpoint_repair_listening_fill.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_generic_tiny_checkpoint_repair_listening_fill.py
+++ b/tests/test_stage_b_generic_tiny_checkpoint_repair_listening_fill.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import argparse
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.fill_stage_b_generic_tiny_checkpoint_repair_listening_notes import (
+    StageBGenericTinyCheckpointRepairListeningFillError,
+    build_listening_fill_report,
+    build_review_rows,
+    note_items,
+    validate_listening_fill_report,
+)
+
+
+def listening_note(rank: int = 1) -> dict:
+    return {
+        "review_rank": rank,
+        "sample_seed": 42 + rank,
+        "sample_index": rank,
+        "midi_path": f"outputs/review/rank_{rank:02d}.mid",
+        "human_review": {
+            "status": "pending",
+        },
+    }
+
+
+def notes_report(*, filled: bool = False, musical_claim: bool = False) -> dict:
+    return {
+        "readiness": {
+            "boundary": "stage_b_generic_tiny_checkpoint_repair_listening_notes",
+            "human_review_filled": filled,
+            "musical_quality_claimed": musical_claim,
+        },
+        "listening_notes": {
+            "status": "pending_human_review",
+            "candidate_count": 2,
+            "notes": [listening_note(1), listening_note(2)],
+        },
+    }
+
+
+def fill_report(*, review_input_present: bool = False, musical_claim: bool = False) -> dict:
+    return {
+        "review_input_present": review_input_present,
+        "fill_status": "review_input_applied" if review_input_present else "pending_review_input",
+        "readiness": {
+            "boundary": "stage_b_generic_tiny_checkpoint_repair_listening_fill",
+            "human_review_filled": review_input_present,
+            "pending_without_review_input": not review_input_present,
+            "musical_quality_claimed": musical_claim,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "next_boundary": "stage_b_generic_tiny_checkpoint_repair_audio_render_package",
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+        },
+        "listening_fill": {
+            "status": "reviewed" if review_input_present else "pending_review_input",
+            "candidate_count": 2,
+            "keep_count": 0,
+        },
+        "next_recommended_issue": "Stage B generic tiny checkpoint repair audio render package",
+    }
+
+
+class StageBGenericTinyCheckpointRepairListeningFillTest(unittest.TestCase):
+    def test_note_items_rejects_already_filled_source(self) -> None:
+        with self.assertRaises(StageBGenericTinyCheckpointRepairListeningFillError):
+            note_items(notes_report(filled=True))
+
+    def test_builds_pending_reviews_without_input(self) -> None:
+        rows = build_review_rows(note_items(notes_report()), None)
+
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["status"], "pending_review_input")
+        self.assertEqual(rows[0]["keep_decision"], "pending")
+
+    def test_accepts_pending_fill_without_quality_claim(self) -> None:
+        summary = validate_listening_fill_report(
+            fill_report(),
+            expected_boundary="stage_b_generic_tiny_checkpoint_repair_listening_fill",
+            require_pending_without_input=True,
+            require_no_quality_without_input=True,
+            require_objective_auto_progress_allowed=True,
+            require_no_broad_quality_claim=True,
+            require_no_brad_style_claim=True,
+        )
+
+        self.assertFalse(summary["review_input_present"])
+        self.assertEqual(summary["fill_status"], "pending_review_input")
+        self.assertFalse(summary["musical_quality_claimed"])
+        self.assertTrue(summary["auto_progress_allowed"])
+
+    def test_rejects_quality_claim_without_input(self) -> None:
+        with self.assertRaises(StageBGenericTinyCheckpointRepairListeningFillError):
+            validate_listening_fill_report(
+                fill_report(musical_claim=True),
+                expected_boundary="stage_b_generic_tiny_checkpoint_repair_listening_fill",
+                require_pending_without_input=True,
+                require_no_quality_without_input=True,
+                require_objective_auto_progress_allowed=True,
+                require_no_broad_quality_claim=True,
+                require_no_brad_style_claim=True,
+            )
+
+    def test_build_report_routes_absent_input_to_audio_render(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            args = argparse.Namespace(issue_number=403)
+            report = build_listening_fill_report(
+                run_dir=root,
+                listening_notes_report_path=root / "notes.json",
+                listening_notes_report=notes_report(),
+                review_input=None,
+                review_rows=build_review_rows(note_items(notes_report()), None),
+                args=args,
+            )
+
+        self.assertEqual(report["fill_status"], "pending_review_input")
+        self.assertFalse(report["readiness"]["musical_quality_claimed"])
+        self.assertEqual(
+            report["decision"]["next_boundary"],
+            "stage_b_generic_tiny_checkpoint_repair_audio_render_package",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Stage B generic tiny checkpoint repair listening fill guard 추가
- review input 부재 상태: `pending_review_input` 유지
- musical quality, broad trained-model quality, Brad style adaptation claim 차단
- objective-only 다음 경계: `stage_b_generic_tiny_checkpoint_repair_audio_render_package`

## Context

- #401 listening notes 결과: candidate `5`, status `pending_human_review`
- human review input 미반영 상태에서 keep/musical quality 판정 불가
- 현재 검토 대상: review input schema, pending fill guard, 다음 자동 진행 경계

## Scope

- `scripts/fill_stage_b_generic_tiny_checkpoint_repair_listening_notes.py` 추가
- `stage-b-generic-tiny-checkpoint-repair-listening-fill` harness mode 추가
- unit test 추가
- `AGENTS.md`, `docs/CURRENT_STATUS_AND_PLAN.md`, `docs/CORE_PLAN.md` handoff 갱신
- 결과 문서 추가: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_LISTENING_FILL_2026-05-30.md`

## Validation

- `./.venv/bin/python -m unittest tests/test_stage_b_generic_tiny_checkpoint_repair_listening_fill.py`
- `./.venv/bin/python -m compileall scripts/fill_stage_b_generic_tiny_checkpoint_repair_listening_notes.py tests/test_stage_b_generic_tiny_checkpoint_repair_listening_fill.py`
- `RUN_ID=issue_403_stage_b_generic_tiny_checkpoint_repair_listening_fill_harness LISTENING_NOTES_RUN_ID=harness_stage_b_generic_tiny_checkpoint_repair_listening_notes bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-listening-fill`
- `bash scripts/agent_harness.sh quick`
- `git diff --cached --check`

## Risk

- human/audio preference 미검증
- musical quality claim 없음
- broad trained-model quality claim 없음
- Brad style adaptation claim 없음

## Follow-up

- Stage B generic tiny checkpoint repair audio render package

Closes #403
