### PR TITLE
Stage B generic base scale checkpoint repeatability consolidation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #469, Stage B generic base scale checkpoint objective gate repeatability sweep.
+- Latest functional issue completed: Issue #471, Stage B generic base scale checkpoint repeatability consolidation.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B generic base scale checkpoint repeatability consolidation.
+- Recommended next issue: Stage B model-core evidence README refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -994,6 +994,14 @@ bash scripts/agent_harness.sh stage-b-generic-base-scale-checkpoint-objective-ga
 ```
 
 This harness repeats the objective gate probe across multiple seed starts and records repeatability while keeping musical quality and human/audio preference unclaimed.
+
+For Stage B generic base scale checkpoint repeatability consolidation changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-generic-base-scale-checkpoint-repeatability-consolidation
+```
+
+This harness consolidates objective MIDI gate repeatability evidence and routes the next boundary to README evidence refresh without claiming musical quality or human/audio preference.
 
 For Stage B generic tiny checkpoint generation probe changes, run:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -178,6 +178,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic base scale checkpoint sustained coverage dead-air repair probe 문서: `docs/STAGE_B_GENERIC_BASE_SCALE_CHECKPOINT_SUSTAINED_COVERAGE_DEAD_AIR_REPAIR_PROBE_2026-06-01.md`
 - generic base scale checkpoint objective gate consolidation 문서: `docs/STAGE_B_GENERIC_BASE_SCALE_CHECKPOINT_OBJECTIVE_GATE_CONSOLIDATION_2026-06-01.md`
 - generic base scale checkpoint objective gate repeatability sweep 문서: `docs/STAGE_B_GENERIC_BASE_SCALE_CHECKPOINT_OBJECTIVE_GATE_REPEATABILITY_SWEEP_2026-06-01.md`
+- generic base scale checkpoint repeatability consolidation 문서: `docs/STAGE_B_GENERIC_BASE_SCALE_CHECKPOINT_REPEATABILITY_CONSOLIDATION_2026-06-01.md`
 - raw generation gate: `stage-b-generation-probe` 통과
 - raw generation repeatability gate: 2-file/3-seed sweep 통과, strict `8/9`
 - raw generation dead-air outlier diagnostics: seed `31` sample `1`, dead-air `0.857`, collapse warning false
@@ -294,6 +295,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - generic base scale checkpoint sustained coverage dead-air repair probe: repair valid/strict/grammar `3/3/3`, dead-air failure delta `1`, sustained coverage delta `0.2708`, next boundary `generic_base_scale_checkpoint_objective_gate_consolidation`
 - generic base scale checkpoint objective gate consolidation: objective gate support `true`, single seed set only `true`, repeatability claim `false`, next boundary `generic_base_scale_checkpoint_objective_gate_repeatability_sweep`
 - generic base scale checkpoint objective gate repeatability sweep: seeds `44/52/60`, valid/strict/grammar `9/9/9`, repeatability claim `true`, quality claim `false`, next boundary `generic_base_scale_checkpoint_repeatability_consolidation`
+- generic base scale checkpoint repeatability consolidation: objective MIDI gate repeatability claim `true`, configured seed sweep repeatability claim `true`, quality claim `false`, next boundary `stage_b_model_core_evidence_readme_refresh`
 - constrained review gate: `stage-b-overlap-gate` 통과
 - focused candidate path: `stage-b-rhythm-phrase-variation` 통과
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #469, Stage B generic base scale checkpoint objective gate repeatability sweep
-- 다음 권장 이슈: `Stage B generic base scale checkpoint repeatability consolidation`
+- latest functional result: Issue #471, Stage B generic base scale checkpoint repeatability consolidation
+- 다음 권장 이슈: `Stage B model-core evidence README refresh`
 
 현재 범위가 아닌 것:
 
@@ -1672,6 +1672,44 @@ Issue #469는 #467에서 선택한 objective gate repeatability target을 seed �
 다음:
 
 - `Stage B generic base scale checkpoint repeatability consolidation`
+
+## Stage B Generic Base Scale Checkpoint Repeatability Consolidation
+
+Issue #471은 #469 seed sweep 결과를 objective MIDI gate repeatability claim으로 통합하고, quality claim 제외 범위를 고정한 작업이다.
+
+변경:
+
+- repeatability consolidation script 추가
+- objective gate repeatability sweep report 입력 검증
+- configured seed sweep repeatability claim과 quality claim 제외 범위 분리
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_GENERIC_BASE_SCALE_CHECKPOINT_REPEATABILITY_CONSOLIDATION_2026-06-01.md`
+- boundary: `stage_b_generic_base_scale_checkpoint_repeatability_consolidation`
+- next boundary: `stage_b_model_core_evidence_readme_refresh`
+- objective MIDI gate repeatability claimed: `true`
+- configured seed sweep repeatability claimed: `true`
+- seeds: `[44, 52, 60]`
+- sample count: `9`
+- valid / strict / grammar gate sample count: `9` / `9` / `9`
+- avg onset / sustained coverage: `0.4236111111111111` / `0.6805555555555556`
+- max longest sustained empty run steps: `4`
+- raw generation quality claimed: `false`
+- human/audio preference claimed: `false`
+- broad trained-model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+
+판단:
+
+- 현재 claim 가능 범위는 configured seed sweep의 objective MIDI gate repeatability
+- musical quality, human/audio preference, broad trained-model quality는 미검증
+- 다음 작업은 README evidence refresh로 이동 가능
+
+다음:
+
+- `Stage B model-core evidence README refresh`
 
 ## Current Muzig Application Resume Wording Result
 

--- a/docs/STAGE_B_GENERIC_BASE_SCALE_CHECKPOINT_REPEATABILITY_CONSOLIDATION_2026-06-01.md
+++ b/docs/STAGE_B_GENERIC_BASE_SCALE_CHECKPOINT_REPEATABILITY_CONSOLIDATION_2026-06-01.md
@@ -1,0 +1,43 @@
+# Stage B Generic Base Scale Checkpoint Repeatability Consolidation
+
+## Summary
+
+- boundary: `stage_b_generic_base_scale_checkpoint_repeatability_consolidation`
+- next boundary: `stage_b_model_core_evidence_readme_refresh`
+- objective MIDI gate repeatability claimed: `true`
+- configured seed sweep repeatability claimed: `true`
+- raw generation quality claimed: `false`
+- human/audio preference claimed: `false`
+- broad trained-model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+- production-ready improviser claimed: `false`
+
+## Evidence
+
+- seeds: `[44, 52, 60]`
+- seed count: `3`
+- sample count: `9`
+- valid / strict / grammar gate sample count: `9` / `9` / `9`
+- valid / strict / grammar gate sample rate: `1.0` / `1.0` / `1.0`
+- avg onset / sustained coverage: `0.4236111111111111` / `0.6805555555555556`
+- max longest sustained empty run steps: `4`
+- strict valid sample delta: `6`
+- sustained coverage delta: `0.04513888888888895`
+
+## Generation Condition
+
+- generation mode: `constrained`
+- constrained note groups per bar: `8`
+- coverage-aware positions: `true`
+- coverage position window: `1`
+- jazz duration tokens: `true`
+- postprocess overlap: `true`
+- max simultaneous notes: `2`
+
+## Not Proven
+
+- `musical_quality`
+- `human_audio_preference`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`
+- `production_ready_improviser`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -188,6 +188,8 @@ Modes:
                 Consolidate current seed-set objective gate support before repeatability.
   stage-b-generic-base-scale-checkpoint-objective-gate-repeatability-sweep
                 Run objective gate repeatability sweep for the generic-base scale checkpoint.
+  stage-b-generic-base-scale-checkpoint-repeatability-consolidation
+                Consolidate objective gate repeatability evidence for the generic-base scale checkpoint.
   stage-b-generic-tiny-checkpoint-generation-probe
                 Probe generation/decode from the generic tiny checkpoint.
   stage-b-generic-tiny-checkpoint-grammar-repair
@@ -3465,6 +3467,24 @@ run_stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep() {
     --require_no_quality_claim
 }
 
+run_stage_b_generic_base_scale_checkpoint_repeatability_consolidation() {
+  local sweep_run_id="${SWEEP_RUN_ID:-harness_stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep}"
+  local run_id="${RUN_ID:-harness_stage_b_generic_base_scale_checkpoint_repeatability_consolidation}"
+  local repeatability_sweep="outputs/stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep/${sweep_run_id}/stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep.json"
+  if [[ ! -f "$repeatability_sweep" ]]; then
+    print_header "Stage B generic base scale checkpoint objective gate repeatability sweep"
+    RUN_ID="$sweep_run_id" run_stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep
+  fi
+  print_header "Stage B generic base scale checkpoint repeatability consolidation"
+  "$PYTHON_BIN" scripts/consolidate_stage_b_generic_base_scale_checkpoint_repeatability.py \
+    --run_id "$run_id" \
+    --repeatability_sweep "$repeatability_sweep" \
+    --doc_path docs/STAGE_B_GENERIC_BASE_SCALE_CHECKPOINT_REPEATABILITY_CONSOLIDATION_2026-06-01.md \
+    --expected_boundary stage_b_generic_base_scale_checkpoint_repeatability_consolidation \
+    --expected_next_boundary stage_b_model_core_evidence_readme_refresh \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -4842,6 +4862,9 @@ case "$MODE" in
     ;;
   stage-b-generic-base-scale-checkpoint-objective-gate-repeatability-sweep)
     run_stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep
+    ;;
+  stage-b-generic-base-scale-checkpoint-repeatability-consolidation)
+    run_stage_b_generic_base_scale_checkpoint_repeatability_consolidation
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/consolidate_stage_b_generic_base_scale_checkpoint_repeatability.py
+++ b/scripts/consolidate_stage_b_generic_base_scale_checkpoint_repeatability.py
@@ -1,0 +1,381 @@
+"""Consolidate generic-base scale checkpoint repeatability evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+
+
+class StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError(ValueError):
+    pass
+
+
+SOURCE_BOUNDARY = "stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep"
+BOUNDARY = "stage_b_generic_base_scale_checkpoint_repeatability_consolidation"
+NEXT_BOUNDARY = "stage_b_model_core_evidence_readme_refresh"
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def validate_repeatability_sweep(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    aggregate = _dict(report.get("aggregate"))
+    comparison = _dict(report.get("comparison"))
+    input_config = _dict(report.get("input"))
+
+    if str(readiness.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError(
+            "objective gate repeatability sweep boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != BOUNDARY:
+        raise StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError(
+            "repeatability sweep must route to consolidation"
+        )
+    if not bool(readiness.get("objective_gate_repeatability_sweep_completed", False)):
+        raise StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError(
+            "repeatability sweep completion required"
+        )
+    if not bool(readiness.get("objective_gate_repeatability_target_qualified", False)):
+        raise StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError(
+            "qualified repeatability target required"
+        )
+    if not bool(readiness.get("repeatability_claimed", False)):
+        raise StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError(
+            "objective repeatability claim required"
+        )
+
+    sample_count = _int(aggregate.get("sample_count"))
+    if sample_count <= 0:
+        raise StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError("sample count required")
+    if _int(aggregate.get("seed_count")) < 3:
+        raise StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError("at least 3 seeds required")
+    if _int(aggregate.get("valid_sample_count")) != sample_count:
+        raise StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError(
+            "all samples must pass valid gate"
+        )
+    if _int(aggregate.get("strict_valid_sample_count")) != sample_count:
+        raise StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError(
+            "all samples must pass strict gate"
+        )
+    if _int(aggregate.get("grammar_gate_sample_count")) != sample_count:
+        raise StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError(
+            "all samples must pass grammar gate"
+        )
+    if _dict(aggregate.get("failure_reasons")):
+        raise StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError(
+            "failure reasons must be absent"
+        )
+    if _dict(aggregate.get("diagnostic_failure_reasons")):
+        raise StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError(
+            "diagnostic failure reasons must be absent"
+        )
+    if _dict(aggregate.get("strict_failure_reasons")):
+        raise StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError(
+            "strict failure reasons must be absent"
+        )
+
+    blocked_claims = [
+        "raw_generation_quality_claimed",
+        "human_audio_preference_claimed",
+        "broad_trained_model_quality_claimed",
+        "brad_style_adaptation_claimed",
+        "production_ready_improviser_claimed",
+    ]
+    claimed = [name for name in blocked_claims if bool(readiness.get(name, True))]
+    if claimed:
+        raise StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError(
+            f"unexpected quality claim: {claimed}"
+        )
+
+    return {
+        "seeds": list(aggregate.get("seeds") or []),
+        "seed_count": _int(aggregate.get("seed_count")),
+        "sample_count": sample_count,
+        "valid_sample_count": _int(aggregate.get("valid_sample_count")),
+        "strict_valid_sample_count": _int(aggregate.get("strict_valid_sample_count")),
+        "grammar_gate_sample_count": _int(aggregate.get("grammar_gate_sample_count")),
+        "valid_sample_rate": _float(aggregate.get("valid_sample_rate")),
+        "strict_valid_sample_rate": _float(aggregate.get("strict_valid_sample_rate")),
+        "grammar_gate_sample_rate": _float(aggregate.get("grammar_gate_sample_rate")),
+        "avg_onset_coverage_ratio": _float(aggregate.get("avg_onset_coverage_ratio")),
+        "avg_sustained_coverage_ratio": _float(aggregate.get("avg_sustained_coverage_ratio")),
+        "max_longest_sustained_empty_run_steps": _int(
+            aggregate.get("max_longest_sustained_empty_run_steps")
+        ),
+        "strict_valid_sample_delta": _int(comparison.get("strict_valid_sample_delta")),
+        "sustained_coverage_delta": _float(comparison.get("sustained_coverage_delta")),
+        "generation_mode": str(input_config.get("generation_mode") or ""),
+        "constrained_note_groups_per_bar": _int(input_config.get("constrained_note_groups_per_bar")),
+        "coverage_aware_positions": bool(input_config.get("coverage_aware_positions", False)),
+        "coverage_position_window": _int(input_config.get("coverage_position_window")),
+        "jazz_duration_tokens": bool(input_config.get("jazz_duration_tokens", False)),
+        "postprocess_overlap": bool(input_config.get("postprocess_overlap", False)),
+        "max_simultaneous_notes": _int(input_config.get("max_simultaneous_notes")),
+    }
+
+
+def build_repeatability_consolidation_report(
+    repeatability_sweep: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> dict[str, Any]:
+    evidence = validate_repeatability_sweep(repeatability_sweep)
+    return {
+        "schema_version": "stage_b_generic_base_scale_checkpoint_repeatability_consolidation_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_schema": str(repeatability_sweep.get("schema_version") or ""),
+        "input_boundary": SOURCE_BOUNDARY,
+        "evidence": evidence,
+        "claim_boundary": {
+            "boundary": BOUNDARY,
+            "objective_midi_gate_repeatability_claimed": True,
+            "configured_seed_sweep_repeatability_claimed": True,
+            "raw_generation_quality_claimed": False,
+            "human_audio_preference_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_improviser_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "decision": "select_model_core_evidence_readme_refresh",
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": (
+                "configured seed sweep passes objective MIDI gates; README evidence can be refreshed "
+                "without claiming listening quality"
+            ),
+        },
+        "proven": [
+            "configured_seed_sweep_valid_gate_repeatability",
+            "configured_seed_sweep_strict_gate_repeatability",
+            "configured_seed_sweep_grammar_gate_repeatability",
+        ],
+        "not_proven": [
+            "musical_quality",
+            "human_audio_preference",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "production_ready_improviser",
+        ],
+        "next_recommended_issue": "Stage B model-core evidence README refresh",
+    }
+
+
+def validate_repeatability_consolidation_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    claim = _dict(report.get("claim_boundary"))
+    decision = _dict(report.get("decision"))
+    evidence = _dict(report.get("evidence"))
+    boundary = str(claim.get("boundary") or "")
+    next_boundary = str(decision.get("next_boundary") or "")
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and next_boundary != expected_next_boundary:
+        raise StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError(
+            f"expected next boundary {expected_next_boundary}, got {next_boundary}"
+        )
+    if not bool(claim.get("objective_midi_gate_repeatability_claimed", False)):
+        raise StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError(
+            "objective MIDI gate repeatability claim required"
+        )
+    if _int(evidence.get("sample_count")) <= 0:
+        raise StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError("sample count required")
+    if _int(evidence.get("strict_valid_sample_count")) != _int(evidence.get("sample_count")):
+        raise StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError(
+            "strict sample count must equal sample count"
+        )
+    if require_no_quality_claim:
+        blocked = [
+            "raw_generation_quality_claimed",
+            "human_audio_preference_claimed",
+            "broad_trained_model_quality_claimed",
+            "brad_style_adaptation_claimed",
+            "production_ready_improviser_claimed",
+        ]
+        claimed = [name for name in blocked if bool(claim.get(name, True))]
+        if claimed:
+            raise StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError(
+                f"unexpected quality claim: {claimed}"
+            )
+    return {
+        "boundary": boundary,
+        "next_boundary": next_boundary,
+        "objective_midi_gate_repeatability_claimed": bool(
+            claim.get("objective_midi_gate_repeatability_claimed", False)
+        ),
+        "configured_seed_sweep_repeatability_claimed": bool(
+            claim.get("configured_seed_sweep_repeatability_claimed", False)
+        ),
+        "seed_count": _int(evidence.get("seed_count")),
+        "sample_count": _int(evidence.get("sample_count")),
+        "valid_sample_count": _int(evidence.get("valid_sample_count")),
+        "strict_valid_sample_count": _int(evidence.get("strict_valid_sample_count")),
+        "grammar_gate_sample_count": _int(evidence.get("grammar_gate_sample_count")),
+        "avg_onset_coverage_ratio": _float(evidence.get("avg_onset_coverage_ratio")),
+        "avg_sustained_coverage_ratio": _float(evidence.get("avg_sustained_coverage_ratio")),
+        "max_longest_sustained_empty_run_steps": _int(
+            evidence.get("max_longest_sustained_empty_run_steps")
+        ),
+        "raw_generation_quality_claimed": bool(claim.get("raw_generation_quality_claimed", True)),
+        "human_audio_preference_claimed": bool(claim.get("human_audio_preference_claimed", True)),
+        "broad_trained_model_quality_claimed": bool(
+            claim.get("broad_trained_model_quality_claimed", True)
+        ),
+        "brad_style_adaptation_claimed": bool(claim.get("brad_style_adaptation_claimed", True)),
+        "production_ready_improviser_claimed": bool(
+            claim.get("production_ready_improviser_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    evidence = report["evidence"]
+    claim = report["claim_boundary"]
+    decision = report["decision"]
+    lines = [
+        "# Stage B Generic Base Scale Checkpoint Repeatability Consolidation",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{claim['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- objective MIDI gate repeatability claimed: `{_bool_token(claim['objective_midi_gate_repeatability_claimed'])}`",
+        f"- configured seed sweep repeatability claimed: `{_bool_token(claim['configured_seed_sweep_repeatability_claimed'])}`",
+        f"- raw generation quality claimed: `{_bool_token(claim['raw_generation_quality_claimed'])}`",
+        f"- human/audio preference claimed: `{_bool_token(claim['human_audio_preference_claimed'])}`",
+        f"- broad trained-model quality claimed: `{_bool_token(claim['broad_trained_model_quality_claimed'])}`",
+        f"- Brad style adaptation claimed: `{_bool_token(claim['brad_style_adaptation_claimed'])}`",
+        f"- production-ready improviser claimed: `{_bool_token(claim['production_ready_improviser_claimed'])}`",
+        "",
+        "## Evidence",
+        "",
+        f"- seeds: `{evidence['seeds']}`",
+        f"- seed count: `{evidence['seed_count']}`",
+        f"- sample count: `{evidence['sample_count']}`",
+        f"- valid / strict / grammar gate sample count: `{evidence['valid_sample_count']}` / `{evidence['strict_valid_sample_count']}` / `{evidence['grammar_gate_sample_count']}`",
+        f"- valid / strict / grammar gate sample rate: `{evidence['valid_sample_rate']}` / `{evidence['strict_valid_sample_rate']}` / `{evidence['grammar_gate_sample_rate']}`",
+        f"- avg onset / sustained coverage: `{evidence['avg_onset_coverage_ratio']}` / `{evidence['avg_sustained_coverage_ratio']}`",
+        f"- max longest sustained empty run steps: `{evidence['max_longest_sustained_empty_run_steps']}`",
+        f"- strict valid sample delta: `{evidence['strict_valid_sample_delta']}`",
+        f"- sustained coverage delta: `{evidence['sustained_coverage_delta']}`",
+        "",
+        "## Generation Condition",
+        "",
+        f"- generation mode: `{evidence['generation_mode']}`",
+        f"- constrained note groups per bar: `{evidence['constrained_note_groups_per_bar']}`",
+        f"- coverage-aware positions: `{_bool_token(evidence['coverage_aware_positions'])}`",
+        f"- coverage position window: `{evidence['coverage_position_window']}`",
+        f"- jazz duration tokens: `{_bool_token(evidence['jazz_duration_tokens'])}`",
+        f"- postprocess overlap: `{_bool_token(evidence['postprocess_overlap'])}`",
+        f"- max simultaneous notes: `{evidence['max_simultaneous_notes']}`",
+        "",
+        "## Not Proven",
+        "",
+    ]
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Consolidate generic-base scale checkpoint repeatability evidence"
+    )
+    parser.add_argument(
+        "--repeatability_sweep",
+        type=str,
+        default="outputs/stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep/"
+        "harness_stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep/"
+        "stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep.json",
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_generic_base_scale_checkpoint_repeatability_consolidation",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_repeatability_consolidation_report(
+        read_json(Path(args.repeatability_sweep)),
+        output_dir=output_dir,
+    )
+    summary = validate_repeatability_consolidation_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    write_json(
+        output_dir / "stage_b_generic_base_scale_checkpoint_repeatability_consolidation.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / "stage_b_generic_base_scale_checkpoint_repeatability_consolidation_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir / "stage_b_generic_base_scale_checkpoint_repeatability_consolidation.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_generic_base_scale_checkpoint_repeatability_consolidation.py
+++ b/tests/test_stage_b_generic_base_scale_checkpoint_repeatability_consolidation.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.consolidate_stage_b_generic_base_scale_checkpoint_repeatability import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    SOURCE_BOUNDARY,
+    StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError,
+    build_repeatability_consolidation_report,
+    validate_repeatability_consolidation_report,
+)
+
+
+def repeatability_sweep_report(
+    *,
+    target_qualified: bool = True,
+    strict_count: int = 9,
+    failures: dict | None = None,
+    quality_claim: bool = False,
+) -> dict:
+    failure_reasons = failures or {}
+    return {
+        "schema_version": "stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep_v1",
+        "readiness": {
+            "boundary": SOURCE_BOUNDARY,
+            "objective_gate_repeatability_sweep_completed": True,
+            "objective_gate_repeatability_target_qualified": target_qualified,
+            "repeatability_claimed": target_qualified,
+            "raw_generation_quality_claimed": quality_claim,
+            "human_audio_preference_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_improviser_claimed": False,
+        },
+        "decision": {
+            "current_boundary": SOURCE_BOUNDARY,
+            "next_boundary": BOUNDARY,
+            "critical_user_input_required": False,
+        },
+        "input": {
+            "generation_mode": "constrained",
+            "constrained_note_groups_per_bar": 8,
+            "coverage_aware_positions": True,
+            "coverage_position_window": 1,
+            "jazz_duration_tokens": True,
+            "postprocess_overlap": True,
+            "max_simultaneous_notes": 2,
+        },
+        "aggregate": {
+            "seeds": [44, 52, 60],
+            "seed_count": 3,
+            "sample_count": 9,
+            "valid_sample_count": strict_count,
+            "strict_valid_sample_count": strict_count,
+            "grammar_gate_sample_count": 9,
+            "valid_sample_rate": strict_count / 9,
+            "strict_valid_sample_rate": strict_count / 9,
+            "grammar_gate_sample_rate": 1.0,
+            "failure_reasons": failure_reasons,
+            "diagnostic_failure_reasons": failure_reasons,
+            "strict_failure_reasons": failure_reasons,
+            "avg_onset_coverage_ratio": 0.4236111111111111,
+            "avg_sustained_coverage_ratio": 0.6805555555555556,
+            "max_longest_sustained_empty_run_steps": 4,
+        },
+        "comparison": {
+            "strict_valid_sample_delta": 6,
+            "sustained_coverage_delta": 0.04513888888888895,
+        },
+    }
+
+
+class StageBGenericBaseScaleCheckpointRepeatabilityConsolidationTest(unittest.TestCase):
+    def test_consolidates_objective_gate_repeatability_without_quality_claim(self) -> None:
+        report = build_repeatability_consolidation_report(
+            repeatability_sweep_report(),
+            output_dir=Path("outputs/repeatability_consolidation"),
+        )
+        summary = validate_repeatability_consolidation_report(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=NEXT_BOUNDARY,
+            require_no_quality_claim=True,
+        )
+
+        self.assertTrue(summary["objective_midi_gate_repeatability_claimed"])
+        self.assertTrue(summary["configured_seed_sweep_repeatability_claimed"])
+        self.assertEqual(summary["seed_count"], 3)
+        self.assertEqual(summary["sample_count"], 9)
+        self.assertEqual(summary["strict_valid_sample_count"], 9)
+        self.assertFalse(summary["human_audio_preference_claimed"])
+        self.assertFalse(summary["broad_trained_model_quality_claimed"])
+        self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
+        self.assertIn("musical_quality", report["not_proven"])
+
+    def test_rejects_unqualified_repeatability_sweep(self) -> None:
+        with self.assertRaises(StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError):
+            build_repeatability_consolidation_report(
+                repeatability_sweep_report(target_qualified=False),
+                output_dir=Path("outputs/repeatability_consolidation"),
+            )
+
+    def test_rejects_partial_strict_pass(self) -> None:
+        with self.assertRaises(StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError):
+            build_repeatability_consolidation_report(
+                repeatability_sweep_report(strict_count=8),
+                output_dir=Path("outputs/repeatability_consolidation"),
+            )
+
+    def test_rejects_failure_reasons(self) -> None:
+        with self.assertRaises(StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError):
+            build_repeatability_consolidation_report(
+                repeatability_sweep_report(failures={"dead-air ratio too high: 0.889 >= 0.800": 1}),
+                output_dir=Path("outputs/repeatability_consolidation"),
+            )
+
+    def test_rejects_quality_claim(self) -> None:
+        with self.assertRaises(StageBGenericBaseScaleCheckpointRepeatabilityConsolidationError):
+            build_repeatability_consolidation_report(
+                repeatability_sweep_report(quality_claim=True),
+                output_dir=Path("outputs/repeatability_consolidation"),
+            )
+
+    def test_boundary_constants_are_stable(self) -> None:
+        self.assertEqual(
+            SOURCE_BOUNDARY,
+            "stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep",
+        )
+        self.assertEqual(BOUNDARY, "stage_b_generic_base_scale_checkpoint_repeatability_consolidation")
+        self.assertEqual(NEXT_BOUNDARY, "stage_b_model_core_evidence_readme_refresh")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- objective gate repeatability sweep 결과 통합
- configured seed sweep repeatability claim과 quality claim 제외 범위 분리
- repeatability consolidation script, harness mode, unit test 추가
- status 문서와 handoff 갱신

## Context

- #469 objective gate repeatability sweep 완료
- seeds: `44/52/60`
- sample count: `9`
- valid / strict / grammar gate sample count: `9 / 9 / 9`
- failure reasons: none
- raw generation quality, human/audio preference, broad trained-model quality, Brad style adaptation claim: `false`

## Result

- boundary: `stage_b_generic_base_scale_checkpoint_repeatability_consolidation`
- next boundary: `stage_b_model_core_evidence_readme_refresh`
- objective MIDI gate repeatability claimed: `true`
- configured seed sweep repeatability claimed: `true`
- avg onset / sustained coverage: `0.4236111111111111 / 0.6805555555555556`
- max longest sustained empty run steps: `4`

## Validation

- `bash scripts/agent_harness.sh stage-b-generic-base-scale-checkpoint-repeatability-consolidation`
- `.venv/bin/python -m unittest tests.test_stage_b_generic_base_scale_checkpoint_repeatability_consolidation tests.test_stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep`
- `.venv/bin/python -m py_compile scripts/consolidate_stage_b_generic_base_scale_checkpoint_repeatability.py scripts/run_stage_b_generic_base_scale_checkpoint_objective_gate_repeatability_sweep.py`
- `bash -n scripts/agent_harness.sh`
- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- Repeatability claim 범위: configured objective MIDI gate와 seed sweep 한정
- Musical quality, human/audio preference, broad trained-model quality, Brad style adaptation 미검증

## Follow-up

- model-core evidence README refresh

Closes #471