### PR TITLE
Stage B generic tiny checkpoint repair phrase continuation sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #411, Stage B generic tiny checkpoint repair phrase continuation decision.
+- Latest functional issue completed: Issue #413, Stage B generic tiny checkpoint repair phrase continuation sweep.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B generic tiny checkpoint repair phrase continuation repair sweep.
+- Recommended next issue: Stage B generic tiny checkpoint repair phrase continuation audio render package.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -978,6 +978,14 @@ bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-phrase-cont
 ```
 
 This harness converts the plunk-and-stop listening rejection into phrase-continuation repair targets without claiming quality.
+
+For Stage B generic tiny checkpoint repair phrase continuation sweep changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-phrase-continuation-sweep
+```
+
+This harness runs a chord-aware phrase-continuation repair sweep and requires at least one objective-qualified candidate without claiming quality.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -150,6 +150,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint repair local audio render attempt 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_LOCAL_AUDIO_RENDER_ATTEMPT_2026-05-30.md`
 - generic tiny checkpoint repair user listening review 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_USER_LISTENING_REVIEW_2026-05-30.md`
 - generic tiny checkpoint repair phrase continuation decision 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_DECISION_2026-05-30.md`
+- generic tiny checkpoint repair phrase continuation sweep 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_SWEEP_2026-05-30.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -238,6 +239,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint repair local audio render attempt: rendered WAV files `5`, technical WAV validation `true`, audio quality claim `false`
 - generic tiny checkpoint repair user listening review: overall `reject_all`, candidate `reject`, primary failure `plunk_and_stop`, keep claim `false`
 - generic tiny checkpoint repair phrase continuation decision: repair target `6`, next boundary `phrase_continuation_repair_sweep`, quality claim `false`
+- generic tiny checkpoint repair phrase continuation sweep: target qualified `1/6`, selected sample `1` seed `62`, next boundary `phrase_continuation_audio_render_package`, quality claim `false`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -1280,6 +1282,19 @@ Issue #312는 constrained decoding으로 adjacent repeat를 줄였지만 dead-ai
 - auto progress allowed: `true`
 - human/audio keep / musical quality / broad model quality claim: `false/false/false`
 - 다음 작업은 repair phrase continuation sweep이다.
+
+현재 generic tiny checkpoint repair phrase continuation sweep:
+
+- Issue #413 result: boundary `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_repair_sweep`
+- next boundary: `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package`
+- sample count: `6`
+- valid / strict / grammar: `3/1/6`
+- target qualified count: `1`
+- selected objective candidate: sample `1`, seed `62`
+- selected note count / coverage / tail empty: `9` / `0.9062481875` / `2`
+- selected chord-role ratio / postprocess removal: `0.5625` / `0.4375`
+- musical quality / broad model quality claim: `false/false`
+- 다음 작업은 repair phrase continuation audio render package다.
 
 ### Phase 5. Brad Style Adaptation
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #411, Stage B generic tiny checkpoint repair phrase continuation decision
-- 다음 권장 이슈: `Stage B generic tiny checkpoint repair phrase continuation repair sweep`
+- latest functional result: Issue #413, Stage B generic tiny checkpoint repair phrase continuation sweep
+- 다음 권장 이슈: `Stage B generic tiny checkpoint repair phrase continuation audio render package`
 
 현재 범위가 아닌 것:
 
@@ -593,6 +593,41 @@ Issue #411은 Issue #409 user listening rejection을 다음 repair sweep target�
 다음:
 
 - `Stage B generic tiny checkpoint repair phrase continuation repair sweep`
+
+## Current Generic Tiny Checkpoint Repair Phrase Continuation Sweep Result
+
+Issue #413은 Issue #409 user listening rejection과 Issue #411 repair target을 기준으로 `plunk_and_stop` 후보를 줄이기 위한 chord-aware phrase-continuation sweep 작업이다.
+
+변경:
+
+- phrase continuation repair sweep script 추가
+- constrained generation 조건: note groups per bar `8`, chord-aware pitches, jazz duration tokens, overlap postprocess
+- target qualification 조건 정의: note count, phrase coverage, tail empty, chord-tone role, postprocess removal, monophonic
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_SWEEP_2026-05-30.md`
+- boundary: `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_repair_sweep`
+- next boundary: `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package`
+- sample count: `6`
+- valid / strict / grammar: `3/1/6`
+- target qualified count: `1`
+- selected objective candidate: sample `1`, seed `62`
+- selected note count / coverage / tail empty: `9` / `0.9062481875` / `2`
+- selected chord-role ratio / postprocess removal: `0.5625` / `0.4375`
+- musical quality claimed: `false`
+- broad trained-model quality claimed: `false`
+
+판단:
+
+- 이전 후보군의 `plunk_and_stop` 실패 판정은 reject-all로 유지
+- 이번 결과는 audio review 전 objective repair candidate 1개 확보까지만 의미
+- 음악적 선호, human/audio keep, broad model quality는 미검증
+
+다음:
+
+- `Stage B generic tiny checkpoint repair phrase continuation audio render package`
 
 ## Current Muzig Application Resume Wording Result
 

--- a/docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_SWEEP_2026-05-30.md
+++ b/docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_SWEEP_2026-05-30.md
@@ -1,0 +1,32 @@
+# Stage B Generic Tiny Checkpoint Repair Phrase Continuation Sweep
+
+## Summary
+
+- boundary: `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_repair_sweep`
+- next boundary: `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package`
+- target passed: `true`
+- target qualified count: `1`
+- candidate count: `6`
+- musical quality claimed: `false`
+
+## Generation
+
+- sample count: `6`
+- valid / strict / grammar: `3/1/6`
+- collapse warning sample rate: `0.5`
+
+## Top Candidates
+
+- sample `1` seed `62` target `true` note_count `9` coverage `0.9062481875` tail_empty `2` chord_role `0.5625` midi `outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep/issue_413_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep/generation_probe/phrase_continuation_chord_aware/samples/stage_b_sample_1.mid`
+- sample `2` seed `63` target `false` note_count `7` coverage `0.6249987499999999` tail_empty `6` chord_role `0.75` midi `outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep/issue_413_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep/generation_probe/phrase_continuation_chord_aware/samples/stage_b_sample_2.mid`
+- sample `5` seed `66` target `false` note_count `9` coverage `0.937498125` tail_empty `0` chord_role `0.6875` midi `outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep/issue_413_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep/generation_probe/phrase_continuation_chord_aware/samples/stage_b_sample_5.mid`
+- sample `3` seed `64` target `false` note_count `10` coverage `0.9062481875` tail_empty `0` chord_role `0.6875` midi `outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep/issue_413_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep/generation_probe/phrase_continuation_chord_aware/samples/stage_b_sample_3.mid`
+- sample `6` seed `67` target `false` note_count `8` coverage `1.0` tail_empty `0` chord_role `0.625` midi `outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep/issue_413_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep/generation_probe/phrase_continuation_chord_aware/samples/stage_b_sample_6.mid`
+
+## Not Proven
+
+- `audio_rendered_quality`
+- `human_audio_keep`
+- `musical_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -184,6 +184,8 @@ Modes:
                 Record user listening rejection for generic tiny checkpoint repair WAV files.
   stage-b-generic-tiny-checkpoint-repair-phrase-continuation-decision
                 Route plunk-and-stop rejection to phrase-continuation repair targets.
+  stage-b-generic-tiny-checkpoint-repair-phrase-continuation-sweep
+                Run phrase-continuation repair sweep from the generic tiny checkpoint.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -2513,6 +2515,35 @@ run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_decision() {
     --require_no_quality_claim
 }
 
+run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep() {
+  local decision_run_id="${DECISION_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_decision}"
+  local user_review_run_id="${USER_REVIEW_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_user_listening_review}"
+  local audio_render_run_id="${AUDIO_RENDER_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt}"
+  local audio_package_run_id="${AUDIO_PACKAGE_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_audio_render_package}"
+  local listening_fill_run_id="${LISTENING_FILL_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_listening_fill}"
+  local listening_notes_run_id="${LISTENING_NOTES_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_listening_notes}"
+  local training_smoke_run_id="${TRAINING_SMOKE_RUN_ID:-harness_stage_b_generic_base_tiny_training_smoke}"
+  local run_id="${RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep}"
+  local checkpoint_dir="outputs/stage_b_generic_base_tiny_training_smoke/${training_smoke_run_id}/checkpoints"
+  local decision_report="outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_decision/${decision_run_id}/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_decision.json"
+  if [[ ! -f "${checkpoint_dir}/checkpoint_epoch1.pt" ]]; then
+    print_header "Stage B generic base tiny training smoke"
+    RUN_ID="$training_smoke_run_id" run_stage_b_generic_base_tiny_training_smoke
+  fi
+  if [[ ! -f "$decision_report" ]]; then
+    print_header "Stage B generic tiny checkpoint repair phrase continuation decision"
+    RUN_ID="$decision_run_id" USER_REVIEW_RUN_ID="$user_review_run_id" AUDIO_RENDER_RUN_ID="$audio_render_run_id" AUDIO_PACKAGE_RUN_ID="$audio_package_run_id" LISTENING_FILL_RUN_ID="$listening_fill_run_id" LISTENING_NOTES_RUN_ID="$listening_notes_run_id" run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_decision
+  fi
+  print_header "Stage B generic tiny checkpoint repair phrase continuation sweep"
+  "$PYTHON_BIN" scripts/run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep.py \
+    --run_id "$run_id" \
+    --checkpoint_dir "$checkpoint_dir" \
+    --decision_report "$decision_report" \
+    --expected_boundary stage_b_generic_tiny_checkpoint_repair_phrase_continuation_repair_sweep \
+    --min_target_qualified 1 \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -3884,6 +3915,9 @@ case "$MODE" in
     ;;
   stage-b-generic-tiny-checkpoint-repair-phrase-continuation-decision)
     run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_decision
+    ;;
+  stage-b-generic-tiny-checkpoint-repair-phrase-continuation-sweep)
+    run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep.py
+++ b/scripts/run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep.py
@@ -1,0 +1,413 @@
+"""Run phrase-continuation repair sweep for the generic tiny checkpoint."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.run_stage_b_generic_tiny_checkpoint_generation_probe import (  # noqa: E402
+    _bool_token,
+    _dict,
+    _float,
+    _int,
+    run_command,
+)
+
+
+class StageBGenericTinyCheckpointRepairPhraseContinuationSweepError(ValueError):
+    pass
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def build_generation_command(
+    args: argparse.Namespace,
+    *,
+    checkpoint_dir: Path,
+    output_root: Path,
+    run_id: str,
+) -> list[str]:
+    return [
+        sys.executable,
+        "scripts/run_stage_b_generation_probe.py",
+        "--output_root",
+        str(output_root),
+        "--run_id",
+        run_id,
+        "--checkpoint_dir",
+        str(checkpoint_dir),
+        "--skip_prepare",
+        "--skip_train",
+        "--issue_number",
+        str(args.issue_number),
+        "--max_sequence",
+        str(args.max_sequence),
+        "--num_samples",
+        str(args.num_samples),
+        "--seed",
+        str(args.seed),
+        "--temperature",
+        str(args.temperature),
+        "--top_k",
+        str(args.top_k),
+        "--min_valid_samples",
+        str(args.min_valid_samples),
+        "--min_strict_valid_samples",
+        str(args.min_strict_valid_samples),
+        "--generation_mode",
+        "constrained",
+        "--constrained_note_groups_per_bar",
+        str(args.note_groups_per_bar),
+        "--jazz_duration_tokens",
+        "--chord_aware_pitches",
+        "--chord_pitch_mode",
+        "tones_tensions",
+        "--chord_pitch_repeat_window",
+        str(args.chord_pitch_repeat_window),
+        "--postprocess_overlap",
+        "--max_simultaneous_notes",
+        str(args.max_simultaneous_notes),
+        "--require_all_grammar_samples",
+    ]
+
+
+def target_failure_reasons(row: dict[str, Any], *, args: argparse.Namespace) -> list[str]:
+    temporal = _dict(row.get("temporal_coverage"))
+    pitch_roles = _dict(row.get("pitch_roles"))
+    collapse = _dict(row.get("collapse"))
+    metrics = _dict(row.get("metrics"))
+    reasons: list[str] = []
+    if not bool(row.get("grammar_gate_passed", False)):
+        reasons.append("grammar_gate_failed")
+    if not bool(row.get("strict_valid", False)):
+        reasons.append("strict_valid_failed")
+    if _int(metrics.get("note_count")) < int(args.min_note_count):
+        reasons.append("note_count_below_target")
+    if _float(metrics.get("phrase_coverage_ratio")) < float(args.min_phrase_coverage_ratio):
+        reasons.append("phrase_coverage_below_target")
+    if _int(temporal.get("tail_empty_steps")) > int(args.max_tail_empty_steps):
+        reasons.append("tail_empty_above_target")
+    if _float(pitch_roles.get("chord_tone_ratio")) < float(args.min_pitch_role_chord_tone_ratio):
+        reasons.append("pitch_role_chord_tone_below_target")
+    if _int(metrics.get("max_simultaneous_notes")) > int(args.max_simultaneous_notes):
+        reasons.append("max_simultaneous_notes_above_target")
+    if _float(collapse.get("postprocess_removal_ratio")) > float(args.max_postprocess_removal_ratio):
+        reasons.append("postprocess_removal_above_target")
+    return reasons
+
+
+def compact_candidate(row: dict[str, Any], *, args: argparse.Namespace) -> dict[str, Any]:
+    temporal = _dict(row.get("temporal_coverage"))
+    pitch_roles = _dict(row.get("pitch_roles"))
+    collapse = _dict(row.get("collapse"))
+    metrics = _dict(row.get("metrics"))
+    reasons = target_failure_reasons(row, args=args)
+    return {
+        "sample_index": _int(row.get("sample_index")),
+        "sample_seed": _int(row.get("sample_seed")),
+        "midi_path": str(row.get("midi_path") or ""),
+        "valid": bool(row.get("valid", False)),
+        "strict_valid": bool(row.get("strict_valid", False)),
+        "grammar_gate_passed": bool(row.get("grammar_gate_passed", False)),
+        "target_qualified": not reasons,
+        "target_failure_reasons": reasons,
+        "note_count": _int(metrics.get("note_count")),
+        "phrase_coverage_ratio": _float(metrics.get("phrase_coverage_ratio")),
+        "dead_air_ratio": _float(metrics.get("dead_air_ratio")),
+        "tail_empty_steps": _int(temporal.get("tail_empty_steps")),
+        "position_span_ratio": _float(temporal.get("position_span_ratio")),
+        "pitch_role_chord_tone_ratio": _float(pitch_roles.get("chord_tone_ratio")),
+        "metrics_chord_tone_ratio": _float(metrics.get("chord_tone_ratio")),
+        "postprocess_removal_ratio": _float(collapse.get("postprocess_removal_ratio")),
+        "max_simultaneous_notes": _int(metrics.get("max_simultaneous_notes")),
+    }
+
+
+def sort_candidates(candidates: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(
+        candidates,
+        key=lambda row: (
+            not bool(row.get("target_qualified", False)),
+            -_float(row.get("pitch_role_chord_tone_ratio")),
+            -_float(row.get("phrase_coverage_ratio")),
+            _float(row.get("dead_air_ratio")),
+            _int(row.get("sample_index")),
+        ),
+    )
+
+
+def build_sweep_report(
+    *,
+    run_dir: Path,
+    checkpoint_dir: Path,
+    generation_result: dict[str, Any],
+    generation_report_path: Path,
+    generation_report: dict[str, Any],
+    decision_report_path: Path,
+    decision_report: dict[str, Any],
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    decision = _dict(decision_report.get("decision"))
+    if str(decision.get("next_boundary") or "") != "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_repair_sweep":
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationSweepError("unexpected phrase-continuation decision boundary")
+    summary = _dict(generation_report.get("summary"))
+    candidates = [compact_candidate(row, args=args) for row in _list(generation_report.get("samples")) if isinstance(row, dict)]
+    ranked = sort_candidates(candidates)
+    target_qualified = [row for row in ranked if bool(row.get("target_qualified", False))]
+    target_passed = bool(
+        _int(generation_result.get("returncode")) == 0
+        and len(target_qualified) >= int(args.min_target_qualified)
+        and _int(summary.get("grammar_gate_sample_count")) == _int(summary.get("sample_count"))
+    )
+    return {
+        "schema_version": "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "run_dir": str(run_dir),
+        "checkpoint_dir": str(checkpoint_dir),
+        "decision_report_path": str(decision_report_path),
+        "generation_report_path": str(generation_report_path),
+        "input": {
+            "issue_number": int(args.issue_number),
+            "num_samples": int(args.num_samples),
+            "seed": int(args.seed),
+            "temperature": float(args.temperature),
+            "top_k": int(args.top_k),
+            "note_groups_per_bar": int(args.note_groups_per_bar),
+            "chord_aware_pitches": True,
+            "max_simultaneous_notes": int(args.max_simultaneous_notes),
+            "min_note_count": int(args.min_note_count),
+            "min_phrase_coverage_ratio": float(args.min_phrase_coverage_ratio),
+            "max_tail_empty_steps": int(args.max_tail_empty_steps),
+            "min_pitch_role_chord_tone_ratio": float(args.min_pitch_role_chord_tone_ratio),
+            "max_postprocess_removal_ratio": float(args.max_postprocess_removal_ratio),
+            "min_target_qualified": int(args.min_target_qualified),
+        },
+        "generation": {
+            "command": generation_result,
+            "summary": {
+                "sample_count": _int(summary.get("sample_count")),
+                "valid_sample_count": _int(summary.get("valid_sample_count")),
+                "strict_valid_sample_count": _int(summary.get("strict_valid_sample_count")),
+                "grammar_gate_sample_count": _int(summary.get("grammar_gate_sample_count")),
+                "collapse_warning_sample_rate": _float(summary.get("collapse_warning_sample_rate")),
+                "failure_reasons": _dict(summary.get("failure_reasons")),
+                "strict_failure_reasons": _dict(summary.get("strict_failure_reasons")),
+            },
+        },
+        "phrase_continuation": {
+            "target_passed": target_passed,
+            "target_qualified_count": len(target_qualified),
+            "candidate_count": len(candidates),
+            "ranked_candidates": ranked,
+        },
+        "readiness": {
+            "boundary": "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_repair_sweep",
+            "phrase_continuation_repair_target_passed": target_passed,
+            "musical_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "current_boundary": "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_repair_sweep",
+            "next_boundary": (
+                "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package"
+                if target_passed
+                else "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep_tuning"
+            ),
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "target qualification is objective-only; listening quality remains unclaimed",
+        },
+        "not_proven": [
+            "audio_rendered_quality",
+            "human_audio_keep",
+            "musical_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B generic tiny checkpoint repair phrase continuation audio render package"
+            if target_passed
+            else "Stage B generic tiny checkpoint repair phrase continuation sweep tuning"
+        ),
+    }
+
+
+def validate_sweep_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    min_target_qualified: int,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    phrase = _dict(report.get("phrase_continuation"))
+    boundary = str(readiness.get("boundary") or "")
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationSweepError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if _int(phrase.get("target_qualified_count")) < min_target_qualified:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationSweepError("target-qualified candidate count below target")
+    if require_no_quality_claim:
+        claimed = [
+            bool(readiness.get("musical_quality_claimed", True)),
+            bool(readiness.get("broad_trained_model_quality_claimed", True)),
+            bool(readiness.get("brad_style_adaptation_claimed", True)),
+        ]
+        if any(claimed):
+            raise StageBGenericTinyCheckpointRepairPhraseContinuationSweepError("quality claims must not be set")
+    return {
+        "boundary": boundary,
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "target_passed": bool(phrase.get("target_passed", False)),
+        "target_qualified_count": _int(phrase.get("target_qualified_count")),
+        "candidate_count": _int(phrase.get("candidate_count")),
+        "musical_quality_claimed": bool(readiness.get("musical_quality_claimed", True)),
+        "broad_trained_model_quality_claimed": bool(readiness.get("broad_trained_model_quality_claimed", True)),
+        "brad_style_adaptation_claimed": bool(readiness.get("brad_style_adaptation_claimed", True)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    generation = report["generation"]["summary"]
+    phrase = report["phrase_continuation"]
+    lines = [
+        "# Stage B Generic Tiny Checkpoint Repair Phrase Continuation Sweep",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{readiness['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- target passed: `{_bool_token(phrase['target_passed'])}`",
+        f"- target qualified count: `{phrase['target_qualified_count']}`",
+        f"- candidate count: `{phrase['candidate_count']}`",
+        f"- musical quality claimed: `{_bool_token(readiness['musical_quality_claimed'])}`",
+        "",
+        "## Generation",
+        "",
+        f"- sample count: `{generation['sample_count']}`",
+        f"- valid / strict / grammar: `{generation['valid_sample_count']}/{generation['strict_valid_sample_count']}/{generation['grammar_gate_sample_count']}`",
+        f"- collapse warning sample rate: `{generation['collapse_warning_sample_rate']}`",
+        "",
+        "## Top Candidates",
+        "",
+    ]
+    for candidate in phrase.get("ranked_candidates", [])[:5]:
+        lines.append(
+            "- "
+            f"sample `{candidate['sample_index']}` seed `{candidate['sample_seed']}` "
+            f"target `{_bool_token(candidate['target_qualified'])}` "
+            f"note_count `{candidate['note_count']}` "
+            f"coverage `{candidate['phrase_coverage_ratio']}` "
+            f"tail_empty `{candidate['tail_empty_steps']}` "
+            f"chord_role `{candidate['pitch_role_chord_tone_ratio']}` "
+            f"midi `{candidate['midi_path']}`"
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run generic tiny checkpoint phrase continuation repair sweep")
+    parser.add_argument("--checkpoint_dir", type=str, required=True)
+    parser.add_argument(
+        "--decision_report",
+        type=str,
+        default="outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_decision/"
+        "harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_decision/"
+        "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_decision.json",
+    )
+    parser.add_argument("--output_root", type=str, default="outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep")
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=413)
+    parser.add_argument("--max_sequence", type=int, default=160)
+    parser.add_argument("--num_samples", type=int, default=6)
+    parser.add_argument("--seed", type=int, default=62)
+    parser.add_argument("--temperature", type=float, default=0.78)
+    parser.add_argument("--top_k", type=int, default=5)
+    parser.add_argument("--min_valid_samples", type=int, default=1)
+    parser.add_argument("--min_strict_valid_samples", type=int, default=1)
+    parser.add_argument("--note_groups_per_bar", type=int, default=8)
+    parser.add_argument("--chord_pitch_repeat_window", type=int, default=2)
+    parser.add_argument("--max_simultaneous_notes", type=int, default=1)
+    parser.add_argument("--min_note_count", type=int, default=8)
+    parser.add_argument("--min_phrase_coverage_ratio", type=float, default=0.85)
+    parser.add_argument("--max_tail_empty_steps", type=int, default=2)
+    parser.add_argument("--min_pitch_role_chord_tone_ratio", type=float, default=0.5)
+    parser.add_argument("--max_postprocess_removal_ratio", type=float, default=0.49)
+    parser.add_argument("--min_target_qualified", type=int, default=1)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    run_dir = Path(args.output_root) / run_id
+    checkpoint_dir = Path(args.checkpoint_dir)
+    if not (checkpoint_dir / "checkpoint_epoch1.pt").exists():
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationSweepError("checkpoint required")
+    decision_report_path = Path(args.decision_report)
+    if not decision_report_path.exists():
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationSweepError("phrase-continuation decision report required")
+    probe_output_root = run_dir / "generation_probe"
+    probe_run_id = "phrase_continuation_chord_aware"
+    command = build_generation_command(
+        args,
+        checkpoint_dir=checkpoint_dir,
+        output_root=probe_output_root,
+        run_id=probe_run_id,
+    )
+    generation_result = run_command(command)
+    generation_report_path = probe_output_root / probe_run_id / "report.json"
+    if not generation_report_path.exists():
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationSweepError("generation report not produced")
+    report = build_sweep_report(
+        run_dir=run_dir,
+        checkpoint_dir=checkpoint_dir,
+        generation_result=generation_result,
+        generation_report_path=generation_report_path,
+        generation_report=read_json(generation_report_path),
+        decision_report_path=decision_report_path,
+        decision_report=read_json(decision_report_path),
+        args=args,
+    )
+    summary = validate_sweep_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        min_target_qualified=int(args.min_target_qualified),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    run_dir.mkdir(parents=True, exist_ok=True)
+    write_json(run_dir / "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep.json", report)
+    write_json(run_dir / "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep_validation_summary.json", summary)
+    markdown = markdown_report(report)
+    write_text(run_dir / "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep.py
+++ b/tests/test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import argparse
+import unittest
+from pathlib import Path
+
+from scripts.run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep import (
+    StageBGenericTinyCheckpointRepairPhraseContinuationSweepError,
+    build_sweep_report,
+    target_failure_reasons,
+    validate_sweep_report,
+)
+
+
+def args() -> argparse.Namespace:
+    return argparse.Namespace(
+        issue_number=413,
+        num_samples=2,
+        seed=62,
+        temperature=0.78,
+        top_k=5,
+        note_groups_per_bar=8,
+        max_simultaneous_notes=1,
+        min_note_count=8,
+        min_phrase_coverage_ratio=0.85,
+        max_tail_empty_steps=2,
+        min_pitch_role_chord_tone_ratio=0.5,
+        max_postprocess_removal_ratio=0.49,
+        min_target_qualified=1,
+    )
+
+
+def decision_report() -> dict:
+    return {
+        "decision": {
+            "next_boundary": "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_repair_sweep",
+        },
+    }
+
+
+def sample_row(*, strict: bool = True, tail_empty: int = 2, chord_ratio: float = 0.5625) -> dict:
+    return {
+        "sample_index": 1,
+        "sample_seed": 62,
+        "midi_path": "sample.mid",
+        "valid": True,
+        "strict_valid": strict,
+        "grammar_gate_passed": True,
+        "metrics": {
+            "note_count": 9,
+            "phrase_coverage_ratio": 0.90625,
+            "dead_air_ratio": 0.625,
+            "max_simultaneous_notes": 1,
+            "chord_tone_ratio": 0.3333,
+        },
+        "temporal_coverage": {
+            "tail_empty_steps": tail_empty,
+            "position_span_ratio": 0.90625,
+        },
+        "pitch_roles": {
+            "chord_tone_ratio": chord_ratio,
+        },
+        "collapse": {
+            "postprocess_removal_ratio": 0.4375,
+        },
+    }
+
+
+class StageBGenericTinyCheckpointRepairPhraseContinuationSweepTest(unittest.TestCase):
+    def test_target_candidate_passes_phrase_continuation_filters(self) -> None:
+        self.assertEqual(target_failure_reasons(sample_row(), args=args()), [])
+
+    def test_tail_empty_failure_is_recorded(self) -> None:
+        self.assertIn("tail_empty_above_target", target_failure_reasons(sample_row(tail_empty=4), args=args()))
+
+    def test_validate_rejects_below_target_candidate_count(self) -> None:
+        report = build_sweep_report(
+            run_dir=Path("outputs/sweep"),
+            checkpoint_dir=Path("checkpoints"),
+            generation_result={"returncode": 0},
+            generation_report_path=Path("report.json"),
+            generation_report={
+                "summary": {
+                    "sample_count": 1,
+                    "valid_sample_count": 1,
+                    "strict_valid_sample_count": 1,
+                    "grammar_gate_sample_count": 1,
+                    "collapse_warning_sample_rate": 0.0,
+                },
+                "samples": [sample_row(chord_ratio=0.25)],
+            },
+            decision_report_path=Path("decision.json"),
+            decision_report=decision_report(),
+            args=args(),
+        )
+
+        with self.assertRaises(StageBGenericTinyCheckpointRepairPhraseContinuationSweepError):
+            validate_sweep_report(
+                report,
+                expected_boundary="stage_b_generic_tiny_checkpoint_repair_phrase_continuation_repair_sweep",
+                min_target_qualified=1,
+                require_no_quality_claim=True,
+            )
+
+    def test_builds_sweep_report_without_quality_claim(self) -> None:
+        report = build_sweep_report(
+            run_dir=Path("outputs/sweep"),
+            checkpoint_dir=Path("checkpoints"),
+            generation_result={"returncode": 0},
+            generation_report_path=Path("report.json"),
+            generation_report={
+                "summary": {
+                    "sample_count": 2,
+                    "valid_sample_count": 1,
+                    "strict_valid_sample_count": 1,
+                    "grammar_gate_sample_count": 2,
+                    "collapse_warning_sample_rate": 0.0,
+                },
+                "samples": [sample_row(), sample_row(strict=False)],
+            },
+            decision_report_path=Path("decision.json"),
+            decision_report=decision_report(),
+            args=args(),
+        )
+        summary = validate_sweep_report(
+            report,
+            expected_boundary="stage_b_generic_tiny_checkpoint_repair_phrase_continuation_repair_sweep",
+            min_target_qualified=1,
+            require_no_quality_claim=True,
+        )
+
+        self.assertEqual(summary["target_qualified_count"], 1)
+        self.assertTrue(summary["target_passed"])
+        self.assertFalse(summary["musical_quality_claimed"])
+        self.assertEqual(
+            summary["next_boundary"],
+            "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package",
+        )
+
+    def test_rejects_wrong_decision_boundary(self) -> None:
+        bad_decision = {"decision": {"next_boundary": "other"}}
+        with self.assertRaises(StageBGenericTinyCheckpointRepairPhraseContinuationSweepError):
+            build_sweep_report(
+                run_dir=Path("outputs/sweep"),
+                checkpoint_dir=Path("checkpoints"),
+                generation_result={"returncode": 0},
+                generation_report_path=Path("report.json"),
+                generation_report={"summary": {}, "samples": [sample_row()]},
+                decision_report_path=Path("decision.json"),
+                decision_report=bad_decision,
+                args=args(),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Stage B generic tiny checkpoint phrase-continuation repair sweep 추가
- `plunk_and_stop` rejection 이후 objective-qualified 후보 탐색 경계 기록
- target-qualified candidate `1/6` 확보, 다음 경계 `phrase_continuation_audio_render_package`

## Context

- Issue #409 user listening review: `reject_all`, primary failure `plunk_and_stop`
- Issue #411 repair target: phrase continuation, terminal dead-air, isolated hit 감소
- 이전 WAV 후보군은 keep claim 없이 reject-all 유지
- audio review 전 objective repair candidate 확보 필요

## Scope

- chord-aware constrained generation sweep script 추가
- target qualification 기준 정의: note count, phrase coverage, tail empty, chord-tone role, postprocess removal, monophonic
- 전용 harness mode 및 unit test 추가
- `CURRENT_STATUS_AND_PLAN`, `CORE_PLAN`, handoff scope 갱신

## Result

- sample count: `6`
- valid / strict / grammar: `3/1/6`
- target qualified count: `1`
- selected objective candidate: sample `1`, seed `62`
- selected note count / coverage / tail empty: `9` / `0.9062481875` / `2`
- selected chord-role ratio / postprocess removal: `0.5625` / `0.4375`
- musical quality claim: `false`
- broad trained-model quality claim: `false`

## Validation

- `./.venv/bin/python -m unittest tests/test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep.py`
- `./.venv/bin/python -m py_compile scripts/run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep.py tests/test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep.py`
- `bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-phrase-continuation-sweep`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- objective-only candidate selection
- audio-rendered quality 미검증
- human/audio keep claim 없음
- broad trained-model quality claim 없음

## Follow-up

- Stage B generic tiny checkpoint repair phrase continuation audio render package

Closes #413
