### PR TITLE
Stage B MIDI-to-solo model-direct user listening review input guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #512, Stage B MIDI-to-solo model-direct listening review package.
+- Latest functional issue completed: Issue #514, Stage B MIDI-to-solo model-direct user listening review input guard.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-direct user listening review fill.
+- Recommended next issue: Stage B MIDI-to-solo model-direct objective-only next decision.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1131,6 +1131,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-listening-review
 ```
 
 This harness packages timing-repaired MIDI candidates as MIDI/WAV review files, writes the pending review input template, and keeps listening preference unclaimed.
+
+For Stage B MIDI-to-solo model-direct user listening review input guard changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-user-listening-review-input-guard
+```
+
+This harness verifies that pending review input blocks preference fill and keeps listening preference unclaimed.
 
 For Stage B generic tiny checkpoint generation probe changes, run:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -122,8 +122,11 @@ MVP가 끝났다고 볼 수 있는 조건:
 - model-direct listening review input template written: `true`
 - model-direct listening review completed: `false`
 - model-direct human/audio preference claim: `false`
-- next review target: `stage_b_midi_to_solo_model_direct_user_listening_review_fill`
-- 근거 문서: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_LISTENING_REVIEW_PACKAGE_2026-06-03.md`
+- model-direct user listening review input guard validated input: `false`
+- model-direct user listening review input guard preference fill allowed: `false`
+- model-direct user listening review input pending fields: status `4`, candidate decision `3`, candidate field `9`
+- next review target: `stage_b_midi_to_solo_model_direct_objective_only_next_decision`
+- 근거 문서: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_USER_LISTENING_REVIEW_INPUT_GUARD_2026-06-03.md`
 - margin-recovered timing/repetition focused listening notes 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_NOTES_2026-05-28.md`
 - margin-recovered timing/repetition focused listening fill 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_FILL_2026-05-28.md`
 - margin-recovered phrase/vocabulary repair 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_REPAIR_2026-05-28.md`
@@ -317,6 +320,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo model-direct pitch contour repair: strict `3/3`, max interval `82 -> 9`, wide interval/register flags `3 -> 0`, dead-air flag `3 -> 3`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_direct_timing_phrase_repair`
 - MIDI-to-solo model-direct timing phrase repair: strict `3/3`, dead-air flags `3 -> 0`, max dead-air ratio `0.6522 -> 0.2258`, max interval guard `9 -> 9`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_direct_listening_review_package`
 - MIDI-to-solo model-direct listening review package: candidates `3`, rendered WAV `3`, duration range `18.926s-19.030s`, review input template `true`, listening review/preference claim `false`, next boundary `stage_b_midi_to_solo_model_direct_user_listening_review_fill`
+- MIDI-to-solo model-direct user listening review input guard: validated input `false`, preference fill allowed `false`, pending status/candidate decision/candidate field `4/3/9`, preference claim `false`, next boundary `stage_b_midi_to_solo_model_direct_objective_only_next_decision`
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
 - generic base readiness audit: phase4 prep ready `true`, broad training execution ready `false`, broad quality/Brad adaptation claim `false`
 - generic base manifest contract: generic split `2433/270`, Brad split `47/11/14`, leakage/overlap `0`, broad training execution ready `false`

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #512, Stage B MIDI-to-solo model-direct listening review package
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-direct user listening review fill`
+- latest functional result: Issue #514, Stage B MIDI-to-solo model-direct user listening review input guard
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-direct objective-only next decision`
 
 현재 범위가 아닌 것:
 
@@ -772,6 +772,47 @@ Rendered WAV:
 다음:
 
 - `Stage B MIDI-to-solo model-direct user listening review fill`
+
+## Stage B MIDI-to-Solo Model-Direct User Listening Review Input Guard Result
+
+Issue #514는 #512 listening review package의 review input template이 아직 pending 상태인지 검증하고 preference fill을 차단한 작업이다.
+
+변경:
+
+- listening review input template parser 추가
+- reviewer / preferred_rank / reject_all / candidate decision pending 상태 검증
+- validated input 부재 시 human/audio preference fill 차단
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_USER_LISTENING_REVIEW_INPUT_GUARD_2026-06-03.md`
+- boundary: `stage_b_midi_to_solo_model_direct_user_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_model_direct_objective_only_next_decision`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- pending status field count: `4`
+- pending candidate decision count: `3`
+- pending candidate field count: `9`
+- human/audio preference claimed: `false`
+- model-direct generation quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- review input 없이 human/audio preference claim 불가
+- user listening review fill은 validated input 수신 전까지 차단
+- 자동 진행은 objective-only next decision 경계로 이동
+- 이 결과는 preference guard evidence이며, 음악적 품질 claim은 아님
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_direct_user_listening_review_input_guard`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-user-listening-review-input-guard`
+
+다음:
+
+- `Stage B MIDI-to-solo model-direct objective-only next decision`
 
 ## Previous Model Decision
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_USER_LISTENING_REVIEW_INPUT_GUARD_2026-06-03.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_USER_LISTENING_REVIEW_INPUT_GUARD_2026-06-03.md
@@ -1,0 +1,23 @@
+# Stage B MIDI-to-Solo Model-Direct User Listening Review Input Guard
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_model_direct_user_listening_review_input_guard`
+- source boundary: `stage_b_midi_to_solo_model_direct_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_model_direct_objective_only_next_decision`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- pending status field count: `4`
+- pending candidate decision count: `3`
+- pending candidate field count: `9`
+- human/audio preference claimed: `false`
+- model-direct generation quality claimed: `false`
+
+## Not Proven
+
+- `listening_review_completed`
+- `human_audio_preference`
+- `model_direct_generation_quality`
+- `midi_to_solo_musical_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -222,6 +222,8 @@ Modes:
                 Repair model-direct timing phrase gaps with compact onset and duration fill.
   stage-b-midi-to-solo-model-direct-listening-review-package
                 Package timing-repaired model-direct MIDI as WAV files and pending listening review input.
+  stage-b-midi-to-solo-model-direct-user-listening-review-input-guard
+                Guard user listening review fill when package review input is still pending.
   stage-b-generic-tiny-checkpoint-generation-probe
                 Probe generation/decode from the generic tiny checkpoint.
   stage-b-generic-tiny-checkpoint-grammar-repair
@@ -3988,6 +3990,36 @@ run_stage_b_midi_to_solo_model_direct_listening_review_package() {
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_model_direct_user_listening_review_input_guard() {
+  local review_package_run_id="${REVIEW_PACKAGE_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_listening_review_package}"
+  local timing_repair_run_id="${TIMING_REPAIR_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_timing_phrase_repair}"
+  local pitch_repair_run_id="${PITCH_REPAIR_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_pitch_contour_repair}"
+  local diagnostics_run_id="${DIAGNOSTICS_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_phrase_quality_diagnostics}"
+  local evidence_run_id="${EVIDENCE_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_audio_evidence_consolidation}"
+  local audio_render_run_id="${AUDIO_RENDER_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_audio_render_package}"
+  local overlap_repair_run_id="${OVERLAP_REPAIR_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_monophonic_overlap_repair}"
+  local previous_direct_run_id="${PREVIOUS_DIRECT_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_8bar_generation_probe}"
+  local sequence_budget_run_id="${SEQUENCE_BUDGET_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_sequence_budget_repair_smoke}"
+  local context_run_id="${CONTEXT_RUN_ID:-harness_stage_b_midi_to_solo_context_extraction}"
+  local scale_run_id="${SCALE_RUN_ID:-max_sequence_160}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_direct_user_listening_review_input_guard}"
+  local review_package="outputs/stage_b_midi_to_solo_model_direct_listening_review_package/${review_package_run_id}/stage_b_midi_to_solo_model_direct_listening_review_package.json"
+  if [[ ! -f "$review_package" ]]; then
+    print_header "Stage B MIDI-to-solo model-direct listening review package"
+    RUN_ID="$review_package_run_id" TIMING_REPAIR_RUN_ID="$timing_repair_run_id" PITCH_REPAIR_RUN_ID="$pitch_repair_run_id" DIAGNOSTICS_RUN_ID="$diagnostics_run_id" EVIDENCE_RUN_ID="$evidence_run_id" AUDIO_RENDER_RUN_ID="$audio_render_run_id" OVERLAP_REPAIR_RUN_ID="$overlap_repair_run_id" PREVIOUS_DIRECT_RUN_ID="$previous_direct_run_id" SEQUENCE_BUDGET_RUN_ID="$sequence_budget_run_id" CONTEXT_RUN_ID="$context_run_id" SCALE_RUN_ID="$scale_run_id" run_stage_b_midi_to_solo_model_direct_listening_review_package
+  fi
+  print_header "Stage B MIDI-to-solo model-direct user listening review input guard"
+  "$PYTHON_BIN" scripts/guard_stage_b_midi_to_solo_model_direct_user_listening_review_input.py \
+    --run_id "$run_id" \
+    --listening_review_package "$review_package" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_USER_LISTENING_REVIEW_INPUT_GUARD_2026-06-03.md \
+    --expected_boundary stage_b_midi_to_solo_model_direct_user_listening_review_input_guard \
+    --expected_next_boundary stage_b_midi_to_solo_model_direct_objective_only_next_decision \
+    --require_guard_completed \
+    --require_pending_input \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -5416,6 +5448,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-model-direct-listening-review-package)
     run_stage_b_midi_to_solo_model_direct_listening_review_package
+    ;;
+  stage-b-midi-to-solo-model-direct-user-listening-review-input-guard)
+    run_stage_b_midi_to_solo_model_direct_user_listening_review_input_guard
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/guard_stage_b_midi_to_solo_model_direct_user_listening_review_input.py
+++ b/scripts/guard_stage_b_midi_to_solo_model_direct_user_listening_review_input.py
@@ -1,0 +1,327 @@
+"""Guard model-direct user listening review fill against missing review input."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+from scripts.build_stage_b_midi_to_solo_model_direct_listening_review_package import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+)
+
+
+class StageBMidiToSoloModelDirectUserListeningReviewInputGuardError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_model_direct_user_listening_review_input_guard"
+FILL_BOUNDARY = "stage_b_midi_to_solo_model_direct_user_listening_review_fill"
+OBJECTIVE_NEXT_BOUNDARY = "stage_b_midi_to_solo_model_direct_objective_only_next_decision"
+SCHEMA_VERSION = "stage_b_midi_to_solo_model_direct_user_listening_review_input_guard_v1"
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise StageBMidiToSoloModelDirectUserListeningReviewInputGuardError(f"report missing: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _clean_cell(value: str) -> str:
+    return value.strip().strip("`").strip()
+
+
+def parse_review_input(markdown: str) -> dict[str, Any]:
+    status: dict[str, str] = {}
+    per_candidate_fields: dict[str, dict[str, str]] = {}
+    current_rank: str | None = None
+    candidate_table_decisions: dict[str, str] = {}
+    for raw_line in markdown.splitlines():
+        line = raw_line.strip()
+        status_match = re.match(r"^- ([a-zA-Z0-9_]+): `?([^`]+)`?$", line)
+        if status_match and current_rank is None:
+            status[status_match.group(1)] = _clean_cell(status_match.group(2))
+            continue
+        rank_match = re.match(r"^### Rank ([0-9]+)$", line)
+        if rank_match:
+            current_rank = rank_match.group(1)
+            per_candidate_fields.setdefault(current_rank, {})
+            continue
+        if status_match and current_rank is not None:
+            per_candidate_fields.setdefault(current_rank, {})[status_match.group(1)] = _clean_cell(
+                status_match.group(2)
+            )
+            continue
+        if line.startswith("|") and not line.startswith("|---") and "decision" not in line:
+            cells = [_clean_cell(cell) for cell in line.strip("|").split("|")]
+            if cells and cells[0].isdigit() and len(cells) >= 8:
+                candidate_table_decisions[cells[0]] = cells[7]
+    required_status_fields = ["reviewer", "reviewed_at", "preferred_rank", "reject_all"]
+    pending_status_fields = [
+        field for field in required_status_fields if status.get(field, "pending").lower() == "pending"
+    ]
+    pending_candidate_decisions = [
+        rank for rank, decision in sorted(candidate_table_decisions.items()) if decision.lower() == "pending"
+    ]
+    pending_candidate_fields: list[str] = []
+    for rank, fields in sorted(per_candidate_fields.items()):
+        for field in ("musical_acceptance", "issue_tags", "short_note"):
+            if fields.get(field, "pending").lower() == "pending":
+                pending_candidate_fields.append(f"rank_{rank}.{field}")
+    validated = not pending_status_fields and not pending_candidate_decisions and not pending_candidate_fields
+    return {
+        "status": status,
+        "candidate_table_decisions": candidate_table_decisions,
+        "per_candidate_fields": per_candidate_fields,
+        "pending_status_fields": pending_status_fields,
+        "pending_candidate_decisions": pending_candidate_decisions,
+        "pending_candidate_fields": pending_candidate_fields,
+        "validated_review_input_present": bool(validated),
+    }
+
+
+def validate_source_package(report: dict[str, Any]) -> dict[str, Any]:
+    boundary = _dict(report.get("listening_review_package_boundary"))
+    decision = _dict(report.get("decision"))
+    if str(boundary.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloModelDirectUserListeningReviewInputGuardError("listening review package boundary required")
+    if str(decision.get("next_boundary") or "") != FILL_BOUNDARY:
+        raise StageBMidiToSoloModelDirectUserListeningReviewInputGuardError("review package must route to fill boundary")
+    if not bool(boundary.get("review_input_template_written", False)):
+        raise StageBMidiToSoloModelDirectUserListeningReviewInputGuardError("review input template required")
+    if bool(boundary.get("human_audio_preference_claimed", True)):
+        raise StageBMidiToSoloModelDirectUserListeningReviewInputGuardError("preference must not be claimed upstream")
+    review_input_path = Path(str(report.get("review_input_template_path") or ""))
+    if not review_input_path.exists():
+        raise StageBMidiToSoloModelDirectUserListeningReviewInputGuardError("review input template missing")
+    return {
+        "boundary": str(boundary.get("boundary") or ""),
+        "candidate_count": _int(boundary.get("candidate_count")),
+        "rendered_audio_file_count": _int(boundary.get("rendered_audio_file_count")),
+        "review_input_template_path": str(review_input_path),
+    }
+
+
+def build_user_listening_review_input_guard_report(
+    source_package: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> dict[str, Any]:
+    source = validate_source_package(source_package)
+    parsed = parse_review_input(Path(source["review_input_template_path"]).read_text(encoding="utf-8"))
+    validated_input = bool(parsed["validated_review_input_present"])
+    next_boundary = FILL_BOUNDARY if validated_input else OBJECTIVE_NEXT_BOUNDARY
+    reason = (
+        "validated listening review input present; route to user listening review fill"
+        if validated_input
+        else "listening review input pending; preference fill blocked"
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "boundary": BOUNDARY,
+        "source_boundary": source["boundary"],
+        "source_package_summary": source,
+        "review_input_summary": parsed,
+        "guard_result": {
+            "review_input_template_present": True,
+            "validated_review_input_present": bool(validated_input),
+            "pending_status_field_count": len(_list(parsed.get("pending_status_fields"))),
+            "pending_candidate_decision_count": len(_list(parsed.get("pending_candidate_decisions"))),
+            "pending_candidate_field_count": len(_list(parsed.get("pending_candidate_fields"))),
+            "preference_fill_allowed": bool(validated_input),
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "user_listening_review_input_guard_completed": True,
+            "validated_review_input_present": bool(validated_input),
+            "preference_fill_allowed": bool(validated_input),
+            "listening_review_completed": False,
+            "human_audio_preference_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": next_boundary,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": reason,
+        },
+        "not_proven": [
+            "listening_review_completed",
+            "human_audio_preference",
+            "model_direct_generation_quality",
+            "midi_to_solo_musical_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo model-direct user listening review fill"
+            if validated_input
+            else "Stage B MIDI-to-solo model-direct objective-only next decision"
+        ),
+    }
+
+
+def validate_user_listening_review_input_guard_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_guard_completed: bool,
+    require_pending_input: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    guard = _dict(report.get("guard_result"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloModelDirectUserListeningReviewInputGuardError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloModelDirectUserListeningReviewInputGuardError("unexpected next boundary")
+    if require_guard_completed and not bool(readiness.get("user_listening_review_input_guard_completed", False)):
+        raise StageBMidiToSoloModelDirectUserListeningReviewInputGuardError("guard completion required")
+    if require_pending_input and bool(guard.get("validated_review_input_present", True)):
+        raise StageBMidiToSoloModelDirectUserListeningReviewInputGuardError("review input should remain pending")
+    if require_no_quality_claim:
+        blocked = [
+            "listening_review_completed",
+            "human_audio_preference_claimed",
+            "model_direct_generation_quality_claimed",
+            "midi_to_solo_musical_quality_claimed",
+            "broad_trained_model_quality_claimed",
+            "brad_style_adaptation_claimed",
+        ]
+        claimed = [name for name in blocked if bool(readiness.get(name, True))]
+        if claimed:
+            raise StageBMidiToSoloModelDirectUserListeningReviewInputGuardError(f"unexpected claim: {claimed}")
+    return {
+        "boundary": boundary,
+        "source_boundary": str(report.get("source_boundary") or ""),
+        "validated_review_input_present": bool(guard.get("validated_review_input_present", True)),
+        "preference_fill_allowed": bool(guard.get("preference_fill_allowed", True)),
+        "pending_status_field_count": _int(guard.get("pending_status_field_count")),
+        "pending_candidate_decision_count": _int(guard.get("pending_candidate_decision_count")),
+        "pending_candidate_field_count": _int(guard.get("pending_candidate_field_count")),
+        "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
+        "model_direct_generation_quality_claimed": bool(
+            readiness.get("model_direct_generation_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    guard = report["guard_result"]
+    lines = [
+        "# Stage B MIDI-to-Solo Model-Direct User Listening Review Input Guard",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- source boundary: `{report['source_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- validated review input present: `{_bool_token(guard['validated_review_input_present'])}`",
+        f"- preference fill allowed: `{_bool_token(guard['preference_fill_allowed'])}`",
+        f"- pending status field count: `{guard['pending_status_field_count']}`",
+        f"- pending candidate decision count: `{guard['pending_candidate_decision_count']}`",
+        f"- pending candidate field count: `{guard['pending_candidate_field_count']}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        f"- model-direct generation quality claimed: `{_bool_token(readiness['model_direct_generation_quality_claimed'])}`",
+        "",
+        "## Not Proven",
+        "",
+    ]
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Guard model-direct listening review fill input")
+    parser.add_argument("--listening_review_package", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_model_direct_user_listening_review_input_guard",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_guard_completed", action="store_true")
+    parser.add_argument("--require_pending_input", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report = build_user_listening_review_input_guard_report(
+        read_json(Path(args.listening_review_package)),
+        output_dir=output_dir,
+    )
+    summary = validate_user_listening_review_input_guard_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_guard_completed=bool(args.require_guard_completed),
+        require_pending_input=bool(args.require_pending_input),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    write_json(output_dir / "stage_b_midi_to_solo_model_direct_user_listening_review_input_guard.json", report)
+    write_json(
+        output_dir / "stage_b_midi_to_solo_model_direct_user_listening_review_input_guard_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_midi_to_solo_model_direct_user_listening_review_input_guard.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_model_direct_user_listening_review_input_guard.py
+++ b/tests/test_stage_b_midi_to_solo_model_direct_user_listening_review_input_guard.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.guard_stage_b_midi_to_solo_model_direct_user_listening_review_input import (
+    BOUNDARY,
+    FILL_BOUNDARY,
+    OBJECTIVE_NEXT_BOUNDARY,
+    StageBMidiToSoloModelDirectUserListeningReviewInputGuardError,
+    build_user_listening_review_input_guard_report,
+    parse_review_input,
+    validate_user_listening_review_input_guard_report,
+)
+
+
+PENDING_TEMPLATE = """# Stage B MIDI-to-Solo Model-Direct Listening Review Input
+
+## Review Status
+
+- reviewer: `pending`
+- reviewed_at: `pending`
+- preferred_rank: `pending`
+- reject_all: `pending`
+- broad_model_quality_claim_allowed: `false`
+
+## Candidates
+
+| rank | midi | wav | note count | unique pitch | max interval | dead-air ratio | decision |
+|---:|---|---|---:|---:|---:|---:|---|
+| 1 | a.mid | a.wav | 32 | 11 | 9 | 0.2258 | `pending` |
+| 2 | b.mid | b.wav | 32 | 15 | 9 | 0.2258 | `pending` |
+| 3 | c.mid | c.wav | 32 | 14 | 8 | 0.2258 | `pending` |
+
+## Per-Candidate Notes
+
+### Rank 1
+
+- musical_acceptance: `pending`
+- issue_tags: `pending`
+- short_note: `pending`
+"""
+
+
+FILLED_TEMPLATE = PENDING_TEMPLATE.replace("`pending`", "`reviewed`", 2).replace(
+    "- preferred_rank: `pending`", "- preferred_rank: `1`"
+).replace("- reject_all: `pending`", "- reject_all: `false`").replace(
+    "| `pending` |", "| `accept` |"
+).replace(
+    "- musical_acceptance: `pending`", "- musical_acceptance: `accept`"
+).replace(
+    "- issue_tags: `pending`", "- issue_tags: `none`"
+).replace(
+    "- short_note: `pending`", "- short_note: `usable timing`"
+)
+
+
+def package_report(template_path: Path, *, preference_claim: bool = False) -> dict:
+    return {
+        "listening_review_package_boundary": {
+            "boundary": "stage_b_midi_to_solo_model_direct_listening_review_package",
+            "source_boundary": "stage_b_midi_to_solo_model_direct_timing_phrase_repair",
+            "candidate_count": 3,
+            "rendered_audio_file_count": 3,
+            "review_input_template_written": True,
+            "human_audio_preference_claimed": preference_claim,
+        },
+        "decision": {
+            "next_boundary": "stage_b_midi_to_solo_model_direct_user_listening_review_fill",
+            "critical_user_input_required": False,
+        },
+        "review_input_template_path": str(template_path),
+    }
+
+
+class StageBMidiToSoloModelDirectUserListeningReviewInputGuardTest(unittest.TestCase):
+    def test_parse_pending_review_input(self) -> None:
+        parsed = parse_review_input(PENDING_TEMPLATE)
+
+        self.assertFalse(parsed["validated_review_input_present"])
+        self.assertIn("reviewer", parsed["pending_status_fields"])
+        self.assertEqual(parsed["pending_candidate_decisions"], ["1", "2", "3"])
+        self.assertIn("rank_1.musical_acceptance", parsed["pending_candidate_fields"])
+
+    def test_blocks_preference_fill_when_input_pending(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            template_path = root / "review.md"
+            template_path.write_text(PENDING_TEMPLATE, encoding="utf-8")
+            report = build_user_listening_review_input_guard_report(
+                package_report(template_path),
+                output_dir=root / "out",
+            )
+            summary = validate_user_listening_review_input_guard_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=OBJECTIVE_NEXT_BOUNDARY,
+                require_guard_completed=True,
+                require_pending_input=True,
+                require_no_quality_claim=True,
+            )
+
+        self.assertFalse(summary["validated_review_input_present"])
+        self.assertFalse(summary["preference_fill_allowed"])
+        self.assertGreater(summary["pending_status_field_count"], 0)
+        self.assertGreater(summary["pending_candidate_decision_count"], 0)
+        self.assertFalse(summary["human_audio_preference_claimed"])
+
+    def test_routes_to_fill_when_input_present(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            template_path = root / "review.md"
+            template_path.write_text(FILLED_TEMPLATE, encoding="utf-8")
+            report = build_user_listening_review_input_guard_report(
+                package_report(template_path),
+                output_dir=root / "out",
+            )
+            summary = validate_user_listening_review_input_guard_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=FILL_BOUNDARY,
+                require_guard_completed=True,
+                require_pending_input=False,
+                require_no_quality_claim=True,
+            )
+
+        self.assertTrue(summary["validated_review_input_present"])
+        self.assertTrue(summary["preference_fill_allowed"])
+
+    def test_rejects_upstream_preference_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            template_path = root / "review.md"
+            template_path.write_text(PENDING_TEMPLATE, encoding="utf-8")
+            with self.assertRaises(StageBMidiToSoloModelDirectUserListeningReviewInputGuardError):
+                build_user_listening_review_input_guard_report(
+                    package_report(template_path, preference_claim=True),
+                    output_dir=root / "out",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Stage B model-direct user listening review input guard
- #512 review input template pending 상태 검증
- validated input 부재 시 preference fill 차단
- objective-only next decision으로 라우팅

## Context

- #512 listening review package 결과: candidates `3`, rendered WAV `3`
- review input template written: `true`
- current review fields: reviewer / preferred_rank / reject_all / candidate decision 모두 `pending`
- 현재 제외된 claim: human/audio preference, musical quality, broad trained model quality
- 이번 검토 대상: 입력 없이 user listening review fill이 실행되지 않도록 guard 추가

## Result

- validated review input present: `false`
- preference fill allowed: `false`
- pending status field count: `4`
- pending candidate decision count: `3`
- pending candidate field count: `9`
- human/audio preference claim: `false`
- model-direct generation quality claim: `false`
- next boundary: `stage_b_midi_to_solo_model_direct_objective_only_next_decision`

## Scope

- review input template parser
- pending input guard report
- no-quality-claim validation
- harness, unit test, status document update

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_direct_user_listening_review_input_guard tests.test_stage_b_midi_to_solo_model_direct_listening_review_package`
- `.venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_model_direct_user_listening_review_input.py scripts/build_stage_b_midi_to_solo_model_direct_listening_review_package.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-user-listening-review-input-guard`
- `bash scripts/agent_harness.sh quick`

## Risk

- actual listening input 없음
- preference fill 차단 상태
- musical quality claim 제외
- broad trained model quality claim 제외

## Follow-up

- Stage B MIDI-to-solo model-direct objective-only next decision

Closes #514
