### PR TITLE
Stage B generic tiny checkpoint repair phrase continuation range interval guard user listening review input

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #427, Stage B generic tiny checkpoint repair phrase continuation range interval guard local audio render attempt.
+- Latest functional issue completed: Issue #429, Stage B generic tiny checkpoint repair phrase continuation range interval guard user listening review input.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B generic tiny checkpoint repair phrase continuation range interval guard user listening review input.
+- Recommended next issue: Stage B generic tiny checkpoint repair phrase continuation range interval guard rejection analysis.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1042,6 +1042,14 @@ bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-phrase-cont
 ```
 
 This harness renders range/interval guard candidates to local WAV files and validates technical metadata without claiming listening quality.
+
+For Stage B generic tiny checkpoint repair phrase continuation range interval guard user listening review changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-phrase-continuation-range-interval-guard-user-listening-review
+```
+
+This harness records user listening rejection for range/interval guard WAV files without claiming audio quality.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -158,6 +158,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint repair phrase continuation range interval guard sweep 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_SWEEP_2026-05-30.md`
 - generic tiny checkpoint repair phrase continuation range interval guard audio render package 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_AUDIO_RENDER_PACKAGE_2026-05-30.md`
 - generic tiny checkpoint repair phrase continuation range interval guard local audio render attempt 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_LOCAL_AUDIO_RENDER_ATTEMPT_2026-05-30.md`
+- generic tiny checkpoint repair phrase continuation range interval guard user listening review 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_USER_LISTENING_REVIEW_2026-05-30.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -254,6 +255,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint repair phrase continuation range interval guard sweep: target qualified `3/48`, top cap `9`, sample seed `70`, top span/max interval/large ratio `21/9/0.0`, next boundary `range_interval_guard_audio_render_package`
 - generic tiny checkpoint repair phrase continuation range interval guard audio render package: planned outputs `3`, renderer `fluidsynth`, soundfont exists `true`, next boundary `range_interval_guard_local_audio_render_attempt`
 - generic tiny checkpoint repair phrase continuation range interval guard local audio render attempt: rendered WAV files `3`, technical validation `true`, duration range `6.818s-7.194s`, next boundary `range_interval_guard_user_listening_review_input`
+- generic tiny checkpoint repair phrase continuation range interval guard user listening review: overall `reject_all`, candidate `reject`, primary failure `subjective_not_musical`, next boundary `range_interval_guard_rejection_analysis`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -1399,6 +1401,17 @@ Issue #312는 constrained decoding으로 adjacent repeat를 줄였지만 dead-ai
 - audio quality / human preference / musical quality claim: `false`
 - critical user input required: `true`
 - 다음 작업은 user listening review input이다.
+
+현재 generic tiny checkpoint repair phrase continuation range interval guard user listening review:
+
+- Issue #429 result: boundary `generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_review_reject_all`
+- next boundary: `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_rejection_analysis`
+- reviewed audio files: `3`
+- overall decision / candidate decision: `reject_all` / `reject`
+- primary failure: `subjective_not_musical`
+- timing / phrase / vocabulary: `outside_or_unclear` / `not_musical` / `not_musical`
+- human audio keep / musical quality claim: `false` / `false`
+- 다음 작업은 range interval guard rejection analysis다.
 
 ### Phase 5. Brad Style Adaptation
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #427, Stage B generic tiny checkpoint repair phrase continuation range interval guard local audio render attempt
-- 다음 권장 이슈: `Stage B generic tiny checkpoint repair phrase continuation range interval guard user listening review input`
+- latest functional result: Issue #429, Stage B generic tiny checkpoint repair phrase continuation range interval guard user listening review input
+- 다음 권장 이슈: `Stage B generic tiny checkpoint repair phrase continuation range interval guard rejection analysis`
 
 현재 범위가 아닌 것:
 
@@ -870,6 +870,39 @@ Issue #427은 range/interval guard 통과 후보 3개를 local WAV로 렌더링�
 다음:
 
 - `Stage B generic tiny checkpoint repair phrase continuation range interval guard user listening review input`
+
+## Current Generic Tiny Checkpoint Repair Phrase Continuation Range Interval Guard User Listening Review Result
+
+Issue #429는 range/interval guard 통과 후 렌더된 WAV 3개에 대한 사용자 청취 결과를 기록한 작업이다.
+
+변경:
+
+- range/interval guard local audio render report 입력 검증 추가
+- single-user listening review 기록 script 추가
+- `reject_all`, candidate `reject`, timing/phrase/vocabulary failure boundary 기록
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_USER_LISTENING_REVIEW_2026-05-30.md`
+- boundary: `generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_review_reject_all`
+- next boundary: `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_rejection_analysis`
+- reviewed audio files: `3`
+- overall decision / candidate decision: `reject_all` / `reject`
+- primary failure: `subjective_not_musical`
+- timing / phrase / vocabulary: `outside_or_unclear` / `not_musical` / `not_musical`
+- human audio keep / musical quality claim: `false` / `false`
+- critical user input required: `false`
+
+판단:
+
+- range/interval objective guard 통과만으로 청취 수용 불가
+- 다음 분석 대상은 objective guard 통과 후보의 MIDI/phrase 구조와 청취 실패 간 차이
+- broad model quality 및 Brad style adaptation claim은 계속 미검증
+
+다음:
+
+- `Stage B generic tiny checkpoint repair phrase continuation range interval guard rejection analysis`
 
 ## Current Muzig Application Resume Wording Result
 

--- a/docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_USER_LISTENING_REVIEW_2026-05-30.md
+++ b/docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_USER_LISTENING_REVIEW_2026-05-30.md
@@ -1,0 +1,37 @@
+# Stage B Generic Tiny Checkpoint Repair Phrase Continuation Range Interval Guard User Listening Review
+
+## Summary
+
+- boundary: `generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_review_reject_all`
+- review status: `reviewed`
+- overall decision: `reject_all`
+- candidate decision: `reject`
+- primary failure: `subjective_not_musical`
+- timing: `outside_or_unclear`
+- phrase: `not_musical`
+- vocabulary: `not_musical`
+- human/audio keep claimed: `false`
+- musical quality claimed: `false`
+- auto progress allowed: `true`
+
+## Assessment
+
+- all range/interval guard candidates rejected by single-user listening review
+- notes: objective range/interval guard passed, but listening review did not accept any rendered candidate
+
+## Reviewed Files
+
+| rank | cap | seed | sample | duration | wav |
+|---:|---:|---:|---:|---:|---|
+| 1 | 9 | 70 | 9 | 7.169 | outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_local_audio_render_attempt/harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_local_audio_render_attempt/audio/rank_01_cap_9_seed_70_sample_9.wav |
+| 2 | 7 | 66 | 5 | 7.194 | outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_local_audio_render_attempt/harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_local_audio_render_attempt/audio/rank_02_cap_7_seed_66_sample_5.wav |
+| 3 | 9 | 62 | 1 | 6.818 | outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_local_audio_render_attempt/harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_local_audio_render_attempt/audio/rank_03_cap_9_seed_62_sample_1.wav |
+
+## Not Proven
+
+- `human_audio_keep`
+- `multi_reviewer_preference`
+- `audio_rendered_quality`
+- `musical_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -200,6 +200,8 @@ Modes:
                 Package range/interval guard candidates for local audio rendering.
   stage-b-generic-tiny-checkpoint-repair-phrase-continuation-range-interval-guard-local-audio-render-attempt
                 Render range/interval guard candidates to local WAV files.
+  stage-b-generic-tiny-checkpoint-repair-phrase-continuation-range-interval-guard-user-listening-review
+                Record user listening rejection for range/interval guard WAV files.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -2774,6 +2776,50 @@ run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_gu
     --require_no_quality_claim
 }
 
+run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_user_listening_review() {
+  local range_local_audio_run_id="${RANGE_LOCAL_AUDIO_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_local_audio_render_attempt}"
+  local range_audio_package_run_id="${RANGE_AUDIO_PACKAGE_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package}"
+  local range_sweep_run_id="${RANGE_SWEEP_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep}"
+  local range_decision_run_id="${RANGE_DECISION_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_decision}"
+  local failure_review_run_id="${FAILURE_REVIEW_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_midi_note_failure_review}"
+  local local_audio_run_id="${LOCAL_AUDIO_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_local_audio_render_attempt}"
+  local phrase_audio_package_run_id="${PHRASE_AUDIO_PACKAGE_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package}"
+  local sweep_run_id="${SWEEP_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep}"
+  local decision_run_id="${DECISION_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_decision}"
+  local user_review_run_id="${USER_REVIEW_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_user_listening_review}"
+  local audio_render_run_id="${AUDIO_RENDER_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt}"
+  local audio_package_run_id="${AUDIO_PACKAGE_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_audio_render_package}"
+  local listening_fill_run_id="${LISTENING_FILL_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_listening_fill}"
+  local listening_notes_run_id="${LISTENING_NOTES_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_listening_notes}"
+  local training_smoke_run_id="${TRAINING_SMOKE_RUN_ID:-harness_stage_b_generic_base_tiny_training_smoke}"
+  local run_id="${RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_user_listening_review}"
+  local range_audio_render_report="outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_local_audio_render_attempt/${range_local_audio_run_id}/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_local_audio_render_attempt.json"
+  if [[ ! -f "$range_audio_render_report" ]]; then
+    print_header "Stage B generic tiny checkpoint repair phrase continuation range interval guard local audio render attempt"
+    RUN_ID="$range_local_audio_run_id" RANGE_AUDIO_PACKAGE_RUN_ID="$range_audio_package_run_id" RANGE_SWEEP_RUN_ID="$range_sweep_run_id" RANGE_DECISION_RUN_ID="$range_decision_run_id" FAILURE_REVIEW_RUN_ID="$failure_review_run_id" LOCAL_AUDIO_RUN_ID="$local_audio_run_id" PHRASE_AUDIO_PACKAGE_RUN_ID="$phrase_audio_package_run_id" SWEEP_RUN_ID="$sweep_run_id" DECISION_RUN_ID="$decision_run_id" USER_REVIEW_RUN_ID="$user_review_run_id" AUDIO_RENDER_RUN_ID="$audio_render_run_id" AUDIO_PACKAGE_RUN_ID="$audio_package_run_id" LISTENING_FILL_RUN_ID="$listening_fill_run_id" LISTENING_NOTES_RUN_ID="$listening_notes_run_id" TRAINING_SMOKE_RUN_ID="$training_smoke_run_id" run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_local_audio_render_attempt
+  fi
+  print_header "Stage B generic tiny checkpoint repair phrase continuation range interval guard user listening review"
+  "$PYTHON_BIN" scripts/fill_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_user_listening_review.py \
+    --run_id "$run_id" \
+    --audio_render_report "$range_audio_render_report" \
+    --doc_path docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_USER_LISTENING_REVIEW_2026-05-30.md \
+    --reviewer "user" \
+    --overall_decision reject_all \
+    --candidate_decision reject \
+    --primary_failure subjective_not_musical \
+    --timing outside_or_unclear \
+    --phrase not_musical \
+    --vocabulary not_musical \
+    --assessment "all range/interval guard candidates rejected by single-user listening review" \
+    --notes "objective range/interval guard passed, but listening review did not accept any rendered candidate" \
+    --expected_boundary generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_review_reject_all \
+    --expected_overall_decision reject_all \
+    --expected_primary_failure subjective_not_musical \
+    --expected_file_count 3 \
+    --require_no_keep_claim \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -4169,6 +4215,9 @@ case "$MODE" in
     ;;
   stage-b-generic-tiny-checkpoint-repair-phrase-continuation-range-interval-guard-local-audio-render-attempt)
     run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_local_audio_render_attempt
+    ;;
+  stage-b-generic-tiny-checkpoint-repair-phrase-continuation-range-interval-guard-user-listening-review)
+    run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_user_listening_review
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/fill_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_user_listening_review.py
+++ b/scripts/fill_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_user_listening_review.py
@@ -1,0 +1,448 @@
+"""Record user listening review for range/interval guard WAV candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.run_stage_b_generic_tiny_checkpoint_generation_probe import (  # noqa: E402
+    _bool_token,
+    _dict,
+    _int,
+)
+
+
+class StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError(
+    ValueError
+):
+    pass
+
+
+AUDIO_BOUNDARY = (
+    "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_local_audio_render_attempt"
+)
+REVIEW_BOUNDARY_REJECT_ALL = (
+    "generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_review_reject_all"
+)
+NEXT_BOUNDARY = (
+    "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_rejection_analysis"
+)
+OVERALL_DECISIONS = {"keep_any", "reject_all", "unclear"}
+CANDIDATE_DECISIONS = {"keep", "needs_followup", "reject", "unclear"}
+PRIMARY_FAILURES = {"subjective_not_musical", "outside_or_unclear", "unclear"}
+ATTRIBUTE_VALUES = {"acceptable", "outside_or_unclear", "weak", "not_musical", "unclear"}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def validate_audio_render_report(report: dict[str, Any]) -> list[dict[str, Any]]:
+    boundary = _dict(report.get("audio_render_boundary"))
+    if str(boundary.get("boundary") or "") != AUDIO_BOUNDARY:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError(
+            "unexpected range/interval guard audio render boundary"
+        )
+    if not bool(boundary.get("render_attempted", False)):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError(
+            "render attempt required"
+        )
+    if not bool(boundary.get("technical_wav_validation", False)):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError(
+            "technical WAV validation required"
+        )
+    if bool(boundary.get("audio_rendered_quality_claimed", True)):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError(
+            "source report must not claim audio quality"
+        )
+    if bool(boundary.get("human_audio_preference_claimed", True)):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError(
+            "source report must not claim human preference"
+        )
+    if bool(boundary.get("musical_quality_claimed", True)):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError(
+            "source report must not claim musical quality"
+        )
+    rendered = [dict(item) for item in _list(report.get("rendered_audio_files")) if isinstance(item, dict)]
+    if not rendered:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError(
+            "rendered audio files required"
+        )
+    return rendered
+
+
+def compact_rendered_item(item: dict[str, Any]) -> dict[str, Any]:
+    wav_file = _dict(item.get("wav_file"))
+    if not bool(wav_file.get("exists", False)):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError(
+            f"missing WAV for rank {item.get('review_rank')}"
+        )
+    return {
+        "review_rank": _int(item.get("review_rank")),
+        "interval_cap": _int(item.get("interval_cap")),
+        "sample_seed": _int(item.get("sample_seed")),
+        "sample_index": _int(item.get("sample_index")),
+        "source_midi_path": str(item.get("source_midi_path") or ""),
+        "wav_path": str(wav_file.get("path") or ""),
+        "duration_seconds": float(wav_file.get("duration_seconds", 0.0) or 0.0),
+        "sample_rate": int(wav_file.get("sample_rate", 0) or 0),
+        "sha256": str(wav_file.get("sha256") or ""),
+    }
+
+
+def build_candidate_reviews(
+    items: list[dict[str, Any]],
+    *,
+    decision: str,
+    primary_failure: str,
+    assessment: str,
+) -> list[dict[str, Any]]:
+    if decision not in CANDIDATE_DECISIONS:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError(
+            f"invalid candidate decision: {decision}"
+        )
+    if primary_failure not in PRIMARY_FAILURES:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError(
+            f"invalid primary failure: {primary_failure}"
+        )
+    return [
+        {
+            "review_rank": item["review_rank"],
+            "interval_cap": item["interval_cap"],
+            "sample_seed": item["sample_seed"],
+            "sample_index": item["sample_index"],
+            "decision": decision,
+            "primary_failure": primary_failure,
+            "assessment": assessment.strip(),
+        }
+        for item in items
+    ]
+
+
+def build_user_listening_review(
+    audio_render_report: dict[str, Any],
+    *,
+    output_dir: Path,
+    reviewer: str,
+    overall_decision: str,
+    candidate_decision: str,
+    primary_failure: str,
+    timing: str,
+    phrase: str,
+    vocabulary: str,
+    assessment: str,
+    notes: str,
+) -> dict[str, Any]:
+    if not reviewer.strip():
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError(
+            "reviewer is required"
+        )
+    if overall_decision not in OVERALL_DECISIONS:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError(
+            f"invalid overall decision: {overall_decision}"
+        )
+    if candidate_decision not in CANDIDATE_DECISIONS:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError(
+            f"invalid candidate decision: {candidate_decision}"
+        )
+    if primary_failure not in PRIMARY_FAILURES:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError(
+            f"invalid primary failure: {primary_failure}"
+        )
+    for field, value in (("timing", timing), ("phrase", phrase), ("vocabulary", vocabulary)):
+        if value not in ATTRIBUTE_VALUES:
+            raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError(
+                f"invalid {field}: {value}"
+            )
+    rendered = validate_audio_render_report(audio_render_report)
+    items = [compact_rendered_item(item) for item in rendered]
+    keep_claimed = overall_decision == "keep_any"
+    return {
+        "schema_version": (
+            "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_user_listening_review_v1"
+        ),
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_audio_render_schema": str(audio_render_report.get("schema_version") or ""),
+        "reviewed_audio_files": items,
+        "user_listening_review": {
+            "status": "reviewed",
+            "reviewer": reviewer.strip(),
+            "review_basis": "single_user_listening_review_of_range_interval_guard_wav_files",
+            "overall_decision": overall_decision,
+            "candidate_decision": candidate_decision,
+            "primary_failure": primary_failure,
+            "timing": timing,
+            "phrase": phrase,
+            "vocabulary": vocabulary,
+            "assessment": assessment.strip(),
+            "notes": notes.strip(),
+            "candidate_reviews": build_candidate_reviews(
+                items,
+                decision=candidate_decision,
+                primary_failure=primary_failure,
+                assessment=assessment,
+            ),
+        },
+        "claim_boundary": {
+            "single_user_review_completed": True,
+            "human_audio_keep_claimed": keep_claimed,
+            "human_audio_preference_claimed": keep_claimed,
+            "human_audio_reject_all_recorded": overall_decision == "reject_all",
+            "audio_render_used": True,
+            "audio_rendered_quality_claimed": False,
+            "musical_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "boundary": (
+                "generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_review_single_user_keep_support"
+                if keep_claimed
+                else REVIEW_BOUNDARY_REJECT_ALL
+            ),
+        },
+        "decision": {
+            "current_boundary": (
+                "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_user_listening_review_input"
+            ),
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "repair_target": primary_failure,
+        },
+        "proven": [
+            "single_user_audio_review_completed",
+            "range_interval_guard_candidates_rejected",
+        ],
+        "not_proven": [
+            "human_audio_keep",
+            "multi_reviewer_preference",
+            "audio_rendered_quality",
+            "musical_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B generic tiny checkpoint repair phrase continuation range interval guard rejection analysis"
+        ),
+    }
+
+
+def validate_user_listening_review(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_overall_decision: str | None,
+    expected_primary_failure: str | None,
+    expected_file_count: int,
+    require_no_keep_claim: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    review = _dict(report.get("user_listening_review"))
+    claim = _dict(report.get("claim_boundary"))
+    boundary = str(claim.get("boundary") or "")
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    overall = str(review.get("overall_decision") or "")
+    if expected_overall_decision and overall != expected_overall_decision:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError(
+            f"expected overall decision {expected_overall_decision}, got {overall}"
+        )
+    primary_failure = str(review.get("primary_failure") or "")
+    if expected_primary_failure and primary_failure != expected_primary_failure:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError(
+            f"expected primary failure {expected_primary_failure}, got {primary_failure}"
+        )
+    reviewed_file_count = len(_list(report.get("reviewed_audio_files")))
+    if reviewed_file_count != expected_file_count:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError(
+            f"expected reviewed file count {expected_file_count}, got {reviewed_file_count}"
+        )
+    if require_no_keep_claim and bool(claim.get("human_audio_keep_claimed", True)):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError(
+            "human/audio keep must not be claimed"
+        )
+    if require_no_quality_claim:
+        claimed = [
+            bool(claim.get("audio_rendered_quality_claimed", True)),
+            bool(claim.get("musical_quality_claimed", True)),
+            bool(claim.get("broad_trained_model_quality_claimed", True)),
+            bool(claim.get("brad_style_adaptation_claimed", True)),
+        ]
+        if any(claimed):
+            raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError(
+                "quality claims must not be set"
+            )
+    decision = _dict(report.get("decision"))
+    return {
+        "boundary": boundary,
+        "review_status": str(review.get("status") or ""),
+        "overall_decision": overall,
+        "candidate_decision": str(review.get("candidate_decision") or ""),
+        "primary_failure": primary_failure,
+        "timing": str(review.get("timing") or ""),
+        "phrase": str(review.get("phrase") or ""),
+        "vocabulary": str(review.get("vocabulary") or ""),
+        "reviewed_audio_file_count": reviewed_file_count,
+        "human_audio_keep_claimed": bool(claim.get("human_audio_keep_claimed", True)),
+        "human_audio_reject_all_recorded": bool(claim.get("human_audio_reject_all_recorded", False)),
+        "audio_rendered_quality_claimed": bool(claim.get("audio_rendered_quality_claimed", True)),
+        "musical_quality_claimed": bool(claim.get("musical_quality_claimed", True)),
+        "auto_progress_allowed": bool(decision.get("auto_progress_allowed", False)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    review = report["user_listening_review"]
+    claim = report["claim_boundary"]
+    decision = report["decision"]
+    lines = [
+        "# Stage B Generic Tiny Checkpoint Repair Phrase Continuation Range Interval Guard User Listening Review",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{claim['boundary']}`",
+        f"- review status: `{review['status']}`",
+        f"- overall decision: `{review['overall_decision']}`",
+        f"- candidate decision: `{review['candidate_decision']}`",
+        f"- primary failure: `{review['primary_failure']}`",
+        f"- timing: `{review['timing']}`",
+        f"- phrase: `{review['phrase']}`",
+        f"- vocabulary: `{review['vocabulary']}`",
+        f"- human/audio keep claimed: `{_bool_token(claim['human_audio_keep_claimed'])}`",
+        f"- musical quality claimed: `{_bool_token(claim['musical_quality_claimed'])}`",
+        f"- auto progress allowed: `{_bool_token(decision['auto_progress_allowed'])}`",
+        "",
+        "## Assessment",
+        "",
+        f"- {review['assessment']}",
+        f"- notes: {review['notes']}",
+        "",
+        "## Reviewed Files",
+        "",
+        "| rank | cap | seed | sample | duration | wav |",
+        "|---:|---:|---:|---:|---:|---|",
+    ]
+    for item in report.get("reviewed_audio_files", []):
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(item.get("review_rank", "")),
+                    str(item.get("interval_cap", "")),
+                    str(item.get("sample_seed", "")),
+                    str(item.get("sample_index", "")),
+                    f"{float(item.get('duration_seconds', 0.0) or 0.0):.3f}",
+                    str(item.get("wav_path", "")),
+                ]
+            )
+            + " |"
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Fill range/interval guard user listening review"
+    )
+    parser.add_argument(
+        "--audio_render_report",
+        type=str,
+        default="outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_local_audio_render_attempt/"
+        "harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_local_audio_render_attempt/"
+        "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_local_audio_render_attempt.json",
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=(
+            "outputs/"
+            "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_user_listening_review"
+        ),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--reviewer", type=str, required=True)
+    parser.add_argument("--overall_decision", type=str, required=True)
+    parser.add_argument("--candidate_decision", type=str, required=True)
+    parser.add_argument("--primary_failure", type=str, required=True)
+    parser.add_argument("--timing", type=str, required=True)
+    parser.add_argument("--phrase", type=str, required=True)
+    parser.add_argument("--vocabulary", type=str, required=True)
+    parser.add_argument("--assessment", type=str, required=True)
+    parser.add_argument("--notes", type=str, default="")
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_overall_decision", type=str, default="")
+    parser.add_argument("--expected_primary_failure", type=str, default="")
+    parser.add_argument("--expected_file_count", type=int, default=3)
+    parser.add_argument("--require_no_keep_claim", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_user_listening_review(
+        read_json(Path(args.audio_render_report)),
+        output_dir=output_dir,
+        reviewer=str(args.reviewer),
+        overall_decision=str(args.overall_decision),
+        candidate_decision=str(args.candidate_decision),
+        primary_failure=str(args.primary_failure),
+        timing=str(args.timing),
+        phrase=str(args.phrase),
+        vocabulary=str(args.vocabulary),
+        assessment=str(args.assessment),
+        notes=str(args.notes),
+    )
+    summary = validate_user_listening_review(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_overall_decision=str(args.expected_overall_decision or ""),
+        expected_primary_failure=str(args.expected_primary_failure or ""),
+        expected_file_count=int(args.expected_file_count),
+        require_no_keep_claim=bool(args.require_no_keep_claim),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir
+        / "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_user_listening_review.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_user_listening_review_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir
+        / "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_user_listening_review.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_user_listening_review.py
+++ b/tests/test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_user_listening_review.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.fill_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_user_listening_review import (
+    AUDIO_BOUNDARY,
+    NEXT_BOUNDARY,
+    REVIEW_BOUNDARY_REJECT_ALL,
+    StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError,
+    build_user_listening_review,
+    validate_user_listening_review,
+)
+
+
+def rendered_item(rank: int) -> dict:
+    return {
+        "review_rank": rank,
+        "interval_cap": 9,
+        "sample_seed": 70 + rank,
+        "sample_index": rank,
+        "source_midi_path": f"sample_{rank}.mid",
+        "wav_file": {
+            "path": f"sample_{rank}.wav",
+            "exists": True,
+            "duration_seconds": 6.8 + rank / 10,
+            "sample_rate": 44100,
+            "sha256": str(rank) * 64,
+        },
+    }
+
+
+def audio_render_report(*, quality_claimed: bool = False) -> dict:
+    return {
+        "schema_version": (
+            "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_local_audio_render_attempt_v1"
+        ),
+        "audio_render_boundary": {
+            "boundary": AUDIO_BOUNDARY,
+            "render_attempted": True,
+            "rendered_audio_file_count": 3,
+            "technical_wav_validation": True,
+            "audio_rendered_quality_claimed": quality_claimed,
+            "human_audio_preference_claimed": False,
+            "musical_quality_claimed": False,
+        },
+        "rendered_audio_files": [
+            rendered_item(1),
+            rendered_item(2),
+            rendered_item(3),
+        ],
+    }
+
+
+class StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewTest(
+    unittest.TestCase
+):
+    def test_records_reject_all_without_keep_or_quality_claim(self) -> None:
+        report = build_user_listening_review(
+            audio_render_report(),
+            output_dir=Path("outputs/review"),
+            reviewer="user",
+            overall_decision="reject_all",
+            candidate_decision="reject",
+            primary_failure="subjective_not_musical",
+            timing="outside_or_unclear",
+            phrase="not_musical",
+            vocabulary="not_musical",
+            assessment="all rendered candidates rejected by single-user listening review",
+            notes="range/interval objective guard was insufficient for listening acceptance",
+        )
+        summary = validate_user_listening_review(
+            report,
+            expected_boundary=REVIEW_BOUNDARY_REJECT_ALL,
+            expected_overall_decision="reject_all",
+            expected_primary_failure="subjective_not_musical",
+            expected_file_count=3,
+            require_no_keep_claim=True,
+            require_no_quality_claim=True,
+        )
+
+        self.assertEqual(summary["reviewed_audio_file_count"], 3)
+        self.assertEqual(summary["candidate_decision"], "reject")
+        self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
+        self.assertFalse(summary["human_audio_keep_claimed"])
+        self.assertFalse(summary["musical_quality_claimed"])
+        self.assertTrue(summary["auto_progress_allowed"])
+
+    def test_rejects_source_quality_claim(self) -> None:
+        with self.assertRaises(
+            StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError
+        ):
+            build_user_listening_review(
+                audio_render_report(quality_claimed=True),
+                output_dir=Path("outputs/review"),
+                reviewer="user",
+                overall_decision="reject_all",
+                candidate_decision="reject",
+                primary_failure="subjective_not_musical",
+                timing="outside_or_unclear",
+                phrase="not_musical",
+                vocabulary="not_musical",
+                assessment="all candidates rejected",
+                notes="",
+            )
+
+    def test_rejects_invalid_primary_failure(self) -> None:
+        with self.assertRaises(
+            StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardUserListeningReviewError
+        ):
+            build_user_listening_review(
+                audio_render_report(),
+                output_dir=Path("outputs/review"),
+                reviewer="user",
+                overall_decision="reject_all",
+                candidate_decision="reject",
+                primary_failure="unsupported_failure",
+                timing="outside_or_unclear",
+                phrase="not_musical",
+                vocabulary="not_musical",
+                assessment="all candidates rejected",
+                notes="",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Single-user listening review for range/interval guard WAV candidates
- Reject-all decision for all three rendered candidates
- Claim boundary update without audio quality or keep claim
- Next boundary: post-guard rejection analysis

## Context
- #427 rendered WAV files: 3
- Technical WAV validation: true
- User listening feedback: all rendered candidates rejected
- Objective range/interval guard passed before audio review, but listening acceptance failed

## Result
- Boundary: generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_review_reject_all
- Reviewed audio files: 3
- Overall decision / candidate decision: reject_all / reject
- Primary failure: subjective_not_musical
- Timing / phrase / vocabulary: outside_or_unclear / not_musical / not_musical
- Human audio keep / musical quality claim: false / false

## Validation
- bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-phrase-continuation-range-interval-guard-user-listening-review
- bash scripts/agent_harness.sh quick
- ./.venv/bin/python -m unittest tests.test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_user_listening_review tests.test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_local_audio_render_attempt
- ./.venv/bin/python -m py_compile scripts/fill_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_user_listening_review.py tests/test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_user_listening_review.py
- git diff --check

## Risk
- Failure reason is subjective listening failure, not a proven single objective cause
- Next work requires MIDI/phrase evidence analysis before selecting another repair target

Closes #429