### PR TITLE
Stage B generic base scale checkpoint objective gate repeatability sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #467, Stage B generic base scale checkpoint objective gate consolidation.
+- Latest functional issue completed: Issue #469, Stage B generic base scale checkpoint objective gate repeatability sweep.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B generic base scale checkpoint objective gate repeatability sweep.
+- Recommended next issue: Stage B generic base scale checkpoint repeatability consolidation.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -986,6 +986,14 @@ bash scripts/agent_harness.sh stage-b-generic-base-scale-checkpoint-objective-ga
 ```
 
 This harness consolidates current seed-set objective gate support and routes the next boundary to repeatability without claiming musical quality or human/audio preference.
+
+For Stage B generic base scale checkpoint objective gate repeatability sweep changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-generic-base-scale-checkpoint-objective-gate-repeatability-sweep
+```
+
+This harness repeats the objective gate probe across multiple seed starts and records repeatability while keeping musical quality and human/audio preference unclaimed.
 
 For Stage B generic tiny checkpoint generation probe changes, run:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -177,6 +177,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic base scale checkpoint duration long-note remaining blocker decision 문서: `docs/STAGE_B_GENERIC_BASE_SCALE_CHECKPOINT_DURATION_LONG_NOTE_REMAINING_BLOCKER_DECISION_2026-06-01.md`
 - generic base scale checkpoint sustained coverage dead-air repair probe 문서: `docs/STAGE_B_GENERIC_BASE_SCALE_CHECKPOINT_SUSTAINED_COVERAGE_DEAD_AIR_REPAIR_PROBE_2026-06-01.md`
 - generic base scale checkpoint objective gate consolidation 문서: `docs/STAGE_B_GENERIC_BASE_SCALE_CHECKPOINT_OBJECTIVE_GATE_CONSOLIDATION_2026-06-01.md`
+- generic base scale checkpoint objective gate repeatability sweep 문서: `docs/STAGE_B_GENERIC_BASE_SCALE_CHECKPOINT_OBJECTIVE_GATE_REPEATABILITY_SWEEP_2026-06-01.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -292,6 +293,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic base scale checkpoint duration long-note remaining blocker decision: selected target `sustained_coverage_dead_air_repair`, dead-air failures `1`, coverage regression `true`, next boundary `generic_base_scale_checkpoint_sustained_coverage_dead_air_repair_probe`
 - generic base scale checkpoint sustained coverage dead-air repair probe: repair valid/strict/grammar `3/3/3`, dead-air failure delta `1`, sustained coverage delta `0.2708`, next boundary `generic_base_scale_checkpoint_objective_gate_consolidation`
 - generic base scale checkpoint objective gate consolidation: objective gate support `true`, single seed set only `true`, repeatability claim `false`, next boundary `generic_base_scale_checkpoint_objective_gate_repeatability_sweep`
+- generic base scale checkpoint objective gate repeatability sweep: seeds `44/52/60`, valid/strict/grammar `9/9/9`, repeatability claim `true`, quality claim `false`, next boundary `generic_base_scale_checkpoint_repeatability_consolidation`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 
@@ -1704,6 +1706,21 @@ Issue #312는 constrained decoding으로 adjacent repeat를 줄였지만 dead-ai
 - avg onset / sustained coverage: `0.3854166666666667` / `0.6354166666666666`
 - repeatability / musical quality / broad model quality / Brad style adaptation claim: `false` / `false` / `false` / `false`
 - 다음 작업은 generic base scale checkpoint objective gate repeatability sweep이다.
+
+현재 generic base scale checkpoint objective gate repeatability sweep:
+
+- Issue #469 result: boundary `stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep`
+- objective gate repeatability target qualified: `true`
+- repeatability claimed: `true`
+- seeds: `[44, 52, 60]`
+- seed count: `3`
+- sample count: `9`
+- valid / strict / grammar gate sample count: `9` / `9` / `9`
+- avg onset / sustained coverage: `0.4236111111111111` / `0.6805555555555556`
+- max longest sustained empty run steps: `4`
+- failure reasons: none
+- raw generation quality / broad model quality / Brad style adaptation claim: `false` / `false` / `false`
+- 다음 작업은 generic base scale checkpoint repeatability consolidation이다.
 
 ### Phase 5. Brad Style Adaptation
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #467, Stage B generic base scale checkpoint objective gate consolidation
-- 다음 권장 이슈: `Stage B generic base scale checkpoint objective gate repeatability sweep`
+- latest functional result: Issue #469, Stage B generic base scale checkpoint objective gate repeatability sweep
+- 다음 권장 이슈: `Stage B generic base scale checkpoint repeatability consolidation`
 
 현재 범위가 아닌 것:
 
@@ -1632,6 +1632,46 @@ Issue #467은 #465 repair 결과를 objective gate support로 통합하고, repe
 다음:
 
 - `Stage B generic base scale checkpoint objective gate repeatability sweep`
+
+## Stage B Generic Base Scale Checkpoint Objective Gate Repeatability Sweep
+
+Issue #469는 #467에서 선택한 objective gate repeatability target을 seed 범위로 확장해 검증한 작업이다.
+
+변경:
+
+- objective gate repeatability sweep script 추가
+- objective gate consolidation report와 repair probe report 입력 검증
+- seed `44`, `52`, `60`에 대해 동일 generation 조건 반복
+- aggregate pass-rate, coverage, failure reason 집계
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_GENERIC_BASE_SCALE_CHECKPOINT_OBJECTIVE_GATE_REPEATABILITY_SWEEP_2026-06-01.md`
+- boundary: `stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep`
+- objective gate repeatability target qualified: `true`
+- repeatability claimed: `true`
+- seeds: `[44, 52, 60]`
+- seed count: `3`
+- sample count: `9`
+- valid / strict / grammar gate sample count: `9` / `9` / `9`
+- avg onset / sustained coverage: `0.4236111111111111` / `0.6805555555555556`
+- max longest sustained empty run steps: `4`
+- failure reasons: none
+- raw generation quality claimed: `false`
+- broad trained model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+- next boundary: `stage_b_generic_base_scale_checkpoint_repeatability_consolidation`
+
+판단:
+
+- 현재 constrained condition은 seed `44/52/60` sweep에서 objective gate 반복성 확보
+- repeatability는 objective MIDI gate 범위로만 claim
+- musical quality, human/audio preference, broad trained-model quality는 별도 검증 전까지 claim 불가
+
+다음:
+
+- `Stage B generic base scale checkpoint repeatability consolidation`
 
 ## Current Muzig Application Resume Wording Result
 

--- a/docs/STAGE_B_GENERIC_BASE_SCALE_CHECKPOINT_OBJECTIVE_GATE_REPEATABILITY_SWEEP_2026-06-01.md
+++ b/docs/STAGE_B_GENERIC_BASE_SCALE_CHECKPOINT_OBJECTIVE_GATE_REPEATABILITY_SWEEP_2026-06-01.md
@@ -1,0 +1,38 @@
+# Stage B Generic Base Scale Checkpoint Objective Gate Repeatability Sweep
+
+## Summary
+
+- boundary: `stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep`
+- next boundary: `stage_b_generic_base_scale_checkpoint_repeatability_consolidation`
+- objective gate repeatability target qualified: `true`
+- repeatability claimed: `true`
+- raw generation quality claimed: `false`
+- broad trained-model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+
+## Aggregate
+
+- seeds: `[44, 52, 60]`
+- seed count: `3`
+- sample count: `9`
+- valid / strict / grammar gate sample count: `9` / `9` / `9`
+- avg onset / sustained coverage: `0.4236111111111111` / `0.6805555555555556`
+- max longest sustained empty run steps: `4`
+
+## Delta
+
+- source sample count: `3`
+- repeatability sample count: `9`
+- strict valid sample delta: `6`
+- sustained coverage delta: `0.04513888888888895`
+
+## Failure Reasons
+
+- none
+
+## Not Proven
+
+- `musical_quality`
+- `human_audio_preference`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -186,6 +186,8 @@ Modes:
                 Run sustained coverage/dead-air repair probe for the generic-base scale checkpoint.
   stage-b-generic-base-scale-checkpoint-objective-gate-consolidation
                 Consolidate current seed-set objective gate support before repeatability.
+  stage-b-generic-base-scale-checkpoint-objective-gate-repeatability-sweep
+                Run objective gate repeatability sweep for the generic-base scale checkpoint.
   stage-b-generic-tiny-checkpoint-generation-probe
                 Probe generation/decode from the generic tiny checkpoint.
   stage-b-generic-tiny-checkpoint-grammar-repair
@@ -3437,6 +3439,32 @@ run_stage_b_generic_base_scale_checkpoint_objective_gate_consolidation() {
     --require_no_quality_claim
 }
 
+run_stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep() {
+  local consolidation_run_id="${CONSOLIDATION_RUN_ID:-harness_stage_b_generic_base_scale_checkpoint_objective_gate_consolidation}"
+  local repair_run_id="${REPAIR_RUN_ID:-harness_stage_b_generic_base_scale_checkpoint_sustained_coverage_dead_air_repair_probe}"
+  local run_id="${RUN_ID:-harness_stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep}"
+  local consolidation="outputs/stage_b_generic_base_scale_checkpoint_objective_gate_consolidation/${consolidation_run_id}/stage_b_generic_base_scale_checkpoint_objective_gate_consolidation.json"
+  local repair_probe="outputs/stage_b_generic_base_scale_checkpoint_sustained_coverage_dead_air_repair_probe/${repair_run_id}/stage_b_generic_base_scale_checkpoint_sustained_coverage_dead_air_repair_probe.json"
+  if [[ ! -f "$repair_probe" ]]; then
+    print_header "Stage B generic base scale checkpoint sustained coverage dead-air repair probe"
+    RUN_ID="$repair_run_id" run_stage_b_generic_base_scale_checkpoint_sustained_coverage_dead_air_repair_probe
+  fi
+  if [[ ! -f "$consolidation" ]]; then
+    print_header "Stage B generic base scale checkpoint objective gate consolidation"
+    RUN_ID="$consolidation_run_id" REPAIR_RUN_ID="$repair_run_id" run_stage_b_generic_base_scale_checkpoint_objective_gate_consolidation
+  fi
+  print_header "Stage B generic base scale checkpoint objective gate repeatability sweep"
+  "$PYTHON_BIN" scripts/run_stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep.py \
+    --run_id "$run_id" \
+    --consolidation "$consolidation" \
+    --repair_probe "$repair_probe" \
+    --doc_path docs/STAGE_B_GENERIC_BASE_SCALE_CHECKPOINT_OBJECTIVE_GATE_REPEATABILITY_SWEEP_2026-06-01.md \
+    --expected_boundary stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep \
+    --expected_next_boundary stage_b_generic_base_scale_checkpoint_repeatability_consolidation \
+    --require_target_qualified \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -4811,6 +4839,9 @@ case "$MODE" in
     ;;
   stage-b-generic-base-scale-checkpoint-objective-gate-consolidation)
     run_stage_b_generic_base_scale_checkpoint_objective_gate_consolidation
+    ;;
+  stage-b-generic-base-scale-checkpoint-objective-gate-repeatability-sweep)
+    run_stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/run_stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep.py
+++ b/scripts/run_stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep.py
@@ -1,0 +1,606 @@
+"""Run objective-gate repeatability sweep for the generic-base scale checkpoint."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+
+
+class StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError(ValueError):
+    pass
+
+
+SOURCE_BOUNDARY = "stage_b_generic_base_scale_checkpoint_objective_gate_consolidation"
+REPAIR_BOUNDARY = "stage_b_generic_base_scale_checkpoint_sustained_coverage_dead_air_repair_probe"
+BOUNDARY = "stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep"
+NEXT_BOUNDARY = "stage_b_generic_base_scale_checkpoint_repeatability_consolidation"
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def parse_seeds(raw: str) -> list[int]:
+    seeds: list[int] = []
+    for part in str(raw).split(","):
+        stripped = part.strip()
+        if not stripped:
+            continue
+        seeds.append(int(stripped))
+    if not seeds:
+        raise StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError("seed list required")
+    return seeds
+
+
+def run_command(command: Sequence[str]) -> dict[str, Any]:
+    completed = subprocess.run(
+        list(command),
+        cwd=str(ROOT_DIR),
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    return {
+        "cmd": list(command),
+        "returncode": int(completed.returncode),
+        "stdout_tail": completed.stdout[-4000:],
+        "stderr_tail": completed.stderr[-4000:],
+    }
+
+
+def merge_counts(target: dict[str, int], source: dict[str, Any]) -> None:
+    for key, value in source.items():
+        target[str(key)] = _int(target.get(str(key))) + _int(value)
+
+
+def validate_consolidation(report: dict[str, Any]) -> dict[str, Any]:
+    decision = _dict(report.get("decision"))
+    claim = _dict(report.get("claim_boundary"))
+    evidence = _dict(report.get("evidence"))
+    if str(decision.get("current_boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError(
+            "objective gate consolidation boundary required"
+        )
+    if str(decision.get("selected_target") or "") != "objective_gate_repeatability_sweep":
+        raise StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError(
+            "objective gate repeatability target required"
+        )
+    if str(decision.get("next_boundary") or "") != BOUNDARY:
+        raise StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError(
+            "consolidation must route to repeatability sweep"
+        )
+    if not bool(evidence.get("objective_gate_support", False)):
+        raise StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError(
+            "objective gate support required"
+        )
+    if not bool(evidence.get("single_seed_set_only", False)):
+        raise StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError(
+            "single seed set boundary required"
+        )
+    if bool(claim.get("repeatability_claimed", True)):
+        raise StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError(
+            "repeatability must not already be claimed"
+        )
+    if bool(claim.get("musical_quality_claimed", True)):
+        raise StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError(
+            "musical quality must not be claimed"
+        )
+    return {
+        "source_sample_count": _int(evidence.get("sample_count")),
+        "source_valid_sample_count": _int(evidence.get("valid_sample_count")),
+        "source_strict_valid_sample_count": _int(evidence.get("strict_valid_sample_count")),
+        "source_grammar_gate_sample_count": _int(evidence.get("grammar_gate_sample_count")),
+        "source_avg_sustained_coverage_ratio": _float(evidence.get("avg_sustained_coverage_ratio")),
+        "constrained_note_groups_per_bar": _int(evidence.get("constrained_note_groups_per_bar")),
+        "jazz_duration_tokens": bool(evidence.get("jazz_duration_tokens", False)),
+        "coverage_aware_positions": bool(evidence.get("coverage_aware_positions", False)),
+    }
+
+
+def validate_repair_probe(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    baseline = _dict(report.get("baseline_repair_summary"))
+    input_config = _dict(report.get("input"))
+    if str(readiness.get("boundary") or "") != REPAIR_BOUNDARY:
+        raise StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError(
+            "sustained coverage dead-air repair boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError(
+            "repair probe must route to objective gate consolidation"
+        )
+    if not bool(readiness.get("sustained_coverage_dead_air_target_qualified", False)):
+        raise StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError(
+            "sustained coverage dead-air target must be qualified"
+        )
+    checkpoint_dir = Path(str(baseline.get("checkpoint_dir") or ""))
+    if not (checkpoint_dir / "checkpoint_epoch1.pt").exists():
+        raise StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError(
+            "scale checkpoint required"
+        )
+    return {
+        "checkpoint_dir": str(checkpoint_dir),
+        "constrained_note_groups_per_bar": _int(input_config.get("constrained_note_groups_per_bar")),
+        "coverage_position_window": _int(input_config.get("coverage_position_window")),
+        "max_simultaneous_notes": _int(input_config.get("max_simultaneous_notes")),
+    }
+
+
+def build_generation_command(
+    args: argparse.Namespace,
+    *,
+    seed: int,
+    checkpoint_dir: Path,
+    probe_output_root: Path,
+    probe_run_id: str,
+) -> list[str]:
+    return [
+        sys.executable,
+        "scripts/run_stage_b_generation_probe.py",
+        "--output_root",
+        str(probe_output_root),
+        "--run_id",
+        probe_run_id,
+        "--checkpoint_dir",
+        str(checkpoint_dir),
+        "--skip_prepare",
+        "--skip_train",
+        "--issue_number",
+        str(args.issue_number),
+        "--max_sequence",
+        str(args.max_sequence),
+        "--num_samples",
+        str(args.num_samples),
+        "--seed",
+        str(seed),
+        "--temperature",
+        str(args.temperature),
+        "--top_k",
+        str(args.top_k),
+        "--min_valid_samples",
+        str(args.min_valid_samples),
+        "--min_strict_valid_samples",
+        str(args.min_strict_valid_samples),
+        "--generation_mode",
+        "constrained",
+        "--constrained_note_groups_per_bar",
+        str(args.constrained_note_groups_per_bar),
+        "--coverage_aware_positions",
+        "--coverage_position_window",
+        str(args.coverage_position_window),
+        "--jazz_duration_tokens",
+        "--postprocess_overlap",
+        "--max_simultaneous_notes",
+        str(args.max_simultaneous_notes),
+    ]
+
+
+def run_seed_probe(
+    args: argparse.Namespace,
+    *,
+    seed: int,
+    checkpoint_dir: Path,
+    probe_output_root: Path,
+) -> dict[str, Any]:
+    probe_run_id = f"seed_{seed}"
+    command_result = run_command(
+        build_generation_command(
+            args,
+            seed=seed,
+            checkpoint_dir=checkpoint_dir,
+            probe_output_root=probe_output_root,
+            probe_run_id=probe_run_id,
+        )
+    )
+    report_path = probe_output_root / probe_run_id / "report.json"
+    generation_report = read_json(report_path) if report_path.exists() else {}
+    summary = _dict(generation_report.get("summary"))
+    return {
+        "seed": int(seed),
+        "generation_report_path": str(report_path),
+        "generation_command": command_result,
+        "sample_count": _int(summary.get("sample_count")),
+        "valid_sample_count": _int(summary.get("valid_sample_count")),
+        "strict_valid_sample_count": _int(summary.get("strict_valid_sample_count")),
+        "grammar_gate_sample_count": _int(summary.get("grammar_gate_sample_count")),
+        "failure_reasons": _dict(summary.get("failure_reasons")),
+        "diagnostic_failure_reasons": _dict(summary.get("diagnostic_failure_reasons")),
+        "strict_failure_reasons": _dict(summary.get("strict_failure_reasons")),
+        "collapse_warning_sample_count": _int(summary.get("collapse_warning_sample_count")),
+        "avg_onset_coverage_ratio": _float(summary.get("avg_onset_coverage_ratio")),
+        "avg_sustained_coverage_ratio": _float(summary.get("avg_sustained_coverage_ratio")),
+        "max_longest_sustained_empty_run_steps": _int(
+            summary.get("max_longest_sustained_empty_run_steps")
+        ),
+        "passed_strict_review_gate": bool(generation_report.get("passed_strict_review_gate", False)),
+        "passed_grammar_gate": bool(generation_report.get("passed_grammar_gate", False)),
+    }
+
+
+def aggregate_seed_rows(seed_rows: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    total_sample_count = sum(_int(row.get("sample_count")) for row in seed_rows)
+    total_valid = sum(_int(row.get("valid_sample_count")) for row in seed_rows)
+    total_strict = sum(_int(row.get("strict_valid_sample_count")) for row in seed_rows)
+    total_grammar = sum(_int(row.get("grammar_gate_sample_count")) for row in seed_rows)
+    failure_reasons: dict[str, int] = {}
+    diagnostic_failure_reasons: dict[str, int] = {}
+    strict_failure_reasons: dict[str, int] = {}
+    for row in seed_rows:
+        merge_counts(failure_reasons, _dict(row.get("failure_reasons")))
+        merge_counts(diagnostic_failure_reasons, _dict(row.get("diagnostic_failure_reasons")))
+        merge_counts(strict_failure_reasons, _dict(row.get("strict_failure_reasons")))
+    weighted_onset = sum(
+        _float(row.get("avg_onset_coverage_ratio")) * _int(row.get("sample_count"))
+        for row in seed_rows
+    )
+    weighted_sustained = sum(
+        _float(row.get("avg_sustained_coverage_ratio")) * _int(row.get("sample_count"))
+        for row in seed_rows
+    )
+    return {
+        "seed_count": len(seed_rows),
+        "seeds": [int(row["seed"]) for row in seed_rows],
+        "sample_count": int(total_sample_count),
+        "valid_sample_count": int(total_valid),
+        "strict_valid_sample_count": int(total_strict),
+        "grammar_gate_sample_count": int(total_grammar),
+        "valid_sample_rate": float(total_valid / total_sample_count) if total_sample_count else 0.0,
+        "strict_valid_sample_rate": float(total_strict / total_sample_count) if total_sample_count else 0.0,
+        "grammar_gate_sample_rate": float(total_grammar / total_sample_count) if total_sample_count else 0.0,
+        "failure_reasons": failure_reasons,
+        "diagnostic_failure_reasons": diagnostic_failure_reasons,
+        "strict_failure_reasons": strict_failure_reasons,
+        "collapse_warning_sample_count": sum(
+            _int(row.get("collapse_warning_sample_count")) for row in seed_rows
+        ),
+        "avg_onset_coverage_ratio": (
+            float(weighted_onset / total_sample_count) if total_sample_count else 0.0
+        ),
+        "avg_sustained_coverage_ratio": (
+            float(weighted_sustained / total_sample_count) if total_sample_count else 0.0
+        ),
+        "max_longest_sustained_empty_run_steps": max(
+            [_int(row.get("max_longest_sustained_empty_run_steps")) for row in seed_rows] or [0]
+        ),
+        "all_seed_commands_succeeded": all(
+            _int(_dict(row.get("generation_command")).get("returncode")) == 0 for row in seed_rows
+        ),
+        "all_seed_strict_review_gate_passed": all(
+            bool(row.get("passed_strict_review_gate", False)) for row in seed_rows
+        ),
+    }
+
+
+def build_sweep_report(
+    *,
+    run_dir: Path,
+    consolidation_summary: dict[str, Any],
+    repair_config: dict[str, Any],
+    seed_rows: list[dict[str, Any]],
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    aggregate = aggregate_seed_rows(seed_rows)
+    target_qualified = (
+        bool(aggregate["all_seed_commands_succeeded"])
+        and bool(aggregate["all_seed_strict_review_gate_passed"])
+        and _int(aggregate["sample_count"]) > 0
+        and _int(aggregate["strict_valid_sample_count"]) == _int(aggregate["sample_count"])
+        and _int(aggregate["grammar_gate_sample_count"]) == _int(aggregate["sample_count"])
+        and not _dict(aggregate.get("diagnostic_failure_reasons"))
+    )
+    return {
+        "schema_version": "stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "run_dir": str(run_dir),
+        "input_boundary": SOURCE_BOUNDARY,
+        "repair_boundary": REPAIR_BOUNDARY,
+        "consolidation_summary": consolidation_summary,
+        "repair_config": repair_config,
+        "input": {
+            "issue_number": int(args.issue_number),
+            "seeds": parse_seeds(args.seeds),
+            "num_samples": int(args.num_samples),
+            "max_sequence": int(args.max_sequence),
+            "temperature": float(args.temperature),
+            "top_k": int(args.top_k),
+            "generation_mode": "constrained",
+            "constrained_note_groups_per_bar": int(args.constrained_note_groups_per_bar),
+            "coverage_aware_positions": True,
+            "coverage_position_window": int(args.coverage_position_window),
+            "jazz_duration_tokens": True,
+            "postprocess_overlap": True,
+            "max_simultaneous_notes": int(args.max_simultaneous_notes),
+        },
+        "seed_rows": seed_rows,
+        "aggregate": aggregate,
+        "comparison": {
+            "source_sample_count": int(consolidation_summary["source_sample_count"]),
+            "repeatability_sample_count": int(aggregate["sample_count"]),
+            "strict_valid_sample_delta": _int(aggregate["strict_valid_sample_count"])
+            - _int(consolidation_summary["source_strict_valid_sample_count"]),
+            "sustained_coverage_delta": _float(aggregate["avg_sustained_coverage_ratio"])
+            - _float(consolidation_summary["source_avg_sustained_coverage_ratio"]),
+            "target_qualified": bool(target_qualified),
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "objective_gate_repeatability_sweep_completed": True,
+            "objective_gate_repeatability_target_qualified": bool(target_qualified),
+            "repeatability_claimed": bool(target_qualified),
+            "raw_generation_quality_claimed": False,
+            "human_audio_preference_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_improviser_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": (
+                "objective gates held across the configured seed sweep; consolidate repeatability "
+                "before any listening or quality claim"
+            ),
+        },
+        "not_proven": [
+            "musical_quality",
+            "human_audio_preference",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": "Stage B generic base scale checkpoint repeatability consolidation",
+    }
+
+
+def validate_sweep_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_target_qualified: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    aggregate = _dict(report.get("aggregate"))
+    comparison = _dict(report.get("comparison"))
+    boundary = str(readiness.get("boundary") or "")
+    next_boundary = str(decision.get("next_boundary") or "")
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and next_boundary != expected_next_boundary:
+        raise StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError(
+            f"expected next boundary {expected_next_boundary}, got {next_boundary}"
+        )
+    if require_target_qualified and not bool(
+        readiness.get("objective_gate_repeatability_target_qualified", False)
+    ):
+        raise StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError(
+            "objective gate repeatability target should qualify"
+        )
+    if _int(aggregate.get("sample_count")) <= 0:
+        raise StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError("sample count required")
+    if _int(aggregate.get("strict_valid_sample_count")) != _int(aggregate.get("sample_count")):
+        raise StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError(
+            "all repeatability samples must pass strict gate"
+        )
+    if _dict(aggregate.get("diagnostic_failure_reasons")):
+        raise StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError(
+            "diagnostic failures must be absent"
+        )
+    if require_no_quality_claim:
+        claimed = [
+            bool(readiness.get("raw_generation_quality_claimed", True)),
+            bool(readiness.get("human_audio_preference_claimed", True)),
+            bool(readiness.get("broad_trained_model_quality_claimed", True)),
+            bool(readiness.get("brad_style_adaptation_claimed", True)),
+            bool(readiness.get("production_ready_improviser_claimed", True)),
+        ]
+        if any(claimed):
+            raise StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError(
+                "quality claims must remain false"
+            )
+    return {
+        "boundary": boundary,
+        "next_boundary": next_boundary,
+        "objective_gate_repeatability_sweep_completed": bool(
+            readiness.get("objective_gate_repeatability_sweep_completed", False)
+        ),
+        "objective_gate_repeatability_target_qualified": bool(
+            readiness.get("objective_gate_repeatability_target_qualified", False)
+        ),
+        "repeatability_claimed": bool(readiness.get("repeatability_claimed", False)),
+        "seed_count": _int(aggregate.get("seed_count")),
+        "sample_count": _int(aggregate.get("sample_count")),
+        "valid_sample_count": _int(aggregate.get("valid_sample_count")),
+        "strict_valid_sample_count": _int(aggregate.get("strict_valid_sample_count")),
+        "grammar_gate_sample_count": _int(aggregate.get("grammar_gate_sample_count")),
+        "avg_sustained_coverage_ratio": _float(aggregate.get("avg_sustained_coverage_ratio")),
+        "strict_valid_sample_delta": _int(comparison.get("strict_valid_sample_delta")),
+        "raw_generation_quality_claimed": bool(readiness.get("raw_generation_quality_claimed", True)),
+        "broad_trained_model_quality_claimed": bool(
+            readiness.get("broad_trained_model_quality_claimed", True)
+        ),
+        "brad_style_adaptation_claimed": bool(readiness.get("brad_style_adaptation_claimed", True)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    aggregate = report["aggregate"]
+    comparison = report["comparison"]
+    lines = [
+        "# Stage B Generic Base Scale Checkpoint Objective Gate Repeatability Sweep",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{readiness['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- objective gate repeatability target qualified: `{_bool_token(readiness['objective_gate_repeatability_target_qualified'])}`",
+        f"- repeatability claimed: `{_bool_token(readiness['repeatability_claimed'])}`",
+        f"- raw generation quality claimed: `{_bool_token(readiness['raw_generation_quality_claimed'])}`",
+        f"- broad trained-model quality claimed: `{_bool_token(readiness['broad_trained_model_quality_claimed'])}`",
+        f"- Brad style adaptation claimed: `{_bool_token(readiness['brad_style_adaptation_claimed'])}`",
+        "",
+        "## Aggregate",
+        "",
+        f"- seeds: `{aggregate['seeds']}`",
+        f"- seed count: `{aggregate['seed_count']}`",
+        f"- sample count: `{aggregate['sample_count']}`",
+        f"- valid / strict / grammar gate sample count: `{aggregate['valid_sample_count']}` / `{aggregate['strict_valid_sample_count']}` / `{aggregate['grammar_gate_sample_count']}`",
+        f"- avg onset / sustained coverage: `{aggregate['avg_onset_coverage_ratio']}` / `{aggregate['avg_sustained_coverage_ratio']}`",
+        f"- max longest sustained empty run steps: `{aggregate['max_longest_sustained_empty_run_steps']}`",
+        "",
+        "## Delta",
+        "",
+        f"- source sample count: `{comparison['source_sample_count']}`",
+        f"- repeatability sample count: `{comparison['repeatability_sample_count']}`",
+        f"- strict valid sample delta: `{comparison['strict_valid_sample_delta']}`",
+        f"- sustained coverage delta: `{comparison['sustained_coverage_delta']}`",
+        "",
+        "## Failure Reasons",
+        "",
+    ]
+    if aggregate["diagnostic_failure_reasons"]:
+        for reason, count in aggregate["diagnostic_failure_reasons"].items():
+            lines.append(f"- `{reason}`: `{count}`")
+    else:
+        lines.append("- none")
+    lines.extend(["", "## Not Proven", ""])
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run Stage B generic base scale checkpoint objective gate repeatability sweep"
+    )
+    parser.add_argument(
+        "--consolidation",
+        type=str,
+        default="outputs/stage_b_generic_base_scale_checkpoint_objective_gate_consolidation/"
+        "harness_stage_b_generic_base_scale_checkpoint_objective_gate_consolidation/"
+        "stage_b_generic_base_scale_checkpoint_objective_gate_consolidation.json",
+    )
+    parser.add_argument(
+        "--repair_probe",
+        type=str,
+        default="outputs/stage_b_generic_base_scale_checkpoint_sustained_coverage_dead_air_repair_probe/"
+        "harness_stage_b_generic_base_scale_checkpoint_sustained_coverage_dead_air_repair_probe/"
+        "stage_b_generic_base_scale_checkpoint_sustained_coverage_dead_air_repair_probe.json",
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=469)
+    parser.add_argument("--seeds", type=str, default="44,52,60")
+    parser.add_argument("--num_samples", type=int, default=3)
+    parser.add_argument("--max_sequence", type=int, default=96)
+    parser.add_argument("--temperature", type=float, default=0.9)
+    parser.add_argument("--top_k", type=int, default=4)
+    parser.add_argument("--min_valid_samples", type=int, default=1)
+    parser.add_argument("--min_strict_valid_samples", type=int, default=1)
+    parser.add_argument("--constrained_note_groups_per_bar", type=int, default=8)
+    parser.add_argument("--coverage_position_window", type=int, default=1)
+    parser.add_argument("--max_simultaneous_notes", type=int, default=2)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_target_qualified", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    run_dir = Path(args.output_root) / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    consolidation_summary = validate_consolidation(read_json(Path(args.consolidation)))
+    repair_config = validate_repair_probe(read_json(Path(args.repair_probe)))
+    checkpoint_dir = Path(str(repair_config["checkpoint_dir"]))
+    probe_output_root = run_dir / "generation_probe"
+    seed_rows = [
+        run_seed_probe(
+            args,
+            seed=seed,
+            checkpoint_dir=checkpoint_dir,
+            probe_output_root=probe_output_root,
+        )
+        for seed in parse_seeds(args.seeds)
+    ]
+    report = build_sweep_report(
+        run_dir=run_dir,
+        consolidation_summary=consolidation_summary,
+        repair_config=repair_config,
+        seed_rows=seed_rows,
+        args=args,
+    )
+    summary = validate_sweep_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_target_qualified=bool(args.require_target_qualified),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    write_json(
+        run_dir / "stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep.json",
+        report,
+    )
+    write_json(
+        run_dir / "stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        run_dir / "stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep.py
+++ b/tests/test_stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import argparse
+import unittest
+from pathlib import Path
+
+from scripts.run_stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    SOURCE_BOUNDARY,
+    StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError,
+    aggregate_seed_rows,
+    build_sweep_report,
+    validate_sweep_report,
+)
+
+
+def seed_row(seed: int, *, strict_count: int = 3, failures: dict | None = None) -> dict:
+    failure_reasons = failures or {}
+    return {
+        "seed": seed,
+        "generation_report_path": f"report_{seed}.json",
+        "generation_command": {"returncode": 0},
+        "sample_count": 3,
+        "valid_sample_count": strict_count,
+        "strict_valid_sample_count": strict_count,
+        "grammar_gate_sample_count": 3,
+        "failure_reasons": failure_reasons,
+        "diagnostic_failure_reasons": failure_reasons,
+        "strict_failure_reasons": failure_reasons,
+        "collapse_warning_sample_count": 0,
+        "avg_onset_coverage_ratio": 0.4,
+        "avg_sustained_coverage_ratio": 0.7,
+        "max_longest_sustained_empty_run_steps": 4,
+        "passed_strict_review_gate": strict_count == 3 and not failure_reasons,
+        "passed_grammar_gate": True,
+    }
+
+
+def sweep_report(
+    *,
+    target_qualified: bool = True,
+    quality_claim: bool = False,
+    strict_count: int = 9,
+    failures: dict | None = None,
+) -> dict:
+    failure_reasons = failures or {}
+    return {
+        "readiness": {
+            "boundary": BOUNDARY,
+            "objective_gate_repeatability_sweep_completed": True,
+            "objective_gate_repeatability_target_qualified": target_qualified,
+            "repeatability_claimed": target_qualified,
+            "raw_generation_quality_claimed": quality_claim,
+            "human_audio_preference_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_improviser_claimed": False,
+        },
+        "decision": {
+            "next_boundary": NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+        "aggregate": {
+            "seed_count": 3,
+            "sample_count": 9,
+            "valid_sample_count": strict_count,
+            "strict_valid_sample_count": strict_count,
+            "grammar_gate_sample_count": 9,
+            "diagnostic_failure_reasons": failure_reasons,
+            "avg_sustained_coverage_ratio": 0.68,
+        },
+        "comparison": {
+            "strict_valid_sample_delta": 6,
+        },
+        "next_recommended_issue": "Stage B generic base scale checkpoint repeatability consolidation",
+    }
+
+
+class StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepTest(unittest.TestCase):
+    def test_aggregate_counts_across_seed_rows(self) -> None:
+        aggregate = aggregate_seed_rows([seed_row(44), seed_row(52), seed_row(60)])
+
+        self.assertEqual(aggregate["seed_count"], 3)
+        self.assertEqual(aggregate["sample_count"], 9)
+        self.assertEqual(aggregate["strict_valid_sample_count"], 9)
+        self.assertEqual(aggregate["grammar_gate_sample_count"], 9)
+        self.assertEqual(aggregate["diagnostic_failure_reasons"], {})
+        self.assertTrue(aggregate["all_seed_strict_review_gate_passed"])
+
+    def test_accepts_repeatability_sweep_without_quality_claim(self) -> None:
+        summary = validate_sweep_report(
+            sweep_report(),
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=NEXT_BOUNDARY,
+            require_target_qualified=True,
+            require_no_quality_claim=True,
+        )
+
+        self.assertTrue(summary["objective_gate_repeatability_target_qualified"])
+        self.assertTrue(summary["repeatability_claimed"])
+        self.assertEqual(summary["seed_count"], 3)
+        self.assertEqual(summary["sample_count"], 9)
+        self.assertEqual(summary["strict_valid_sample_count"], 9)
+        self.assertFalse(summary["raw_generation_quality_claimed"])
+
+    def test_rejects_unqualified_repeatability_target(self) -> None:
+        with self.assertRaises(StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError):
+            validate_sweep_report(
+                sweep_report(target_qualified=False),
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                require_target_qualified=True,
+                require_no_quality_claim=True,
+            )
+
+    def test_rejects_partial_strict_pass(self) -> None:
+        with self.assertRaises(StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError):
+            validate_sweep_report(
+                sweep_report(strict_count=8),
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                require_target_qualified=True,
+                require_no_quality_claim=True,
+            )
+
+    def test_rejects_diagnostic_failures(self) -> None:
+        with self.assertRaises(StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError):
+            validate_sweep_report(
+                sweep_report(failures={"dead-air ratio too high: 0.889 >= 0.800": 1}),
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                require_target_qualified=True,
+                require_no_quality_claim=True,
+            )
+
+    def test_rejects_quality_claim(self) -> None:
+        with self.assertRaises(StageBGenericBaseScaleCheckpointObjectiveGateRepeatabilitySweepError):
+            validate_sweep_report(
+                sweep_report(quality_claim=True),
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                require_target_qualified=True,
+                require_no_quality_claim=True,
+            )
+
+    def test_build_report_records_repeatability_delta(self) -> None:
+        args = argparse.Namespace(
+            issue_number=469,
+            seeds="44,52,60",
+            num_samples=3,
+            max_sequence=96,
+            temperature=0.9,
+            top_k=4,
+            constrained_note_groups_per_bar=8,
+            coverage_position_window=1,
+            max_simultaneous_notes=2,
+        )
+        report = build_sweep_report(
+            run_dir=Path("outputs/repeatability"),
+            consolidation_summary={
+                "source_sample_count": 3,
+                "source_strict_valid_sample_count": 3,
+                "source_avg_sustained_coverage_ratio": 0.6354166666666666,
+            },
+            repair_config={"checkpoint_dir": "checkpoints"},
+            seed_rows=[seed_row(44), seed_row(52), seed_row(60)],
+            args=args,
+        )
+
+        self.assertTrue(report["comparison"]["target_qualified"])
+        self.assertEqual(report["aggregate"]["sample_count"], 9)
+        self.assertEqual(report["aggregate"]["strict_valid_sample_count"], 9)
+        self.assertEqual(report["comparison"]["strict_valid_sample_delta"], 6)
+        self.assertEqual(report["decision"]["next_boundary"], NEXT_BOUNDARY)
+
+    def test_boundary_constants_are_stable(self) -> None:
+        self.assertEqual(SOURCE_BOUNDARY, "stage_b_generic_base_scale_checkpoint_objective_gate_consolidation")
+        self.assertEqual(BOUNDARY, "stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- objective gate repeatability sweep 추가
- seed `44`, `52`, `60`에서 동일 constrained generation 조건 반복
- aggregate pass-rate, coverage, failure reason 기록
- 상태 문서와 required harness 갱신

## Context

- #467 consolidation 결과 single seed set objective gate support만 확인
- source sample count: `3`
- source valid / strict / grammar sample count: `3 / 3 / 3`
- source repeatability claim: `false`

## Result

- seeds: `[44, 52, 60]`
- seed count: `3`
- sample count: `9`
- valid / strict / grammar sample count: `9 / 9 / 9`
- avg onset / sustained coverage: `0.4236111111111111 / 0.6805555555555556`
- max longest sustained empty run steps: `4`
- failure reasons: none
- repeatability claim: `true`
- raw generation quality, broad trained-model quality, Brad style adaptation claim: `false / false / false`

## Validation

- `bash scripts/agent_harness.sh stage-b-generic-base-scale-checkpoint-objective-gate-repeatability-sweep`
- `.venv/bin/python -m unittest tests.test_stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep tests.test_stage_b_generic_base_scale_checkpoint_objective_gate_consolidation`
- `.venv/bin/python -m py_compile scripts/run_stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep.py scripts/consolidate_stage_b_generic_base_scale_checkpoint_objective_gate.py`
- `bash -n scripts/agent_harness.sh`
- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- Repeatability claim is limited to objective MIDI gates for the configured seed sweep.
- Musical quality and listening preference remain unclaimed.

## Follow-up

- repeatability consolidation

Closes #469
