### PR TITLE
Stage B MIDI-to-solo context extraction MVP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #481, Stage B MIDI-to-solo MVP input contract and run plan.
+- Latest functional issue completed: Issue #483, Stage B MIDI-to-solo context extraction MVP.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo context extraction MVP.
+- Recommended next issue: Stage B MIDI-to-solo training resource probe.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1011,6 +1011,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-contract
 ```
 
 This harness defines the input MIDI to ranked jazz solo MIDI candidate contract, including constrained decoding, candidate ranking, and retrieval fallback boundaries.
+
+For Stage B MIDI-to-solo context extraction changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-context-extraction
+```
+
+This harness extracts bar/position/chord/bass context rows from an input MIDI fixture without claiming harmony-analysis quality or completed MIDI-to-solo generation.
 
 For Stage B generic tiny checkpoint generation probe changes, run:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -259,6 +259,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - Muzig application wording refresh: resume project bullet `5`, short bullet `3`, 자기소개 section `3`, AI 음악 실험/검증 claim만 사용
 - Muzig application final review package: long bullet `5`, short bullet `3`, 자기소개 paragraph `3`, 지원 동기 paragraph `2`, 최종 claim check 포함
 - MIDI-to-solo MVP input contract: target date `2026-06-11`, candidate count `32`, exported MIDI `3`, target solo bars `8`, fallback `phrase_retrieval_data_motif_hybrid`, next boundary `stage_b_midi_to_solo_context_extraction_mvp`
+- MIDI-to-solo context extraction MVP: context bars `8`, context events `128`, inferred/carried/unknown chord bars `4/4/0`, bass-note bars `4`, next boundary `stage_b_midi_to_solo_training_resource_probe`
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
 - generic base readiness audit: phase4 prep ready `true`, broad training execution ready `false`, broad quality/Brad adaptation claim `false`
 - generic base manifest contract: generic split `2433/270`, Brad split `47/11/14`, leakage/overlap `0`, broad training execution ready `false`

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #481, Stage B MIDI-to-solo MVP input contract and run plan
-- 다음 권장 이슈: `Stage B MIDI-to-solo context extraction MVP`
+- latest functional result: Issue #483, Stage B MIDI-to-solo context extraction MVP
+- 다음 권장 이슈: `Stage B MIDI-to-solo training resource probe`
 
 현재 범위가 아닌 것:
 
@@ -66,6 +66,51 @@ Issue #481은 입력 MIDI를 받아 jazz solo MIDI 후보를 출력하는 MVP의
 다음:
 
 - `Stage B MIDI-to-solo context extraction MVP`
+
+## Stage B MIDI-to-Solo Context Extraction MVP Result
+
+Issue #483은 입력 MIDI에서 생성 conditioning에 필요한 bar/position/chord/bass context rows를 추출하는 MVP 작업이다.
+
+변경:
+
+- MIDI-to-solo context extraction script 추가
+- fixture MIDI 생성 경로 추가
+- pitch-class/bass 기반 chord root/quality inference 추가
+- 빈 마디 chord carry-forward 처리 추가
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_CONTEXT_EXTRACTION_MVP_2026-06-03.md`
+- boundary: `stage_b_midi_to_solo_context_extraction_mvp`
+- next boundary: `stage_b_midi_to_solo_training_resource_probe`
+- context bars: `8`
+- positions per bar: `16`
+- context event count: `128`
+- inferred chord bars: `4`
+- carry-forward chord bars: `4`
+- unknown chord bars: `0`
+- low-confidence bars: `4`
+- bass-note bars: `4`
+- MIDI-to-solo MVP claimed: `false`
+- harmony analysis quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- 입력 MIDI 기반 generation context row 생성 가능
+- explicit chord event가 있으면 pitch-class inference보다 우선 적용
+- 빈 마디는 직전 chord carry-forward와 낮은 confidence로 기록
+- chord inference 품질은 최종 claim이 아니라 다음 candidate ranking penalty 대상
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_context_extraction`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-context-extraction`
+
+다음:
+
+- `Stage B MIDI-to-solo training resource probe`
 
 ## Previous Model Decision
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_CONTEXT_EXTRACTION_MVP_2026-06-03.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_CONTEXT_EXTRACTION_MVP_2026-06-03.md
@@ -1,0 +1,31 @@
+# Stage B MIDI-to-Solo Context Extraction MVP
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_context_extraction_mvp`
+- next boundary: `stage_b_midi_to_solo_training_resource_probe`
+- input MIDI: `outputs/stage_b_midi_to_solo_context_extraction/harness_stage_b_midi_to_solo_context_extraction/fixture.mid`
+- context extraction completed: `true`
+- MIDI-to-solo MVP claimed: `false`
+- harmony analysis quality claimed: `false`
+
+## Context Summary
+
+- tempo BPM: `120.0`
+- context bars: `8`
+- positions per bar: `16`
+- context event count: `128`
+- explicit / inferred / carried / unknown chord bars: `0` / `4` / `4` / `0`
+- low-confidence bars: `4`
+- bass-note bars: `4`
+
+## Bar Contexts
+
+- bar `0`: `C` `maj7`, bass `36`, source `pitch_class_inference`, confidence `0.9`
+- bar `1`: `F` `dom7`, bass `41`, source `pitch_class_inference`, confidence `0.9`
+- bar `2`: `G` `dom7`, bass `43`, source `pitch_class_inference`, confidence `0.9`
+- bar `3`: `C` `maj7`, bass `36`, source `pitch_class_inference`, confidence `0.9`
+- bar `4`: `C` `maj7`, bass `None`, source `carry_forward_empty_bar`, confidence `0.45`
+- bar `5`: `C` `maj7`, bass `None`, source `carry_forward_empty_bar`, confidence `0.45`
+- bar `6`: `C` `maj7`, bass `None`, source `carry_forward_empty_bar`, confidence `0.45`
+- bar `7`: `C` `maj7`, bass `None`, source `carry_forward_empty_bar`, confidence `0.45`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -192,6 +192,8 @@ Modes:
                 Consolidate objective gate repeatability evidence for the generic-base scale checkpoint.
   stage-b-midi-to-solo-mvp-contract
                 Define the MIDI-to-solo MVP input/output contract and run plan.
+  stage-b-midi-to-solo-context-extraction
+                Extract MIDI-to-solo context rows from an input MIDI fixture.
   stage-b-generic-tiny-checkpoint-generation-probe
                 Probe generation/decode from the generic tiny checkpoint.
   stage-b-generic-tiny-checkpoint-grammar-repair
@@ -3499,6 +3501,18 @@ run_stage_b_midi_to_solo_mvp_contract() {
     --require_no_final_claim
 }
 
+run_stage_b_midi_to_solo_context_extraction() {
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_context_extraction}"
+  print_header "Stage B MIDI-to-solo context extraction MVP"
+  "$PYTHON_BIN" scripts/extract_stage_b_midi_to_solo_context.py \
+    --run_id "$run_id" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_CONTEXT_EXTRACTION_MVP_2026-06-03.md \
+    --expected_boundary stage_b_midi_to_solo_context_extraction_mvp \
+    --expected_next_boundary stage_b_midi_to_solo_training_resource_probe \
+    --min_context_bars 4 \
+    --require_no_final_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -4882,6 +4896,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-mvp-contract)
     run_stage_b_midi_to_solo_mvp_contract
+    ;;
+  stage-b-midi-to-solo-context-extraction)
+    run_stage_b_midi_to_solo_context_extraction
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/extract_stage_b_midi_to_solo_context.py
+++ b/scripts/extract_stage_b_midi_to_solo_context.py
@@ -1,0 +1,542 @@
+"""Extract MIDI context for the Stage B MIDI-to-solo MVP."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+import pretty_midi
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+from scripts.stage_b_tokens import (  # noqa: E402
+    CHORD_QUALITIES,
+    CHORD_ROOTS,
+    PC_TO_CANONICAL_ROOT,
+    POSITIONS_PER_BAR,
+    parse_chord_symbol,
+)
+
+
+class StageBMidiToSoloContextExtractionError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_context_extraction_mvp"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_training_resource_probe"
+SCHEMA_VERSION = "stage_b_midi_to_solo_context_extraction_v1"
+
+QUALITY_TEMPLATES = {
+    "maj": {0, 4, 7},
+    "min": {0, 3, 7},
+    "dom7": {0, 4, 7, 10},
+    "maj7": {0, 4, 7, 11},
+    "min7": {0, 3, 7, 10},
+    "halfdim": {0, 3, 6, 10},
+    "dim": {0, 3, 6},
+    "sus": {0, 5, 7},
+}
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def load_tempo_bpm(pm: pretty_midi.PrettyMIDI) -> float:
+    _, tempos = pm.get_tempo_changes()
+    if len(tempos):
+        return float(tempos[0])
+    try:
+        estimated = float(pm.estimate_tempo())
+    except (ValueError, ZeroDivisionError):
+        estimated = 120.0
+    return estimated if estimated > 0 else 120.0
+
+
+def bar_duration_sec(tempo_bpm: float, beats_per_bar: int = 4) -> float:
+    return (60.0 / max(1e-6, float(tempo_bpm))) * int(beats_per_bar)
+
+
+def iter_non_drum_notes(pm: pretty_midi.PrettyMIDI) -> Iterable[pretty_midi.Note]:
+    for instrument in pm.instruments:
+        if instrument.is_drum:
+            continue
+        for note in instrument.notes:
+            yield note
+
+
+def note_bar_index(note: pretty_midi.Note, *, tempo_bpm: float, beats_per_bar: int = 4) -> int:
+    return max(0, int(math.floor(float(note.start) / bar_duration_sec(tempo_bpm, beats_per_bar))))
+
+
+def normalize_chord_text(text: str) -> str:
+    cleaned = str(text or "").strip()
+    cleaned = re.sub(r"^(chord|changes?)\s*[:=]\s*", "", cleaned, flags=re.IGNORECASE)
+    return cleaned
+
+
+def explicit_chord_events(pm: pretty_midi.PrettyMIDI, *, tempo_bpm: float) -> dict[int, dict[str, Any]]:
+    events: dict[int, dict[str, Any]] = {}
+    for attr in ("text_events", "lyrics"):
+        for event in getattr(pm, attr, []) or []:
+            text = normalize_chord_text(getattr(event, "text", ""))
+            root, quality = parse_chord_symbol(text)
+            if root == "N" or quality == "unknown":
+                continue
+            bar_index = max(0, int(math.floor(float(getattr(event, "time", 0.0)) / bar_duration_sec(tempo_bpm))))
+            events[bar_index] = {
+                "root": root,
+                "quality": quality,
+                "source": "explicit_text_event",
+                "confidence": 1.0,
+                "symbol": text,
+            }
+    return events
+
+
+def collect_bar_pitch_classes(
+    pm: pretty_midi.PrettyMIDI,
+    *,
+    tempo_bpm: float,
+    bar_count: int,
+) -> list[Counter[int]]:
+    counters = [Counter() for _ in range(bar_count)]
+    for note in iter_non_drum_notes(pm):
+        bar_index = note_bar_index(note, tempo_bpm=tempo_bpm)
+        if 0 <= bar_index < bar_count:
+            counters[bar_index][int(note.pitch) % 12] += 1
+    return counters
+
+
+def collect_bar_bass_notes(
+    pm: pretty_midi.PrettyMIDI,
+    *,
+    tempo_bpm: float,
+    bar_count: int,
+) -> list[int | None]:
+    pitches_by_bar: list[list[int]] = [[] for _ in range(bar_count)]
+    for note in iter_non_drum_notes(pm):
+        bar_index = note_bar_index(note, tempo_bpm=tempo_bpm)
+        if 0 <= bar_index < bar_count:
+            pitches_by_bar[bar_index].append(int(note.pitch))
+    return [min(pitches) if pitches else None for pitches in pitches_by_bar]
+
+
+def score_quality(pitch_classes: set[int], root_pc: int, quality: str) -> int:
+    template = QUALITY_TEMPLATES[quality]
+    normalized = {(pc - root_pc) % 12 for pc in pitch_classes}
+    return len(normalized & template) * 2 - len(template - normalized)
+
+
+def infer_chord_from_bar(
+    pitch_counter: Counter[int],
+    *,
+    bass_note: int | None,
+) -> dict[str, Any]:
+    if not pitch_counter:
+        return {
+            "root": "N",
+            "quality": "unknown",
+            "source": "empty_bar_fallback",
+            "confidence": 0.0,
+            "symbol": "N",
+        }
+
+    pitch_classes = set(int(pc) for pc in pitch_counter)
+    root_candidates = [int(bass_note) % 12] if bass_note is not None else []
+    root_candidates.extend(pc for pc, _ in pitch_counter.most_common())
+
+    best: tuple[int, int, str] | None = None
+    for root_pc in dict.fromkeys(root_candidates):
+        for quality in QUALITY_TEMPLATES:
+            score = score_quality(pitch_classes, root_pc, quality)
+            if bass_note is not None and root_pc == int(bass_note) % 12:
+                score += 2
+            candidate = (score, root_pc, quality)
+            if best is None or candidate > best:
+                best = candidate
+
+    if best is None:
+        return {
+            "root": "N",
+            "quality": "unknown",
+            "source": "pitch_class_inference_failed",
+            "confidence": 0.0,
+            "symbol": "N",
+        }
+
+    score, root_pc, quality = best
+    root = PC_TO_CANONICAL_ROOT.get(root_pc, "N")
+    confidence = max(0.25, min(0.9, 0.45 + 0.08 * score))
+    if root not in CHORD_ROOTS or quality not in CHORD_QUALITIES:
+        return {
+            "root": "N",
+            "quality": "unknown",
+            "source": "pitch_class_inference_unsupported",
+            "confidence": 0.0,
+            "symbol": "N",
+        }
+    return {
+        "root": root,
+        "quality": quality,
+        "source": "pitch_class_inference",
+        "confidence": round(float(confidence), 4),
+        "symbol": f"{root}:{quality}",
+    }
+
+
+def build_fixture_midi(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pm = pretty_midi.PrettyMIDI(initial_tempo=120)
+    comp = pretty_midi.Instrument(program=0, is_drum=False, name="piano_comping")
+    bass = pretty_midi.Instrument(program=32, is_drum=False, name="bass")
+    chord_pitches = [
+        [48, 52, 55, 59],
+        [53, 57, 60, 63],
+        [55, 59, 62, 65],
+        [48, 52, 55, 59],
+    ]
+    bass_pitches = [36, 41, 43, 36]
+    for bar_index, pitches in enumerate(chord_pitches):
+        start = float(bar_index * 2.0)
+        for pitch in pitches:
+            comp.notes.append(pretty_midi.Note(velocity=70, pitch=pitch, start=start, end=start + 1.75))
+        bass.notes.append(
+            pretty_midi.Note(velocity=82, pitch=bass_pitches[bar_index], start=start, end=start + 1.75)
+        )
+    pm.instruments.extend([comp, bass])
+    pm.write(str(path))
+    return path
+
+
+def extract_context_from_midi(
+    midi_path: Path,
+    *,
+    target_context_bars: int = 8,
+    beats_per_bar: int = 4,
+) -> dict[str, Any]:
+    if not midi_path.exists():
+        raise StageBMidiToSoloContextExtractionError(f"input MIDI does not exist: {midi_path}")
+    pm = pretty_midi.PrettyMIDI(str(midi_path))
+    tempo_bpm = load_tempo_bpm(pm)
+    end_time = max([float(note.end) for note in iter_non_drum_notes(pm)] or [0.0])
+    detected_bars = max(1, int(math.ceil(end_time / bar_duration_sec(tempo_bpm, beats_per_bar))))
+    bar_count = max(int(target_context_bars), detected_bars)
+
+    explicit_events = explicit_chord_events(pm, tempo_bpm=tempo_bpm)
+    pitch_counters = collect_bar_pitch_classes(pm, tempo_bpm=tempo_bpm, bar_count=bar_count)
+    bass_notes = collect_bar_bass_notes(pm, tempo_bpm=tempo_bpm, bar_count=bar_count)
+
+    bar_contexts: list[dict[str, Any]] = []
+    for bar_index in range(bar_count):
+        chord = explicit_events.get(bar_index)
+        if chord is None:
+            chord = infer_chord_from_bar(pitch_counters[bar_index], bass_note=bass_notes[bar_index])
+        if (
+            chord["root"] == "N"
+            and not pitch_counters[bar_index]
+            and bar_contexts
+            and bar_contexts[-1]["chord_root"] != "N"
+        ):
+            previous = bar_contexts[-1]
+            chord = {
+                "root": previous["chord_root"],
+                "quality": previous["chord_quality"],
+                "source": "carry_forward_empty_bar",
+                "confidence": round(min(float(previous["chord_confidence"]), 0.45), 4),
+                "symbol": previous["chord_symbol"],
+            }
+        bar_contexts.append(
+            {
+                "bar_index": int(bar_index),
+                "tempo": float(round(tempo_bpm, 4)),
+                "chord_root": chord["root"],
+                "chord_quality": chord["quality"],
+                "chord_source": chord["source"],
+                "chord_confidence": float(chord["confidence"]),
+                "chord_symbol": chord["symbol"],
+                "bass_note": bass_notes[bar_index],
+                "pitch_class_count": int(sum(pitch_counters[bar_index].values())),
+                "unique_pitch_class_count": int(len(pitch_counters[bar_index])),
+            }
+        )
+
+    context_events: list[dict[str, Any]] = []
+    for bar_index, bar_context in enumerate(bar_contexts):
+        next_context = bar_contexts[bar_index + 1] if bar_index + 1 < len(bar_contexts) else bar_context
+        for position_index in range(POSITIONS_PER_BAR):
+            context_events.append(
+                {
+                    "bar_index": int(bar_index),
+                    "position_index": int(position_index),
+                    "tempo": float(bar_context["tempo"]),
+                    "chord_root": str(bar_context["chord_root"]),
+                    "chord_quality": str(bar_context["chord_quality"]),
+                    "next_chord_root": str(next_context["chord_root"]),
+                    "next_chord_quality": str(next_context["chord_quality"]),
+                    "bass_note": bar_context["bass_note"],
+                    "chord_confidence": float(bar_context["chord_confidence"]),
+                    "chord_source": str(bar_context["chord_source"]),
+                }
+            )
+
+    return {
+        "midi_path": str(midi_path),
+        "tempo_bpm": float(round(tempo_bpm, 4)),
+        "beats_per_bar": int(beats_per_bar),
+        "positions_per_bar": int(POSITIONS_PER_BAR),
+        "detected_bars": int(detected_bars),
+        "context_bars": int(bar_count),
+        "bar_contexts": bar_contexts,
+        "context_events": context_events,
+    }
+
+
+def build_context_report(
+    *,
+    midi_path: Path,
+    output_dir: Path,
+    target_context_bars: int,
+    issue_number: int,
+) -> dict[str, Any]:
+    context = extract_context_from_midi(midi_path, target_context_bars=target_context_bars)
+    bar_contexts = list(context["bar_contexts"])
+    event_count = len(context["context_events"])
+    unknown_bars = [
+        item for item in bar_contexts if item["chord_root"] == "N" or item["chord_quality"] == "unknown"
+    ]
+    inferred_bars = [item for item in bar_contexts if item["chord_source"] == "pitch_class_inference"]
+    explicit_bars = [item for item in bar_contexts if item["chord_source"] == "explicit_text_event"]
+    carried_bars = [item for item in bar_contexts if item["chord_source"] == "carry_forward_empty_bar"]
+    low_confidence_bars = [item for item in bar_contexts if float(item["chord_confidence"]) < 0.5]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "input": {
+            "midi_path": str(midi_path),
+            "target_context_bars": int(target_context_bars),
+        },
+        "context": context,
+        "summary": {
+            "context_bars": int(context["context_bars"]),
+            "positions_per_bar": int(context["positions_per_bar"]),
+            "context_event_count": int(event_count),
+            "explicit_chord_bar_count": int(len(explicit_bars)),
+            "inferred_chord_bar_count": int(len(inferred_bars)),
+            "carry_forward_chord_bar_count": int(len(carried_bars)),
+            "unknown_chord_bar_count": int(len(unknown_bars)),
+            "low_confidence_bar_count": int(len(low_confidence_bars)),
+            "bass_note_bar_count": int(sum(1 for item in bar_contexts if item["bass_note"] is not None)),
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "context_extraction_completed": True,
+            "required_context_fields_present": True,
+            "midi_to_solo_mvp_claimed": False,
+            "harmony_analysis_quality_claimed": False,
+            "brad_style_fine_tuning_completed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": (
+                "MIDI context rows are available for conditioned generation; low-confidence chord "
+                "inference remains a ranking penalty, not a blocker"
+            ),
+        },
+        "next_recommended_issue": "Stage B MIDI-to-solo training resource probe",
+    }
+
+
+def validate_context_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    min_context_bars: int,
+    require_no_final_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    decision = _dict(report.get("decision"))
+    readiness = _dict(report.get("readiness"))
+    summary = _dict(report.get("summary"))
+    context = _dict(report.get("context"))
+    next_boundary = str(decision.get("next_boundary") or "")
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloContextExtractionError(f"expected boundary {expected_boundary}, got {boundary}")
+    if expected_next_boundary and next_boundary != expected_next_boundary:
+        raise StageBMidiToSoloContextExtractionError(
+            f"expected next boundary {expected_next_boundary}, got {next_boundary}"
+        )
+    if _int(summary.get("context_bars")) < int(min_context_bars):
+        raise StageBMidiToSoloContextExtractionError("context bars below minimum")
+    expected_events = _int(summary.get("context_bars")) * POSITIONS_PER_BAR
+    if _int(summary.get("context_event_count")) != expected_events:
+        raise StageBMidiToSoloContextExtractionError("context event count does not match bars * positions")
+    if _int(summary.get("bass_note_bar_count")) <= 0:
+        raise StageBMidiToSoloContextExtractionError("at least one bass-note bar required")
+    required_fields = {
+        "bar_index",
+        "position_index",
+        "tempo",
+        "chord_root",
+        "chord_quality",
+        "next_chord_root",
+        "next_chord_quality",
+        "bass_note",
+        "chord_confidence",
+        "chord_source",
+    }
+    for event in context.get("context_events") or []:
+        missing = required_fields - set(event)
+        if missing:
+            raise StageBMidiToSoloContextExtractionError(f"context event missing fields: {sorted(missing)}")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloContextExtractionError("context extraction should not require critical user input")
+    if require_no_final_claim:
+        blocked = [
+            "midi_to_solo_mvp_claimed",
+            "harmony_analysis_quality_claimed",
+            "brad_style_fine_tuning_completed",
+        ]
+        claimed = [name for name in blocked if bool(readiness.get(name, True))]
+        if claimed:
+            raise StageBMidiToSoloContextExtractionError(f"unexpected final claim: {claimed}")
+    return {
+        "boundary": boundary,
+        "next_boundary": next_boundary,
+        "context_bars": _int(summary.get("context_bars")),
+        "context_event_count": _int(summary.get("context_event_count")),
+        "inferred_chord_bar_count": _int(summary.get("inferred_chord_bar_count")),
+        "carry_forward_chord_bar_count": _int(summary.get("carry_forward_chord_bar_count")),
+        "unknown_chord_bar_count": _int(summary.get("unknown_chord_bar_count")),
+        "low_confidence_bar_count": _int(summary.get("low_confidence_bar_count")),
+        "bass_note_bar_count": _int(summary.get("bass_note_bar_count")),
+        "midi_to_solo_mvp_claimed": bool(readiness.get("midi_to_solo_mvp_claimed", True)),
+        "harmony_analysis_quality_claimed": bool(
+            readiness.get("harmony_analysis_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    decision = report["decision"]
+    readiness = report["readiness"]
+    context = report["context"]
+    lines = [
+        "# Stage B MIDI-to-Solo Context Extraction MVP",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- input MIDI: `{report['input']['midi_path']}`",
+        f"- context extraction completed: `{_bool_token(readiness['context_extraction_completed'])}`",
+        f"- MIDI-to-solo MVP claimed: `{_bool_token(readiness['midi_to_solo_mvp_claimed'])}`",
+        f"- harmony analysis quality claimed: `{_bool_token(readiness['harmony_analysis_quality_claimed'])}`",
+        "",
+        "## Context Summary",
+        "",
+        f"- tempo BPM: `{context['tempo_bpm']}`",
+        f"- context bars: `{summary['context_bars']}`",
+        f"- positions per bar: `{context['positions_per_bar']}`",
+        f"- context event count: `{summary['context_event_count']}`",
+        f"- explicit / inferred / carried / unknown chord bars: `{summary['explicit_chord_bar_count']}` / `{summary['inferred_chord_bar_count']}` / `{summary['carry_forward_chord_bar_count']}` / `{summary['unknown_chord_bar_count']}`",
+        f"- low-confidence bars: `{summary['low_confidence_bar_count']}`",
+        f"- bass-note bars: `{summary['bass_note_bar_count']}`",
+        "",
+        "## Bar Contexts",
+        "",
+    ]
+    for item in context["bar_contexts"]:
+        lines.append(
+            f"- bar `{item['bar_index']}`: `{item['chord_root']}` `{item['chord_quality']}`, "
+            f"bass `{item['bass_note']}`, source `{item['chord_source']}`, confidence `{item['chord_confidence']}`"
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Extract MIDI-to-solo MVP context from an input MIDI")
+    parser.add_argument("--input_midi", type=str, default="")
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_context_extraction",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=483)
+    parser.add_argument("--target_context_bars", type=int, default=8)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--min_context_bars", type=int, default=4)
+    parser.add_argument("--require_no_final_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    input_midi = Path(args.input_midi) if args.input_midi else build_fixture_midi(output_dir / "fixture.mid")
+    report = build_context_report(
+        midi_path=input_midi,
+        output_dir=output_dir,
+        target_context_bars=int(args.target_context_bars),
+        issue_number=int(args.issue_number),
+    )
+    summary = validate_context_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        min_context_bars=int(args.min_context_bars),
+        require_no_final_claim=bool(args.require_no_final_claim),
+    )
+    write_json(output_dir / "stage_b_midi_to_solo_context_extraction.json", report)
+    write_json(output_dir / "stage_b_midi_to_solo_context_extraction_validation_summary.json", summary)
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_midi_to_solo_context_extraction.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_context_extraction.py
+++ b/tests/test_stage_b_midi_to_solo_context_extraction.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import pretty_midi
+
+from scripts.extract_stage_b_midi_to_solo_context import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloContextExtractionError,
+    build_context_report,
+    build_fixture_midi,
+    extract_context_from_midi,
+    validate_context_report,
+)
+from scripts.stage_b_tokens import POSITIONS_PER_BAR
+
+
+class StageBMidiToSoloContextExtractionTest(unittest.TestCase):
+    def test_extracts_required_context_from_fixture_midi(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp)
+            midi_path = build_fixture_midi(output_dir / "fixture.mid")
+            report = build_context_report(
+                midi_path=midi_path,
+                output_dir=output_dir,
+                target_context_bars=8,
+                issue_number=483,
+            )
+            summary = validate_context_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                min_context_bars=4,
+                require_no_final_claim=True,
+            )
+
+            self.assertEqual(summary["context_bars"], 8)
+            self.assertEqual(summary["context_event_count"], 8 * POSITIONS_PER_BAR)
+            self.assertGreaterEqual(summary["inferred_chord_bar_count"], 4)
+            self.assertGreaterEqual(summary["carry_forward_chord_bar_count"], 4)
+            self.assertEqual(summary["unknown_chord_bar_count"], 0)
+            self.assertGreater(summary["bass_note_bar_count"], 0)
+            self.assertFalse(summary["midi_to_solo_mvp_claimed"])
+            self.assertFalse(summary["harmony_analysis_quality_claimed"])
+            self.assertFalse(summary["critical_user_input_required"])
+
+    def test_explicit_chord_event_overrides_pitch_class_inference(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            midi_path = build_fixture_midi(Path(tmp) / "fixture_with_text.mid")
+            pm = pretty_midi.PrettyMIDI(str(midi_path))
+            pm.text_events.append(pretty_midi.Text("Dm7", 0.0))
+            pm.write(str(midi_path))
+
+            context = extract_context_from_midi(midi_path, target_context_bars=4)
+            first_bar = context["bar_contexts"][0]
+
+            self.assertEqual(first_bar["chord_root"], "D")
+            self.assertEqual(first_bar["chord_quality"], "min7")
+            self.assertEqual(first_bar["chord_source"], "explicit_text_event")
+            self.assertEqual(first_bar["chord_confidence"], 1.0)
+
+    def test_rejects_missing_input_midi(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(StageBMidiToSoloContextExtractionError):
+                extract_context_from_midi(Path(tmp) / "missing.mid")
+
+    def test_rejects_too_few_context_bars(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp)
+            midi_path = build_fixture_midi(output_dir / "fixture.mid")
+            report = build_context_report(
+                midi_path=midi_path,
+                output_dir=output_dir,
+                target_context_bars=4,
+                issue_number=483,
+            )
+
+            with self.assertRaises(StageBMidiToSoloContextExtractionError):
+                validate_context_report(
+                    report,
+                    expected_boundary=BOUNDARY,
+                    expected_next_boundary=NEXT_BOUNDARY,
+                    min_context_bars=8,
+                    require_no_final_claim=True,
+                )
+
+    def test_rejects_final_quality_claims(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp)
+            midi_path = build_fixture_midi(output_dir / "fixture.mid")
+            report = build_context_report(
+                midi_path=midi_path,
+                output_dir=output_dir,
+                target_context_bars=8,
+                issue_number=483,
+            )
+            report["readiness"]["harmony_analysis_quality_claimed"] = True
+
+            with self.assertRaises(StageBMidiToSoloContextExtractionError):
+                validate_context_report(
+                    report,
+                    expected_boundary=BOUNDARY,
+                    expected_next_boundary=NEXT_BOUNDARY,
+                    min_context_bars=4,
+                    require_no_final_claim=True,
+                )
+
+    def test_boundary_constants_are_stable(self) -> None:
+        self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_context_extraction_mvp")
+        self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_training_resource_probe")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- 입력 MIDI fixture에서 bar/position/chord/bass context rows 추출
- pitch-class/bass 기반 chord root/quality inference와 empty-bar carry-forward 추가
- 전용 harness mode, unit test, status 문서 갱신

## Context

- #481에서 MIDI-to-solo MVP 입출력 계약과 required context fields 정의
- 다음 단계인 conditioned generation 전에 입력 MIDI context row 필요
- harmony analysis quality, MIDI-to-solo completion, Brad style fine-tuning claim 제외

## Result

- boundary: `stage_b_midi_to_solo_context_extraction_mvp`
- next boundary: `stage_b_midi_to_solo_training_resource_probe`
- context bars: `8`
- context event count: `128`
- inferred / carried / unknown chord bars: `4 / 4 / 0`
- bass-note bars: `4`
- low-confidence bars: `4`

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_context_extraction tests.test_stage_b_midi_to_solo_mvp_contract`
- `.venv/bin/python -m py_compile scripts/extract_stage_b_midi_to_solo_context.py scripts/define_stage_b_midi_to_solo_mvp_contract.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-context-extraction`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- staged diff forbidden-public-name grep: no matches

## Risk

- chord inference heuristic quality not claimed
- carry-forward chord rows treated as low-confidence context
- final MIDI-to-solo generation path still pending

## Follow-up

- Stage B MIDI-to-solo training resource probe

Closes #483