### PR TITLE
Stage B MIDI-to-solo model-direct phrase quality diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #503, Stage B MIDI-to-solo model-direct audio evidence consolidation.
+- Latest functional issue completed: Issue #505, Stage B MIDI-to-solo model-direct phrase quality diagnostics.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-direct phrase quality diagnostics.
+- Recommended next issue: Stage B MIDI-to-solo model-direct pitch contour repetition repair.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1099,6 +1099,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-audio-evidence-c
 ```
 
 This harness consolidates model-direct objective MIDI evidence and WAV render evidence without claiming model quality, musical quality, or human preference.
+
+For Stage B MIDI-to-solo model-direct phrase quality diagnostics changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-phrase-quality-diagnostics
+```
+
+This harness diagnoses note-level phrase risks from model-direct MIDI candidates and routes the next repair boundary without claiming musical quality or human preference.
 
 For Stage B generic tiny checkpoint generation probe changes, run:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -104,8 +104,11 @@ MVP가 끝났다고 볼 수 있는 조건:
 - model-direct MIDI-to-WAV technical path completed: `true`
 - model-direct generation quality claimed: `false`
 - human/audio preference claimed: `false`
-- next repair target: `stage_b_midi_to_solo_model_direct_phrase_quality_diagnostics`
-- 근거 문서: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_AUDIO_EVIDENCE_CONSOLIDATION_2026-06-03.md`
+- model-direct phrase diagnostics flags: `dead_air_gap=3`, `wide_interval_contour=3`, `wide_register_span=3`
+- model-direct max interval max: `82`
+- model-direct max dead-air ratio: `0.6522`
+- next repair target: `stage_b_midi_to_solo_model_direct_pitch_contour_repetition_repair`
+- 근거 문서: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_PHRASE_QUALITY_DIAGNOSTICS_2026-06-03.md`
 - margin-recovered timing/repetition focused listening notes 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_NOTES_2026-05-28.md`
 - margin-recovered timing/repetition focused listening fill 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_FILL_2026-05-28.md`
 - margin-recovered phrase/vocabulary repair 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_REPAIR_2026-05-28.md`
@@ -295,6 +298,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo model-direct monophonic overlap repair: source `model_checkpoint_direct_constrained`, valid/strict `3/3`, avg postprocess removal ratio `0.0`, collapse warning sample rate `0.0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_direct_audio_render_package`
 - MIDI-to-solo model-direct audio render package: rendered WAV `3`, sample rate `44100`, duration range `19.585s-22.390s`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_direct_audio_evidence_consolidation`
 - MIDI-to-solo model-direct audio evidence consolidation: objective gate `true`, audio render `true`, MIDI-to-WAV technical path `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_direct_phrase_quality_diagnostics`
+- MIDI-to-solo model-direct phrase quality diagnostics: candidates `3`, flags `dead_air_gap=3`, `wide_interval_contour=3`, `wide_register_span=3`, max interval `82`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_direct_pitch_contour_repetition_repair`
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
 - generic base readiness audit: phase4 prep ready `true`, broad training execution ready `false`, broad quality/Brad adaptation claim `false`
 - generic base manifest contract: generic split `2433/270`, Brad split `47/11/14`, leakage/overlap `0`, broad training execution ready `false`

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #503, Stage B MIDI-to-solo model-direct audio evidence consolidation
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-direct phrase quality diagnostics`
+- latest functional result: Issue #505, Stage B MIDI-to-solo model-direct phrase quality diagnostics
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-direct pitch contour repetition repair`
 
 현재 범위가 아닌 것:
 
@@ -592,6 +592,50 @@ Issue #503은 #499 objective gate evidence와 #501 WAV render evidence를 하나
 다음:
 
 - `Stage B MIDI-to-solo model-direct phrase quality diagnostics`
+
+## Stage B MIDI-to-Solo Model-Direct Phrase Quality Diagnostics Result
+
+Issue #505는 #503 model-direct MIDI 후보 3개를 note-level 지표로 진단해 다음 repair target을 분리한 작업이다.
+
+변경:
+
+- model-direct audio evidence report 입력 검증 추가
+- MIDI note 기반 pitch range, interval, adjacent repeat, duration, IOI, dead-air 지표 계산
+- candidate-level diagnostic flags 기록
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_PHRASE_QUALITY_DIAGNOSTICS_2026-06-03.md`
+- boundary: `stage_b_midi_to_solo_model_direct_phrase_quality_diagnostics`
+- next boundary: `stage_b_midi_to_solo_model_direct_pitch_contour_repetition_repair`
+- candidate count: `3`
+- flag counts: `dead_air_gap=3`, `wide_interval_contour=3`, `wide_register_span=3`
+- max interval max: `82`
+- adjacent pitch repeat total: `0`
+- max duration most-common ratio: `0.4167`
+- max dead-air ratio: `0.6522`
+- model-direct generation quality claimed: `false`
+- human/audio preference claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- 현재 direct MIDI 후보는 objective gate와 WAV render는 통과했지만, note-level 진단에서 넓은 도약과 넓은 register span이 모든 후보에서 관측
+- dead-air gap도 모든 후보에서 관측
+- 다음 repair target은 pitch contour/register/repetition 계열
+- 이 결과는 문제 지표 분리이며, 음악적 품질 claim은 아님
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_direct_phrase_quality_diagnostics`
+- `.venv/bin/python -m py_compile scripts/diagnose_stage_b_midi_to_solo_model_direct_phrase_quality.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-phrase-quality-diagnostics`
+
+다음:
+
+- `Stage B MIDI-to-solo model-direct pitch contour repetition repair`
 
 ## Previous Model Decision
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_PHRASE_QUALITY_DIAGNOSTICS_2026-06-03.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_PHRASE_QUALITY_DIAGNOSTICS_2026-06-03.md
@@ -1,0 +1,30 @@
+# Stage B MIDI-to-Solo Model-Direct Phrase Quality Diagnostics
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_model_direct_phrase_quality_diagnostics`
+- next boundary: `stage_b_midi_to_solo_model_direct_pitch_contour_repetition_repair`
+- candidate count: `3`
+- flag counts: `{'dead_air_gap': 3, 'wide_interval_contour': 3, 'wide_register_span': 3}`
+- max interval max: `82`
+- adjacent pitch repeat total: `0`
+- max duration most-common ratio: `0.4166666666666667`
+- max dead-air ratio: `0.6521739130434783`
+- model-direct generation quality claimed: `false`
+- human/audio preference claimed: `false`
+
+## Candidate Diagnostics
+
+| rank | notes | unique pitch | range | max interval | adjacent repeats | duration ratio | dead-air | flags |
+|---:|---:|---:|---|---:|---:|---:|---:|---|
+| 1 | 24 | 20 | 26-108 | 82 | 0 | 0.417 | 0.652 | wide_interval_contour, dead_air_gap, wide_register_span |
+| 2 | 24 | 20 | 21-103 | 69 | 0 | 0.417 | 0.652 | wide_interval_contour, dead_air_gap, wide_register_span |
+| 3 | 24 | 19 | 28-102 | 53 | 0 | 0.417 | 0.652 | wide_interval_contour, dead_air_gap, wide_register_span |
+
+## Not Proven
+
+- `model_direct_generation_quality`
+- `midi_to_solo_musical_quality`
+- `human_audio_preference`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -214,6 +214,8 @@ Modes:
                 Render repaired model-direct MIDI candidates to WAV and validate technical metadata.
   stage-b-midi-to-solo-model-direct-audio-evidence-consolidation
                 Consolidate model-direct objective gate and WAV render evidence.
+  stage-b-midi-to-solo-model-direct-phrase-quality-diagnostics
+                Diagnose model-direct MIDI phrase risks from note-level evidence.
   stage-b-generic-tiny-checkpoint-generation-probe
                 Probe generation/decode from the generic tiny checkpoint.
   stage-b-generic-tiny-checkpoint-grammar-repair
@@ -3845,6 +3847,31 @@ run_stage_b_midi_to_solo_model_direct_audio_evidence_consolidation() {
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_model_direct_phrase_quality_diagnostics() {
+  local evidence_run_id="${EVIDENCE_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_audio_evidence_consolidation}"
+  local audio_render_run_id="${AUDIO_RENDER_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_audio_render_package}"
+  local overlap_repair_run_id="${OVERLAP_REPAIR_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_monophonic_overlap_repair}"
+  local previous_direct_run_id="${PREVIOUS_DIRECT_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_8bar_generation_probe}"
+  local sequence_budget_run_id="${SEQUENCE_BUDGET_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_sequence_budget_repair_smoke}"
+  local context_run_id="${CONTEXT_RUN_ID:-harness_stage_b_midi_to_solo_context_extraction}"
+  local scale_run_id="${SCALE_RUN_ID:-max_sequence_160}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_direct_phrase_quality_diagnostics}"
+  local evidence_report="outputs/stage_b_midi_to_solo_model_direct_audio_evidence_consolidation/${evidence_run_id}/stage_b_midi_to_solo_model_direct_audio_evidence_consolidation.json"
+  if [[ ! -f "$evidence_report" ]]; then
+    print_header "Stage B MIDI-to-solo model-direct audio evidence consolidation"
+    RUN_ID="$evidence_run_id" AUDIO_RENDER_RUN_ID="$audio_render_run_id" OVERLAP_REPAIR_RUN_ID="$overlap_repair_run_id" PREVIOUS_DIRECT_RUN_ID="$previous_direct_run_id" SEQUENCE_BUDGET_RUN_ID="$sequence_budget_run_id" CONTEXT_RUN_ID="$context_run_id" SCALE_RUN_ID="$scale_run_id" run_stage_b_midi_to_solo_model_direct_audio_evidence_consolidation
+  fi
+  print_header "Stage B MIDI-to-solo model-direct phrase quality diagnostics"
+  "$PYTHON_BIN" scripts/diagnose_stage_b_midi_to_solo_model_direct_phrase_quality.py \
+    --run_id "$run_id" \
+    --audio_evidence_report "$evidence_report" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_PHRASE_QUALITY_DIAGNOSTICS_2026-06-03.md \
+    --expected_boundary stage_b_midi_to_solo_model_direct_phrase_quality_diagnostics \
+    --min_candidate_count 3 \
+    --require_diagnostics_completed \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -5261,6 +5288,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-model-direct-audio-evidence-consolidation)
     run_stage_b_midi_to_solo_model_direct_audio_evidence_consolidation
+    ;;
+  stage-b-midi-to-solo-model-direct-phrase-quality-diagnostics)
+    run_stage_b_midi_to_solo_model_direct_phrase_quality_diagnostics
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/diagnose_stage_b_midi_to_solo_model_direct_phrase_quality.py
+++ b/scripts/diagnose_stage_b_midi_to_solo_model_direct_phrase_quality.py
@@ -1,0 +1,405 @@
+"""Diagnose phrase-quality risks from model-direct MIDI note evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pretty_midi
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+
+
+class StageBMidiToSoloModelDirectPhraseQualityDiagnosticsError(ValueError):
+    pass
+
+
+SOURCE_BOUNDARY = "stage_b_midi_to_solo_model_direct_audio_evidence_consolidation"
+BOUNDARY = "stage_b_midi_to_solo_model_direct_phrase_quality_diagnostics"
+PITCH_REPAIR_BOUNDARY = "stage_b_midi_to_solo_model_direct_pitch_contour_repetition_repair"
+TIMING_REPAIR_BOUNDARY = "stage_b_midi_to_solo_model_direct_timing_phrase_repair"
+LISTENING_REVIEW_BOUNDARY = "stage_b_midi_to_solo_model_direct_listening_review_package"
+SCHEMA_VERSION = "stage_b_midi_to_solo_model_direct_phrase_quality_diagnostics_v1"
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def load_midi_notes(path: str | Path) -> list[pretty_midi.Note]:
+    midi = pretty_midi.PrettyMIDI(str(path))
+    notes: list[pretty_midi.Note] = []
+    for instrument in midi.instruments:
+        if not instrument.is_drum:
+            notes.extend(instrument.notes)
+    return sorted(notes, key=lambda note: (float(note.start), int(note.pitch), float(note.end)))
+
+
+def repeated_ngram_count(pitches: list[int], n: int) -> int:
+    if len(pitches) < n * 2:
+        return 0
+    grams = [tuple(pitches[index : index + n]) for index in range(len(pitches) - n + 1)]
+    counts = Counter(grams)
+    return sum(count - 1 for count in counts.values() if count > 1)
+
+
+def most_common_ratio(values: list[float | int], *, precision: int = 3) -> float:
+    if not values:
+        return 0.0
+    rounded = [round(float(value), precision) for value in values]
+    return max(Counter(rounded).values()) / len(rounded)
+
+
+def note_metrics_for_path(path: str | Path, *, dead_air_threshold_seconds: float) -> dict[str, Any]:
+    notes = load_midi_notes(path)
+    if not notes:
+        return {
+            "midi_path": str(path),
+            "note_count": 0,
+            "diagnostic_flags": ["empty_midi"],
+        }
+    pitches = [int(note.pitch) for note in notes]
+    starts = [float(note.start) for note in notes]
+    durations = [max(0.0, float(note.end) - float(note.start)) for note in notes]
+    intervals = [abs(pitches[index] - pitches[index - 1]) for index in range(1, len(pitches))]
+    iois = [max(0.0, starts[index] - starts[index - 1]) for index in range(1, len(starts))]
+    dead_air_events = sum(1 for gap in iois if gap >= float(dead_air_threshold_seconds))
+    adjacent_pitch_repeats = sum(1 for index in range(1, len(pitches)) if pitches[index] == pitches[index - 1])
+    large_intervals = [interval for interval in intervals if interval >= 12]
+    max_interval = max(intervals) if intervals else 0
+    pitch_min = min(pitches)
+    pitch_max = max(pitches)
+    duration_most_common_ratio = most_common_ratio(durations)
+    ioi_most_common_ratio = most_common_ratio(iois)
+    flags: list[str] = []
+    if len(set(pitches)) < 8:
+        flags.append("narrow_pitch_vocabulary")
+    if adjacent_pitch_repeats > 0:
+        flags.append("adjacent_pitch_repetition")
+    if max_interval >= 12 or (len(large_intervals) / max(1, len(intervals))) >= 0.20:
+        flags.append("wide_interval_contour")
+    if duration_most_common_ratio >= 0.75:
+        flags.append("duration_monotony")
+    if ioi_most_common_ratio >= 0.75:
+        flags.append("ioi_monotony")
+    if dead_air_events / max(1, len(iois)) >= 0.35:
+        flags.append("dead_air_gap")
+    if pitch_max - pitch_min > 24:
+        flags.append("wide_register_span")
+    return {
+        "midi_path": str(path),
+        "note_count": len(notes),
+        "unique_pitch_count": len(set(pitches)),
+        "unique_pitch_class_count": len({pitch % 12 for pitch in pitches}),
+        "pitch_min": pitch_min,
+        "pitch_max": pitch_max,
+        "pitch_span": pitch_max - pitch_min,
+        "max_interval": max_interval,
+        "avg_abs_interval": sum(intervals) / len(intervals) if intervals else 0.0,
+        "large_interval_count": len(large_intervals),
+        "large_interval_ratio": len(large_intervals) / max(1, len(intervals)),
+        "adjacent_pitch_repeats": adjacent_pitch_repeats,
+        "repeated_3gram_count": repeated_ngram_count(pitches, 3),
+        "repeated_4gram_count": repeated_ngram_count(pitches, 4),
+        "avg_duration_seconds": sum(durations) / len(durations),
+        "max_duration_seconds": max(durations),
+        "unique_duration_count": len({round(duration, 3) for duration in durations}),
+        "duration_most_common_ratio": duration_most_common_ratio,
+        "unique_ioi_count": len({round(ioi, 3) for ioi in iois}),
+        "ioi_most_common_ratio": ioi_most_common_ratio,
+        "dead_air_ratio": dead_air_events / max(1, len(iois)),
+        "phrase_start_seconds": min(starts),
+        "phrase_end_seconds": max(float(note.end) for note in notes),
+        "diagnostic_flags": flags,
+    }
+
+
+def next_boundary_from_flags(candidates: list[dict[str, Any]]) -> str:
+    all_flags = {flag for candidate in candidates for flag in _list(candidate.get("diagnostic_flags"))}
+    if {"wide_interval_contour", "adjacent_pitch_repetition", "narrow_pitch_vocabulary"} & all_flags:
+        return PITCH_REPAIR_BOUNDARY
+    if {"duration_monotony", "ioi_monotony", "dead_air_gap"} & all_flags:
+        return TIMING_REPAIR_BOUNDARY
+    return LISTENING_REVIEW_BOUNDARY
+
+
+def build_phrase_quality_diagnostics_report(
+    *,
+    evidence_report: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+    dead_air_threshold_seconds: float,
+) -> dict[str, Any]:
+    readiness = _dict(evidence_report.get("readiness"))
+    objective = _dict(evidence_report.get("objective_evidence"))
+    if str(evidence_report.get("boundary") or readiness.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloModelDirectPhraseQualityDiagnosticsError("audio evidence boundary required")
+    if not bool(readiness.get("model_direct_midi_to_wav_technical_path_completed", False)):
+        raise StageBMidiToSoloModelDirectPhraseQualityDiagnosticsError("model-direct technical path must be complete")
+    if bool(readiness.get("model_direct_generation_quality_claimed", True)):
+        raise StageBMidiToSoloModelDirectPhraseQualityDiagnosticsError("model quality must not be claimed upstream")
+    midi_paths = [str(path) for path in _list(objective.get("midi_paths"))]
+    if len(midi_paths) < 3:
+        raise StageBMidiToSoloModelDirectPhraseQualityDiagnosticsError("at least 3 MIDI paths required")
+    candidates = [
+        {
+            "rank": index,
+            **note_metrics_for_path(path, dead_air_threshold_seconds=dead_air_threshold_seconds),
+        }
+        for index, path in enumerate(midi_paths[:3], start=1)
+    ]
+    next_boundary = next_boundary_from_flags(candidates)
+    flag_counts = Counter(flag for candidate in candidates for flag in _list(candidate.get("diagnostic_flags")))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundary": SOURCE_BOUNDARY,
+        "diagnostic_config": {
+            "dead_air_threshold_seconds": float(dead_air_threshold_seconds),
+            "wide_interval_threshold_semitones": 12,
+            "duration_monotony_ratio_threshold": 0.75,
+            "ioi_monotony_ratio_threshold": 0.75,
+            "dead_air_ratio_threshold": 0.35,
+        },
+        "candidate_diagnostics": candidates,
+        "aggregate": {
+            "candidate_count": len(candidates),
+            "flag_counts": dict(sorted(flag_counts.items())),
+            "max_interval_max": max((_int(candidate.get("max_interval")) for candidate in candidates), default=0),
+            "adjacent_pitch_repeat_total": sum(
+                _int(candidate.get("adjacent_pitch_repeats")) for candidate in candidates
+            ),
+            "max_duration_most_common_ratio": max(
+                (_float(candidate.get("duration_most_common_ratio")) for candidate in candidates),
+                default=0.0,
+            ),
+            "max_dead_air_ratio": max(
+                (_float(candidate.get("dead_air_ratio")) for candidate in candidates),
+                default=0.0,
+            ),
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "phrase_quality_diagnostics_completed": True,
+            "model_direct_midi_to_wav_technical_path_completed": True,
+            "model_direct_generation_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "human_audio_preference_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": next_boundary,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "MIDI note diagnostics selected the next repair boundary without musical quality claim",
+        },
+        "not_proven": [
+            "model_direct_generation_quality",
+            "midi_to_solo_musical_quality",
+            "human_audio_preference",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": {
+            PITCH_REPAIR_BOUNDARY: "Stage B MIDI-to-solo model-direct pitch contour repetition repair",
+            TIMING_REPAIR_BOUNDARY: "Stage B MIDI-to-solo model-direct timing phrase repair",
+            LISTENING_REVIEW_BOUNDARY: "Stage B MIDI-to-solo model-direct listening review package",
+        }[next_boundary],
+    }
+
+
+def validate_phrase_quality_diagnostics_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    require_diagnostics_completed: bool,
+    require_no_quality_claim: bool,
+    min_candidate_count: int,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    aggregate = _dict(report.get("aggregate"))
+    candidates = _list(report.get("candidate_diagnostics"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloModelDirectPhraseQualityDiagnosticsError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if require_diagnostics_completed and not bool(readiness.get("phrase_quality_diagnostics_completed", False)):
+        raise StageBMidiToSoloModelDirectPhraseQualityDiagnosticsError("diagnostics must be completed")
+    if len(candidates) < int(min_candidate_count):
+        raise StageBMidiToSoloModelDirectPhraseQualityDiagnosticsError("candidate diagnostics below threshold")
+    for candidate in candidates[: int(min_candidate_count)]:
+        if not Path(str(_dict(candidate).get("midi_path") or "")).exists():
+            raise StageBMidiToSoloModelDirectPhraseQualityDiagnosticsError("diagnostic MIDI path missing")
+        if _int(_dict(candidate).get("note_count")) <= 0:
+            raise StageBMidiToSoloModelDirectPhraseQualityDiagnosticsError("diagnostic note count required")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloModelDirectPhraseQualityDiagnosticsError("critical user input should not be required")
+    if require_no_quality_claim:
+        blocked = [
+            "model_direct_generation_quality_claimed",
+            "midi_to_solo_musical_quality_claimed",
+            "human_audio_preference_claimed",
+            "broad_trained_model_quality_claimed",
+            "brad_style_adaptation_claimed",
+        ]
+        claimed = [name for name in blocked if bool(readiness.get(name, True))]
+        if claimed:
+            raise StageBMidiToSoloModelDirectPhraseQualityDiagnosticsError(
+                f"unexpected quality claim: {claimed}"
+            )
+    return {
+        "boundary": boundary,
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "candidate_count": _int(aggregate.get("candidate_count")),
+        "flag_counts": _dict(aggregate.get("flag_counts")),
+        "max_interval_max": _int(aggregate.get("max_interval_max")),
+        "adjacent_pitch_repeat_total": _int(aggregate.get("adjacent_pitch_repeat_total")),
+        "max_duration_most_common_ratio": _float(aggregate.get("max_duration_most_common_ratio")),
+        "max_dead_air_ratio": _float(aggregate.get("max_dead_air_ratio")),
+        "model_direct_generation_quality_claimed": bool(
+            readiness.get("model_direct_generation_quality_claimed", True)
+        ),
+        "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    aggregate = report["aggregate"]
+    lines = [
+        "# Stage B MIDI-to-Solo Model-Direct Phrase Quality Diagnostics",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- candidate count: `{aggregate['candidate_count']}`",
+        f"- flag counts: `{aggregate['flag_counts']}`",
+        f"- max interval max: `{aggregate['max_interval_max']}`",
+        f"- adjacent pitch repeat total: `{aggregate['adjacent_pitch_repeat_total']}`",
+        f"- max duration most-common ratio: `{aggregate['max_duration_most_common_ratio']}`",
+        f"- max dead-air ratio: `{aggregate['max_dead_air_ratio']}`",
+        f"- model-direct generation quality claimed: `{_bool_token(readiness['model_direct_generation_quality_claimed'])}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        "",
+        "## Candidate Diagnostics",
+        "",
+        "| rank | notes | unique pitch | range | max interval | adjacent repeats | duration ratio | dead-air | flags |",
+        "|---:|---:|---:|---|---:|---:|---:|---:|---|",
+    ]
+    for candidate in report.get("candidate_diagnostics", []):
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(candidate["rank"]),
+                    str(candidate["note_count"]),
+                    str(candidate["unique_pitch_count"]),
+                    f"{candidate['pitch_min']}-{candidate['pitch_max']}",
+                    str(candidate["max_interval"]),
+                    str(candidate["adjacent_pitch_repeats"]),
+                    f"{float(candidate['duration_most_common_ratio']):.3f}",
+                    f"{float(candidate['dead_air_ratio']):.3f}",
+                    ", ".join(candidate["diagnostic_flags"]) or "none",
+                ]
+            )
+            + " |"
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Diagnose model-direct phrase-quality risks")
+    parser.add_argument("--audio_evidence_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_model_direct_phrase_quality_diagnostics",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=505)
+    parser.add_argument("--dead_air_threshold_seconds", type=float, default=0.5)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--min_candidate_count", type=int, default=3)
+    parser.add_argument("--require_diagnostics_completed", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report = build_phrase_quality_diagnostics_report(
+        evidence_report=read_json(Path(args.audio_evidence_report)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+        dead_air_threshold_seconds=float(args.dead_air_threshold_seconds),
+    )
+    summary = validate_phrase_quality_diagnostics_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        require_diagnostics_completed=bool(args.require_diagnostics_completed),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+        min_candidate_count=int(args.min_candidate_count),
+    )
+    write_json(output_dir / "stage_b_midi_to_solo_model_direct_phrase_quality_diagnostics.json", report)
+    write_json(
+        output_dir / "stage_b_midi_to_solo_model_direct_phrase_quality_diagnostics_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_midi_to_solo_model_direct_phrase_quality_diagnostics.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_model_direct_phrase_quality_diagnostics.py
+++ b/tests/test_stage_b_midi_to_solo_model_direct_phrase_quality_diagnostics.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import pretty_midi
+
+from scripts.diagnose_stage_b_midi_to_solo_model_direct_phrase_quality import (
+    BOUNDARY,
+    PITCH_REPAIR_BOUNDARY,
+    StageBMidiToSoloModelDirectPhraseQualityDiagnosticsError,
+    build_phrase_quality_diagnostics_report,
+    note_metrics_for_path,
+    validate_phrase_quality_diagnostics_report,
+)
+
+
+def write_midi(path: Path, pitches: list[int], *, step: float = 0.5, duration: float = 0.25) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    midi = pretty_midi.PrettyMIDI(initial_tempo=120)
+    piano = pretty_midi.Instrument(program=0, is_drum=False, name="solo")
+    for index, pitch in enumerate(pitches):
+        start = index * step
+        piano.notes.append(pretty_midi.Note(velocity=84, pitch=pitch, start=start, end=start + duration))
+    midi.instruments.append(piano)
+    midi.write(str(path))
+    return str(path)
+
+
+def evidence_report(root: Path, *, quality_claim: bool = False) -> dict:
+    midi_paths = [
+        write_midi(root / "sample_1.mid", [60, 60, 72, 61, 73, 62, 74, 63]),
+        write_midi(root / "sample_2.mid", [64, 76, 65, 77, 66, 78, 67, 79]),
+        write_midi(root / "sample_3.mid", [67, 67, 79, 68, 80, 69, 81, 70]),
+    ]
+    return {
+        "boundary": "stage_b_midi_to_solo_model_direct_audio_evidence_consolidation",
+        "readiness": {
+            "boundary": "stage_b_midi_to_solo_model_direct_audio_evidence_consolidation",
+            "model_direct_midi_to_wav_technical_path_completed": True,
+            "model_direct_generation_quality_claimed": quality_claim,
+            "human_audio_preference_claimed": False,
+        },
+        "objective_evidence": {
+            "midi_paths": midi_paths,
+        },
+    }
+
+
+class StageBMidiToSoloModelDirectPhraseQualityDiagnosticsTest(unittest.TestCase):
+    def test_note_metrics_detect_pitch_and_rhythm_flags(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            midi_path = write_midi(Path(temp_dir) / "candidate.mid", [60, 60, 72, 61, 73, 62, 74, 63])
+            metrics = note_metrics_for_path(midi_path, dead_air_threshold_seconds=0.4)
+
+        self.assertEqual(metrics["note_count"], 8)
+        self.assertEqual(metrics["adjacent_pitch_repeats"], 1)
+        self.assertGreaterEqual(metrics["max_interval"], 12)
+        self.assertIn("adjacent_pitch_repetition", metrics["diagnostic_flags"])
+        self.assertIn("wide_interval_contour", metrics["diagnostic_flags"])
+        self.assertIn("duration_monotony", metrics["diagnostic_flags"])
+
+    def test_builds_diagnostics_and_routes_pitch_repair_without_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            report = build_phrase_quality_diagnostics_report(
+                evidence_report=evidence_report(root),
+                output_dir=root / "out",
+                issue_number=505,
+                dead_air_threshold_seconds=0.4,
+            )
+            summary = validate_phrase_quality_diagnostics_report(
+                report,
+                expected_boundary=BOUNDARY,
+                require_diagnostics_completed=True,
+                require_no_quality_claim=True,
+                min_candidate_count=3,
+            )
+
+        self.assertEqual(summary["candidate_count"], 3)
+        self.assertEqual(summary["next_boundary"], PITCH_REPAIR_BOUNDARY)
+        self.assertGreaterEqual(summary["flag_counts"]["wide_interval_contour"], 1)
+        self.assertGreaterEqual(summary["adjacent_pitch_repeat_total"], 1)
+        self.assertFalse(summary["model_direct_generation_quality_claimed"])
+        self.assertFalse(summary["human_audio_preference_claimed"])
+        self.assertFalse(summary["critical_user_input_required"])
+
+    def test_rejects_upstream_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with self.assertRaises(StageBMidiToSoloModelDirectPhraseQualityDiagnosticsError):
+                build_phrase_quality_diagnostics_report(
+                    evidence_report=evidence_report(root, quality_claim=True),
+                    output_dir=root / "out",
+                    issue_number=505,
+                    dead_air_threshold_seconds=0.4,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- model-direct MIDI candidate note-level diagnostics
- interval, register span, duration, IOI, dead-air metrics
- next repair target selection without quality claim

## Context

- #503: model-direct MIDI-to-WAV technical path completed
- strict valid sample count: `3`
- rendered WAV count: `3`
- current claim boundary: technical path and objective gate only

## Result

- candidate count: `3`
- flag counts: `dead_air_gap=3`, `wide_interval_contour=3`, `wide_register_span=3`
- max interval max: `82`
- adjacent pitch repeat total: `0`
- max duration most-common ratio: `0.4167`
- max dead-air ratio: `0.6522`
- model-direct generation quality claimed: `false`
- human/audio preference claimed: `false`
- next boundary: `stage_b_midi_to_solo_model_direct_pitch_contour_repetition_repair`

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_direct_phrase_quality_diagnostics tests.test_stage_b_midi_to_solo_model_direct_audio_evidence_consolidation`
- `.venv/bin/python -m py_compile scripts/diagnose_stage_b_midi_to_solo_model_direct_phrase_quality.py scripts/consolidate_stage_b_midi_to_solo_model_direct_audio_evidence.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-phrase-quality-diagnostics`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- diagnostics are not musical quality judgment
- no audio quality claim
- no human/audio preference claim

## Follow-up

- Stage B MIDI-to-solo model-direct pitch contour repetition repair

Closes #505