### PR TITLE
Stage B sparse phrase model-core review decision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #443, Stage B generic tiny checkpoint repair phrase continuation range interval guard sparse phrase rejection analysis.
+- Latest functional issue completed: Issue #445, Stage B generic tiny checkpoint repair phrase continuation range interval guard sparse phrase model core review decision.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B generic tiny checkpoint repair phrase continuation range interval guard sparse phrase model core review decision.
+- Recommended next issue: Stage B generic model-core training data plan.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1106,6 +1106,14 @@ bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-phrase-cont
 ```
 
 This harness analyzes rejected sparse phrase MIDI candidates and records whether objective proxy evidence is insufficient before routing to model-core review.
+
+For Stage B generic tiny checkpoint repair phrase continuation range interval guard sparse phrase model core review changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-phrase-continuation-range-interval-guard-sparse-phrase-model-core-review
+```
+
+This harness records the stop decision for the constraint/postprocess repair loop and routes the next work to model-core training/data planning.
 
 If a harness mode is too slow or fails for an environment reason, record the reason clearly in the final answer.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -165,6 +165,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint repair phrase continuation range interval guard sparse phrase local audio render attempt 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_SPARSE_PHRASE_LOCAL_AUDIO_RENDER_ATTEMPT_2026-05-30.md`
 - generic tiny checkpoint repair phrase continuation range interval guard sparse phrase user listening review 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_SPARSE_PHRASE_USER_LISTENING_REVIEW_2026-06-01.md`
 - generic tiny checkpoint repair phrase continuation range interval guard sparse phrase rejection analysis 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_SPARSE_PHRASE_REJECTION_ANALYSIS_2026-06-01.md`
+- generic tiny checkpoint repair phrase continuation range interval guard sparse phrase model core review decision 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_SPARSE_PHRASE_MODEL_CORE_REVIEW_DECISION_2026-06-01.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -268,6 +269,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint repair phrase continuation range interval guard sparse phrase local audio render attempt: rendered WAV files `3`, technical validation `true`, duration range `6.792s-7.094s`, next boundary `sparse_phrase_user_listening_review_input`
 - generic tiny checkpoint repair phrase continuation range interval guard sparse phrase user listening review: overall `reject_all`, candidate `reject`, primary failure `subjective_not_musical`, keep claim `false`, next boundary `sparse_phrase_rejection_analysis`
 - generic tiny checkpoint repair phrase continuation range interval guard sparse phrase rejection analysis: candidates without objective flags `1/3`, objective proxy gap `true`, next boundary `sparse_phrase_model_core_review_decision`
+- generic tiny checkpoint repair phrase continuation range interval guard sparse phrase model core review decision: continue repair loop `false`, tiny checkpoint `diagnostic_only`, next boundary `generic_model_core_training_data_plan`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -1513,6 +1515,18 @@ Issue #312는 constrained decoding으로 adjacent repeat를 줄였지만 dead-ai
 - musical quality / quality cause claim: `false` / `false`
 - 판단: 추가 후처리 규칙 반복보다 model core, dataset, training boundary 검토 필요
 - 다음 작업은 sparse phrase model core review decision이다.
+
+현재 generic tiny checkpoint repair phrase continuation range interval guard sparse phrase model core review decision:
+
+- Issue #445 result: boundary `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_model_core_review_decision`
+- decision: `stop_constraint_postprocess_repair_loop`
+- continue constraint/postprocess repair loop: `false`
+- tiny checkpoint role: `diagnostic_only`
+- model core transition required: `true`
+- objective proxy gap recorded: `true`
+- candidate without objective flags: `1`
+- musical quality / broad trained model quality claim: `false` / `false`
+- 다음 작업은 generic model-core training data plan이다.
 
 ### Phase 5. Brad Style Adaptation
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #443, Stage B generic tiny checkpoint repair phrase continuation range interval guard sparse phrase rejection analysis
-- 다음 권장 이슈: `Stage B generic tiny checkpoint repair phrase continuation range interval guard sparse phrase model core review decision`
+- latest functional result: Issue #445, Stage B generic tiny checkpoint repair phrase continuation range interval guard sparse phrase model core review decision
+- 다음 권장 이슈: `Stage B generic model-core training data plan`
 
 현재 범위가 아닌 것:
 
@@ -1148,6 +1148,42 @@ Issue #443은 Issue #441 reject_all 결과를 MIDI evidence 기준으로 재분�
 다음:
 
 - `Stage B generic tiny checkpoint repair phrase continuation range interval guard sparse phrase model core review decision`
+
+## Stage B Generic Tiny Checkpoint Repair Phrase Continuation Range Interval Guard Sparse Phrase Model Core Review Decision
+
+Issue #445는 Issue #443 objective proxy gap 결과를 기준으로 constraint/postprocess repair loop 중단 여부를 결정한 작업이다.
+
+변경:
+
+- sparse phrase rejection analysis report 입력 검증 추가
+- objective proxy gap, reject_all, no-quality-claim boundary 확인
+- `continue_constraint_postprocess_repair_loop=false` 결정 기록
+- tiny checkpoint 역할을 `diagnostic_only`로 지정
+- 다음 경계를 generic model-core training data plan으로 지정
+
+결과:
+
+- document: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_SPARSE_PHRASE_MODEL_CORE_REVIEW_DECISION_2026-06-01.md`
+- boundary: `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_model_core_review_decision`
+- decision: `stop_constraint_postprocess_repair_loop`
+- continue constraint/postprocess repair loop: `false`
+- tiny checkpoint role: `diagnostic_only`
+- model core transition required: `true`
+- objective proxy gap recorded: `true`
+- candidate without objective flags: `1`
+- musical quality claimed: `false`
+- broad trained model quality claimed: `false`
+- next boundary: `stage_b_generic_model_core_training_data_plan`
+
+판단:
+
+- 현재 방법론은 validation/failure isolation 용도로는 유효
+- 음악 품질 개선 루프로는 중단 필요
+- 다음 작업은 모델 코어 데이터/학습 계획 수립
+
+다음:
+
+- `Stage B generic model-core training data plan`
 
 ## Current Muzig Application Resume Wording Result
 

--- a/docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_SPARSE_PHRASE_MODEL_CORE_REVIEW_DECISION_2026-06-01.md
+++ b/docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_SPARSE_PHRASE_MODEL_CORE_REVIEW_DECISION_2026-06-01.md
@@ -1,0 +1,28 @@
+# Stage B Generic Tiny Checkpoint Repair Phrase Continuation Range Interval Guard Sparse Phrase Model Core Review Decision
+
+## Summary
+
+- boundary: `stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_model_core_review_decision`
+- decision: `stop_constraint_postprocess_repair_loop`
+- continue constraint/postprocess repair loop: `false`
+- tiny checkpoint role: `diagnostic_only`
+- model core transition required: `true`
+- objective proxy gap recorded: `true`
+- candidate without objective flags: `1`
+- musical quality claimed: `false`
+- broad trained model quality claimed: `false`
+- next boundary: `stage_b_generic_model_core_training_data_plan`
+
+## Evidence
+
+- single-user reject_all candidate count: `3`
+- common objective evidence flags: ``
+- candidates without objective flags: `1`
+
+## Not Proven
+
+- `musical_quality`
+- `quality_root_cause`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`
+- `production_ready_improviser`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -206,6 +206,8 @@ Modes:
                 Record user listening rejection for sparse phrase repair WAV files.
   stage-b-generic-tiny-checkpoint-repair-phrase-continuation-range-interval-guard-sparse-phrase-rejection-analysis
                 Analyze sparse phrase rejection evidence and record objective proxy gap.
+  stage-b-generic-tiny-checkpoint-repair-phrase-continuation-range-interval-guard-sparse-phrase-model-core-review
+                Decide model-core transition after sparse phrase objective proxy gap.
   stage-b-constrained-probe
                 Run a constrained Stage B note-group smoke.
   stage-b-overlap-gate
@@ -3107,6 +3109,48 @@ run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_gu
     --require_proxy_gap
 }
 
+run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_model_core_review() {
+  local sparse_rejection_run_id="${SPARSE_REJECTION_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_rejection_analysis}"
+  local sparse_user_review_run_id="${SPARSE_USER_REVIEW_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_user_listening_review}"
+  local sparse_local_audio_run_id="${SPARSE_LOCAL_AUDIO_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_local_audio_render_attempt}"
+  local sparse_audio_package_run_id="${SPARSE_AUDIO_PACKAGE_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_audio_render_package}"
+  local sparse_sweep_run_id="${SPARSE_SWEEP_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_repair_sweep}"
+  local sparse_decision_run_id="${SPARSE_DECISION_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_repair_decision}"
+  local rejection_analysis_run_id="${REJECTION_ANALYSIS_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_rejection_analysis}"
+  local range_user_review_run_id="${RANGE_USER_REVIEW_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_user_listening_review}"
+  local range_local_audio_run_id="${RANGE_LOCAL_AUDIO_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_local_audio_render_attempt}"
+  local range_audio_package_run_id="${RANGE_AUDIO_PACKAGE_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_audio_render_package}"
+  local range_sweep_run_id="${RANGE_SWEEP_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sweep}"
+  local range_decision_run_id="${RANGE_DECISION_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_decision}"
+  local failure_review_run_id="${FAILURE_REVIEW_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_midi_note_failure_review}"
+  local local_audio_run_id="${LOCAL_AUDIO_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_local_audio_render_attempt}"
+  local phrase_audio_package_run_id="${PHRASE_AUDIO_PACKAGE_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_audio_render_package}"
+  local sweep_run_id="${SWEEP_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_sweep}"
+  local decision_run_id="${DECISION_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_decision}"
+  local user_review_run_id="${USER_REVIEW_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_user_listening_review}"
+  local audio_render_run_id="${AUDIO_RENDER_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_local_audio_render_attempt}"
+  local audio_package_run_id="${AUDIO_PACKAGE_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_audio_render_package}"
+  local listening_fill_run_id="${LISTENING_FILL_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_listening_fill}"
+  local listening_notes_run_id="${LISTENING_NOTES_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_listening_notes}"
+  local training_smoke_run_id="${TRAINING_SMOKE_RUN_ID:-harness_stage_b_generic_base_tiny_training_smoke}"
+  local run_id="${RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_model_core_review_decision}"
+  local sparse_rejection_analysis="outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_rejection_analysis/${sparse_rejection_run_id}/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_rejection_analysis.json"
+  if [[ ! -f "$sparse_rejection_analysis" ]]; then
+    print_header "Stage B generic tiny checkpoint repair phrase continuation range interval guard sparse phrase rejection analysis"
+    RUN_ID="$sparse_rejection_run_id" SPARSE_USER_REVIEW_RUN_ID="$sparse_user_review_run_id" SPARSE_LOCAL_AUDIO_RUN_ID="$sparse_local_audio_run_id" SPARSE_AUDIO_PACKAGE_RUN_ID="$sparse_audio_package_run_id" SPARSE_SWEEP_RUN_ID="$sparse_sweep_run_id" SPARSE_DECISION_RUN_ID="$sparse_decision_run_id" REJECTION_ANALYSIS_RUN_ID="$rejection_analysis_run_id" RANGE_USER_REVIEW_RUN_ID="$range_user_review_run_id" RANGE_LOCAL_AUDIO_RUN_ID="$range_local_audio_run_id" RANGE_AUDIO_PACKAGE_RUN_ID="$range_audio_package_run_id" RANGE_SWEEP_RUN_ID="$range_sweep_run_id" RANGE_DECISION_RUN_ID="$range_decision_run_id" FAILURE_REVIEW_RUN_ID="$failure_review_run_id" LOCAL_AUDIO_RUN_ID="$local_audio_run_id" PHRASE_AUDIO_PACKAGE_RUN_ID="$phrase_audio_package_run_id" SWEEP_RUN_ID="$sweep_run_id" DECISION_RUN_ID="$decision_run_id" USER_REVIEW_RUN_ID="$user_review_run_id" AUDIO_RENDER_RUN_ID="$audio_render_run_id" AUDIO_PACKAGE_RUN_ID="$audio_package_run_id" LISTENING_FILL_RUN_ID="$listening_fill_run_id" LISTENING_NOTES_RUN_ID="$listening_notes_run_id" TRAINING_SMOKE_RUN_ID="$training_smoke_run_id" run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_rejection_analysis
+  fi
+  print_header "Stage B generic tiny checkpoint repair phrase continuation range interval guard sparse phrase model core review"
+  "$PYTHON_BIN" scripts/decide_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_model_core_review.py \
+    --run_id "$run_id" \
+    --sparse_rejection_analysis "$sparse_rejection_analysis" \
+    --doc_path docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_SPARSE_PHRASE_MODEL_CORE_REVIEW_DECISION_2026-06-01.md \
+    --expected_boundary stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_model_core_review_decision \
+    --expected_next_boundary stage_b_generic_model_core_training_data_plan \
+    --require_stop_repair_loop \
+    --require_diagnostic_only \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -4526,6 +4570,9 @@ case "$MODE" in
     ;;
   stage-b-generic-tiny-checkpoint-repair-phrase-continuation-range-interval-guard-sparse-phrase-rejection-analysis)
     run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_rejection_analysis
+    ;;
+  stage-b-generic-tiny-checkpoint-repair-phrase-continuation-range-interval-guard-sparse-phrase-model-core-review)
+    run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_model_core_review
     ;;
   stage-b-constrained-probe)
     run_stage_b_constrained_probe

--- a/scripts/decide_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_model_core_review.py
+++ b/scripts/decide_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_model_core_review.py
@@ -1,0 +1,346 @@
+"""Decide model-core transition after sparse phrase repair rejection analysis."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSparsePhraseModelCoreReviewError(
+    ValueError
+):
+    pass
+
+
+SOURCE_BOUNDARY = (
+    "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_"
+    "sparse_phrase_rejection_analysis"
+)
+BOUNDARY = (
+    "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_"
+    "sparse_phrase_model_core_review_decision"
+)
+NEXT_BOUNDARY = "stage_b_generic_model_core_training_data_plan"
+EXPECTED_TARGET = "model_core_review_after_objective_proxy_gap"
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def validate_sparse_rejection_analysis(report: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any], list[Any]]:
+    boundary = _dict(report.get("analysis_boundary"))
+    rejection = _dict(report.get("rejection_analysis"))
+    proxy_gap = _dict(rejection.get("objective_proxy_gap"))
+    candidates = _list(report.get("candidates"))
+    decision = _dict(report.get("decision"))
+
+    if str(boundary.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSparsePhraseModelCoreReviewError(
+            "sparse phrase rejection analysis boundary required"
+        )
+    if not bool(boundary.get("input_reject_all_verified", False)):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSparsePhraseModelCoreReviewError(
+            "reject_all source verification required"
+        )
+    if not bool(boundary.get("objective_proxy_gap_recorded", False)):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSparsePhraseModelCoreReviewError(
+            "objective proxy gap must be recorded"
+        )
+    if not bool(proxy_gap.get("recorded", False)):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSparsePhraseModelCoreReviewError(
+            "objective proxy gap detail must be recorded"
+        )
+    if not _list(rejection.get("candidates_without_evidence_flags")):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSparsePhraseModelCoreReviewError(
+            "at least one candidate without objective evidence flags required"
+        )
+    if str(rejection.get("primary_next_review_target") or "") != EXPECTED_TARGET:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSparsePhraseModelCoreReviewError(
+            "model-core review target required"
+        )
+    if str(decision.get("next_boundary") or "") != BOUNDARY:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSparsePhraseModelCoreReviewError(
+            "source report must route to model-core review decision"
+        )
+    if bool(boundary.get("musical_quality_claimed", True)) or bool(boundary.get("quality_cause_claimed", True)):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSparsePhraseModelCoreReviewError(
+            "source report must not claim musical quality or quality cause"
+        )
+    if len(candidates) < 1:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSparsePhraseModelCoreReviewError(
+            "candidate evidence required"
+        )
+    return boundary, rejection, candidates
+
+
+def build_model_core_review_decision(
+    sparse_rejection_analysis: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> dict[str, Any]:
+    boundary, rejection, candidates = validate_sparse_rejection_analysis(sparse_rejection_analysis)
+    without_flags = [int(rank) for rank in _list(rejection.get("candidates_without_evidence_flags"))]
+    common_flags = [str(flag) for flag in _list(rejection.get("common_evidence_flags"))]
+    return {
+        "schema_version": (
+            "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_"
+            "sparse_phrase_model_core_review_decision_v1"
+        ),
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_schema": str(sparse_rejection_analysis.get("schema_version") or ""),
+        "input_boundary": SOURCE_BOUNDARY,
+        "methodology_evidence": {
+            "single_user_reject_all_candidate_count": int(boundary.get("analyzed_candidate_count", len(candidates)) or 0),
+            "common_objective_evidence_flags": common_flags,
+            "candidate_without_objective_flag_count": len(without_flags),
+            "candidates_without_objective_flags": without_flags,
+            "objective_proxy_gap_recorded": True,
+            "objective_proxy_gap_interpretation": (
+                "objective_midi_proxy_not_sufficient_for_listening_acceptance"
+            ),
+            "constraint_repairs_already_checked": [
+                "grammar_repair",
+                "phrase_continuation",
+                "range_interval_guard",
+                "sparse_phrase_objective_gate",
+            ],
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "decision": "stop_constraint_postprocess_repair_loop",
+            "continue_constraint_postprocess_repair_loop": False,
+            "tiny_checkpoint_role": "diagnostic_only",
+            "model_core_transition_required": True,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": (
+                "single-user listening rejected all sparse phrase candidates, and objective MIDI flags do not "
+                "consistently explain the rejection; further rule repairs should not be treated as model-quality progress"
+            ),
+        },
+        "claim_boundary": {
+            "boundary": BOUNDARY,
+            "constraint_repair_loop_stop_claimed": True,
+            "tiny_checkpoint_diagnostic_only_claimed": True,
+            "musical_quality_claimed": False,
+            "quality_root_cause_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_improviser_claimed": False,
+        },
+        "proven": [
+            "single_user_reject_all_consumed",
+            "objective_proxy_gap_recorded",
+            "constraint_postprocess_repair_loop_not_selected_for_next_step",
+            "tiny_checkpoint_marked_diagnostic_only",
+        ],
+        "not_proven": [
+            "musical_quality",
+            "quality_root_cause",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "production_ready_improviser",
+        ],
+        "next_recommended_issue": "Stage B generic model-core training data plan",
+    }
+
+
+def validate_model_core_review_decision(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_stop_repair_loop: bool,
+    require_diagnostic_only: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    decision = _dict(report.get("decision"))
+    claim = _dict(report.get("claim_boundary"))
+    evidence = _dict(report.get("methodology_evidence"))
+    boundary = str(decision.get("current_boundary") or "")
+    next_boundary = str(decision.get("next_boundary") or "")
+
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSparsePhraseModelCoreReviewError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and next_boundary != expected_next_boundary:
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSparsePhraseModelCoreReviewError(
+            f"expected next boundary {expected_next_boundary}, got {next_boundary}"
+        )
+    if require_stop_repair_loop and bool(decision.get("continue_constraint_postprocess_repair_loop", True)):
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSparsePhraseModelCoreReviewError(
+            "constraint/postprocess repair loop must stop"
+        )
+    if require_diagnostic_only and str(decision.get("tiny_checkpoint_role") or "") != "diagnostic_only":
+        raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSparsePhraseModelCoreReviewError(
+            "tiny checkpoint must be diagnostic-only"
+        )
+    if require_no_quality_claim:
+        claimed = [
+            bool(claim.get("musical_quality_claimed", True)),
+            bool(claim.get("quality_root_cause_claimed", True)),
+            bool(claim.get("broad_trained_model_quality_claimed", True)),
+            bool(claim.get("brad_style_adaptation_claimed", True)),
+            bool(claim.get("production_ready_improviser_claimed", True)),
+        ]
+        if any(claimed):
+            raise StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSparsePhraseModelCoreReviewError(
+                "quality claims must not be set"
+            )
+    return {
+        "boundary": boundary,
+        "input_boundary": str(report.get("input_boundary") or ""),
+        "decision": str(decision.get("decision") or ""),
+        "continue_constraint_postprocess_repair_loop": bool(
+            decision.get("continue_constraint_postprocess_repair_loop", True)
+        ),
+        "tiny_checkpoint_role": str(decision.get("tiny_checkpoint_role") or ""),
+        "model_core_transition_required": bool(decision.get("model_core_transition_required", False)),
+        "objective_proxy_gap_recorded": bool(evidence.get("objective_proxy_gap_recorded", False)),
+        "candidate_without_objective_flag_count": int(
+            evidence.get("candidate_without_objective_flag_count", 0) or 0
+        ),
+        "musical_quality_claimed": bool(claim.get("musical_quality_claimed", True)),
+        "broad_trained_model_quality_claimed": bool(claim.get("broad_trained_model_quality_claimed", True)),
+        "auto_progress_allowed": bool(decision.get("auto_progress_allowed", False)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_boundary": next_boundary,
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    evidence = report["methodology_evidence"]
+    decision = report["decision"]
+    claim = report["claim_boundary"]
+    lines = [
+        "# Stage B Generic Tiny Checkpoint Repair Phrase Continuation Range Interval Guard Sparse Phrase Model Core Review Decision",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{decision['current_boundary']}`",
+        f"- decision: `{decision['decision']}`",
+        f"- continue constraint/postprocess repair loop: `{_bool_token(decision['continue_constraint_postprocess_repair_loop'])}`",
+        f"- tiny checkpoint role: `{decision['tiny_checkpoint_role']}`",
+        f"- model core transition required: `{_bool_token(decision['model_core_transition_required'])}`",
+        f"- objective proxy gap recorded: `{_bool_token(evidence['objective_proxy_gap_recorded'])}`",
+        f"- candidate without objective flags: `{evidence['candidate_without_objective_flag_count']}`",
+        f"- musical quality claimed: `{_bool_token(claim['musical_quality_claimed'])}`",
+        f"- broad trained model quality claimed: `{_bool_token(claim['broad_trained_model_quality_claimed'])}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        "",
+        "## Evidence",
+        "",
+        f"- single-user reject_all candidate count: `{evidence['single_user_reject_all_candidate_count']}`",
+        f"- common objective evidence flags: `{', '.join(evidence['common_objective_evidence_flags'])}`",
+        f"- candidates without objective flags: `{', '.join(str(rank) for rank in evidence['candidates_without_objective_flags'])}`",
+        "",
+        "## Not Proven",
+        "",
+    ]
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Decide model-core transition after sparse phrase rejection analysis")
+    parser.add_argument(
+        "--sparse_rejection_analysis",
+        type=str,
+        default="outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_"
+        "sparse_phrase_rejection_analysis/"
+        "harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_"
+        "sparse_phrase_rejection_analysis/"
+        "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_"
+        "sparse_phrase_rejection_analysis.json",
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=(
+            "outputs/"
+            "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_"
+            "sparse_phrase_model_core_review_decision"
+        ),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--expected_boundary", type=str, default=BOUNDARY)
+    parser.add_argument("--expected_next_boundary", type=str, default=NEXT_BOUNDARY)
+    parser.add_argument("--require_stop_repair_loop", action="store_true")
+    parser.add_argument("--require_diagnostic_only", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_model_core_review_decision(
+        read_json(Path(args.sparse_rejection_analysis)),
+        output_dir=output_dir,
+    )
+    summary = validate_model_core_review_decision(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_stop_repair_loop=bool(args.require_stop_repair_loop),
+        require_diagnostic_only=bool(args.require_diagnostic_only),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir
+        / "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_model_core_review_decision.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_model_core_review_decision_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir
+        / "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_model_core_review_decision.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_model_core_review.py
+++ b/tests/test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_model_core_review.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.decide_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_model_core_review import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    SOURCE_BOUNDARY,
+    StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSparsePhraseModelCoreReviewError,
+    build_model_core_review_decision,
+    validate_model_core_review_decision,
+)
+
+
+def sparse_rejection_analysis(*, quality_claimed: bool = False, proxy_gap: bool = True) -> dict:
+    return {
+        "schema_version": (
+            "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_"
+            "sparse_phrase_rejection_analysis_v1"
+        ),
+        "analysis_boundary": {
+            "boundary": SOURCE_BOUNDARY,
+            "input_reject_all_verified": True,
+            "analyzed_candidate_count": 3,
+            "human_audio_keep_claimed": False,
+            "human_audio_preference_claimed": False,
+            "musical_quality_claimed": quality_claimed,
+            "quality_cause_claimed": False,
+            "objective_proxy_gap_recorded": proxy_gap,
+        },
+        "rejection_analysis": {
+            "candidate_count": 3,
+            "evidence_flag_counts": {
+                "compressed_pitch_vocabulary": 2,
+                "repetitive_duration_profile": 2,
+            },
+            "common_evidence_flags": [],
+            "candidates_without_evidence_flags": [1] if proxy_gap else [],
+            "objective_proxy_gap": {
+                "recorded": proxy_gap,
+                "all_candidates_rejected_by_listening_review": True,
+                "candidate_without_flag_count": 1 if proxy_gap else 0,
+                "interpretation": "objective_midi_proxy_not_sufficient_for_listening_acceptance",
+            },
+            "primary_next_review_target": "model_core_review_after_objective_proxy_gap",
+            "cause_claim": "not_claimed",
+        },
+        "candidates": [{"review_rank": 1}, {"review_rank": 2}, {"review_rank": 3}],
+        "decision": {
+            "next_boundary": BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSparsePhraseModelCoreReviewTest(
+    unittest.TestCase
+):
+    def test_stops_repair_loop_and_routes_to_model_core_plan(self) -> None:
+        report = build_model_core_review_decision(
+            sparse_rejection_analysis(),
+            output_dir=Path("outputs/model_core_review"),
+        )
+        summary = validate_model_core_review_decision(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=NEXT_BOUNDARY,
+            require_stop_repair_loop=True,
+            require_diagnostic_only=True,
+            require_no_quality_claim=True,
+        )
+
+        self.assertEqual(summary["decision"], "stop_constraint_postprocess_repair_loop")
+        self.assertFalse(summary["continue_constraint_postprocess_repair_loop"])
+        self.assertEqual(summary["tiny_checkpoint_role"], "diagnostic_only")
+        self.assertTrue(summary["model_core_transition_required"])
+        self.assertTrue(summary["objective_proxy_gap_recorded"])
+        self.assertEqual(summary["candidate_without_objective_flag_count"], 1)
+        self.assertFalse(summary["musical_quality_claimed"])
+        self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
+
+    def test_rejects_quality_claim_source(self) -> None:
+        with self.assertRaises(
+            StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSparsePhraseModelCoreReviewError
+        ):
+            build_model_core_review_decision(
+                sparse_rejection_analysis(quality_claimed=True),
+                output_dir=Path("outputs/model_core_review"),
+            )
+
+    def test_rejects_absent_proxy_gap(self) -> None:
+        with self.assertRaises(
+            StageBGenericTinyCheckpointRepairPhraseContinuationRangeIntervalGuardSparsePhraseModelCoreReviewError
+        ):
+            build_model_core_review_decision(
+                sparse_rejection_analysis(proxy_gap=False),
+                output_dir=Path("outputs/model_core_review"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Sparse phrase objective proxy gap 기준 방법론 전환 결정 기록
- constraint/postprocess repair loop 중단 결정
- tiny checkpoint 역할 `diagnostic_only` 지정
- 다음 경계 `stage_b_generic_model_core_training_data_plan` 지정

## Context

- #443 결과, sparse phrase 청취 탈락 후보 3개 중 1개는 기존 objective MIDI flag 없음
- 공통 objective evidence flag 없음
- 후처리/constraint 수리 반복은 validation/failure isolation 용도로는 유효하지만 음악 품질 개선 경로로는 중단 필요

## Scope

- model core review decision script 추가
- no-quality, no-broad-quality claim boundary 유지
- 전용 harness mode와 unit test 추가
- CURRENT_STATUS_AND_PLAN, CORE_PLAN, AGENTS handoff 갱신

## Validation

- `bash scripts/agent_harness.sh stage-b-generic-tiny-checkpoint-repair-phrase-continuation-range-interval-guard-sparse-phrase-model-core-review`
- `.venv/bin/python -m unittest tests.test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_model_core_review tests.test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_rejection_analysis`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_model_core_review.py tests/test_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_model_core_review.py`
- `bash -n scripts/agent_harness.sh`
- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- Single-user listening review 기반 결정
- musical quality, quality root cause, broad trained model quality 미확정
- 다음 작업은 실제 model-core training/data boundary 검토 필요

Closes #445
