### PR TITLE
Stage B generic base scale checkpoint objective gate consolidation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #465, Stage B generic base scale checkpoint sustained coverage dead-air repair probe.
+- Latest functional issue completed: Issue #467, Stage B generic base scale checkpoint objective gate consolidation.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B generic base scale checkpoint objective gate consolidation.
+- Recommended next issue: Stage B generic base scale checkpoint objective gate repeatability sweep.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -978,6 +978,14 @@ bash scripts/agent_harness.sh stage-b-generic-base-scale-checkpoint-sustained-co
 ```
 
 This harness increases constrained note-group density while preserving duration-token guardrails, then verifies dead-air failure removal, sustained coverage recovery, and no broad model quality claim.
+
+For Stage B generic base scale checkpoint objective gate consolidation changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-generic-base-scale-checkpoint-objective-gate-consolidation
+```
+
+This harness consolidates current seed-set objective gate support and routes the next boundary to repeatability without claiming musical quality or human/audio preference.
 
 For Stage B generic tiny checkpoint generation probe changes, run:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -176,6 +176,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic base scale checkpoint duration long-note repair probe 문서: `docs/STAGE_B_GENERIC_BASE_SCALE_CHECKPOINT_DURATION_LONG_NOTE_REPAIR_PROBE_2026-06-01.md`
 - generic base scale checkpoint duration long-note remaining blocker decision 문서: `docs/STAGE_B_GENERIC_BASE_SCALE_CHECKPOINT_DURATION_LONG_NOTE_REMAINING_BLOCKER_DECISION_2026-06-01.md`
 - generic base scale checkpoint sustained coverage dead-air repair probe 문서: `docs/STAGE_B_GENERIC_BASE_SCALE_CHECKPOINT_SUSTAINED_COVERAGE_DEAD_AIR_REPAIR_PROBE_2026-06-01.md`
+- generic base scale checkpoint objective gate consolidation 문서: `docs/STAGE_B_GENERIC_BASE_SCALE_CHECKPOINT_OBJECTIVE_GATE_CONSOLIDATION_2026-06-01.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -290,6 +291,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic base scale checkpoint duration long-note repair probe: repair valid/strict/grammar `2/2/3`, long-note failure delta `2`, coverage delta `0.0208/-0.2708`, next boundary `generic_base_scale_checkpoint_duration_long_note_remaining_blocker_decision`
 - generic base scale checkpoint duration long-note remaining blocker decision: selected target `sustained_coverage_dead_air_repair`, dead-air failures `1`, coverage regression `true`, next boundary `generic_base_scale_checkpoint_sustained_coverage_dead_air_repair_probe`
 - generic base scale checkpoint sustained coverage dead-air repair probe: repair valid/strict/grammar `3/3/3`, dead-air failure delta `1`, sustained coverage delta `0.2708`, next boundary `generic_base_scale_checkpoint_objective_gate_consolidation`
+- generic base scale checkpoint objective gate consolidation: objective gate support `true`, single seed set only `true`, repeatability claim `false`, next boundary `generic_base_scale_checkpoint_objective_gate_repeatability_sweep`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -1689,6 +1691,19 @@ Issue #312는 constrained decoding으로 adjacent repeat를 줄였지만 dead-ai
 - remaining failure reason: none
 - raw generation quality / broad model quality / Brad style adaptation claim: `false` / `false` / `false`
 - 다음 작업은 generic base scale checkpoint objective gate consolidation이다.
+
+현재 generic base scale checkpoint objective gate consolidation:
+
+- Issue #467 result: boundary `stage_b_generic_base_scale_checkpoint_objective_gate_consolidation`
+- decision: `select_objective_gate_repeatability_sweep`
+- selected target: `objective_gate_repeatability_sweep`
+- objective gate support: `true`
+- single seed set only: `true`
+- valid / strict / grammar gate sample count: `3` / `3` / `3`
+- dead-air / long-note failure count: `0` / `0`
+- avg onset / sustained coverage: `0.3854166666666667` / `0.6354166666666666`
+- repeatability / musical quality / broad model quality / Brad style adaptation claim: `false` / `false` / `false` / `false`
+- 다음 작업은 generic base scale checkpoint objective gate repeatability sweep이다.
 
 ### Phase 5. Brad Style Adaptation
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #465, Stage B generic base scale checkpoint sustained coverage dead-air repair probe
-- 다음 권장 이슈: `Stage B generic base scale checkpoint objective gate consolidation`
+- latest functional result: Issue #467, Stage B generic base scale checkpoint objective gate consolidation
+- 다음 권장 이슈: `Stage B generic base scale checkpoint objective gate repeatability sweep`
 
 현재 범위가 아닌 것:
 
@@ -1592,6 +1592,46 @@ Issue #465는 #463에서 선택한 sustained coverage/dead-air target을 scale c
 다음:
 
 - `Stage B generic base scale checkpoint objective gate consolidation`
+
+## Stage B Generic Base Scale Checkpoint Objective Gate Consolidation
+
+Issue #467은 #465 repair 결과를 objective gate support로 통합하고, repeatability claim을 분리한 작업이다.
+
+변경:
+
+- objective gate consolidation script 추가
+- sustained coverage/dead-air repair probe report 입력 검증
+- valid/strict/grammar all-pass, failure reason absence, long-note guardrail 유지 확인
+- repeatability, musical quality, human/audio preference claim guard 유지
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_GENERIC_BASE_SCALE_CHECKPOINT_OBJECTIVE_GATE_CONSOLIDATION_2026-06-01.md`
+- boundary: `stage_b_generic_base_scale_checkpoint_objective_gate_consolidation`
+- decision: `select_objective_gate_repeatability_sweep`
+- selected target: `objective_gate_repeatability_sweep`
+- objective gate support: `true`
+- single seed set only: `true`
+- sample count: `3`
+- valid / strict / grammar gate sample count: `3` / `3` / `3`
+- dead-air / long-note failure count: `0` / `0`
+- avg onset / sustained coverage: `0.3854166666666667` / `0.6354166666666666`
+- repeatability claimed: `false`
+- musical quality claimed: `false`
+- broad trained model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+- next boundary: `stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep`
+
+판단:
+
+- 현재 seed set에서는 objective MIDI gate support 존재
+- repeatability와 listening quality는 아직 미검증
+- 다음 단계는 같은 조건을 seed 범위로 넓힌 repeatability sweep
+
+다음:
+
+- `Stage B generic base scale checkpoint objective gate repeatability sweep`
 
 ## Current Muzig Application Resume Wording Result
 

--- a/docs/STAGE_B_GENERIC_BASE_SCALE_CHECKPOINT_OBJECTIVE_GATE_CONSOLIDATION_2026-06-01.md
+++ b/docs/STAGE_B_GENERIC_BASE_SCALE_CHECKPOINT_OBJECTIVE_GATE_CONSOLIDATION_2026-06-01.md
@@ -1,0 +1,31 @@
+# Stage B Generic Base Scale Checkpoint Objective Gate Consolidation
+
+## Summary
+
+- boundary: `stage_b_generic_base_scale_checkpoint_objective_gate_consolidation`
+- decision: `select_objective_gate_repeatability_sweep`
+- selected target: `objective_gate_repeatability_sweep`
+- objective gate support: `true`
+- single seed set only: `true`
+- repeatability claimed: `false`
+- musical quality claimed: `false`
+- broad trained-model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+- next boundary: `stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep`
+
+## Evidence
+
+- sample count: `3`
+- valid / strict / grammar gate sample count: `3` / `3` / `3`
+- dead-air / long-note failure count: `0` / `0`
+- avg onset / sustained coverage: `0.3854166666666667` / `0.6354166666666666`
+- constrained note groups per bar: `8`
+- jazz duration tokens: `true`
+
+## Not Proven
+
+- `repeatability`
+- `musical_quality`
+- `human_audio_preference`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -184,6 +184,8 @@ Modes:
                 Decide the remaining blocker after duration/long-note repair qualification.
   stage-b-generic-base-scale-checkpoint-sustained-coverage-dead-air-repair-probe
                 Run sustained coverage/dead-air repair probe for the generic-base scale checkpoint.
+  stage-b-generic-base-scale-checkpoint-objective-gate-consolidation
+                Consolidate current seed-set objective gate support before repeatability.
   stage-b-generic-tiny-checkpoint-generation-probe
                 Probe generation/decode from the generic tiny checkpoint.
   stage-b-generic-tiny-checkpoint-grammar-repair
@@ -3416,6 +3418,25 @@ run_stage_b_generic_base_scale_checkpoint_sustained_coverage_dead_air_repair_pro
     --require_no_quality_claim
 }
 
+run_stage_b_generic_base_scale_checkpoint_objective_gate_consolidation() {
+  local repair_run_id="${REPAIR_RUN_ID:-harness_stage_b_generic_base_scale_checkpoint_sustained_coverage_dead_air_repair_probe}"
+  local run_id="${RUN_ID:-harness_stage_b_generic_base_scale_checkpoint_objective_gate_consolidation}"
+  local repair_probe="outputs/stage_b_generic_base_scale_checkpoint_sustained_coverage_dead_air_repair_probe/${repair_run_id}/stage_b_generic_base_scale_checkpoint_sustained_coverage_dead_air_repair_probe.json"
+  if [[ ! -f "$repair_probe" ]]; then
+    print_header "Stage B generic base scale checkpoint sustained coverage dead-air repair probe"
+    RUN_ID="$repair_run_id" run_stage_b_generic_base_scale_checkpoint_sustained_coverage_dead_air_repair_probe
+  fi
+  print_header "Stage B generic base scale checkpoint objective gate consolidation"
+  "$PYTHON_BIN" scripts/consolidate_stage_b_generic_base_scale_checkpoint_objective_gate.py \
+    --run_id "$run_id" \
+    --repair_probe "$repair_probe" \
+    --doc_path docs/STAGE_B_GENERIC_BASE_SCALE_CHECKPOINT_OBJECTIVE_GATE_CONSOLIDATION_2026-06-01.md \
+    --expected_boundary stage_b_generic_base_scale_checkpoint_objective_gate_consolidation \
+    --expected_next_boundary stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep \
+    --require_repeatability_target \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -4787,6 +4808,9 @@ case "$MODE" in
     ;;
   stage-b-generic-base-scale-checkpoint-sustained-coverage-dead-air-repair-probe)
     run_stage_b_generic_base_scale_checkpoint_sustained_coverage_dead_air_repair_probe
+    ;;
+  stage-b-generic-base-scale-checkpoint-objective-gate-consolidation)
+    run_stage_b_generic_base_scale_checkpoint_objective_gate_consolidation
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/consolidate_stage_b_generic_base_scale_checkpoint_objective_gate.py
+++ b/scripts/consolidate_stage_b_generic_base_scale_checkpoint_objective_gate.py
@@ -1,0 +1,367 @@
+"""Consolidate objective-gate evidence for the generic-base scale checkpoint."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+
+
+class StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError(ValueError):
+    pass
+
+
+SOURCE_BOUNDARY = "stage_b_generic_base_scale_checkpoint_sustained_coverage_dead_air_repair_probe"
+BOUNDARY = "stage_b_generic_base_scale_checkpoint_objective_gate_consolidation"
+NEXT_BOUNDARY = "stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep"
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def validate_repair_probe(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    repair = _dict(report.get("repair_summary"))
+    comparison = _dict(report.get("comparison"))
+    input_config = _dict(report.get("input"))
+    if str(readiness.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError(
+            "sustained coverage dead-air repair boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != BOUNDARY:
+        raise StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError(
+            "repair probe must route to objective gate consolidation"
+        )
+    if not bool(readiness.get("sustained_coverage_dead_air_target_qualified", False)):
+        raise StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError(
+            "sustained coverage dead-air target must be qualified"
+        )
+    if bool(readiness.get("raw_generation_quality_claimed", True)):
+        raise StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError(
+            "raw generation quality must not be claimed"
+        )
+    if bool(readiness.get("broad_trained_model_quality_claimed", True)):
+        raise StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError(
+            "broad trained-model quality must not be claimed"
+        )
+    if bool(readiness.get("brad_style_adaptation_claimed", True)):
+        raise StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError(
+            "Brad style adaptation must not be claimed"
+        )
+    sample_count = _int(repair.get("sample_count"))
+    if sample_count <= 0:
+        raise StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError("sample count required")
+    if _int(repair.get("valid_sample_count")) != sample_count:
+        raise StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError("all samples must pass valid gate")
+    if _int(repair.get("strict_valid_sample_count")) != sample_count:
+        raise StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError("all samples must pass strict gate")
+    if _int(repair.get("grammar_gate_sample_count")) != sample_count:
+        raise StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError("all samples must pass grammar gate")
+    if _int(repair.get("dead_air_failure_count")) != 0:
+        raise StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError(
+            "dead-air failures must be absent"
+        )
+    if _int(repair.get("long_note_failure_count")) != 0:
+        raise StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError(
+            "long-note failures must be absent"
+        )
+    if _dict(repair.get("diagnostic_failure_reasons")):
+        raise StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError(
+            "diagnostic failure reasons must be empty"
+        )
+    return {
+        "sample_count": sample_count,
+        "valid_sample_count": _int(repair.get("valid_sample_count")),
+        "strict_valid_sample_count": _int(repair.get("strict_valid_sample_count")),
+        "grammar_gate_sample_count": _int(repair.get("grammar_gate_sample_count")),
+        "dead_air_failure_count": _int(repair.get("dead_air_failure_count")),
+        "long_note_failure_count": _int(repair.get("long_note_failure_count")),
+        "avg_onset_coverage_ratio": _float(repair.get("avg_onset_coverage_ratio")),
+        "avg_sustained_coverage_ratio": _float(repair.get("avg_sustained_coverage_ratio")),
+        "max_longest_sustained_empty_run_steps": _int(
+            repair.get("max_longest_sustained_empty_run_steps")
+        ),
+        "dead_air_failure_delta": _int(comparison.get("dead_air_failure_delta")),
+        "valid_sample_delta": _int(comparison.get("valid_sample_delta")),
+        "strict_valid_sample_delta": _int(comparison.get("strict_valid_sample_delta")),
+        "onset_coverage_delta": _float(comparison.get("onset_coverage_delta")),
+        "sustained_coverage_delta": _float(comparison.get("sustained_coverage_delta")),
+        "long_note_failure_reintroduced": bool(
+            comparison.get("long_note_failure_reintroduced", True)
+        ),
+        "constrained_note_groups_per_bar": _int(input_config.get("constrained_note_groups_per_bar")),
+        "jazz_duration_tokens": bool(input_config.get("jazz_duration_tokens", False)),
+        "coverage_aware_positions": bool(input_config.get("coverage_aware_positions", False)),
+    }
+
+
+def build_consolidation_report(
+    repair_probe: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> dict[str, Any]:
+    evidence = validate_repair_probe(repair_probe)
+    return {
+        "schema_version": "stage_b_generic_base_scale_checkpoint_objective_gate_consolidation_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_schema": str(repair_probe.get("schema_version") or ""),
+        "input_boundary": SOURCE_BOUNDARY,
+        "evidence": {
+            **evidence,
+            "objective_gate_support": True,
+            "single_seed_set_only": True,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "decision": "select_objective_gate_repeatability_sweep",
+            "selected_target": "objective_gate_repeatability_sweep",
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": (
+                "current seed set passes objective MIDI gates, but repeatability and listening quality "
+                "remain unproven"
+            ),
+        },
+        "claim_boundary": {
+            "boundary": BOUNDARY,
+            "objective_gate_support_consolidated": True,
+            "repeatability_claimed": False,
+            "musical_quality_claimed": False,
+            "human_audio_preference_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_improviser_claimed": False,
+        },
+        "proven": [
+            "objective_gate_support_for_current_seed_set",
+            "dead_air_failure_removed_for_current_seed_set",
+            "long_note_guardrail_preserved_for_current_seed_set",
+        ],
+        "not_proven": [
+            "repeatability",
+            "musical_quality",
+            "human_audio_preference",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": "Stage B generic base scale checkpoint objective gate repeatability sweep",
+    }
+
+
+def validate_consolidation_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_repeatability_target: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    decision = _dict(report.get("decision"))
+    claim = _dict(report.get("claim_boundary"))
+    evidence = _dict(report.get("evidence"))
+    boundary = str(decision.get("current_boundary") or "")
+    next_boundary = str(decision.get("next_boundary") or "")
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and next_boundary != expected_next_boundary:
+        raise StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError(
+            f"expected next boundary {expected_next_boundary}, got {next_boundary}"
+        )
+    if require_repeatability_target and str(decision.get("selected_target") or "") != (
+        "objective_gate_repeatability_sweep"
+    ):
+        raise StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError(
+            "objective gate repeatability target required"
+        )
+    if not bool(evidence.get("objective_gate_support", False)):
+        raise StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError(
+            "objective gate support required"
+        )
+    if _int(evidence.get("dead_air_failure_count")) != 0:
+        raise StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError(
+            "dead-air failures must remain absent"
+        )
+    if _int(evidence.get("long_note_failure_count")) != 0:
+        raise StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError(
+            "long-note failures must remain absent"
+        )
+    if bool(evidence.get("long_note_failure_reintroduced", True)):
+        raise StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError(
+            "long-note failure must not be reintroduced"
+        )
+    if require_no_quality_claim:
+        claimed = [
+            bool(claim.get("repeatability_claimed", True)),
+            bool(claim.get("musical_quality_claimed", True)),
+            bool(claim.get("human_audio_preference_claimed", True)),
+            bool(claim.get("broad_trained_model_quality_claimed", True)),
+            bool(claim.get("brad_style_adaptation_claimed", True)),
+            bool(claim.get("production_ready_improviser_claimed", True)),
+        ]
+        if any(claimed):
+            raise StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError(
+                "quality and repeatability claims must remain false"
+            )
+    return {
+        "boundary": boundary,
+        "input_boundary": str(report.get("input_boundary") or ""),
+        "decision": str(decision.get("decision") or ""),
+        "selected_target": str(decision.get("selected_target") or ""),
+        "objective_gate_support": bool(evidence.get("objective_gate_support", False)),
+        "single_seed_set_only": bool(evidence.get("single_seed_set_only", False)),
+        "sample_count": _int(evidence.get("sample_count")),
+        "valid_sample_count": _int(evidence.get("valid_sample_count")),
+        "strict_valid_sample_count": _int(evidence.get("strict_valid_sample_count")),
+        "grammar_gate_sample_count": _int(evidence.get("grammar_gate_sample_count")),
+        "dead_air_failure_count": _int(evidence.get("dead_air_failure_count")),
+        "long_note_failure_count": _int(evidence.get("long_note_failure_count")),
+        "avg_sustained_coverage_ratio": _float(evidence.get("avg_sustained_coverage_ratio")),
+        "repeatability_claimed": bool(claim.get("repeatability_claimed", True)),
+        "musical_quality_claimed": bool(claim.get("musical_quality_claimed", True)),
+        "broad_trained_model_quality_claimed": bool(
+            claim.get("broad_trained_model_quality_claimed", True)
+        ),
+        "brad_style_adaptation_claimed": bool(claim.get("brad_style_adaptation_claimed", True)),
+        "auto_progress_allowed": bool(decision.get("auto_progress_allowed", False)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_boundary": next_boundary,
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    evidence = report["evidence"]
+    decision = report["decision"]
+    claim = report["claim_boundary"]
+    lines = [
+        "# Stage B Generic Base Scale Checkpoint Objective Gate Consolidation",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{decision['current_boundary']}`",
+        f"- decision: `{decision['decision']}`",
+        f"- selected target: `{decision['selected_target']}`",
+        f"- objective gate support: `{_bool_token(evidence['objective_gate_support'])}`",
+        f"- single seed set only: `{_bool_token(evidence['single_seed_set_only'])}`",
+        f"- repeatability claimed: `{_bool_token(claim['repeatability_claimed'])}`",
+        f"- musical quality claimed: `{_bool_token(claim['musical_quality_claimed'])}`",
+        f"- broad trained-model quality claimed: `{_bool_token(claim['broad_trained_model_quality_claimed'])}`",
+        f"- Brad style adaptation claimed: `{_bool_token(claim['brad_style_adaptation_claimed'])}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        "",
+        "## Evidence",
+        "",
+        f"- sample count: `{evidence['sample_count']}`",
+        (
+            "- valid / strict / grammar gate sample count: "
+            f"`{evidence['valid_sample_count']}` / `{evidence['strict_valid_sample_count']}` / "
+            f"`{evidence['grammar_gate_sample_count']}`"
+        ),
+        f"- dead-air / long-note failure count: `{evidence['dead_air_failure_count']}` / `{evidence['long_note_failure_count']}`",
+        f"- avg onset / sustained coverage: `{evidence['avg_onset_coverage_ratio']}` / `{evidence['avg_sustained_coverage_ratio']}`",
+        f"- constrained note groups per bar: `{evidence['constrained_note_groups_per_bar']}`",
+        f"- jazz duration tokens: `{_bool_token(evidence['jazz_duration_tokens'])}`",
+        "",
+        "## Not Proven",
+        "",
+    ]
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Consolidate Stage B generic base scale checkpoint objective gate evidence"
+    )
+    parser.add_argument(
+        "--repair_probe",
+        type=str,
+        default="outputs/stage_b_generic_base_scale_checkpoint_sustained_coverage_dead_air_repair_probe/"
+        "harness_stage_b_generic_base_scale_checkpoint_sustained_coverage_dead_air_repair_probe/"
+        "stage_b_generic_base_scale_checkpoint_sustained_coverage_dead_air_repair_probe.json",
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_generic_base_scale_checkpoint_objective_gate_consolidation",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_repeatability_target", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    report = build_consolidation_report(
+        read_json(Path(args.repair_probe)),
+        output_dir=output_dir,
+    )
+    summary = validate_consolidation_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_repeatability_target=bool(args.require_repeatability_target),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    write_json(
+        output_dir / "stage_b_generic_base_scale_checkpoint_objective_gate_consolidation.json",
+        report,
+    )
+    write_json(
+        output_dir / "stage_b_generic_base_scale_checkpoint_objective_gate_consolidation_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir / "stage_b_generic_base_scale_checkpoint_objective_gate_consolidation.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_generic_base_scale_checkpoint_objective_gate_consolidation.py
+++ b/tests/test_stage_b_generic_base_scale_checkpoint_objective_gate_consolidation.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.consolidate_stage_b_generic_base_scale_checkpoint_objective_gate import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    SOURCE_BOUNDARY,
+    StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError,
+    build_consolidation_report,
+    validate_consolidation_report,
+)
+
+
+def repair_probe(
+    *,
+    target_qualified: bool = True,
+    all_pass: bool = True,
+    quality_claim: bool = False,
+    dead_air_failure_count: int = 0,
+    long_note_failure_count: int = 0,
+) -> dict:
+    sample_count = 3
+    pass_count = sample_count if all_pass else 2
+    return {
+        "schema_version": "stage_b_generic_base_scale_checkpoint_sustained_coverage_dead_air_repair_probe_v1",
+        "readiness": {
+            "boundary": SOURCE_BOUNDARY,
+            "sustained_coverage_dead_air_target_qualified": target_qualified,
+            "raw_generation_quality_claimed": quality_claim,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "next_boundary": BOUNDARY,
+            "critical_user_input_required": False,
+        },
+        "input": {
+            "constrained_note_groups_per_bar": 8,
+            "jazz_duration_tokens": True,
+            "coverage_aware_positions": True,
+        },
+        "repair_summary": {
+            "sample_count": sample_count,
+            "valid_sample_count": pass_count,
+            "strict_valid_sample_count": pass_count,
+            "grammar_gate_sample_count": pass_count,
+            "dead_air_failure_count": dead_air_failure_count,
+            "long_note_failure_count": long_note_failure_count,
+            "diagnostic_failure_reasons": {},
+            "avg_onset_coverage_ratio": 0.3854166666666667,
+            "avg_sustained_coverage_ratio": 0.6354166666666666,
+            "max_longest_sustained_empty_run_steps": 4,
+        },
+        "comparison": {
+            "dead_air_failure_delta": 1,
+            "valid_sample_delta": 1,
+            "strict_valid_sample_delta": 1,
+            "onset_coverage_delta": 0.19791666666666669,
+            "sustained_coverage_delta": 0.2708333333333333,
+            "long_note_failure_reintroduced": long_note_failure_count > 0,
+        },
+    }
+
+
+class StageBGenericBaseScaleCheckpointObjectiveGateConsolidationTest(unittest.TestCase):
+    def test_selects_objective_gate_repeatability_sweep(self) -> None:
+        report = build_consolidation_report(
+            repair_probe(),
+            output_dir=Path("outputs/objective_gate"),
+        )
+        summary = validate_consolidation_report(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=NEXT_BOUNDARY,
+            require_repeatability_target=True,
+            require_no_quality_claim=True,
+        )
+
+        self.assertEqual(summary["decision"], "select_objective_gate_repeatability_sweep")
+        self.assertEqual(summary["selected_target"], "objective_gate_repeatability_sweep")
+        self.assertTrue(summary["objective_gate_support"])
+        self.assertTrue(summary["single_seed_set_only"])
+        self.assertEqual(summary["valid_sample_count"], 3)
+        self.assertEqual(summary["strict_valid_sample_count"], 3)
+        self.assertEqual(summary["grammar_gate_sample_count"], 3)
+        self.assertEqual(summary["dead_air_failure_count"], 0)
+        self.assertEqual(summary["long_note_failure_count"], 0)
+        self.assertFalse(summary["repeatability_claimed"])
+        self.assertFalse(summary["musical_quality_claimed"])
+        self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
+
+    def test_rejects_unqualified_repair(self) -> None:
+        with self.assertRaises(StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError):
+            build_consolidation_report(
+                repair_probe(target_qualified=False),
+                output_dir=Path("outputs/objective_gate"),
+            )
+
+    def test_rejects_partial_objective_gate_pass(self) -> None:
+        with self.assertRaises(StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError):
+            build_consolidation_report(
+                repair_probe(all_pass=False),
+                output_dir=Path("outputs/objective_gate"),
+            )
+
+    def test_rejects_remaining_dead_air_failure(self) -> None:
+        with self.assertRaises(StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError):
+            build_consolidation_report(
+                repair_probe(dead_air_failure_count=1),
+                output_dir=Path("outputs/objective_gate"),
+            )
+
+    def test_rejects_long_note_regression(self) -> None:
+        with self.assertRaises(StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError):
+            build_consolidation_report(
+                repair_probe(long_note_failure_count=1),
+                output_dir=Path("outputs/objective_gate"),
+            )
+
+    def test_rejects_quality_claim(self) -> None:
+        with self.assertRaises(StageBGenericBaseScaleCheckpointObjectiveGateConsolidationError):
+            build_consolidation_report(
+                repair_probe(quality_claim=True),
+                output_dir=Path("outputs/objective_gate"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- #465 repair result를 objective gate support로 consolidation
- repeatability / musical quality / human-audio preference claim 분리
- next boundary를 objective gate repeatability sweep으로 설정
- 상태 문서와 required harness 갱신

## Context

- repair valid / strict / grammar sample count: `3 / 3 / 3`
- repair dead-air / long-note failure count: `0 / 0`
- avg onset / sustained coverage: `0.3854166666666667 / 0.6354166666666666`
- constrained note groups per bar: `8`
- jazz duration tokens: `true`

## Decision

- selected target: `objective_gate_repeatability_sweep`
- objective gate support: `true`
- single seed set only: `true`
- repeatability, musical quality, broad trained-model quality, Brad style adaptation claim: `false / false / false / false`

## Validation

- `bash scripts/agent_harness.sh stage-b-generic-base-scale-checkpoint-objective-gate-consolidation`
- `.venv/bin/python -m unittest tests.test_stage_b_generic_base_scale_checkpoint_objective_gate_consolidation tests.test_stage_b_generic_base_scale_checkpoint_sustained_coverage_dead_air_repair_probe`
- `.venv/bin/python -m py_compile scripts/consolidate_stage_b_generic_base_scale_checkpoint_objective_gate.py scripts/run_stage_b_generic_base_scale_checkpoint_sustained_coverage_dead_air_repair_probe.py`
- `bash -n scripts/agent_harness.sh`
- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- Current evidence is a single seed set only.
- Musical quality and listening preference remain unclaimed.

## Follow-up

- objective gate repeatability sweep

Closes #467


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project roadmap and milestone tracking with completion of a development checkpoint.
  * Added comprehensive documentation for a project stage including evidence metrics and validation results.

* **Tests**
  * Added new test suite to validate project checkpoint consolidation and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->