### PR TITLE
Stage B generic model-core training data plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #445, Stage B generic tiny checkpoint repair phrase continuation range interval guard sparse phrase model core review decision.
+- Latest functional issue completed: Issue #447, Stage B generic model-core training data plan.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B generic model-core training data plan.
+- Recommended next issue: Stage B generic full manifest window preparation.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -898,6 +898,14 @@ bash scripts/agent_harness.sh stage-b-generic-base-tiny-training-smoke
 ```
 
 This harness copies a small generic Stage B window token subset into the training path and verifies the training command succeeds without claiming broad model quality.
+
+For Stage B generic model-core training data plan changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-generic-model-core-training-data-plan
+```
+
+This harness consolidates the repair-loop stop decision, manifest contract, window smoke, and tiny training smoke into the next full-window preparation plan without claiming broad trained-model quality.
 
 For Stage B generic tiny checkpoint generation probe changes, run:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -166,6 +166,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint repair phrase continuation range interval guard sparse phrase user listening review 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_SPARSE_PHRASE_USER_LISTENING_REVIEW_2026-06-01.md`
 - generic tiny checkpoint repair phrase continuation range interval guard sparse phrase rejection analysis 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_SPARSE_PHRASE_REJECTION_ANALYSIS_2026-06-01.md`
 - generic tiny checkpoint repair phrase continuation range interval guard sparse phrase model core review decision 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_SPARSE_PHRASE_MODEL_CORE_REVIEW_DECISION_2026-06-01.md`
+- generic model-core training data plan 문서: `docs/STAGE_B_GENERIC_MODEL_CORE_TRAINING_DATA_PLAN_2026-06-01.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -270,6 +271,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint repair phrase continuation range interval guard sparse phrase user listening review: overall `reject_all`, candidate `reject`, primary failure `subjective_not_musical`, keep claim `false`, next boundary `sparse_phrase_rejection_analysis`
 - generic tiny checkpoint repair phrase continuation range interval guard sparse phrase rejection analysis: candidates without objective flags `1/3`, objective proxy gap `true`, next boundary `sparse_phrase_model_core_review_decision`
 - generic tiny checkpoint repair phrase continuation range interval guard sparse phrase model core review decision: continue repair loop `false`, tiny checkpoint `diagnostic_only`, next boundary `generic_model_core_training_data_plan`
+- generic model-core training data plan: generic train/val `2433/270`, repair loop `stopped`, next boundary `generic_full_manifest_window_preparation`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -1527,6 +1529,19 @@ Issue #312는 constrained decoding으로 adjacent repeat를 줄였지만 dead-ai
 - candidate without objective flags: `1`
 - musical quality / broad trained model quality claim: `false` / `false`
 - 다음 작업은 generic model-core training data plan이다.
+
+현재 generic model-core training data plan:
+
+- Issue #447 result: boundary `stage_b_generic_model_core_training_data_plan`
+- repair loop status: `stopped`
+- tiny checkpoint role: `diagnostic_only`
+- generic train / val files: `2433` / `270`
+- Brad split: `47` / `11` / `14`
+- window smoke token max / vocab: `544` / `547`
+- tiny training selected records: `32` / `8`
+- full window preparation / full training executed: `false` / `false`
+- broad trained model quality claim: `false`
+- 다음 작업은 generic full manifest window preparation이다.
 
 ### Phase 5. Brad Style Adaptation
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #445, Stage B generic tiny checkpoint repair phrase continuation range interval guard sparse phrase model core review decision
-- 다음 권장 이슈: `Stage B generic model-core training data plan`
+- latest functional result: Issue #447, Stage B generic model-core training data plan
+- 다음 권장 이슈: `Stage B generic full manifest window preparation`
 
 현재 범위가 아닌 것:
 
@@ -1184,6 +1184,44 @@ Issue #445는 Issue #443 objective proxy gap 결과를 기준으로 constraint/p
 다음:
 
 - `Stage B generic model-core training data plan`
+
+## Stage B Generic Model-Core Training Data Plan
+
+Issue #447은 constraint/postprocess repair loop 중단 이후 generic model-core 경로를 다시 정렬한 작업이다.
+
+변경:
+
+- model-core review decision report 입력 검증 추가
+- generic/Brad manifest contract, generic window smoke, tiny training smoke 결과 연결
+- repair loop status를 `stopped`로 유지
+- tiny checkpoint 역할을 `diagnostic_only`로 유지
+- full window preparation과 full training 미실행 claim guard 유지
+- 다음 경계를 full generic Stage B window preparation으로 지정
+
+결과:
+
+- document: `docs/STAGE_B_GENERIC_MODEL_CORE_TRAINING_DATA_PLAN_2026-06-01.md`
+- boundary: `stage_b_generic_model_core_training_data_plan`
+- repair loop status: `stopped`
+- tiny checkpoint role: `diagnostic_only`
+- generic train / val files: `2433` / `270`
+- Brad split: `47` / `11` / `14`
+- window smoke token max / vocab: `544` / `547`
+- tiny training selected records: `32` / `8`
+- best validation loss: `6.1427`
+- full window preparation / full training executed: `false` / `false`
+- broad trained model quality claimed: `false`
+- next boundary: `stage_b_generic_full_manifest_window_preparation`
+
+판단:
+
+- 현재 방법론은 후처리 후보 수리 중단
+- 다음 실행 단위는 full generic train/val manifest의 Stage B window preparation
+- full training과 Brad adaptation은 full window/token guard 이후 판단
+
+다음:
+
+- `Stage B generic full manifest window preparation`
 
 ## Current Muzig Application Resume Wording Result
 

--- a/docs/STAGE_B_GENERIC_MODEL_CORE_TRAINING_DATA_PLAN_2026-06-01.md
+++ b/docs/STAGE_B_GENERIC_MODEL_CORE_TRAINING_DATA_PLAN_2026-06-01.md
@@ -1,0 +1,41 @@
+# Stage B Generic Model-Core Training Data Plan
+
+## Summary
+
+- boundary: `stage_b_generic_model_core_training_data_plan`
+- repair loop status: `stopped`
+- tiny checkpoint role: `diagnostic_only`
+- next method: `generic_manifest_full_window_preparation_then_training`
+- generic train / val files: `2433` / `270`
+- Brad files excluded from generic base: `true`
+- full window preparation executed: `false`
+- full training executed: `false`
+- broad trained model quality claimed: `false`
+- next boundary: `stage_b_generic_full_manifest_window_preparation`
+
+## Evidence
+
+- manifest generic train / val: `2433` / `270`
+- manifest Brad split: `47` / `11` / `14`
+- window smoke selected train / val files: `6` / `3`
+- window smoke token max / vocab: `544` / `547`
+- tiny training selected train / val records: `32` / `8`
+- tiny training best validation loss: `6.1427`
+
+## Execution Order
+
+| step | name | goal | stop condition |
+|---:|---|---|---|
+| 1 | `full_generic_manifest_window_preparation` | convert full non-Brad generic train/val manifests to Stage B windows | token ids exceed vocab or train/val boundary changes |
+| 2 | `full_window_token_guard` | record train/val window counts, non-empty token counts, max token id, vocab fit | empty validation split or vocab overflow |
+| 3 | `generic_base_training_scale_smoke` | run controlled larger-than-tiny training with validation loss and checkpoint metadata | training returncode nonzero or validation artifact missing |
+| 4 | `generic_base_generation_probe` | evaluate raw model output before constrained rescue | raw generation fails structural gate; record as model-core failure |
+| 5 | `review_package_and_audio_boundary` | render only structurally reviewable candidates for listening review | no candidate passes objective review gate |
+
+## Not Proven
+
+- `full_generic_window_preparation`
+- `full_generic_training_run`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`
+- `production_ready_improviser`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -164,6 +164,8 @@ Modes:
                 Prepare Stage B duration-explicit windows from generic split manifest prefix.
   stage-b-generic-base-tiny-training-smoke
                 Run a tiny training smoke from generic Stage B window records.
+  stage-b-generic-model-core-training-data-plan
+                Build the generic model-core training data plan after repair-loop stop.
   stage-b-generic-tiny-checkpoint-generation-probe
                 Probe generation/decode from the generic tiny checkpoint.
   stage-b-generic-tiny-checkpoint-grammar-repair
@@ -3151,6 +3153,48 @@ run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_gu
     --require_no_quality_claim
 }
 
+run_stage_b_generic_model_core_training_data_plan() {
+  local model_core_run_id="${MODEL_CORE_RUN_ID:-harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_model_core_review_decision}"
+  local manifest_contract_run_id="${MANIFEST_CONTRACT_RUN_ID:-harness_stage_b_generic_base_manifest_contract}"
+  local window_smoke_run_id="${WINDOW_SMOKE_RUN_ID:-harness_stage_b_generic_manifest_window_smoke}"
+  local training_smoke_run_id="${TRAINING_SMOKE_RUN_ID:-harness_stage_b_generic_base_tiny_training_smoke}"
+  local run_id="${RUN_ID:-harness_stage_b_generic_model_core_training_data_plan}"
+  local model_core_decision="outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_model_core_review_decision/${model_core_run_id}/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_model_core_review_decision.json"
+  local manifest_contract="outputs/stage_b_generic_base_manifest_contract/${manifest_contract_run_id}/stage_b_generic_base_manifest_contract.json"
+  local window_smoke="outputs/stage_b_generic_manifest_window_smoke/${window_smoke_run_id}/stage_b_generic_manifest_window_smoke.json"
+  local tiny_training_smoke="outputs/stage_b_generic_base_tiny_training_smoke/${training_smoke_run_id}/stage_b_generic_base_tiny_training_smoke.json"
+  if [[ ! -f "$model_core_decision" ]]; then
+    print_header "Stage B generic tiny checkpoint repair phrase continuation range interval guard sparse phrase model core review"
+    RUN_ID="$model_core_run_id" run_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_sparse_phrase_model_core_review
+  fi
+  if [[ ! -f "$manifest_contract" ]]; then
+    print_header "Stage B generic base manifest contract"
+    RUN_ID="$manifest_contract_run_id" run_stage_b_generic_base_manifest_contract
+  fi
+  if [[ ! -f "$window_smoke" ]]; then
+    print_header "Stage B generic manifest window smoke"
+    RUN_ID="$window_smoke_run_id" MANIFEST_CONTRACT_RUN_ID="$manifest_contract_run_id" run_stage_b_generic_manifest_window_smoke
+  fi
+  if [[ ! -f "$tiny_training_smoke" ]]; then
+    print_header "Stage B generic base tiny training smoke"
+    RUN_ID="$training_smoke_run_id" WINDOW_SMOKE_RUN_ID="$window_smoke_run_id" run_stage_b_generic_base_tiny_training_smoke
+  fi
+  print_header "Stage B generic model-core training data plan"
+  "$PYTHON_BIN" scripts/plan_stage_b_generic_model_core_training_data.py \
+    --run_id "$run_id" \
+    --model_core_decision "$model_core_decision" \
+    --manifest_contract "$manifest_contract" \
+    --window_smoke "$window_smoke" \
+    --tiny_training_smoke "$tiny_training_smoke" \
+    --doc_path docs/STAGE_B_GENERIC_MODEL_CORE_TRAINING_DATA_PLAN_2026-06-01.md \
+    --expected_boundary stage_b_generic_model_core_training_data_plan \
+    --expected_next_boundary stage_b_generic_full_manifest_window_preparation \
+    --min_generic_train_files 2000 \
+    --min_generic_val_files 200 \
+    --require_stop_repair_loop \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -4492,6 +4536,9 @@ case "$MODE" in
     ;;
   stage-b-generic-base-tiny-training-smoke)
     run_stage_b_generic_base_tiny_training_smoke
+    ;;
+  stage-b-generic-model-core-training-data-plan)
+    run_stage_b_generic_model_core_training_data_plan
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/plan_stage_b_generic_model_core_training_data.py
+++ b/scripts/plan_stage_b_generic_model_core_training_data.py
@@ -1,0 +1,482 @@
+"""Build the generic model-core training data plan after repair-loop stop."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class StageBGenericModelCoreTrainingDataPlanError(ValueError):
+    pass
+
+
+MODEL_CORE_DECISION_BOUNDARY = (
+    "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_"
+    "sparse_phrase_model_core_review_decision"
+)
+MANIFEST_CONTRACT_BOUNDARY = "stage_b_generic_base_manifest_contract"
+WINDOW_SMOKE_BOUNDARY = "stage_b_generic_stage_b_window_prepare_smoke"
+TINY_TRAINING_BOUNDARY = "stage_b_generic_base_tiny_training_smoke"
+PLAN_BOUNDARY = "stage_b_generic_model_core_training_data_plan"
+NEXT_BOUNDARY = "stage_b_generic_full_manifest_window_preparation"
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def validate_model_core_decision(report: dict[str, Any]) -> dict[str, Any]:
+    decision = _dict(report.get("decision"))
+    claim = _dict(report.get("claim_boundary"))
+    evidence = _dict(report.get("methodology_evidence"))
+    if str(decision.get("current_boundary") or "") != MODEL_CORE_DECISION_BOUNDARY:
+        raise StageBGenericModelCoreTrainingDataPlanError("model-core review decision boundary required")
+    if str(decision.get("next_boundary") or "") != PLAN_BOUNDARY:
+        raise StageBGenericModelCoreTrainingDataPlanError("model-core review decision must route to training data plan")
+    if bool(decision.get("continue_constraint_postprocess_repair_loop", True)):
+        raise StageBGenericModelCoreTrainingDataPlanError("constraint/postprocess repair loop must be stopped")
+    if str(decision.get("tiny_checkpoint_role") or "") != "diagnostic_only":
+        raise StageBGenericModelCoreTrainingDataPlanError("tiny checkpoint must be diagnostic-only")
+    if not bool(decision.get("model_core_transition_required", False)):
+        raise StageBGenericModelCoreTrainingDataPlanError("model-core transition must be required")
+    if not bool(evidence.get("objective_proxy_gap_recorded", False)):
+        raise StageBGenericModelCoreTrainingDataPlanError("objective proxy gap evidence required")
+    blocked = [
+        "musical_quality_claimed",
+        "quality_root_cause_claimed",
+        "broad_trained_model_quality_claimed",
+        "brad_style_adaptation_claimed",
+        "production_ready_improviser_claimed",
+    ]
+    claimed = [name for name in blocked if bool(claim.get(name, True))]
+    if claimed:
+        raise StageBGenericModelCoreTrainingDataPlanError(f"unsupported model-core claims: {claimed}")
+    return {
+        "decision": str(decision.get("decision") or ""),
+        "tiny_checkpoint_role": str(decision.get("tiny_checkpoint_role") or ""),
+        "candidate_without_objective_flag_count": _int(
+            evidence.get("candidate_without_objective_flag_count")
+        ),
+    }
+
+
+def validate_manifest_contract(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    guards = _dict(report.get("guards"))
+    counts = _dict(report.get("split_counts"))
+    if str(readiness.get("boundary") or "") != MANIFEST_CONTRACT_BOUNDARY:
+        raise StageBGenericModelCoreTrainingDataPlanError("manifest contract boundary required")
+    if not bool(readiness.get("manifest_contract_ready", False)):
+        raise StageBGenericModelCoreTrainingDataPlanError("manifest contract must be ready")
+    if bool(readiness.get("broad_training_execution_ready", True)):
+        raise StageBGenericModelCoreTrainingDataPlanError("broad training must remain blocked at contract stage")
+    leak_fields = [
+        "generic_brad_leak_count",
+        "brad_non_brad_leak_count",
+        "overlap_path_count",
+        "duplicate_exact_hash_group_count",
+        "duplicate_exact_file_count",
+    ]
+    leaks = {name: _int(guards.get(name)) for name in leak_fields}
+    if any(value != 0 for value in leaks.values()):
+        raise StageBGenericModelCoreTrainingDataPlanError(f"manifest leakage guard failed: {leaks}")
+    return {
+        "generic_jazz_train": _int(counts.get("generic_jazz_train")),
+        "generic_jazz_val": _int(counts.get("generic_jazz_val")),
+        "brad_adaptation_train": _int(counts.get("brad_adaptation_train")),
+        "brad_adaptation_val": _int(counts.get("brad_adaptation_val")),
+        "brad_test_holdout": _int(counts.get("brad_test_holdout")),
+        "generic_leak_count": leaks["generic_brad_leak_count"],
+        "overlap_path_count": leaks["overlap_path_count"],
+    }
+
+
+def validate_window_smoke(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    input_config = _dict(report.get("input"))
+    token_stats = _dict(report.get("token_stats"))
+    dataset_summary = _dict(report.get("dataset_summary"))
+    if str(readiness.get("boundary") or "") != WINDOW_SMOKE_BOUNDARY:
+        raise StageBGenericModelCoreTrainingDataPlanError("window smoke boundary required")
+    if not bool(readiness.get("stage_b_window_prepare_smoke_ready", False)):
+        raise StageBGenericModelCoreTrainingDataPlanError("window smoke must be ready")
+    if bool(readiness.get("generic_base_training_execution_ready", True)):
+        raise StageBGenericModelCoreTrainingDataPlanError("generic base training must remain blocked after smoke")
+    if _int(token_stats.get("max_token_id")) >= _int(token_stats.get("vocab_size")):
+        raise StageBGenericModelCoreTrainingDataPlanError("window smoke token ids must fit vocab")
+    return {
+        "selected_train_files": _int(input_config.get("selected_train_files")),
+        "selected_val_files": _int(input_config.get("selected_val_files")),
+        "window_bars": _int(input_config.get("window_bars")),
+        "window_stride_bars": _int(input_config.get("window_stride_bars")),
+        "min_window_target_notes": _int(input_config.get("min_window_target_notes")),
+        "token_files": _int(token_stats.get("files")),
+        "non_empty_token_files": _int(token_stats.get("non_empty_files")),
+        "max_token_id": _int(token_stats.get("max_token_id")),
+        "vocab_size": _int(token_stats.get("vocab_size")),
+        "train_manifest": str(dataset_summary.get("train_manifest") or ""),
+        "val_manifest": str(dataset_summary.get("val_manifest") or ""),
+    }
+
+
+def validate_tiny_training_smoke(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    token_stats = _dict(report.get("token_stats"))
+    training = _dict(report.get("training"))
+    input_config = _dict(report.get("input"))
+    if str(readiness.get("boundary") or "") != TINY_TRAINING_BOUNDARY:
+        raise StageBGenericModelCoreTrainingDataPlanError("tiny training smoke boundary required")
+    if not bool(readiness.get("tiny_training_smoke_passed", False)):
+        raise StageBGenericModelCoreTrainingDataPlanError("tiny training smoke must pass")
+    if not bool(readiness.get("generic_base_training_path_smoked", False)):
+        raise StageBGenericModelCoreTrainingDataPlanError("generic training path smoke required")
+    if bool(readiness.get("broad_training_execution_ready", True)):
+        raise StageBGenericModelCoreTrainingDataPlanError("broad training execution must remain blocked")
+    if _int(training.get("returncode")) != 0:
+        raise StageBGenericModelCoreTrainingDataPlanError("tiny training command must succeed")
+    if not bool(token_stats.get("fits_vocab", False)):
+        raise StageBGenericModelCoreTrainingDataPlanError("tiny training tokens must fit vocab")
+    return {
+        "selected_train_records": _int(input_config.get("selected_train_records")),
+        "selected_val_records": _int(input_config.get("selected_val_records")),
+        "token_files": _int(token_stats.get("files")),
+        "non_empty_token_files": _int(token_stats.get("non_empty_files")),
+        "max_token_id": _int(token_stats.get("max_token_id")),
+        "vocab_size": _int(token_stats.get("vocab_size")),
+        "best_validation_loss": _float(training.get("best_validation_loss")),
+        "returncode": _int(training.get("returncode")),
+    }
+
+
+def build_training_data_plan(
+    model_core_decision: dict[str, Any],
+    manifest_contract: dict[str, Any],
+    window_smoke: dict[str, Any],
+    tiny_training_smoke: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> dict[str, Any]:
+    model = validate_model_core_decision(model_core_decision)
+    manifest = validate_manifest_contract(manifest_contract)
+    window = validate_window_smoke(window_smoke)
+    tiny = validate_tiny_training_smoke(tiny_training_smoke)
+    return {
+        "schema_version": "stage_b_generic_model_core_training_data_plan_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "input_boundaries": {
+            "model_core_decision": MODEL_CORE_DECISION_BOUNDARY,
+            "manifest_contract": MANIFEST_CONTRACT_BOUNDARY,
+            "window_smoke": WINDOW_SMOKE_BOUNDARY,
+            "tiny_training_smoke": TINY_TRAINING_BOUNDARY,
+        },
+        "methodology_reset": {
+            "repair_loop_status": "stopped",
+            "tiny_checkpoint_role": model["tiny_checkpoint_role"],
+            "objective_proxy_gap_candidate_count": model["candidate_without_objective_flag_count"],
+            "next_method": "generic_manifest_full_window_preparation_then_training",
+        },
+        "evidence_summary": {
+            "manifest": manifest,
+            "window_smoke": window,
+            "tiny_training_smoke": tiny,
+        },
+        "training_data_plan": {
+            "plan_boundary": PLAN_BOUNDARY,
+            "data_source": "generic_jazz_train_val_manifest",
+            "generic_train_file_count": manifest["generic_jazz_train"],
+            "generic_val_file_count": manifest["generic_jazz_val"],
+            "brad_files_excluded_from_generic_base": True,
+            "brad_holdout_preserved": True,
+            "window_parameters": {
+                "sequence_format": "stage_b_v1",
+                "role": "lead",
+                "window_bars": window["window_bars"],
+                "window_stride_bars": window["window_stride_bars"],
+                "min_window_target_notes": window["min_window_target_notes"],
+                "token_vocab_guard": "max_token_id_lt_vocab_size",
+            },
+            "execution_order": [
+                {
+                    "step": 1,
+                    "name": "full_generic_manifest_window_preparation",
+                    "goal": "convert full non-Brad generic train/val manifests to Stage B windows",
+                    "stop_condition": "token ids exceed vocab or train/val boundary changes",
+                },
+                {
+                    "step": 2,
+                    "name": "full_window_token_guard",
+                    "goal": "record train/val window counts, non-empty token counts, max token id, vocab fit",
+                    "stop_condition": "empty validation split or vocab overflow",
+                },
+                {
+                    "step": 3,
+                    "name": "generic_base_training_scale_smoke",
+                    "goal": "run controlled larger-than-tiny training with validation loss and checkpoint metadata",
+                    "stop_condition": "training returncode nonzero or validation artifact missing",
+                },
+                {
+                    "step": 4,
+                    "name": "generic_base_generation_probe",
+                    "goal": "evaluate raw model output before constrained rescue",
+                    "stop_condition": "raw generation fails structural gate; record as model-core failure",
+                },
+                {
+                    "step": 5,
+                    "name": "review_package_and_audio_boundary",
+                    "goal": "render only structurally reviewable candidates for listening review",
+                    "stop_condition": "no candidate passes objective review gate",
+                },
+            ],
+        },
+        "claim_boundary": {
+            "boundary": PLAN_BOUNDARY,
+            "training_data_plan_ready": True,
+            "full_training_executed": False,
+            "full_window_preparation_executed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_improviser_claimed": False,
+        },
+        "decision": {
+            "current_boundary": PLAN_BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "next_recommended_issue": "Stage B generic full manifest window preparation",
+        },
+        "proven": [
+            "repair_loop_stopped_before_new_training_plan",
+            "generic_brad_manifest_contract_ready",
+            "stage_b_window_smoke_ready",
+            "generic_tiny_training_path_smoked",
+        ],
+        "not_proven": [
+            "full_generic_window_preparation",
+            "full_generic_training_run",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "production_ready_improviser",
+        ],
+    }
+
+
+def validate_training_data_plan(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_stop_repair_loop: bool,
+    require_no_quality_claim: bool,
+    min_generic_train_files: int,
+    min_generic_val_files: int,
+) -> dict[str, Any]:
+    claim = _dict(report.get("claim_boundary"))
+    decision = _dict(report.get("decision"))
+    reset = _dict(report.get("methodology_reset"))
+    plan = _dict(report.get("training_data_plan"))
+    boundary = str(claim.get("boundary") or "")
+    next_boundary = str(decision.get("next_boundary") or "")
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBGenericModelCoreTrainingDataPlanError(f"expected boundary {expected_boundary}, got {boundary}")
+    if expected_next_boundary and next_boundary != expected_next_boundary:
+        raise StageBGenericModelCoreTrainingDataPlanError(
+            f"expected next boundary {expected_next_boundary}, got {next_boundary}"
+        )
+    if require_stop_repair_loop and str(reset.get("repair_loop_status") or "") != "stopped":
+        raise StageBGenericModelCoreTrainingDataPlanError("repair loop must be stopped")
+    if _int(plan.get("generic_train_file_count")) < min_generic_train_files:
+        raise StageBGenericModelCoreTrainingDataPlanError("generic train file count below threshold")
+    if _int(plan.get("generic_val_file_count")) < min_generic_val_files:
+        raise StageBGenericModelCoreTrainingDataPlanError("generic val file count below threshold")
+    if require_no_quality_claim:
+        claimed = [
+            bool(claim.get("full_training_executed", True)),
+            bool(claim.get("full_window_preparation_executed", True)),
+            bool(claim.get("broad_trained_model_quality_claimed", True)),
+            bool(claim.get("brad_style_adaptation_claimed", True)),
+            bool(claim.get("production_ready_improviser_claimed", True)),
+        ]
+        if any(claimed):
+            raise StageBGenericModelCoreTrainingDataPlanError("training or quality claims must remain false")
+    return {
+        "boundary": boundary,
+        "repair_loop_status": str(reset.get("repair_loop_status") or ""),
+        "tiny_checkpoint_role": str(reset.get("tiny_checkpoint_role") or ""),
+        "generic_train_file_count": _int(plan.get("generic_train_file_count")),
+        "generic_val_file_count": _int(plan.get("generic_val_file_count")),
+        "brad_files_excluded_from_generic_base": bool(plan.get("brad_files_excluded_from_generic_base", False)),
+        "training_data_plan_ready": bool(claim.get("training_data_plan_ready", False)),
+        "full_training_executed": bool(claim.get("full_training_executed", True)),
+        "broad_trained_model_quality_claimed": bool(claim.get("broad_trained_model_quality_claimed", True)),
+        "auto_progress_allowed": bool(decision.get("auto_progress_allowed", False)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_boundary": next_boundary,
+        "next_recommended_issue": str(decision.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    reset = report["methodology_reset"]
+    evidence = report["evidence_summary"]
+    plan = report["training_data_plan"]
+    claim = report["claim_boundary"]
+    decision = report["decision"]
+    lines = [
+        "# Stage B Generic Model-Core Training Data Plan",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{claim['boundary']}`",
+        f"- repair loop status: `{reset['repair_loop_status']}`",
+        f"- tiny checkpoint role: `{reset['tiny_checkpoint_role']}`",
+        f"- next method: `{reset['next_method']}`",
+        f"- generic train / val files: `{plan['generic_train_file_count']}` / `{plan['generic_val_file_count']}`",
+        f"- Brad files excluded from generic base: `{_bool_token(plan['brad_files_excluded_from_generic_base'])}`",
+        f"- full window preparation executed: `{_bool_token(claim['full_window_preparation_executed'])}`",
+        f"- full training executed: `{_bool_token(claim['full_training_executed'])}`",
+        f"- broad trained model quality claimed: `{_bool_token(claim['broad_trained_model_quality_claimed'])}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        "",
+        "## Evidence",
+        "",
+        f"- manifest generic train / val: `{evidence['manifest']['generic_jazz_train']}` / `{evidence['manifest']['generic_jazz_val']}`",
+        f"- manifest Brad split: `{evidence['manifest']['brad_adaptation_train']}` / `{evidence['manifest']['brad_adaptation_val']}` / `{evidence['manifest']['brad_test_holdout']}`",
+        f"- window smoke selected train / val files: `{evidence['window_smoke']['selected_train_files']}` / `{evidence['window_smoke']['selected_val_files']}`",
+        f"- window smoke token max / vocab: `{evidence['window_smoke']['max_token_id']}` / `{evidence['window_smoke']['vocab_size']}`",
+        f"- tiny training selected train / val records: `{evidence['tiny_training_smoke']['selected_train_records']}` / `{evidence['tiny_training_smoke']['selected_val_records']}`",
+        f"- tiny training best validation loss: `{evidence['tiny_training_smoke']['best_validation_loss']:.4f}`",
+        "",
+        "## Execution Order",
+        "",
+        "| step | name | goal | stop condition |",
+        "|---:|---|---|---|",
+    ]
+    for item in plan["execution_order"]:
+        lines.append(
+            f"| {item['step']} | `{item['name']}` | {item['goal']} | {item['stop_condition']} |"
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build Stage B generic model-core training data plan")
+    parser.add_argument(
+        "--model_core_decision",
+        type=str,
+        default="outputs/stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_"
+        "sparse_phrase_model_core_review_decision/"
+        "harness_stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_"
+        "sparse_phrase_model_core_review_decision/"
+        "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_"
+        "sparse_phrase_model_core_review_decision.json",
+    )
+    parser.add_argument(
+        "--manifest_contract",
+        type=str,
+        default="outputs/stage_b_generic_base_manifest_contract/"
+        "harness_stage_b_generic_base_manifest_contract/stage_b_generic_base_manifest_contract.json",
+    )
+    parser.add_argument(
+        "--window_smoke",
+        type=str,
+        default="outputs/stage_b_generic_manifest_window_smoke/"
+        "harness_stage_b_generic_manifest_window_smoke/stage_b_generic_manifest_window_smoke.json",
+    )
+    parser.add_argument(
+        "--tiny_training_smoke",
+        type=str,
+        default="outputs/stage_b_generic_base_tiny_training_smoke/"
+        "harness_stage_b_generic_base_tiny_training_smoke/stage_b_generic_base_tiny_training_smoke.json",
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_generic_model_core_training_data_plan",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--expected_boundary", type=str, default=PLAN_BOUNDARY)
+    parser.add_argument("--expected_next_boundary", type=str, default=NEXT_BOUNDARY)
+    parser.add_argument("--min_generic_train_files", type=int, default=2000)
+    parser.add_argument("--min_generic_val_files", type=int, default=200)
+    parser.add_argument("--require_stop_repair_loop", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_training_data_plan(
+        read_json(Path(args.model_core_decision)),
+        read_json(Path(args.manifest_contract)),
+        read_json(Path(args.window_smoke)),
+        read_json(Path(args.tiny_training_smoke)),
+        output_dir=output_dir,
+    )
+    summary = validate_training_data_plan(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_stop_repair_loop=bool(args.require_stop_repair_loop),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+        min_generic_train_files=int(args.min_generic_train_files),
+        min_generic_val_files=int(args.min_generic_val_files),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "stage_b_generic_model_core_training_data_plan.json", report)
+    write_json(output_dir / "stage_b_generic_model_core_training_data_plan_validation_summary.json", summary)
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_generic_model_core_training_data_plan.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_generic_model_core_training_data_plan.py
+++ b/tests/test_stage_b_generic_model_core_training_data_plan.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.plan_stage_b_generic_model_core_training_data import (
+    NEXT_BOUNDARY,
+    PLAN_BOUNDARY,
+    StageBGenericModelCoreTrainingDataPlanError,
+    build_training_data_plan,
+    validate_training_data_plan,
+)
+
+
+def model_core_decision(*, continue_repair: bool = False) -> dict:
+    return {
+        "decision": {
+            "current_boundary": (
+                "stage_b_generic_tiny_checkpoint_repair_phrase_continuation_range_interval_guard_"
+                "sparse_phrase_model_core_review_decision"
+            ),
+            "decision": "stop_constraint_postprocess_repair_loop",
+            "continue_constraint_postprocess_repair_loop": continue_repair,
+            "tiny_checkpoint_role": "diagnostic_only",
+            "model_core_transition_required": True,
+            "next_boundary": PLAN_BOUNDARY,
+        },
+        "methodology_evidence": {
+            "objective_proxy_gap_recorded": True,
+            "candidate_without_objective_flag_count": 1,
+        },
+        "claim_boundary": {
+            "musical_quality_claimed": False,
+            "quality_root_cause_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_improviser_claimed": False,
+        },
+    }
+
+
+def manifest_contract(*, leak_count: int = 0) -> dict:
+    return {
+        "readiness": {
+            "boundary": "stage_b_generic_base_manifest_contract",
+            "manifest_contract_ready": True,
+            "broad_training_execution_ready": False,
+        },
+        "split_counts": {
+            "generic_jazz_train": 2433,
+            "generic_jazz_val": 270,
+            "brad_adaptation_train": 47,
+            "brad_adaptation_val": 11,
+            "brad_test_holdout": 14,
+        },
+        "guards": {
+            "generic_brad_leak_count": leak_count,
+            "brad_non_brad_leak_count": 0,
+            "overlap_path_count": 0,
+            "duplicate_exact_hash_group_count": 0,
+            "duplicate_exact_file_count": 0,
+        },
+    }
+
+
+def window_smoke(*, max_token_id: int = 544, vocab_size: int = 547) -> dict:
+    return {
+        "readiness": {
+            "boundary": "stage_b_generic_stage_b_window_prepare_smoke",
+            "stage_b_window_prepare_smoke_ready": True,
+            "generic_base_training_execution_ready": False,
+        },
+        "input": {
+            "selected_train_files": 6,
+            "selected_val_files": 3,
+            "window_bars": 2,
+            "window_stride_bars": 1,
+            "min_window_target_notes": 4,
+        },
+        "token_stats": {
+            "files": 747,
+            "non_empty_files": 747,
+            "max_token_id": max_token_id,
+            "vocab_size": vocab_size,
+        },
+        "dataset_summary": {
+            "train_manifest": "generic_jazz_train.txt",
+            "val_manifest": "generic_jazz_val.txt",
+        },
+    }
+
+
+def tiny_training_smoke(*, returncode: int = 0) -> dict:
+    return {
+        "readiness": {
+            "boundary": "stage_b_generic_base_tiny_training_smoke",
+            "tiny_training_smoke_passed": True,
+            "generic_base_training_path_smoked": True,
+            "broad_training_execution_ready": False,
+        },
+        "input": {
+            "selected_train_records": 32,
+            "selected_val_records": 8,
+        },
+        "token_stats": {
+            "files": 40,
+            "non_empty_files": 40,
+            "max_token_id": 544,
+            "vocab_size": 547,
+            "fits_vocab": True,
+        },
+        "training": {
+            "returncode": returncode,
+            "best_validation_loss": 6.1427,
+        },
+    }
+
+
+class StageBGenericModelCoreTrainingDataPlanTest(unittest.TestCase):
+    def test_builds_plan_from_ready_inputs_without_training_claim(self) -> None:
+        report = build_training_data_plan(
+            model_core_decision(),
+            manifest_contract(),
+            window_smoke(),
+            tiny_training_smoke(),
+            output_dir=Path("outputs/plan"),
+        )
+        summary = validate_training_data_plan(
+            report,
+            expected_boundary=PLAN_BOUNDARY,
+            expected_next_boundary=NEXT_BOUNDARY,
+            require_stop_repair_loop=True,
+            require_no_quality_claim=True,
+            min_generic_train_files=2000,
+            min_generic_val_files=200,
+        )
+
+        self.assertEqual(summary["repair_loop_status"], "stopped")
+        self.assertEqual(summary["tiny_checkpoint_role"], "diagnostic_only")
+        self.assertEqual(summary["generic_train_file_count"], 2433)
+        self.assertEqual(summary["generic_val_file_count"], 270)
+        self.assertFalse(summary["full_training_executed"])
+        self.assertFalse(summary["broad_trained_model_quality_claimed"])
+        self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
+
+    def test_rejects_unstopped_repair_loop(self) -> None:
+        with self.assertRaises(StageBGenericModelCoreTrainingDataPlanError):
+            build_training_data_plan(
+                model_core_decision(continue_repair=True),
+                manifest_contract(),
+                window_smoke(),
+                tiny_training_smoke(),
+                output_dir=Path("outputs/plan"),
+            )
+
+    def test_rejects_manifest_leak(self) -> None:
+        with self.assertRaises(StageBGenericModelCoreTrainingDataPlanError):
+            build_training_data_plan(
+                model_core_decision(),
+                manifest_contract(leak_count=1),
+                window_smoke(),
+                tiny_training_smoke(),
+                output_dir=Path("outputs/plan"),
+            )
+
+    def test_rejects_vocab_overflow(self) -> None:
+        with self.assertRaises(StageBGenericModelCoreTrainingDataPlanError):
+            build_training_data_plan(
+                model_core_decision(),
+                manifest_contract(),
+                window_smoke(max_token_id=547, vocab_size=547),
+                tiny_training_smoke(),
+                output_dir=Path("outputs/plan"),
+            )
+
+    def test_rejects_failed_training_smoke(self) -> None:
+        with self.assertRaises(StageBGenericModelCoreTrainingDataPlanError):
+            build_training_data_plan(
+                model_core_decision(),
+                manifest_contract(),
+                window_smoke(),
+                tiny_training_smoke(returncode=1),
+                output_dir=Path("outputs/plan"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- 후처리 수리 루프 중단 이후 generic model-core 실행 계획 재정렬
- model-core decision, manifest contract, window smoke, tiny training smoke 입력 검증 연결
- generic train/val `2433/270` 기준 full Stage B window preparation으로 다음 경계 지정
- full training, broad model quality, Brad adaptation claim 차단 유지

## Context

- #445 결과, constraint/postprocess repair loop 중단 및 tiny checkpoint `diagnostic_only` 결정
- 기존 generic/Brad manifest contract, window smoke, tiny training smoke는 준비 증거로 존재
- 다음 실행 단위는 추가 repair sweep이 아니라 full generic train/val manifest의 Stage B window preparation

## Scope

- training data plan script 추가
- 전용 harness mode와 unit test 추가
- `docs/STAGE_B_GENERIC_MODEL_CORE_TRAINING_DATA_PLAN_2026-06-01.md` 생성
- CURRENT_STATUS_AND_PLAN, CORE_PLAN, AGENTS handoff 갱신

## Validation

- `bash scripts/agent_harness.sh stage-b-generic-model-core-training-data-plan`
- `.venv/bin/python -m unittest tests.test_stage_b_generic_model_core_training_data_plan`
- `.venv/bin/python -m py_compile scripts/plan_stage_b_generic_model_core_training_data.py tests/test_stage_b_generic_model_core_training_data_plan.py`
- `bash -n scripts/agent_harness.sh`
- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- Full window preparation 미실행
- Full generic training 미실행
- Broad trained-model quality, Brad style adaptation 미검증

Closes #447
