### PR TITLE
Stage B model-core portfolio bullet refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #473, Stage B model-core evidence README refresh.
+- Latest functional issue completed: Issue #475, Stage B model-core portfolio bullet refresh.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B model-core portfolio bullet refresh.
+- Recommended next issue: Muzig application resume wording refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -135,6 +135,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - duration coverage fill outside-soloing repair final decision 문서: `docs/STAGE_B_DURATION_COVERAGE_FILL_OUTSIDE_SOLOING_REPAIR_FINAL_DECISION_2026-05-29.md`
 - model-core evidence README refresh: `README.md`
 - model-core portfolio bullet draft 문서: `docs/STAGE_B_MODEL_CORE_PORTFOLIO_BULLET_DRAFT_2026-05-29.md`
+- model-core portfolio bullet refresh 문서: `docs/STAGE_B_MODEL_CORE_PORTFOLIO_BULLET_REFRESH_2026-06-01.md`
 - Muzig application resume wording 문서: `docs/MUZIG_APPLICATION_RESUME_WORDING_2026-05-29.md`
 - generic base readiness audit 문서: `docs/STAGE_B_GENERIC_BASE_READINESS_AUDIT_2026-05-29.md`
 - generic base manifest contract 문서: `docs/STAGE_B_GENERIC_BASE_MANIFEST_CONTRACT_2026-05-29.md`
@@ -251,7 +252,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - duration coverage fill outside-soloing repair repeatability consolidation: objective source support `2/2`, policy support `3/3`, variants qualified `6/6`, pending review preserved, preference claim `false`
 - duration coverage fill outside-soloing repair final decision: final boundary `outside_soloing_repair_objective_path_complete`, next boundary `stage_b_model_core_evidence_readme_refresh`, preference claim `false`
 - model-core evidence README refresh: generic base scale checkpoint repeatability consolidation 기준 README 갱신, objective repeatability `9/9/9`, quality claim `false`
-- model-core portfolio bullet draft: resume bullet `6`, metric 근거와 unsupported claim guard 분리
+- model-core portfolio bullet refresh: resume bullet `6`, short bullet `3`, generic base checkpoint repeatability `9/9/9`, unsupported claim guard 유지
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
 - generic base readiness audit: phase4 prep ready `true`, broad training execution ready `false`, broad quality/Brad adaptation claim `false`
 - generic base manifest contract: generic split `2433/270`, Brad split `47/11/14`, leakage/overlap `0`, broad training execution ready `false`

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #473, Stage B model-core evidence README refresh
-- 다음 권장 이슈: `Stage B model-core portfolio bullet refresh`
+- latest functional result: Issue #475, Stage B model-core portfolio bullet refresh
+- 다음 권장 이슈: `Muzig application resume wording refresh`
 
 현재 범위가 아닌 것:
 
@@ -1746,6 +1746,40 @@ Issue #473은 README를 #471 repeatability consolidation 기준으로 갱신한 
 다음:
 
 - `Stage B model-core portfolio bullet refresh`
+
+## Stage B Model-Core Portfolio Bullet Refresh
+
+Issue #475는 #473 README evidence를 이력서 bullet과 면접 답변 근거로 압축한 작업이다.
+
+변경:
+
+- portfolio bullet refresh 문서 추가
+- project entry, resume bullets, short resume version, interview summary 작성
+- generic base scale checkpoint repeatability consolidation 수치 반영
+- unsupported claim guard 유지
+
+결과:
+
+- document: `docs/STAGE_B_MODEL_CORE_PORTFOLIO_BULLET_REFRESH_2026-06-01.md`
+- resume bullets: `6`
+- short resume bullets: `3`
+- interview summary rows: `5`
+- claim boundary: 사용 가능 `5`, 사용 금지 `5`
+- generic train/val: `2433/270`
+- tokenized records: `154136/21845`
+- scale smoke best validation loss: `5.9031`
+- constrained objective repair: valid/strict/grammar `3/3/3`
+- repeatability sweep: valid/strict/grammar `9/9/9`
+
+판단:
+
+- 이력서 claim 가능 범위는 model-core validation pipeline, objective MIDI review gate, configured seed sweep objective repeatability
+- 완성된 재즈 피아노 생성 모델, Brad style adaptation, broad trained-model quality, human/audio preference claim 제외
+- 다음 작업은 Muzig 지원 문구에 최신 bullet 반영
+
+다음:
+
+- `Muzig application resume wording refresh`
 
 ## Current Muzig Application Resume Wording Result
 

--- a/docs/STAGE_B_MODEL_CORE_PORTFOLIO_BULLET_REFRESH_2026-06-01.md
+++ b/docs/STAGE_B_MODEL_CORE_PORTFOLIO_BULLET_REFRESH_2026-06-01.md
@@ -1,0 +1,50 @@
+# Stage B Model-Core Portfolio Bullet Refresh
+
+## Project Entry
+
+**Jazz Piano MIDI 모델 검증 파이프라인 | Model-Core / ML Pipeline | 2026.05 - 2026.06**
+
+Python, PyTorch, pretty_midi, music21, mido, NumPy, Pandas
+
+## Resume Bullets
+
+- `.mid` 파일 생성만으로 성공을 판단하던 문제를 note count, unique pitch, phrase coverage, dead-air, max active notes, long-note ratio 기반 objective MIDI review gate로 전환해 one-note collapse, long sustain block, chord block 실패를 분리
+- Brad style adaptation 이전 generic base 검증 기준 부재를 generic/Brad manifest split과 leakage guard로 분리하고, generic train/val `2433/270`, Brad split `47/11/14`, full generic tokenized records `154136/21845` 생성
+- Stage B duration-explicit representation으로 `BAR`, `POSITION`, `CHORD_ROOT`, `CHORD_QUALITY`, `NOTE_PITCH`, `NOTE_DURATION`, `VELOCITY` token 구조를 구성하고 max token id/vocab `544/547` guard로 window dataset 검증
+- generic base scale checkpoint training smoke에서 selected train/val `128/32`, best validation loss `5.9031`, checkpoint `1`을 확보한 뒤 raw generation valid/strict/grammar `0/0/0` 실패를 note count `2-4` 문제로 분리
+- raw checkpoint generation 실패 이후 density/coverage, duration/long-note, sustained coverage/dead-air repair boundary를 순차 검증해 constrained objective repair valid/strict/grammar `3/3/3`, dead-air/long-note `0/0` 달성
+- 단일 seed objective gate 과장 위험을 seed `44/52/60` repeatability sweep으로 확장해 sample `9`, valid/strict/grammar `9/9/9`, failure reasons none을 확인하고 musical quality, human/audio preference, Brad style adaptation claim은 제외
+
+## Short Resume Version
+
+- Symbolic MIDI 기반 jazz piano solo-line 생성 model-core pipeline 구축: dataset audit, Stage B tokenization, training smoke, generation decode, objective MIDI review gate 연결
+- generic base scale checkpoint raw generation valid/strict/grammar `0/0/0` 실패를 density, duration, dead-air repair boundary로 분리하고 constrained objective repair `3/3/3`까지 개선
+- seed `44/52/60` repeatability sweep에서 objective MIDI gate `9/9/9` 통과를 확인하되 broad model quality, human/audio preference, Brad style adaptation claim은 제외
+
+## Interview Summary
+
+| 질문 | 답변 근거 |
+|---|---|
+| 무엇을 만들었는가 | symbolic MIDI 기반 jazz piano solo-line 생성 모델을 검증하기 위한 dataset -> window -> training smoke -> checkpoint -> generation -> decode -> objective review pipeline |
+| 가장 큰 문제 | `.mid` 파일은 생성되지만 raw checkpoint generation valid/strict/grammar `0/0/0`, note count `2-4`, long sustain, dead-air 등으로 solo-line 품질 판단 불가 |
+| 핵심 해결 | Stage B duration-explicit representation, objective MIDI review gate, repair boundary 분리, seed repeatability sweep |
+| 수치 근거 | generic train/val `2433/270`, tokenized records `154136/21845`, best validation loss `5.9031`, constrained repair `3/3/3`, repeatability `9/9/9` |
+| 현재 한계 | human/audio preference 미검증, broad trained-model quality 미검증, Brad style adaptation 미진행 |
+
+## Claim Boundary
+
+사용 가능:
+
+- symbolic MIDI model-core validation pipeline
+- Stage B duration-explicit tokenization
+- generic base scale checkpoint training smoke
+- objective MIDI review gate
+- configured seed sweep objective repeatability
+
+사용 금지:
+
+- 완성된 재즈 피아노 생성 모델
+- Brad style adaptation 완료
+- production-ready improviser
+- broad trained-model quality 검증 완료
+- human/audio preference 검증 완료


### PR DESCRIPTION
## Summary

- README 최신 evidence 기반 portfolio bullet 문서 추가
- generic base scale checkpoint repeatability consolidation 수치 반영
- resume bullets, short resume version, interview summary, claim boundary 갱신
- handoff 문서와 CORE_PLAN next boundary 갱신

## Context

- #473 README evidence refresh 완료
- full generic tokenized train / val records: `154136 / 21845`
- scale smoke best validation loss: `5.9031`
- constrained objective repair: valid / strict / grammar `3 / 3 / 3`
- repeatability sweep: valid / strict / grammar `9 / 9 / 9`
- unsupported claim guard 유지 필요

## Result

- resume bullets: `6`
- short resume bullets: `3`
- interview summary rows: `5`
- claim boundary: 사용 가능 `5`, 사용 금지 `5`
- next recommended issue: Muzig application resume wording refresh

## Validation

- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- staged forbidden phrase check

## Risk

- 이력서 문구 claim은 objective MIDI evidence 범위로 제한
- musical quality, human/audio preference, broad trained-model quality, Brad style adaptation claim 제외

## Follow-up

- Muzig application resume wording refresh

Closes #475