### PR TITLE
Stage B generic tiny checkpoint repair local audio render attempt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #405, Stage B generic tiny checkpoint repair audio render package.
+- Latest functional issue completed: Issue #407, Stage B generic tiny checkpoint repair local audio render attempt.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B generic tiny checkpoint repair local audio render attempt.
+- Recommended next issue: Stage B generic tiny checkpoint repair user listening review input.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -954,6 +954,14 @@ bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-audio-rende
 ```
 
 This harness packages the pending repair candidates for local WAV rendering without attempting render or claiming audio quality.
+
+For Stage B generic tiny checkpoint repair local audio render attempt changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-local-audio-render-attempt
+```
+
+This harness renders the packaged repair candidates to local WAV files and validates WAV metadata without claiming listening quality.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -147,6 +147,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint repair listening notes 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_LISTENING_NOTES_2026-05-30.md`
 - generic tiny checkpoint repair listening fill 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_LISTENING_FILL_2026-05-30.md`
 - generic tiny checkpoint repair audio render package 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_AUDIO_RENDER_PACKAGE_2026-05-30.md`
+- generic tiny checkpoint repair local audio render attempt 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_LOCAL_AUDIO_RENDER_ATTEMPT_2026-05-30.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -232,6 +233,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint repair listening notes: candidate notes `5`, status `pending_human_review`, musical quality claim `false`
 - generic tiny checkpoint repair listening fill: review input `false`, fill status `pending_review_input`, candidate `5`, auto progress `true`, musical quality claim `false`
 - generic tiny checkpoint repair audio render package: planned audio outputs `5`, render status `ready_for_local_render`, audio quality claim `false`
+- generic tiny checkpoint repair local audio render attempt: rendered WAV files `5`, technical WAV validation `true`, audio quality claim `false`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -1246,6 +1248,15 @@ Issue #312는 constrained decoding으로 adjacent repeat를 줄였지만 dead-ai
 - render attempted: `false`
 - audio rendered quality / human audio preference / musical quality claim: `false/false/false`
 - 다음 작업은 repair local audio render attempt다.
+
+현재 generic tiny checkpoint repair local audio render attempt:
+
+- Issue #407 result: rendered audio files `5`
+- technical WAV validation: `true`
+- sample rate: `44100`
+- duration seconds range: `7.766-10.657`
+- audio rendered quality / human audio preference / musical quality claim: `false/false/false`
+- 다음 작업은 repair user listening review input이다.
 
 ### Phase 5. Brad Style Adaptation
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #405, Stage B generic tiny checkpoint repair audio render package
-- 다음 권장 이슈: `Stage B generic tiny checkpoint repair local audio render attempt`
+- latest functional result: Issue #407, Stage B generic tiny checkpoint repair local audio render attempt
+- 다음 권장 이슈: `Stage B generic tiny checkpoint repair user listening review input`
 
 현재 범위가 아닌 것:
 
@@ -485,6 +485,44 @@ Issue #405는 Issue #403 listening fill 후보 `5`개를 local WAV render 대상
 다음:
 
 - `Stage B generic tiny checkpoint repair local audio render attempt`
+
+## Current Generic Tiny Checkpoint Repair Local Audio Render Attempt Result
+
+Issue #407은 Issue #405 audio render package 후보 `5`개를 FluidSynth와 GeneralUser GS soundfont로 WAV 렌더한 작업이다.
+
+변경:
+
+- generic tiny checkpoint repair local audio render attempt script 추가
+- 후보 `5`개 WAV 생성
+- WAV duration, sample rate, size, sha256 technical validation 기록
+- audio quality, human/audio preference, musical quality claim guard 유지
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_LOCAL_AUDIO_RENDER_ATTEMPT_2026-05-30.md`
+- render attempted: `true`
+- rendered audio file count: `5`
+- technical WAV validation: `true`
+- sample rate: `44100`
+- rank 1 duration seconds: `8.491`
+- rank 2 duration seconds: `10.657`
+- rank 3 duration seconds: `7.766`
+- rank 4 duration seconds: `10.101`
+- rank 5 duration seconds: `10.024`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- musical quality claimed: `false`
+
+판단:
+
+- WAV 파일 생성과 technical validation 완료
+- 현재 단계는 음질/선호 판정이 아니라 청취 리뷰 입력 준비
+- 다음 품질 판단에는 human listening review input 필요
+
+다음:
+
+- `Stage B generic tiny checkpoint repair user listening review input`
 
 ## Current Muzig Application Resume Wording Result
 

--- a/docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_LOCAL_AUDIO_RENDER_ATTEMPT_2026-05-30.md
+++ b/docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_LOCAL_AUDIO_RENDER_ATTEMPT_2026-05-30.md
@@ -1,0 +1,29 @@
+# Stage B Generic Tiny Checkpoint Repair Local Audio Render Attempt
+
+## Summary
+
+- boundary: `stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt`
+- render attempted: `true`
+- rendered audio file count: `5`
+- technical WAV validation: `true`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- musical quality claimed: `false`
+
+## Rendered Files
+
+| rank | seed | sample | wav path | duration | sample rate | size | sha256 |
+|---:|---:|---:|---|---:|---:|---:|---|
+| 1 | 47 | 6 | outputs/stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt/issue_407_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt/audio/rank_01_seed_47_sample_6.wav | 8.491 | 44100 | 1497900 | b6c786f1decb |
+| 2 | 45 | 4 | outputs/stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt/issue_407_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt/audio/rank_02_seed_45_sample_4.wav | 10.657 | 44100 | 1879852 | ca069e2c9237 |
+| 3 | 42 | 1 | outputs/stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt/issue_407_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt/audio/rank_03_seed_42_sample_1.wav | 7.766 | 44100 | 1369900 | f2de9b01579a |
+| 4 | 43 | 2 | outputs/stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt/issue_407_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt/audio/rank_04_seed_43_sample_2.wav | 10.101 | 44100 | 1781804 | dad8d66a51e8 |
+| 5 | 46 | 5 | outputs/stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt/issue_407_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt/audio/rank_05_seed_46_sample_5.wav | 10.024 | 44100 | 1768236 | d6a60f7b9367 |
+
+## Not Proven
+
+- `audio_rendered_quality`
+- `human_audio_preference`
+- `musical_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -178,6 +178,8 @@ Modes:
                 Guard or fill generic tiny checkpoint repair listening notes.
   stage-b-generic-tiny-checkpoint-repair-audio-render-package
                 Package generic tiny checkpoint repair candidates for local audio rendering.
+  stage-b-generic-tiny-checkpoint-repair-local-audio-render-attempt
+                Render generic tiny checkpoint repair candidates to local WAV files.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -2432,6 +2434,27 @@ run_stage_b_generic_tiny_checkpoint_repair_audio_render_package() {
     --require_no_audio_claim
 }
 
+run_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt() {
+  local audio_package_run_id="${AUDIO_PACKAGE_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_audio_render_package}"
+  local listening_fill_run_id="${LISTENING_FILL_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_listening_fill}"
+  local listening_notes_run_id="${LISTENING_NOTES_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_listening_notes}"
+  local run_id="${RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt}"
+  local local_audio_render_package="outputs/stage_b_generic_tiny_checkpoint_repair_audio_render_package/${audio_package_run_id}/stage_b_generic_tiny_checkpoint_repair_audio_render_package.json"
+  local soundfont="${SOUNDFONT_PATH:-$HOME/.local/share/soundfonts/generaluser-gs/v1.471.sf2}"
+  if [[ ! -f "$local_audio_render_package" ]]; then
+    print_header "Stage B generic tiny checkpoint repair audio render package"
+    RUN_ID="$audio_package_run_id" LISTENING_FILL_RUN_ID="$listening_fill_run_id" LISTENING_NOTES_RUN_ID="$listening_notes_run_id" run_stage_b_generic_tiny_checkpoint_repair_audio_render_package
+  fi
+  print_header "Stage B generic tiny checkpoint repair local audio render attempt"
+  "$PYTHON_BIN" scripts/render_stage_b_generic_tiny_checkpoint_repair_audio.py \
+    --run_id "$run_id" \
+    --local_audio_render_package "$local_audio_render_package" \
+    --soundfont "$soundfont" \
+    --expected_boundary stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt \
+    --expected_file_count 5 \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -3794,6 +3817,9 @@ case "$MODE" in
     ;;
   stage-b-generic-tiny-checkpoint-repair-audio-render-package)
     run_stage_b_generic_tiny_checkpoint_repair_audio_render_package
+    ;;
+  stage-b-generic-tiny-checkpoint-repair-local-audio-render-attempt)
+    run_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/render_stage_b_generic_tiny_checkpoint_repair_audio.py
+++ b/scripts/render_stage_b_generic_tiny_checkpoint_repair_audio.py
@@ -1,0 +1,392 @@
+"""Render generic tiny checkpoint repair MIDI candidates to local WAV files."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+import wave
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.run_stage_b_generic_tiny_checkpoint_generation_probe import (  # noqa: E402
+    _bool_token,
+    _dict,
+    _int,
+)
+
+
+class StageBGenericTinyCheckpointRepairAudioRenderError(ValueError):
+    pass
+
+
+CommandRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def wav_meta(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise StageBGenericTinyCheckpointRepairAudioRenderError(f"WAV not found: {path}")
+    with wave.open(str(path), "rb") as handle:
+        channels = handle.getnchannels()
+        sample_width = handle.getsampwidth()
+        sample_rate = handle.getframerate()
+        frame_count = handle.getnframes()
+    return {
+        "path": str(path),
+        "exists": True,
+        "size_bytes": int(path.stat().st_size),
+        "sha256": sha256_file(path),
+        "channels": int(channels),
+        "sample_width_bytes": int(sample_width),
+        "sample_rate": int(sample_rate),
+        "frame_count": int(frame_count),
+        "duration_seconds": float(frame_count / sample_rate) if sample_rate else 0.0,
+    }
+
+
+def item_output_stem(item: dict[str, Any]) -> str:
+    return f"rank_{item['review_rank']:02d}_seed_{item['sample_seed']}_sample_{item['sample_index']}"
+
+
+def required_review_items(local_audio_render_package: dict[str, Any]) -> list[dict[str, Any]]:
+    boundary = _dict(local_audio_render_package.get("local_audio_render_boundary"))
+    if str(boundary.get("boundary") or "") != "stage_b_generic_tiny_checkpoint_repair_audio_render_package":
+        raise StageBGenericTinyCheckpointRepairAudioRenderError("unexpected audio render package boundary")
+    if str(boundary.get("status") or "") != "ready_for_local_render":
+        raise StageBGenericTinyCheckpointRepairAudioRenderError("audio render package is not ready for local render")
+    if bool(boundary.get("render_attempted", True)):
+        raise StageBGenericTinyCheckpointRepairAudioRenderError("source package must not already attempt rendering")
+    if bool(boundary.get("audio_rendered_quality_claimed", True)):
+        raise StageBGenericTinyCheckpointRepairAudioRenderError("source package must not claim audio quality")
+    if bool(boundary.get("human_audio_preference_claimed", True)):
+        raise StageBGenericTinyCheckpointRepairAudioRenderError("source package must not claim human preference")
+    items = local_audio_render_package.get("review_items")
+    if not isinstance(items, list) or not items:
+        raise StageBGenericTinyCheckpointRepairAudioRenderError("review items required")
+    compacted: list[dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        midi_file = _dict(item.get("midi_file"))
+        midi_path = str(midi_file.get("path") or "")
+        if bool(midi_file.get("required", False)) and not Path(midi_path).exists():
+            raise StageBGenericTinyCheckpointRepairAudioRenderError(f"required MIDI not found: {midi_path}")
+        compacted.append(
+            {
+                "review_rank": _int(item.get("review_rank")),
+                "sample_seed": _int(item.get("sample_seed")),
+                "sample_index": _int(item.get("sample_index")),
+                "midi_path": midi_path,
+            }
+        )
+    if not compacted:
+        raise StageBGenericTinyCheckpointRepairAudioRenderError("no renderable review items")
+    return compacted
+
+
+def build_render_plan(
+    local_audio_render_package: dict[str, Any],
+    *,
+    output_dir: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+) -> list[dict[str, Any]]:
+    renderer = Path(renderer_path)
+    soundfont = Path(soundfont_path).expanduser()
+    if not renderer.exists():
+        raise StageBGenericTinyCheckpointRepairAudioRenderError(f"renderer not found: {renderer}")
+    if not soundfont.exists():
+        raise StageBGenericTinyCheckpointRepairAudioRenderError(f"soundfont not found: {soundfont}")
+    plan: list[dict[str, Any]] = []
+    for item in required_review_items(local_audio_render_package):
+        output_stem = item_output_stem(item)
+        wav_path = output_dir / "audio" / f"{output_stem}.wav"
+        plan.append(
+            {
+                "review_rank": item["review_rank"],
+                "sample_seed": item["sample_seed"],
+                "sample_index": item["sample_index"],
+                "midi_path": item["midi_path"],
+                "wav_path": str(wav_path),
+                "command": [
+                    str(renderer),
+                    "-ni",
+                    "-F",
+                    str(wav_path),
+                    "-r",
+                    str(sample_rate),
+                    str(soundfont),
+                    item["midi_path"],
+                ],
+            }
+        )
+    return plan
+
+
+def default_runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(list(command), check=False, text=True, capture_output=True)
+
+
+def execute_render_plan(
+    plan: list[dict[str, Any]],
+    *,
+    runner: CommandRunner = default_runner,
+) -> list[dict[str, Any]]:
+    rendered: list[dict[str, Any]] = []
+    for item in plan:
+        wav_path = Path(str(item["wav_path"]))
+        wav_path.parent.mkdir(parents=True, exist_ok=True)
+        completed = runner(item["command"])
+        if completed.returncode != 0:
+            raise StageBGenericTinyCheckpointRepairAudioRenderError(
+                f"render failed for rank {item['review_rank']}: {completed.stderr or completed.stdout}"
+            )
+        rendered.append(
+            {
+                "review_rank": item["review_rank"],
+                "sample_seed": item["sample_seed"],
+                "sample_index": item["sample_index"],
+                "source_midi_path": item["midi_path"],
+                "wav_file": wav_meta(wav_path),
+                "command": list(item["command"]),
+                "stdout_tail": (completed.stdout or "")[-1000:],
+                "stderr_tail": (completed.stderr or "")[-1000:],
+            }
+        )
+    return rendered
+
+
+def build_audio_render_report(
+    local_audio_render_package: dict[str, Any],
+    *,
+    output_dir: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+    runner: CommandRunner = default_runner,
+) -> dict[str, Any]:
+    if not renderer_path:
+        renderer_path = str(_dict(local_audio_render_package.get("renderer_probe")).get("selected_renderer") or "")
+    if not soundfont_path:
+        soundfont_path = str(_dict(local_audio_render_package.get("renderer_probe")).get("soundfont_path") or "")
+    plan = build_render_plan(
+        local_audio_render_package,
+        output_dir=output_dir,
+        renderer_path=renderer_path,
+        soundfont_path=soundfont_path,
+        sample_rate=sample_rate,
+    )
+    rendered = execute_render_plan(plan, runner=runner)
+    return {
+        "schema_version": "stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_local_audio_render_package_schema": str(local_audio_render_package.get("schema_version") or ""),
+        "renderer": {
+            "name": "fluidsynth",
+            "path": renderer_path,
+            "version": "",
+        },
+        "soundfont": {
+            "path": str(Path(soundfont_path).expanduser()),
+            "sha256": sha256_file(Path(soundfont_path).expanduser()),
+        },
+        "rendered_audio_files": rendered,
+        "audio_render_boundary": {
+            "boundary": "stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt",
+            "render_attempted": True,
+            "rendered_audio_file_count": len(rendered),
+            "audio_output_claimed": True,
+            "technical_wav_validation": True,
+            "audio_rendered_quality_claimed": False,
+            "human_audio_preference_claimed": False,
+            "musical_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "current_boundary": "stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt",
+            "next_boundary": "stage_b_generic_tiny_checkpoint_repair_user_listening_review_input",
+            "auto_progress_allowed": False,
+            "critical_user_input_required": True,
+            "reason": "human listening input required before audio quality or preference claim",
+        },
+        "not_proven": [
+            "audio_rendered_quality",
+            "human_audio_preference",
+            "musical_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": "Stage B generic tiny checkpoint repair user listening review input",
+    }
+
+
+def validate_audio_render_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_file_count: int,
+    expected_sample_rate: int,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = _dict(report.get("audio_render_boundary"))
+    if expected_boundary and str(boundary.get("boundary") or "") != expected_boundary:
+        raise StageBGenericTinyCheckpointRepairAudioRenderError(
+            f"expected boundary {expected_boundary}, got {boundary.get('boundary')}"
+        )
+    files = report.get("rendered_audio_files")
+    if not isinstance(files, list) or len(files) != expected_file_count:
+        raise StageBGenericTinyCheckpointRepairAudioRenderError(f"expected {expected_file_count} rendered files")
+    for item in files:
+        wav_file = _dict(item.get("wav_file"))
+        if not bool(wav_file.get("exists", False)):
+            raise StageBGenericTinyCheckpointRepairAudioRenderError(f"missing rendered wav for rank {item.get('review_rank')}")
+        if int(wav_file.get("sample_rate", 0) or 0) != expected_sample_rate:
+            raise StageBGenericTinyCheckpointRepairAudioRenderError(
+                f"unexpected sample rate for rank {item.get('review_rank')}"
+            )
+        if int(wav_file.get("frame_count", 0) or 0) <= 0:
+            raise StageBGenericTinyCheckpointRepairAudioRenderError(f"empty wav for rank {item.get('review_rank')}")
+        if int(wav_file.get("size_bytes", 0) or 0) <= 44:
+            raise StageBGenericTinyCheckpointRepairAudioRenderError(f"invalid wav size for rank {item.get('review_rank')}")
+    if require_no_quality_claim:
+        claimed = [
+            bool(boundary.get("audio_rendered_quality_claimed", True)),
+            bool(boundary.get("human_audio_preference_claimed", True)),
+            bool(boundary.get("musical_quality_claimed", True)),
+            bool(boundary.get("broad_trained_model_quality_claimed", True)),
+            bool(boundary.get("brad_style_adaptation_claimed", True)),
+        ]
+        if any(claimed):
+            raise StageBGenericTinyCheckpointRepairAudioRenderError("quality or preference claims must not be set")
+    decision = _dict(report.get("decision"))
+    return {
+        "boundary": str(boundary.get("boundary") or ""),
+        "render_attempted": bool(boundary.get("render_attempted", False)),
+        "rendered_audio_file_count": int(boundary.get("rendered_audio_file_count", 0) or 0),
+        "technical_wav_validation": bool(boundary.get("technical_wav_validation", False)),
+        "audio_rendered_quality_claimed": bool(boundary.get("audio_rendered_quality_claimed", True)),
+        "human_audio_preference_claimed": bool(boundary.get("human_audio_preference_claimed", True)),
+        "musical_quality_claimed": bool(boundary.get("musical_quality_claimed", True)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", False)),
+        "wav_paths": [str(_dict(item.get("wav_file")).get("path") or "") for item in files],
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    boundary = report["audio_render_boundary"]
+    lines = [
+        "# Stage B Generic Tiny Checkpoint Repair Local Audio Render Attempt",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{boundary['boundary']}`",
+        f"- render attempted: `{_bool_token(boundary['render_attempted'])}`",
+        f"- rendered audio file count: `{boundary['rendered_audio_file_count']}`",
+        f"- technical WAV validation: `{_bool_token(boundary['technical_wav_validation'])}`",
+        f"- audio rendered quality claimed: `{_bool_token(boundary['audio_rendered_quality_claimed'])}`",
+        f"- human/audio preference claimed: `{_bool_token(boundary['human_audio_preference_claimed'])}`",
+        f"- musical quality claimed: `{_bool_token(boundary['musical_quality_claimed'])}`",
+        "",
+        "## Rendered Files",
+        "",
+        "| rank | seed | sample | wav path | duration | sample rate | size | sha256 |",
+        "|---:|---:|---:|---|---:|---:|---:|---|",
+    ]
+    for item in report.get("rendered_audio_files", []):
+        wav_file = item["wav_file"]
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(item["review_rank"]),
+                    str(item["sample_seed"]),
+                    str(item["sample_index"]),
+                    str(wav_file["path"]),
+                    f"{float(wav_file['duration_seconds']):.3f}",
+                    str(wav_file["sample_rate"]),
+                    str(wav_file["size_bytes"]),
+                    str(wav_file["sha256"][:12]),
+                ]
+            )
+            + " |"
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    default_soundfont = Path.home() / ".local/share/soundfonts/generaluser-gs/v1.471.sf2"
+    parser = argparse.ArgumentParser(description="Render generic tiny checkpoint repair audio")
+    parser.add_argument("--local_audio_render_package", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--renderer", type=str, default=shutil.which("fluidsynth") or "")
+    parser.add_argument("--soundfont", type=str, default=str(default_soundfont))
+    parser.add_argument("--sample_rate", type=int, default=44100)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_file_count", type=int, default=5)
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_audio_render_report(
+        read_json(Path(args.local_audio_render_package)),
+        output_dir=output_dir,
+        renderer_path=str(args.renderer or ""),
+        soundfont_path=str(args.soundfont or ""),
+        sample_rate=int(args.sample_rate),
+    )
+    summary = validate_audio_render_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_file_count=int(args.expected_file_count),
+        expected_sample_rate=int(args.sample_rate),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt.json", report)
+    write_json(
+        output_dir / "stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt.py
+++ b/tests/test_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+import wave
+from pathlib import Path
+from typing import Sequence
+
+from scripts.render_stage_b_generic_tiny_checkpoint_repair_audio import (
+    StageBGenericTinyCheckpointRepairAudioRenderError,
+    build_audio_render_report,
+    validate_audio_render_report,
+)
+
+
+def fake_midi(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"MThd\x00\x00\x00\x06\x00\x00\x00\x01\x00`MTrk\x00\x00\x00\x04\x00\xff/\x00")
+
+
+def write_wav(path: Path, sample_rate: int = 44100) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(2)
+        handle.setsampwidth(2)
+        handle.setframerate(sample_rate)
+        handle.writeframes(b"\x00\x00\x00\x00" * sample_rate)
+
+
+def fake_runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    output_index = list(command).index("-F") + 1
+    write_wav(Path(command[output_index]))
+    return subprocess.CompletedProcess(list(command), 0, stdout="rendered", stderr="")
+
+
+def local_audio_render_package(root: Path, *, status: str = "ready_for_local_render") -> dict:
+    midi_a = root / "rank_01.mid"
+    midi_b = root / "rank_02.mid"
+    fake_midi(midi_a)
+    fake_midi(midi_b)
+    return {
+        "schema_version": "stage_b_generic_tiny_checkpoint_repair_audio_render_package_v1",
+        "renderer_probe": {
+            "selected_renderer": str(root / "fluidsynth"),
+            "soundfont_path": str(root / "piano.sf2"),
+        },
+        "local_audio_render_boundary": {
+            "boundary": "stage_b_generic_tiny_checkpoint_repair_audio_render_package",
+            "status": status,
+            "render_attempted": False,
+            "audio_rendered_quality_claimed": False,
+            "human_audio_preference_claimed": False,
+        },
+        "review_items": [
+            {
+                "review_rank": 1,
+                "sample_seed": 47,
+                "sample_index": 6,
+                "midi_file": {"path": str(midi_a), "required": True},
+            },
+            {
+                "review_rank": 2,
+                "sample_seed": 45,
+                "sample_index": 4,
+                "midi_file": {"path": str(midi_b), "required": True},
+            },
+        ],
+    }
+
+
+class StageBGenericTinyCheckpointRepairLocalAudioRenderAttemptTest(unittest.TestCase):
+    def test_renders_wav_files_without_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            soundfont = root / "piano.sf2"
+            renderer.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            report = build_audio_render_report(
+                local_audio_render_package(root),
+                output_dir=root / "rendered",
+                renderer_path=str(renderer),
+                soundfont_path=str(soundfont),
+                sample_rate=44100,
+                runner=fake_runner,
+            )
+            summary = validate_audio_render_report(
+                report,
+                expected_boundary="stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt",
+                expected_file_count=2,
+                expected_sample_rate=44100,
+                require_no_quality_claim=True,
+            )
+
+            self.assertTrue(summary["render_attempted"])
+            self.assertEqual(summary["rendered_audio_file_count"], 2)
+            self.assertTrue(summary["technical_wav_validation"])
+            self.assertFalse(summary["audio_rendered_quality_claimed"])
+            self.assertFalse(summary["human_audio_preference_claimed"])
+            self.assertTrue(summary["critical_user_input_required"])
+
+    def test_rejects_not_ready_package(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            soundfont = root / "piano.sf2"
+            renderer.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+
+            with self.assertRaises(StageBGenericTinyCheckpointRepairAudioRenderError):
+                build_audio_render_report(
+                    local_audio_render_package(root, status="soundfont_missing"),
+                    output_dir=root / "rendered",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(soundfont),
+                    sample_rate=44100,
+                    runner=fake_runner,
+                )
+
+    def test_rejects_missing_soundfont(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            renderer.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+
+            with self.assertRaises(StageBGenericTinyCheckpointRepairAudioRenderError):
+                build_audio_render_report(
+                    local_audio_render_package(root),
+                    output_dir=root / "rendered",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(root / "missing.sf2"),
+                    sample_rate=44100,
+                    runner=fake_runner,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Stage B generic tiny checkpoint repair 후보 `5`개 WAV render 실행
- rendered WAV file count `5`
- technical WAV validation `true`
- audio quality, human/audio preference, musical quality claim 차단 유지

## Context

- #405 결과: planned audio outputs `5`, render status `ready_for_local_render`
- renderer: `fluidsynth`
- soundfont: GeneralUser GS `v1.471.sf2`
- 현재 검토 대상: WAV 생성과 technical metadata 검증

## Scope

- `scripts/render_stage_b_generic_tiny_checkpoint_repair_audio.py` 추가
- `stage-b-generic-tiny-checkpoint-repair-local-audio-render-attempt` harness mode 추가
- unit test 추가
- `AGENTS.md`, `docs/CURRENT_STATUS_AND_PLAN.md`, `docs/CORE_PLAN.md` handoff 갱신
- 결과 문서 추가: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_LOCAL_AUDIO_RENDER_ATTEMPT_2026-05-30.md`

## Validation

- `./.venv/bin/python -m unittest tests/test_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt.py`
- `./.venv/bin/python -m compileall scripts/render_stage_b_generic_tiny_checkpoint_repair_audio.py tests/test_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt.py`
- `RUN_ID=issue_407_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt_harness AUDIO_PACKAGE_RUN_ID=harness_stage_b_generic_tiny_checkpoint_repair_audio_render_package LISTENING_FILL_RUN_ID=harness_stage_b_generic_tiny_checkpoint_repair_listening_fill LISTENING_NOTES_RUN_ID=harness_stage_b_generic_tiny_checkpoint_repair_listening_notes bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-local-audio-render-attempt`
- `bash scripts/agent_harness.sh quick`
- `git diff --cached --check`

## Risk

- WAV 파일은 로컬 산출물이며 원격 업로드 대상 제외
- audio rendered quality claim 없음
- human/audio preference claim 없음
- musical quality claim 없음
- broad trained-model quality claim 없음

## Follow-up

- Stage B generic tiny checkpoint repair user listening review input

Closes #407
