### PR TITLE
Stage B generic full manifest window preparation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #447, Stage B generic model-core training data plan.
+- Latest functional issue completed: Issue #449, Stage B generic full manifest window preparation.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B generic full manifest window preparation.
+- Recommended next issue: Stage B generic base training scale smoke.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -906,6 +906,14 @@ bash scripts/agent_harness.sh stage-b-generic-model-core-training-data-plan
 ```
 
 This harness consolidates the repair-loop stop decision, manifest contract, window smoke, and tiny training smoke into the next full-window preparation plan without claiming broad trained-model quality.
+
+For Stage B generic full manifest window preparation changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-generic-full-manifest-window-preparation
+```
+
+This harness prepares the full generic train/val manifests as Stage B window records and validates token/vocab guards without running training.
 
 For Stage B generic tiny checkpoint generation probe changes, run:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -167,6 +167,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint repair phrase continuation range interval guard sparse phrase rejection analysis 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_SPARSE_PHRASE_REJECTION_ANALYSIS_2026-06-01.md`
 - generic tiny checkpoint repair phrase continuation range interval guard sparse phrase model core review decision 문서: `docs/STAGE_B_GENERIC_TINY_CHECKPOINT_REPAIR_PHRASE_CONTINUATION_RANGE_INTERVAL_GUARD_SPARSE_PHRASE_MODEL_CORE_REVIEW_DECISION_2026-06-01.md`
 - generic model-core training data plan 문서: `docs/STAGE_B_GENERIC_MODEL_CORE_TRAINING_DATA_PLAN_2026-06-01.md`
+- generic full manifest window preparation 문서: `docs/STAGE_B_GENERIC_FULL_MANIFEST_WINDOW_PREPARATION_2026-06-01.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -272,6 +273,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic tiny checkpoint repair phrase continuation range interval guard sparse phrase rejection analysis: candidates without objective flags `1/3`, objective proxy gap `true`, next boundary `sparse_phrase_model_core_review_decision`
 - generic tiny checkpoint repair phrase continuation range interval guard sparse phrase model core review decision: continue repair loop `false`, tiny checkpoint `diagnostic_only`, next boundary `generic_model_core_training_data_plan`
 - generic model-core training data plan: generic train/val `2433/270`, repair loop `stopped`, next boundary `generic_full_manifest_window_preparation`
+- generic full manifest window preparation: tokenized train/val `154136/21845`, max token id/vocab `544/547`, next boundary `generic_base_training_scale_smoke`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -1542,6 +1544,19 @@ Issue #312는 constrained decoding으로 adjacent repeat를 줄였지만 dead-ai
 - full window preparation / full training executed: `false` / `false`
 - broad trained model quality claim: `false`
 - 다음 작업은 generic full manifest window preparation이다.
+
+현재 generic full manifest window preparation:
+
+- Issue #449 result: boundary `stage_b_generic_full_manifest_window_preparation`
+- train / val manifest files: `2433` / `270`
+- generated samples: `175981`
+- tokenized train / val files: `154136` / `21845`
+- max token id / vocab size: `544` / `547`
+- fits vocab: `true`
+- full training executed: `false`
+- broad trained model quality claim: `false`
+- output size: 약 `2.7GB`
+- 다음 작업은 generic base training scale smoke다.
 
 ### Phase 5. Brad Style Adaptation
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #447, Stage B generic model-core training data plan
-- 다음 권장 이슈: `Stage B generic full manifest window preparation`
+- latest functional result: Issue #449, Stage B generic full manifest window preparation
+- 다음 권장 이슈: `Stage B generic base training scale smoke`
 
 현재 범위가 아닌 것:
 
@@ -1222,6 +1222,43 @@ Issue #447은 constraint/postprocess repair loop 중단 이후 generic model-cor
 다음:
 
 - `Stage B generic full manifest window preparation`
+
+## Stage B Generic Full Manifest Window Preparation
+
+Issue #449는 #447 계획에 따라 full non-Brad generic train/val manifest를 Stage B window records로 준비한 작업이다.
+
+변경:
+
+- full generic manifest window preparation script 추가
+- training data plan 입력 검증 추가
+- generic train/val manifest 전체 복사 및 explicit split boundary 보존
+- `prepare_role_dataset.py` 기반 Stage B window/tokenized records 생성
+- full training 미실행, broad quality claim guard 유지
+
+결과:
+
+- document: `docs/STAGE_B_GENERIC_FULL_MANIFEST_WINDOW_PREPARATION_2026-06-01.md`
+- boundary: `stage_b_generic_full_manifest_window_preparation`
+- train / val manifest files: `2433` / `270`
+- generated samples: `175981`
+- tokenized train / val files: `154136` / `21845`
+- max token id / vocab size: `544` / `547`
+- fits vocab: `true`
+- full training executed: `false`
+- broad trained model quality claimed: `false`
+- output size: 약 `2.7GB`
+- next boundary: `stage_b_generic_base_training_scale_smoke`
+
+판단:
+
+- full generic Stage B window preparation 가능
+- train/val split 유지
+- 다음 단계는 controlled training scale smoke
+- 아직 broad trained model quality 또는 Brad style adaptation 증거 아님
+
+다음:
+
+- `Stage B generic base training scale smoke`
 
 ## Current Muzig Application Resume Wording Result
 

--- a/docs/STAGE_B_GENERIC_FULL_MANIFEST_WINDOW_PREPARATION_2026-06-01.md
+++ b/docs/STAGE_B_GENERIC_FULL_MANIFEST_WINDOW_PREPARATION_2026-06-01.md
@@ -1,0 +1,36 @@
+# Stage B Generic Full Manifest Window Preparation
+
+## Summary
+
+- boundary: `stage_b_generic_full_manifest_window_preparation`
+- next boundary: `stage_b_generic_base_training_scale_smoke`
+- full manifest window preparation ready: `true`
+- training scale smoke ready: `true`
+- full training executed: `false`
+- broad trained-model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+
+## Input
+
+- train files: `2433`
+- val files: `270`
+- window bars: `2`
+- window stride bars: `2`
+- min window target notes: `4`
+
+## Tokenized Records
+
+- tokenized train files: `154136`
+- tokenized val files: `21845`
+- max token id: `544`
+- vocab size: `547`
+- fits vocab: `true`
+- dataset train samples: `154136`
+- dataset val samples: `21845`
+
+## Not Proven
+
+- `generic_base_training_scale_smoke`
+- `full_generic_training_run`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -166,6 +166,8 @@ Modes:
                 Run a tiny training smoke from generic Stage B window records.
   stage-b-generic-model-core-training-data-plan
                 Build the generic model-core training data plan after repair-loop stop.
+  stage-b-generic-full-manifest-window-preparation
+                Prepare full generic train/val manifests as Stage B window records.
   stage-b-generic-tiny-checkpoint-generation-probe
                 Probe generation/decode from the generic tiny checkpoint.
   stage-b-generic-tiny-checkpoint-grammar-repair
@@ -3195,6 +3197,35 @@ run_stage_b_generic_model_core_training_data_plan() {
     --require_no_quality_claim
 }
 
+run_stage_b_generic_full_manifest_window_preparation() {
+  local plan_run_id="${PLAN_RUN_ID:-harness_stage_b_generic_model_core_training_data_plan}"
+  local manifest_contract_run_id="${MANIFEST_CONTRACT_RUN_ID:-harness_stage_b_generic_base_manifest_contract}"
+  local run_id="${RUN_ID:-harness_stage_b_generic_full_manifest_window_preparation}"
+  local training_data_plan="outputs/stage_b_generic_model_core_training_data_plan/${plan_run_id}/stage_b_generic_model_core_training_data_plan.json"
+  local manifests_dir="outputs/stage_b_generic_base_manifest_contract/${manifest_contract_run_id}/manifests"
+  if [[ ! -f "$training_data_plan" ]]; then
+    print_header "Stage B generic model-core training data plan"
+    RUN_ID="$plan_run_id" MANIFEST_CONTRACT_RUN_ID="$manifest_contract_run_id" run_stage_b_generic_model_core_training_data_plan
+  fi
+  if [[ ! -f "${manifests_dir}/generic_jazz_train.txt" || ! -f "${manifests_dir}/generic_jazz_val.txt" ]]; then
+    print_header "Stage B generic base manifest contract"
+    RUN_ID="$manifest_contract_run_id" run_stage_b_generic_base_manifest_contract
+  fi
+  print_header "Stage B generic full manifest window preparation"
+  "$PYTHON_BIN" scripts/run_stage_b_generic_full_manifest_window_preparation.py \
+    --run_id "$run_id" \
+    --training_data_plan "$training_data_plan" \
+    --manifests_dir "$manifests_dir" \
+    --doc_path docs/STAGE_B_GENERIC_FULL_MANIFEST_WINDOW_PREPARATION_2026-06-01.md \
+    --expected_boundary stage_b_generic_full_manifest_window_preparation \
+    --expected_next_boundary stage_b_generic_base_training_scale_smoke \
+    --require_ready \
+    --require_no_training_claim \
+    --require_no_quality_claim \
+    --min_tokenized_train_files 1 \
+    --min_tokenized_val_files 1
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -4539,6 +4570,9 @@ case "$MODE" in
     ;;
   stage-b-generic-model-core-training-data-plan)
     run_stage_b_generic_model_core_training_data_plan
+    ;;
+  stage-b-generic-full-manifest-window-preparation)
+    run_stage_b_generic_full_manifest_window_preparation
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/run_stage_b_generic_full_manifest_window_preparation.py
+++ b/scripts/run_stage_b_generic_full_manifest_window_preparation.py
@@ -1,0 +1,401 @@
+"""Prepare full generic manifests as Stage B duration-explicit windows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+from scripts.run_manifest_prepare_smoke import read_manifest_paths  # noqa: E402
+from scripts.run_stage_b_window_tiny_overfit import token_stats  # noqa: E402
+
+
+class StageBGenericFullManifestWindowPreparationError(ValueError):
+    pass
+
+
+PLAN_BOUNDARY = "stage_b_generic_model_core_training_data_plan"
+BOUNDARY = "stage_b_generic_full_manifest_window_preparation"
+NEXT_BOUNDARY = "stage_b_generic_base_training_scale_smoke"
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def run_command(command: Sequence[str]) -> None:
+    print("+ " + " ".join(str(part) for part in command))
+    subprocess.run(command, cwd=ROOT_DIR, check=True)
+
+
+def count_npy_files(path: Path) -> int:
+    return len(sorted(path.glob("*.npy")))
+
+
+def validate_training_data_plan(report: dict[str, Any]) -> dict[str, Any]:
+    claim = _dict(report.get("claim_boundary"))
+    decision = _dict(report.get("decision"))
+    plan = _dict(report.get("training_data_plan"))
+    params = _dict(plan.get("window_parameters"))
+    if str(claim.get("boundary") or "") != PLAN_BOUNDARY:
+        raise StageBGenericFullManifestWindowPreparationError("training data plan boundary required")
+    if not bool(claim.get("training_data_plan_ready", False)):
+        raise StageBGenericFullManifestWindowPreparationError("training data plan must be ready")
+    if str(decision.get("next_boundary") or "") != BOUNDARY:
+        raise StageBGenericFullManifestWindowPreparationError("training data plan must route to full window preparation")
+    if bool(claim.get("full_training_executed", True)):
+        raise StageBGenericFullManifestWindowPreparationError("full training must not be executed before window prep")
+    if bool(claim.get("broad_trained_model_quality_claimed", True)):
+        raise StageBGenericFullManifestWindowPreparationError("broad quality claim must remain false")
+    return {
+        "generic_train_file_count": _int(plan.get("generic_train_file_count")),
+        "generic_val_file_count": _int(plan.get("generic_val_file_count")),
+        "window_bars": _int(params.get("window_bars")),
+        "window_stride_bars": _int(params.get("window_stride_bars")),
+        "min_window_target_notes": _int(params.get("min_window_target_notes")),
+    }
+
+
+def copy_manifest(src: Path, dst: Path) -> int:
+    if not src.exists():
+        raise StageBGenericFullManifestWindowPreparationError(f"manifest missing: {src}")
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dst)
+    return len(read_manifest_paths(dst))
+
+
+def build_full_window_report(
+    *,
+    run_dir: Path,
+    training_data_plan: dict[str, Any],
+    source_manifests_dir: Path,
+    train_manifest: Path,
+    val_manifest: Path,
+    roles_dir: Path,
+    train_file_count: int,
+    val_file_count: int,
+    window_bars: int,
+    window_stride_bars: int,
+    min_window_target_notes: int,
+) -> dict[str, Any]:
+    plan = validate_training_data_plan(training_data_plan)
+    role_root = roles_dir / "lead"
+    summary_path = role_root / "dataset_summary.json"
+    dataset_summary = read_json(summary_path)
+    tokenized_dir = role_root / "tokenized"
+    stats = token_stats(tokenized_dir)
+    tokenized_train = count_npy_files(tokenized_dir / "train")
+    tokenized_val = count_npy_files(tokenized_dir / "val")
+    split_counts = _dict(dataset_summary.get("input_split_file_counts"))
+    ready = (
+        train_file_count == plan["generic_train_file_count"]
+        and val_file_count == plan["generic_val_file_count"]
+        and _int(split_counts.get("train")) == train_file_count
+        and _int(split_counts.get("val")) == val_file_count
+        and tokenized_train > 0
+        and tokenized_val > 0
+        and bool(stats.get("fits_vocab", False))
+        and str(dataset_summary.get("sequence_format") or "") == "stage_b_v1"
+        and _int(dataset_summary.get("stage_b_window_bars")) == int(window_bars)
+        and _int(dataset_summary.get("stage_b_window_stride_bars")) == int(window_stride_bars)
+    )
+    return {
+        "schema_version": "stage_b_generic_full_manifest_window_preparation_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "run_dir": str(run_dir),
+        "source_training_data_plan_schema": str(training_data_plan.get("schema_version") or ""),
+        "source_manifests_dir": str(source_manifests_dir),
+        "full_train_manifest": str(train_manifest),
+        "full_val_manifest": str(val_manifest),
+        "roles_dir": str(roles_dir),
+        "input": {
+            "train_file_count": int(train_file_count),
+            "val_file_count": int(val_file_count),
+            "window_bars": int(window_bars),
+            "window_stride_bars": int(window_stride_bars),
+            "min_window_target_notes": int(min_window_target_notes),
+        },
+        "dataset_summary": dataset_summary,
+        "token_stats": {
+            **stats,
+            "tokenized_train_files": int(tokenized_train),
+            "tokenized_val_files": int(tokenized_val),
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "full_manifest_window_preparation_ready": ready,
+            "generic_base_training_scale_smoke_ready": ready,
+            "full_training_executed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_improviser_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": (
+                "full non-Brad generic train/val manifests prepared as Stage B windows; "
+                "next step is controlled training scale smoke, not broad quality claim"
+            ),
+        },
+        "proven": [
+            "full_generic_manifest_train_val_boundary_preserved",
+            "stage_b_full_window_token_records_created",
+            "full_window_token_vocab_guard_passed",
+        ],
+        "not_proven": [
+            "generic_base_training_scale_smoke",
+            "full_generic_training_run",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": "Stage B generic base training scale smoke",
+    }
+
+
+def validate_full_window_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_ready: bool,
+    require_no_training_claim: bool,
+    require_no_quality_claim: bool,
+    min_tokenized_train_files: int,
+    min_tokenized_val_files: int,
+) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    token = _dict(report.get("token_stats"))
+    boundary = str(readiness.get("boundary") or "")
+    next_boundary = str(decision.get("next_boundary") or "")
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBGenericFullManifestWindowPreparationError(f"expected boundary {expected_boundary}, got {boundary}")
+    if expected_next_boundary and next_boundary != expected_next_boundary:
+        raise StageBGenericFullManifestWindowPreparationError(
+            f"expected next boundary {expected_next_boundary}, got {next_boundary}"
+        )
+    if require_ready and not bool(readiness.get("full_manifest_window_preparation_ready", False)):
+        raise StageBGenericFullManifestWindowPreparationError("full manifest window preparation must be ready")
+    if _int(token.get("tokenized_train_files")) < min_tokenized_train_files:
+        raise StageBGenericFullManifestWindowPreparationError("tokenized train records below threshold")
+    if _int(token.get("tokenized_val_files")) < min_tokenized_val_files:
+        raise StageBGenericFullManifestWindowPreparationError("tokenized val records below threshold")
+    if not bool(token.get("fits_vocab", False)):
+        raise StageBGenericFullManifestWindowPreparationError("token ids must fit vocab")
+    if require_no_training_claim and bool(readiness.get("full_training_executed", True)):
+        raise StageBGenericFullManifestWindowPreparationError("full training must not be claimed")
+    if require_no_quality_claim:
+        claimed = [
+            bool(readiness.get("broad_trained_model_quality_claimed", True)),
+            bool(readiness.get("brad_style_adaptation_claimed", True)),
+            bool(readiness.get("production_ready_improviser_claimed", True)),
+        ]
+        if any(claimed):
+            raise StageBGenericFullManifestWindowPreparationError("quality claims must remain false")
+    return {
+        "boundary": boundary,
+        "next_boundary": next_boundary,
+        "full_manifest_window_preparation_ready": bool(
+            readiness.get("full_manifest_window_preparation_ready", False)
+        ),
+        "generic_base_training_scale_smoke_ready": bool(
+            readiness.get("generic_base_training_scale_smoke_ready", False)
+        ),
+        "train_file_count": _int(_dict(report.get("input")).get("train_file_count")),
+        "val_file_count": _int(_dict(report.get("input")).get("val_file_count")),
+        "tokenized_train_files": _int(token.get("tokenized_train_files")),
+        "tokenized_val_files": _int(token.get("tokenized_val_files")),
+        "max_token_id": _int(token.get("max_token_id")),
+        "vocab_size": _int(token.get("vocab_size")),
+        "fits_vocab": bool(token.get("fits_vocab", False)),
+        "full_training_executed": bool(readiness.get("full_training_executed", True)),
+        "broad_trained_model_quality_claimed": bool(
+            readiness.get("broad_trained_model_quality_claimed", True)
+        ),
+        "auto_progress_allowed": bool(decision.get("auto_progress_allowed", False)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    inputs = report["input"]
+    token = report["token_stats"]
+    summary = report["dataset_summary"]
+    lines = [
+        "# Stage B Generic Full Manifest Window Preparation",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{readiness['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- full manifest window preparation ready: `{_bool_token(readiness['full_manifest_window_preparation_ready'])}`",
+        f"- training scale smoke ready: `{_bool_token(readiness['generic_base_training_scale_smoke_ready'])}`",
+        f"- full training executed: `{_bool_token(readiness['full_training_executed'])}`",
+        f"- broad trained-model quality claimed: `{_bool_token(readiness['broad_trained_model_quality_claimed'])}`",
+        f"- Brad style adaptation claimed: `{_bool_token(readiness['brad_style_adaptation_claimed'])}`",
+        "",
+        "## Input",
+        "",
+        f"- train files: `{inputs['train_file_count']}`",
+        f"- val files: `{inputs['val_file_count']}`",
+        f"- window bars: `{inputs['window_bars']}`",
+        f"- window stride bars: `{inputs['window_stride_bars']}`",
+        f"- min window target notes: `{inputs['min_window_target_notes']}`",
+        "",
+        "## Tokenized Records",
+        "",
+        f"- tokenized train files: `{token['tokenized_train_files']}`",
+        f"- tokenized val files: `{token['tokenized_val_files']}`",
+        f"- max token id: `{token['max_token_id']}`",
+        f"- vocab size: `{token['vocab_size']}`",
+        f"- fits vocab: `{_bool_token(token['fits_vocab'])}`",
+        f"- dataset train samples: `{summary.get('train_samples')}`",
+        f"- dataset val samples: `{summary.get('val_samples')}`",
+        "",
+        "## Not Proven",
+        "",
+    ]
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Prepare full generic manifests as Stage B windows")
+    parser.add_argument(
+        "--training_data_plan",
+        type=str,
+        default="outputs/stage_b_generic_model_core_training_data_plan/"
+        "harness_stage_b_generic_model_core_training_data_plan/"
+        "stage_b_generic_model_core_training_data_plan.json",
+    )
+    parser.add_argument(
+        "--manifests_dir",
+        type=str,
+        default="outputs/stage_b_generic_base_manifest_contract/"
+        "harness_stage_b_generic_base_manifest_contract/manifests",
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_generic_full_manifest_window_preparation",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--expected_boundary", type=str, default=BOUNDARY)
+    parser.add_argument("--expected_next_boundary", type=str, default=NEXT_BOUNDARY)
+    parser.add_argument("--require_ready", action="store_true")
+    parser.add_argument("--require_no_training_claim", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    parser.add_argument("--min_tokenized_train_files", type=int, default=1)
+    parser.add_argument("--min_tokenized_val_files", type=int, default=1)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    run_dir = Path(args.output_root) / run_id
+    if run_dir.exists():
+        shutil.rmtree(run_dir)
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    training_data_plan = read_json(Path(args.training_data_plan))
+    plan = validate_training_data_plan(training_data_plan)
+
+    manifests_dir = Path(args.manifests_dir)
+    train_manifest = run_dir / "manifests" / "generic_jazz_train.txt"
+    val_manifest = run_dir / "manifests" / "generic_jazz_val.txt"
+    train_count = copy_manifest(manifests_dir / "generic_jazz_train.txt", train_manifest)
+    val_count = copy_manifest(manifests_dir / "generic_jazz_val.txt", val_manifest)
+
+    roles_dir = run_dir / "roles"
+    run_command(
+        [
+            sys.executable,
+            "scripts/prepare_role_dataset.py",
+            "--train_manifest",
+            str(train_manifest),
+            "--val_manifest",
+            str(val_manifest),
+            "--output_dir",
+            str(roles_dir),
+            "--role",
+            "lead",
+            "--sequence_format",
+            "stage_b_v1",
+            "--stage_b_window_bars",
+            str(plan["window_bars"]),
+            "--stage_b_window_stride_bars",
+            str(plan["window_stride_bars"]),
+            "--stage_b_min_window_target_notes",
+            str(plan["min_window_target_notes"]),
+            "--overwrite",
+        ]
+    )
+
+    report = build_full_window_report(
+        run_dir=run_dir,
+        training_data_plan=training_data_plan,
+        source_manifests_dir=manifests_dir,
+        train_manifest=train_manifest,
+        val_manifest=val_manifest,
+        roles_dir=roles_dir,
+        train_file_count=train_count,
+        val_file_count=val_count,
+        window_bars=plan["window_bars"],
+        window_stride_bars=plan["window_stride_bars"],
+        min_window_target_notes=plan["min_window_target_notes"],
+    )
+    summary = validate_full_window_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_ready=bool(args.require_ready),
+        require_no_training_claim=bool(args.require_no_training_claim),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+        min_tokenized_train_files=int(args.min_tokenized_train_files),
+        min_tokenized_val_files=int(args.min_tokenized_val_files),
+    )
+    write_json(run_dir / "stage_b_generic_full_manifest_window_preparation.json", report)
+    write_json(run_dir / "stage_b_generic_full_manifest_window_preparation_validation_summary.json", summary)
+    markdown = markdown_report(report)
+    write_text(run_dir / "stage_b_generic_full_manifest_window_preparation.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_generic_full_manifest_window_preparation.py
+++ b/tests/test_stage_b_generic_full_manifest_window_preparation.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.run_stage_b_generic_full_manifest_window_preparation import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBGenericFullManifestWindowPreparationError,
+    validate_full_window_report,
+    validate_training_data_plan,
+)
+
+
+def training_data_plan(*, quality_claimed: bool = False) -> dict:
+    return {
+        "claim_boundary": {
+            "boundary": "stage_b_generic_model_core_training_data_plan",
+            "training_data_plan_ready": True,
+            "full_training_executed": False,
+            "broad_trained_model_quality_claimed": quality_claimed,
+        },
+        "decision": {
+            "next_boundary": BOUNDARY,
+        },
+        "training_data_plan": {
+            "generic_train_file_count": 2433,
+            "generic_val_file_count": 270,
+            "window_parameters": {
+                "window_bars": 2,
+                "window_stride_bars": 2,
+                "min_window_target_notes": 4,
+            },
+        },
+    }
+
+
+def full_window_report(
+    *,
+    ready: bool = True,
+    train_records: int = 100,
+    val_records: int = 10,
+    fits_vocab: bool = True,
+    quality_claimed: bool = False,
+) -> dict:
+    return {
+        "readiness": {
+            "boundary": BOUNDARY,
+            "full_manifest_window_preparation_ready": ready,
+            "generic_base_training_scale_smoke_ready": ready,
+            "full_training_executed": False,
+            "broad_trained_model_quality_claimed": quality_claimed,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_improviser_claimed": False,
+        },
+        "decision": {
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+        },
+        "input": {
+            "train_file_count": 2433,
+            "val_file_count": 270,
+        },
+        "token_stats": {
+            "tokenized_train_files": train_records,
+            "tokenized_val_files": val_records,
+            "max_token_id": 544,
+            "vocab_size": 547,
+            "fits_vocab": fits_vocab,
+        },
+        "next_recommended_issue": "Stage B generic base training scale smoke",
+    }
+
+
+class StageBGenericFullManifestWindowPreparationTest(unittest.TestCase):
+    def test_validates_training_data_plan(self) -> None:
+        plan = validate_training_data_plan(training_data_plan())
+
+        self.assertEqual(plan["generic_train_file_count"], 2433)
+        self.assertEqual(plan["generic_val_file_count"], 270)
+        self.assertEqual(plan["window_bars"], 2)
+
+    def test_rejects_quality_claim_in_plan(self) -> None:
+        with self.assertRaises(StageBGenericFullManifestWindowPreparationError):
+            validate_training_data_plan(training_data_plan(quality_claimed=True))
+
+    def test_validates_ready_full_window_report(self) -> None:
+        summary = validate_full_window_report(
+            full_window_report(),
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=NEXT_BOUNDARY,
+            require_ready=True,
+            require_no_training_claim=True,
+            require_no_quality_claim=True,
+            min_tokenized_train_files=1,
+            min_tokenized_val_files=1,
+        )
+
+        self.assertTrue(summary["full_manifest_window_preparation_ready"])
+        self.assertTrue(summary["generic_base_training_scale_smoke_ready"])
+        self.assertFalse(summary["full_training_executed"])
+        self.assertFalse(summary["broad_trained_model_quality_claimed"])
+        self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
+
+    def test_rejects_vocab_overflow(self) -> None:
+        with self.assertRaises(StageBGenericFullManifestWindowPreparationError):
+            validate_full_window_report(
+                full_window_report(fits_vocab=False),
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                require_ready=True,
+                require_no_training_claim=True,
+                require_no_quality_claim=True,
+                min_tokenized_train_files=1,
+                min_tokenized_val_files=1,
+            )
+
+    def test_rejects_missing_val_records(self) -> None:
+        with self.assertRaises(StageBGenericFullManifestWindowPreparationError):
+            validate_full_window_report(
+                full_window_report(val_records=0),
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                require_ready=True,
+                require_no_training_claim=True,
+                require_no_quality_claim=True,
+                min_tokenized_train_files=1,
+                min_tokenized_val_files=1,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Full non-Brad generic train/val manifest를 Stage B window records로 준비
- explicit train/val boundary 유지
- token/vocab guard 통과 기록
- full training과 broad quality claim 차단 유지

## Context

- #447 결과, 다음 실행 단위는 full generic manifest window preparation
- generic train/val manifest count: `2433/270`
- 후처리 repair loop는 중단, tiny checkpoint는 diagnostic-only

## Scope

- full manifest window preparation script 추가
- 전용 harness mode와 unit test 추가
- `docs/STAGE_B_GENERIC_FULL_MANIFEST_WINDOW_PREPARATION_2026-06-01.md` 생성
- CURRENT_STATUS_AND_PLAN, CORE_PLAN, AGENTS handoff 갱신

## Result

- generated samples: `175981`
- tokenized train / val files: `154136` / `21845`
- max token id / vocab size: `544` / `547`
- fits vocab: `true`
- output size: about `2.7GB`
- full training executed: `false`

## Validation

- `bash scripts/agent_harness.sh stage-b-generic-full-manifest-window-preparation`
- `.venv/bin/python -m unittest tests.test_stage_b_generic_full_manifest_window_preparation tests.test_stage_b_generic_model_core_training_data_plan`
- `.venv/bin/python -m py_compile scripts/run_stage_b_generic_full_manifest_window_preparation.py tests/test_stage_b_generic_full_manifest_window_preparation.py`
- `bash -n scripts/agent_harness.sh`
- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- Full training 미실행
- Broad trained-model quality 미검증
- Brad style adaptation 미검증
- Large generated local output under `outputs/`; not committed

Closes #449
