### PR TITLE
Stage B generic tiny checkpoint repair phrase continuation range interval guard sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #421, Stage B generic tiny checkpoint repair phrase continuation range interval guard decision.
+- Latest functional issue completed: Issue #423, Stage B generic tiny checkpoint repair phrase continuation range interval guard sweep.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B generic tiny checkpoint repair phrase continuation range interval guard sweep.
+- Recommended next issue: Stage B generic tiny checkpoint repair phrase continuation range interval guard audio render package.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1018,6 +1018,14 @@ bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-phrase-cont
 ```
 
 This harness converts the MIDI note failure evidence into range/interval guard targets without claiming repaired candidate quality.
+
+For Stage B generic tiny checkpoint repair phrase continuation range interval guard sweep changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-phrase-continuation-range-interval-guard-sweep
+```
+
+This harness runs constrained interval-cap sweeps and verifies actual MIDI note range/interval guard candidates without claiming listening quality.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -155,6 +155,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint repair phrase continuation local audio render attempt 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_LOCAL_AUDIO_RENDER_ATTEMPT_2026-05-30.md`
 - generic tiny checkpoint repair phrase continuation MIDI note failure review 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_MIDI_NOTE_FAILURE_REVIEW_2026-05-30.md`
 - generic tiny checkpoint repair phrase continuation range interval guard decision 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_DECISION_2026-05-30.md`
+- generic tiny checkpoint repair phrase continuation range interval guard sweep 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_SWEEP_2026-05-30.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -248,6 +249,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint repair phrase continuation local audio render attempt: rendered WAV files `1`, technical WAV validation `true`, audio quality claim `false`
 - generic tiny checkpoint repair phrase continuation MIDI note failure review: reject_all, pitch span `60`, max interval `60`, large interval ratio `0.875`, next boundary `range_interval_guard_decision`
 - generic tiny checkpoint repair phrase continuation range interval guard decision: target pitch span `24`, max interval `12`, large interval ratio `0.35`, severe interval count `0`
+- generic tiny checkpoint repair phrase continuation range interval guard sweep: target qualified `3/48`, top cap `9`, sample seed `70`, top span/max interval/large ratio `21/9/0.0`, next boundary `range_interval_guard_audio_render_package`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -1357,6 +1359,18 @@ Issue #312는 constrained decoding으로 adjacent repeat를 줄였지만 dead-ai
 - repair target count: `5`
 - musical quality claim: `false`
 - 다음 작업은 repair phrase continuation range interval guard sweep이다.
+
+현재 generic tiny checkpoint repair phrase continuation range interval guard sweep:
+
+- Issue #423 result: boundary `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep`
+- next boundary: `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package`
+- interval cap sweep: `12/9/7/5`
+- target qualified: `3/48`
+- top candidate: interval cap `9`, sample seed `70`, sample `9`
+- top note count / phrase coverage / tail empty: `11` / `1.0` / `0`
+- top pitch span / max abs interval / large interval ratio: `21` / `9` / `0.0`
+- quality claim: `false`
+- 다음 작업은 repair phrase continuation range interval guard audio render package다.
 
 ### Phase 5. Brad Style Adaptation
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #421, Stage B generic tiny checkpoint repair phrase continuation range interval guard decision
-- 다음 권장 이슈: `Stage B generic tiny checkpoint repair phrase continuation range interval guard sweep`
+- latest functional result: Issue #423, Stage B generic tiny checkpoint repair phrase continuation range interval guard sweep
+- 다음 권장 이슈: `Stage B generic tiny checkpoint repair phrase continuation range interval guard audio render package`
 
 현재 범위가 아닌 것:
 
@@ -772,6 +772,39 @@ Issue #421은 Issue #419의 MIDI note failure를 다음 repair sweep target으�
 다음:
 
 - `Stage B generic tiny checkpoint repair phrase continuation range interval guard sweep`
+
+## Current Generic Tiny Checkpoint Repair Phrase Continuation Range Interval Guard Sweep Result
+
+Issue #423은 range/interval guard decision을 실제 constrained generation sweep에 적용한 작업이다.
+
+변경:
+
+- generation probe pitch range / adjacent interval cap 인자 추가
+- interval cap `12/9/7/5` sweep script 추가
+- actual MIDI note audit 기반 target qualification 기록
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_SWEEP_2026-05-30.md`
+- boundary: `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep`
+- next boundary: `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package`
+- target qualified: `3/48`
+- top candidate: interval cap `9`, sample seed `70`, sample `9`
+- top note count / coverage / tail empty: `11` / `1.0` / `0`
+- top pitch span / max interval / large interval ratio: `21` / `9` / `0.0`
+- musical quality claimed: `false`
+
+판단:
+
+- `cap=12`는 target candidate `0`으로 range/interval guard 미충족
+- `cap=9`는 target candidate `2`, `cap=7`은 target candidate `1`
+- audio package 단계 전 actual MIDI note guard 통과 후보 확보
+- listening quality와 human/audio keep claim은 미검증
+
+다음:
+
+- `Stage B generic tiny checkpoint repair phrase continuation range interval guard audio render package`
 
 ## Current Muzig Application Resume Wording Result
 

--- a/docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_SWEEP_2026-05-30.md
+++ b/docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_SWEEP_2026-05-30.md
@@ -1,0 +1,42 @@
+# Stage B Generic Tiny Checkpoint Repair Phrase Continuation Range Interval Guard Sweep
+
+## Summary
+
+- boundary: `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep`
+- next boundary: `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package`
+- target passed: `true`
+- target qualified count: `3`
+- candidate count: `48`
+- generation success: `true`
+- all samples grammar valid: `true`
+- musical quality claimed: `false`
+
+## Generation Runs
+
+| interval cap | samples | valid | strict | grammar | target qualified | collapse warning rate |
+|---:|---:|---:|---:|---:|---:|---:|
+| 12 | 12 | 5 | 4 | 12 | 0 | 0.417 |
+| 9 | 12 | 6 | 5 | 12 | 2 | 0.583 |
+| 7 | 12 | 3 | 2 | 12 | 1 | 0.667 |
+| 5 | 12 | 2 | 1 | 12 | 0 | 0.833 |
+
+## Top Candidates
+
+| rank | cap | seed | sample | target | notes | coverage | tail | postprocess removal | pitch range | span | max interval | large ratio | failures | midi |
+|---:|---:|---:|---:|:---:|---:|---:|---:|---:|---|---:|---:|---:|---|---|
+| 1 | 9 | 70 | 9 | true | 11 | 1.000 | 0 | 0.312 | 53-74 | 21 | 9 | 0.000 | none | outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep/harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep/generation_probe/cap_9_seed_62/samples/stage_b_sample_9.mid |
+| 2 | 7 | 66 | 5 | true | 9 | 0.906 | 0 | 0.438 | 51-63 | 12 | 12 | 0.125 | none | outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep/harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep/generation_probe/cap_7_seed_62/samples/stage_b_sample_5.mid |
+| 3 | 9 | 62 | 1 | true | 9 | 0.875 | 1 | 0.438 | 51-68 | 17 | 12 | 0.125 | none | outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep/harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep/generation_probe/cap_9_seed_62/samples/stage_b_sample_1.mid |
+| 4 | 7 | 62 | 1 | false | 7 | 0.875 | 0 | 0.562 | 58-67 | 9 | 5 | 0.000 | strict_valid_failed, note_count_below_target, postprocess_removal_above_target | outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep/harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep/generation_probe/cap_7_seed_62/samples/stage_b_sample_1.mid |
+| 5 | 5 | 65 | 4 | false | 7 | 0.812 | 0 | 0.562 | 58-67 | 9 | 7 | 0.000 | strict_valid_failed, note_count_below_target, phrase_coverage_below_target, postprocess_removal_above_target | outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep/harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep/generation_probe/cap_5_seed_62/samples/stage_b_sample_4.mid |
+| 6 | 5 | 69 | 8 | false | 8 | 0.781 | 0 | 0.500 | 50-63 | 13 | 8 | 0.000 | strict_valid_failed, phrase_coverage_below_target, postprocess_removal_above_target | outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep/harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep/generation_probe/cap_5_seed_62/samples/stage_b_sample_8.mid |
+| 7 | 7 | 63 | 2 | false | 6 | 0.781 | 0 | 0.625 | 48-68 | 20 | 8 | 0.000 | strict_valid_failed, note_count_below_target, phrase_coverage_below_target, postprocess_removal_above_target | outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep/harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep/generation_probe/cap_7_seed_62/samples/stage_b_sample_2.mid |
+| 8 | 5 | 66 | 5 | false | 10 | 1.000 | 0 | 0.375 | 48-60 | 12 | 9 | 0.000 | strict_valid_failed | outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep/harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep/generation_probe/cap_5_seed_62/samples/stage_b_sample_5.mid |
+
+## Not Proven
+
+- `audio_rendered_quality`
+- `human_audio_keep`
+- `musical_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -194,6 +194,8 @@ Modes:
                 Record phrase-continuation rejection with MIDI note sequence failure evidence.
   stage-b-generic-tiny-checkpoint-repair-phrase-continuation-range-interval-guard-decision
                 Convert MIDI note failure evidence into range/interval guard targets.
+  stage-b-generic-tiny-checkpoint-repair-phrase-continuation-range-interval-guard-sweep
+                Run constrained range/interval cap sweep and audit actual MIDI notes.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -2666,6 +2668,41 @@ run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_gu
     --require_no_quality_claim
 }
 
+run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep() {
+  local range_decision_run_id="${RANGE_DECISION_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_decision}"
+  local failure_review_run_id="${FAILURE_REVIEW_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_midi_note_failure_review}"
+  local local_audio_run_id="${LOCAL_AUDIO_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_local_audio_render_attempt}"
+  local phrase_audio_package_run_id="${PHRASE_AUDIO_PACKAGE_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package}"
+  local sweep_run_id="${SWEEP_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep}"
+  local decision_run_id="${DECISION_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_decision}"
+  local user_review_run_id="${USER_REVIEW_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_user_listening_review}"
+  local audio_render_run_id="${AUDIO_RENDER_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt}"
+  local audio_package_run_id="${AUDIO_PACKAGE_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_audio_render_package}"
+  local listening_fill_run_id="${LISTENING_FILL_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_listening_fill}"
+  local listening_notes_run_id="${LISTENING_NOTES_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_listening_notes}"
+  local training_smoke_run_id="${TRAINING_SMOKE_RUN_ID:-harness_stage_b_generic_base_tiny_training_smoke}"
+  local run_id="${RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep}"
+  local checkpoint_dir="outputs/stage_b_generic_base_tiny_training_smoke/${training_smoke_run_id}/checkpoints"
+  local range_decision_report="outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_decision/${range_decision_run_id}/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_decision.json"
+  if [[ ! -f "${checkpoint_dir}/checkpoint_epoch1.pt" ]]; then
+    print_header "Stage B generic base tiny training smoke"
+    RUN_ID="$training_smoke_run_id" run_stage_b_generic_base_tiny_training_smoke
+  fi
+  if [[ ! -f "$range_decision_report" ]]; then
+    print_header "Stage B generic tiny checkpoint repair phrase continuation range interval guard decision"
+    RUN_ID="$range_decision_run_id" FAILURE_REVIEW_RUN_ID="$failure_review_run_id" LOCAL_AUDIO_RUN_ID="$local_audio_run_id" PHRASE_AUDIO_PACKAGE_RUN_ID="$phrase_audio_package_run_id" SWEEP_RUN_ID="$sweep_run_id" DECISION_RUN_ID="$decision_run_id" USER_REVIEW_RUN_ID="$user_review_run_id" AUDIO_RENDER_RUN_ID="$audio_render_run_id" AUDIO_PACKAGE_RUN_ID="$audio_package_run_id" LISTENING_FILL_RUN_ID="$listening_fill_run_id" LISTENING_NOTES_RUN_ID="$listening_notes_run_id" TRAINING_SMOKE_RUN_ID="$training_smoke_run_id" run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_decision
+  fi
+  print_header "Stage B generic tiny checkpoint repair phrase continuation range interval guard sweep"
+  "$PYTHON_BIN" scripts/run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep.py \
+    --run_id "$run_id" \
+    --checkpoint_dir "$checkpoint_dir" \
+    --decision_report "$range_decision_report" \
+    --doc_path docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_SWEEP_2026-05-30.md \
+    --expected_boundary stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep \
+    --min_target_qualified 1 \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -4052,6 +4089,9 @@ case "$MODE" in
     ;;
   stage-b-generic-tiny-checkpoint-repair-phrase-continuation-range-interval-guard-decision)
     run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_decision
+    ;;
+  stage-b-generic-tiny-checkpoint-repair-phrase-continuation-range-interval-guard-sweep)
+    run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/run_stage_b_generation_probe.py
+++ b/scripts/run_stage_b_generation_probe.py
@@ -848,6 +848,9 @@ def chord_aware_pitch_tokens(
     recent_pitches: Sequence[int] | None = None,
     repeat_window: int = 2,
     group_index: int | None = None,
+    pitch_min: int | None = None,
+    pitch_max: int | None = None,
+    max_adjacent_interval: int | None = None,
 ) -> list[int]:
     if pitch_mode == "approach_tensions":
         resolving_group = bool(group_index is not None and int(group_index) % 2 == 1)
@@ -857,13 +860,18 @@ def chord_aware_pitch_tokens(
             pitch_classes = chord_approach_pitch_classes(chord)
     else:
         pitch_classes = chord_pitch_classes(chord, pitch_mode=pitch_mode)
+    lower = max(int(PIANO_PITCH_MIN), int(pitch_min) if pitch_min is not None else int(PIANO_PITCH_MIN))
+    upper = min(int(PIANO_PITCH_MAX), int(pitch_max) if pitch_max is not None else int(PIANO_PITCH_MAX))
+    if lower > upper:
+        raise ValueError(f"invalid pitch range: {lower}>{upper}")
+
     tokens = [
         note_pitch_token(pitch)
-        for pitch in range(int(PIANO_PITCH_MIN), int(PIANO_PITCH_MAX) + 1)
+        for pitch in range(lower, upper + 1)
         if pitch % 12 in pitch_classes
     ]
     if not tokens:
-        return list(range(TOKEN_NOTE_PITCH_START, TOKEN_NOTE_PITCH_END + 1))
+        tokens = [note_pitch_token(pitch) for pitch in range(lower, upper + 1)]
 
     if pitch_mode == "approach_tensions" and recent_pitches and group_index is not None and int(group_index) % 2 == 1:
         last_pitch = int(list(recent_pitches)[-1])
@@ -872,6 +880,14 @@ def chord_aware_pitch_tokens(
         ]
         if near_resolution_tokens:
             tokens = near_resolution_tokens
+
+    if recent_pitches and max_adjacent_interval is not None and int(max_adjacent_interval) >= 0:
+        last_pitch = int(list(recent_pitches)[-1])
+        interval_filtered = [
+            token for token in tokens if abs(pitch_from_token(token) - last_pitch) <= int(max_adjacent_interval)
+        ]
+        if interval_filtered:
+            tokens = interval_filtered
 
     window = max(0, int(repeat_window))
     if not recent_pitches or window == 0:
@@ -897,6 +913,9 @@ def generate_stage_b_constrained_tokens(
     chord_aware_pitches: bool = False,
     chord_pitch_mode: str = "tones_tensions",
     chord_pitch_repeat_window: int = 2,
+    pitch_min: int | None = None,
+    pitch_max: int | None = None,
+    max_adjacent_interval: int | None = None,
     jazz_rhythm_positions: bool = False,
     jazz_duration_tokens: bool = False,
     jazz_rhythm_profile: str = "swing_motif",
@@ -942,6 +961,9 @@ def generate_stage_b_constrained_tokens(
                         recent_pitches=recent_pitches,
                         repeat_window=chord_pitch_repeat_window,
                         group_index=group_index,
+                        pitch_min=pitch_min,
+                        pitch_max=pitch_max,
+                        max_adjacent_interval=max_adjacent_interval,
                     )
                 if jazz_duration_tokens and family_index == 3:
                     allowed = jazz_rhythm_duration_tokens(
@@ -1356,6 +1378,9 @@ def build_parser() -> argparse.ArgumentParser:
         default="tones_tensions",
     )
     parser.add_argument("--chord_pitch_repeat_window", type=int, default=2)
+    parser.add_argument("--constrained_pitch_min", type=int, default=None)
+    parser.add_argument("--constrained_pitch_max", type=int, default=None)
+    parser.add_argument("--constrained_max_adjacent_interval", type=int, default=None)
     parser.add_argument("--jazz_rhythm_positions", action="store_true")
     parser.add_argument("--jazz_duration_tokens", action="store_true")
     parser.add_argument("--jazz_rhythm_profile", choices=("swing_motif",), default="swing_motif")
@@ -1438,6 +1463,9 @@ def main() -> int:
         "chord_aware_pitches": bool(args.chord_aware_pitches),
         "chord_pitch_mode": args.chord_pitch_mode,
         "chord_pitch_repeat_window": int(args.chord_pitch_repeat_window),
+        "constrained_pitch_min": args.constrained_pitch_min,
+        "constrained_pitch_max": args.constrained_pitch_max,
+        "constrained_max_adjacent_interval": args.constrained_max_adjacent_interval,
         "jazz_rhythm_positions": bool(args.jazz_rhythm_positions),
         "jazz_duration_tokens": bool(args.jazz_duration_tokens),
         "jazz_rhythm_profile": args.jazz_rhythm_profile,
@@ -1503,6 +1531,9 @@ def main() -> int:
                 chord_aware_pitches=args.chord_aware_pitches,
                 chord_pitch_mode=args.chord_pitch_mode,
                 chord_pitch_repeat_window=args.chord_pitch_repeat_window,
+                pitch_min=args.constrained_pitch_min,
+                pitch_max=args.constrained_pitch_max,
+                max_adjacent_interval=args.constrained_max_adjacent_interval,
                 jazz_rhythm_positions=args.jazz_rhythm_positions,
                 jazz_duration_tokens=args.jazz_duration_tokens,
                 jazz_rhythm_profile=args.jazz_rhythm_profile,

--- a/scripts/run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep.py
+++ b/scripts/run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep.py
@@ -1,0 +1,633 @@
+"""Run range/interval guard sweep for phrase-continuation repair candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.fill_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_midi_note_failure_review import (  # noqa: E402
+    note_audit,
+)
+from scripts.run_stage_b_generic_tiny_checkpoint_generation_probe import (  # noqa: E402
+    _bool_token,
+    _dict,
+    _float,
+    _int,
+    run_command,
+)
+
+
+class StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSweepError(ValueError):
+    pass
+
+
+SCHEMA_VERSION = "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep_v1"
+BOUNDARY = "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep"
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def parse_int_list(value: str) -> list[int]:
+    items = [item.strip() for item in str(value or "").split(",") if item.strip()]
+    if not items:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSweepError(
+            "at least one interval cap is required"
+        )
+    return [int(item) for item in items]
+
+
+def validate_guard_decision(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    targets = _dict(report.get("guard_targets"))
+    if str(readiness.get("boundary") or "") != (
+        "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_decision"
+    ):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSweepError(
+            "range/interval guard decision boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != BOUNDARY:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSweepError(
+            "unexpected range/interval guard next boundary"
+        )
+    if bool(readiness.get("musical_quality_claimed", True)):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSweepError(
+            "source decision must not claim musical quality"
+        )
+    required = (
+        "max_pitch_span",
+        "max_abs_interval",
+        "max_large_interval_ratio",
+        "max_severe_interval_count",
+        "preferred_pitch_floor",
+        "preferred_pitch_ceiling",
+        "large_interval_threshold",
+        "severe_interval_threshold",
+    )
+    missing = [key for key in required if key not in targets]
+    if missing:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSweepError(
+            f"guard targets missing: {missing}"
+        )
+    return targets
+
+
+def build_generation_command(
+    args: argparse.Namespace,
+    *,
+    checkpoint_dir: Path,
+    output_root: Path,
+    run_id: str,
+    interval_cap: int,
+    targets: dict[str, Any],
+) -> list[str]:
+    return [
+        sys.executable,
+        "scripts/run_stage_b_generation_probe.py",
+        "--output_root",
+        str(output_root),
+        "--run_id",
+        run_id,
+        "--checkpoint_dir",
+        str(checkpoint_dir),
+        "--skip_prepare",
+        "--skip_train",
+        "--issue_number",
+        str(args.issue_number),
+        "--max_sequence",
+        str(args.max_sequence),
+        "--num_samples",
+        str(args.num_samples),
+        "--seed",
+        str(args.seed),
+        "--temperature",
+        str(args.temperature),
+        "--top_k",
+        str(args.top_k),
+        "--min_valid_samples",
+        str(args.min_valid_samples),
+        "--min_strict_valid_samples",
+        str(args.min_strict_valid_samples),
+        "--generation_mode",
+        "constrained",
+        "--constrained_note_groups_per_bar",
+        str(args.note_groups_per_bar),
+        "--jazz_duration_tokens",
+        "--chord_aware_pitches",
+        "--chord_pitch_mode",
+        str(args.chord_pitch_mode),
+        "--chord_pitch_repeat_window",
+        str(args.chord_pitch_repeat_window),
+        "--constrained_pitch_min",
+        str(_int(targets.get("preferred_pitch_floor"))),
+        "--constrained_pitch_max",
+        str(_int(targets.get("preferred_pitch_ceiling"))),
+        "--constrained_max_adjacent_interval",
+        str(interval_cap),
+        "--postprocess_overlap",
+        "--max_simultaneous_notes",
+        str(args.max_simultaneous_notes),
+        "--require_all_grammar_samples",
+    ]
+
+
+def target_failure_reasons(row: dict[str, Any], audit: dict[str, Any], *, args: argparse.Namespace) -> list[str]:
+    temporal = _dict(row.get("temporal_coverage"))
+    collapse = _dict(row.get("collapse"))
+    metrics = _dict(row.get("metrics"))
+    targets = _dict(audit.get("targets"))
+    reasons: list[str] = []
+    if not bool(row.get("grammar_gate_passed", False)):
+        reasons.append("grammar_gate_failed")
+    if not bool(row.get("strict_valid", False)):
+        reasons.append("strict_valid_failed")
+    if _int(metrics.get("note_count")) < int(args.min_note_count):
+        reasons.append("note_count_below_target")
+    if _float(metrics.get("phrase_coverage_ratio")) < float(args.min_phrase_coverage_ratio):
+        reasons.append("phrase_coverage_below_target")
+    if _int(temporal.get("tail_empty_steps")) > int(args.max_tail_empty_steps):
+        reasons.append("tail_empty_above_target")
+    if _int(metrics.get("max_simultaneous_notes")) > int(args.max_simultaneous_notes):
+        reasons.append("max_simultaneous_notes_above_target")
+    if _float(collapse.get("postprocess_removal_ratio")) > float(args.max_postprocess_removal_ratio):
+        reasons.append("postprocess_removal_above_target")
+    if _int(audit.get("pitch_span")) > _int(targets.get("max_pitch_span")):
+        reasons.append("pitch_span_above_target")
+    if _int(audit.get("max_abs_interval")) > _int(targets.get("max_abs_interval")):
+        reasons.append("max_interval_above_target")
+    if _float(audit.get("large_interval_ratio")) > _float(targets.get("max_large_interval_ratio")):
+        reasons.append("large_interval_ratio_above_target")
+    if _int(audit.get("severe_interval_count")) > int(args.max_severe_interval_count):
+        reasons.append("severe_interval_present")
+    return reasons
+
+
+def compact_candidate(
+    row: dict[str, Any],
+    *,
+    interval_cap: int,
+    args: argparse.Namespace,
+    targets: dict[str, Any],
+) -> dict[str, Any]:
+    midi_path = Path(str(row.get("midi_path") or ""))
+    audit = note_audit(
+        midi_path,
+        max_pitch_span=_int(targets.get("max_pitch_span")),
+        max_abs_interval=_int(targets.get("max_abs_interval")),
+        max_large_interval_ratio=_float(targets.get("max_large_interval_ratio")),
+        large_interval_threshold=_int(targets.get("large_interval_threshold")),
+        severe_interval_threshold=_int(targets.get("severe_interval_threshold")),
+    )
+    reasons = target_failure_reasons(row, audit, args=args)
+    temporal = _dict(row.get("temporal_coverage"))
+    collapse = _dict(row.get("collapse"))
+    pitch_roles = _dict(row.get("pitch_roles"))
+    metrics = _dict(row.get("metrics"))
+    return {
+        "sample_index": _int(row.get("sample_index")),
+        "sample_seed": _int(row.get("sample_seed")),
+        "interval_cap": int(interval_cap),
+        "midi_path": str(midi_path),
+        "valid": bool(row.get("valid", False)),
+        "strict_valid": bool(row.get("strict_valid", False)),
+        "grammar_gate_passed": bool(row.get("grammar_gate_passed", False)),
+        "target_qualified": not reasons,
+        "target_failure_reasons": reasons,
+        "note_count": _int(metrics.get("note_count")),
+        "phrase_coverage_ratio": _float(metrics.get("phrase_coverage_ratio")),
+        "dead_air_ratio": _float(metrics.get("dead_air_ratio")),
+        "tail_empty_steps": _int(temporal.get("tail_empty_steps")),
+        "position_span_ratio": _float(temporal.get("position_span_ratio")),
+        "postprocess_removal_ratio": _float(collapse.get("postprocess_removal_ratio")),
+        "max_simultaneous_notes": _int(metrics.get("max_simultaneous_notes")),
+        "pitch_role_chord_tone_ratio": _float(pitch_roles.get("chord_tone_ratio")),
+        "midi_note_audit": {
+            "note_count": _int(audit.get("note_count")),
+            "pitch_min": audit.get("pitch_min"),
+            "pitch_max": audit.get("pitch_max"),
+            "pitch_span": _int(audit.get("pitch_span")),
+            "pitch_sequence": _list(audit.get("pitch_sequence")),
+            "pitch_name_sequence": _list(audit.get("pitch_name_sequence")),
+            "intervals": _list(audit.get("intervals")),
+            "max_abs_interval": _int(audit.get("max_abs_interval")),
+            "large_interval_count": _int(audit.get("large_interval_count")),
+            "large_interval_ratio": _float(audit.get("large_interval_ratio")),
+            "severe_interval_count": _int(audit.get("severe_interval_count")),
+            "failure_reasons": _list(audit.get("failure_reasons")),
+        },
+    }
+
+
+def sort_candidates(candidates: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(
+        [dict(row) for row in candidates],
+        key=lambda row: (
+            not bool(row.get("target_qualified", False)),
+            _int(_dict(row.get("midi_note_audit")).get("max_abs_interval")),
+            _int(_dict(row.get("midi_note_audit")).get("pitch_span")),
+            -_float(row.get("phrase_coverage_ratio")),
+            _float(row.get("postprocess_removal_ratio")),
+            _int(row.get("interval_cap")),
+            _int(row.get("sample_index")),
+        ),
+    )
+
+
+def build_sweep_report(
+    *,
+    run_dir: Path,
+    checkpoint_dir: Path,
+    decision_report_path: Path,
+    decision_report: dict[str, Any],
+    generation_runs: Sequence[dict[str, Any]],
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    targets = validate_guard_decision(decision_report)
+    runs: list[dict[str, Any]] = []
+    all_candidates: list[dict[str, Any]] = []
+    for generation_run in generation_runs:
+        generation_report = _dict(generation_run.get("report"))
+        summary = _dict(generation_report.get("summary"))
+        interval_cap = _int(generation_run.get("interval_cap"))
+        candidates = [
+            compact_candidate(row, interval_cap=interval_cap, args=args, targets=targets)
+            for row in _list(generation_report.get("samples"))
+            if isinstance(row, dict)
+        ]
+        ranked = sort_candidates(candidates)
+        all_candidates.extend(ranked)
+        runs.append(
+            {
+                "interval_cap": interval_cap,
+                "generation_result": _dict(generation_run.get("result")),
+                "generation_report_path": str(generation_run.get("report_path") or ""),
+                "summary": {
+                    "sample_count": _int(summary.get("sample_count")),
+                    "valid_sample_count": _int(summary.get("valid_sample_count")),
+                    "strict_valid_sample_count": _int(summary.get("strict_valid_sample_count")),
+                    "grammar_gate_sample_count": _int(summary.get("grammar_gate_sample_count")),
+                    "passed_generation_gate": bool(summary.get("passed_generation_gate", False)),
+                    "passed_strict_generation_gate": bool(summary.get("passed_strict_generation_gate", False)),
+                    "collapse_warning_sample_rate": _float(summary.get("collapse_warning_sample_rate")),
+                },
+                "target_qualified_count": sum(1 for row in ranked if bool(row.get("target_qualified", False))),
+                "top_candidates": ranked[:5],
+            }
+        )
+    ranked_candidates = sort_candidates(all_candidates)
+    target_qualified = [row for row in ranked_candidates if bool(row.get("target_qualified", False))]
+    generation_success = all(_int(_dict(row.get("result")).get("returncode")) == 0 for row in generation_runs)
+    grammar_all = all(
+        _int(_dict(_dict(row.get("report")).get("summary")).get("grammar_gate_sample_count"))
+        == _int(_dict(_dict(row.get("report")).get("summary")).get("sample_count"))
+        for row in generation_runs
+    )
+    target_passed = bool(
+        generation_success
+        and grammar_all
+        and len(target_qualified) >= int(args.min_target_qualified)
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "run_dir": str(run_dir),
+        "checkpoint_dir": str(checkpoint_dir),
+        "decision_report_path": str(decision_report_path),
+        "input": {
+            "issue_number": int(args.issue_number),
+            "num_samples_per_cap": int(args.num_samples),
+            "seed": int(args.seed),
+            "temperature": float(args.temperature),
+            "top_k": int(args.top_k),
+            "note_groups_per_bar": int(args.note_groups_per_bar),
+            "interval_caps": parse_int_list(str(args.interval_caps)),
+            "pitch_range": [
+                _int(targets.get("preferred_pitch_floor")),
+                _int(targets.get("preferred_pitch_ceiling")),
+            ],
+            "min_note_count": int(args.min_note_count),
+            "min_phrase_coverage_ratio": float(args.min_phrase_coverage_ratio),
+            "max_tail_empty_steps": int(args.max_tail_empty_steps),
+            "max_postprocess_removal_ratio": float(args.max_postprocess_removal_ratio),
+            "min_target_qualified": int(args.min_target_qualified),
+        },
+        "guard_targets": targets,
+        "generation_runs": runs,
+        "range_interval_guard": {
+            "target_passed": target_passed,
+            "target_qualified_count": len(target_qualified),
+            "candidate_count": len(ranked_candidates),
+            "generation_success": generation_success,
+            "all_samples_grammar_valid": grammar_all,
+            "ranked_candidates": ranked_candidates,
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "range_interval_guard_target_passed": target_passed,
+            "musical_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": (
+                "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package"
+                if target_passed
+                else "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep_tuning"
+            ),
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "actual MIDI note range/interval guard evaluated after overlap postprocess",
+        },
+        "not_proven": [
+            "audio_rendered_quality",
+            "human_audio_keep",
+            "musical_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B generic tiny checkpoint repair phrase continuation range interval guard audio render package"
+            if target_passed
+            else "Stage B generic tiny checkpoint repair phrase continuation range interval guard sweep tuning"
+        ),
+    }
+
+
+def validate_sweep_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    min_generation_runs: int,
+    min_candidate_count: int,
+    min_target_qualified: int,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    guard = _dict(report.get("range_interval_guard"))
+    boundary = str(readiness.get("boundary") or "")
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSweepError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if len(_list(report.get("generation_runs"))) < int(min_generation_runs):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSweepError(
+            "generation run count below target"
+        )
+    if _int(guard.get("candidate_count")) < int(min_candidate_count):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSweepError(
+            "candidate count below target"
+        )
+    if _int(guard.get("target_qualified_count")) < int(min_target_qualified):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSweepError(
+            "target-qualified count below target"
+        )
+    if not bool(guard.get("generation_success", False)):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSweepError(
+            "generation command failed"
+        )
+    if not bool(guard.get("all_samples_grammar_valid", False)):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSweepError(
+            "not all samples passed grammar gate"
+        )
+    if require_no_quality_claim:
+        claimed = [
+            bool(readiness.get("musical_quality_claimed", True)),
+            bool(readiness.get("broad_trained_model_quality_claimed", True)),
+            bool(readiness.get("brad_style_adaptation_claimed", True)),
+        ]
+        if any(claimed):
+            raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSweepError(
+                "quality claims must not be set"
+            )
+    top = _dict(_list(guard.get("ranked_candidates"))[0]) if _list(guard.get("ranked_candidates")) else {}
+    top_audit = _dict(top.get("midi_note_audit"))
+    return {
+        "boundary": boundary,
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "target_passed": bool(guard.get("target_passed", False)),
+        "target_qualified_count": _int(guard.get("target_qualified_count")),
+        "candidate_count": _int(guard.get("candidate_count")),
+        "top_interval_cap": _int(top.get("interval_cap")),
+        "top_sample_seed": _int(top.get("sample_seed")),
+        "top_note_count": _int(top.get("note_count")),
+        "top_phrase_coverage_ratio": _float(top.get("phrase_coverage_ratio")),
+        "top_pitch_span": _int(top_audit.get("pitch_span")),
+        "top_max_abs_interval": _int(top_audit.get("max_abs_interval")),
+        "top_large_interval_ratio": _float(top_audit.get("large_interval_ratio")),
+        "top_target_qualified": bool(top.get("target_qualified", False)),
+        "musical_quality_claimed": bool(readiness.get("musical_quality_claimed", True)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    guard = report["range_interval_guard"]
+    lines = [
+        "# Stage B Generic Tiny Checkpoint Repair Phrase Continuation Range Interval Guard Sweep",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{readiness['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- target passed: `{_bool_token(guard['target_passed'])}`",
+        f"- target qualified count: `{guard['target_qualified_count']}`",
+        f"- candidate count: `{guard['candidate_count']}`",
+        f"- generation success: `{_bool_token(guard['generation_success'])}`",
+        f"- all samples grammar valid: `{_bool_token(guard['all_samples_grammar_valid'])}`",
+        f"- musical quality claimed: `{_bool_token(readiness['musical_quality_claimed'])}`",
+        "",
+        "## Generation Runs",
+        "",
+        "| interval cap | samples | valid | strict | grammar | target qualified | collapse warning rate |",
+        "|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for run in report.get("generation_runs", []):
+        summary = _dict(run.get("summary"))
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(run.get("interval_cap")),
+                    str(summary.get("sample_count")),
+                    str(summary.get("valid_sample_count")),
+                    str(summary.get("strict_valid_sample_count")),
+                    str(summary.get("grammar_gate_sample_count")),
+                    str(run.get("target_qualified_count")),
+                    f"{_float(summary.get('collapse_warning_sample_rate')):.3f}",
+                ]
+            )
+            + " |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Top Candidates",
+            "",
+            "| rank | cap | seed | sample | target | notes | coverage | tail | postprocess removal | pitch range | span | max interval | large ratio | failures | midi |",
+            "|---:|---:|---:|---:|:---:|---:|---:|---:|---:|---|---:|---:|---:|---|---|",
+        ]
+    )
+    for rank, candidate in enumerate(guard.get("ranked_candidates", [])[:8], start=1):
+        audit = _dict(candidate.get("midi_note_audit"))
+        pitch_range = f"{audit.get('pitch_min')}-{audit.get('pitch_max')}"
+        failures = ", ".join(_list(candidate.get("target_failure_reasons"))) or "none"
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(rank),
+                    str(candidate.get("interval_cap")),
+                    str(candidate.get("sample_seed")),
+                    str(candidate.get("sample_index")),
+                    _bool_token(bool(candidate.get("target_qualified", False))),
+                    str(candidate.get("note_count")),
+                    f"{_float(candidate.get('phrase_coverage_ratio')):.3f}",
+                    str(candidate.get("tail_empty_steps")),
+                    f"{_float(candidate.get('postprocess_removal_ratio')):.3f}",
+                    pitch_range,
+                    str(audit.get("pitch_span")),
+                    str(audit.get("max_abs_interval")),
+                    f"{_float(audit.get('large_interval_ratio')):.3f}",
+                    failures,
+                    str(candidate.get("midi_path")),
+                ]
+            )
+            + " |"
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run phrase-continuation range/interval guard sweep")
+    parser.add_argument("--checkpoint_dir", type=str, required=True)
+    parser.add_argument(
+        "--decision_report",
+        type=str,
+        default="outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_decision/"
+        "harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_decision/"
+        "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_decision.json",
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=423)
+    parser.add_argument("--max_sequence", type=int, default=160)
+    parser.add_argument("--num_samples", type=int, default=12)
+    parser.add_argument("--seed", type=int, default=62)
+    parser.add_argument("--temperature", type=float, default=0.78)
+    parser.add_argument("--top_k", type=int, default=5)
+    parser.add_argument("--min_valid_samples", type=int, default=1)
+    parser.add_argument("--min_strict_valid_samples", type=int, default=1)
+    parser.add_argument("--note_groups_per_bar", type=int, default=8)
+    parser.add_argument("--chord_pitch_mode", type=str, default="tones_tensions")
+    parser.add_argument("--chord_pitch_repeat_window", type=int, default=2)
+    parser.add_argument("--interval_caps", type=str, default="12,9,7,5")
+    parser.add_argument("--max_simultaneous_notes", type=int, default=1)
+    parser.add_argument("--min_note_count", type=int, default=8)
+    parser.add_argument("--min_phrase_coverage_ratio", type=float, default=0.85)
+    parser.add_argument("--max_tail_empty_steps", type=int, default=2)
+    parser.add_argument("--max_postprocess_removal_ratio", type=float, default=0.49)
+    parser.add_argument("--max_severe_interval_count", type=int, default=0)
+    parser.add_argument("--min_target_qualified", type=int, default=1)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    run_dir = Path(args.output_root) / run_id
+    checkpoint_dir = Path(args.checkpoint_dir)
+    if not (checkpoint_dir / "checkpoint_epoch1.pt").exists():
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSweepError(
+            "checkpoint required"
+        )
+    decision_report_path = Path(args.decision_report)
+    if not decision_report_path.exists():
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSweepError(
+            "range/interval guard decision report required"
+        )
+    decision_report = read_json(decision_report_path)
+    targets = validate_guard_decision(decision_report)
+    probe_output_root = run_dir / "generation_probe"
+    generation_runs: list[dict[str, Any]] = []
+    for interval_cap in parse_int_list(str(args.interval_caps)):
+        probe_run_id = f"cap_{interval_cap}_seed_{int(args.seed)}"
+        command = build_generation_command(
+            args,
+            checkpoint_dir=checkpoint_dir,
+            output_root=probe_output_root,
+            run_id=probe_run_id,
+            interval_cap=interval_cap,
+            targets=targets,
+        )
+        result = run_command(command)
+        report_path = probe_output_root / probe_run_id / "report.json"
+        if not report_path.exists():
+            raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSweepError(
+                f"generation report not produced: {report_path}"
+            )
+        generation_runs.append(
+            {
+                "interval_cap": int(interval_cap),
+                "result": result,
+                "report_path": str(report_path),
+                "report": read_json(report_path),
+            }
+        )
+    report = build_sweep_report(
+        run_dir=run_dir,
+        checkpoint_dir=checkpoint_dir,
+        decision_report_path=decision_report_path,
+        decision_report=decision_report,
+        generation_runs=generation_runs,
+        args=args,
+    )
+    summary = validate_sweep_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        min_generation_runs=len(parse_int_list(str(args.interval_caps))),
+        min_candidate_count=len(parse_int_list(str(args.interval_caps))) * int(args.num_samples),
+        min_target_qualified=int(args.min_target_qualified),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    run_dir.mkdir(parents=True, exist_ok=True)
+    write_json(run_dir / "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep.json", report)
+    write_json(
+        run_dir
+        / "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(run_dir / "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_generation_probe.py
+++ b/tests/test_stage_b_generation_probe.py
@@ -277,6 +277,35 @@ class StageBGenerationProbeTest(unittest.TestCase):
         self.assertNotIn(note_pitch_token(72), tokens)
         self.assertIn(note_pitch_token(60), tokens)
 
+    def test_chord_aware_pitch_tokens_can_limit_pitch_range(self) -> None:
+        tokens = chord_aware_pitch_tokens(
+            "Cm7",
+            pitch_mode="tones",
+            repeat_window=0,
+            pitch_min=48,
+            pitch_max=60,
+        )
+        pitches = {pitch_from_token(token) for token in tokens}
+
+        self.assertTrue(pitches)
+        self.assertLessEqual(max(pitches), 60)
+        self.assertGreaterEqual(min(pitches), 48)
+
+    def test_chord_aware_pitch_tokens_can_limit_adjacent_interval(self) -> None:
+        tokens = chord_aware_pitch_tokens(
+            "Cm7",
+            pitch_mode="tones_tensions",
+            recent_pitches=[60],
+            repeat_window=0,
+            pitch_min=48,
+            pitch_max=84,
+            max_adjacent_interval=5,
+        )
+        pitches = {pitch_from_token(token) for token in tokens}
+
+        self.assertTrue(pitches)
+        self.assertTrue(all(abs(pitch - 60) <= 5 for pitch in pitches))
+
     def test_chord_pitch_classes_can_include_tensions(self) -> None:
         self.assertEqual(chord_pitch_classes("Cmaj7", pitch_mode="tones"), {0, 4, 7, 11})
         self.assertIn(2, chord_pitch_classes("Cmaj7", pitch_mode="tones_tensions"))

--- a/tests/test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep.py
+++ b/tests/test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import argparse
+import tempfile
+import unittest
+from pathlib import Path
+
+import mido
+
+from scripts.run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep import (
+    BOUNDARY,
+    StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSweepError,
+    build_sweep_report,
+    compact_candidate,
+    validate_guard_decision,
+    validate_sweep_report,
+)
+
+
+def write_midi(path: Path, pitches: list[int]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    midi = mido.MidiFile(ticks_per_beat=220)
+    track = mido.MidiTrack()
+    midi.tracks.append(track)
+    track.append(mido.Message("program_change", program=0, time=0))
+    for index, pitch in enumerate(pitches):
+        delta = 55 if index else 0
+        track.append(mido.Message("note_on", note=pitch, velocity=64, time=delta))
+        track.append(mido.Message("note_off", note=pitch, velocity=0, time=55))
+    track.append(mido.MetaMessage("end_of_track", time=0))
+    midi.save(path)
+
+
+def decision_report(*, next_boundary: str = BOUNDARY) -> dict:
+    return {
+        "schema_version": "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_decision_v1",
+        "readiness": {
+            "boundary": "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_decision",
+            "musical_quality_claimed": False,
+        },
+        "decision": {
+            "next_boundary": next_boundary,
+        },
+        "guard_targets": {
+            "max_pitch_span": 24,
+            "max_abs_interval": 12,
+            "max_large_interval_ratio": 0.35,
+            "max_severe_interval_count": 0,
+            "preferred_pitch_floor": 48,
+            "preferred_pitch_ceiling": 84,
+            "large_interval_threshold": 12,
+            "severe_interval_threshold": 24,
+        },
+    }
+
+
+def args() -> argparse.Namespace:
+    return argparse.Namespace(
+        issue_number=423,
+        max_sequence=160,
+        num_samples=2,
+        seed=62,
+        temperature=0.78,
+        top_k=5,
+        min_valid_samples=1,
+        min_strict_valid_samples=1,
+        note_groups_per_bar=8,
+        chord_pitch_mode="tones_tensions",
+        chord_pitch_repeat_window=2,
+        interval_caps="9",
+        max_simultaneous_notes=1,
+        min_note_count=8,
+        min_phrase_coverage_ratio=0.85,
+        max_tail_empty_steps=2,
+        max_postprocess_removal_ratio=0.49,
+        max_severe_interval_count=0,
+        min_target_qualified=1,
+    )
+
+
+def sample_row(path: Path, *, strict: bool = True, coverage: float = 0.9) -> dict:
+    return {
+        "sample_index": 1,
+        "sample_seed": 70,
+        "midi_path": str(path),
+        "valid": True,
+        "strict_valid": strict,
+        "grammar_gate_passed": True,
+        "metrics": {
+            "note_count": 9,
+            "phrase_coverage_ratio": coverage,
+            "dead_air_ratio": 0.75,
+            "max_simultaneous_notes": 1,
+        },
+        "temporal_coverage": {
+            "tail_empty_steps": 0,
+            "position_span_ratio": 1.0,
+        },
+        "collapse": {
+            "postprocess_removal_ratio": 0.3125,
+        },
+        "pitch_roles": {
+            "chord_tone_ratio": 0.75,
+        },
+    }
+
+
+def generation_report(row: dict) -> dict:
+    return {
+        "summary": {
+            "sample_count": 1,
+            "valid_sample_count": 1,
+            "strict_valid_sample_count": 1 if row["strict_valid"] else 0,
+            "grammar_gate_sample_count": 1,
+            "passed_generation_gate": True,
+            "passed_strict_generation_gate": True,
+            "collapse_warning_sample_rate": 0.0,
+        },
+        "samples": [row],
+    }
+
+
+class StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSweepTest(unittest.TestCase):
+    def test_compact_candidate_uses_actual_midi_note_guard(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            midi_path = Path(temp_dir) / "sample.mid"
+            write_midi(midi_path, [53, 60, 67, 60, 58, 63, 67, 65, 62])
+
+            candidate = compact_candidate(
+                sample_row(midi_path),
+                interval_cap=9,
+                args=args(),
+                targets=validate_guard_decision(decision_report()),
+            )
+
+            self.assertTrue(candidate["target_qualified"])
+            self.assertEqual(candidate["midi_note_audit"]["pitch_span"], 14)
+            self.assertEqual(candidate["midi_note_audit"]["max_abs_interval"], 7)
+            self.assertEqual(candidate["target_failure_reasons"], [])
+
+    def test_builds_sweep_report_with_target_candidate_without_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            midi_path = Path(temp_dir) / "sample.mid"
+            write_midi(midi_path, [53, 60, 67, 60, 58, 63, 67, 65, 62])
+            run_args = args()
+            report = build_sweep_report(
+                run_dir=Path(temp_dir) / "run",
+                checkpoint_dir=Path(temp_dir) / "checkpoints",
+                decision_report_path=Path(temp_dir) / "decision.json",
+                decision_report=decision_report(),
+                generation_runs=[
+                    {
+                        "interval_cap": 9,
+                        "result": {"returncode": 0},
+                        "report_path": str(Path(temp_dir) / "report.json"),
+                        "report": generation_report(sample_row(midi_path)),
+                    }
+                ],
+                args=run_args,
+            )
+            summary = validate_sweep_report(
+                report,
+                expected_boundary=BOUNDARY,
+                min_generation_runs=1,
+                min_candidate_count=1,
+                min_target_qualified=1,
+                require_no_quality_claim=True,
+            )
+
+            self.assertTrue(summary["target_passed"])
+            self.assertEqual(summary["target_qualified_count"], 1)
+            self.assertEqual(summary["top_interval_cap"], 9)
+            self.assertFalse(summary["musical_quality_claimed"])
+            self.assertFalse(summary["critical_user_input_required"])
+
+    def test_records_failed_target_candidate_as_tuning_boundary(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            midi_path = Path(temp_dir) / "sample.mid"
+            write_midi(midi_path, [48, 72, 51, 75, 53, 77, 55, 79])
+            run_args = args()
+            report = build_sweep_report(
+                run_dir=Path(temp_dir) / "run",
+                checkpoint_dir=Path(temp_dir) / "checkpoints",
+                decision_report_path=Path(temp_dir) / "decision.json",
+                decision_report=decision_report(),
+                generation_runs=[
+                    {
+                        "interval_cap": 12,
+                        "result": {"returncode": 0},
+                        "report_path": str(Path(temp_dir) / "report.json"),
+                        "report": generation_report(sample_row(midi_path)),
+                    }
+                ],
+                args=run_args,
+            )
+            summary = validate_sweep_report(
+                report,
+                expected_boundary=BOUNDARY,
+                min_generation_runs=1,
+                min_candidate_count=1,
+                min_target_qualified=0,
+                require_no_quality_claim=True,
+            )
+
+            self.assertFalse(summary["target_passed"])
+            self.assertEqual(summary["target_qualified_count"], 0)
+            self.assertIn("sweep_tuning", summary["next_boundary"])
+            top = report["range_interval_guard"]["ranked_candidates"][0]
+            self.assertIn("max_interval_above_target", top["target_failure_reasons"])
+
+    def test_rejects_unexpected_decision_boundary(self) -> None:
+        with self.assertRaises(StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSweepError):
+            validate_guard_decision(decision_report(next_boundary="wrong_boundary"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Range/interval guard sweep for phrase-continuation repair candidates
- Generation probe pitch range and adjacent interval cap options
- Actual MIDI note audit for target qualification after overlap postprocess
- Status docs and harness mode update

## Context
- #421 range/interval guard decision target: pitch span <= 24, max adjacent interval <= 12, large interval ratio <= 0.35, severe interval count 0
- Previous rejected phrase-continuation candidate: pitch span 60, max interval 60, large interval ratio 0.875
- Remaining check: repaired candidate existence under actual MIDI note sequence, not token-level proxy only

## Result
- Sweep caps: 12 / 9 / 7 / 5
- Target qualified: 3 / 48
- Top candidate: cap 9, sample seed 70, sample 9
- Top note count / coverage / tail empty: 11 / 1.0 / 0
- Top pitch span / max interval / large interval ratio: 21 / 9 / 0.0
- Musical quality claim: false

## Validation
- bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-phrase-continuation-range-interval-guard-sweep
- bash scripts/agent_harness.sh quick
- ./.venv/bin/python -m unittest tests.test_stage_b_generation_probe tests.test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep tests.test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_decision
- ./.venv/bin/python -m py_compile scripts/run_stage_b_generation_probe.py scripts/run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep.py tests/test_stage_b_generation_probe.py tests/test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep.py
- git diff --check

## Risk
- Objective-only pass; listening quality and human/audio keep not claimed
- Audio render package still required before WAV review

Closes #423

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable pitch constraint options for constrained generation (pitch range and maximum interval bounds).
  * Introduced new sweep command for checkpoint repair with interval validation and automated report generation.

* **Documentation**
  * Updated progress tracking and project status documentation.
  * Added new sweep results documentation with boundary configuration and candidate evaluation metrics.

* **Tests**
  * Added test coverage for pitch constraint validation and sweep report generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohhalim/fine_tuning_art-tatum_midi_solo/pull/424?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->