### PR TITLE
Stage B MIDI-to-solo model-direct audio render package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #499, Stage B MIDI-to-solo model-direct monophonic overlap repair.
+- Latest functional issue completed: Issue #501, Stage B MIDI-to-solo model-direct audio render package.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-direct audio render package.
+- Recommended next issue: Stage B MIDI-to-solo model-direct audio evidence consolidation.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1083,6 +1083,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-monophonic-overl
 ```
 
 This harness caps generated durations to the next planned position, compares the repaired outputs against the prior 8-bar probe, and records review-gate evidence without claiming model quality or human preference.
+
+For Stage B MIDI-to-solo model-direct audio render package changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-audio-render-package
+```
+
+This harness renders repaired model-direct MIDI candidates to WAV files and validates technical WAV metadata without claiming audio quality, model quality, or human preference.
 
 For Stage B generic tiny checkpoint generation probe changes, run:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -97,8 +97,12 @@ MVP가 끝났다고 볼 수 있는 조건:
 - min postprocess note count: `24`
 - avg postprocess removal ratio: `0.0`
 - collapse warning sample rate: `0.0`
-- next repair target: `stage_b_midi_to_solo_model_direct_audio_render_package`
-- 근거 문서: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_MONOPHONIC_OVERLAP_REPAIR_2026-06-03.md`
+- model-direct rendered WAV files: `3`
+- model-direct WAV sample rate: `44100`
+- model-direct WAV duration range: `19.585s-22.390s`
+- model-direct technical WAV validation: `true`
+- next repair target: `stage_b_midi_to_solo_model_direct_audio_evidence_consolidation`
+- 근거 문서: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_AUDIO_RENDER_PACKAGE_2026-06-03.md`
 - margin-recovered timing/repetition focused listening notes 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_NOTES_2026-05-28.md`
 - margin-recovered timing/repetition focused listening fill 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_FILL_2026-05-28.md`
 - margin-recovered phrase/vocabulary repair 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_REPAIR_2026-05-28.md`
@@ -286,6 +290,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo candidate audio render package: rendered WAV `3`, sample rate `44100`, technical validation `true`, preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_execution_consolidation`
 - MIDI-to-solo MVP execution consolidation: technical path `true`, source `context_conditioned_fallback`, exported/rendered `3/3`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_direct_generation_repair`
 - MIDI-to-solo model-direct monophonic overlap repair: source `model_checkpoint_direct_constrained`, valid/strict `3/3`, avg postprocess removal ratio `0.0`, collapse warning sample rate `0.0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_direct_audio_render_package`
+- MIDI-to-solo model-direct audio render package: rendered WAV `3`, sample rate `44100`, duration range `19.585s-22.390s`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_direct_audio_evidence_consolidation`
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
 - generic base readiness audit: phase4 prep ready `true`, broad training execution ready `false`, broad quality/Brad adaptation claim `false`
 - generic base manifest contract: generic split `2433/270`, Brad split `47/11/14`, leakage/overlap `0`, broad training execution ready `false`

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #499, Stage B MIDI-to-solo model-direct monophonic overlap repair
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-direct audio render package`
+- latest functional result: Issue #501, Stage B MIDI-to-solo model-direct audio render package
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-direct audio evidence consolidation`
 
 현재 범위가 아닌 것:
 
@@ -498,6 +498,55 @@ Issue #499는 #497 direct 8-bar generation의 review gate 실패를 duration ove
 다음:
 
 - `Stage B MIDI-to-solo model-direct audio render package`
+
+## Stage B MIDI-to-Solo Model-Direct Audio Render Package Result
+
+Issue #501은 #499 repaired model-direct MIDI 후보 3개를 WAV로 렌더하고 기술 metadata를 검증한 작업이다.
+
+변경:
+
+- model-direct overlap repair report 입력 검증 추가
+- repaired direct MIDI 3개 WAV render script 추가
+- WAV sample rate, frame count, size, sha256 metadata 기록
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_AUDIO_RENDER_PACKAGE_2026-06-03.md`
+- boundary: `stage_b_midi_to_solo_model_direct_audio_render_package`
+- source boundary: `stage_b_midi_to_solo_model_direct_monophonic_overlap_repair`
+- next boundary: `stage_b_midi_to_solo_model_direct_audio_evidence_consolidation`
+- rendered audio file count: `3`
+- sample rate: `44100`
+- duration range: `19.585s` - `22.390s`
+- technical WAV validation: `true`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- model-direct generation quality claimed: `false`
+- critical user input required: `false`
+
+WAV:
+
+- `outputs/stage_b_midi_to_solo_model_direct_audio_render_package/harness_stage_b_midi_to_solo_model_direct_audio_render_package/audio/model_direct_sample_01.wav`
+- `outputs/stage_b_midi_to_solo_model_direct_audio_render_package/harness_stage_b_midi_to_solo_model_direct_audio_render_package/audio/model_direct_sample_02.wav`
+- `outputs/stage_b_midi_to_solo_model_direct_audio_render_package/harness_stage_b_midi_to_solo_model_direct_audio_render_package/audio/model_direct_sample_03.wav`
+
+판단:
+
+- fallback 없는 model-direct MIDI 후보의 MIDI -> WAV local render 경로 확인
+- technical WAV validation은 출력 파일 검증이며, 음악적 품질이나 선호 claim은 아님
+- 다음 작업은 #499 objective evidence와 #501 audio render evidence의 claim boundary 통합
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_direct_audio_render`
+- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_model_direct_audio.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-audio-render-package`
+
+다음:
+
+- `Stage B MIDI-to-solo model-direct audio evidence consolidation`
 
 ## Previous Model Decision
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_AUDIO_RENDER_PACKAGE_2026-06-03.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_AUDIO_RENDER_PACKAGE_2026-06-03.md
@@ -1,0 +1,30 @@
+# Stage B MIDI-to-Solo Model-Direct Audio Render Package
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_model_direct_audio_render_package`
+- source boundary: `stage_b_midi_to_solo_model_direct_monophonic_overlap_repair`
+- next boundary: `stage_b_midi_to_solo_model_direct_audio_evidence_consolidation`
+- render attempted: `true`
+- rendered audio file count: `3`
+- technical WAV validation: `true`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- model-direct generation quality claimed: `false`
+
+## Rendered Files
+
+| rank | sample | wav path | duration | sample rate | size | sha256 |
+|---:|---:|---|---:|---:|---:|---|
+| 1 | 1 | outputs/stage_b_midi_to_solo_model_direct_audio_render_package/harness_stage_b_midi_to_solo_model_direct_audio_render_package/audio/model_direct_sample_01.wav | 22.390 | 44100 | 3949612 | fd78ec4d6fdb |
+| 2 | 2 | outputs/stage_b_midi_to_solo_model_direct_audio_render_package/harness_stage_b_midi_to_solo_model_direct_audio_render_package/audio/model_direct_sample_02.wav | 21.355 | 44100 | 3767084 | 683ba60bd525 |
+| 3 | 3 | outputs/stage_b_midi_to_solo_model_direct_audio_render_package/harness_stage_b_midi_to_solo_model_direct_audio_render_package/audio/model_direct_sample_03.wav | 19.585 | 44100 | 3454764 | c0f273d5e926 |
+
+## Not Proven
+
+- `audio_rendered_quality`
+- `human_audio_preference`
+- `model_direct_generation_quality`
+- `midi_to_solo_mvp_completion`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -210,6 +210,8 @@ Modes:
                 Run fallback-free model-direct 8-bar MIDI generation and record review gate evidence.
   stage-b-midi-to-solo-model-direct-monophonic-overlap-repair
                 Repair model-direct overlap by capping duration to the next planned position.
+  stage-b-midi-to-solo-model-direct-audio-render-package
+                Render repaired model-direct MIDI candidates to WAV and validate technical metadata.
   stage-b-generic-tiny-checkpoint-generation-probe
                 Probe generation/decode from the generic tiny checkpoint.
   stage-b-generic-tiny-checkpoint-grammar-repair
@@ -3791,6 +3793,28 @@ run_stage_b_midi_to_solo_model_direct_monophonic_overlap_repair() {
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_model_direct_audio_render_package() {
+  local overlap_repair_run_id="${OVERLAP_REPAIR_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_monophonic_overlap_repair}"
+  local previous_direct_run_id="${PREVIOUS_DIRECT_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_8bar_generation_probe}"
+  local sequence_budget_run_id="${SEQUENCE_BUDGET_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_sequence_budget_repair_smoke}"
+  local context_run_id="${CONTEXT_RUN_ID:-harness_stage_b_midi_to_solo_context_extraction}"
+  local scale_run_id="${SCALE_RUN_ID:-max_sequence_160}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_direct_audio_render_package}"
+  local overlap_repair="outputs/stage_b_midi_to_solo_model_direct_monophonic_overlap_repair/${overlap_repair_run_id}/stage_b_midi_to_solo_model_direct_monophonic_overlap_repair.json"
+  if [[ ! -f "$overlap_repair" ]]; then
+    print_header "Stage B MIDI-to-solo model-direct monophonic overlap repair"
+    RUN_ID="$overlap_repair_run_id" PREVIOUS_DIRECT_RUN_ID="$previous_direct_run_id" SEQUENCE_BUDGET_RUN_ID="$sequence_budget_run_id" CONTEXT_RUN_ID="$context_run_id" SCALE_RUN_ID="$scale_run_id" run_stage_b_midi_to_solo_model_direct_monophonic_overlap_repair
+  fi
+  print_header "Stage B MIDI-to-solo model-direct audio render package"
+  "$PYTHON_BIN" scripts/render_stage_b_midi_to_solo_model_direct_audio.py \
+    --run_id "$run_id" \
+    --model_direct_overlap_repair "$overlap_repair" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_AUDIO_RENDER_PACKAGE_2026-06-03.md \
+    --expected_boundary stage_b_midi_to_solo_model_direct_audio_render_package \
+    --expected_file_count 3 \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -5201,6 +5225,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-model-direct-monophonic-overlap-repair)
     run_stage_b_midi_to_solo_model_direct_monophonic_overlap_repair
+    ;;
+  stage-b-midi-to-solo-model-direct-audio-render-package)
+    run_stage_b_midi_to_solo_model_direct_audio_render_package
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/render_stage_b_midi_to_solo_model_direct_audio.py
+++ b/scripts/render_stage_b_midi_to_solo_model_direct_audio.py
@@ -1,0 +1,387 @@
+"""Render Stage B MIDI-to-solo model-direct candidates to WAV files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.render_stage_b_midi_to_solo_candidate_audio import (  # noqa: E402
+    default_soundfont_candidates,
+    resolve_soundfont,
+    sha256_file,
+    wav_meta,
+)
+
+
+class StageBMidiToSoloModelDirectAudioRenderError(ValueError):
+    pass
+
+
+SOURCE_BOUNDARY = "stage_b_midi_to_solo_model_direct_monophonic_overlap_repair"
+BOUNDARY = "stage_b_midi_to_solo_model_direct_audio_render_package"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_model_direct_audio_evidence_consolidation"
+SCHEMA_VERSION = "stage_b_midi_to_solo_model_direct_audio_render_package_v1"
+CommandRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def default_runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(list(command), check=False, text=True, capture_output=True)
+
+
+def validate_source_report(report: dict[str, Any], expected_count: int) -> list[dict[str, Any]]:
+    readiness = _dict(report.get("readiness"))
+    generation = _dict(report.get("repaired_generation_summary"))
+    if str(report.get("boundary") or readiness.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloModelDirectAudioRenderError("model-direct overlap repair boundary required")
+    if not bool(readiness.get("direct_generation_review_gate_passed", False)):
+        raise StageBMidiToSoloModelDirectAudioRenderError("direct generation review gate must pass")
+    if bool(readiness.get("model_direct_generation_quality_claimed", True)):
+        raise StageBMidiToSoloModelDirectAudioRenderError("model-direct quality must not be claimed")
+    if bool(readiness.get("human_audio_preference_claimed", True)):
+        raise StageBMidiToSoloModelDirectAudioRenderError("human/audio preference must not be claimed")
+    if _int(generation.get("valid_sample_count")) < int(expected_count):
+        raise StageBMidiToSoloModelDirectAudioRenderError("not enough valid direct MIDI samples")
+    if _int(generation.get("strict_valid_sample_count")) < int(expected_count):
+        raise StageBMidiToSoloModelDirectAudioRenderError("not enough strict-valid direct MIDI samples")
+    paths = [str(path) for path in _list(generation.get("midi_paths"))[: int(expected_count)]]
+    if len(paths) < int(expected_count):
+        raise StageBMidiToSoloModelDirectAudioRenderError("not enough MIDI paths")
+    candidates: list[dict[str, Any]] = []
+    for index, midi_path_text in enumerate(paths, start=1):
+        midi_path = Path(midi_path_text)
+        if not midi_path.exists():
+            raise StageBMidiToSoloModelDirectAudioRenderError(f"direct MIDI not found: {midi_path}")
+        candidates.append(
+            {
+                "rank": index,
+                "sample_index": index,
+                "midi_path": str(midi_path),
+                "source_valid": True,
+                "source_strict_valid": True,
+                "source_note_count": _int(generation.get("min_postprocess_note_count")),
+            }
+        )
+    return candidates
+
+
+def build_render_plan(
+    candidates: list[dict[str, Any]],
+    *,
+    output_dir: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+) -> list[dict[str, Any]]:
+    renderer = Path(renderer_path)
+    soundfont = Path(soundfont_path).expanduser()
+    if not renderer.exists():
+        raise StageBMidiToSoloModelDirectAudioRenderError(f"renderer not found: {renderer}")
+    if not soundfont.exists():
+        raise StageBMidiToSoloModelDirectAudioRenderError(f"soundfont not found: {soundfont}")
+    plan: list[dict[str, Any]] = []
+    for item in candidates:
+        wav_path = output_dir / "audio" / f"model_direct_sample_{int(item['sample_index']):02d}.wav"
+        plan.append(
+            {
+                **item,
+                "wav_path": str(wav_path),
+                "command": [
+                    str(renderer),
+                    "-ni",
+                    "-F",
+                    str(wav_path),
+                    "-r",
+                    str(sample_rate),
+                    str(soundfont),
+                    str(item["midi_path"]),
+                ],
+            }
+        )
+    return plan
+
+
+def execute_render_plan(
+    plan: list[dict[str, Any]],
+    *,
+    runner: CommandRunner = default_runner,
+) -> list[dict[str, Any]]:
+    rendered: list[dict[str, Any]] = []
+    for item in plan:
+        wav_path = Path(str(item["wav_path"]))
+        wav_path.parent.mkdir(parents=True, exist_ok=True)
+        completed = runner(item["command"])
+        if completed.returncode != 0:
+            raise StageBMidiToSoloModelDirectAudioRenderError(
+                f"render failed for sample {item['sample_index']}: {completed.stderr or completed.stdout}"
+            )
+        rendered.append(
+            {
+                "rank": item["rank"],
+                "sample_index": item["sample_index"],
+                "source_midi_path": item["midi_path"],
+                "source_valid": item["source_valid"],
+                "source_strict_valid": item["source_strict_valid"],
+                "source_note_count": item["source_note_count"],
+                "wav_file": wav_meta(wav_path),
+                "command": list(item["command"]),
+                "stdout_tail": (completed.stdout or "")[-1000:],
+                "stderr_tail": (completed.stderr or "")[-1000:],
+            }
+        )
+    return rendered
+
+
+def build_audio_render_report(
+    source_report: dict[str, Any],
+    *,
+    output_dir: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+    expected_file_count: int,
+    runner: CommandRunner = default_runner,
+) -> dict[str, Any]:
+    candidates = validate_source_report(source_report, expected_count=expected_file_count)
+    resolved_renderer = renderer_path or shutil.which("fluidsynth") or ""
+    resolved_soundfont = resolve_soundfont(soundfont_path)
+    plan = build_render_plan(
+        candidates,
+        output_dir=output_dir,
+        renderer_path=resolved_renderer,
+        soundfont_path=resolved_soundfont,
+        sample_rate=sample_rate,
+    )
+    rendered = execute_render_plan(plan, runner=runner)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_boundary": SOURCE_BOUNDARY,
+        "source_generation_summary": _dict(source_report.get("repaired_generation_summary")),
+        "renderer": {
+            "name": "fluidsynth",
+            "path": resolved_renderer,
+        },
+        "soundfont": {
+            "path": str(Path(resolved_soundfont).expanduser()),
+            "sha256": sha256_file(Path(resolved_soundfont).expanduser()),
+            "default_candidates_checked": [str(path) for path in default_soundfont_candidates()],
+        },
+        "rendered_audio_files": rendered,
+        "audio_render_boundary": {
+            "boundary": BOUNDARY,
+            "render_attempted": True,
+            "rendered_audio_file_count": int(len(rendered)),
+            "technical_wav_validation": True,
+            "audio_output_claimed": True,
+            "audio_rendered_quality_claimed": False,
+            "human_audio_preference_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "musical_quality_claimed": False,
+            "midi_to_solo_mvp_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "strict-valid model-direct MIDI rendered to WAV; quality and preference remain unclaimed",
+        },
+        "not_proven": [
+            "audio_rendered_quality",
+            "human_audio_preference",
+            "model_direct_generation_quality",
+            "midi_to_solo_mvp_completion",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": "Stage B MIDI-to-solo model-direct audio evidence consolidation",
+    }
+
+
+def validate_audio_render_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_file_count: int,
+    expected_sample_rate: int,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = _dict(report.get("audio_render_boundary"))
+    if expected_boundary and str(boundary.get("boundary") or "") != expected_boundary:
+        raise StageBMidiToSoloModelDirectAudioRenderError(
+            f"expected boundary {expected_boundary}, got {boundary.get('boundary')}"
+        )
+    files = _list(report.get("rendered_audio_files"))
+    if len(files) != int(expected_file_count):
+        raise StageBMidiToSoloModelDirectAudioRenderError(f"expected {expected_file_count} rendered files")
+    for item in files:
+        wav_file = _dict(_dict(item).get("wav_file"))
+        if not bool(wav_file.get("exists", False)):
+            raise StageBMidiToSoloModelDirectAudioRenderError("missing rendered WAV")
+        if _int(wav_file.get("sample_rate")) != int(expected_sample_rate):
+            raise StageBMidiToSoloModelDirectAudioRenderError("unexpected sample rate")
+        if _int(wav_file.get("frame_count")) <= 0:
+            raise StageBMidiToSoloModelDirectAudioRenderError("empty WAV")
+        if _int(wav_file.get("size_bytes")) <= 44:
+            raise StageBMidiToSoloModelDirectAudioRenderError("invalid WAV size")
+    if require_no_quality_claim:
+        blocked = [
+            "audio_rendered_quality_claimed",
+            "human_audio_preference_claimed",
+            "model_direct_generation_quality_claimed",
+            "musical_quality_claimed",
+            "midi_to_solo_mvp_claimed",
+            "broad_trained_model_quality_claimed",
+            "brad_style_adaptation_claimed",
+        ]
+        claimed = [name for name in blocked if bool(boundary.get(name, True))]
+        if claimed:
+            raise StageBMidiToSoloModelDirectAudioRenderError(f"unexpected quality claim: {claimed}")
+    decision = _dict(report.get("decision"))
+    return {
+        "boundary": str(boundary.get("boundary") or ""),
+        "source_boundary": str(report.get("source_boundary") or ""),
+        "render_attempted": bool(boundary.get("render_attempted", False)),
+        "rendered_audio_file_count": _int(boundary.get("rendered_audio_file_count")),
+        "technical_wav_validation": bool(boundary.get("technical_wav_validation", False)),
+        "audio_rendered_quality_claimed": bool(boundary.get("audio_rendered_quality_claimed", True)),
+        "human_audio_preference_claimed": bool(boundary.get("human_audio_preference_claimed", True)),
+        "model_direct_generation_quality_claimed": bool(
+            boundary.get("model_direct_generation_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "wav_paths": [str(_dict(_dict(item).get("wav_file")).get("path") or "") for item in files],
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    boundary = report["audio_render_boundary"]
+    decision = report["decision"]
+    lines = [
+        "# Stage B MIDI-to-Solo Model-Direct Audio Render Package",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{boundary['boundary']}`",
+        f"- source boundary: `{report['source_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- render attempted: `{_bool_token(boundary['render_attempted'])}`",
+        f"- rendered audio file count: `{boundary['rendered_audio_file_count']}`",
+        f"- technical WAV validation: `{_bool_token(boundary['technical_wav_validation'])}`",
+        f"- audio rendered quality claimed: `{_bool_token(boundary['audio_rendered_quality_claimed'])}`",
+        f"- human/audio preference claimed: `{_bool_token(boundary['human_audio_preference_claimed'])}`",
+        f"- model-direct generation quality claimed: `{_bool_token(boundary['model_direct_generation_quality_claimed'])}`",
+        "",
+        "## Rendered Files",
+        "",
+        "| rank | sample | wav path | duration | sample rate | size | sha256 |",
+        "|---:|---:|---|---:|---:|---:|---|",
+    ]
+    for item in report.get("rendered_audio_files", []):
+        wav_file = item["wav_file"]
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(item["rank"]),
+                    str(item["sample_index"]),
+                    str(wav_file["path"]),
+                    f"{float(wav_file['duration_seconds']):.3f}",
+                    str(wav_file["sample_rate"]),
+                    str(wav_file["size_bytes"]),
+                    str(wav_file["sha256"][:12]),
+                ]
+            )
+            + " |"
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Render MIDI-to-solo model-direct WAV files")
+    parser.add_argument("--model_direct_overlap_repair", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_model_direct_audio_render_package",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--renderer", type=str, default=shutil.which("fluidsynth") or "")
+    parser.add_argument("--soundfont", type=str, default="")
+    parser.add_argument("--sample_rate", type=int, default=44100)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_file_count", type=int, default=3)
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_audio_render_report(
+        read_json(Path(args.model_direct_overlap_repair)),
+        output_dir=output_dir,
+        renderer_path=str(args.renderer or ""),
+        soundfont_path=str(args.soundfont or ""),
+        sample_rate=int(args.sample_rate),
+        expected_file_count=int(args.expected_file_count),
+    )
+    summary = validate_audio_render_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_file_count=int(args.expected_file_count),
+        expected_sample_rate=int(args.sample_rate),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "stage_b_midi_to_solo_model_direct_audio_render_package.json", report)
+    write_json(output_dir / "stage_b_midi_to_solo_model_direct_audio_render_package_validation_summary.json", summary)
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_midi_to_solo_model_direct_audio_render_package.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_model_direct_audio_render.py
+++ b/tests/test_stage_b_midi_to_solo_model_direct_audio_render.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+import wave
+from pathlib import Path
+from typing import Sequence
+
+from scripts.render_stage_b_midi_to_solo_model_direct_audio import (
+    BOUNDARY,
+    StageBMidiToSoloModelDirectAudioRenderError,
+    build_audio_render_report,
+    validate_audio_render_report,
+)
+
+
+def fake_midi(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"MThd\x00\x00\x00\x06\x00\x00\x00\x01\x00`MTrk\x00\x00\x00\x04\x00\xff/\x00")
+
+
+def write_wav(path: Path, sample_rate: int = 44100) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(2)
+        handle.setsampwidth(2)
+        handle.setframerate(sample_rate)
+        handle.writeframes(b"\x00\x00\x00\x00" * sample_rate)
+
+
+def fake_runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    output_index = list(command).index("-F") + 1
+    write_wav(Path(command[output_index]))
+    return subprocess.CompletedProcess(list(command), 0, stdout="rendered", stderr="")
+
+
+def source_report(root: Path, *, quality_claim: bool = False, strict_count: int = 3) -> dict:
+    midi_paths = [root / f"stage_b_sample_{index}.mid" for index in range(1, 4)]
+    for path in midi_paths:
+        fake_midi(path)
+    return {
+        "boundary": "stage_b_midi_to_solo_model_direct_monophonic_overlap_repair",
+        "readiness": {
+            "direct_generation_review_gate_passed": True,
+            "model_direct_generation_quality_claimed": quality_claim,
+            "human_audio_preference_claimed": False,
+        },
+        "repaired_generation_summary": {
+            "sample_count": 3,
+            "valid_sample_count": 3,
+            "strict_valid_sample_count": strict_count,
+            "min_postprocess_note_count": 24,
+            "midi_paths": [str(path) for path in midi_paths],
+        },
+    }
+
+
+class StageBMidiToSoloModelDirectAudioRenderTest(unittest.TestCase):
+    def test_renders_model_direct_wavs_without_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            soundfont = root / "piano.sf2"
+            renderer.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            report = build_audio_render_report(
+                source_report(root),
+                output_dir=root / "rendered",
+                renderer_path=str(renderer),
+                soundfont_path=str(soundfont),
+                sample_rate=44100,
+                expected_file_count=3,
+                runner=fake_runner,
+            )
+            summary = validate_audio_render_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_file_count=3,
+                expected_sample_rate=44100,
+                require_no_quality_claim=True,
+            )
+
+            self.assertEqual(summary["source_boundary"], "stage_b_midi_to_solo_model_direct_monophonic_overlap_repair")
+            self.assertTrue(summary["render_attempted"])
+            self.assertEqual(summary["rendered_audio_file_count"], 3)
+            self.assertTrue(summary["technical_wav_validation"])
+            self.assertFalse(summary["audio_rendered_quality_claimed"])
+            self.assertFalse(summary["human_audio_preference_claimed"])
+            self.assertFalse(summary["model_direct_generation_quality_claimed"])
+            self.assertFalse(summary["critical_user_input_required"])
+            self.assertEqual(summary["next_boundary"], "stage_b_midi_to_solo_model_direct_audio_evidence_consolidation")
+
+    def test_rejects_unqualified_direct_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            soundfont = root / "piano.sf2"
+            renderer.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            with self.assertRaises(StageBMidiToSoloModelDirectAudioRenderError):
+                build_audio_render_report(
+                    source_report(root, strict_count=2),
+                    output_dir=root / "rendered",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(soundfont),
+                    sample_rate=44100,
+                    expected_file_count=3,
+                    runner=fake_runner,
+                )
+
+    def test_rejects_upstream_model_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            soundfont = root / "piano.sf2"
+            renderer.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            with self.assertRaises(StageBMidiToSoloModelDirectAudioRenderError):
+                build_audio_render_report(
+                    source_report(root, quality_claim=True),
+                    output_dir=root / "rendered",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(soundfont),
+                    sample_rate=44100,
+                    expected_file_count=3,
+                    runner=fake_runner,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- #499 repaired model-direct MIDI candidates WAV render
- technical WAV metadata validation
- quality and human preference claim guard

## Context

- #499 result: valid/strict `3/3`
- avg postprocess removal ratio: `0.0`
- collapse warning sample rate: `0.0`
- next boundary: `stage_b_midi_to_solo_model_direct_audio_render_package`

## Result

- rendered WAV files: `3`
- sample rate: `44100`
- duration range: `19.585s-22.390s`
- technical WAV validation: `true`
- audio rendered quality claimed: `false`
- human/audio preference claimed: `false`
- model-direct generation quality claimed: `false`
- next boundary: `stage_b_midi_to_solo_model_direct_audio_evidence_consolidation`

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_direct_audio_render tests.test_stage_b_midi_to_solo_model_direct_monophonic_overlap_repair tests.test_stage_b_generation_probe`
- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_model_direct_audio.py scripts/run_stage_b_midi_to_solo_model_direct_monophonic_overlap_repair.py scripts/run_stage_b_generation_probe.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-audio-render-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- WAV render success is technical output validation only
- no musical quality claim
- no human/audio preference claim

## Follow-up

- Stage B MIDI-to-solo model-direct audio evidence consolidation

Closes #501