### PR TITLE
Stage B MIDI-to-solo training resource probe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #483, Stage B MIDI-to-solo context extraction MVP.
+- Latest functional issue completed: Issue #485, Stage B MIDI-to-solo training resource probe.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo training resource probe.
+- Recommended next issue: Stage B MIDI-to-solo conditioned generation probe.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1019,6 +1019,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-context-extraction
 ```
 
 This harness extracts bar/position/chord/bass context rows from an input MIDI fixture without claiming harmony-analysis quality or completed MIDI-to-solo generation.
+
+For Stage B MIDI-to-solo training resource probe changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-training-resource-probe
+```
+
+This harness checks context extraction, full Stage B window records, and scale-smoke checkpoint resources before conditioned generation without claiming final MIDI-to-solo output quality.
 
 For Stage B generic tiny checkpoint generation probe changes, run:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -260,6 +260,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - Muzig application final review package: long bullet `5`, short bullet `3`, 자기소개 paragraph `3`, 지원 동기 paragraph `2`, 최종 claim check 포함
 - MIDI-to-solo MVP input contract: target date `2026-06-11`, candidate count `32`, exported MIDI `3`, target solo bars `8`, fallback `phrase_retrieval_data_motif_hybrid`, next boundary `stage_b_midi_to_solo_context_extraction_mvp`
 - MIDI-to-solo context extraction MVP: context bars `8`, context events `128`, inferred/carried/unknown chord bars `4/4/0`, bass-note bars `4`, next boundary `stage_b_midi_to_solo_training_resource_probe`
+- MIDI-to-solo training resource probe: ready `true`, context events `128`, full tokenized train/val `154136/21845`, scale-smoke train/val `128/32`, checkpoint count `1`, next boundary `stage_b_midi_to_solo_conditioned_generation_probe`
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
 - generic base readiness audit: phase4 prep ready `true`, broad training execution ready `false`, broad quality/Brad adaptation claim `false`
 - generic base manifest contract: generic split `2433/270`, Brad split `47/11/14`, leakage/overlap `0`, broad training execution ready `false`

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #483, Stage B MIDI-to-solo context extraction MVP
-- 다음 권장 이슈: `Stage B MIDI-to-solo training resource probe`
+- latest functional result: Issue #485, Stage B MIDI-to-solo training resource probe
+- 다음 권장 이슈: `Stage B MIDI-to-solo conditioned generation probe`
 
 현재 범위가 아닌 것:
 
@@ -111,6 +111,51 @@ Issue #483은 입력 MIDI에서 생성 conditioning에 필요한 bar/position/ch
 다음:
 
 - `Stage B MIDI-to-solo training resource probe`
+
+## Stage B MIDI-to-Solo Training Resource Probe Result
+
+Issue #485는 MIDI-to-solo context extraction 결과를 기존 Stage B full window resource와 scale-smoke checkpoint evidence에 연결한 readiness probe 작업이다.
+
+변경:
+
+- MIDI-to-solo training resource probe script 추가
+- context extraction report, full window preparation report, training scale smoke report 연결
+- conditioned generation probe 준비 여부 검증
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_TRAINING_RESOURCE_PROBE_2026-06-03.md`
+- boundary: `stage_b_midi_to_solo_training_resource_probe`
+- next boundary: `stage_b_midi_to_solo_conditioned_generation_probe`
+- training resource ready: `true`
+- conditioned generation probe ready: `true`
+- context event count: `128`
+- context bars: `8`
+- full tokenized train / val files: `154136` / `21845`
+- scale-smoke selected train / val records: `128` / `32`
+- scale-smoke best validation loss: `5.9031`
+- scale-smoke checkpoint count: `1`
+- MIDI-to-solo MVP claimed: `false`
+- conditioned generation completed: `false`
+- broad training executed: `false`
+- critical user input required: `false`
+
+판단:
+
+- 입력 MIDI context rows와 Stage B window/token resource 연결 가능
+- scale-smoke checkpoint resource 존재
+- 다음 작업은 completed model claim이 아니라 conditioned generation probe
+- broad training, Brad style adaptation, musical quality claim 제외
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_training_resource_probe`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-training-resource-probe`
+
+다음:
+
+- `Stage B MIDI-to-solo conditioned generation probe`
 
 ## Previous Model Decision
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_TRAINING_RESOURCE_PROBE_2026-06-03.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_TRAINING_RESOURCE_PROBE_2026-06-03.md
@@ -1,0 +1,39 @@
+# Stage B MIDI-to-Solo Training Resource Probe
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_training_resource_probe`
+- next boundary: `stage_b_midi_to_solo_conditioned_generation_probe`
+- training resource ready: `true`
+- conditioned generation probe ready: `true`
+- MIDI-to-solo MVP claimed: `false`
+- conditioned generation completed: `false`
+
+## Context Resource
+
+- context bars: `8`
+- context event count: `128`
+- inferred / carried / unknown chord bars: `4` / `4` / `0`
+- missing context fields: `0`
+
+## Stage B Window Resource
+
+- sequence format: `stage_b_v1`
+- train / val manifest files: `2433` / `270`
+- tokenized train / val files: `154136` / `21845`
+- max token id / vocab size: `544` / `547`
+- fits vocab: `true`
+
+## Scale-Smoke Resource
+
+- selected train / val records: `128` / `32`
+- best validation loss: `5.9031`
+- checkpoint count: `1`
+- lora weights exists: `true`
+
+## Claim Boundary
+
+- broad training executed: `false`
+- broad trained-model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+- musical quality claimed: `false`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -194,6 +194,8 @@ Modes:
                 Define the MIDI-to-solo MVP input/output contract and run plan.
   stage-b-midi-to-solo-context-extraction
                 Extract MIDI-to-solo context rows from an input MIDI fixture.
+  stage-b-midi-to-solo-training-resource-probe
+                Check MIDI-to-solo context, Stage B windows, and scale-smoke checkpoint resources.
   stage-b-generic-tiny-checkpoint-generation-probe
                 Probe generation/decode from the generic tiny checkpoint.
   stage-b-generic-tiny-checkpoint-grammar-repair
@@ -3513,6 +3515,39 @@ run_stage_b_midi_to_solo_context_extraction() {
     --require_no_final_claim
 }
 
+run_stage_b_midi_to_solo_training_resource_probe() {
+  local context_run_id="${CONTEXT_RUN_ID:-harness_stage_b_midi_to_solo_context_extraction}"
+  local full_window_run_id="${FULL_WINDOW_RUN_ID:-harness_stage_b_generic_full_manifest_window_preparation}"
+  local scale_training_run_id="${SCALE_TRAINING_RUN_ID:-harness_stage_b_generic_base_training_scale_smoke}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_training_resource_probe}"
+  local context_report="outputs/stage_b_midi_to_solo_context_extraction/${context_run_id}/stage_b_midi_to_solo_context_extraction.json"
+  local full_window_preparation="outputs/stage_b_generic_full_manifest_window_preparation/${full_window_run_id}/stage_b_generic_full_manifest_window_preparation.json"
+  local training_scale_smoke="outputs/stage_b_generic_base_training_scale_smoke/${scale_training_run_id}/stage_b_generic_base_training_scale_smoke.json"
+  if [[ ! -f "$context_report" ]]; then
+    print_header "Stage B MIDI-to-solo context extraction MVP"
+    RUN_ID="$context_run_id" run_stage_b_midi_to_solo_context_extraction
+  fi
+  if [[ ! -f "$full_window_preparation" ]]; then
+    print_header "Stage B generic full manifest window preparation"
+    RUN_ID="$full_window_run_id" run_stage_b_generic_full_manifest_window_preparation
+  fi
+  if [[ ! -f "$training_scale_smoke" ]]; then
+    print_header "Stage B generic base training scale smoke"
+    RUN_ID="$scale_training_run_id" FULL_WINDOW_RUN_ID="$full_window_run_id" run_stage_b_generic_base_training_scale_smoke
+  fi
+  print_header "Stage B MIDI-to-solo training resource probe"
+  "$PYTHON_BIN" scripts/check_stage_b_midi_to_solo_training_resource_probe.py \
+    --run_id "$run_id" \
+    --context_report "$context_report" \
+    --full_window_preparation "$full_window_preparation" \
+    --training_scale_smoke "$training_scale_smoke" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_TRAINING_RESOURCE_PROBE_2026-06-03.md \
+    --expected_boundary stage_b_midi_to_solo_training_resource_probe \
+    --expected_next_boundary stage_b_midi_to_solo_conditioned_generation_probe \
+    --require_ready \
+    --require_no_final_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -4899,6 +4934,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-context-extraction)
     run_stage_b_midi_to_solo_context_extraction
+    ;;
+  stage-b-midi-to-solo-training-resource-probe)
+    run_stage_b_midi_to_solo_training_resource_probe
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/check_stage_b_midi_to_solo_training_resource_probe.py
+++ b/scripts/check_stage_b_midi_to_solo_training_resource_probe.py
@@ -1,0 +1,464 @@
+"""Check training/eval resource readiness for the Stage B MIDI-to-solo path."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+
+
+class StageBMidiToSoloTrainingResourceProbeError(ValueError):
+    pass
+
+
+CONTEXT_BOUNDARY = "stage_b_midi_to_solo_context_extraction_mvp"
+FULL_WINDOW_BOUNDARY = "stage_b_generic_full_manifest_window_preparation"
+SCALE_SMOKE_BOUNDARY = "stage_b_generic_base_training_scale_smoke"
+BOUNDARY = "stage_b_midi_to_solo_training_resource_probe"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_conditioned_generation_probe"
+SCHEMA_VERSION = "stage_b_midi_to_solo_training_resource_probe_v1"
+
+REQUIRED_CONTEXT_FIELDS = {
+    "bar_index",
+    "position_index",
+    "tempo",
+    "chord_root",
+    "chord_quality",
+    "next_chord_root",
+    "next_chord_quality",
+    "bass_note",
+    "chord_confidence",
+    "chord_source",
+}
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise StageBMidiToSoloTrainingResourceProbeError(f"report missing: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def context_summary(context_report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(context_report.get("readiness"))
+    summary = _dict(context_report.get("summary"))
+    context = _dict(context_report.get("context"))
+    events = _list(context.get("context_events"))
+    missing_fields: set[str] = set()
+    for event in events:
+        if isinstance(event, dict):
+            missing_fields.update(REQUIRED_CONTEXT_FIELDS - set(event))
+        else:
+            missing_fields.update(REQUIRED_CONTEXT_FIELDS)
+    boundary = str(context_report.get("boundary") or readiness.get("boundary") or "")
+    return {
+        "boundary": boundary,
+        "context_extraction_completed": bool(readiness.get("context_extraction_completed", False)),
+        "required_context_fields_present": bool(readiness.get("required_context_fields_present", False))
+        and not missing_fields,
+        "context_bars": _int(summary.get("context_bars")),
+        "positions_per_bar": _int(summary.get("positions_per_bar")),
+        "context_event_count": _int(summary.get("context_event_count")),
+        "inferred_chord_bar_count": _int(summary.get("inferred_chord_bar_count")),
+        "carry_forward_chord_bar_count": _int(summary.get("carry_forward_chord_bar_count")),
+        "unknown_chord_bar_count": _int(summary.get("unknown_chord_bar_count")),
+        "low_confidence_bar_count": _int(summary.get("low_confidence_bar_count")),
+        "bass_note_bar_count": _int(summary.get("bass_note_bar_count")),
+        "missing_context_fields": sorted(missing_fields),
+        "midi_to_solo_mvp_claimed": bool(readiness.get("midi_to_solo_mvp_claimed", True)),
+        "harmony_analysis_quality_claimed": bool(
+            readiness.get("harmony_analysis_quality_claimed", True)
+        ),
+    }
+
+
+def full_window_summary(full_window_report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(full_window_report.get("readiness"))
+    token = _dict(full_window_report.get("token_stats"))
+    inputs = _dict(full_window_report.get("input"))
+    dataset = _dict(full_window_report.get("dataset_summary"))
+    return {
+        "boundary": str(readiness.get("boundary") or ""),
+        "full_manifest_window_preparation_ready": bool(
+            readiness.get("full_manifest_window_preparation_ready", False)
+        ),
+        "sequence_format": str(dataset.get("sequence_format") or ""),
+        "train_file_count": _int(inputs.get("train_file_count")),
+        "val_file_count": _int(inputs.get("val_file_count")),
+        "window_bars": _int(inputs.get("window_bars")),
+        "window_stride_bars": _int(inputs.get("window_stride_bars")),
+        "min_window_target_notes": _int(inputs.get("min_window_target_notes")),
+        "tokenized_train_files": _int(token.get("tokenized_train_files")),
+        "tokenized_val_files": _int(token.get("tokenized_val_files")),
+        "max_token_id": _int(token.get("max_token_id")),
+        "vocab_size": _int(token.get("vocab_size")),
+        "fits_vocab": bool(token.get("fits_vocab", False)),
+        "full_training_executed": bool(readiness.get("full_training_executed", True)),
+        "broad_trained_model_quality_claimed": bool(
+            readiness.get("broad_trained_model_quality_claimed", True)
+        ),
+        "brad_style_adaptation_claimed": bool(readiness.get("brad_style_adaptation_claimed", True)),
+    }
+
+
+def scale_smoke_summary(scale_smoke_report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(scale_smoke_report.get("readiness"))
+    inputs = _dict(scale_smoke_report.get("input"))
+    token = _dict(scale_smoke_report.get("token_stats"))
+    training = _dict(scale_smoke_report.get("training"))
+    artifacts = _dict(scale_smoke_report.get("artifacts"))
+    return {
+        "boundary": str(readiness.get("boundary") or ""),
+        "training_scale_smoke_passed": bool(readiness.get("training_scale_smoke_passed", False)),
+        "generic_base_scale_checkpoint_generation_probe_ready": bool(
+            readiness.get("generic_base_scale_checkpoint_generation_probe_ready", False)
+        ),
+        "selected_train_records": _int(inputs.get("selected_train_records")),
+        "selected_val_records": _int(inputs.get("selected_val_records")),
+        "token_records": _int(token.get("files")),
+        "max_token_id": _int(token.get("max_token_id")),
+        "vocab_size": _int(token.get("vocab_size")),
+        "fits_vocab": bool(token.get("fits_vocab", False)),
+        "training_returncode": _int(training.get("returncode")),
+        "best_validation_loss": _float(training.get("best_validation_loss")),
+        "checkpoint_count": _int(artifacts.get("checkpoint_count")),
+        "lora_weights_exists": bool(artifacts.get("lora_weights_exists", False)),
+        "full_generic_training_executed": bool(readiness.get("full_generic_training_executed", True)),
+        "broad_trained_model_quality_claimed": bool(
+            readiness.get("broad_trained_model_quality_claimed", True)
+        ),
+        "brad_style_adaptation_claimed": bool(readiness.get("brad_style_adaptation_claimed", True)),
+    }
+
+
+def build_resource_probe_report(
+    *,
+    context_report: dict[str, Any],
+    full_window_report: dict[str, Any],
+    scale_smoke_report: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+) -> dict[str, Any]:
+    context = context_summary(context_report)
+    full_window = full_window_summary(full_window_report)
+    scale_smoke = scale_smoke_summary(scale_smoke_report)
+    compatible = (
+        context["boundary"] == CONTEXT_BOUNDARY
+        and context["context_extraction_completed"]
+        and context["required_context_fields_present"]
+        and context["context_event_count"] > 0
+        and context["positions_per_bar"] == 16
+        and full_window["boundary"] == FULL_WINDOW_BOUNDARY
+        and full_window["full_manifest_window_preparation_ready"]
+        and full_window["sequence_format"] == "stage_b_v1"
+        and full_window["fits_vocab"]
+        and scale_smoke["boundary"] == SCALE_SMOKE_BOUNDARY
+        and scale_smoke["training_scale_smoke_passed"]
+        and scale_smoke["generic_base_scale_checkpoint_generation_probe_ready"]
+        and scale_smoke["fits_vocab"]
+        and scale_smoke["checkpoint_count"] > 0
+        and scale_smoke["best_validation_loss"] is not None
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundaries": {
+            "context": CONTEXT_BOUNDARY,
+            "full_window": FULL_WINDOW_BOUNDARY,
+            "scale_smoke": SCALE_SMOKE_BOUNDARY,
+        },
+        "context_resource": context,
+        "full_window_resource": full_window,
+        "scale_smoke_resource": scale_smoke,
+        "compatibility": {
+            "context_fields_match_generation_contract": bool(
+                context["required_context_fields_present"] and context["positions_per_bar"] == 16
+            ),
+            "stage_b_window_resource_available": bool(
+                full_window["full_manifest_window_preparation_ready"] and full_window["fits_vocab"]
+            ),
+            "scale_checkpoint_resource_available": bool(
+                scale_smoke["training_scale_smoke_passed"] and scale_smoke["checkpoint_count"] > 0
+            ),
+            "conditioned_generation_probe_ready": bool(compatible),
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "training_resource_probe_completed": True,
+            "midi_to_solo_training_resource_ready": bool(compatible),
+            "conditioned_generation_probe_ready": bool(compatible),
+            "midi_to_solo_mvp_claimed": False,
+            "conditioned_generation_completed": False,
+            "broad_training_executed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "musical_quality_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": (
+                "MIDI context rows, full Stage B window resources, and scale-smoke checkpoint "
+                "evidence are available for a conditioned generation probe"
+            ),
+        },
+        "not_proven": [
+            "conditioned_generation_output",
+            "ranked_solo_midi_candidates",
+            "midi_to_solo_mvp_completion",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "human_audio_preference",
+        ],
+        "next_recommended_issue": "Stage B MIDI-to-solo conditioned generation probe",
+    }
+
+
+def validate_resource_probe_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_ready: bool,
+    require_no_final_claim: bool,
+    min_context_events: int,
+    min_full_train_records: int,
+    min_full_val_records: int,
+    min_scale_train_records: int,
+    min_scale_val_records: int,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    context = _dict(report.get("context_resource"))
+    full_window = _dict(report.get("full_window_resource"))
+    scale_smoke = _dict(report.get("scale_smoke_resource"))
+    next_boundary = str(decision.get("next_boundary") or "")
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloTrainingResourceProbeError(f"expected boundary {expected_boundary}, got {boundary}")
+    if expected_next_boundary and next_boundary != expected_next_boundary:
+        raise StageBMidiToSoloTrainingResourceProbeError(
+            f"expected next boundary {expected_next_boundary}, got {next_boundary}"
+        )
+    if require_ready and not bool(readiness.get("midi_to_solo_training_resource_ready", False)):
+        raise StageBMidiToSoloTrainingResourceProbeError("training resource must be ready")
+    if _int(context.get("context_event_count")) < int(min_context_events):
+        raise StageBMidiToSoloTrainingResourceProbeError("context event count below threshold")
+    if _list(context.get("missing_context_fields")):
+        raise StageBMidiToSoloTrainingResourceProbeError("context fields missing")
+    if _int(full_window.get("tokenized_train_files")) < int(min_full_train_records):
+        raise StageBMidiToSoloTrainingResourceProbeError("full train token records below threshold")
+    if _int(full_window.get("tokenized_val_files")) < int(min_full_val_records):
+        raise StageBMidiToSoloTrainingResourceProbeError("full val token records below threshold")
+    if not bool(full_window.get("fits_vocab", False)):
+        raise StageBMidiToSoloTrainingResourceProbeError("full window token vocab guard failed")
+    if _int(scale_smoke.get("selected_train_records")) < int(min_scale_train_records):
+        raise StageBMidiToSoloTrainingResourceProbeError("scale-smoke train records below threshold")
+    if _int(scale_smoke.get("selected_val_records")) < int(min_scale_val_records):
+        raise StageBMidiToSoloTrainingResourceProbeError("scale-smoke val records below threshold")
+    if not bool(scale_smoke.get("fits_vocab", False)):
+        raise StageBMidiToSoloTrainingResourceProbeError("scale-smoke token vocab guard failed")
+    if _int(scale_smoke.get("checkpoint_count")) <= 0:
+        raise StageBMidiToSoloTrainingResourceProbeError("scale-smoke checkpoint missing")
+    if scale_smoke.get("best_validation_loss") is None:
+        raise StageBMidiToSoloTrainingResourceProbeError("scale-smoke validation loss missing")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloTrainingResourceProbeError("critical user input should not be required")
+    if require_no_final_claim:
+        blocked = [
+            "midi_to_solo_mvp_claimed",
+            "conditioned_generation_completed",
+            "broad_training_executed",
+            "broad_trained_model_quality_claimed",
+            "brad_style_adaptation_claimed",
+            "musical_quality_claimed",
+        ]
+        claimed = [name for name in blocked if bool(readiness.get(name, True))]
+        if claimed:
+            raise StageBMidiToSoloTrainingResourceProbeError(f"unexpected final claim: {claimed}")
+        upstream_claims = [
+            bool(context.get("midi_to_solo_mvp_claimed", True)),
+            bool(context.get("harmony_analysis_quality_claimed", True)),
+            bool(full_window.get("broad_trained_model_quality_claimed", True)),
+            bool(full_window.get("brad_style_adaptation_claimed", True)),
+            bool(scale_smoke.get("broad_trained_model_quality_claimed", True)),
+            bool(scale_smoke.get("brad_style_adaptation_claimed", True)),
+        ]
+        if any(upstream_claims):
+            raise StageBMidiToSoloTrainingResourceProbeError("upstream quality claims must remain false")
+    return {
+        "boundary": boundary,
+        "next_boundary": next_boundary,
+        "midi_to_solo_training_resource_ready": bool(
+            readiness.get("midi_to_solo_training_resource_ready", False)
+        ),
+        "conditioned_generation_probe_ready": bool(
+            readiness.get("conditioned_generation_probe_ready", False)
+        ),
+        "context_event_count": _int(context.get("context_event_count")),
+        "context_bars": _int(context.get("context_bars")),
+        "full_tokenized_train_files": _int(full_window.get("tokenized_train_files")),
+        "full_tokenized_val_files": _int(full_window.get("tokenized_val_files")),
+        "scale_selected_train_records": _int(scale_smoke.get("selected_train_records")),
+        "scale_selected_val_records": _int(scale_smoke.get("selected_val_records")),
+        "scale_best_validation_loss": scale_smoke.get("best_validation_loss"),
+        "scale_checkpoint_count": _int(scale_smoke.get("checkpoint_count")),
+        "midi_to_solo_mvp_claimed": bool(readiness.get("midi_to_solo_mvp_claimed", True)),
+        "conditioned_generation_completed": bool(
+            readiness.get("conditioned_generation_completed", True)
+        ),
+        "broad_training_executed": bool(readiness.get("broad_training_executed", True)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    context = report["context_resource"]
+    full_window = report["full_window_resource"]
+    scale_smoke = report["scale_smoke_resource"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    lines = [
+        "# Stage B MIDI-to-Solo Training Resource Probe",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- training resource ready: `{_bool_token(readiness['midi_to_solo_training_resource_ready'])}`",
+        f"- conditioned generation probe ready: `{_bool_token(readiness['conditioned_generation_probe_ready'])}`",
+        f"- MIDI-to-solo MVP claimed: `{_bool_token(readiness['midi_to_solo_mvp_claimed'])}`",
+        f"- conditioned generation completed: `{_bool_token(readiness['conditioned_generation_completed'])}`",
+        "",
+        "## Context Resource",
+        "",
+        f"- context bars: `{context['context_bars']}`",
+        f"- context event count: `{context['context_event_count']}`",
+        f"- inferred / carried / unknown chord bars: `{context['inferred_chord_bar_count']}` / `{context['carry_forward_chord_bar_count']}` / `{context['unknown_chord_bar_count']}`",
+        f"- missing context fields: `{len(context['missing_context_fields'])}`",
+        "",
+        "## Stage B Window Resource",
+        "",
+        f"- sequence format: `{full_window['sequence_format']}`",
+        f"- train / val manifest files: `{full_window['train_file_count']}` / `{full_window['val_file_count']}`",
+        f"- tokenized train / val files: `{full_window['tokenized_train_files']}` / `{full_window['tokenized_val_files']}`",
+        f"- max token id / vocab size: `{full_window['max_token_id']}` / `{full_window['vocab_size']}`",
+        f"- fits vocab: `{_bool_token(full_window['fits_vocab'])}`",
+        "",
+        "## Scale-Smoke Resource",
+        "",
+        f"- selected train / val records: `{scale_smoke['selected_train_records']}` / `{scale_smoke['selected_val_records']}`",
+        f"- best validation loss: `{scale_smoke['best_validation_loss']}`",
+        f"- checkpoint count: `{scale_smoke['checkpoint_count']}`",
+        f"- lora weights exists: `{_bool_token(scale_smoke['lora_weights_exists'])}`",
+        "",
+        "## Claim Boundary",
+        "",
+        f"- broad training executed: `{_bool_token(readiness['broad_training_executed'])}`",
+        f"- broad trained-model quality claimed: `{_bool_token(readiness['broad_trained_model_quality_claimed'])}`",
+        f"- Brad style adaptation claimed: `{_bool_token(readiness['brad_style_adaptation_claimed'])}`",
+        f"- musical quality claimed: `{_bool_token(readiness['musical_quality_claimed'])}`",
+    ]
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Check MIDI-to-solo training resource readiness")
+    parser.add_argument("--context_report", type=str, required=True)
+    parser.add_argument("--full_window_preparation", type=str, required=True)
+    parser.add_argument("--training_scale_smoke", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_training_resource_probe",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=485)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_ready", action="store_true")
+    parser.add_argument("--require_no_final_claim", action="store_true")
+    parser.add_argument("--min_context_events", type=int, default=128)
+    parser.add_argument("--min_full_train_records", type=int, default=100000)
+    parser.add_argument("--min_full_val_records", type=int, default=10000)
+    parser.add_argument("--min_scale_train_records", type=int, default=64)
+    parser.add_argument("--min_scale_val_records", type=int, default=16)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_resource_probe_report(
+        context_report=read_json(Path(args.context_report)),
+        full_window_report=read_json(Path(args.full_window_preparation)),
+        scale_smoke_report=read_json(Path(args.training_scale_smoke)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+    )
+    summary = validate_resource_probe_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_ready=bool(args.require_ready),
+        require_no_final_claim=bool(args.require_no_final_claim),
+        min_context_events=int(args.min_context_events),
+        min_full_train_records=int(args.min_full_train_records),
+        min_full_val_records=int(args.min_full_val_records),
+        min_scale_train_records=int(args.min_scale_train_records),
+        min_scale_val_records=int(args.min_scale_val_records),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "stage_b_midi_to_solo_training_resource_probe.json", report)
+    write_json(output_dir / "stage_b_midi_to_solo_training_resource_probe_validation_summary.json", summary)
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_midi_to_solo_training_resource_probe.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_training_resource_probe.py
+++ b/tests/test_stage_b_midi_to_solo_training_resource_probe.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.check_stage_b_midi_to_solo_training_resource_probe import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    REQUIRED_CONTEXT_FIELDS,
+    StageBMidiToSoloTrainingResourceProbeError,
+    build_resource_probe_report,
+    validate_resource_probe_report,
+)
+
+
+def context_report(*, missing_field: bool = False, final_claim: bool = False) -> dict:
+    event = {field: None for field in REQUIRED_CONTEXT_FIELDS}
+    event.update(
+        {
+            "bar_index": 0,
+            "position_index": 0,
+            "tempo": 120.0,
+            "chord_root": "C",
+            "chord_quality": "maj7",
+            "next_chord_root": "F",
+            "next_chord_quality": "dom7",
+            "bass_note": 36,
+            "chord_confidence": 0.9,
+            "chord_source": "pitch_class_inference",
+        }
+    )
+    if missing_field:
+        event.pop("chord_source")
+    return {
+        "boundary": "stage_b_midi_to_solo_context_extraction_mvp",
+        "summary": {
+            "context_bars": 8,
+            "positions_per_bar": 16,
+            "context_event_count": 128,
+            "inferred_chord_bar_count": 4,
+            "carry_forward_chord_bar_count": 4,
+            "unknown_chord_bar_count": 0,
+            "low_confidence_bar_count": 4,
+            "bass_note_bar_count": 4,
+        },
+        "context": {"context_events": [event] * 128},
+        "readiness": {
+            "context_extraction_completed": True,
+            "required_context_fields_present": True,
+            "midi_to_solo_mvp_claimed": final_claim,
+            "harmony_analysis_quality_claimed": False,
+        },
+    }
+
+
+def full_window_report(*, train_files: int = 154136, quality_claim: bool = False) -> dict:
+    return {
+        "readiness": {
+            "boundary": "stage_b_generic_full_manifest_window_preparation",
+            "full_manifest_window_preparation_ready": True,
+            "full_training_executed": False,
+            "broad_trained_model_quality_claimed": quality_claim,
+            "brad_style_adaptation_claimed": False,
+        },
+        "input": {
+            "train_file_count": 2433,
+            "val_file_count": 270,
+            "window_bars": 2,
+            "window_stride_bars": 2,
+            "min_window_target_notes": 4,
+        },
+        "dataset_summary": {"sequence_format": "stage_b_v1"},
+        "token_stats": {
+            "tokenized_train_files": train_files,
+            "tokenized_val_files": 21845,
+            "max_token_id": 544,
+            "vocab_size": 547,
+            "fits_vocab": True,
+        },
+    }
+
+
+def scale_smoke_report(*, checkpoint_count: int = 1, loss: float | None = 5.9031) -> dict:
+    return {
+        "readiness": {
+            "boundary": "stage_b_generic_base_training_scale_smoke",
+            "training_scale_smoke_passed": True,
+            "generic_base_scale_checkpoint_generation_probe_ready": True,
+            "full_generic_training_executed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "input": {
+            "selected_train_records": 128,
+            "selected_val_records": 32,
+        },
+        "token_stats": {
+            "files": 160,
+            "max_token_id": 544,
+            "vocab_size": 547,
+            "fits_vocab": True,
+        },
+        "training": {
+            "returncode": 0,
+            "best_validation_loss": loss,
+        },
+        "artifacts": {
+            "checkpoint_count": checkpoint_count,
+            "lora_weights_exists": True,
+        },
+    }
+
+
+def build_report(**overrides: dict) -> dict:
+    return build_resource_probe_report(
+        context_report=overrides.get("context_report") or context_report(),
+        full_window_report=overrides.get("full_window_report") or full_window_report(),
+        scale_smoke_report=overrides.get("scale_smoke_report") or scale_smoke_report(),
+        output_dir=Path("outputs/resource_probe"),
+        issue_number=485,
+    )
+
+
+class StageBMidiToSoloTrainingResourceProbeTest(unittest.TestCase):
+    def test_accepts_ready_training_resource_without_final_claim(self) -> None:
+        summary = validate_resource_probe_report(
+            build_report(),
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=NEXT_BOUNDARY,
+            require_ready=True,
+            require_no_final_claim=True,
+            min_context_events=128,
+            min_full_train_records=100000,
+            min_full_val_records=10000,
+            min_scale_train_records=64,
+            min_scale_val_records=16,
+        )
+
+        self.assertTrue(summary["midi_to_solo_training_resource_ready"])
+        self.assertTrue(summary["conditioned_generation_probe_ready"])
+        self.assertEqual(summary["context_event_count"], 128)
+        self.assertEqual(summary["full_tokenized_train_files"], 154136)
+        self.assertEqual(summary["scale_selected_train_records"], 128)
+        self.assertEqual(summary["scale_checkpoint_count"], 1)
+        self.assertEqual(summary["scale_best_validation_loss"], 5.9031)
+        self.assertFalse(summary["midi_to_solo_mvp_claimed"])
+        self.assertFalse(summary["conditioned_generation_completed"])
+        self.assertFalse(summary["broad_training_executed"])
+
+    def test_rejects_missing_context_field(self) -> None:
+        with self.assertRaises(StageBMidiToSoloTrainingResourceProbeError):
+            validate_resource_probe_report(
+                build_report(context_report=context_report(missing_field=True)),
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                require_ready=True,
+                require_no_final_claim=True,
+                min_context_events=128,
+                min_full_train_records=100000,
+                min_full_val_records=10000,
+                min_scale_train_records=64,
+                min_scale_val_records=16,
+            )
+
+    def test_rejects_small_full_window_resource(self) -> None:
+        with self.assertRaises(StageBMidiToSoloTrainingResourceProbeError):
+            validate_resource_probe_report(
+                build_report(full_window_report=full_window_report(train_files=999)),
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                require_ready=True,
+                require_no_final_claim=True,
+                min_context_events=128,
+                min_full_train_records=100000,
+                min_full_val_records=10000,
+                min_scale_train_records=64,
+                min_scale_val_records=16,
+            )
+
+    def test_rejects_missing_scale_checkpoint(self) -> None:
+        with self.assertRaises(StageBMidiToSoloTrainingResourceProbeError):
+            validate_resource_probe_report(
+                build_report(scale_smoke_report=scale_smoke_report(checkpoint_count=0)),
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                require_ready=True,
+                require_no_final_claim=True,
+                min_context_events=128,
+                min_full_train_records=100000,
+                min_full_val_records=10000,
+                min_scale_train_records=64,
+                min_scale_val_records=16,
+            )
+
+    def test_rejects_upstream_final_claims(self) -> None:
+        with self.assertRaises(StageBMidiToSoloTrainingResourceProbeError):
+            validate_resource_probe_report(
+                build_report(context_report=context_report(final_claim=True)),
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                require_ready=True,
+                require_no_final_claim=True,
+                min_context_events=128,
+                min_full_train_records=100000,
+                min_full_val_records=10000,
+                min_scale_train_records=64,
+                min_scale_val_records=16,
+            )
+
+    def test_boundary_constants_are_stable(self) -> None:
+        self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_training_resource_probe")
+        self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_conditioned_generation_probe")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- MIDI-to-solo context extraction report를 Stage B full window resource와 scale-smoke checkpoint evidence에 연결
- conditioned generation probe 준비 여부 검증
- 전용 harness mode, unit test, status 문서 갱신

## Context

- #481에서 MIDI-to-solo MVP 입출력 계약 정의
- #483에서 입력 MIDI context extraction 완료
- 다음 generation probe 전에 context/window/checkpoint resource 연결 여부 확인 필요

## Result

- boundary: `stage_b_midi_to_solo_training_resource_probe`
- next boundary: `stage_b_midi_to_solo_conditioned_generation_probe`
- training resource ready: `true`
- conditioned generation probe ready: `true`
- context event count: `128`
- full tokenized train / val files: `154136 / 21845`
- scale-smoke train / val records: `128 / 32`
- scale-smoke best validation loss: `5.9031`
- scale-smoke checkpoint count: `1`

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_training_resource_probe tests.test_stage_b_midi_to_solo_context_extraction tests.test_stage_b_midi_to_solo_mvp_contract`
- `.venv/bin/python -m py_compile scripts/check_stage_b_midi_to_solo_training_resource_probe.py scripts/extract_stage_b_midi_to_solo_context.py scripts/define_stage_b_midi_to_solo_mvp_contract.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-training-resource-probe`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- staged diff forbidden-public-name grep: no matches

## Risk

- conditioned generation output not produced in this scope
- broad training, Brad style adaptation, musical quality claim excluded
- scale-smoke checkpoint is readiness evidence, not final model quality evidence

## Follow-up

- Stage B MIDI-to-solo conditioned generation probe

Closes #485