### PR TITLE
Stage B generic tiny checkpoint repair user listening review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #407, Stage B generic tiny checkpoint repair local audio render attempt.
+- Latest functional issue completed: Issue #409, Stage B generic tiny checkpoint repair user listening review input.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B generic tiny checkpoint repair user listening review input.
+- Recommended next issue: Stage B generic tiny checkpoint repair phrase continuation repair decision.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -962,6 +962,14 @@ bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-local-audio
 ```
 
 This harness renders the packaged repair candidates to local WAV files and validates WAV metadata without claiming listening quality.
+
+For Stage B generic tiny checkpoint repair user listening review changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-user-listening-review
+```
+
+This harness records the single-user reject-all listening result and routes the plunk-and-stop failure to the next repair decision.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -148,6 +148,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint repair listening fill 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_LISTENING_FILL_2026-05-30.md`
 - generic tiny checkpoint repair audio render package 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_AUDIO_RENDER_PACKAGE_2026-05-30.md`
 - generic tiny checkpoint repair local audio render attempt 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_LOCAL_AUDIO_RENDER_ATTEMPT_2026-05-30.md`
+- generic tiny checkpoint repair user listening review 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_USER_LISTENING_REVIEW_2026-05-30.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -234,6 +235,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint repair listening fill: review input `false`, fill status `pending_review_input`, candidate `5`, auto progress `true`, musical quality claim `false`
 - generic tiny checkpoint repair audio render package: planned audio outputs `5`, render status `ready_for_local_render`, audio quality claim `false`
 - generic tiny checkpoint repair local audio render attempt: rendered WAV files `5`, technical WAV validation `true`, audio quality claim `false`
+- generic tiny checkpoint repair user listening review: overall `reject_all`, candidate `reject`, primary failure `plunk_and_stop`, keep claim `false`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -1257,6 +1259,16 @@ Issue #312는 constrained decoding으로 adjacent repeat를 줄였지만 dead-ai
 - duration seconds range: `7.766-10.657`
 - audio rendered quality / human audio preference / musical quality claim: `false/false/false`
 - 다음 작업은 repair user listening review input이다.
+
+현재 generic tiny checkpoint repair user listening review:
+
+- Issue #409 result: reviewed audio files `5`
+- overall decision: `reject_all`
+- candidate decision: `reject`
+- primary failure: `plunk_and_stop`
+- timing / phrase / vocabulary: `too_short_or_stiff` / `fragmented` / `not_musical`
+- human/audio keep claim: `false`
+- 다음 작업은 repair phrase continuation decision이다.
 
 ### Phase 5. Brad Style Adaptation
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #407, Stage B generic tiny checkpoint repair local audio render attempt
-- 다음 권장 이슈: `Stage B generic tiny checkpoint repair user listening review input`
+- latest functional result: Issue #409, Stage B generic tiny checkpoint repair user listening review input
+- 다음 권장 이슈: `Stage B generic tiny checkpoint repair phrase continuation repair decision`
 
 현재 범위가 아닌 것:
 
@@ -523,6 +523,43 @@ Issue #407은 Issue #405 audio render package 후보 `5`개를 FluidSynth와 Gen
 다음:
 
 - `Stage B generic tiny checkpoint repair user listening review input`
+
+## Current Generic Tiny Checkpoint Repair User Listening Review Result
+
+Issue #409는 Issue #407 WAV `5`개에 대한 user listening review 입력을 반영한 작업이다.
+
+변경:
+
+- generic tiny checkpoint repair user listening review fill script 추가
+- user listening input을 `reject_all`로 기록
+- 후보별 decision을 `reject`로 기록
+- primary failure를 `plunk_and_stop`으로 기록
+- timing, phrase, vocabulary failure boundary 기록
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_USER_LISTENING_REVIEW_2026-05-30.md`
+- reviewed audio file count: `5`
+- overall decision: `reject_all`
+- candidate decision: `reject`
+- primary failure: `plunk_and_stop`
+- timing: `too_short_or_stiff`
+- phrase: `fragmented`
+- vocabulary: `not_musical`
+- human/audio keep claimed: `false`
+- musical quality claimed: `false`
+- auto progress allowed: `true`
+
+판단:
+
+- 현재 후보 `5`개는 keep 후보 아님
+- 실패 지점은 outside soloing 해석보다 짧은 fragment, phrase continuation 부족, plunk-and-stop output
+- 다음 작업은 해당 실패를 repair target으로 바꾸는 decision boundary
+
+다음:
+
+- `Stage B generic tiny checkpoint repair phrase continuation repair decision`
 
 ## Current Muzig Application Resume Wording Result
 

--- a/docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_USER_LISTENING_REVIEW_2026-05-30.md
+++ b/docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_USER_LISTENING_REVIEW_2026-05-30.md
@@ -1,0 +1,37 @@
+# Stage B Generic Tiny Checkpoint Repair User Listening Review
+
+## Summary
+
+- boundary: `generic_tiny_checkpoint_repair_audio_review_reject_all`
+- review status: `reviewed`
+- overall decision: `reject_all`
+- candidate decision: `reject`
+- primary failure: `plunk_and_stop`
+- timing: `too_short_or_stiff`
+- phrase: `fragmented`
+- vocabulary: `not_musical`
+- human/audio keep claimed: `false`
+- musical quality claimed: `false`
+- auto progress allowed: `true`
+
+## Assessment
+
+- all candidates only plunk briefly and end
+- notes: user listened to all five WAV files; all candidates felt like short plunk-and-stop fragments
+
+## Reviewed Files
+
+- rank `1` seed `47` sample `6` wav `outputs/stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt/issue_407_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt/audio/rank_01_seed_47_sample_6.wav`
+- rank `2` seed `45` sample `4` wav `outputs/stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt/issue_407_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt/audio/rank_02_seed_45_sample_4.wav`
+- rank `3` seed `42` sample `1` wav `outputs/stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt/issue_407_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt/audio/rank_03_seed_42_sample_1.wav`
+- rank `4` seed `43` sample `2` wav `outputs/stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt/issue_407_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt/audio/rank_04_seed_43_sample_2.wav`
+- rank `5` seed `46` sample `5` wav `outputs/stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt/issue_407_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt/audio/rank_05_seed_46_sample_5.wav`
+
+## Not Proven
+
+- `human_audio_keep`
+- `multi_reviewer_preference`
+- `audio_rendered_quality`
+- `musical_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -180,6 +180,8 @@ Modes:
                 Package generic tiny checkpoint repair candidates for local audio rendering.
   stage-b-generic-tiny-checkpoint-repair-local-audio-render-attempt
                 Render generic tiny checkpoint repair candidates to local WAV files.
+  stage-b-generic-tiny-checkpoint-repair-user-listening-review
+                Record user listening rejection for generic tiny checkpoint repair WAV files.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -2455,6 +2457,38 @@ run_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt() {
     --require_no_quality_claim
 }
 
+run_stage_b_generic_tiny_checkpoint_repair_user_listening_review() {
+  local audio_render_run_id="${AUDIO_RENDER_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt}"
+  local audio_package_run_id="${AUDIO_PACKAGE_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_audio_render_package}"
+  local listening_fill_run_id="${LISTENING_FILL_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_listening_fill}"
+  local listening_notes_run_id="${LISTENING_NOTES_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_listening_notes}"
+  local run_id="${RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_user_listening_review}"
+  local audio_render_report="outputs/stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt/${audio_render_run_id}/stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt.json"
+  if [[ ! -f "$audio_render_report" ]]; then
+    print_header "Stage B generic tiny checkpoint repair local audio render attempt"
+    RUN_ID="$audio_render_run_id" AUDIO_PACKAGE_RUN_ID="$audio_package_run_id" LISTENING_FILL_RUN_ID="$listening_fill_run_id" LISTENING_NOTES_RUN_ID="$listening_notes_run_id" run_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt
+  fi
+  print_header "Stage B generic tiny checkpoint repair user listening review"
+  "$PYTHON_BIN" scripts/fill_stage_b_generic_tiny_checkpoint_repair_user_listening_review.py \
+    --run_id "$run_id" \
+    --audio_render_report "$audio_render_report" \
+    --reviewer "user" \
+    --overall_decision reject_all \
+    --candidate_decision reject \
+    --primary_failure plunk_and_stop \
+    --timing too_short_or_stiff \
+    --phrase fragmented \
+    --vocabulary not_musical \
+    --assessment "all candidates only plunk briefly and end" \
+    --notes "user listened to all five WAV files; all candidates felt like short plunk-and-stop fragments" \
+    --expected_boundary generic_tiny_checkpoint_repair_audio_review_reject_all \
+    --expected_overall_decision reject_all \
+    --expected_primary_failure plunk_and_stop \
+    --expected_file_count 5 \
+    --require_no_keep_claim \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -3820,6 +3854,9 @@ case "$MODE" in
     ;;
   stage-b-generic-tiny-checkpoint-repair-local-audio-render-attempt)
     run_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt
+    ;;
+  stage-b-generic-tiny-checkpoint-repair-user-listening-review)
+    run_stage_b_generic_tiny_checkpoint_repair_user_listening_review
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/fill_stage_b_generic_tiny_checkpoint_repair_user_listening_review.py
+++ b/scripts/fill_stage_b_generic_tiny_checkpoint_repair_user_listening_review.py
@@ -1,0 +1,371 @@
+"""Fill user listening review for generic tiny checkpoint repair WAV candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.run_stage_b_generic_tiny_checkpoint_generation_probe import (  # noqa: E402
+    _bool_token,
+    _dict,
+    _int,
+)
+
+
+class StageBGenericTinyCheckpointRepairUserListeningReviewError(ValueError):
+    pass
+
+
+OVERALL_DECISIONS = {"keep_any", "reject_all", "unclear"}
+CANDIDATE_DECISIONS = {"keep", "needs_followup", "reject", "unclear"}
+FAILURE_VALUES = {"plunk_and_stop", "outside_or_unclear", "too_sparse", "fragmented", "unclear"}
+TIMING_VALUES = {"too_short_or_stiff", "outside_or_unclear", "acceptable", "unclear"}
+PHRASE_VALUES = {"fragmented", "weak", "acceptable", "unclear"}
+VOCABULARY_VALUES = {"not_musical", "thin", "acceptable", "unclear"}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def compact_rendered_item(item: dict[str, Any]) -> dict[str, Any]:
+    wav_file = _dict(item.get("wav_file"))
+    if not bool(wav_file.get("exists", False)):
+        raise StageBGenericTinyCheckpointRepairUserListeningReviewError(
+            f"missing WAV for rank {item.get('review_rank')}"
+        )
+    return {
+        "review_rank": _int(item.get("review_rank")),
+        "sample_seed": _int(item.get("sample_seed")),
+        "sample_index": _int(item.get("sample_index")),
+        "source_midi_path": str(item.get("source_midi_path") or ""),
+        "wav_path": str(wav_file.get("path") or ""),
+        "duration_seconds": float(wav_file.get("duration_seconds", 0.0) or 0.0),
+        "sample_rate": int(wav_file.get("sample_rate", 0) or 0),
+        "sha256": str(wav_file.get("sha256") or ""),
+    }
+
+
+def rendered_audio_items(audio_render_report: dict[str, Any]) -> list[dict[str, Any]]:
+    boundary = _dict(audio_render_report.get("audio_render_boundary"))
+    if str(boundary.get("boundary") or "") != "stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt":
+        raise StageBGenericTinyCheckpointRepairUserListeningReviewError("unexpected audio render boundary")
+    if not bool(boundary.get("render_attempted", False)):
+        raise StageBGenericTinyCheckpointRepairUserListeningReviewError("render attempt is required")
+    if not bool(boundary.get("technical_wav_validation", False)):
+        raise StageBGenericTinyCheckpointRepairUserListeningReviewError("technical WAV validation is required")
+    if bool(boundary.get("audio_rendered_quality_claimed", True)):
+        raise StageBGenericTinyCheckpointRepairUserListeningReviewError("source report must not claim audio quality")
+    if bool(boundary.get("human_audio_preference_claimed", True)):
+        raise StageBGenericTinyCheckpointRepairUserListeningReviewError("source report must not claim human preference")
+    if bool(boundary.get("musical_quality_claimed", True)):
+        raise StageBGenericTinyCheckpointRepairUserListeningReviewError("source report must not claim musical quality")
+    items = [compact_rendered_item(item) for item in _list(audio_render_report.get("rendered_audio_files")) if isinstance(item, dict)]
+    if not items:
+        raise StageBGenericTinyCheckpointRepairUserListeningReviewError("rendered audio files required")
+    return items
+
+
+def build_candidate_reviews(
+    items: list[dict[str, Any]],
+    *,
+    decision: str,
+    primary_failure: str,
+    assessment: str,
+) -> list[dict[str, Any]]:
+    if decision not in CANDIDATE_DECISIONS:
+        raise StageBGenericTinyCheckpointRepairUserListeningReviewError(f"invalid candidate decision: {decision}")
+    if primary_failure not in FAILURE_VALUES:
+        raise StageBGenericTinyCheckpointRepairUserListeningReviewError(f"invalid primary failure: {primary_failure}")
+    return [
+        {
+            "review_rank": item["review_rank"],
+            "sample_seed": item["sample_seed"],
+            "sample_index": item["sample_index"],
+            "decision": decision,
+            "primary_failure": primary_failure,
+            "assessment": assessment.strip(),
+        }
+        for item in items
+    ]
+
+
+def build_user_listening_review(
+    audio_render_report: dict[str, Any],
+    *,
+    output_dir: Path,
+    reviewer: str,
+    overall_decision: str,
+    candidate_decision: str,
+    primary_failure: str,
+    timing: str,
+    phrase: str,
+    vocabulary: str,
+    assessment: str,
+    notes: str,
+) -> dict[str, Any]:
+    if not reviewer.strip():
+        raise StageBGenericTinyCheckpointRepairUserListeningReviewError("reviewer is required")
+    if overall_decision not in OVERALL_DECISIONS:
+        raise StageBGenericTinyCheckpointRepairUserListeningReviewError(f"invalid overall decision: {overall_decision}")
+    if candidate_decision not in CANDIDATE_DECISIONS:
+        raise StageBGenericTinyCheckpointRepairUserListeningReviewError(f"invalid candidate decision: {candidate_decision}")
+    if primary_failure not in FAILURE_VALUES:
+        raise StageBGenericTinyCheckpointRepairUserListeningReviewError(f"invalid primary failure: {primary_failure}")
+    if timing not in TIMING_VALUES:
+        raise StageBGenericTinyCheckpointRepairUserListeningReviewError(f"invalid timing: {timing}")
+    if phrase not in PHRASE_VALUES:
+        raise StageBGenericTinyCheckpointRepairUserListeningReviewError(f"invalid phrase: {phrase}")
+    if vocabulary not in VOCABULARY_VALUES:
+        raise StageBGenericTinyCheckpointRepairUserListeningReviewError(f"invalid vocabulary: {vocabulary}")
+    items = rendered_audio_items(audio_render_report)
+    keep_claimed = overall_decision == "keep_any"
+    return {
+        "schema_version": "stage_b_generic_tiny_checkpoint_repair_user_listening_review_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_audio_render_schema": str(audio_render_report.get("schema_version") or ""),
+        "reviewed_audio_files": items,
+        "user_listening_review": {
+            "status": "reviewed",
+            "reviewer": reviewer.strip(),
+            "review_basis": "single_user_listening_review_of_generic_tiny_checkpoint_repair_wav_files",
+            "overall_decision": overall_decision,
+            "candidate_decision": candidate_decision,
+            "primary_failure": primary_failure,
+            "timing": timing,
+            "phrase": phrase,
+            "vocabulary": vocabulary,
+            "assessment": assessment.strip(),
+            "notes": notes.strip(),
+            "candidate_reviews": build_candidate_reviews(
+                items,
+                decision=candidate_decision,
+                primary_failure=primary_failure,
+                assessment=assessment,
+            ),
+        },
+        "claim_boundary": {
+            "single_user_review_completed": True,
+            "human_audio_keep_claimed": keep_claimed,
+            "human_audio_preference_claimed": keep_claimed,
+            "human_audio_reject_all_recorded": overall_decision == "reject_all",
+            "audio_render_used": True,
+            "audio_rendered_quality_claimed": False,
+            "musical_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "boundary": (
+                "generic_tiny_checkpoint_repair_audio_review_single_user_keep_support"
+                if keep_claimed
+                else "generic_tiny_checkpoint_repair_audio_review_reject_all"
+            ),
+        },
+        "decision": {
+            "current_boundary": "stage_b_generic_tiny_checkpoint_repair_user_listening_review_input",
+            "next_boundary": "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_repair_decision",
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "repair_target": primary_failure,
+        },
+        "proven": [
+            "single_user_audio_review_completed",
+            "generic_tiny_checkpoint_repair_current_candidates_rejected",
+        ],
+        "not_proven": [
+            "human_audio_keep",
+            "multi_reviewer_preference",
+            "audio_rendered_quality",
+            "musical_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": "Stage B generic tiny checkpoint repair phrase continuation repair decision",
+    }
+
+
+def validate_user_listening_review(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_overall_decision: str | None,
+    expected_primary_failure: str | None,
+    expected_file_count: int,
+    require_no_keep_claim: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    review = _dict(report.get("user_listening_review"))
+    claim = _dict(report.get("claim_boundary"))
+    boundary = str(claim.get("boundary") or "")
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBGenericTinyCheckpointRepairUserListeningReviewError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    overall = str(review.get("overall_decision") or "")
+    if expected_overall_decision and overall != expected_overall_decision:
+        raise StageBGenericTinyCheckpointRepairUserListeningReviewError(
+            f"expected overall decision {expected_overall_decision}, got {overall}"
+        )
+    primary_failure = str(review.get("primary_failure") or "")
+    if expected_primary_failure and primary_failure != expected_primary_failure:
+        raise StageBGenericTinyCheckpointRepairUserListeningReviewError(
+            f"expected primary failure {expected_primary_failure}, got {primary_failure}"
+        )
+    reviewed_file_count = len(_list(report.get("reviewed_audio_files")))
+    if reviewed_file_count != expected_file_count:
+        raise StageBGenericTinyCheckpointRepairUserListeningReviewError(
+            f"expected reviewed file count {expected_file_count}, got {reviewed_file_count}"
+        )
+    if require_no_keep_claim and bool(claim.get("human_audio_keep_claimed", True)):
+        raise StageBGenericTinyCheckpointRepairUserListeningReviewError("human/audio keep must not be claimed")
+    if require_no_quality_claim:
+        claimed = [
+            bool(claim.get("audio_rendered_quality_claimed", True)),
+            bool(claim.get("musical_quality_claimed", True)),
+            bool(claim.get("broad_trained_model_quality_claimed", True)),
+            bool(claim.get("brad_style_adaptation_claimed", True)),
+        ]
+        if any(claimed):
+            raise StageBGenericTinyCheckpointRepairUserListeningReviewError("quality claims must not be set")
+    decision = _dict(report.get("decision"))
+    return {
+        "boundary": boundary,
+        "review_status": str(review.get("status") or ""),
+        "overall_decision": overall,
+        "candidate_decision": str(review.get("candidate_decision") or ""),
+        "primary_failure": primary_failure,
+        "timing": str(review.get("timing") or ""),
+        "phrase": str(review.get("phrase") or ""),
+        "vocabulary": str(review.get("vocabulary") or ""),
+        "reviewed_audio_file_count": reviewed_file_count,
+        "human_audio_keep_claimed": bool(claim.get("human_audio_keep_claimed", True)),
+        "human_audio_reject_all_recorded": bool(claim.get("human_audio_reject_all_recorded", False)),
+        "audio_rendered_quality_claimed": bool(claim.get("audio_rendered_quality_claimed", True)),
+        "musical_quality_claimed": bool(claim.get("musical_quality_claimed", True)),
+        "auto_progress_allowed": bool(decision.get("auto_progress_allowed", False)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    review = report["user_listening_review"]
+    claim = report["claim_boundary"]
+    decision = report["decision"]
+    lines = [
+        "# Stage B Generic Tiny Checkpoint Repair User Listening Review",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{claim['boundary']}`",
+        f"- review status: `{review['status']}`",
+        f"- overall decision: `{review['overall_decision']}`",
+        f"- candidate decision: `{review['candidate_decision']}`",
+        f"- primary failure: `{review['primary_failure']}`",
+        f"- timing: `{review['timing']}`",
+        f"- phrase: `{review['phrase']}`",
+        f"- vocabulary: `{review['vocabulary']}`",
+        f"- human/audio keep claimed: `{_bool_token(claim['human_audio_keep_claimed'])}`",
+        f"- musical quality claimed: `{_bool_token(claim['musical_quality_claimed'])}`",
+        f"- auto progress allowed: `{_bool_token(decision['auto_progress_allowed'])}`",
+        "",
+        "## Assessment",
+        "",
+        f"- {review['assessment']}",
+        f"- notes: {review['notes']}",
+        "",
+        "## Reviewed Files",
+        "",
+    ]
+    for item in report.get("reviewed_audio_files", []):
+        lines.append(
+            "- "
+            f"rank `{item['review_rank']}` "
+            f"seed `{item['sample_seed']}` "
+            f"sample `{item['sample_index']}` "
+            f"wav `{item['wav_path']}`"
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Fill generic tiny checkpoint repair user listening review")
+    parser.add_argument(
+        "--audio_render_report",
+        type=str,
+        default="outputs/stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt/"
+        "harness_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt/"
+        "stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt.json",
+    )
+    parser.add_argument("--output_root", type=str, default="outputs/stage_b_generic_tiny_checkpoint_repair_user_listening_review")
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--reviewer", type=str, required=True)
+    parser.add_argument("--overall_decision", type=str, required=True)
+    parser.add_argument("--candidate_decision", type=str, required=True)
+    parser.add_argument("--primary_failure", type=str, required=True)
+    parser.add_argument("--timing", type=str, required=True)
+    parser.add_argument("--phrase", type=str, required=True)
+    parser.add_argument("--vocabulary", type=str, required=True)
+    parser.add_argument("--assessment", type=str, required=True)
+    parser.add_argument("--notes", type=str, default="")
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_overall_decision", type=str, default="")
+    parser.add_argument("--expected_primary_failure", type=str, default="")
+    parser.add_argument("--expected_file_count", type=int, default=5)
+    parser.add_argument("--require_no_keep_claim", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_user_listening_review(
+        read_json(Path(args.audio_render_report)),
+        output_dir=output_dir,
+        reviewer=str(args.reviewer),
+        overall_decision=str(args.overall_decision),
+        candidate_decision=str(args.candidate_decision),
+        primary_failure=str(args.primary_failure),
+        timing=str(args.timing),
+        phrase=str(args.phrase),
+        vocabulary=str(args.vocabulary),
+        assessment=str(args.assessment),
+        notes=str(args.notes),
+    )
+    summary = validate_user_listening_review(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_overall_decision=str(args.expected_overall_decision or ""),
+        expected_primary_failure=str(args.expected_primary_failure or ""),
+        expected_file_count=int(args.expected_file_count),
+        require_no_keep_claim=bool(args.require_no_keep_claim),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "stage_b_generic_tiny_checkpoint_repair_user_listening_review.json", report)
+    write_json(output_dir / "stage_b_generic_tiny_checkpoint_repair_user_listening_review_validation_summary.json", summary)
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_generic_tiny_checkpoint_repair_user_listening_review.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_generic_tiny_checkpoint_repair_user_listening_review.py
+++ b/tests/test_stage_b_generic_tiny_checkpoint_repair_user_listening_review.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.fill_stage_b_generic_tiny_checkpoint_repair_user_listening_review import (
+    StageBGenericTinyCheckpointRepairUserListeningReviewError,
+    build_user_listening_review,
+    validate_user_listening_review,
+)
+
+
+def audio_render_report(*, quality_claimed: bool = False) -> dict:
+    return {
+        "schema_version": "stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt_v1",
+        "audio_render_boundary": {
+            "boundary": "stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt",
+            "render_attempted": True,
+            "technical_wav_validation": True,
+            "audio_rendered_quality_claimed": quality_claimed,
+            "human_audio_preference_claimed": False,
+            "musical_quality_claimed": False,
+        },
+        "rendered_audio_files": [
+            {
+                "review_rank": 1,
+                "sample_seed": 47,
+                "sample_index": 6,
+                "source_midi_path": "rank_01.mid",
+                "wav_file": {
+                    "path": "rank_01.wav",
+                    "exists": True,
+                    "duration_seconds": 8.491,
+                    "sample_rate": 44100,
+                    "sha256": "a" * 64,
+                },
+            },
+            {
+                "review_rank": 2,
+                "sample_seed": 45,
+                "sample_index": 4,
+                "source_midi_path": "rank_02.mid",
+                "wav_file": {
+                    "path": "rank_02.wav",
+                    "exists": True,
+                    "duration_seconds": 10.657,
+                    "sample_rate": 44100,
+                    "sha256": "b" * 64,
+                },
+            },
+        ],
+    }
+
+
+class StageBGenericTinyCheckpointRepairUserListeningReviewTest(unittest.TestCase):
+    def test_records_reject_all_plunk_and_stop_without_quality_claim(self) -> None:
+        report = build_user_listening_review(
+            audio_render_report(),
+            output_dir=Path("outputs/review"),
+            reviewer="user",
+            overall_decision="reject_all",
+            candidate_decision="reject",
+            primary_failure="plunk_and_stop",
+            timing="too_short_or_stiff",
+            phrase="fragmented",
+            vocabulary="not_musical",
+            assessment="all candidates only plunk briefly and end",
+            notes="single user listening review",
+        )
+        summary = validate_user_listening_review(
+            report,
+            expected_boundary="generic_tiny_checkpoint_repair_audio_review_reject_all",
+            expected_overall_decision="reject_all",
+            expected_primary_failure="plunk_and_stop",
+            expected_file_count=2,
+            require_no_keep_claim=True,
+            require_no_quality_claim=True,
+        )
+
+        self.assertEqual(summary["candidate_decision"], "reject")
+        self.assertEqual(summary["primary_failure"], "plunk_and_stop")
+        self.assertFalse(summary["human_audio_keep_claimed"])
+        self.assertFalse(summary["musical_quality_claimed"])
+        self.assertTrue(summary["auto_progress_allowed"])
+
+    def test_rejects_source_audio_quality_claim(self) -> None:
+        with self.assertRaises(StageBGenericTinyCheckpointRepairUserListeningReviewError):
+            build_user_listening_review(
+                audio_render_report(quality_claimed=True),
+                output_dir=Path("outputs/review"),
+                reviewer="user",
+                overall_decision="reject_all",
+                candidate_decision="reject",
+                primary_failure="plunk_and_stop",
+                timing="too_short_or_stiff",
+                phrase="fragmented",
+                vocabulary="not_musical",
+                assessment="all candidates only plunk briefly and end",
+                notes="",
+            )
+
+    def test_rejects_invalid_failure_value(self) -> None:
+        with self.assertRaises(StageBGenericTinyCheckpointRepairUserListeningReviewError):
+            build_user_listening_review(
+                audio_render_report(),
+                output_dir=Path("outputs/review"),
+                reviewer="user",
+                overall_decision="reject_all",
+                candidate_decision="reject",
+                primary_failure="invalid",
+                timing="too_short_or_stiff",
+                phrase="fragmented",
+                vocabulary="not_musical",
+                assessment="all candidates only plunk briefly and end",
+                notes="",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Stage B generic tiny checkpoint repair WAV `5`개 user listening review 반영
- overall decision: `reject_all`
- candidate decision: `reject`
- primary failure: `plunk_and_stop`
- keep, musical quality, broad quality claim 차단 유지

## Context

- #407 결과: rendered WAV files `5`, technical WAV validation `true`
- user listening input: 후보 `5`개 모두 짧은 plunk-and-stop fragment
- 현재 검토 대상: single-user listening result 기록과 다음 repair decision boundary

## Scope

- `scripts/fill_stage_b_generic_tiny_checkpoint_repair_user_listening_review.py` 추가
- `stage-b-generic-tiny-checkpoint-repair-user-listening-review` harness mode 추가
- unit test 추가
- `AGENTS.md`, `docs/CURRENT_STATUS_AND_PLAN.md`, `docs/CORE_PLAN.md` handoff 갱신
- 결과 문서 추가: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_USER_LISTENING_REVIEW_2026-05-30.md`

## Validation

- `./.venv/bin/python -m unittest tests/test_stage_b_generic_tiny_checkpoint_repair_user_listening_review.py`
- `./.venv/bin/python -m compileall scripts/fill_stage_b_generic_tiny_checkpoint_repair_user_listening_review.py tests/test_stage_b_generic_tiny_checkpoint_repair_user_listening_review.py`
- `RUN_ID=issue_409_stage_b_generic_tiny_checkpoint_repair_user_listening_review_harness AUDIO_RENDER_RUN_ID=harness_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt AUDIO_PACKAGE_RUN_ID=harness_stage_b_generic_tiny_checkpoint_repair_audio_render_package LISTENING_FILL_RUN_ID=harness_stage_b_generic_tiny_checkpoint_repair_listening_fill LISTENING_NOTES_RUN_ID=harness_stage_b_generic_tiny_checkpoint_repair_listening_notes bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-user-listening-review`
- `bash scripts/agent_harness.sh quick`
- `git diff --cached --check`

## Risk

- single-user listening review만 반영
- keep candidate 없음
- audio rendered quality claim 없음
- musical quality claim 없음
- broad trained-model quality claim 없음

## Follow-up

- Stage B generic tiny checkpoint repair phrase continuation repair decision

Closes #409


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new script and tooling to enable user listening review workflow for checkpoint repair evaluation.

* **Documentation**
  * Added comprehensive documentation for Stage B generic tiny checkpoint repair user listening review process, including outcomes and assessment methodology.
  * Updated project status tracking and planning records.

* **Tests**
  * Added test coverage for user listening review functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohhalim/fine_tuning_art-tatum_midi_solo/pull/410?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->