### PR TITLE
Stage B generic tiny checkpoint repair phrase continuation range interval guard audio render package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #423, Stage B generic tiny checkpoint repair phrase continuation range interval guard sweep.
+- Latest functional issue completed: Issue #425, Stage B generic tiny checkpoint repair phrase continuation range interval guard audio render package.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B generic tiny checkpoint repair phrase continuation range interval guard audio render package.
+- Recommended next issue: Stage B generic tiny checkpoint repair phrase continuation range interval guard local audio render attempt.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1026,6 +1026,14 @@ bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-phrase-cont
 ```
 
 This harness runs constrained interval-cap sweeps and verifies actual MIDI note range/interval guard candidates without claiming listening quality.
+
+For Stage B generic tiny checkpoint repair phrase continuation range interval guard audio render package changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-phrase-continuation-range-interval-guard-audio-render-package
+```
+
+This harness packages range/interval guard candidates for local WAV rendering without attempting render or claiming listening quality.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -156,6 +156,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint repair phrase continuation MIDI note failure review 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_MIDI_NOTE_FAILURE_REVIEW_2026-05-30.md`
 - generic tiny checkpoint repair phrase continuation range interval guard decision 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_DECISION_2026-05-30.md`
 - generic tiny checkpoint repair phrase continuation range interval guard sweep 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_SWEEP_2026-05-30.md`
+- generic tiny checkpoint repair phrase continuation range interval guard audio render package 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_AUDIO_RENDER_PACKAGE_2026-05-30.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -250,6 +251,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint repair phrase continuation MIDI note failure review: reject_all, pitch span `60`, max interval `60`, large interval ratio `0.875`, next boundary `range_interval_guard_decision`
 - generic tiny checkpoint repair phrase continuation range interval guard decision: target pitch span `24`, max interval `12`, large interval ratio `0.35`, severe interval count `0`
 - generic tiny checkpoint repair phrase continuation range interval guard sweep: target qualified `3/48`, top cap `9`, sample seed `70`, top span/max interval/large ratio `21/9/0.0`, next boundary `range_interval_guard_audio_render_package`
+- generic tiny checkpoint repair phrase continuation range interval guard audio render package: planned outputs `3`, renderer `fluidsynth`, soundfont exists `true`, next boundary `range_interval_guard_local_audio_render_attempt`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -1371,6 +1373,18 @@ Issue #312는 constrained decoding으로 adjacent repeat를 줄였지만 dead-ai
 - top pitch span / max abs interval / large interval ratio: `21` / `9` / `0.0`
 - quality claim: `false`
 - 다음 작업은 repair phrase continuation range interval guard audio render package다.
+
+현재 generic tiny checkpoint repair phrase continuation range interval guard audio render package:
+
+- Issue #425 result: boundary `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package`
+- next boundary: `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_local_audio_render_attempt`
+- render status: `ready_for_local_render`
+- selected renderer / soundfont exists: `fluidsynth` / `true`
+- planned audio outputs: `3`
+- target-qualified ranks: `1-3`
+- render attempted: `false`
+- audio quality / human preference / musical quality claim: `false`
+- 다음 작업은 repair phrase continuation range interval guard local audio render attempt다.
 
 ### Phase 5. Brad Style Adaptation
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #423, Stage B generic tiny checkpoint repair phrase continuation range interval guard sweep
-- 다음 권장 이슈: `Stage B generic tiny checkpoint repair phrase continuation range interval guard audio render package`
+- latest functional result: Issue #425, Stage B generic tiny checkpoint repair phrase continuation range interval guard audio render package
+- 다음 권장 이슈: `Stage B generic tiny checkpoint repair phrase continuation range interval guard local audio render attempt`
 
 현재 범위가 아닌 것:
 
@@ -805,6 +805,38 @@ Issue #423은 range/interval guard decision을 실제 constrained generation swe
 다음:
 
 - `Stage B generic tiny checkpoint repair phrase continuation range interval guard audio render package`
+
+## Current Generic Tiny Checkpoint Repair Phrase Continuation Range Interval Guard Audio Render Package Result
+
+Issue #425는 range/interval guard 통과 후보를 local WAV render 대상 package로 정리한 작업이다.
+
+변경:
+
+- range/interval guard sweep report 입력 검증 추가
+- target-qualified MIDI candidate package script 추가
+- planned WAV output, renderer, soundfont readiness 기록
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_AUDIO_RENDER_PACKAGE_2026-05-30.md`
+- boundary: `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package`
+- next boundary: `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_local_audio_render_attempt`
+- render status: `ready_for_local_render`
+- selected renderer / soundfont exists: `fluidsynth` / `true`
+- planned audio outputs: `3`
+- render attempted: `false`
+- audio rendered quality / human preference / musical quality claim: `false`
+
+판단:
+
+- #423 target-qualified MIDI 후보 `3`개를 모두 local render 대상으로 유지
+- 현재 단계는 render readiness와 command plan만 기록
+- WAV 파일 생성, 청취 판단, musical quality claim은 다음 boundary
+
+다음:
+
+- `Stage B generic tiny checkpoint repair phrase continuation range interval guard local audio render attempt`
 
 ## Current Muzig Application Resume Wording Result
 

--- a/docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_AUDIO_RENDER_PACKAGE_2026-05-30.md
+++ b/docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_AUDIO_RENDER_PACKAGE_2026-05-30.md
@@ -1,0 +1,30 @@
+# Stage B Generic Tiny Checkpoint Repair Phrase Continuation Range Interval Guard Audio Render Package
+
+## Summary
+
+- boundary: `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package`
+- render status: `ready_for_local_render`
+- selected renderer: `fluidsynth`
+- soundfont exists: `true`
+- planned audio outputs: `3`
+- render attempted: `false`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- musical quality claimed: `false`
+
+## Selected Candidates
+
+| rank | cap | seed | sample | notes | coverage | tail empty | pitch span | max interval | MIDI exists | planned WAV | command ready |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|---|:---:|
+| 1 | 9 | 70 | 9 | 11 | 1.0 | 0 | 21 | 9 | true | outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package/harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package/audio/rank_01_cap_9_seed_70_sample_9.wav | true |
+| 2 | 7 | 66 | 5 | 9 | 0.9062481875 | 0 | 12 | 12 | true | outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package/harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package/audio/rank_02_cap_7_seed_66_sample_5.wav | true |
+| 3 | 9 | 62 | 1 | 9 | 0.8749982499999999 | 1 | 17 | 12 | true | outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package/harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package/audio/rank_03_cap_9_seed_62_sample_1.wav | true |
+
+## Not Proven
+
+- `audio_output`
+- `audio_rendered_quality`
+- `human_audio_preference`
+- `musical_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -196,6 +196,8 @@ Modes:
                 Convert MIDI note failure evidence into range/interval guard targets.
   stage-b-generic-tiny-checkpoint-repair-phrase-continuation-range-interval-guard-sweep
                 Run constrained range/interval cap sweep and audit actual MIDI notes.
+  stage-b-generic-tiny-checkpoint-repair-phrase-continuation-range-interval-guard-audio-render-package
+                Package range/interval guard candidates for local audio rendering.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -2703,6 +2705,40 @@ run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_gu
     --require_no_quality_claim
 }
 
+run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package() {
+  local range_sweep_run_id="${RANGE_SWEEP_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep}"
+  local range_decision_run_id="${RANGE_DECISION_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_decision}"
+  local failure_review_run_id="${FAILURE_REVIEW_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_midi_note_failure_review}"
+  local local_audio_run_id="${LOCAL_AUDIO_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_local_audio_render_attempt}"
+  local phrase_audio_package_run_id="${PHRASE_AUDIO_PACKAGE_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package}"
+  local sweep_run_id="${SWEEP_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep}"
+  local decision_run_id="${DECISION_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_decision}"
+  local user_review_run_id="${USER_REVIEW_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_user_listening_review}"
+  local audio_render_run_id="${AUDIO_RENDER_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt}"
+  local audio_package_run_id="${AUDIO_PACKAGE_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_audio_render_package}"
+  local listening_fill_run_id="${LISTENING_FILL_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_listening_fill}"
+  local listening_notes_run_id="${LISTENING_NOTES_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_listening_notes}"
+  local training_smoke_run_id="${TRAINING_SMOKE_RUN_ID:-harness_stage_b_generic_base_tiny_training_smoke}"
+  local run_id="${RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package}"
+  local range_sweep_report="outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep/${range_sweep_run_id}/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep.json"
+  local soundfont="${SOUNDFONT_PATH:-$HOME/.local/share/soundfonts/generaluser-gs/v1.471.sf2}"
+  if [[ ! -f "$range_sweep_report" ]]; then
+    print_header "Stage B generic tiny checkpoint repair phrase continuation range interval guard sweep"
+    RUN_ID="$range_sweep_run_id" RANGE_DECISION_RUN_ID="$range_decision_run_id" FAILURE_REVIEW_RUN_ID="$failure_review_run_id" LOCAL_AUDIO_RUN_ID="$local_audio_run_id" PHRASE_AUDIO_PACKAGE_RUN_ID="$phrase_audio_package_run_id" SWEEP_RUN_ID="$sweep_run_id" DECISION_RUN_ID="$decision_run_id" USER_REVIEW_RUN_ID="$user_review_run_id" AUDIO_RENDER_RUN_ID="$audio_render_run_id" AUDIO_PACKAGE_RUN_ID="$audio_package_run_id" LISTENING_FILL_RUN_ID="$listening_fill_run_id" LISTENING_NOTES_RUN_ID="$listening_notes_run_id" TRAINING_SMOKE_RUN_ID="$training_smoke_run_id" run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep
+  fi
+  print_header "Stage B generic tiny checkpoint repair phrase continuation range interval guard audio render package"
+  "$PYTHON_BIN" scripts/build_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package.py \
+    --run_id "$run_id" \
+    --sweep_report "$range_sweep_report" \
+    --soundfont "$soundfont" \
+    --doc_path docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_AUDIO_RENDER_PACKAGE_2026-05-30.md \
+    --expected_boundary stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package \
+    --min_planned_outputs 1 \
+    --require_target_qualified \
+    --require_required_midi_exists \
+    --require_no_audio_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -4092,6 +4128,9 @@ case "$MODE" in
     ;;
   stage-b-generic-tiny-checkpoint-repair-phrase-continuation-range-interval-guard-sweep)
     run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep
+    ;;
+  stage-b-generic-tiny-checkpoint-repair-phrase-continuation-range-interval-guard-audio-render-package)
+    run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/build_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package.py
+++ b/scripts/build_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package.py
@@ -1,0 +1,426 @@
+"""Build audio render package metadata for range/interval guard candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.build_stage_b_generic_tiny_checkpoint_repair_audio_render_package import (  # noqa: E402
+    file_meta,
+    renderer_probe,
+)
+from scripts.build_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package import (  # noqa: E402
+    render_command,
+)
+from scripts.run_stage_b_generic_tiny_checkpoint_generation_probe import (  # noqa: E402
+    _bool_token,
+    _dict,
+    _float,
+    _int,
+)
+
+
+class StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardAudioRenderPackageError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package"
+SCHEMA_VERSION = (
+    "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package_v1"
+)
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def validate_sweep_report(report: dict[str, Any]) -> list[dict[str, Any]]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    guard = _dict(report.get("range_interval_guard"))
+    if str(readiness.get("boundary") or "") != (
+        "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep"
+    ):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardAudioRenderPackageError(
+            "unexpected range/interval guard sweep boundary"
+        )
+    if not bool(guard.get("target_passed", False)):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardAudioRenderPackageError(
+            "range/interval guard target must pass before audio package"
+        )
+    if _int(guard.get("target_qualified_count")) < 1:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardAudioRenderPackageError(
+            "target-qualified candidate required"
+        )
+    if str(decision.get("next_boundary") or "") != BOUNDARY:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardAudioRenderPackageError(
+            "unexpected next boundary"
+        )
+    claimed = [
+        bool(readiness.get("musical_quality_claimed", True)),
+        bool(readiness.get("broad_trained_model_quality_claimed", True)),
+        bool(readiness.get("brad_style_adaptation_claimed", True)),
+    ]
+    if any(claimed):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardAudioRenderPackageError(
+            "quality claims must not be set"
+        )
+    ranked = [dict(row) for row in _list(guard.get("ranked_candidates")) if isinstance(row, dict)]
+    selected = [row for row in ranked if bool(row.get("target_qualified", False))]
+    if not selected:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardAudioRenderPackageError(
+            "target-qualified candidate list empty"
+        )
+    return selected
+
+
+def compact_candidate(candidate: dict[str, Any], *, review_rank: int) -> dict[str, Any]:
+    audit = _dict(candidate.get("midi_note_audit"))
+    return {
+        "review_rank": int(review_rank),
+        "interval_cap": _int(candidate.get("interval_cap")),
+        "sample_seed": _int(candidate.get("sample_seed")),
+        "sample_index": _int(candidate.get("sample_index")),
+        "midi_file": file_meta(str(candidate.get("midi_path") or ""), required=True),
+        "target_qualified": bool(candidate.get("target_qualified", False)),
+        "note_count": _int(candidate.get("note_count")),
+        "phrase_coverage_ratio": _float(candidate.get("phrase_coverage_ratio")),
+        "dead_air_ratio": _float(candidate.get("dead_air_ratio")),
+        "tail_empty_steps": _int(candidate.get("tail_empty_steps")),
+        "postprocess_removal_ratio": _float(candidate.get("postprocess_removal_ratio")),
+        "max_simultaneous_notes": _int(candidate.get("max_simultaneous_notes")),
+        "midi_note_audit": {
+            "pitch_min": audit.get("pitch_min"),
+            "pitch_max": audit.get("pitch_max"),
+            "pitch_span": _int(audit.get("pitch_span")),
+            "max_abs_interval": _int(audit.get("max_abs_interval")),
+            "large_interval_ratio": _float(audit.get("large_interval_ratio")),
+            "severe_interval_count": _int(audit.get("severe_interval_count")),
+            "pitch_sequence": _list(audit.get("pitch_sequence")),
+            "intervals": _list(audit.get("intervals")),
+        },
+    }
+
+
+def item_output_stem(item: dict[str, Any]) -> str:
+    return (
+        f"rank_{item['review_rank']:02d}_cap_{item['interval_cap']}"
+        f"_seed_{item['sample_seed']}_sample_{item['sample_index']}"
+    )
+
+
+def build_audio_render_package(
+    sweep_report: dict[str, Any],
+    *,
+    output_dir: Path,
+    requested_renderer: str = "",
+    soundfont_path: str = "",
+    renderer_paths: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    selected_candidates = validate_sweep_report(sweep_report)
+    probe = renderer_probe(
+        requested_renderer=requested_renderer,
+        soundfont_path=soundfont_path,
+        renderer_paths=renderer_paths,
+    )
+    review_items = [
+        compact_candidate(candidate, review_rank=index)
+        for index, candidate in enumerate(selected_candidates, start=1)
+    ]
+    planned_outputs: list[dict[str, Any]] = []
+    for item in review_items:
+        output_stem = item_output_stem(item)
+        output_wav_path = output_dir / "audio" / f"{output_stem}.wav"
+        midi_path = str(item["midi_file"]["path"])
+        planned_outputs.append(
+            {
+                "review_rank": item["review_rank"],
+                "interval_cap": item["interval_cap"],
+                "sample_seed": item["sample_seed"],
+                "sample_index": item["sample_index"],
+                "source_midi_path": midi_path,
+                "planned_wav_path": str(output_wav_path),
+                "planned_wav_exists": output_wav_path.exists(),
+                "render_command": render_command(probe, midi_path, str(output_wav_path)),
+            }
+        )
+    render_ready = str(probe["status"]) == "ready_for_local_render"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_sweep_schema": str(sweep_report.get("schema_version") or ""),
+        "source_sweep_run_dir": str(sweep_report.get("run_dir") or ""),
+        "review_items": review_items,
+        "renderer_probe": probe,
+        "planned_audio_outputs": planned_outputs,
+        "local_audio_render_boundary": {
+            "boundary": BOUNDARY,
+            "status": str(probe["status"]),
+            "render_attempted": False,
+            "planned_audio_output_count": len(planned_outputs),
+            "rendered_audio_file_count": 0,
+            "audio_output_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "human_audio_preference_claimed": False,
+            "musical_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": (
+                "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_local_audio_render_attempt"
+                if render_ready
+                else "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_tooling_setup"
+            ),
+            "auto_progress_allowed": render_ready,
+            "critical_user_input_required": not render_ready,
+        },
+        "not_proven": [
+            "audio_output",
+            "audio_rendered_quality",
+            "human_audio_preference",
+            "musical_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B generic tiny checkpoint repair phrase continuation range interval guard local audio render attempt"
+            if render_ready
+            else "Stage B generic tiny checkpoint repair phrase continuation range interval guard audio render tooling setup"
+        ),
+    }
+
+
+def validate_audio_render_package(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_status: str | None,
+    min_planned_outputs: int,
+    require_target_qualified: bool,
+    require_required_midi_exists: bool,
+    require_no_audio_claim: bool,
+) -> dict[str, Any]:
+    boundary = _dict(report.get("local_audio_render_boundary"))
+    status = str(boundary.get("status") or "")
+    if expected_boundary and str(boundary.get("boundary") or "") != expected_boundary:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardAudioRenderPackageError(
+            f"expected boundary {expected_boundary}, got {boundary.get('boundary')}"
+        )
+    if expected_status and status != expected_status:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardAudioRenderPackageError(
+            f"expected status {expected_status}, got {status}"
+        )
+    planned_outputs = _list(report.get("planned_audio_outputs"))
+    if len(planned_outputs) < min_planned_outputs:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardAudioRenderPackageError(
+            f"planned output count below target: {len(planned_outputs)} < {min_planned_outputs}"
+        )
+    review_items = _list(report.get("review_items"))
+    if require_target_qualified and not all(bool(_dict(item).get("target_qualified", False)) for item in review_items):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardAudioRenderPackageError(
+            "review items must be target-qualified"
+        )
+    if require_required_midi_exists:
+        missing = []
+        for item in review_items:
+            midi_file = _dict(_dict(item).get("midi_file"))
+            if bool(midi_file.get("required", False)) and not bool(midi_file.get("exists", False)):
+                missing.append(str(midi_file.get("path") or "midi_file"))
+        if missing:
+            raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardAudioRenderPackageError(
+                f"missing required MIDI files: {missing}"
+            )
+    if require_no_audio_claim:
+        claimed = [
+            bool(boundary.get("render_attempted", True)),
+            bool(boundary.get("audio_output_claimed", True)),
+            bool(boundary.get("audio_rendered_quality_claimed", True)),
+            bool(boundary.get("human_audio_preference_claimed", True)),
+            bool(boundary.get("musical_quality_claimed", True)),
+            bool(boundary.get("broad_trained_model_quality_claimed", True)),
+            bool(boundary.get("brad_style_adaptation_claimed", True)),
+        ]
+        if any(claimed):
+            raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardAudioRenderPackageError(
+                "audio or quality claims must not be set"
+            )
+    decision = _dict(report.get("decision"))
+    return {
+        "boundary": str(boundary.get("boundary") or ""),
+        "render_status": status,
+        "selected_renderer_name": str(_dict(report.get("renderer_probe")).get("selected_renderer_name") or ""),
+        "soundfont_exists": bool(_dict(report.get("renderer_probe")).get("soundfont_exists", False)),
+        "planned_audio_output_count": len(planned_outputs),
+        "render_attempted": bool(boundary.get("render_attempted", True)),
+        "audio_rendered_quality_claimed": bool(boundary.get("audio_rendered_quality_claimed", True)),
+        "human_audio_preference_claimed": bool(boundary.get("human_audio_preference_claimed", True)),
+        "auto_progress_allowed": bool(decision.get("auto_progress_allowed", False)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    boundary = report["local_audio_render_boundary"]
+    probe = report["renderer_probe"]
+    lines = [
+        "# Stage B Generic Tiny Checkpoint Repair Phrase Continuation Range Interval Guard Audio Render Package",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{boundary['boundary']}`",
+        f"- render status: `{boundary['status']}`",
+        f"- selected renderer: `{probe['selected_renderer_name']}`",
+        f"- soundfont exists: `{_bool_token(probe['soundfont_exists'])}`",
+        f"- planned audio outputs: `{boundary['planned_audio_output_count']}`",
+        f"- render attempted: `{_bool_token(boundary['render_attempted'])}`",
+        f"- audio rendered quality claimed: `{_bool_token(boundary['audio_rendered_quality_claimed'])}`",
+        f"- human/audio preference claimed: `{_bool_token(boundary['human_audio_preference_claimed'])}`",
+        f"- musical quality claimed: `{_bool_token(boundary['musical_quality_claimed'])}`",
+        "",
+        "## Selected Candidates",
+        "",
+        "| rank | cap | seed | sample | notes | coverage | tail empty | pitch span | max interval | MIDI exists | planned WAV | command ready |",
+        "|---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|---|:---:|",
+    ]
+    review_by_key = {
+        (
+            _int(item.get("review_rank")),
+            _int(item.get("interval_cap")),
+            _int(item.get("sample_seed")),
+            _int(item.get("sample_index")),
+        ): item
+        for item in report.get("review_items", [])
+        if isinstance(item, dict)
+    }
+    for item in report.get("planned_audio_outputs", []):
+        key = (
+            _int(item.get("review_rank")),
+            _int(item.get("interval_cap")),
+            _int(item.get("sample_seed")),
+            _int(item.get("sample_index")),
+        )
+        review_item = _dict(review_by_key.get(key))
+        audit = _dict(review_item.get("midi_note_audit"))
+        midi_exists = bool(_dict(review_item.get("midi_file")).get("exists", False))
+        command_ready = bool(item.get("render_command"))
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(item.get("review_rank", "")),
+                    str(item.get("interval_cap", "")),
+                    str(item.get("sample_seed", "")),
+                    str(item.get("sample_index", "")),
+                    str(review_item.get("note_count", "")),
+                    str(review_item.get("phrase_coverage_ratio", "")),
+                    str(review_item.get("tail_empty_steps", "")),
+                    str(audit.get("pitch_span", "")),
+                    str(audit.get("max_abs_interval", "")),
+                    _bool_token(midi_exists),
+                    str(item.get("planned_wav_path") or ""),
+                    _bool_token(command_ready),
+                ]
+            )
+            + " |"
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    default_soundfont = Path.home() / ".local/share/soundfonts/generaluser-gs/v1.471.sf2"
+    parser = argparse.ArgumentParser(
+        description="Build range/interval guard audio render package metadata"
+    )
+    parser.add_argument(
+        "--sweep_report",
+        type=str,
+        default="outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep/"
+        "harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep/"
+        "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep.json",
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=(
+            "outputs/"
+            "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package"
+        ),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--renderer", type=str, default="")
+    parser.add_argument("--soundfont", type=str, default=str(default_soundfont))
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_status", type=str, default="")
+    parser.add_argument("--min_planned_outputs", type=int, default=1)
+    parser.add_argument("--require_target_qualified", action="store_true")
+    parser.add_argument("--require_required_midi_exists", action="store_true")
+    parser.add_argument("--require_no_audio_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    sweep_report_path = Path(args.sweep_report)
+    if not sweep_report_path.exists():
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardAudioRenderPackageError(
+            "range/interval guard sweep report required"
+        )
+    report = build_audio_render_package(
+        read_json(sweep_report_path),
+        output_dir=output_dir,
+        requested_renderer=str(args.renderer or ""),
+        soundfont_path=str(args.soundfont or ""),
+    )
+    summary = validate_audio_render_package(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_status=str(args.expected_status or ""),
+        min_planned_outputs=int(args.min_planned_outputs),
+        require_target_qualified=bool(args.require_target_qualified),
+        require_required_midi_exists=bool(args.require_required_midi_exists),
+        require_no_audio_claim=bool(args.require_no_audio_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir
+        / "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir
+        / "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package.py
+++ b/tests/test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.build_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package import (
+    BOUNDARY,
+    StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardAudioRenderPackageError,
+    build_audio_render_package,
+    validate_audio_render_package,
+)
+
+
+def fake_midi(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"MThd\x00\x00\x00\x06\x00\x00\x00\x01\x00`MTrk\x00\x00\x00\x04\x00\xff/\x00")
+
+
+def fake_executable(path: Path) -> None:
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def candidate(root: Path, *, target_qualified: bool = True) -> dict:
+    midi_path = root / "stage_b_sample_9.mid"
+    fake_midi(midi_path)
+    return {
+        "sample_index": 9,
+        "sample_seed": 70,
+        "interval_cap": 9,
+        "midi_path": str(midi_path),
+        "target_qualified": target_qualified,
+        "note_count": 11,
+        "phrase_coverage_ratio": 1.0,
+        "dead_air_ratio": 0.75,
+        "tail_empty_steps": 0,
+        "postprocess_removal_ratio": 0.3125,
+        "max_simultaneous_notes": 1,
+        "midi_note_audit": {
+            "pitch_min": 53,
+            "pitch_max": 74,
+            "pitch_span": 21,
+            "max_abs_interval": 9,
+            "large_interval_ratio": 0.0,
+            "severe_interval_count": 0,
+            "pitch_sequence": [74, 65, 62, 63, 58, 58, 60, 53, 60, 53, 55],
+            "intervals": [-9, -3, 1, -5, 0, 2, -7, 7, -7, 2],
+        },
+    }
+
+
+def sweep_report(
+    root: Path,
+    *,
+    target_passed: bool = True,
+    quality_claimed: bool = False,
+) -> dict:
+    return {
+        "schema_version": "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep_v1",
+        "run_dir": str(root / "sweep"),
+        "readiness": {
+            "boundary": "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep",
+            "range_interval_guard_target_passed": target_passed,
+            "musical_quality_claimed": quality_claimed,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "next_boundary": BOUNDARY,
+        },
+        "range_interval_guard": {
+            "target_passed": target_passed,
+            "target_qualified_count": 1 if target_passed else 0,
+            "candidate_count": 1,
+            "ranked_candidates": [
+                candidate(root, target_qualified=target_passed),
+            ],
+        },
+    }
+
+
+class StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardAudioRenderPackageTest(
+    unittest.TestCase
+):
+    def test_builds_ready_package_for_target_qualified_candidates(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            soundfont = root / "piano.sf2"
+            fake_executable(renderer)
+            soundfont.write_bytes(b"sf2")
+            report = build_audio_render_package(
+                sweep_report(root),
+                output_dir=root / "render_package",
+                requested_renderer="fluidsynth",
+                soundfont_path=str(soundfont),
+                renderer_paths={"fluidsynth": str(renderer), "timidity": ""},
+            )
+            summary = validate_audio_render_package(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_status="ready_for_local_render",
+                min_planned_outputs=1,
+                require_target_qualified=True,
+                require_required_midi_exists=True,
+                require_no_audio_claim=True,
+            )
+
+            self.assertEqual(summary["render_status"], "ready_for_local_render")
+            self.assertEqual(summary["planned_audio_output_count"], 1)
+            self.assertTrue(report["review_items"][0]["target_qualified"])
+            self.assertEqual(report["review_items"][0]["interval_cap"], 9)
+            self.assertEqual(report["review_items"][0]["midi_note_audit"]["max_abs_interval"], 9)
+            self.assertTrue(report["planned_audio_outputs"][0]["render_command"])
+            self.assertIn(str(soundfont), report["planned_audio_outputs"][0]["render_command"])
+            self.assertFalse(summary["audio_rendered_quality_claimed"])
+            self.assertFalse(summary["human_audio_preference_claimed"])
+
+    def test_rejects_unqualified_sweep(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertRaises(
+                StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardAudioRenderPackageError
+            ):
+                build_audio_render_package(
+                    sweep_report(Path(temp_dir), target_passed=False),
+                    output_dir=Path(temp_dir) / "render_package",
+                )
+
+    def test_rejects_quality_claimed_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertRaises(
+                StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardAudioRenderPackageError
+            ):
+                build_audio_render_package(
+                    sweep_report(Path(temp_dir), quality_claimed=True),
+                    output_dir=Path(temp_dir) / "render_package",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Range/interval guard audio render package
- Target-qualified MIDI candidate selection from #423 sweep report
- Renderer and soundfont readiness metadata
- Planned WAV outputs for local render attempt

## Context
- #423 target-qualified candidates: 3 / 48
- Top candidate: cap 9, sample seed 70, sample 9
- Top pitch span / max interval / large interval ratio: 21 / 9 / 0.0
- Current boundary requires render readiness only; audio quality and human preference remain unclaimed

## Result
- Render status: ready_for_local_render
- Selected renderer: fluidsynth
- Soundfont exists: true
- Planned audio outputs: 3
- Render attempted: false
- Audio rendered quality / human preference / musical quality claim: false

## Validation
- bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-phrase-continuation-range-interval-guard-audio-render-package
- bash scripts/agent_harness.sh quick
- ./.venv/bin/python -m unittest tests.test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package tests.test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep
- ./.venv/bin/python -m py_compile scripts/build_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package.py tests/test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package.py
- git diff --check

## Risk
- WAV files not rendered in this boundary
- Listening quality and human/audio keep claims remain false

Closes #425