### PR TITLE
Stage B generic tiny checkpoint repair phrase continuation audio render package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #413, Stage B generic tiny checkpoint repair phrase continuation sweep.
+- Latest functional issue completed: Issue #415, Stage B generic tiny checkpoint repair phrase continuation audio render package.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B generic tiny checkpoint repair phrase continuation audio render package.
+- Recommended next issue: Stage B generic tiny checkpoint repair phrase continuation local audio render attempt.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -986,6 +986,14 @@ bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-phrase-cont
 ```
 
 This harness runs a chord-aware phrase-continuation repair sweep and requires at least one objective-qualified candidate without claiming quality.
+
+For Stage B generic tiny checkpoint repair phrase continuation audio render package changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-phrase-continuation-audio-render-package
+```
+
+This harness packages the selected phrase-continuation repair candidate for local WAV rendering without claiming audio quality.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -151,6 +151,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint repair user listening review 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_USER_LISTENING_REVIEW_2026-05-30.md`
 - generic tiny checkpoint repair phrase continuation decision 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_DECISION_2026-05-30.md`
 - generic tiny checkpoint repair phrase continuation sweep 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_SWEEP_2026-05-30.md`
+- generic tiny checkpoint repair phrase continuation audio render package 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_AUDIO_RENDER_PACKAGE_2026-05-30.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -240,6 +241,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint repair user listening review: overall `reject_all`, candidate `reject`, primary failure `plunk_and_stop`, keep claim `false`
 - generic tiny checkpoint repair phrase continuation decision: repair target `6`, next boundary `phrase_continuation_repair_sweep`, quality claim `false`
 - generic tiny checkpoint repair phrase continuation sweep: target qualified `1/6`, selected sample `1` seed `62`, next boundary `phrase_continuation_audio_render_package`, quality claim `false`
+- generic tiny checkpoint repair phrase continuation audio render package: planned audio outputs `1`, render status `ready_for_local_render`, audio quality claim `false`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -1295,6 +1297,19 @@ Issue #312는 constrained decoding으로 adjacent repeat를 줄였지만 dead-ai
 - selected chord-role ratio / postprocess removal: `0.5625` / `0.4375`
 - musical quality / broad model quality claim: `false/false`
 - 다음 작업은 repair phrase continuation audio render package다.
+
+현재 generic tiny checkpoint repair phrase continuation audio render package:
+
+- Issue #415 result: boundary `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package`
+- next boundary: `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_local_audio_render_attempt`
+- render status: `ready_for_local_render`
+- selected renderer: `fluidsynth`
+- soundfont exists: `true`
+- planned audio outputs: `1`
+- selected objective candidate: sample `1`, seed `62`
+- render attempted: `false`
+- audio rendered quality / human audio preference claim: `false/false`
+- 다음 작업은 repair phrase continuation local audio render attempt다.
 
 ### Phase 5. Brad Style Adaptation
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #413, Stage B generic tiny checkpoint repair phrase continuation sweep
-- 다음 권장 이슈: `Stage B generic tiny checkpoint repair phrase continuation audio render package`
+- latest functional result: Issue #415, Stage B generic tiny checkpoint repair phrase continuation audio render package
+- 다음 권장 이슈: `Stage B generic tiny checkpoint repair phrase continuation local audio render attempt`
 
 현재 범위가 아닌 것:
 
@@ -628,6 +628,42 @@ Issue #413은 Issue #409 user listening rejection과 Issue #411 repair target을
 다음:
 
 - `Stage B generic tiny checkpoint repair phrase continuation audio render package`
+
+## Current Generic Tiny Checkpoint Repair Phrase Continuation Audio Render Package Result
+
+Issue #415는 Issue #413의 selected objective candidate를 local WAV render 입력으로 패키징한 작업이다.
+
+변경:
+
+- phrase continuation audio render package script 추가
+- target-qualified candidate 1개 추출
+- MIDI path, planned WAV path, renderer/soundfont readiness 기록
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_AUDIO_RENDER_PACKAGE_2026-05-30.md`
+- boundary: `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package`
+- next boundary: `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_local_audio_render_attempt`
+- render status: `ready_for_local_render`
+- selected renderer: `fluidsynth`
+- soundfont exists: `true`
+- planned audio outputs: `1`
+- selected candidate: sample `1`, seed `62`
+- selected note count / coverage / tail empty: `9` / `0.9062481875` / `2`
+- render attempted: `false`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+
+판단:
+
+- 이번 작업은 WAV 생성 전 패키지 경계
+- audio quality와 human preference는 아직 미검증
+- 다음 작업에서 실제 WAV 렌더 및 technical metadata 검증 필요
+
+다음:
+
+- `Stage B generic tiny checkpoint repair phrase continuation local audio render attempt`
 
 ## Current Muzig Application Resume Wording Result
 

--- a/docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_AUDIO_RENDER_PACKAGE_2026-05-30.md
+++ b/docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_AUDIO_RENDER_PACKAGE_2026-05-30.md
@@ -1,0 +1,28 @@
+# Stage B Generic Tiny Checkpoint Repair Phrase Continuation Audio Render Package
+
+## Summary
+
+- boundary: `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package`
+- render status: `ready_for_local_render`
+- selected renderer: `fluidsynth`
+- soundfont exists: `true`
+- planned audio outputs: `1`
+- render attempted: `false`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- musical quality claimed: `false`
+
+## Selected Candidate
+
+| rank | seed | sample | notes | coverage | tail empty | chord role | MIDI exists | planned WAV | command ready |
+|---:|---:|---:|---:|---:|---:|---:|:---:|---|:---:|
+| 1 | 62 | 1 | 9 | 0.9062481875 | 2 | 0.5625 | true | outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package/issue_415_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package/audio/rank_01_seed_62_sample_1.wav | true |
+
+## Not Proven
+
+- `audio_output`
+- `audio_rendered_quality`
+- `human_audio_preference`
+- `musical_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -186,6 +186,8 @@ Modes:
                 Route plunk-and-stop rejection to phrase-continuation repair targets.
   stage-b-generic-tiny-checkpoint-repair-phrase-continuation-sweep
                 Run phrase-continuation repair sweep from the generic tiny checkpoint.
+  stage-b-generic-tiny-checkpoint-repair-phrase-continuation-audio-render-package
+                Package the phrase-continuation repair candidate for local audio rendering.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -2544,6 +2546,34 @@ run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep() {
     --require_no_quality_claim
 }
 
+run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package() {
+  local sweep_run_id="${SWEEP_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep}"
+  local decision_run_id="${DECISION_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_decision}"
+  local user_review_run_id="${USER_REVIEW_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_user_listening_review}"
+  local audio_render_run_id="${AUDIO_RENDER_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt}"
+  local audio_package_run_id="${AUDIO_PACKAGE_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_audio_render_package}"
+  local listening_fill_run_id="${LISTENING_FILL_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_listening_fill}"
+  local listening_notes_run_id="${LISTENING_NOTES_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_listening_notes}"
+  local training_smoke_run_id="${TRAINING_SMOKE_RUN_ID:-harness_stage_b_generic_base_tiny_training_smoke}"
+  local run_id="${RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package}"
+  local sweep_report="outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep/${sweep_run_id}/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep.json"
+  local soundfont="${SOUNDFONT_PATH:-$HOME/.local/share/soundfonts/generaluser-gs/v1.471.sf2}"
+  if [[ ! -f "$sweep_report" ]]; then
+    print_header "Stage B generic tiny checkpoint repair phrase continuation sweep"
+    RUN_ID="$sweep_run_id" DECISION_RUN_ID="$decision_run_id" USER_REVIEW_RUN_ID="$user_review_run_id" AUDIO_RENDER_RUN_ID="$audio_render_run_id" AUDIO_PACKAGE_RUN_ID="$audio_package_run_id" LISTENING_FILL_RUN_ID="$listening_fill_run_id" LISTENING_NOTES_RUN_ID="$listening_notes_run_id" TRAINING_SMOKE_RUN_ID="$training_smoke_run_id" run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep
+  fi
+  print_header "Stage B generic tiny checkpoint repair phrase continuation audio render package"
+  "$PYTHON_BIN" scripts/build_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package.py \
+    --run_id "$run_id" \
+    --sweep_report "$sweep_report" \
+    --soundfont "$soundfont" \
+    --expected_boundary stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package \
+    --min_planned_outputs 1 \
+    --require_target_qualified \
+    --require_required_midi_exists \
+    --require_no_audio_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -3918,6 +3948,9 @@ case "$MODE" in
     ;;
   stage-b-generic-tiny-checkpoint-repair-phrase-continuation-sweep)
     run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep
+    ;;
+  stage-b-generic-tiny-checkpoint-repair-phrase-continuation-audio-render-package)
+    run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/build_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package.py
+++ b/scripts/build_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package.py
@@ -1,0 +1,381 @@
+"""Build audio render package metadata for the phrase-continuation repair candidate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.build_stage_b_generic_tiny_checkpoint_repair_audio_render_package import (  # noqa: E402
+    file_meta,
+    render_command,
+    renderer_probe,
+)
+from scripts.run_stage_b_generic_tiny_checkpoint_generation_probe import (  # noqa: E402
+    _bool_token,
+    _dict,
+    _float,
+    _int,
+)
+
+
+class StageBGenericTinyCheckpointRepairPhraseContinuationAudioRenderPackageError(ValueError):
+    pass
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def validate_sweep_report(report: dict[str, Any]) -> list[dict[str, Any]]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    phrase = _dict(report.get("phrase_continuation"))
+    if str(readiness.get("boundary") or "") != "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_repair_sweep":
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationAudioRenderPackageError(
+            "unexpected phrase-continuation sweep boundary"
+        )
+    if not bool(phrase.get("target_passed", False)):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationAudioRenderPackageError(
+            "phrase-continuation target must pass before audio package"
+        )
+    if _int(phrase.get("target_qualified_count")) < 1:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationAudioRenderPackageError(
+            "target-qualified candidate required"
+        )
+    if str(decision.get("next_boundary") or "") != (
+        "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package"
+    ):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationAudioRenderPackageError("unexpected next boundary")
+    claimed = [
+        bool(readiness.get("musical_quality_claimed", True)),
+        bool(readiness.get("broad_trained_model_quality_claimed", True)),
+        bool(readiness.get("brad_style_adaptation_claimed", True)),
+    ]
+    if any(claimed):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationAudioRenderPackageError(
+            "quality claims must not be set"
+        )
+    ranked = [dict(row) for row in _list(phrase.get("ranked_candidates")) if isinstance(row, dict)]
+    selected = [row for row in ranked if bool(row.get("target_qualified", False))]
+    if not selected:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationAudioRenderPackageError(
+            "target-qualified candidate list empty"
+        )
+    return selected
+
+
+def compact_candidate(candidate: dict[str, Any], *, review_rank: int) -> dict[str, Any]:
+    return {
+        "review_rank": int(review_rank),
+        "sample_seed": _int(candidate.get("sample_seed")),
+        "sample_index": _int(candidate.get("sample_index")),
+        "midi_file": file_meta(str(candidate.get("midi_path") or ""), required=True),
+        "target_qualified": bool(candidate.get("target_qualified", False)),
+        "note_count": _int(candidate.get("note_count")),
+        "phrase_coverage_ratio": _float(candidate.get("phrase_coverage_ratio")),
+        "dead_air_ratio": _float(candidate.get("dead_air_ratio")),
+        "tail_empty_steps": _int(candidate.get("tail_empty_steps")),
+        "pitch_role_chord_tone_ratio": _float(candidate.get("pitch_role_chord_tone_ratio")),
+        "postprocess_removal_ratio": _float(candidate.get("postprocess_removal_ratio")),
+        "max_simultaneous_notes": _int(candidate.get("max_simultaneous_notes")),
+    }
+
+
+def item_output_stem(item: dict[str, Any]) -> str:
+    return f"rank_{item['review_rank']:02d}_seed_{item['sample_seed']}_sample_{item['sample_index']}"
+
+
+def build_audio_render_package(
+    sweep_report: dict[str, Any],
+    *,
+    output_dir: Path,
+    requested_renderer: str = "",
+    soundfont_path: str = "",
+    renderer_paths: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    selected_candidates = validate_sweep_report(sweep_report)
+    probe = renderer_probe(
+        requested_renderer=requested_renderer,
+        soundfont_path=soundfont_path,
+        renderer_paths=renderer_paths,
+    )
+    review_items = [
+        compact_candidate(candidate, review_rank=index)
+        for index, candidate in enumerate(selected_candidates, start=1)
+    ]
+    planned_outputs: list[dict[str, Any]] = []
+    for item in review_items:
+        output_stem = item_output_stem(item)
+        output_wav_path = output_dir / "audio" / f"{output_stem}.wav"
+        midi_path = str(item["midi_file"]["path"])
+        planned_outputs.append(
+            {
+                "review_rank": item["review_rank"],
+                "sample_seed": item["sample_seed"],
+                "sample_index": item["sample_index"],
+                "source_midi_path": midi_path,
+                "planned_wav_path": str(output_wav_path),
+                "planned_wav_exists": output_wav_path.exists(),
+                "render_command": render_command(probe, midi_path, str(output_wav_path)),
+            }
+        )
+    render_ready = str(probe["status"]) == "ready_for_local_render"
+    return {
+        "schema_version": "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_sweep_schema": str(sweep_report.get("schema_version") or ""),
+        "source_sweep_run_dir": str(sweep_report.get("run_dir") or ""),
+        "review_items": review_items,
+        "renderer_probe": probe,
+        "planned_audio_outputs": planned_outputs,
+        "local_audio_render_boundary": {
+            "boundary": "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package",
+            "status": str(probe["status"]),
+            "render_attempted": False,
+            "planned_audio_output_count": len(planned_outputs),
+            "rendered_audio_file_count": 0,
+            "audio_output_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "human_audio_preference_claimed": False,
+            "musical_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "current_boundary": "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package",
+            "next_boundary": (
+                "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_local_audio_render_attempt"
+                if render_ready
+                else "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_tooling_setup"
+            ),
+            "auto_progress_allowed": render_ready,
+            "critical_user_input_required": not render_ready,
+        },
+        "not_proven": [
+            "audio_output",
+            "audio_rendered_quality",
+            "human_audio_preference",
+            "musical_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B generic tiny checkpoint repair phrase continuation local audio render attempt"
+            if render_ready
+            else "Stage B generic tiny checkpoint repair phrase continuation audio render tooling setup"
+        ),
+    }
+
+
+def validate_audio_render_package(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_status: str | None,
+    min_planned_outputs: int,
+    require_target_qualified: bool,
+    require_required_midi_exists: bool,
+    require_no_audio_claim: bool,
+) -> dict[str, Any]:
+    boundary = _dict(report.get("local_audio_render_boundary"))
+    status = str(boundary.get("status") or "")
+    if expected_boundary and str(boundary.get("boundary") or "") != expected_boundary:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationAudioRenderPackageError(
+            f"expected boundary {expected_boundary}, got {boundary.get('boundary')}"
+        )
+    if expected_status and status != expected_status:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationAudioRenderPackageError(
+            f"expected status {expected_status}, got {status}"
+        )
+    planned_outputs = report.get("planned_audio_outputs")
+    if not isinstance(planned_outputs, list):
+        planned_outputs = []
+    if len(planned_outputs) < min_planned_outputs:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationAudioRenderPackageError(
+            f"planned output count below target: {len(planned_outputs)} < {min_planned_outputs}"
+        )
+    review_items = _list(report.get("review_items"))
+    if require_target_qualified and not all(bool(_dict(item).get("target_qualified", False)) for item in review_items):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationAudioRenderPackageError(
+            "review items must be target-qualified"
+        )
+    if require_required_midi_exists:
+        missing = []
+        for item in review_items:
+            midi_file = _dict(_dict(item).get("midi_file"))
+            if bool(midi_file.get("required", False)) and not bool(midi_file.get("exists", False)):
+                missing.append(str(midi_file.get("path") or "midi_file"))
+        if missing:
+            raise StageBGenericTinyCheckpointRepairPhraseContinuationAudioRenderPackageError(
+                f"missing required MIDI files: {missing}"
+            )
+    if require_no_audio_claim:
+        claimed = [
+            bool(boundary.get("render_attempted", True)),
+            bool(boundary.get("audio_output_claimed", True)),
+            bool(boundary.get("audio_rendered_quality_claimed", True)),
+            bool(boundary.get("human_audio_preference_claimed", True)),
+            bool(boundary.get("musical_quality_claimed", True)),
+            bool(boundary.get("broad_trained_model_quality_claimed", True)),
+            bool(boundary.get("brad_style_adaptation_claimed", True)),
+        ]
+        if any(claimed):
+            raise StageBGenericTinyCheckpointRepairPhraseContinuationAudioRenderPackageError(
+                "audio or quality claims must not be set"
+            )
+    decision = _dict(report.get("decision"))
+    return {
+        "boundary": str(boundary.get("boundary") or ""),
+        "render_status": status,
+        "selected_renderer_name": str(_dict(report.get("renderer_probe")).get("selected_renderer_name") or ""),
+        "soundfont_exists": bool(_dict(report.get("renderer_probe")).get("soundfont_exists", False)),
+        "planned_audio_output_count": len(planned_outputs),
+        "render_attempted": bool(boundary.get("render_attempted", True)),
+        "audio_rendered_quality_claimed": bool(boundary.get("audio_rendered_quality_claimed", True)),
+        "human_audio_preference_claimed": bool(boundary.get("human_audio_preference_claimed", True)),
+        "auto_progress_allowed": bool(decision.get("auto_progress_allowed", False)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    boundary = report["local_audio_render_boundary"]
+    probe = report["renderer_probe"]
+    lines = [
+        "# Stage B Generic Tiny Checkpoint Repair Phrase Continuation Audio Render Package",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{boundary['boundary']}`",
+        f"- render status: `{boundary['status']}`",
+        f"- selected renderer: `{probe['selected_renderer_name']}`",
+        f"- soundfont exists: `{_bool_token(probe['soundfont_exists'])}`",
+        f"- planned audio outputs: `{boundary['planned_audio_output_count']}`",
+        f"- render attempted: `{_bool_token(boundary['render_attempted'])}`",
+        f"- audio rendered quality claimed: `{_bool_token(boundary['audio_rendered_quality_claimed'])}`",
+        f"- human/audio preference claimed: `{_bool_token(boundary['human_audio_preference_claimed'])}`",
+        f"- musical quality claimed: `{_bool_token(boundary['musical_quality_claimed'])}`",
+        "",
+        "## Selected Candidate",
+        "",
+        "| rank | seed | sample | notes | coverage | tail empty | chord role | MIDI exists | planned WAV | command ready |",
+        "|---:|---:|---:|---:|---:|---:|---:|:---:|---|:---:|",
+    ]
+    review_by_key = {
+        (_int(item.get("review_rank")), _int(item.get("sample_seed")), _int(item.get("sample_index"))): item
+        for item in report.get("review_items", [])
+        if isinstance(item, dict)
+    }
+    for item in report.get("planned_audio_outputs", []):
+        key = (_int(item.get("review_rank")), _int(item.get("sample_seed")), _int(item.get("sample_index")))
+        review_item = _dict(review_by_key.get(key))
+        midi_exists = bool(_dict(review_item.get("midi_file")).get("exists", False))
+        command_ready = bool(item.get("render_command"))
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(item.get("review_rank") or ""),
+                    str(item.get("sample_seed") or ""),
+                    str(item.get("sample_index") or ""),
+                    str(review_item.get("note_count") or ""),
+                    str(review_item.get("phrase_coverage_ratio") or ""),
+                    str(review_item.get("tail_empty_steps") or ""),
+                    str(review_item.get("pitch_role_chord_tone_ratio") or ""),
+                    _bool_token(midi_exists),
+                    str(item.get("planned_wav_path") or ""),
+                    _bool_token(command_ready),
+                ]
+            )
+            + " |"
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    default_soundfont = Path.home() / ".local/share/soundfonts/generaluser-gs/v1.471.sf2"
+    parser = argparse.ArgumentParser(
+        description="Build phrase-continuation repair audio render package metadata"
+    )
+    parser.add_argument(
+        "--sweep_report",
+        type=str,
+        default="outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep/"
+        "harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep/"
+        "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep.json",
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--renderer", type=str, default="")
+    parser.add_argument("--soundfont", type=str, default=str(default_soundfont))
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_status", type=str, default="")
+    parser.add_argument("--min_planned_outputs", type=int, default=1)
+    parser.add_argument("--require_target_qualified", action="store_true")
+    parser.add_argument("--require_required_midi_exists", action="store_true")
+    parser.add_argument("--require_no_audio_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    sweep_report_path = Path(args.sweep_report)
+    if not sweep_report_path.exists():
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationAudioRenderPackageError(
+            "phrase-continuation sweep report required"
+        )
+    report = build_audio_render_package(
+        read_json(sweep_report_path),
+        output_dir=output_dir,
+        requested_renderer=str(args.renderer or ""),
+        soundfont_path=str(args.soundfont or ""),
+    )
+    summary = validate_audio_render_package(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_status=str(args.expected_status or ""),
+        min_planned_outputs=int(args.min_planned_outputs),
+        require_target_qualified=bool(args.require_target_qualified),
+        require_required_midi_exists=bool(args.require_required_midi_exists),
+        require_no_audio_claim=bool(args.require_no_audio_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir / "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package.json",
+        report,
+    )
+    write_json(
+        output_dir / "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package.py
+++ b/tests/test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.build_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package import (
+    StageBGenericTinyCheckpointRepairPhraseContinuationAudioRenderPackageError,
+    build_audio_render_package,
+    validate_audio_render_package,
+)
+
+
+def fake_midi(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"MThd\x00\x00\x00\x06\x00\x00\x00\x01\x00`MTrk\x00\x00\x00\x04\x00\xff/\x00")
+
+
+def fake_executable(path: Path) -> None:
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def sweep_report(root: Path, *, target_passed: bool = True, quality_claimed: bool = False) -> dict:
+    midi_path = root / "stage_b_sample_1.mid"
+    fake_midi(midi_path)
+    return {
+        "schema_version": "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep_v1",
+        "run_dir": str(root / "sweep"),
+        "readiness": {
+            "boundary": "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_repair_sweep",
+            "phrase_continuation_repair_target_passed": target_passed,
+            "musical_quality_claimed": quality_claimed,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "next_boundary": "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package",
+        },
+        "phrase_continuation": {
+            "target_passed": target_passed,
+            "target_qualified_count": 1 if target_passed else 0,
+            "candidate_count": 1,
+            "ranked_candidates": [
+                {
+                    "sample_index": 1,
+                    "sample_seed": 62,
+                    "midi_path": str(midi_path),
+                    "target_qualified": target_passed,
+                    "note_count": 9,
+                    "phrase_coverage_ratio": 0.90625,
+                    "dead_air_ratio": 0.625,
+                    "tail_empty_steps": 2,
+                    "pitch_role_chord_tone_ratio": 0.5625,
+                    "postprocess_removal_ratio": 0.4375,
+                    "max_simultaneous_notes": 1,
+                }
+            ],
+        },
+    }
+
+
+class StageBGenericTinyCheckpointRepairPhraseContinuationAudioRenderPackageTest(unittest.TestCase):
+    def test_builds_ready_single_candidate_package_without_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            soundfont = root / "piano.sf2"
+            fake_executable(renderer)
+            soundfont.write_bytes(b"sf2")
+            report = build_audio_render_package(
+                sweep_report(root),
+                output_dir=root / "render_package",
+                requested_renderer="fluidsynth",
+                soundfont_path=str(soundfont),
+                renderer_paths={"fluidsynth": str(renderer), "timidity": ""},
+            )
+            summary = validate_audio_render_package(
+                report,
+                expected_boundary="stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package",
+                expected_status="ready_for_local_render",
+                min_planned_outputs=1,
+                require_target_qualified=True,
+                require_required_midi_exists=True,
+                require_no_audio_claim=True,
+            )
+
+            self.assertEqual(summary["render_status"], "ready_for_local_render")
+            self.assertEqual(summary["planned_audio_output_count"], 1)
+            self.assertTrue(report["review_items"][0]["target_qualified"])
+            self.assertTrue(report["planned_audio_outputs"][0]["render_command"])
+            self.assertIn(str(soundfont), report["planned_audio_outputs"][0]["render_command"])
+            self.assertFalse(summary["audio_rendered_quality_claimed"])
+            self.assertFalse(summary["human_audio_preference_claimed"])
+
+    def test_rejects_unqualified_sweep(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertRaises(StageBGenericTinyCheckpointRepairPhraseContinuationAudioRenderPackageError):
+                build_audio_render_package(
+                    sweep_report(Path(temp_dir), target_passed=False),
+                    output_dir=Path(temp_dir) / "render_package",
+                )
+
+    def test_rejects_quality_claimed_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertRaises(StageBGenericTinyCheckpointRepairPhraseContinuationAudioRenderPackageError):
+                build_audio_render_package(
+                    sweep_report(Path(temp_dir), quality_claimed=True),
+                    output_dir=Path(temp_dir) / "render_package",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Stage B phrase-continuation repair candidate audio render package 추가
- selected objective candidate `1`개를 local WAV render 입력으로 변환
- renderer/soundfont readiness 확인, audio 품질 claim 제외

## Context

- #409 user listening review: `reject_all`, primary failure `plunk_and_stop`
- #411 repair target: phrase continuation, terminal dead-air, isolated hit 감소
- #413 phrase-continuation sweep: target qualified `1/6`, selected sample `1` seed `62`
- 다음 단계: selected candidate WAV 생성 및 technical metadata 검증

## Scope

- phrase-continuation sweep report 입력 검증
- target-qualified candidate 추출 및 planned WAV path 생성
- renderer/soundfont readiness 기록
- 전용 harness mode, unit test, status docs 갱신

## Result

- boundary: `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package`
- next boundary: `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_local_audio_render_attempt`
- render status: `ready_for_local_render`
- selected renderer: `fluidsynth`
- soundfont exists: `true`
- planned audio outputs: `1`
- render attempted: `false`
- audio rendered quality claim: `false`
- human/audio preference claim: `false`

## Validation

- `./.venv/bin/python -m unittest tests/test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package.py`
- `./.venv/bin/python -m py_compile scripts/build_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package.py tests/test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package.py`
- `bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-phrase-continuation-audio-render-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- WAV render 미수행
- audio quality 미검증
- human/audio keep claim 없음
- broad trained-model quality claim 없음

## Follow-up

- Stage B generic tiny checkpoint repair phrase continuation local audio render attempt

Closes #415
