### PR TITLE
Stage B MIDI-to-solo MVP execution consolidation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #489, Stage B MIDI-to-solo candidate audio render package.
+- Latest functional issue completed: Issue #491, Stage B MIDI-to-solo MVP execution consolidation.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo MVP execution consolidation.
+- Recommended next issue: Stage B MIDI-to-solo model-direct generation repair.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1043,6 +1043,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-candidate-audio-render-packag
 ```
 
 This harness renders exported MIDI-to-solo candidates to local WAV files and validates technical WAV metadata without claiming audio quality or human preference.
+
+For Stage B MIDI-to-solo MVP execution consolidation changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-execution-consolidation
+```
+
+This harness consolidates the input-to-context-to-MIDI-to-WAV technical path while keeping musical quality, model-direct generation quality, and human preference unclaimed.
 
 For Stage B generic tiny checkpoint generation probe changes, run:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -263,6 +263,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo training resource probe: ready `true`, context events `128`, full tokenized train/val `154136/21845`, scale-smoke train/val `128/32`, checkpoint count `1`, next boundary `stage_b_midi_to_solo_conditioned_generation_probe`
 - MIDI-to-solo conditioned generation probe: source `context_conditioned_fallback`, candidates `8`, exported/qualified `3/3`, best note/unique/max-sim `60/14/1`, next boundary `stage_b_midi_to_solo_candidate_audio_render_package`
 - MIDI-to-solo candidate audio render package: rendered WAV `3`, sample rate `44100`, technical validation `true`, preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_execution_consolidation`
+- MIDI-to-solo MVP execution consolidation: technical path `true`, source `context_conditioned_fallback`, exported/rendered `3/3`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_direct_generation_repair`
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
 - generic base readiness audit: phase4 prep ready `true`, broad training execution ready `false`, broad quality/Brad adaptation claim `false`
 - generic base manifest contract: generic split `2433/270`, Brad split `47/11/14`, leakage/overlap `0`, broad training execution ready `false`

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #489, Stage B MIDI-to-solo candidate audio render package
-- 다음 권장 이슈: `Stage B MIDI-to-solo MVP execution consolidation`
+- latest functional result: Issue #491, Stage B MIDI-to-solo MVP execution consolidation
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-direct generation repair`
 
 현재 범위가 아닌 것:
 
@@ -256,6 +256,52 @@ Rendered WAV:
 다음:
 
 - `Stage B MIDI-to-solo MVP execution consolidation`
+
+## Stage B MIDI-to-Solo MVP Execution Consolidation Result
+
+Issue #491은 #481, #483, #485, #487, #489 결과를 묶어 `input MIDI -> context -> ranked MIDI -> WAV` 실행 경로를 통합 검증한 작업이다.
+
+변경:
+
+- MIDI-to-solo MVP execution consolidation script 추가
+- contract, context, resource, generation, audio render report 연결
+- MIDI/WAV artifact existence 검증
+- technical MVP completion과 musical quality claim 분리
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MVP_EXECUTION_CONSOLIDATION_2026-06-03.md`
+- boundary: `stage_b_midi_to_solo_mvp_execution_consolidation`
+- next boundary: `stage_b_midi_to_solo_model_direct_generation_repair`
+- technical execution path completed: `true`
+- MIDI-to-solo technical MVP completed: `true`
+- input to ranked MIDI completed: `true`
+- input to rendered audio completed: `true`
+- generation source: `context_conditioned_fallback`
+- exported candidate count: `3`
+- rendered audio file count: `3`
+- technical WAV validation: `true`
+- musical quality claimed: `false`
+- model checkpoint direct generation quality claimed: `false`
+- human/audio preference claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- 기술 실행 경로 기준 MVP는 완료
+- 현재 후보 생성 source는 `context_conditioned_fallback`
+- 모델 checkpoint 직접 8-bar generation 품질은 아직 미검증
+- 다음 작업은 model-direct generation repair
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_execution_consolidation`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-execution-consolidation`
+
+다음:
+
+- `Stage B MIDI-to-solo model-direct generation repair`
 
 ## Previous Model Decision
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MVP_EXECUTION_CONSOLIDATION_2026-06-03.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MVP_EXECUTION_CONSOLIDATION_2026-06-03.md
@@ -1,0 +1,38 @@
+# Stage B MIDI-to-Solo MVP Execution Consolidation
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_mvp_execution_consolidation`
+- next boundary: `stage_b_midi_to_solo_model_direct_generation_repair`
+- technical execution path completed: `true`
+- MIDI-to-solo technical MVP completed: `true`
+- musical quality claimed: `false`
+- human/audio preference claimed: `false`
+
+## Execution Path
+
+- context event count: `128`
+- generation source: `context_conditioned_fallback`
+- exported candidate count: `3`
+- rendered audio file count: `3`
+- technical WAV validation: `true`
+
+## MIDI Paths
+
+- `outputs/stage_b_midi_to_solo_conditioned_generation_probe/harness_stage_b_midi_to_solo_conditioned_generation_probe/midi/rank_01_seed_489.mid`
+- `outputs/stage_b_midi_to_solo_conditioned_generation_probe/harness_stage_b_midi_to_solo_conditioned_generation_probe/midi/rank_02_seed_488.mid`
+- `outputs/stage_b_midi_to_solo_conditioned_generation_probe/harness_stage_b_midi_to_solo_conditioned_generation_probe/midi/rank_03_seed_487.mid`
+
+## WAV Paths
+
+- `outputs/stage_b_midi_to_solo_candidate_audio_render_package/harness_stage_b_midi_to_solo_candidate_audio_render_package/audio/rank_01_seed_489.wav`
+- `outputs/stage_b_midi_to_solo_candidate_audio_render_package/harness_stage_b_midi_to_solo_candidate_audio_render_package/audio/rank_02_seed_488.wav`
+- `outputs/stage_b_midi_to_solo_candidate_audio_render_package/harness_stage_b_midi_to_solo_candidate_audio_render_package/audio/rank_03_seed_487.wav`
+
+## Not Proven
+
+- `musical_quality`
+- `human_audio_preference`
+- `model_checkpoint_direct_8bar_generation_quality`
+- `brad_style_adaptation`
+- `production_ready_improviser`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -200,6 +200,8 @@ Modes:
                 Export ranked context-conditioned MIDI-to-solo candidates.
   stage-b-midi-to-solo-candidate-audio-render-package
                 Render exported MIDI-to-solo candidates to local WAV files.
+  stage-b-midi-to-solo-mvp-execution-consolidation
+                Consolidate input-to-MIDI-to-WAV technical execution evidence.
   stage-b-generic-tiny-checkpoint-generation-probe
                 Probe generation/decode from the generic tiny checkpoint.
   stage-b-generic-tiny-checkpoint-grammar-repair
@@ -3596,6 +3598,53 @@ run_stage_b_midi_to_solo_candidate_audio_render_package() {
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_mvp_execution_consolidation() {
+  local contract_run_id="${CONTRACT_RUN_ID:-harness_stage_b_midi_to_solo_mvp_contract}"
+  local context_run_id="${CONTEXT_RUN_ID:-harness_stage_b_midi_to_solo_context_extraction}"
+  local resource_run_id="${RESOURCE_RUN_ID:-harness_stage_b_midi_to_solo_training_resource_probe}"
+  local generation_run_id="${GENERATION_RUN_ID:-harness_stage_b_midi_to_solo_conditioned_generation_probe}"
+  local audio_run_id="${AUDIO_RUN_ID:-harness_stage_b_midi_to_solo_candidate_audio_render_package}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_mvp_execution_consolidation}"
+  local contract_report="outputs/stage_b_midi_to_solo_mvp_contract/${contract_run_id}/stage_b_midi_to_solo_mvp_contract.json"
+  local context_report="outputs/stage_b_midi_to_solo_context_extraction/${context_run_id}/stage_b_midi_to_solo_context_extraction.json"
+  local resource_probe="outputs/stage_b_midi_to_solo_training_resource_probe/${resource_run_id}/stage_b_midi_to_solo_training_resource_probe.json"
+  local generation_probe="outputs/stage_b_midi_to_solo_conditioned_generation_probe/${generation_run_id}/stage_b_midi_to_solo_conditioned_generation_probe.json"
+  local audio_render="outputs/stage_b_midi_to_solo_candidate_audio_render_package/${audio_run_id}/stage_b_midi_to_solo_candidate_audio_render_package.json"
+  if [[ ! -f "$contract_report" ]]; then
+    print_header "Stage B MIDI-to-solo MVP input contract"
+    RUN_ID="$contract_run_id" run_stage_b_midi_to_solo_mvp_contract
+  fi
+  if [[ ! -f "$context_report" ]]; then
+    print_header "Stage B MIDI-to-solo context extraction MVP"
+    RUN_ID="$context_run_id" run_stage_b_midi_to_solo_context_extraction
+  fi
+  if [[ ! -f "$resource_probe" ]]; then
+    print_header "Stage B MIDI-to-solo training resource probe"
+    RUN_ID="$resource_run_id" CONTEXT_RUN_ID="$context_run_id" run_stage_b_midi_to_solo_training_resource_probe
+  fi
+  if [[ ! -f "$generation_probe" ]]; then
+    print_header "Stage B MIDI-to-solo conditioned generation probe"
+    RUN_ID="$generation_run_id" CONTEXT_RUN_ID="$context_run_id" RESOURCE_RUN_ID="$resource_run_id" run_stage_b_midi_to_solo_conditioned_generation_probe
+  fi
+  if [[ ! -f "$audio_render" ]]; then
+    print_header "Stage B MIDI-to-solo candidate audio render package"
+    RUN_ID="$audio_run_id" GENERATION_RUN_ID="$generation_run_id" run_stage_b_midi_to_solo_candidate_audio_render_package
+  fi
+  print_header "Stage B MIDI-to-solo MVP execution consolidation"
+  "$PYTHON_BIN" scripts/consolidate_stage_b_midi_to_solo_mvp_execution.py \
+    --run_id "$run_id" \
+    --contract_report "$contract_report" \
+    --context_report "$context_report" \
+    --resource_probe "$resource_probe" \
+    --generation_probe "$generation_probe" \
+    --audio_render "$audio_render" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_EXECUTION_CONSOLIDATION_2026-06-03.md \
+    --expected_boundary stage_b_midi_to_solo_mvp_execution_consolidation \
+    --expected_next_boundary stage_b_midi_to_solo_model_direct_generation_repair \
+    --require_technical_mvp \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -4991,6 +5040,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-candidate-audio-render-package)
     run_stage_b_midi_to_solo_candidate_audio_render_package
+    ;;
+  stage-b-midi-to-solo-mvp-execution-consolidation)
+    run_stage_b_midi_to_solo_mvp_execution_consolidation
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/consolidate_stage_b_midi_to_solo_mvp_execution.py
+++ b/scripts/consolidate_stage_b_midi_to_solo_mvp_execution.py
@@ -1,0 +1,329 @@
+"""Consolidate the Stage B MIDI-to-solo MVP execution path evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+
+
+class StageBMidiToSoloMvpExecutionConsolidationError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_mvp_execution_consolidation"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_model_direct_generation_repair"
+SCHEMA_VERSION = "stage_b_midi_to_solo_mvp_execution_consolidation_v1"
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise StageBMidiToSoloMvpExecutionConsolidationError(f"report missing: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def file_exists(path: str) -> bool:
+    return bool(path and Path(path).exists())
+
+
+def build_execution_consolidation_report(
+    *,
+    contract_report: dict[str, Any],
+    context_report: dict[str, Any],
+    resource_probe: dict[str, Any],
+    generation_probe: dict[str, Any],
+    audio_render: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+) -> dict[str, Any]:
+    contract_output = _dict(contract_report.get("output_contract"))
+    contract_gate = _dict(contract_report.get("objective_gate"))
+    context_summary = _dict(context_report.get("summary"))
+    resource_readiness = _dict(resource_probe.get("readiness"))
+    generation_readiness = _dict(generation_probe.get("readiness"))
+    generation_summary = _dict(generation_probe.get("summary"))
+    audio_boundary = _dict(audio_render.get("audio_render_boundary"))
+    decision = _dict(audio_render.get("decision"))
+    top_candidates = _list(generation_probe.get("top_candidates"))
+    rendered_audio_files = _list(audio_render.get("rendered_audio_files"))
+
+    midi_paths = [str(_dict(item).get("export_midi_path") or "") for item in top_candidates]
+    wav_paths = [str(_dict(_dict(item).get("wav_file")).get("path") or "") for item in rendered_audio_files]
+    technical_path_completed = (
+        str(contract_report.get("boundary") or "") == "stage_b_midi_to_solo_mvp_input_contract"
+        and str(context_report.get("boundary") or "") == "stage_b_midi_to_solo_context_extraction_mvp"
+        and str(resource_probe.get("boundary") or "") == "stage_b_midi_to_solo_training_resource_probe"
+        and str(generation_probe.get("boundary") or "") == "stage_b_midi_to_solo_conditioned_generation_probe"
+        and str(audio_boundary.get("boundary") or "") == "stage_b_midi_to_solo_candidate_audio_render_package"
+        and bool(resource_readiness.get("midi_to_solo_training_resource_ready", False))
+        and bool(generation_readiness.get("ranked_midi_candidates_exported", False))
+        and bool(audio_boundary.get("technical_wav_validation", False))
+        and all(file_exists(path) for path in midi_paths)
+        and all(file_exists(path) for path in wav_paths)
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundaries": {
+            "contract": str(contract_report.get("boundary") or ""),
+            "context": str(context_report.get("boundary") or ""),
+            "resource": str(resource_probe.get("boundary") or ""),
+            "generation": str(generation_probe.get("boundary") or ""),
+            "audio": str(audio_boundary.get("boundary") or ""),
+        },
+        "contract": {
+            "target_date": str(contract_report.get("target_date") or ""),
+            "candidate_count": _int(contract_output.get("candidate_count")),
+            "export_top_midi_count": _int(contract_output.get("export_top_midi_count")),
+            "target_solo_bars": _int(contract_output.get("target_solo_bars")),
+            "min_note_count": _int(contract_gate.get("min_note_count")),
+            "min_unique_pitch_count": _int(contract_gate.get("min_unique_pitch_count")),
+            "max_simultaneous_notes": _int(contract_gate.get("max_simultaneous_notes")),
+        },
+        "execution_path": {
+            "context_event_count": _int(context_summary.get("context_event_count")),
+            "resource_ready": bool(resource_readiness.get("midi_to_solo_training_resource_ready", False)),
+            "generation_source": str(_dict(generation_probe.get("generation_config")).get("generation_source") or ""),
+            "candidate_count": _int(generation_summary.get("candidate_count")),
+            "exported_candidate_count": _int(generation_summary.get("exported_candidate_count")),
+            "exported_qualified_candidate_count": _int(
+                generation_summary.get("exported_qualified_candidate_count")
+            ),
+            "rendered_audio_file_count": _int(audio_boundary.get("rendered_audio_file_count")),
+            "technical_wav_validation": bool(audio_boundary.get("technical_wav_validation", False)),
+            "midi_paths": midi_paths,
+            "wav_paths": wav_paths,
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "technical_execution_path_completed": bool(technical_path_completed),
+            "input_to_ranked_midi_completed": bool(
+                technical_path_completed and _int(generation_summary.get("exported_candidate_count")) >= 3
+            ),
+            "input_to_rendered_audio_completed": bool(
+                technical_path_completed and _int(audio_boundary.get("rendered_audio_file_count")) >= 3
+            ),
+            "midi_to_solo_technical_mvp_completed": bool(technical_path_completed),
+            "midi_to_solo_musical_quality_claimed": False,
+            "model_checkpoint_direct_generation_quality_claimed": False,
+            "human_audio_preference_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": (
+                "technical input-to-MIDI-to-WAV path is complete; next repair target is direct "
+                "model-conditioned generation rather than quality claim"
+            ),
+            "source_audio_next_boundary": str(decision.get("next_boundary") or ""),
+        },
+        "not_proven": [
+            "musical_quality",
+            "human_audio_preference",
+            "model_checkpoint_direct_8bar_generation_quality",
+            "brad_style_adaptation",
+            "production_ready_improviser",
+        ],
+        "next_recommended_issue": "Stage B MIDI-to-solo model-direct generation repair",
+    }
+
+
+def validate_execution_consolidation_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_technical_mvp: bool,
+    require_no_quality_claim: bool,
+    min_exported_candidates: int,
+    min_rendered_wav_files: int,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    path = _dict(report.get("execution_path"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloMvpExecutionConsolidationError(f"expected boundary {expected_boundary}, got {boundary}")
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloMvpExecutionConsolidationError("unexpected next boundary")
+    if require_technical_mvp and not bool(readiness.get("midi_to_solo_technical_mvp_completed", False)):
+        raise StageBMidiToSoloMvpExecutionConsolidationError("technical MVP path must be complete")
+    if _int(path.get("exported_candidate_count")) < int(min_exported_candidates):
+        raise StageBMidiToSoloMvpExecutionConsolidationError("exported candidate count below threshold")
+    if _int(path.get("rendered_audio_file_count")) < int(min_rendered_wav_files):
+        raise StageBMidiToSoloMvpExecutionConsolidationError("rendered wav count below threshold")
+    if not bool(path.get("technical_wav_validation", False)):
+        raise StageBMidiToSoloMvpExecutionConsolidationError("technical wav validation required")
+    for item in _list(path.get("midi_paths")) + _list(path.get("wav_paths")):
+        if not file_exists(str(item)):
+            raise StageBMidiToSoloMvpExecutionConsolidationError(f"artifact missing: {item}")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloMvpExecutionConsolidationError("critical user input should not be required")
+    if require_no_quality_claim:
+        blocked = [
+            "midi_to_solo_musical_quality_claimed",
+            "model_checkpoint_direct_generation_quality_claimed",
+            "human_audio_preference_claimed",
+            "broad_trained_model_quality_claimed",
+            "brad_style_adaptation_claimed",
+        ]
+        claimed = [name for name in blocked if bool(readiness.get(name, True))]
+        if claimed:
+            raise StageBMidiToSoloMvpExecutionConsolidationError(f"unexpected quality claim: {claimed}")
+    return {
+        "boundary": boundary,
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "technical_execution_path_completed": bool(readiness.get("technical_execution_path_completed", False)),
+        "midi_to_solo_technical_mvp_completed": bool(
+            readiness.get("midi_to_solo_technical_mvp_completed", False)
+        ),
+        "input_to_ranked_midi_completed": bool(readiness.get("input_to_ranked_midi_completed", False)),
+        "input_to_rendered_audio_completed": bool(readiness.get("input_to_rendered_audio_completed", False)),
+        "generation_source": str(path.get("generation_source") or ""),
+        "exported_candidate_count": _int(path.get("exported_candidate_count")),
+        "rendered_audio_file_count": _int(path.get("rendered_audio_file_count")),
+        "technical_wav_validation": bool(path.get("technical_wav_validation", False)),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "model_checkpoint_direct_generation_quality_claimed": bool(
+            readiness.get("model_checkpoint_direct_generation_quality_claimed", True)
+        ),
+        "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    path = report["execution_path"]
+    lines = [
+        "# Stage B MIDI-to-Solo MVP Execution Consolidation",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- technical execution path completed: `{_bool_token(readiness['technical_execution_path_completed'])}`",
+        f"- MIDI-to-solo technical MVP completed: `{_bool_token(readiness['midi_to_solo_technical_mvp_completed'])}`",
+        f"- musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        "",
+        "## Execution Path",
+        "",
+        f"- context event count: `{path['context_event_count']}`",
+        f"- generation source: `{path['generation_source']}`",
+        f"- exported candidate count: `{path['exported_candidate_count']}`",
+        f"- rendered audio file count: `{path['rendered_audio_file_count']}`",
+        f"- technical WAV validation: `{_bool_token(path['technical_wav_validation'])}`",
+        "",
+        "## MIDI Paths",
+        "",
+    ]
+    for item in path["midi_paths"]:
+        lines.append(f"- `{item}`")
+    lines.extend(["", "## WAV Paths", ""])
+    for item in path["wav_paths"]:
+        lines.append(f"- `{item}`")
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Consolidate MIDI-to-solo MVP execution evidence")
+    parser.add_argument("--contract_report", type=str, required=True)
+    parser.add_argument("--context_report", type=str, required=True)
+    parser.add_argument("--resource_probe", type=str, required=True)
+    parser.add_argument("--generation_probe", type=str, required=True)
+    parser.add_argument("--audio_render", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_mvp_execution_consolidation",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=491)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_technical_mvp", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    parser.add_argument("--min_exported_candidates", type=int, default=3)
+    parser.add_argument("--min_rendered_wav_files", type=int, default=3)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_execution_consolidation_report(
+        contract_report=read_json(Path(args.contract_report)),
+        context_report=read_json(Path(args.context_report)),
+        resource_probe=read_json(Path(args.resource_probe)),
+        generation_probe=read_json(Path(args.generation_probe)),
+        audio_render=read_json(Path(args.audio_render)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+    )
+    summary = validate_execution_consolidation_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_technical_mvp=bool(args.require_technical_mvp),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+        min_exported_candidates=int(args.min_exported_candidates),
+        min_rendered_wav_files=int(args.min_rendered_wav_files),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "stage_b_midi_to_solo_mvp_execution_consolidation.json", report)
+    write_json(output_dir / "stage_b_midi_to_solo_mvp_execution_consolidation_validation_summary.json", summary)
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_midi_to_solo_mvp_execution_consolidation.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_mvp_execution_consolidation.py
+++ b/tests/test_stage_b_midi_to_solo_mvp_execution_consolidation.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.consolidate_stage_b_midi_to_solo_mvp_execution import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloMvpExecutionConsolidationError,
+    build_execution_consolidation_report,
+    validate_execution_consolidation_report,
+)
+
+
+def touch(path: Path) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"x")
+    return str(path)
+
+
+def reports(root: Path, *, quality_claim: bool = False) -> dict[str, dict]:
+    midi_paths = [touch(root / f"rank_{index:02d}.mid") for index in range(1, 4)]
+    wav_paths = [touch(root / f"rank_{index:02d}.wav") for index in range(1, 4)]
+    return {
+        "contract": {
+            "boundary": "stage_b_midi_to_solo_mvp_input_contract",
+            "target_date": "2026-06-11",
+            "output_contract": {
+                "candidate_count": 32,
+                "export_top_midi_count": 3,
+                "target_solo_bars": 8,
+            },
+            "objective_gate": {
+                "min_note_count": 24,
+                "min_unique_pitch_count": 8,
+                "max_simultaneous_notes": 1,
+            },
+        },
+        "context": {
+            "boundary": "stage_b_midi_to_solo_context_extraction_mvp",
+            "summary": {"context_event_count": 128},
+        },
+        "resource": {
+            "boundary": "stage_b_midi_to_solo_training_resource_probe",
+            "readiness": {"midi_to_solo_training_resource_ready": True},
+        },
+        "generation": {
+            "boundary": "stage_b_midi_to_solo_conditioned_generation_probe",
+            "generation_config": {"generation_source": "context_conditioned_fallback"},
+            "summary": {
+                "candidate_count": 8,
+                "exported_candidate_count": 3,
+                "exported_qualified_candidate_count": 3,
+            },
+            "readiness": {"ranked_midi_candidates_exported": True},
+            "top_candidates": [{"export_midi_path": path} for path in midi_paths],
+        },
+        "audio": {
+            "audio_render_boundary": {
+                "boundary": "stage_b_midi_to_solo_candidate_audio_render_package",
+                "rendered_audio_file_count": 3,
+                "technical_wav_validation": True,
+            },
+            "decision": {"next_boundary": "stage_b_midi_to_solo_mvp_execution_consolidation"},
+            "rendered_audio_files": [{"wav_file": {"path": path}} for path in wav_paths],
+        },
+    }
+
+
+class StageBMidiToSoloMvpExecutionConsolidationTest(unittest.TestCase):
+    def test_consolidates_technical_mvp_without_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            data = reports(Path(tmp))
+            report = build_execution_consolidation_report(
+                contract_report=data["contract"],
+                context_report=data["context"],
+                resource_probe=data["resource"],
+                generation_probe=data["generation"],
+                audio_render=data["audio"],
+                output_dir=Path(tmp) / "out",
+                issue_number=491,
+            )
+            summary = validate_execution_consolidation_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                require_technical_mvp=True,
+                require_no_quality_claim=True,
+                min_exported_candidates=3,
+                min_rendered_wav_files=3,
+            )
+
+            self.assertTrue(summary["technical_execution_path_completed"])
+            self.assertTrue(summary["midi_to_solo_technical_mvp_completed"])
+            self.assertTrue(summary["input_to_ranked_midi_completed"])
+            self.assertTrue(summary["input_to_rendered_audio_completed"])
+            self.assertEqual(summary["generation_source"], "context_conditioned_fallback")
+            self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+            self.assertFalse(summary["model_checkpoint_direct_generation_quality_claimed"])
+            self.assertFalse(summary["human_audio_preference_claimed"])
+
+    def test_rejects_missing_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            data = reports(Path(tmp))
+            Path(data["generation"]["top_candidates"][0]["export_midi_path"]).unlink()
+            report = build_execution_consolidation_report(
+                contract_report=data["contract"],
+                context_report=data["context"],
+                resource_probe=data["resource"],
+                generation_probe=data["generation"],
+                audio_render=data["audio"],
+                output_dir=Path(tmp) / "out",
+                issue_number=491,
+            )
+            with self.assertRaises(StageBMidiToSoloMvpExecutionConsolidationError):
+                validate_execution_consolidation_report(
+                    report,
+                    expected_boundary=BOUNDARY,
+                    expected_next_boundary=NEXT_BOUNDARY,
+                    require_technical_mvp=True,
+                    require_no_quality_claim=True,
+                    min_exported_candidates=3,
+                    min_rendered_wav_files=3,
+                )
+
+    def test_boundary_constants_are_stable(self) -> None:
+        self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_mvp_execution_consolidation")
+        self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_model_direct_generation_repair")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- #481/#483/#485/#487/#489 report를 하나의 execution boundary로 통합
- `input MIDI -> context -> ranked MIDI -> WAV` technical path completion 검증
- technical MVP completion과 musical quality/model-direct generation/human preference claim 분리
- 전용 harness mode, unit test, status 문서 갱신

## Context

- #489에서 ranked MIDI candidates 3개 WAV render와 technical validation 완료
- 현재 generation source는 `context_conditioned_fallback`
- model checkpoint direct 8-bar generation quality는 아직 미검증

## Result

- boundary: `stage_b_midi_to_solo_mvp_execution_consolidation`
- next boundary: `stage_b_midi_to_solo_model_direct_generation_repair`
- technical execution path completed: `true`
- MIDI-to-solo technical MVP completed: `true`
- input to ranked MIDI completed: `true`
- input to rendered audio completed: `true`
- generation source: `context_conditioned_fallback`
- exported candidate count: `3`
- rendered audio file count: `3`
- technical WAV validation: `true`
- musical quality claimed: `false`
- model checkpoint direct generation quality claimed: `false`
- human/audio preference claimed: `false`

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_execution_consolidation tests.test_stage_b_midi_to_solo_candidate_audio_render tests.test_stage_b_midi_to_solo_conditioned_generation_probe tests.test_stage_b_midi_to_solo_training_resource_probe tests.test_stage_b_midi_to_solo_context_extraction tests.test_stage_b_midi_to_solo_mvp_contract`
- `.venv/bin/python -m py_compile scripts/consolidate_stage_b_midi_to_solo_mvp_execution.py scripts/render_stage_b_midi_to_solo_candidate_audio.py scripts/run_stage_b_midi_to_solo_conditioned_generation_probe.py scripts/check_stage_b_midi_to_solo_training_resource_probe.py scripts/extract_stage_b_midi_to_solo_context.py scripts/define_stage_b_midi_to_solo_mvp_contract.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-execution-consolidation`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- staged diff forbidden-public-name grep: no matches

## Risk

- technical MVP completion is not a musical quality claim
- current generation path uses context-conditioned fallback
- direct checkpoint-conditioned generation repair remains follow-up work

## Follow-up

- Stage B MIDI-to-solo model-direct generation repair

Closes #491