### PR TITLE
Stage B MIDI-to-solo model-direct timing phrase repair

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #507, Stage B MIDI-to-solo model-direct pitch contour repetition repair.
+- Latest functional issue completed: Issue #510, Stage B MIDI-to-solo model-direct timing phrase repair.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-direct timing phrase repair.
+- Recommended next issue: Stage B MIDI-to-solo model-direct listening review package.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1115,6 +1115,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-pitch-contour-re
 ```
 
 This harness applies model-direct pitch range and adjacent interval guards, compares note-level diagnostics before/after, and keeps musical quality and human preference unclaimed.
+
+For Stage B MIDI-to-solo model-direct timing phrase repair changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-timing-phrase-repair
+```
+
+This harness applies compact timing positions and duration fill, compares note-level dead-air diagnostics before/after, and keeps musical quality and human preference unclaimed.
 
 For Stage B generic tiny checkpoint generation probe changes, run:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -111,8 +111,13 @@ MVP가 끝났다고 볼 수 있는 조건:
 - model-direct wide interval flag count: `3 -> 0`
 - model-direct wide register flag count: `3 -> 0`
 - model-direct dead-air flag count: `3 -> 3`
-- next repair target: `stage_b_midi_to_solo_model_direct_timing_phrase_repair`
-- 근거 문서: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_PITCH_CONTOUR_REPETITION_REPAIR_2026-06-03.md`
+- model-direct timing phrase repair strict valid sample count: `3/3`
+- model-direct timing phrase repair dead-air flag count: `3 -> 0`
+- model-direct timing phrase repair max dead-air ratio: `0.6522 -> 0.2258`
+- model-direct timing phrase repair max interval guard: `9 -> 9`
+- model-direct timing phrase repair quality/preference claim: `false`
+- next review target: `stage_b_midi_to_solo_model_direct_listening_review_package`
+- 근거 문서: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_TIMING_PHRASE_REPAIR_2026-06-03.md`
 - margin-recovered timing/repetition focused listening notes 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_NOTES_2026-05-28.md`
 - margin-recovered timing/repetition focused listening fill 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_FILL_2026-05-28.md`
 - margin-recovered phrase/vocabulary repair 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_REPAIR_2026-05-28.md`
@@ -304,6 +309,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo model-direct audio evidence consolidation: objective gate `true`, audio render `true`, MIDI-to-WAV technical path `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_direct_phrase_quality_diagnostics`
 - MIDI-to-solo model-direct phrase quality diagnostics: candidates `3`, flags `dead_air_gap=3`, `wide_interval_contour=3`, `wide_register_span=3`, max interval `82`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_direct_pitch_contour_repetition_repair`
 - MIDI-to-solo model-direct pitch contour repair: strict `3/3`, max interval `82 -> 9`, wide interval/register flags `3 -> 0`, dead-air flag `3 -> 3`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_direct_timing_phrase_repair`
+- MIDI-to-solo model-direct timing phrase repair: strict `3/3`, dead-air flags `3 -> 0`, max dead-air ratio `0.6522 -> 0.2258`, max interval guard `9 -> 9`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_direct_listening_review_package`
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
 - generic base readiness audit: phase4 prep ready `true`, broad training execution ready `false`, broad quality/Brad adaptation claim `false`
 - generic base manifest contract: generic split `2433/270`, Brad split `47/11/14`, leakage/overlap `0`, broad training execution ready `false`

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #507, Stage B MIDI-to-solo model-direct pitch contour repetition repair
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-direct timing phrase repair`
+- latest functional result: Issue #510, Stage B MIDI-to-solo model-direct timing phrase repair
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-direct listening review package`
 
 현재 범위가 아닌 것:
 
@@ -680,6 +680,48 @@ Issue #507은 #505에서 분리한 wide interval/register blocker를 constrained
 다음:
 
 - `Stage B MIDI-to-solo model-direct timing phrase repair`
+
+## Stage B MIDI-to-Solo Model-Direct Timing Phrase Repair Result
+
+Issue #510은 #507 이후 남은 dead-air gap blocker를 compact onset pattern과 duration fill로 수리한 작업이다.
+
+변경:
+
+- compact phrase rhythm profile 추가
+- direct generation command에 jazz rhythm profile / duration fill option 전달 추가
+- note group density `4/bar`, profile `compact_phrase`, duration fill 조건으로 repaired direct MIDI 생성
+- #507 pitch contour repair 대비 before/after 지표 비교
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_TIMING_PHRASE_REPAIR_2026-06-03.md`
+- boundary: `stage_b_midi_to_solo_model_direct_timing_phrase_repair`
+- next boundary: `stage_b_midi_to_solo_model_direct_listening_review_package`
+- strict valid sample count: `3`
+- dead-air flag count: `3` -> `0`
+- max dead-air ratio: `0.6522` -> `0.2258`
+- max interval max: `9` -> `9`
+- timing phrase repair passed: `true`
+- model-direct generation quality claimed: `false`
+- human/audio preference claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- pitch/register guard 유지 상태에서 dead-air diagnostic 제거
+- compact onset pattern과 duration fill 조합 필요
+- 다음 boundary는 listening review package
+- 이 결과는 objective timing repair evidence이며, 음악적 품질 claim은 아님
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_generation_probe tests.test_stage_b_midi_to_solo_model_direct_pitch_contour_repair tests.test_stage_b_midi_to_solo_model_direct_timing_phrase_repair`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-timing-phrase-repair`
+
+다음:
+
+- `Stage B MIDI-to-solo model-direct listening review package`
 
 ## Previous Model Decision
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_TIMING_PHRASE_REPAIR_2026-06-03.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_TIMING_PHRASE_REPAIR_2026-06-03.md
@@ -1,0 +1,27 @@
+# Stage B MIDI-to-Solo Model-Direct Timing Phrase Repair
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_model_direct_timing_phrase_repair`
+- next boundary: `stage_b_midi_to_solo_model_direct_listening_review_package`
+- strict review gate passed: `true`
+- timing phrase repair passed: `true`
+- jazz rhythm profile: `compact_phrase`
+- fill duration to next position: `true`
+- model-direct generation quality claimed: `false`
+- human/audio preference claimed: `false`
+
+## Before / After
+
+- dead-air flag count: `3` -> `0`
+- max dead-air ratio: `0.6522` -> `0.2258`
+- max interval max: `9` -> `9`
+- max pitch span: `22` -> `24`
+
+## Not Proven
+
+- `model_direct_generation_quality`
+- `midi_to_solo_musical_quality`
+- `human_audio_preference`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -218,6 +218,8 @@ Modes:
                 Diagnose model-direct MIDI phrase risks from note-level evidence.
   stage-b-midi-to-solo-model-direct-pitch-contour-repair
                 Repair model-direct pitch/register contour with range and interval guards.
+  stage-b-midi-to-solo-model-direct-timing-phrase-repair
+                Repair model-direct timing phrase gaps with compact onset and duration fill.
   stage-b-generic-tiny-checkpoint-generation-probe
                 Probe generation/decode from the generic tiny checkpoint.
   stage-b-generic-tiny-checkpoint-grammar-repair
@@ -3915,6 +3917,48 @@ run_stage_b_midi_to_solo_model_direct_pitch_contour_repair() {
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_model_direct_timing_phrase_repair() {
+  local pitch_repair_run_id="${PITCH_REPAIR_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_pitch_contour_repair}"
+  local diagnostics_run_id="${DIAGNOSTICS_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_phrase_quality_diagnostics}"
+  local evidence_run_id="${EVIDENCE_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_audio_evidence_consolidation}"
+  local audio_render_run_id="${AUDIO_RENDER_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_audio_render_package}"
+  local overlap_repair_run_id="${OVERLAP_REPAIR_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_monophonic_overlap_repair}"
+  local previous_direct_run_id="${PREVIOUS_DIRECT_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_8bar_generation_probe}"
+  local sequence_budget_run_id="${SEQUENCE_BUDGET_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_sequence_budget_repair_smoke}"
+  local context_run_id="${CONTEXT_RUN_ID:-harness_stage_b_midi_to_solo_context_extraction}"
+  local scale_run_id="${SCALE_RUN_ID:-max_sequence_160}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_direct_timing_phrase_repair}"
+  local pitch_repair="outputs/stage_b_midi_to_solo_model_direct_pitch_contour_repetition_repair/${pitch_repair_run_id}/stage_b_midi_to_solo_model_direct_pitch_contour_repetition_repair.json"
+  local sequence_budget_repair="outputs/stage_b_midi_to_solo_model_direct_sequence_budget_repair_smoke/${sequence_budget_run_id}/stage_b_midi_to_solo_model_direct_sequence_budget_repair_smoke.json"
+  local context_report="outputs/stage_b_midi_to_solo_context_extraction/${context_run_id}/stage_b_midi_to_solo_context_extraction.json"
+  local repaired_training_scale_smoke="outputs/stage_b_midi_to_solo_model_direct_sequence_budget_repair_smoke/${sequence_budget_run_id}/scale_smoke/${scale_run_id}/stage_b_generic_base_training_scale_smoke.json"
+  if [[ ! -f "$pitch_repair" ]]; then
+    print_header "Stage B MIDI-to-solo model-direct pitch contour repair"
+    RUN_ID="$pitch_repair_run_id" DIAGNOSTICS_RUN_ID="$diagnostics_run_id" EVIDENCE_RUN_ID="$evidence_run_id" AUDIO_RENDER_RUN_ID="$audio_render_run_id" OVERLAP_REPAIR_RUN_ID="$overlap_repair_run_id" PREVIOUS_DIRECT_RUN_ID="$previous_direct_run_id" SEQUENCE_BUDGET_RUN_ID="$sequence_budget_run_id" CONTEXT_RUN_ID="$context_run_id" SCALE_RUN_ID="$scale_run_id" run_stage_b_midi_to_solo_model_direct_pitch_contour_repair
+  fi
+  if [[ ! -f "$sequence_budget_repair" || ! -f "$repaired_training_scale_smoke" ]]; then
+    print_header "Stage B MIDI-to-solo model-direct sequence budget repair smoke"
+    RUN_ID="$sequence_budget_run_id" SCALE_RUN_ID="$scale_run_id" run_stage_b_midi_to_solo_model_direct_sequence_budget_repair_smoke
+  fi
+  if [[ ! -f "$context_report" ]]; then
+    print_header "Stage B MIDI-to-solo context extraction MVP"
+    RUN_ID="$context_run_id" run_stage_b_midi_to_solo_context_extraction
+  fi
+  print_header "Stage B MIDI-to-solo model-direct timing phrase repair"
+  "$PYTHON_BIN" scripts/run_stage_b_midi_to_solo_model_direct_timing_phrase_repair.py \
+    --run_id "$run_id" \
+    --source_pitch_repair "$pitch_repair" \
+    --sequence_budget_repair "$sequence_budget_repair" \
+    --context_report "$context_report" \
+    --repaired_training_scale_smoke "$repaired_training_scale_smoke" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_TIMING_PHRASE_REPAIR_2026-06-03.md \
+    --expected_boundary stage_b_midi_to_solo_model_direct_timing_phrase_repair \
+    --expected_next_boundary stage_b_midi_to_solo_model_direct_listening_review_package \
+    --require_repair_completed \
+    --require_timing_repair_passed \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -5337,6 +5381,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-model-direct-pitch-contour-repair)
     run_stage_b_midi_to_solo_model_direct_pitch_contour_repair
+    ;;
+  stage-b-midi-to-solo-model-direct-timing-phrase-repair)
+    run_stage_b_midi_to_solo_model_direct_timing_phrase_repair
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/run_stage_b_generation_probe.py
+++ b/scripts/run_stage_b_generation_probe.py
@@ -570,6 +570,12 @@ JAZZ_RHYTHM_POSITION_PATTERNS = {
         [0, 2, 5, 6, 8, 11, 13, 14],
         [2, 4, 5, 8, 10, 12, 13, 15],
     ],
+    "compact_phrase": [
+        [0, 1, 4, 7],
+        [1, 2, 5, 8],
+        [0, 1, 3, 6],
+        [2, 3, 6, 9],
+    ],
 }
 
 JAZZ_RHYTHM_DURATION_PATTERNS = {
@@ -578,6 +584,12 @@ JAZZ_RHYTHM_DURATION_PATTERNS = {
         [1, 3, 1, 2, 2, 1, 3, 2],
         [3, 1, 2, 1, 4, 1, 2, 2],
         [1, 2, 2, 3, 1, 2, 1, 4],
+    ],
+    "compact_phrase": [
+        [1, 2, 2, 3],
+        [2, 1, 2, 3],
+        [1, 2, 3, 2],
+        [2, 1, 3, 2],
     ],
 }
 
@@ -690,6 +702,30 @@ def cap_duration_tokens_to_next_position(
         if is_note_duration_token(token) and duration_steps_from_token(token) <= max_duration_steps
     ]
     return filtered or [note_duration_token(max_duration_steps)]
+
+
+def fill_duration_token_to_next_position(
+    *,
+    current_position: int | None,
+    bar_index: int,
+    group_index: int,
+    note_groups_per_bar: int,
+    coverage_aware_positions: bool = False,
+    coverage_position_window: int = 0,
+    jazz_rhythm_positions: bool = False,
+    jazz_rhythm_profile: str = "swing_motif",
+) -> list[int]:
+    return cap_duration_tokens_to_next_position(
+        [note_duration_token(step) for step in range(1, int(MAX_DURATION_STEPS) + 1)],
+        current_position=current_position,
+        bar_index=bar_index,
+        group_index=group_index,
+        note_groups_per_bar=note_groups_per_bar,
+        coverage_aware_positions=coverage_aware_positions,
+        coverage_position_window=coverage_position_window,
+        jazz_rhythm_positions=jazz_rhythm_positions,
+        jazz_rhythm_profile=jazz_rhythm_profile,
+    )[-1:]
 
 
 def chord_pitch_classes(chord: str | None, pitch_mode: str = "tones_tensions") -> set[int]:
@@ -991,6 +1027,7 @@ def generate_stage_b_constrained_tokens(
     jazz_duration_tokens: bool = False,
     jazz_rhythm_profile: str = "swing_motif",
     cap_duration_to_next_position: bool = False,
+    fill_duration_to_next_position: bool = False,
 ) -> list[int]:
     tokens = [int(token) for token in primer_tokens]
     recent_pitches: list[int] = []
@@ -1042,7 +1079,18 @@ def generate_stage_b_constrained_tokens(
                         note_groups_per_bar=note_groups_per_bar,
                         profile=jazz_rhythm_profile,
                     )
-                if cap_duration_to_next_position and family_index == 3:
+                if fill_duration_to_next_position and family_index == 3:
+                    allowed = fill_duration_token_to_next_position(
+                        current_position=current_position,
+                        bar_index=bar_index,
+                        group_index=group_index,
+                        note_groups_per_bar=note_groups_per_bar,
+                        coverage_aware_positions=coverage_aware_positions,
+                        coverage_position_window=coverage_position_window,
+                        jazz_rhythm_positions=jazz_rhythm_positions,
+                        jazz_rhythm_profile=jazz_rhythm_profile,
+                    )
+                elif cap_duration_to_next_position and family_index == 3:
                     allowed = cap_duration_tokens_to_next_position(
                         allowed,
                         current_position=current_position,
@@ -1467,8 +1515,13 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--constrained_max_adjacent_interval", type=int, default=None)
     parser.add_argument("--jazz_rhythm_positions", action="store_true")
     parser.add_argument("--jazz_duration_tokens", action="store_true")
-    parser.add_argument("--jazz_rhythm_profile", choices=("swing_motif",), default="swing_motif")
+    parser.add_argument(
+        "--jazz_rhythm_profile",
+        choices=tuple(sorted(JAZZ_RHYTHM_POSITION_PATTERNS)),
+        default="swing_motif",
+    )
     parser.add_argument("--cap_duration_to_next_position", action="store_true")
+    parser.add_argument("--fill_duration_to_next_position", action="store_true")
     parser.add_argument("--postprocess_overlap", action="store_true")
     parser.add_argument("--max_simultaneous_notes", type=int, default=2)
     parser.add_argument("--min_valid_samples", type=int, default=1)
@@ -1555,6 +1608,7 @@ def main() -> int:
         "jazz_duration_tokens": bool(args.jazz_duration_tokens),
         "jazz_rhythm_profile": args.jazz_rhythm_profile,
         "cap_duration_to_next_position": bool(args.cap_duration_to_next_position),
+        "fill_duration_to_next_position": bool(args.fill_duration_to_next_position),
         "postprocess_overlap": bool(args.postprocess_overlap),
     }
 
@@ -1624,6 +1678,7 @@ def main() -> int:
                 jazz_duration_tokens=args.jazz_duration_tokens,
                 jazz_rhythm_profile=args.jazz_rhythm_profile,
                 cap_duration_to_next_position=args.cap_duration_to_next_position,
+                fill_duration_to_next_position=args.fill_duration_to_next_position,
             )
         else:
             generated_tokens = generate_stage_b_tokens(

--- a/scripts/run_stage_b_midi_to_solo_model_direct_8bar_generation_probe.py
+++ b/scripts/run_stage_b_midi_to_solo_model_direct_8bar_generation_probe.py
@@ -219,6 +219,14 @@ def build_generation_command(
     ]
     if bool(getattr(args, "cap_duration_to_next_position", False)):
         command.append("--cap_duration_to_next_position")
+    if bool(getattr(args, "fill_duration_to_next_position", False)):
+        command.append("--fill_duration_to_next_position")
+    if bool(getattr(args, "jazz_rhythm_positions", False)):
+        command.append("--jazz_rhythm_positions")
+    if bool(getattr(args, "jazz_duration_tokens", False)):
+        command.append("--jazz_duration_tokens")
+    if getattr(args, "jazz_rhythm_profile", None):
+        command.extend(["--jazz_rhythm_profile", str(args.jazz_rhythm_profile)])
     if getattr(args, "constrained_pitch_min", None) is not None:
         command.extend(["--constrained_pitch_min", str(args.constrained_pitch_min)])
     if getattr(args, "constrained_pitch_max", None) is not None:

--- a/scripts/run_stage_b_midi_to_solo_model_direct_timing_phrase_repair.py
+++ b/scripts/run_stage_b_midi_to_solo_model_direct_timing_phrase_repair.py
@@ -1,0 +1,432 @@
+"""Run model-direct timing phrase repair for MIDI-to-solo candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+from scripts.diagnose_stage_b_midi_to_solo_model_direct_phrase_quality import (  # noqa: E402
+    LISTENING_REVIEW_BOUNDARY,
+)
+from scripts.run_stage_b_midi_to_solo_model_direct_8bar_generation_probe import (  # noqa: E402
+    build_generation_command,
+    run_command,
+    summarize_context,
+    summarize_generation,
+    summarize_repaired_scale_smoke,
+    summarize_sequence_budget_repair,
+)
+from scripts.run_stage_b_midi_to_solo_model_direct_pitch_contour_repair import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+    TIMING_REPAIR_BOUNDARY as BOUNDARY,
+    summarize_repaired_diagnostics,
+)
+
+
+class StageBMidiToSoloModelDirectTimingPhraseRepairError(ValueError):
+    pass
+
+
+FAIL_NEXT_BOUNDARY = "stage_b_midi_to_solo_model_direct_timing_phrase_repair_followup"
+SCHEMA_VERSION = "stage_b_midi_to_solo_model_direct_timing_phrase_repair_v1"
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise StageBMidiToSoloModelDirectTimingPhraseRepairError(f"report missing: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def validate_source_pitch_repair(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    result = _dict(report.get("repair_result"))
+    diagnostics = _dict(report.get("repaired_diagnostics_summary"))
+    boundary = str(report.get("boundary") or readiness.get("boundary") or "")
+    if boundary != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloModelDirectTimingPhraseRepairError("pitch contour repair boundary required")
+    if str(decision.get("next_boundary") or "") != BOUNDARY:
+        raise StageBMidiToSoloModelDirectTimingPhraseRepairError("pitch repair must route to timing repair")
+    if not bool(readiness.get("pitch_contour_repair_passed", False)):
+        raise StageBMidiToSoloModelDirectTimingPhraseRepairError("pitch contour repair pass required")
+    if bool(readiness.get("model_direct_generation_quality_claimed", True)):
+        raise StageBMidiToSoloModelDirectTimingPhraseRepairError("upstream model quality must not be claimed")
+    return {
+        "boundary": boundary,
+        "candidate_count": _int(diagnostics.get("candidate_count")),
+        "flag_counts": _dict(diagnostics.get("flag_counts")),
+        "max_interval_max": _int(diagnostics.get("max_interval_max")),
+        "max_pitch_span": _int(diagnostics.get("max_pitch_span")),
+        "max_dead_air_ratio": _float(diagnostics.get("max_dead_air_ratio")),
+        "previous_dead_air_flag_count": _int(result.get("repaired_dead_air_flag_count")),
+    }
+
+
+def build_timing_phrase_repair_report(
+    *,
+    source_pitch_repair: dict[str, Any],
+    sequence_budget_repair: dict[str, Any],
+    context_report: dict[str, Any],
+    repaired_training_scale_smoke: dict[str, Any],
+    generation_result: dict[str, Any],
+    generation_report: dict[str, Any],
+    generation_report_path: Path,
+    output_dir: Path,
+    issue_number: int,
+    target_bars: int,
+    note_groups_per_bar: int,
+    jazz_rhythm_profile: str,
+    constrained_pitch_min: int,
+    constrained_pitch_max: int,
+    constrained_max_adjacent_interval: int,
+    dead_air_threshold_seconds: float,
+) -> dict[str, Any]:
+    source = validate_source_pitch_repair(source_pitch_repair)
+    sequence = summarize_sequence_budget_repair(sequence_budget_repair)
+    context = summarize_context(context_report, target_bars=int(target_bars))
+    scale = summarize_repaired_scale_smoke(repaired_training_scale_smoke)
+    generation = summarize_generation(generation_report)
+    diagnostics = summarize_repaired_diagnostics(
+        [str(path) for path in _list(generation.get("midi_paths"))],
+        dead_air_threshold_seconds=float(dead_air_threshold_seconds),
+    )
+    command_succeeded = _int(generation_result.get("returncode")) == 0
+    flag_counts = _dict(diagnostics.get("flag_counts"))
+    dead_air_removed = _int(flag_counts.get("dead_air_gap", 0)) == 0
+    wide_interval_still_removed = _int(flag_counts.get("wide_interval_contour", 0)) == 0
+    wide_register_still_removed = _int(flag_counts.get("wide_register_span", 0)) == 0
+    max_interval_guard_kept = _int(diagnostics.get("max_interval_max")) <= _int(source.get("max_interval_max"))
+    dead_air_ratio_reduced = _float(diagnostics.get("max_dead_air_ratio")) < _float(source.get("max_dead_air_ratio"))
+    repair_passed = bool(
+        command_succeeded
+        and generation["passed_strict_review_gate"]
+        and generation["all_midi_paths_exist"]
+        and dead_air_removed
+        and wide_interval_still_removed
+        and wide_register_still_removed
+        and max_interval_guard_kept
+        and dead_air_ratio_reduced
+    )
+    next_boundary = LISTENING_REVIEW_BOUNDARY if repair_passed else FAIL_NEXT_BOUNDARY
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundaries": {
+            "pitch_contour_repair": source["boundary"],
+            "sequence_budget_repair": sequence["boundary"],
+            "context": context["boundary"],
+            "repaired_training_scale_smoke": scale["boundary"],
+        },
+        "source_pitch_repair_summary": source,
+        "sequence_budget_summary": sequence,
+        "context_summary": context,
+        "repaired_scale_smoke_summary": scale,
+        "repair_config": {
+            "generation_source": "model_checkpoint_direct_constrained",
+            "target_bars": int(target_bars),
+            "note_groups_per_bar": int(note_groups_per_bar),
+            "max_sequence": int(scale["max_sequence"]),
+            "jazz_rhythm_positions": True,
+            "jazz_duration_tokens": False,
+            "jazz_rhythm_profile": str(jazz_rhythm_profile),
+            "cap_duration_to_next_position": False,
+            "fill_duration_to_next_position": True,
+            "constrained_pitch_min": int(constrained_pitch_min),
+            "constrained_pitch_max": int(constrained_pitch_max),
+            "constrained_max_adjacent_interval": int(constrained_max_adjacent_interval),
+        },
+        "generation_report_path": str(generation_report_path),
+        "generation_command": generation_result,
+        "generation_summary": generation,
+        "repaired_diagnostics_summary": diagnostics,
+        "repair_result": {
+            "previous_dead_air_flag_count": _int(source.get("previous_dead_air_flag_count")),
+            "repaired_dead_air_flag_count": _int(flag_counts.get("dead_air_gap", 0)),
+            "previous_max_dead_air_ratio": _float(source.get("max_dead_air_ratio")),
+            "repaired_max_dead_air_ratio": _float(diagnostics.get("max_dead_air_ratio")),
+            "previous_max_interval_max": _int(source.get("max_interval_max")),
+            "repaired_max_interval_max": _int(diagnostics.get("max_interval_max")),
+            "previous_max_pitch_span": _int(source.get("max_pitch_span")),
+            "repaired_max_pitch_span": _int(diagnostics.get("max_pitch_span")),
+            "dead_air_removed": bool(dead_air_removed),
+            "dead_air_ratio_reduced": bool(dead_air_ratio_reduced),
+            "max_interval_guard_kept": bool(max_interval_guard_kept),
+            "timing_phrase_repair_passed": bool(repair_passed),
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "timing_phrase_repair_completed": bool(command_succeeded),
+            "direct_generated_midi_written": bool(generation["all_midi_paths_exist"]),
+            "strict_review_gate_passed": bool(generation["passed_strict_review_gate"]),
+            "timing_phrase_repair_passed": bool(repair_passed),
+            "model_direct_generation_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "human_audio_preference_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": next_boundary,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": (
+                "timing dead-air diagnostics repaired; route to listening review package"
+                if repair_passed
+                else "timing dead-air diagnostics still require follow-up"
+            ),
+        },
+        "not_proven": [
+            "model_direct_generation_quality",
+            "midi_to_solo_musical_quality",
+            "human_audio_preference",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo model-direct listening review package"
+            if repair_passed
+            else "Stage B MIDI-to-solo model-direct timing phrase repair follow-up"
+        ),
+    }
+
+
+def validate_timing_phrase_repair_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_repair_completed: bool,
+    require_timing_repair_passed: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    result = _dict(report.get("repair_result"))
+    generation = _dict(report.get("generation_summary"))
+    diagnostics = _dict(report.get("repaired_diagnostics_summary"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloModelDirectTimingPhraseRepairError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloModelDirectTimingPhraseRepairError("unexpected next boundary")
+    if require_repair_completed and not bool(readiness.get("timing_phrase_repair_completed", False)):
+        raise StageBMidiToSoloModelDirectTimingPhraseRepairError("repair command must complete")
+    if not bool(readiness.get("direct_generated_midi_written", False)):
+        raise StageBMidiToSoloModelDirectTimingPhraseRepairError("generated MIDI files required")
+    if not bool(generation.get("passed_strict_review_gate", False)):
+        raise StageBMidiToSoloModelDirectTimingPhraseRepairError("strict review gate required")
+    if require_timing_repair_passed and not bool(result.get("timing_phrase_repair_passed", False)):
+        raise StageBMidiToSoloModelDirectTimingPhraseRepairError("timing phrase repair should pass")
+    if _int(diagnostics.get("candidate_count")) < 3:
+        raise StageBMidiToSoloModelDirectTimingPhraseRepairError("repaired diagnostics candidate count required")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloModelDirectTimingPhraseRepairError("critical user input should not be required")
+    if require_no_quality_claim:
+        blocked = [
+            "model_direct_generation_quality_claimed",
+            "midi_to_solo_musical_quality_claimed",
+            "human_audio_preference_claimed",
+            "broad_trained_model_quality_claimed",
+            "brad_style_adaptation_claimed",
+        ]
+        claimed = [name for name in blocked if bool(readiness.get(name, True))]
+        if claimed:
+            raise StageBMidiToSoloModelDirectTimingPhraseRepairError(f"unexpected quality claim: {claimed}")
+    return {
+        "boundary": boundary,
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "strict_valid_sample_count": _int(generation.get("strict_valid_sample_count")),
+        "previous_dead_air_flag_count": _int(result.get("previous_dead_air_flag_count")),
+        "repaired_dead_air_flag_count": _int(result.get("repaired_dead_air_flag_count")),
+        "previous_max_dead_air_ratio": _float(result.get("previous_max_dead_air_ratio")),
+        "repaired_max_dead_air_ratio": _float(result.get("repaired_max_dead_air_ratio")),
+        "previous_max_interval_max": _int(result.get("previous_max_interval_max")),
+        "repaired_max_interval_max": _int(result.get("repaired_max_interval_max")),
+        "dead_air_removed": bool(result.get("dead_air_removed", False)),
+        "dead_air_ratio_reduced": bool(result.get("dead_air_ratio_reduced", False)),
+        "max_interval_guard_kept": bool(result.get("max_interval_guard_kept", False)),
+        "timing_phrase_repair_passed": bool(result.get("timing_phrase_repair_passed", False)),
+        "model_direct_generation_quality_claimed": bool(
+            readiness.get("model_direct_generation_quality_claimed", True)
+        ),
+        "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    result = report["repair_result"]
+    config = report["repair_config"]
+    lines = [
+        "# Stage B MIDI-to-Solo Model-Direct Timing Phrase Repair",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- strict review gate passed: `{_bool_token(readiness['strict_review_gate_passed'])}`",
+        f"- timing phrase repair passed: `{_bool_token(readiness['timing_phrase_repair_passed'])}`",
+        f"- jazz rhythm profile: `{config['jazz_rhythm_profile']}`",
+        f"- fill duration to next position: `{_bool_token(config['fill_duration_to_next_position'])}`",
+        f"- model-direct generation quality claimed: `{_bool_token(readiness['model_direct_generation_quality_claimed'])}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        "",
+        "## Before / After",
+        "",
+        f"- dead-air flag count: `{result['previous_dead_air_flag_count']}` -> `{result['repaired_dead_air_flag_count']}`",
+        f"- max dead-air ratio: `{result['previous_max_dead_air_ratio']:.4f}` -> `{result['repaired_max_dead_air_ratio']:.4f}`",
+        f"- max interval max: `{result['previous_max_interval_max']}` -> `{result['repaired_max_interval_max']}`",
+        f"- max pitch span: `{result['previous_max_pitch_span']}` -> `{result['repaired_max_pitch_span']}`",
+        "",
+        "## Not Proven",
+        "",
+    ]
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run model-direct timing phrase repair")
+    parser.add_argument("--source_pitch_repair", type=str, required=True)
+    parser.add_argument("--sequence_budget_repair", type=str, required=True)
+    parser.add_argument("--context_report", type=str, required=True)
+    parser.add_argument("--repaired_training_scale_smoke", type=str, required=True)
+    parser.add_argument("--output_root", type=str, default="outputs/stage_b_midi_to_solo_model_direct_timing_phrase_repair")
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=510)
+    parser.add_argument("--target_bars", type=int, default=8)
+    parser.add_argument("--note_groups_per_bar", type=int, default=4)
+    parser.add_argument("--num_samples", type=int, default=3)
+    parser.add_argument("--seed", type=int, default=510)
+    parser.add_argument("--max_sequence", type=int, default=160)
+    parser.add_argument("--chord_pitch_mode", type=str, default="tones_tensions")
+    parser.add_argument("--max_simultaneous_notes", type=int, default=1)
+    parser.add_argument("--min_valid_samples", type=int, default=1)
+    parser.add_argument("--min_strict_valid_samples", type=int, default=1)
+    parser.add_argument("--constrained_pitch_min", type=int, default=55)
+    parser.add_argument("--constrained_pitch_max", type=int, default=79)
+    parser.add_argument("--constrained_max_adjacent_interval", type=int, default=9)
+    parser.add_argument("--jazz_rhythm_positions", action="store_true", default=True)
+    parser.add_argument("--jazz_duration_tokens", action="store_true", default=False)
+    parser.add_argument("--jazz_rhythm_profile", type=str, default="compact_phrase")
+    parser.add_argument("--cap_duration_to_next_position", action="store_true", default=False)
+    parser.add_argument("--fill_duration_to_next_position", action="store_true", default=True)
+    parser.add_argument("--dead_air_threshold_seconds", type=float, default=0.5)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_repair_completed", action="store_true")
+    parser.add_argument("--require_timing_repair_passed", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    output_dir.mkdir(parents=True, exist_ok=True)
+    source_pitch_repair = read_json(Path(args.source_pitch_repair))
+    sequence_budget_repair = read_json(Path(args.sequence_budget_repair))
+    context_report = read_json(Path(args.context_report))
+    repaired_training_scale_smoke = read_json(Path(args.repaired_training_scale_smoke))
+    context_summary = summarize_context(context_report, target_bars=int(args.target_bars))
+    scale_summary = summarize_repaired_scale_smoke(repaired_training_scale_smoke)
+    generation_output_root = output_dir / "generation_probe"
+    generation_run_id = "timing_phrase_repair"
+    generation_result = run_command(
+        build_generation_command(
+            args=args,
+            checkpoint_dir=Path(scale_summary["checkpoint_dir"]),
+            generation_output_root=generation_output_root,
+            generation_run_id=generation_run_id,
+            context_summary=context_summary,
+        )
+    )
+    generation_report_path = generation_output_root / generation_run_id / "report.json"
+    generation_report = read_json(generation_report_path) if generation_report_path.exists() else {}
+    report = build_timing_phrase_repair_report(
+        source_pitch_repair=source_pitch_repair,
+        sequence_budget_repair=sequence_budget_repair,
+        context_report=context_report,
+        repaired_training_scale_smoke=repaired_training_scale_smoke,
+        generation_result=generation_result,
+        generation_report=generation_report,
+        generation_report_path=generation_report_path,
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+        target_bars=int(args.target_bars),
+        note_groups_per_bar=int(args.note_groups_per_bar),
+        jazz_rhythm_profile=str(args.jazz_rhythm_profile),
+        constrained_pitch_min=int(args.constrained_pitch_min),
+        constrained_pitch_max=int(args.constrained_pitch_max),
+        constrained_max_adjacent_interval=int(args.constrained_max_adjacent_interval),
+        dead_air_threshold_seconds=float(args.dead_air_threshold_seconds),
+    )
+    summary = validate_timing_phrase_repair_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_repair_completed=bool(args.require_repair_completed),
+        require_timing_repair_passed=bool(args.require_timing_repair_passed),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    write_json(output_dir / "stage_b_midi_to_solo_model_direct_timing_phrase_repair.json", report)
+    write_json(
+        output_dir / "stage_b_midi_to_solo_model_direct_timing_phrase_repair_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_midi_to_solo_model_direct_timing_phrase_repair.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_model_direct_timing_phrase_repair.py
+++ b/tests/test_stage_b_midi_to_solo_model_direct_timing_phrase_repair.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import argparse
+import tempfile
+import unittest
+from pathlib import Path
+
+import pretty_midi
+
+from scripts.diagnose_stage_b_midi_to_solo_model_direct_phrase_quality import LISTENING_REVIEW_BOUNDARY
+from scripts.run_stage_b_midi_to_solo_model_direct_8bar_generation_probe import build_generation_command
+from scripts.run_stage_b_midi_to_solo_model_direct_timing_phrase_repair import (
+    BOUNDARY,
+    StageBMidiToSoloModelDirectTimingPhraseRepairError,
+    build_timing_phrase_repair_report,
+    validate_timing_phrase_repair_report,
+)
+
+
+def write_compact_midi(path: Path) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    midi = pretty_midi.PrettyMIDI(initial_tempo=120)
+    piano = pretty_midi.Instrument(program=0, is_drum=False, name="solo")
+    positions = [[0, 1, 4, 7], [1, 2, 5, 8], [0, 1, 3, 6], [2, 3, 6, 9]]
+    pitches = [60, 62, 64, 65, 67, 69, 71, 72, 74, 72, 71, 69, 67, 65, 64, 62]
+    note_index = 0
+    for bar_index in range(8):
+        for position in positions[bar_index % len(positions)]:
+            start = bar_index * 2.0 + position * 0.125
+            pitch = pitches[note_index % len(pitches)]
+            piano.notes.append(pretty_midi.Note(velocity=84, pitch=pitch, start=start, end=start + 0.125))
+            note_index += 1
+    midi.instruments.append(piano)
+    midi.write(str(path))
+    return str(path)
+
+
+def source_pitch_repair() -> dict:
+    return {
+        "boundary": "stage_b_midi_to_solo_model_direct_pitch_contour_repetition_repair",
+        "readiness": {
+            "boundary": "stage_b_midi_to_solo_model_direct_pitch_contour_repetition_repair",
+            "pitch_contour_repair_passed": True,
+            "model_direct_generation_quality_claimed": False,
+        },
+        "decision": {
+            "next_boundary": BOUNDARY,
+            "critical_user_input_required": False,
+        },
+        "repair_result": {
+            "repaired_dead_air_flag_count": 3,
+        },
+        "repaired_diagnostics_summary": {
+            "candidate_count": 3,
+            "flag_counts": {"dead_air_gap": 3},
+            "max_interval_max": 9,
+            "max_pitch_span": 24,
+            "max_dead_air_ratio": 0.6522,
+        },
+    }
+
+
+def sequence_budget_repair() -> dict:
+    return {
+        "boundary": "stage_b_midi_to_solo_model_direct_sequence_budget_repair_smoke",
+        "repair_result": {
+            "previous_max_sequence": 96,
+            "repaired_max_sequence": 160,
+            "minimum_contract_tokens": 123,
+            "repaired_direct_note_capacity": 33,
+            "target_min_note_count": 24,
+        },
+        "readiness": {
+            "model_direct_8bar_generation_probe_ready": True,
+            "model_direct_generation_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "human_audio_preference_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {"next_boundary": "stage_b_midi_to_solo_model_direct_8bar_generation_probe"},
+    }
+
+
+def context_report() -> dict:
+    return {
+        "boundary": "stage_b_midi_to_solo_context_extraction_mvp",
+        "summary": {
+            "context_bars": 8,
+            "context_event_count": 128,
+            "unknown_chord_bar_count": 0,
+            "low_confidence_bar_count": 4,
+        },
+        "context": {
+            "bar_contexts": [
+                {"bar_index": index, "tempo": 120.0, "chord_root": "C", "chord_quality": "maj7"}
+                for index in range(8)
+            ]
+        },
+        "readiness": {"context_extraction_completed": True},
+    }
+
+
+def scale_smoke(checkpoint_dir: Path) -> dict:
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    (checkpoint_dir / "checkpoint_epoch1.pt").write_bytes(b"stub")
+    return {
+        "checkpoint_dir": str(checkpoint_dir),
+        "readiness": {
+            "boundary": "stage_b_generic_base_training_scale_smoke",
+            "training_scale_smoke_passed": True,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "training_config": {"max_sequence": 160},
+        "training": {"best_validation_loss": 6.1293},
+        "artifacts": {"checkpoint_count": 1, "lora_weights_exists": True},
+    }
+
+
+def generation_report(root: Path) -> dict:
+    midi_paths = [write_compact_midi(root / f"stage_b_sample_{index}.mid") for index in range(1, 4)]
+    return {
+        "summary": {
+            "sample_count": 3,
+            "valid_sample_count": 3,
+            "strict_valid_sample_count": 3,
+            "grammar_gate_sample_count": 3,
+            "passed_generation_gate": True,
+            "passed_grammar_gate": True,
+            "passed_strict_review_gate": True,
+            "collapse_warning_sample_count": 0,
+            "collapse_warning_sample_rate": 0.0,
+            "avg_postprocess_removal_ratio": 0.0,
+        },
+        "samples": [
+            {
+                "midi_path": path,
+                "grammar": {"complete_note_groups": 32},
+                "postprocess": {"before_note_count": 32, "after_note_count": 32},
+                "metrics": {"note_count": 32},
+            }
+            for path in midi_paths
+        ],
+    }
+
+
+class StageBMidiToSoloModelDirectTimingPhraseRepairTest(unittest.TestCase):
+    def test_command_builder_passes_timing_profile_options(self) -> None:
+        args = argparse.Namespace(
+            issue_number=510,
+            max_sequence=160,
+            num_samples=3,
+            seed=510,
+            target_bars=8,
+            note_groups_per_bar=4,
+            chord_pitch_mode="tones_tensions",
+            max_simultaneous_notes=1,
+            min_valid_samples=1,
+            min_strict_valid_samples=1,
+            jazz_rhythm_positions=True,
+            jazz_duration_tokens=False,
+            jazz_rhythm_profile="compact_phrase",
+            cap_duration_to_next_position=False,
+            fill_duration_to_next_position=True,
+            constrained_pitch_min=55,
+            constrained_pitch_max=79,
+            constrained_max_adjacent_interval=9,
+        )
+        command = build_generation_command(
+            args=args,
+            checkpoint_dir=Path("checkpoints"),
+            generation_output_root=Path("out"),
+            generation_run_id="repair",
+            context_summary={"bpm": 120, "chord_progression": ["Cmaj7"] * 8},
+        )
+
+        self.assertIn("--jazz_rhythm_positions", command)
+        self.assertIn("--fill_duration_to_next_position", command)
+        self.assertIn("--jazz_rhythm_profile", command)
+        self.assertIn("compact_phrase", command)
+        self.assertNotIn("--cap_duration_to_next_position", command)
+
+    def test_records_timing_repair_and_routes_listening_review(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            report = build_timing_phrase_repair_report(
+                source_pitch_repair=source_pitch_repair(),
+                sequence_budget_repair=sequence_budget_repair(),
+                context_report=context_report(),
+                repaired_training_scale_smoke=scale_smoke(root / "checkpoints"),
+                generation_result={"returncode": 0, "cmd": [], "stdout_tail": "", "stderr_tail": ""},
+                generation_report=generation_report(root / "samples"),
+                generation_report_path=root / "generation" / "report.json",
+                output_dir=root / "out",
+                issue_number=510,
+                target_bars=8,
+                note_groups_per_bar=4,
+                jazz_rhythm_profile="compact_phrase",
+                constrained_pitch_min=55,
+                constrained_pitch_max=79,
+                constrained_max_adjacent_interval=9,
+                dead_air_threshold_seconds=0.5,
+            )
+            summary = validate_timing_phrase_repair_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=LISTENING_REVIEW_BOUNDARY,
+                require_repair_completed=True,
+                require_timing_repair_passed=True,
+                require_no_quality_claim=True,
+            )
+
+        self.assertEqual(summary["strict_valid_sample_count"], 3)
+        self.assertEqual(summary["previous_dead_air_flag_count"], 3)
+        self.assertEqual(summary["repaired_dead_air_flag_count"], 0)
+        self.assertLess(summary["repaired_max_dead_air_ratio"], summary["previous_max_dead_air_ratio"])
+        self.assertLessEqual(summary["repaired_max_interval_max"], summary["previous_max_interval_max"])
+        self.assertTrue(summary["timing_phrase_repair_passed"])
+        self.assertFalse(summary["model_direct_generation_quality_claimed"])
+        self.assertFalse(summary["human_audio_preference_claimed"])
+
+    def test_rejects_unrouted_pitch_repair(self) -> None:
+        source = source_pitch_repair()
+        source["decision"]["next_boundary"] = "other"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with self.assertRaises(StageBMidiToSoloModelDirectTimingPhraseRepairError):
+                build_timing_phrase_repair_report(
+                    source_pitch_repair=source,
+                    sequence_budget_repair=sequence_budget_repair(),
+                    context_report=context_report(),
+                    repaired_training_scale_smoke=scale_smoke(root / "checkpoints"),
+                    generation_result={"returncode": 0, "cmd": [], "stdout_tail": "", "stderr_tail": ""},
+                    generation_report=generation_report(root / "samples"),
+                    generation_report_path=root / "generation" / "report.json",
+                    output_dir=root / "out",
+                    issue_number=510,
+                    target_bars=8,
+                    note_groups_per_bar=4,
+                    jazz_rhythm_profile="compact_phrase",
+                    constrained_pitch_min=55,
+                    constrained_pitch_max=79,
+                    constrained_max_adjacent_interval=9,
+                    dead_air_threshold_seconds=0.5,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Stage B model-direct timing phrase repair
- compact phrase onset profile 추가
- 다음 planned position까지 duration fill option 추가
- dead-air objective diagnostic 제거

## Context

- #507 pitch contour repair 결과: max interval `82 -> 9`
- wide interval/register flags: `3 -> 0`
- 잔여 blocker: dead-air flag `3 -> 3`
- 기존 coverage-aware 4 notes/bar: strict gate 통과, max dead-air ratio `0.6522 -> 0.4839`
- compact onset 단독: phrase diagnostic 개선 가능, review gate dead-air 실패
- 최종 선택: compact onset + duration fill 조합

## Result

- strict valid sample count: `3`
- dead-air flag count: `3 -> 0`
- max dead-air ratio: `0.6522 -> 0.2258`
- max interval guard: `9 -> 9`
- timing phrase repair passed: `true`
- model-direct generation quality claim: `false`
- human/audio preference claim: `false`

## Scope

- `compact_phrase` rhythm profile 추가
- `fill_duration_to_next_position` constrained decoder option 추가
- timing phrase repair script / harness / unit test 추가
- current status, core plan, handoff 문서 갱신

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_generation_probe tests.test_stage_b_midi_to_solo_model_direct_pitch_contour_repair tests.test_stage_b_midi_to_solo_model_direct_timing_phrase_repair`
- `.venv/bin/python -m py_compile scripts/run_stage_b_generation_probe.py scripts/run_stage_b_midi_to_solo_model_direct_8bar_generation_probe.py scripts/run_stage_b_midi_to_solo_model_direct_timing_phrase_repair.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-timing-phrase-repair`
- `bash scripts/agent_harness.sh quick`

## Risk

- objective MIDI timing repair evidence only
- musical quality claim 제외
- human/audio preference claim 제외
- broad trained model quality claim 제외

## Follow-up

- Stage B MIDI-to-solo model-direct listening review package

Closes #510
