### PR TITLE
Stage B MIDI-to-solo candidate audio render package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #487, Stage B MIDI-to-solo conditioned generation probe.
+- Latest functional issue completed: Issue #489, Stage B MIDI-to-solo candidate audio render package.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo candidate audio render package.
+- Recommended next issue: Stage B MIDI-to-solo MVP execution consolidation.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1035,6 +1035,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-conditioned-generation-probe
 ```
 
 This harness exports ranked context-conditioned MIDI candidates and verifies objective gates without claiming completed MVP quality or human/audio preference.
+
+For Stage B MIDI-to-solo candidate audio render package changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-candidate-audio-render-package
+```
+
+This harness renders exported MIDI-to-solo candidates to local WAV files and validates technical WAV metadata without claiming audio quality or human preference.
 
 For Stage B generic tiny checkpoint generation probe changes, run:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -262,6 +262,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo context extraction MVP: context bars `8`, context events `128`, inferred/carried/unknown chord bars `4/4/0`, bass-note bars `4`, next boundary `stage_b_midi_to_solo_training_resource_probe`
 - MIDI-to-solo training resource probe: ready `true`, context events `128`, full tokenized train/val `154136/21845`, scale-smoke train/val `128/32`, checkpoint count `1`, next boundary `stage_b_midi_to_solo_conditioned_generation_probe`
 - MIDI-to-solo conditioned generation probe: source `context_conditioned_fallback`, candidates `8`, exported/qualified `3/3`, best note/unique/max-sim `60/14/1`, next boundary `stage_b_midi_to_solo_candidate_audio_render_package`
+- MIDI-to-solo candidate audio render package: rendered WAV `3`, sample rate `44100`, technical validation `true`, preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_execution_consolidation`
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
 - generic base readiness audit: phase4 prep ready `true`, broad training execution ready `false`, broad quality/Brad adaptation claim `false`
 - generic base manifest contract: generic split `2433/270`, Brad split `47/11/14`, leakage/overlap `0`, broad training execution ready `false`

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #487, Stage B MIDI-to-solo conditioned generation probe
-- 다음 권장 이슈: `Stage B MIDI-to-solo candidate audio render package`
+- latest functional result: Issue #489, Stage B MIDI-to-solo candidate audio render package
+- 다음 권장 이슈: `Stage B MIDI-to-solo MVP execution consolidation`
 
 현재 범위가 아닌 것:
 
@@ -210,6 +210,52 @@ Exported MIDI:
 다음:
 
 - `Stage B MIDI-to-solo candidate audio render package`
+
+## Stage B MIDI-to-Solo Candidate Audio Render Package Result
+
+Issue #489는 #487에서 export한 ranked MIDI solo candidates를 로컬 WAV로 render하고 technical metadata를 검증한 작업이다.
+
+변경:
+
+- MIDI-to-solo candidate audio render script 추가
+- fluidsynth/soundfont 기반 WAV render 실행
+- WAV sample rate, frame count, size, sha256 metadata 검증
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_CANDIDATE_AUDIO_RENDER_PACKAGE_2026-06-03.md`
+- boundary: `stage_b_midi_to_solo_candidate_audio_render_package`
+- next boundary: `stage_b_midi_to_solo_mvp_execution_consolidation`
+- render attempted: `true`
+- rendered audio file count: `3`
+- technical WAV validation: `true`
+- sample rate: `44100`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo MVP claimed: `false`
+- critical user input required: `false`
+
+Rendered WAV:
+
+- rank 1: `outputs/stage_b_midi_to_solo_candidate_audio_render_package/harness_stage_b_midi_to_solo_candidate_audio_render_package/audio/rank_01_seed_489.wav`
+- rank 2: `outputs/stage_b_midi_to_solo_candidate_audio_render_package/harness_stage_b_midi_to_solo_candidate_audio_render_package/audio/rank_02_seed_488.wav`
+- rank 3: `outputs/stage_b_midi_to_solo_candidate_audio_render_package/harness_stage_b_midi_to_solo_candidate_audio_render_package/audio/rank_03_seed_487.wav`
+
+판단:
+
+- `input.mid -> context -> ranked MIDI -> WAV` 실행 경로는 technical validation 기준 연결 완료
+- audio quality와 human preference는 아직 claim하지 않음
+- 다음 작업은 실행 경로, 산출물, claim boundary 통합 정리
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_candidate_audio_render`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-candidate-audio-render-package`
+
+다음:
+
+- `Stage B MIDI-to-solo MVP execution consolidation`
 
 ## Previous Model Decision
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_CANDIDATE_AUDIO_RENDER_PACKAGE_2026-06-03.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_CANDIDATE_AUDIO_RENDER_PACKAGE_2026-06-03.md
@@ -1,0 +1,28 @@
+# Stage B MIDI-to-Solo Candidate Audio Render Package
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_candidate_audio_render_package`
+- next boundary: `stage_b_midi_to_solo_mvp_execution_consolidation`
+- render attempted: `true`
+- rendered audio file count: `3`
+- technical WAV validation: `true`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo MVP claimed: `false`
+
+## Rendered Files
+
+| rank | seed | wav path | duration | sample rate | size | sha256 |
+|---:|---:|---|---:|---:|---:|---|
+| 1 | 489 | outputs/stage_b_midi_to_solo_candidate_audio_render_package/harness_stage_b_midi_to_solo_candidate_audio_render_package/audio/rank_01_seed_489.wav | 18.617 | 44100 | 3284012 | 47291649d233 |
+| 2 | 488 | outputs/stage_b_midi_to_solo_candidate_audio_render_package/harness_stage_b_midi_to_solo_candidate_audio_render_package/audio/rank_02_seed_488.wav | 18.991 | 44100 | 3350060 | 6ca39bbd762c |
+| 3 | 487 | outputs/stage_b_midi_to_solo_candidate_audio_render_package/harness_stage_b_midi_to_solo_candidate_audio_render_package/audio/rank_03_seed_487.wav | 18.977 | 44100 | 3347500 | 2e4522ca8445 |
+
+## Not Proven
+
+- `audio_rendered_quality`
+- `human_audio_preference`
+- `midi_to_solo_mvp_completion`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -198,6 +198,8 @@ Modes:
                 Check MIDI-to-solo context, Stage B windows, and scale-smoke checkpoint resources.
   stage-b-midi-to-solo-conditioned-generation-probe
                 Export ranked context-conditioned MIDI-to-solo candidates.
+  stage-b-midi-to-solo-candidate-audio-render-package
+                Render exported MIDI-to-solo candidates to local WAV files.
   stage-b-generic-tiny-checkpoint-generation-probe
                 Probe generation/decode from the generic tiny checkpoint.
   stage-b-generic-tiny-checkpoint-grammar-repair
@@ -3576,6 +3578,24 @@ run_stage_b_midi_to_solo_conditioned_generation_probe() {
     --require_no_final_claim
 }
 
+run_stage_b_midi_to_solo_candidate_audio_render_package() {
+  local generation_run_id="${GENERATION_RUN_ID:-harness_stage_b_midi_to_solo_conditioned_generation_probe}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_candidate_audio_render_package}"
+  local generation_report="outputs/stage_b_midi_to_solo_conditioned_generation_probe/${generation_run_id}/stage_b_midi_to_solo_conditioned_generation_probe.json"
+  if [[ ! -f "$generation_report" ]]; then
+    print_header "Stage B MIDI-to-solo conditioned generation probe"
+    RUN_ID="$generation_run_id" run_stage_b_midi_to_solo_conditioned_generation_probe
+  fi
+  print_header "Stage B MIDI-to-solo candidate audio render package"
+  "$PYTHON_BIN" scripts/render_stage_b_midi_to_solo_candidate_audio.py \
+    --run_id "$run_id" \
+    --conditioned_generation_report "$generation_report" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_CANDIDATE_AUDIO_RENDER_PACKAGE_2026-06-03.md \
+    --expected_boundary stage_b_midi_to_solo_candidate_audio_render_package \
+    --expected_file_count 3 \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -4968,6 +4988,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-conditioned-generation-probe)
     run_stage_b_midi_to_solo_conditioned_generation_probe
+    ;;
+  stage-b-midi-to-solo-candidate-audio-render-package)
+    run_stage_b_midi_to_solo_candidate_audio_render_package
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/render_stage_b_midi_to_solo_candidate_audio.py
+++ b/scripts/render_stage_b_midi_to_solo_candidate_audio.py
@@ -1,0 +1,419 @@
+"""Render Stage B MIDI-to-solo exported candidates to WAV files."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+import wave
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+
+
+class StageBMidiToSoloCandidateAudioRenderError(ValueError):
+    pass
+
+
+SOURCE_BOUNDARY = "stage_b_midi_to_solo_conditioned_generation_probe"
+BOUNDARY = "stage_b_midi_to_solo_candidate_audio_render_package"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_mvp_execution_consolidation"
+SCHEMA_VERSION = "stage_b_midi_to_solo_candidate_audio_render_package_v1"
+CommandRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise StageBMidiToSoloCandidateAudioRenderError(f"report missing: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def wav_meta(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise StageBMidiToSoloCandidateAudioRenderError(f"WAV not found: {path}")
+    with wave.open(str(path), "rb") as handle:
+        channels = handle.getnchannels()
+        sample_width = handle.getsampwidth()
+        sample_rate = handle.getframerate()
+        frame_count = handle.getnframes()
+    return {
+        "path": str(path),
+        "exists": True,
+        "size_bytes": int(path.stat().st_size),
+        "sha256": sha256_file(path),
+        "channels": int(channels),
+        "sample_width_bytes": int(sample_width),
+        "sample_rate": int(sample_rate),
+        "frame_count": int(frame_count),
+        "duration_seconds": float(frame_count / sample_rate) if sample_rate else 0.0,
+    }
+
+
+def default_soundfont_candidates() -> list[Path]:
+    candidates = [
+        Path.home() / ".local/share/soundfonts/generaluser-gs/v1.471.sf2",
+        Path("/opt/homebrew/Cellar/fluid-synth/2.5.4/share/fluid-synth/sf2/VintageDreamsWaves-v2.sf3"),
+        Path("/opt/homebrew/Cellar/fluid-synth/2.5.4/share/fluid-synth/sf2/VintageDreamsWaves-v2.sf2"),
+    ]
+    candidates.extend(sorted(Path("/opt/homebrew/Cellar").glob("fluid-synth/*/share/fluid-synth/sf2/*.sf3")))
+    candidates.extend(sorted(Path("/opt/homebrew/Cellar").glob("fluid-synth/*/share/fluid-synth/sf2/*.sf2")))
+    return candidates
+
+
+def resolve_soundfont(soundfont_path: str) -> str:
+    if soundfont_path:
+        return str(Path(soundfont_path).expanduser())
+    for candidate in default_soundfont_candidates():
+        if candidate.exists():
+            return str(candidate)
+    return ""
+
+
+def validate_source_report(report: dict[str, Any], expected_count: int) -> list[dict[str, Any]]:
+    readiness = _dict(report.get("readiness"))
+    if str(report.get("boundary") or readiness.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloCandidateAudioRenderError("conditioned generation boundary required")
+    if not bool(readiness.get("ranked_midi_candidates_exported", False)):
+        raise StageBMidiToSoloCandidateAudioRenderError("ranked MIDI candidates must be exported")
+    if bool(readiness.get("human_audio_preference_claimed", True)):
+        raise StageBMidiToSoloCandidateAudioRenderError("human/audio preference must not be claimed")
+    items = _list(report.get("top_candidates"))
+    if len(items) < int(expected_count):
+        raise StageBMidiToSoloCandidateAudioRenderError("not enough top candidates")
+    compacted: list[dict[str, Any]] = []
+    for item in items[: int(expected_count)]:
+        row = _dict(item)
+        midi_path = Path(str(row.get("export_midi_path") or ""))
+        if not midi_path.exists():
+            raise StageBMidiToSoloCandidateAudioRenderError(f"exported MIDI not found: {midi_path}")
+        compacted.append(
+            {
+                "rank": _int(row.get("rank")),
+                "seed": _int(row.get("seed")),
+                "midi_path": str(midi_path),
+                "score": row.get("score"),
+                "note_count": _int(row.get("note_count")),
+                "unique_pitch_count": _int(row.get("unique_pitch_count")),
+            }
+        )
+    return compacted
+
+
+def build_render_plan(
+    candidates: list[dict[str, Any]],
+    *,
+    output_dir: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+) -> list[dict[str, Any]]:
+    renderer = Path(renderer_path)
+    soundfont = Path(soundfont_path).expanduser()
+    if not renderer.exists():
+        raise StageBMidiToSoloCandidateAudioRenderError(f"renderer not found: {renderer}")
+    if not soundfont.exists():
+        raise StageBMidiToSoloCandidateAudioRenderError(f"soundfont not found: {soundfont}")
+    plan: list[dict[str, Any]] = []
+    for item in candidates:
+        wav_path = output_dir / "audio" / f"rank_{int(item['rank']):02d}_seed_{int(item['seed'])}.wav"
+        plan.append(
+            {
+                **item,
+                "wav_path": str(wav_path),
+                "command": [
+                    str(renderer),
+                    "-ni",
+                    "-F",
+                    str(wav_path),
+                    "-r",
+                    str(sample_rate),
+                    str(soundfont),
+                    str(item["midi_path"]),
+                ],
+            }
+        )
+    return plan
+
+
+def default_runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(list(command), check=False, text=True, capture_output=True)
+
+
+def execute_render_plan(plan: list[dict[str, Any]], *, runner: CommandRunner = default_runner) -> list[dict[str, Any]]:
+    rendered: list[dict[str, Any]] = []
+    for item in plan:
+        wav_path = Path(str(item["wav_path"]))
+        wav_path.parent.mkdir(parents=True, exist_ok=True)
+        completed = runner(item["command"])
+        if completed.returncode != 0:
+            raise StageBMidiToSoloCandidateAudioRenderError(
+                f"render failed for rank {item['rank']}: {completed.stderr or completed.stdout}"
+            )
+        rendered.append(
+            {
+                "rank": item["rank"],
+                "seed": item["seed"],
+                "source_midi_path": item["midi_path"],
+                "source_score": item["score"],
+                "source_note_count": item["note_count"],
+                "source_unique_pitch_count": item["unique_pitch_count"],
+                "wav_file": wav_meta(wav_path),
+                "command": list(item["command"]),
+                "stdout_tail": (completed.stdout or "")[-1000:],
+                "stderr_tail": (completed.stderr or "")[-1000:],
+            }
+        )
+    return rendered
+
+
+def build_audio_render_report(
+    source_report: dict[str, Any],
+    *,
+    output_dir: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+    expected_file_count: int,
+    runner: CommandRunner = default_runner,
+) -> dict[str, Any]:
+    candidates = validate_source_report(source_report, expected_count=expected_file_count)
+    resolved_renderer = renderer_path or shutil.which("fluidsynth") or ""
+    resolved_soundfont = resolve_soundfont(soundfont_path)
+    plan = build_render_plan(
+        candidates,
+        output_dir=output_dir,
+        renderer_path=resolved_renderer,
+        soundfont_path=resolved_soundfont,
+        sample_rate=sample_rate,
+    )
+    rendered = execute_render_plan(plan, runner=runner)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_boundary": SOURCE_BOUNDARY,
+        "renderer": {
+            "name": "fluidsynth",
+            "path": resolved_renderer,
+        },
+        "soundfont": {
+            "path": str(Path(resolved_soundfont).expanduser()),
+            "sha256": sha256_file(Path(resolved_soundfont).expanduser()),
+        },
+        "rendered_audio_files": rendered,
+        "audio_render_boundary": {
+            "boundary": BOUNDARY,
+            "render_attempted": True,
+            "rendered_audio_file_count": int(len(rendered)),
+            "technical_wav_validation": True,
+            "audio_output_claimed": True,
+            "audio_rendered_quality_claimed": False,
+            "human_audio_preference_claimed": False,
+            "musical_quality_claimed": False,
+            "midi_to_solo_mvp_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "ranked MIDI candidates rendered to WAV; preference and quality review remain unclaimed",
+        },
+        "not_proven": [
+            "audio_rendered_quality",
+            "human_audio_preference",
+            "midi_to_solo_mvp_completion",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": "Stage B MIDI-to-solo MVP execution consolidation",
+    }
+
+
+def validate_audio_render_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_file_count: int,
+    expected_sample_rate: int,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = _dict(report.get("audio_render_boundary"))
+    if expected_boundary and str(boundary.get("boundary") or "") != expected_boundary:
+        raise StageBMidiToSoloCandidateAudioRenderError(
+            f"expected boundary {expected_boundary}, got {boundary.get('boundary')}"
+        )
+    files = _list(report.get("rendered_audio_files"))
+    if len(files) != int(expected_file_count):
+        raise StageBMidiToSoloCandidateAudioRenderError(f"expected {expected_file_count} rendered files")
+    for item in files:
+        wav_file = _dict(_dict(item).get("wav_file"))
+        if not bool(wav_file.get("exists", False)):
+            raise StageBMidiToSoloCandidateAudioRenderError("missing rendered wav")
+        if _int(wav_file.get("sample_rate")) != int(expected_sample_rate):
+            raise StageBMidiToSoloCandidateAudioRenderError("unexpected sample rate")
+        if _int(wav_file.get("frame_count")) <= 0:
+            raise StageBMidiToSoloCandidateAudioRenderError("empty wav")
+        if _int(wav_file.get("size_bytes")) <= 44:
+            raise StageBMidiToSoloCandidateAudioRenderError("invalid wav size")
+    if require_no_quality_claim:
+        blocked = [
+            "audio_rendered_quality_claimed",
+            "human_audio_preference_claimed",
+            "musical_quality_claimed",
+            "midi_to_solo_mvp_claimed",
+            "broad_trained_model_quality_claimed",
+            "brad_style_adaptation_claimed",
+        ]
+        claimed = [name for name in blocked if bool(boundary.get(name, True))]
+        if claimed:
+            raise StageBMidiToSoloCandidateAudioRenderError(f"unexpected quality claim: {claimed}")
+    decision = _dict(report.get("decision"))
+    return {
+        "boundary": str(boundary.get("boundary") or ""),
+        "render_attempted": bool(boundary.get("render_attempted", False)),
+        "rendered_audio_file_count": _int(boundary.get("rendered_audio_file_count")),
+        "technical_wav_validation": bool(boundary.get("technical_wav_validation", False)),
+        "audio_rendered_quality_claimed": bool(boundary.get("audio_rendered_quality_claimed", True)),
+        "human_audio_preference_claimed": bool(boundary.get("human_audio_preference_claimed", True)),
+        "midi_to_solo_mvp_claimed": bool(boundary.get("midi_to_solo_mvp_claimed", True)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "wav_paths": [str(_dict(_dict(item).get("wav_file")).get("path") or "") for item in files],
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    boundary = report["audio_render_boundary"]
+    decision = report["decision"]
+    lines = [
+        "# Stage B MIDI-to-Solo Candidate Audio Render Package",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{boundary['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- render attempted: `{_bool_token(boundary['render_attempted'])}`",
+        f"- rendered audio file count: `{boundary['rendered_audio_file_count']}`",
+        f"- technical WAV validation: `{_bool_token(boundary['technical_wav_validation'])}`",
+        f"- audio rendered quality claimed: `{_bool_token(boundary['audio_rendered_quality_claimed'])}`",
+        f"- human/audio preference claimed: `{_bool_token(boundary['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo MVP claimed: `{_bool_token(boundary['midi_to_solo_mvp_claimed'])}`",
+        "",
+        "## Rendered Files",
+        "",
+        "| rank | seed | wav path | duration | sample rate | size | sha256 |",
+        "|---:|---:|---|---:|---:|---:|---|",
+    ]
+    for item in report.get("rendered_audio_files", []):
+        wav_file = item["wav_file"]
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(item["rank"]),
+                    str(item["seed"]),
+                    str(wav_file["path"]),
+                    f"{float(wav_file['duration_seconds']):.3f}",
+                    str(wav_file["sample_rate"]),
+                    str(wav_file["size_bytes"]),
+                    str(wav_file["sha256"][:12]),
+                ]
+            )
+            + " |"
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Render MIDI-to-solo candidate WAV files")
+    parser.add_argument("--conditioned_generation_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_candidate_audio_render_package",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--renderer", type=str, default=shutil.which("fluidsynth") or "")
+    parser.add_argument("--soundfont", type=str, default="")
+    parser.add_argument("--sample_rate", type=int, default=44100)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_file_count", type=int, default=3)
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_audio_render_report(
+        read_json(Path(args.conditioned_generation_report)),
+        output_dir=output_dir,
+        renderer_path=str(args.renderer or ""),
+        soundfont_path=str(args.soundfont or ""),
+        sample_rate=int(args.sample_rate),
+        expected_file_count=int(args.expected_file_count),
+    )
+    summary = validate_audio_render_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_file_count=int(args.expected_file_count),
+        expected_sample_rate=int(args.sample_rate),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "stage_b_midi_to_solo_candidate_audio_render_package.json", report)
+    write_json(output_dir / "stage_b_midi_to_solo_candidate_audio_render_package_validation_summary.json", summary)
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_midi_to_solo_candidate_audio_render_package.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_candidate_audio_render.py
+++ b/tests/test_stage_b_midi_to_solo_candidate_audio_render.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+import wave
+from pathlib import Path
+from typing import Sequence
+
+from scripts.render_stage_b_midi_to_solo_candidate_audio import (
+    BOUNDARY,
+    StageBMidiToSoloCandidateAudioRenderError,
+    build_audio_render_report,
+    validate_audio_render_report,
+)
+
+
+def fake_midi(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"MThd\x00\x00\x00\x06\x00\x00\x00\x01\x00`MTrk\x00\x00\x00\x04\x00\xff/\x00")
+
+
+def write_wav(path: Path, sample_rate: int = 44100) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(2)
+        handle.setsampwidth(2)
+        handle.setframerate(sample_rate)
+        handle.writeframes(b"\x00\x00\x00\x00" * sample_rate)
+
+
+def fake_runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    output_index = list(command).index("-F") + 1
+    write_wav(Path(command[output_index]))
+    return subprocess.CompletedProcess(list(command), 0, stdout="rendered", stderr="")
+
+
+def source_report(root: Path, *, preference_claim: bool = False) -> dict:
+    midi_paths = [root / f"rank_{index:02d}.mid" for index in range(1, 4)]
+    for path in midi_paths:
+        fake_midi(path)
+    return {
+        "boundary": "stage_b_midi_to_solo_conditioned_generation_probe",
+        "readiness": {
+            "ranked_midi_candidates_exported": True,
+            "human_audio_preference_claimed": preference_claim,
+        },
+        "top_candidates": [
+            {
+                "rank": index,
+                "seed": 486 + index,
+                "export_midi_path": str(path),
+                "score": 1.5 + index,
+                "note_count": 60,
+                "unique_pitch_count": 14,
+            }
+            for index, path in enumerate(midi_paths, start=1)
+        ],
+    }
+
+
+class StageBMidiToSoloCandidateAudioRenderTest(unittest.TestCase):
+    def test_renders_wav_files_without_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            soundfont = root / "piano.sf2"
+            renderer.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            report = build_audio_render_report(
+                source_report(root),
+                output_dir=root / "rendered",
+                renderer_path=str(renderer),
+                soundfont_path=str(soundfont),
+                sample_rate=44100,
+                expected_file_count=3,
+                runner=fake_runner,
+            )
+            summary = validate_audio_render_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_file_count=3,
+                expected_sample_rate=44100,
+                require_no_quality_claim=True,
+            )
+
+            self.assertTrue(summary["render_attempted"])
+            self.assertEqual(summary["rendered_audio_file_count"], 3)
+            self.assertTrue(summary["technical_wav_validation"])
+            self.assertFalse(summary["audio_rendered_quality_claimed"])
+            self.assertFalse(summary["human_audio_preference_claimed"])
+            self.assertFalse(summary["midi_to_solo_mvp_claimed"])
+            self.assertFalse(summary["critical_user_input_required"])
+
+    def test_rejects_missing_soundfont(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            renderer.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            with self.assertRaises(StageBMidiToSoloCandidateAudioRenderError):
+                build_audio_render_report(
+                    source_report(root),
+                    output_dir=root / "rendered",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(root / "missing.sf2"),
+                    sample_rate=44100,
+                    expected_file_count=3,
+                    runner=fake_runner,
+                )
+
+    def test_rejects_upstream_human_preference_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            soundfont = root / "piano.sf2"
+            renderer.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            with self.assertRaises(StageBMidiToSoloCandidateAudioRenderError):
+                build_audio_render_report(
+                    source_report(root, preference_claim=True),
+                    output_dir=root / "rendered",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(soundfont),
+                    sample_rate=44100,
+                    expected_file_count=3,
+                    runner=fake_runner,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- #487 exported MIDI candidates 3개를 WAV로 render
- fluidsynth/soundfont 기반 technical WAV metadata 검증 추가
- 전용 harness mode, unit test, status 문서 갱신

## Context

- #487에서 ranked MIDI solo candidates export 완료
- next boundary: `stage_b_midi_to_solo_candidate_audio_render_package`
- audio quality와 human preference는 render 성공과 분리 필요

## Result

- boundary: `stage_b_midi_to_solo_candidate_audio_render_package`
- next boundary: `stage_b_midi_to_solo_mvp_execution_consolidation`
- render attempted: `true`
- rendered audio file count: `3`
- technical WAV validation: `true`
- sample rate: `44100`
- audio rendered quality claimed: `false`
- human/audio preference claimed: `false`
- MIDI-to-solo MVP claimed: `false`

## Rendered WAV

- `outputs/stage_b_midi_to_solo_candidate_audio_render_package/harness_stage_b_midi_to_solo_candidate_audio_render_package/audio/rank_01_seed_489.wav`
- `outputs/stage_b_midi_to_solo_candidate_audio_render_package/harness_stage_b_midi_to_solo_candidate_audio_render_package/audio/rank_02_seed_488.wav`
- `outputs/stage_b_midi_to_solo_candidate_audio_render_package/harness_stage_b_midi_to_solo_candidate_audio_render_package/audio/rank_03_seed_487.wav`

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_candidate_audio_render tests.test_stage_b_midi_to_solo_conditioned_generation_probe tests.test_stage_b_midi_to_solo_training_resource_probe tests.test_stage_b_midi_to_solo_context_extraction tests.test_stage_b_midi_to_solo_mvp_contract`
- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_candidate_audio.py scripts/run_stage_b_midi_to_solo_conditioned_generation_probe.py scripts/check_stage_b_midi_to_solo_training_resource_probe.py scripts/extract_stage_b_midi_to_solo_context.py scripts/define_stage_b_midi_to_solo_mvp_contract.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-candidate-audio-render-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- staged diff forbidden-public-name grep: no matches

## Risk

- audio quality and human preference not claimed
- MVP completion not claimed until execution boundary consolidation
- render output depends on local soundfont availability

## Follow-up

- Stage B MIDI-to-solo MVP execution consolidation

Closes #489