### PR TITLE
Stage B generic tiny checkpoint repair audio render package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #403, Stage B generic tiny checkpoint repair listening fill.
+- Latest functional issue completed: Issue #405, Stage B generic tiny checkpoint repair audio render package.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B generic tiny checkpoint repair audio render package.
+- Recommended next issue: Stage B generic tiny checkpoint repair local audio render attempt.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -946,6 +946,14 @@ bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-listening-f
 ```
 
 This harness guards listening-note fill when human review input is absent and keeps musical quality claims blocked.
+
+For Stage B generic tiny checkpoint repair audio render package changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-audio-render-package
+```
+
+This harness packages the pending repair candidates for local WAV rendering without attempting render or claiming audio quality.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -146,6 +146,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint repair review package 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_REVIEW_PACKAGE_2026-05-30.md`
 - generic tiny checkpoint repair listening notes 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_LISTENING_NOTES_2026-05-30.md`
 - generic tiny checkpoint repair listening fill 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_LISTENING_FILL_2026-05-30.md`
+- generic tiny checkpoint repair audio render package 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_AUDIO_RENDER_PACKAGE_2026-05-30.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -230,6 +231,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint repair review package: strict-valid candidates `5`, failed rows `1`, musical quality claim `false`
 - generic tiny checkpoint repair listening notes: candidate notes `5`, status `pending_human_review`, musical quality claim `false`
 - generic tiny checkpoint repair listening fill: review input `false`, fill status `pending_review_input`, candidate `5`, auto progress `true`, musical quality claim `false`
+- generic tiny checkpoint repair audio render package: planned audio outputs `5`, render status `ready_for_local_render`, audio quality claim `false`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -1234,6 +1236,16 @@ Issue #312는 constrained decoding으로 adjacent repeat를 줄였지만 dead-ai
 - musical quality / broad trained-model quality / Brad style adaptation claim: `false/false/false`
 - objective-only auto progress allowed: `true`
 - 다음 작업은 repair audio render package다.
+
+현재 generic tiny checkpoint repair audio render package:
+
+- Issue #405 result: planned audio outputs `5`
+- render status: `ready_for_local_render`
+- selected renderer: `fluidsynth`
+- soundfont exists: `true`
+- render attempted: `false`
+- audio rendered quality / human audio preference / musical quality claim: `false/false/false`
+- 다음 작업은 repair local audio render attempt다.
 
 ### Phase 5. Brad Style Adaptation
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #403, Stage B generic tiny checkpoint repair listening fill
-- 다음 권장 이슈: `Stage B generic tiny checkpoint repair audio render package`
+- latest functional result: Issue #405, Stage B generic tiny checkpoint repair audio render package
+- 다음 권장 이슈: `Stage B generic tiny checkpoint repair local audio render attempt`
 
 현재 범위가 아닌 것:
 
@@ -450,6 +450,41 @@ Issue #403은 Issue #401 pending listening notes에 대해 review input 부재 �
 다음:
 
 - `Stage B generic tiny checkpoint repair audio render package`
+
+## Current Generic Tiny Checkpoint Repair Audio Render Package Result
+
+Issue #405는 Issue #403 listening fill 후보 `5`개를 local WAV render 대상으로 package한 작업이다.
+
+변경:
+
+- generic tiny checkpoint repair audio render package script 추가
+- 후보별 MIDI path, planned WAV path, render command readiness 기록
+- renderer/soundfont probe 추가
+- render attempt, audio output claim, audio quality claim, human/audio preference claim 분리
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_AUDIO_RENDER_PACKAGE_2026-05-30.md`
+- render status: `ready_for_local_render`
+- selected renderer: `fluidsynth`
+- soundfont exists: `true`
+- planned audio outputs: `5`
+- render attempted: `false`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- musical quality claimed: `false`
+- auto progress allowed: `true`
+
+판단:
+
+- review 후보 `5`개 모두 MIDI 존재 확인
+- 현재 단계는 WAV render 준비 package이며, 실제 WAV 생성은 아직 미실행
+- local renderer/soundfont 준비 상태 확인 완료
+
+다음:
+
+- `Stage B generic tiny checkpoint repair local audio render attempt`
 
 ## Current Muzig Application Resume Wording Result
 

--- a/docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_AUDIO_RENDER_PACKAGE_2026-05-30.md
+++ b/docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_AUDIO_RENDER_PACKAGE_2026-05-30.md
@@ -1,0 +1,32 @@
+# Stage B Generic Tiny Checkpoint Repair Audio Render Package
+
+## Summary
+
+- boundary: `stage_b_generic_tiny_checkpoint_repair_audio_render_package`
+- render status: `ready_for_local_render`
+- selected renderer: `fluidsynth`
+- soundfont exists: `true`
+- planned audio outputs: `5`
+- render attempted: `false`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- musical quality claimed: `false`
+
+## Planned Outputs
+
+| rank | seed | sample | MIDI exists | planned WAV | command ready |
+|---:|---:|---:|:---:|---|:---:|
+| 1 | 47 | 6 | true | outputs/stage_b_generic_tiny_checkpoint_repair_audio_render_package/issue_405_stage_b_generic_tiny_checkpoint_repair_audio_render_package/audio/rank_01_seed_47_sample_6.wav | true |
+| 2 | 45 | 4 | true | outputs/stage_b_generic_tiny_checkpoint_repair_audio_render_package/issue_405_stage_b_generic_tiny_checkpoint_repair_audio_render_package/audio/rank_02_seed_45_sample_4.wav | true |
+| 3 | 42 | 1 | true | outputs/stage_b_generic_tiny_checkpoint_repair_audio_render_package/issue_405_stage_b_generic_tiny_checkpoint_repair_audio_render_package/audio/rank_03_seed_42_sample_1.wav | true |
+| 4 | 43 | 2 | true | outputs/stage_b_generic_tiny_checkpoint_repair_audio_render_package/issue_405_stage_b_generic_tiny_checkpoint_repair_audio_render_package/audio/rank_04_seed_43_sample_2.wav | true |
+| 5 | 46 | 5 | true | outputs/stage_b_generic_tiny_checkpoint_repair_audio_render_package/issue_405_stage_b_generic_tiny_checkpoint_repair_audio_render_package/audio/rank_05_seed_46_sample_5.wav | true |
+
+## Not Proven
+
+- `audio_output`
+- `audio_rendered_quality`
+- `human_audio_preference`
+- `musical_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -176,6 +176,8 @@ Modes:
                 Build pending listening notes for generic tiny checkpoint repair candidates.
   stage-b-generic-tiny-checkpoint-repair-listening-fill
                 Guard or fill generic tiny checkpoint repair listening notes.
+  stage-b-generic-tiny-checkpoint-repair-audio-render-package
+                Package generic tiny checkpoint repair candidates for local audio rendering.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -2409,6 +2411,27 @@ run_stage_b_generic_tiny_checkpoint_repair_listening_fill() {
     --require_no_brad_style_claim
 }
 
+run_stage_b_generic_tiny_checkpoint_repair_audio_render_package() {
+  local listening_fill_run_id="${LISTENING_FILL_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_listening_fill}"
+  local listening_notes_run_id="${LISTENING_NOTES_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_listening_notes}"
+  local run_id="${RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_audio_render_package}"
+  local listening_fill_report="outputs/stage_b_generic_tiny_checkpoint_repair_listening_fill/${listening_fill_run_id}/stage_b_generic_tiny_checkpoint_repair_listening_fill.json"
+  local soundfont="${SOUNDFONT_PATH:-$HOME/.local/share/soundfonts/generaluser-gs/v1.471.sf2}"
+  if [[ ! -f "$listening_fill_report" ]]; then
+    print_header "Stage B generic tiny checkpoint repair listening fill"
+    RUN_ID="$listening_fill_run_id" LISTENING_NOTES_RUN_ID="$listening_notes_run_id" run_stage_b_generic_tiny_checkpoint_repair_listening_fill
+  fi
+  print_header "Stage B generic tiny checkpoint repair audio render package"
+  "$PYTHON_BIN" scripts/build_stage_b_generic_tiny_checkpoint_repair_audio_render_package.py \
+    --run_id "$run_id" \
+    --listening_fill_report "$listening_fill_report" \
+    --soundfont "$soundfont" \
+    --expected_boundary stage_b_generic_tiny_checkpoint_repair_audio_render_package \
+    --min_planned_outputs 5 \
+    --require_required_midi_exists \
+    --require_no_audio_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -3768,6 +3791,9 @@ case "$MODE" in
     ;;
   stage-b-generic-tiny-checkpoint-repair-listening-fill)
     run_stage_b_generic_tiny_checkpoint_repair_listening_fill
+    ;;
+  stage-b-generic-tiny-checkpoint-repair-audio-render-package)
+    run_stage_b_generic_tiny_checkpoint_repair_audio_render_package
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/build_stage_b_generic_tiny_checkpoint_repair_audio_render_package.py
+++ b/scripts/build_stage_b_generic_tiny_checkpoint_repair_audio_render_package.py
@@ -1,0 +1,406 @@
+"""Build audio render package metadata for generic tiny checkpoint repair candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.run_stage_b_generic_tiny_checkpoint_generation_probe import (  # noqa: E402
+    _bool_token,
+    _dict,
+    _int,
+)
+
+
+class StageBGenericTinyCheckpointRepairAudioRenderPackageError(ValueError):
+    pass
+
+
+def file_meta(path: str, *, required: bool) -> dict[str, Any]:
+    if not path:
+        return {
+            "path": "",
+            "required": required,
+            "exists": False,
+            "size_bytes": 0,
+        }
+    target = Path(path)
+    exists = target.exists()
+    if required and not exists:
+        raise StageBGenericTinyCheckpointRepairAudioRenderPackageError(f"required file not found: {path}")
+    return {
+        "path": path,
+        "required": required,
+        "exists": exists,
+        "size_bytes": int(target.stat().st_size) if exists else 0,
+    }
+
+
+def resolve_tool(name: str, renderer_paths: dict[str, str] | None = None) -> str:
+    if renderer_paths and name in renderer_paths:
+        return str(renderer_paths.get(name) or "")
+    return shutil.which(name) or ""
+
+
+def renderer_probe(
+    *,
+    requested_renderer: str,
+    soundfont_path: str,
+    renderer_paths: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    fluidsynth_path = resolve_tool("fluidsynth", renderer_paths)
+    timidity_path = resolve_tool("timidity", renderer_paths)
+    selected = ""
+    status = "renderer_unavailable"
+    soundfont = Path(soundfont_path).expanduser() if soundfont_path else None
+    soundfont_exists = bool(soundfont and soundfont.exists())
+    resolved_soundfont_path = str(soundfont) if soundfont else ""
+
+    if requested_renderer:
+        if requested_renderer == "fluidsynth":
+            selected = fluidsynth_path
+            if not selected:
+                status = "renderer_unavailable"
+            else:
+                status = "ready_for_local_render" if soundfont_exists else "soundfont_missing"
+        elif requested_renderer == "timidity":
+            selected = timidity_path
+            status = "ready_for_local_render" if selected else "renderer_unavailable"
+        else:
+            raise StageBGenericTinyCheckpointRepairAudioRenderPackageError(
+                f"unsupported renderer: {requested_renderer}"
+            )
+    elif fluidsynth_path:
+        selected = fluidsynth_path
+        status = "ready_for_local_render" if soundfont_exists else "soundfont_missing"
+    elif timidity_path:
+        selected = timidity_path
+        status = "ready_for_local_render"
+
+    return {
+        "requested_renderer": requested_renderer,
+        "selected_renderer": selected,
+        "selected_renderer_name": "fluidsynth" if selected == fluidsynth_path and fluidsynth_path else "timidity"
+        if selected == timidity_path and timidity_path
+        else "",
+        "fluidsynth_path": fluidsynth_path,
+        "timidity_path": timidity_path,
+        "soundfont_path": resolved_soundfont_path,
+        "soundfont_exists": soundfont_exists,
+        "status": status,
+    }
+
+
+def validate_listening_fill_report(report: dict[str, Any]) -> list[dict[str, Any]]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    fill = _dict(report.get("listening_fill"))
+    if str(readiness.get("boundary") or "") != "stage_b_generic_tiny_checkpoint_repair_listening_fill":
+        raise StageBGenericTinyCheckpointRepairAudioRenderPackageError("unexpected listening fill boundary")
+    if bool(report.get("review_input_present", True)):
+        raise StageBGenericTinyCheckpointRepairAudioRenderPackageError("review input must be absent for this package")
+    if str(report.get("fill_status") or "") != "pending_review_input":
+        raise StageBGenericTinyCheckpointRepairAudioRenderPackageError("fill status must remain pending")
+    if str(fill.get("status") or "") != "pending_review_input":
+        raise StageBGenericTinyCheckpointRepairAudioRenderPackageError("listening fill must remain pending")
+    if bool(readiness.get("human_review_filled", True)):
+        raise StageBGenericTinyCheckpointRepairAudioRenderPackageError("human review must not be marked filled")
+    if bool(readiness.get("musical_quality_claimed", True)):
+        raise StageBGenericTinyCheckpointRepairAudioRenderPackageError("musical quality must not be claimed")
+    if bool(readiness.get("broad_trained_model_quality_claimed", True)):
+        raise StageBGenericTinyCheckpointRepairAudioRenderPackageError("broad trained-model quality must not be claimed")
+    if bool(readiness.get("brad_style_adaptation_claimed", True)):
+        raise StageBGenericTinyCheckpointRepairAudioRenderPackageError("Brad style adaptation must not be claimed")
+    if str(decision.get("next_boundary") or "") != "stage_b_generic_tiny_checkpoint_repair_audio_render_package":
+        raise StageBGenericTinyCheckpointRepairAudioRenderPackageError("unexpected next boundary")
+    reviews = fill.get("candidate_reviews")
+    if not isinstance(reviews, list) or not reviews:
+        raise StageBGenericTinyCheckpointRepairAudioRenderPackageError("candidate reviews required")
+    return [dict(review) for review in reviews if isinstance(review, dict)]
+
+
+def compact_review_item(review: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "review_rank": _int(review.get("review_rank")),
+        "sample_seed": _int(review.get("sample_seed")),
+        "sample_index": _int(review.get("sample_index")),
+        "midi_file": file_meta(str(review.get("midi_path") or ""), required=True),
+        "listening_status": str(review.get("status") or ""),
+        "keep_decision": str(review.get("keep_decision") or ""),
+    }
+
+
+def item_output_stem(item: dict[str, Any]) -> str:
+    return f"rank_{item['review_rank']:02d}_seed_{item['sample_seed']}_sample_{item['sample_index']}"
+
+
+def render_command(probe: dict[str, Any], midi_path: str, output_wav_path: str) -> list[str]:
+    renderer_name = str(probe.get("selected_renderer_name") or "")
+    renderer = str(probe.get("selected_renderer") or "")
+    if str(probe.get("status") or "") != "ready_for_local_render" or not renderer:
+        return []
+    if renderer_name == "fluidsynth":
+        return [
+            renderer,
+            "-ni",
+            str(probe.get("soundfont_path") or ""),
+            midi_path,
+            "-F",
+            output_wav_path,
+            "-r",
+            "44100",
+        ]
+    if renderer_name == "timidity":
+        return [renderer, midi_path, "-Ow", "-o", output_wav_path]
+    return []
+
+
+def build_audio_render_package(
+    listening_fill_report: dict[str, Any],
+    *,
+    output_dir: Path,
+    requested_renderer: str = "",
+    soundfont_path: str = "",
+    renderer_paths: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    reviews = validate_listening_fill_report(listening_fill_report)
+    probe = renderer_probe(
+        requested_renderer=requested_renderer,
+        soundfont_path=soundfont_path,
+        renderer_paths=renderer_paths,
+    )
+    review_items = [compact_review_item(review) for review in reviews]
+    planned_outputs: list[dict[str, Any]] = []
+    for item in review_items:
+        output_stem = item_output_stem(item)
+        output_wav_path = output_dir / "audio" / f"{output_stem}.wav"
+        midi_path = str(item["midi_file"]["path"])
+        planned_outputs.append(
+            {
+                "review_rank": item["review_rank"],
+                "sample_seed": item["sample_seed"],
+                "sample_index": item["sample_index"],
+                "source_midi_path": midi_path,
+                "planned_wav_path": str(output_wav_path),
+                "planned_wav_exists": output_wav_path.exists(),
+                "render_command": render_command(probe, midi_path, str(output_wav_path)),
+            }
+        )
+    render_ready = str(probe["status"]) == "ready_for_local_render"
+    return {
+        "schema_version": "stage_b_generic_tiny_checkpoint_repair_audio_render_package_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_listening_fill_schema": str(listening_fill_report.get("schema_version") or ""),
+        "source_listening_fill_run_dir": str(listening_fill_report.get("run_dir") or ""),
+        "review_items": review_items,
+        "renderer_probe": probe,
+        "planned_audio_outputs": planned_outputs,
+        "local_audio_render_boundary": {
+            "boundary": "stage_b_generic_tiny_checkpoint_repair_audio_render_package",
+            "status": str(probe["status"]),
+            "render_attempted": False,
+            "planned_audio_output_count": len(planned_outputs),
+            "rendered_audio_file_count": 0,
+            "audio_output_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "human_audio_preference_claimed": False,
+            "musical_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "current_boundary": "stage_b_generic_tiny_checkpoint_repair_audio_render_package",
+            "next_boundary": "stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt"
+            if render_ready
+            else "stage_b_generic_tiny_checkpoint_repair_audio_render_tooling_setup",
+            "auto_progress_allowed": render_ready,
+            "critical_user_input_required": not render_ready,
+        },
+        "not_proven": [
+            "audio_output",
+            "audio_rendered_quality",
+            "human_audio_preference",
+            "musical_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": "Stage B generic tiny checkpoint repair local audio render attempt"
+        if render_ready
+        else "Stage B generic tiny checkpoint repair audio render tooling setup",
+    }
+
+
+def validate_audio_render_package(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_status: str | None,
+    min_planned_outputs: int,
+    require_required_midi_exists: bool,
+    require_no_audio_claim: bool,
+) -> dict[str, Any]:
+    boundary = _dict(report.get("local_audio_render_boundary"))
+    status = str(boundary.get("status") or "")
+    if expected_boundary and str(boundary.get("boundary") or "") != expected_boundary:
+        raise StageBGenericTinyCheckpointRepairAudioRenderPackageError(
+            f"expected boundary {expected_boundary}, got {boundary.get('boundary')}"
+        )
+    if expected_status and status != expected_status:
+        raise StageBGenericTinyCheckpointRepairAudioRenderPackageError(f"expected status {expected_status}, got {status}")
+    planned_outputs = report.get("planned_audio_outputs")
+    if not isinstance(planned_outputs, list):
+        planned_outputs = []
+    if len(planned_outputs) < min_planned_outputs:
+        raise StageBGenericTinyCheckpointRepairAudioRenderPackageError(
+            f"planned output count below target: {len(planned_outputs)} < {min_planned_outputs}"
+        )
+    if require_required_midi_exists:
+        missing = []
+        for item in report.get("review_items", []):
+            midi_file = _dict(item.get("midi_file"))
+            if bool(midi_file.get("required", False)) and not bool(midi_file.get("exists", False)):
+                missing.append(str(midi_file.get("path") or "midi_file"))
+        if missing:
+            raise StageBGenericTinyCheckpointRepairAudioRenderPackageError(f"missing required MIDI files: {missing}")
+    if require_no_audio_claim:
+        claimed = [
+            bool(boundary.get("render_attempted", True)),
+            bool(boundary.get("audio_output_claimed", True)),
+            bool(boundary.get("audio_rendered_quality_claimed", True)),
+            bool(boundary.get("human_audio_preference_claimed", True)),
+            bool(boundary.get("musical_quality_claimed", True)),
+            bool(boundary.get("broad_trained_model_quality_claimed", True)),
+            bool(boundary.get("brad_style_adaptation_claimed", True)),
+        ]
+        if any(claimed):
+            raise StageBGenericTinyCheckpointRepairAudioRenderPackageError("audio or quality claims must not be set")
+    decision = _dict(report.get("decision"))
+    return {
+        "boundary": str(boundary.get("boundary") or ""),
+        "render_status": status,
+        "selected_renderer_name": str(_dict(report.get("renderer_probe")).get("selected_renderer_name") or ""),
+        "soundfont_exists": bool(_dict(report.get("renderer_probe")).get("soundfont_exists", False)),
+        "planned_audio_output_count": len(planned_outputs),
+        "render_attempted": bool(boundary.get("render_attempted", True)),
+        "audio_rendered_quality_claimed": bool(boundary.get("audio_rendered_quality_claimed", True)),
+        "human_audio_preference_claimed": bool(boundary.get("human_audio_preference_claimed", True)),
+        "auto_progress_allowed": bool(decision.get("auto_progress_allowed", False)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    boundary = report["local_audio_render_boundary"]
+    probe = report["renderer_probe"]
+    lines = [
+        "# Stage B Generic Tiny Checkpoint Repair Audio Render Package",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{boundary['boundary']}`",
+        f"- render status: `{boundary['status']}`",
+        f"- selected renderer: `{probe['selected_renderer_name']}`",
+        f"- soundfont exists: `{_bool_token(probe['soundfont_exists'])}`",
+        f"- planned audio outputs: `{boundary['planned_audio_output_count']}`",
+        f"- render attempted: `{_bool_token(boundary['render_attempted'])}`",
+        f"- audio rendered quality claimed: `{_bool_token(boundary['audio_rendered_quality_claimed'])}`",
+        f"- human/audio preference claimed: `{_bool_token(boundary['human_audio_preference_claimed'])}`",
+        f"- musical quality claimed: `{_bool_token(boundary['musical_quality_claimed'])}`",
+        "",
+        "## Planned Outputs",
+        "",
+        "| rank | seed | sample | MIDI exists | planned WAV | command ready |",
+        "|---:|---:|---:|:---:|---|:---:|",
+    ]
+    for item in report.get("planned_audio_outputs", []):
+        midi_exists = Path(str(item.get("source_midi_path") or "")).exists()
+        command_ready = bool(item.get("render_command"))
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(item.get("review_rank") or ""),
+                    str(item.get("sample_seed") or ""),
+                    str(item.get("sample_index") or ""),
+                    _bool_token(midi_exists),
+                    str(item.get("planned_wav_path") or ""),
+                    _bool_token(command_ready),
+                ]
+            )
+            + " |"
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    default_soundfont = Path.home() / ".local/share/soundfonts/generaluser-gs/v1.471.sf2"
+    parser = argparse.ArgumentParser(description="Build generic tiny checkpoint repair audio render package metadata")
+    parser.add_argument(
+        "--listening_fill_report",
+        type=str,
+        default="outputs/stage_b_generic_tiny_checkpoint_repair_listening_fill/"
+        "harness_stage_b_generic_tiny_checkpoint_repair_listening_fill/"
+        "stage_b_generic_tiny_checkpoint_repair_listening_fill.json",
+    )
+    parser.add_argument("--output_root", type=str, default="outputs/stage_b_generic_tiny_checkpoint_repair_audio_render_package")
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--renderer", type=str, default="")
+    parser.add_argument("--soundfont", type=str, default=str(default_soundfont))
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_status", type=str, default="")
+    parser.add_argument("--min_planned_outputs", type=int, default=5)
+    parser.add_argument("--require_required_midi_exists", action="store_true")
+    parser.add_argument("--require_no_audio_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    listening_fill_report_path = Path(args.listening_fill_report)
+    if not listening_fill_report_path.exists():
+        raise StageBGenericTinyCheckpointRepairAudioRenderPackageError("listening fill report required")
+    report = build_audio_render_package(
+        read_json(listening_fill_report_path),
+        output_dir=output_dir,
+        requested_renderer=str(args.renderer or ""),
+        soundfont_path=str(args.soundfont or ""),
+    )
+    summary = validate_audio_render_package(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_status=str(args.expected_status or ""),
+        min_planned_outputs=int(args.min_planned_outputs),
+        require_required_midi_exists=bool(args.require_required_midi_exists),
+        require_no_audio_claim=bool(args.require_no_audio_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "stage_b_generic_tiny_checkpoint_repair_audio_render_package.json", report)
+    write_json(output_dir / "stage_b_generic_tiny_checkpoint_repair_audio_render_package_validation_summary.json", summary)
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_generic_tiny_checkpoint_repair_audio_render_package.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_generic_tiny_checkpoint_repair_audio_render_package.py
+++ b/tests/test_stage_b_generic_tiny_checkpoint_repair_audio_render_package.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.build_stage_b_generic_tiny_checkpoint_repair_audio_render_package import (
+    StageBGenericTinyCheckpointRepairAudioRenderPackageError,
+    build_audio_render_package,
+    validate_audio_render_package,
+)
+
+
+def fake_midi(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"MThd\x00\x00\x00\x06\x00\x00\x00\x01\x00`MTrk\x00\x00\x00\x04\x00\xff/\x00")
+
+
+def fake_executable(path: Path) -> None:
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def listening_fill_report(root: Path, *, quality_claimed: bool = False) -> dict:
+    midi_a = root / "rank_01.mid"
+    midi_b = root / "rank_02.mid"
+    fake_midi(midi_a)
+    fake_midi(midi_b)
+    return {
+        "schema_version": "stage_b_generic_tiny_checkpoint_repair_listening_fill_v1",
+        "run_dir": str(root / "fill"),
+        "review_input_present": False,
+        "fill_status": "pending_review_input",
+        "readiness": {
+            "boundary": "stage_b_generic_tiny_checkpoint_repair_listening_fill",
+            "human_review_filled": False,
+            "musical_quality_claimed": quality_claimed,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "next_boundary": "stage_b_generic_tiny_checkpoint_repair_audio_render_package",
+        },
+        "listening_fill": {
+            "status": "pending_review_input",
+            "candidate_count": 2,
+            "keep_count": 0,
+            "candidate_reviews": [
+                {
+                    "review_rank": 1,
+                    "sample_seed": 47,
+                    "sample_index": 6,
+                    "midi_path": str(midi_a),
+                    "status": "pending_review_input",
+                    "keep_decision": "pending",
+                },
+                {
+                    "review_rank": 2,
+                    "sample_seed": 45,
+                    "sample_index": 4,
+                    "midi_path": str(midi_b),
+                    "status": "pending_review_input",
+                    "keep_decision": "pending",
+                },
+            ],
+        },
+    }
+
+
+class StageBGenericTinyCheckpointRepairAudioRenderPackageTest(unittest.TestCase):
+    def test_records_ready_commands_without_audio_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            soundfont = root / "piano.sf2"
+            fake_executable(renderer)
+            soundfont.write_bytes(b"sf2")
+            report = build_audio_render_package(
+                listening_fill_report(root),
+                output_dir=root / "render_package",
+                requested_renderer="fluidsynth",
+                soundfont_path=str(soundfont),
+                renderer_paths={"fluidsynth": str(renderer), "timidity": ""},
+            )
+            summary = validate_audio_render_package(
+                report,
+                expected_boundary="stage_b_generic_tiny_checkpoint_repair_audio_render_package",
+                expected_status="ready_for_local_render",
+                min_planned_outputs=2,
+                require_required_midi_exists=True,
+                require_no_audio_claim=True,
+            )
+
+            self.assertEqual(summary["render_status"], "ready_for_local_render")
+            self.assertEqual(summary["planned_audio_output_count"], 2)
+            self.assertTrue(report["planned_audio_outputs"][0]["render_command"])
+            self.assertIn(str(soundfont), report["planned_audio_outputs"][0]["render_command"])
+            self.assertFalse(summary["audio_rendered_quality_claimed"])
+            self.assertFalse(summary["human_audio_preference_claimed"])
+
+    def test_records_soundfont_missing_without_render_command(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            fake_executable(renderer)
+            report = build_audio_render_package(
+                listening_fill_report(root),
+                output_dir=root / "render_package",
+                requested_renderer="fluidsynth",
+                soundfont_path=str(root / "missing.sf2"),
+                renderer_paths={"fluidsynth": str(renderer), "timidity": ""},
+            )
+            summary = validate_audio_render_package(
+                report,
+                expected_boundary="stage_b_generic_tiny_checkpoint_repair_audio_render_package",
+                expected_status="soundfont_missing",
+                min_planned_outputs=2,
+                require_required_midi_exists=True,
+                require_no_audio_claim=True,
+            )
+
+            self.assertEqual(summary["render_status"], "soundfont_missing")
+            self.assertFalse(report["planned_audio_outputs"][0]["render_command"])
+            self.assertFalse(summary["auto_progress_allowed"])
+
+    def test_rejects_quality_claimed_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertRaises(StageBGenericTinyCheckpointRepairAudioRenderPackageError):
+                build_audio_render_package(
+                    listening_fill_report(Path(temp_dir), quality_claimed=True),
+                    output_dir=Path(temp_dir) / "render_package",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Stage B generic tiny checkpoint repair 후보 `5`개 local WAV render package 추가
- renderer/soundfont readiness 기록
- planned WAV path와 render command readiness 기록
- render attempt, audio output claim, audio quality claim, human/audio preference claim 분리

## Context

- #403 결과: review input `false`, fill status `pending_review_input`, candidate `5`
- musical quality, broad trained-model quality, Brad style adaptation claim `false`
- 현재 로컬 probe: `fluidsynth` + soundfont 준비 상태 확인
- 이번 검토 대상: WAV 생성 전 package boundary

## Scope

- `scripts/build_stage_b_generic_tiny_checkpoint_repair_audio_render_package.py` 추가
- `stage-b-generic-tiny-checkpoint-repair-audio-render-package` harness mode 추가
- unit test 추가
- `AGENTS.md`, `docs/CURRENT_STATUS_AND_PLAN.md`, `docs/CORE_PLAN.md` handoff 갱신
- 결과 문서 추가: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_AUDIO_RENDER_PACKAGE_2026-05-30.md`

## Validation

- `./.venv/bin/python -m unittest tests/test_stage_b_generic_tiny_checkpoint_repair_audio_render_package.py`
- `./.venv/bin/python -m compileall scripts/build_stage_b_generic_tiny_checkpoint_repair_audio_render_package.py tests/test_stage_b_generic_tiny_checkpoint_repair_audio_render_package.py`
- `RUN_ID=issue_405_stage_b_generic_tiny_checkpoint_repair_audio_render_package_harness LISTENING_FILL_RUN_ID=harness_stage_b_generic_tiny_checkpoint_repair_listening_fill LISTENING_NOTES_RUN_ID=harness_stage_b_generic_tiny_checkpoint_repair_listening_notes bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-audio-render-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --cached --check`

## Risk

- WAV render attempt 미포함
- audio rendered quality claim 없음
- human/audio preference claim 없음
- musical quality claim 없음
- broad trained-model quality claim 없음

## Follow-up

- Stage B generic tiny checkpoint repair local audio render attempt

Closes #405
