### PR TITLE
Stage B MIDI-to-solo direct listening review fill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #514, Stage B MIDI-to-solo model-direct user listening review input guard.
+- Latest functional issue completed: Issue #516, Stage B MIDI-to-solo model-direct user listening review fill.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-direct objective-only next decision.
+- Recommended next issue: Stage B MIDI-to-solo model-direct songlike melody rejection analysis.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -867,6 +867,14 @@ bash scripts/agent_harness.sh stage-b-duration-coverage-outside-soloing-repair-f
 ```
 
 This harness records the objective-only final boundary and routes the next automatic task to model-core evidence README refresh without claiming human/audio preference.
+
+For Stage B MIDI-to-solo model-direct user listening review fill changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-user-listening-review-fill
+```
+
+This harness records single-user listening input for the rendered model-direct WAV candidates without claiming human/audio keep preference or broad MIDI-to-solo musical quality.
 
 For Stage B generic jazz base readiness audit changes, run:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -125,8 +125,14 @@ MVP가 끝났다고 볼 수 있는 조건:
 - model-direct user listening review input guard validated input: `false`
 - model-direct user listening review input guard preference fill allowed: `false`
 - model-direct user listening review input pending fields: status `4`, candidate decision `3`, candidate field `9`
-- next review target: `stage_b_midi_to_solo_model_direct_objective_only_next_decision`
-- 근거 문서: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_USER_LISTENING_REVIEW_INPUT_GUARD_2026-06-03.md`
+- model-direct user listening review status: `reviewed`
+- model-direct user listening review preferred rank: `3`
+- model-direct user listening review overall decision: `reject_all`
+- model-direct user listening review primary failure: `songlike_melody_not_soloing`
+- model-direct human/audio keep claim: `false`
+- model-direct MIDI-to-solo musical quality claim: `false`
+- next review target: `stage_b_midi_to_solo_model_direct_songlike_melody_rejection_analysis`
+- 근거 문서: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_USER_LISTENING_REVIEW_FILL_2026-06-03.md`
 - margin-recovered timing/repetition focused listening notes 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_NOTES_2026-05-28.md`
 - margin-recovered timing/repetition focused listening fill 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_FILL_2026-05-28.md`
 - margin-recovered phrase/vocabulary repair 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_REPAIR_2026-05-28.md`
@@ -321,6 +327,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo model-direct timing phrase repair: strict `3/3`, dead-air flags `3 -> 0`, max dead-air ratio `0.6522 -> 0.2258`, max interval guard `9 -> 9`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_direct_listening_review_package`
 - MIDI-to-solo model-direct listening review package: candidates `3`, rendered WAV `3`, duration range `18.926s-19.030s`, review input template `true`, listening review/preference claim `false`, next boundary `stage_b_midi_to_solo_model_direct_user_listening_review_fill`
 - MIDI-to-solo model-direct user listening review input guard: validated input `false`, preference fill allowed `false`, pending status/candidate decision/candidate field `4/3/9`, preference claim `false`, next boundary `stage_b_midi_to_solo_model_direct_objective_only_next_decision`
+- MIDI-to-solo model-direct user listening review fill: preferred rank `3`, overall `reject_all`, primary failure `songlike_melody_not_soloing`, keep/quality claim `false`, next boundary `stage_b_midi_to_solo_model_direct_songlike_melody_rejection_analysis`
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
 - generic base readiness audit: phase4 prep ready `true`, broad training execution ready `false`, broad quality/Brad adaptation claim `false`
 - generic base manifest contract: generic split `2433/270`, Brad split `47/11/14`, leakage/overlap `0`, broad training execution ready `false`

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -1,6 +1,6 @@
 # Current Status and Plan
 
-작성일: 2026-06-01
+작성일: 2026-06-03
 
 ## Current Focus
 
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #514, Stage B MIDI-to-solo model-direct user listening review input guard
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-direct objective-only next decision`
+- latest functional result: Issue #516, Stage B MIDI-to-solo model-direct user listening review fill
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-direct songlike melody rejection analysis`
 
 현재 범위가 아닌 것:
 
@@ -813,6 +813,52 @@ Issue #514는 #512 listening review package의 review input template이 아직 p
 다음:
 
 - `Stage B MIDI-to-solo model-direct objective-only next decision`
+
+## Stage B MIDI-to-Solo Model-Direct User Listening Review Fill Result
+
+Issue #516은 #512 WAV 후보 3개에 대한 single-user listening review 입력을 반영한 작업이다.
+
+변경:
+
+- user listening review fill script 추가
+- rank 3 relative best 입력 기록
+- 전체 후보 reject 판단과 `songlike_melody_not_soloing` 실패 유형 기록
+- human/audio keep claim과 MIDI-to-solo musical quality claim 차단
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_USER_LISTENING_REVIEW_FILL_2026-06-03.md`
+- boundary: `stage_b_midi_to_solo_model_direct_user_listening_review_fill`
+- claim boundary: `model_direct_listening_review_songlike_rejection`
+- next boundary: `stage_b_midi_to_solo_model_direct_songlike_melody_rejection_analysis`
+- review status: `reviewed`
+- preferred rank: `3`
+- overall decision: `reject_all`
+- candidate decision for preferred rank: `relative_best_needs_followup`
+- primary failure: `songlike_melody_not_soloing`
+- timing / phrase / vocabulary: `songlike_not_soloing`
+- reviewed candidate count: `3`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- 3번 후보는 상대적으로 가장 낫지만 keep 후보 아님
+- 현재 후보군은 jazz soloing보다 단순 songlike melody로 인지
+- 이전 timing/objective repair는 dead-air와 interval guard 개선 evidence로 제한
+- 다음 검토 대상은 songlike contour, phrase vocabulary, jazz articulation repair
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_direct_user_listening_review_fill`
+- `.venv/bin/python -m py_compile scripts/fill_stage_b_midi_to_solo_model_direct_user_listening_review.py`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-user-listening-review-fill`
+
+다음:
+
+- `Stage B MIDI-to-solo model-direct songlike melody rejection analysis`
 
 ## Previous Model Decision
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_USER_LISTENING_REVIEW_FILL_2026-06-03.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_USER_LISTENING_REVIEW_FILL_2026-06-03.md
@@ -1,0 +1,44 @@
+# Stage B MIDI-to-Solo Model-Direct User Listening Review Fill
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_model_direct_user_listening_review_fill`
+- claim boundary: `model_direct_listening_review_songlike_rejection`
+- next boundary: `stage_b_midi_to_solo_model_direct_songlike_melody_rejection_analysis`
+- review status: `reviewed`
+- preferred rank: `3`
+- overall decision: `reject_all`
+- primary failure: `songlike_melody_not_soloing`
+- timing: `songlike_not_soloing`
+- phrase: `songlike_not_soloing`
+- vocabulary: `songlike_not_soloing`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Assessment
+
+- rank 3 is relatively best, but all candidates sound like simple song melody rather than jazz soloing
+- notes: single user listening review of three rendered WAV files
+
+## Candidate Reviews
+
+| rank | decision | relative best | musical acceptance | primary failure |
+|---:|---|---|---|---|
+| 1 | `reject` | `false` | `reject` | `songlike_melody_not_soloing` |
+| 2 | `reject` | `false` | `reject` | `songlike_melody_not_soloing` |
+| 3 | `relative_best_needs_followup` | `true` | `reject` | `songlike_melody_not_soloing` |
+
+## Reviewed Files
+
+- rank `1`: `outputs/stage_b_midi_to_solo_model_direct_listening_review_package/harness_stage_b_midi_to_solo_model_direct_listening_review_package/audio/timing_repair_rank_01.wav`
+- rank `2`: `outputs/stage_b_midi_to_solo_model_direct_listening_review_package/harness_stage_b_midi_to_solo_model_direct_listening_review_package/audio/timing_repair_rank_02.wav`
+- rank `3`: `outputs/stage_b_midi_to_solo_model_direct_listening_review_package/harness_stage_b_midi_to_solo_model_direct_listening_review_package/audio/timing_repair_rank_03.wav`
+
+## Not Proven
+
+- `human_audio_keep_preference`
+- `jazz_solo_musical_quality`
+- `model_direct_generation_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`
+- `production_ready_improviser`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -4020,6 +4020,55 @@ run_stage_b_midi_to_solo_model_direct_user_listening_review_input_guard() {
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_model_direct_user_listening_review_fill() {
+  local review_package_run_id="${REVIEW_PACKAGE_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_listening_review_package}"
+  local input_guard_run_id="${INPUT_GUARD_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_user_listening_review_input_guard}"
+  local timing_repair_run_id="${TIMING_REPAIR_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_timing_phrase_repair}"
+  local pitch_repair_run_id="${PITCH_REPAIR_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_pitch_contour_repair}"
+  local diagnostics_run_id="${DIAGNOSTICS_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_phrase_quality_diagnostics}"
+  local evidence_run_id="${EVIDENCE_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_audio_evidence_consolidation}"
+  local audio_render_run_id="${AUDIO_RENDER_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_audio_render_package}"
+  local overlap_repair_run_id="${OVERLAP_REPAIR_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_monophonic_overlap_repair}"
+  local previous_direct_run_id="${PREVIOUS_DIRECT_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_8bar_generation_probe}"
+  local sequence_budget_run_id="${SEQUENCE_BUDGET_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_sequence_budget_repair_smoke}"
+  local context_run_id="${CONTEXT_RUN_ID:-harness_stage_b_midi_to_solo_context_extraction}"
+  local scale_run_id="${SCALE_RUN_ID:-max_sequence_160}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_direct_user_listening_review_fill}"
+  local review_package="outputs/stage_b_midi_to_solo_model_direct_listening_review_package/${review_package_run_id}/stage_b_midi_to_solo_model_direct_listening_review_package.json"
+  local input_guard="outputs/stage_b_midi_to_solo_model_direct_user_listening_review_input_guard/${input_guard_run_id}/stage_b_midi_to_solo_model_direct_user_listening_review_input_guard.json"
+  if [[ ! -f "$review_package" ]]; then
+    print_header "Stage B MIDI-to-solo model-direct listening review package"
+    RUN_ID="$review_package_run_id" TIMING_REPAIR_RUN_ID="$timing_repair_run_id" PITCH_REPAIR_RUN_ID="$pitch_repair_run_id" DIAGNOSTICS_RUN_ID="$diagnostics_run_id" EVIDENCE_RUN_ID="$evidence_run_id" AUDIO_RENDER_RUN_ID="$audio_render_run_id" OVERLAP_REPAIR_RUN_ID="$overlap_repair_run_id" PREVIOUS_DIRECT_RUN_ID="$previous_direct_run_id" SEQUENCE_BUDGET_RUN_ID="$sequence_budget_run_id" CONTEXT_RUN_ID="$context_run_id" SCALE_RUN_ID="$scale_run_id" run_stage_b_midi_to_solo_model_direct_listening_review_package
+  fi
+  if [[ ! -f "$input_guard" ]]; then
+    print_header "Stage B MIDI-to-solo model-direct user listening review input guard"
+    RUN_ID="$input_guard_run_id" REVIEW_PACKAGE_RUN_ID="$review_package_run_id" TIMING_REPAIR_RUN_ID="$timing_repair_run_id" PITCH_REPAIR_RUN_ID="$pitch_repair_run_id" DIAGNOSTICS_RUN_ID="$diagnostics_run_id" EVIDENCE_RUN_ID="$evidence_run_id" AUDIO_RENDER_RUN_ID="$audio_render_run_id" OVERLAP_REPAIR_RUN_ID="$overlap_repair_run_id" PREVIOUS_DIRECT_RUN_ID="$previous_direct_run_id" SEQUENCE_BUDGET_RUN_ID="$sequence_budget_run_id" CONTEXT_RUN_ID="$context_run_id" SCALE_RUN_ID="$scale_run_id" run_stage_b_midi_to_solo_model_direct_user_listening_review_input_guard
+  fi
+  print_header "Stage B MIDI-to-solo model-direct user listening review fill"
+  "$PYTHON_BIN" scripts/fill_stage_b_midi_to_solo_model_direct_user_listening_review.py \
+    --run_id "$run_id" \
+    --listening_review_package "$review_package" \
+    --input_guard_report "$input_guard" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_USER_LISTENING_REVIEW_FILL_2026-06-03.md \
+    --reviewer user \
+    --preferred_rank 3 \
+    --overall_decision reject_all \
+    --candidate_decision relative_best_needs_followup \
+    --timing songlike_not_soloing \
+    --phrase songlike_not_soloing \
+    --vocabulary songlike_not_soloing \
+    --primary_failure songlike_melody_not_soloing \
+    --assessment "rank 3 is relatively best, but all candidates sound like simple song melody rather than jazz soloing" \
+    --notes "single user listening review of three rendered WAV files" \
+    --expected_boundary stage_b_midi_to_solo_model_direct_user_listening_review_fill \
+    --expected_next_boundary stage_b_midi_to_solo_model_direct_songlike_melody_rejection_analysis \
+    --expected_overall_decision reject_all \
+    --expected_preferred_rank 3 \
+    --require_review_completed \
+    --require_no_keep_claim \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -5451,6 +5500,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-model-direct-user-listening-review-input-guard)
     run_stage_b_midi_to_solo_model_direct_user_listening_review_input_guard
+    ;;
+  stage-b-midi-to-solo-model-direct-user-listening-review-fill)
+    run_stage_b_midi_to_solo_model_direct_user_listening_review_fill
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/fill_stage_b_midi_to_solo_model_direct_user_listening_review.py
+++ b/scripts/fill_stage_b_midi_to_solo_model_direct_user_listening_review.py
@@ -1,0 +1,516 @@
+"""Fill model-direct user listening review from rendered WAV feedback."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+from scripts.build_stage_b_midi_to_solo_model_direct_listening_review_package import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+)
+from scripts.guard_stage_b_midi_to_solo_model_direct_user_listening_review_input import (  # noqa: E402
+    BOUNDARY as GUARD_BOUNDARY,
+)
+
+
+class StageBMidiToSoloModelDirectUserListeningReviewFillError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_model_direct_user_listening_review_fill"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_model_direct_songlike_melody_rejection_analysis"
+CLAIM_BOUNDARY = "model_direct_listening_review_songlike_rejection"
+SCHEMA_VERSION = "stage_b_midi_to_solo_model_direct_user_listening_review_fill_v1"
+
+OVERALL_DECISIONS = {"keep_any", "reject_all", "unclear"}
+CANDIDATE_DECISIONS = {"keep", "relative_best_needs_followup", "needs_followup", "reject", "unclear"}
+ATTRIBUTE_VALUES = {"acceptable", "songlike_not_soloing", "weak", "unclear"}
+PRIMARY_FAILURES = {
+    "songlike_melody_not_soloing",
+    "simple_scale_melody",
+    "not_jazz_phrase_vocabulary",
+    "too_regular_contour",
+    "rhythm_too_plain",
+    "unclear",
+}
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise StageBMidiToSoloModelDirectUserListeningReviewFillError(f"report missing: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def compact_rendered_candidate(item: dict[str, Any]) -> dict[str, Any]:
+    wav_file = _dict(item.get("wav_file"))
+    if not bool(wav_file.get("exists", False)):
+        raise StageBMidiToSoloModelDirectUserListeningReviewFillError(
+            f"missing WAV for rank {item.get('rank')}"
+        )
+    return {
+        "rank": _int(item.get("rank")),
+        "sample_index": _int(item.get("sample_index")),
+        "midi_path": str(item.get("package_midi_path") or item.get("source_midi_path") or ""),
+        "wav_path": str(wav_file.get("path") or ""),
+        "duration_seconds": _float(wav_file.get("duration_seconds")),
+        "sample_rate": _int(wav_file.get("sample_rate")),
+        "sha256": str(wav_file.get("sha256") or ""),
+        "note_count": _int(item.get("source_note_count")),
+        "unique_pitch_count": _int(item.get("source_unique_pitch_count")),
+        "max_interval": _int(item.get("source_max_interval")),
+        "dead_air_ratio": _float(item.get("source_dead_air_ratio")),
+        "source_diagnostic_flags": _list(item.get("source_diagnostic_flags")),
+    }
+
+
+def validate_source_package(source_package: dict[str, Any]) -> list[dict[str, Any]]:
+    boundary = _dict(source_package.get("listening_review_package_boundary"))
+    decision = _dict(source_package.get("decision"))
+    if str(boundary.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloModelDirectUserListeningReviewFillError("listening review package boundary required")
+    if str(decision.get("next_boundary") or "") != BOUNDARY:
+        raise StageBMidiToSoloModelDirectUserListeningReviewFillError("source package must route to review fill")
+    if not bool(boundary.get("technical_wav_validation", False)):
+        raise StageBMidiToSoloModelDirectUserListeningReviewFillError("technical WAV validation required")
+    blocked_claims = [
+        "listening_review_completed",
+        "human_audio_preference_claimed",
+        "model_direct_generation_quality_claimed",
+        "midi_to_solo_musical_quality_claimed",
+        "broad_trained_model_quality_claimed",
+        "brad_style_adaptation_claimed",
+    ]
+    claimed = [name for name in blocked_claims if bool(boundary.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloModelDirectUserListeningReviewFillError(f"unexpected upstream claim: {claimed}")
+    candidates = [
+        compact_rendered_candidate(item)
+        for item in _list(source_package.get("rendered_audio_files"))
+        if isinstance(item, dict)
+    ]
+    if _int(boundary.get("candidate_count")) != len(candidates):
+        raise StageBMidiToSoloModelDirectUserListeningReviewFillError("candidate count mismatch")
+    if len(candidates) < 1:
+        raise StageBMidiToSoloModelDirectUserListeningReviewFillError("rendered candidates required")
+    return candidates
+
+
+def validate_guard_report(guard_report: dict[str, Any] | None) -> dict[str, Any]:
+    if guard_report is None:
+        return {
+            "guard_report_used": False,
+            "validated_review_input_present": None,
+            "preference_fill_allowed": None,
+        }
+    if str(guard_report.get("boundary") or "") != GUARD_BOUNDARY:
+        raise StageBMidiToSoloModelDirectUserListeningReviewFillError("input guard boundary required")
+    guard = _dict(guard_report.get("guard_result"))
+    readiness = _dict(guard_report.get("readiness"))
+    if bool(readiness.get("human_audio_preference_claimed", False)):
+        raise StageBMidiToSoloModelDirectUserListeningReviewFillError("guard report must not claim preference")
+    return {
+        "guard_report_used": True,
+        "validated_review_input_present": bool(guard.get("validated_review_input_present", False)),
+        "preference_fill_allowed": bool(guard.get("preference_fill_allowed", False)),
+        "pending_status_field_count": _int(guard.get("pending_status_field_count")),
+        "pending_candidate_decision_count": _int(guard.get("pending_candidate_decision_count")),
+        "pending_candidate_field_count": _int(guard.get("pending_candidate_field_count")),
+    }
+
+
+def build_candidate_reviews(
+    candidates: list[dict[str, Any]],
+    *,
+    preferred_rank: int,
+    overall_decision: str,
+    candidate_decision: str,
+    primary_failure: str,
+    assessment: str,
+) -> list[dict[str, Any]]:
+    if overall_decision not in OVERALL_DECISIONS:
+        raise StageBMidiToSoloModelDirectUserListeningReviewFillError(
+            f"invalid overall decision: {overall_decision}"
+        )
+    if candidate_decision not in CANDIDATE_DECISIONS:
+        raise StageBMidiToSoloModelDirectUserListeningReviewFillError(
+            f"invalid candidate decision: {candidate_decision}"
+        )
+    ranks = {item["rank"] for item in candidates}
+    if preferred_rank not in ranks:
+        raise StageBMidiToSoloModelDirectUserListeningReviewFillError(
+            f"preferred rank not in candidates: {preferred_rank}"
+        )
+    reviews: list[dict[str, Any]] = []
+    for item in candidates:
+        if overall_decision == "reject_all":
+            decision = candidate_decision if item["rank"] == preferred_rank else "reject"
+            musical_acceptance = "reject"
+        elif item["rank"] == preferred_rank:
+            decision = "keep"
+            musical_acceptance = "keep"
+        else:
+            decision = "needs_followup"
+            musical_acceptance = "needs_followup"
+        reviews.append(
+            {
+                "rank": item["rank"],
+                "decision": decision,
+                "musical_acceptance": musical_acceptance,
+                "relative_best": item["rank"] == preferred_rank,
+                "primary_failure": primary_failure,
+                "assessment": assessment.strip(),
+            }
+        )
+    return reviews
+
+
+def build_user_listening_review_fill(
+    source_package: dict[str, Any],
+    *,
+    output_dir: Path,
+    reviewer: str,
+    preferred_rank: int,
+    overall_decision: str,
+    candidate_decision: str,
+    timing: str,
+    phrase: str,
+    vocabulary: str,
+    primary_failure: str,
+    assessment: str,
+    notes: str,
+    guard_report: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not reviewer.strip():
+        raise StageBMidiToSoloModelDirectUserListeningReviewFillError("reviewer is required")
+    for field, value in (("timing", timing), ("phrase", phrase), ("vocabulary", vocabulary)):
+        if value not in ATTRIBUTE_VALUES:
+            raise StageBMidiToSoloModelDirectUserListeningReviewFillError(f"invalid {field}: {value}")
+    if primary_failure not in PRIMARY_FAILURES:
+        raise StageBMidiToSoloModelDirectUserListeningReviewFillError(
+            f"invalid primary failure: {primary_failure}"
+        )
+    candidates = validate_source_package(source_package)
+    guard_summary = validate_guard_report(guard_report)
+    keep_claimed = overall_decision == "keep_any"
+    candidate_reviews = build_candidate_reviews(
+        candidates,
+        preferred_rank=int(preferred_rank),
+        overall_decision=overall_decision,
+        candidate_decision=candidate_decision,
+        primary_failure=primary_failure,
+        assessment=assessment,
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "boundary": BOUNDARY,
+        "source_boundary": SOURCE_BOUNDARY,
+        "reviewed_candidates": candidates,
+        "input_guard_summary": guard_summary,
+        "user_listening_review": {
+            "status": "reviewed",
+            "reviewer": reviewer.strip(),
+            "review_basis": "single_user_listening_review_of_rendered_wav",
+            "preferred_rank": int(preferred_rank),
+            "relative_preference_recorded": True,
+            "overall_decision": overall_decision,
+            "candidate_decision_for_preferred_rank": candidate_decision,
+            "timing": timing,
+            "phrase": phrase,
+            "vocabulary": vocabulary,
+            "primary_failure": primary_failure,
+            "assessment": assessment.strip(),
+            "notes": notes.strip(),
+            "candidate_reviews": candidate_reviews,
+        },
+        "claim_boundary": {
+            "boundary": CLAIM_BOUNDARY if not keep_claimed else "model_direct_listening_review_single_user_keep",
+            "single_user_review_completed": True,
+            "relative_preference_recorded": True,
+            "overall_reject_all": overall_decision == "reject_all",
+            "human_audio_preference_claimed": keep_claimed,
+            "model_direct_candidate_keep_claimed": keep_claimed,
+            "audio_render_used": True,
+            "audio_rendered_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "broad_model_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "user_listening_review_completed": True,
+            "relative_preference_recorded": True,
+            "human_audio_preference_claimed": keep_claimed,
+            "model_direct_candidate_keep_claimed": keep_claimed,
+            "model_direct_generation_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "single-user review rejected current model-direct candidates as songlike rather than soloing",
+        },
+        "proven": [
+            "single_user_listening_review_recorded",
+            "relative_best_rank_recorded",
+            "current_candidate_set_rejected_for_songlike_melody",
+        ],
+        "not_proven": [
+            "human_audio_keep_preference",
+            "jazz_solo_musical_quality",
+            "model_direct_generation_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "production_ready_improviser",
+        ],
+        "next_recommended_issue": "Stage B MIDI-to-solo model-direct songlike melody rejection analysis",
+    }
+
+
+def validate_user_listening_review_fill(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    expected_overall_decision: str | None,
+    expected_preferred_rank: int | None,
+    require_review_completed: bool,
+    require_no_keep_claim: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    review = _dict(report.get("user_listening_review"))
+    claim = _dict(report.get("claim_boundary"))
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloModelDirectUserListeningReviewFillError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloModelDirectUserListeningReviewFillError("unexpected next boundary")
+    if expected_overall_decision and str(review.get("overall_decision") or "") != expected_overall_decision:
+        raise StageBMidiToSoloModelDirectUserListeningReviewFillError("unexpected overall decision")
+    if expected_preferred_rank is not None and _int(review.get("preferred_rank")) != int(expected_preferred_rank):
+        raise StageBMidiToSoloModelDirectUserListeningReviewFillError("unexpected preferred rank")
+    if require_review_completed and not bool(readiness.get("user_listening_review_completed", False)):
+        raise StageBMidiToSoloModelDirectUserListeningReviewFillError("review completion required")
+    if require_no_keep_claim:
+        blocked = [
+            "human_audio_preference_claimed",
+            "model_direct_candidate_keep_claimed",
+        ]
+        claimed = [name for name in blocked if bool(claim.get(name, True))]
+        if claimed:
+            raise StageBMidiToSoloModelDirectUserListeningReviewFillError(f"unexpected keep claim: {claimed}")
+    if require_no_quality_claim:
+        blocked_quality = [
+            "audio_rendered_quality_claimed",
+            "model_direct_generation_quality_claimed",
+            "midi_to_solo_musical_quality_claimed",
+            "broad_model_quality_claimed",
+            "broad_trained_model_quality_claimed",
+            "brad_style_adaptation_claimed",
+        ]
+        claimed_quality = [name for name in blocked_quality if bool(claim.get(name, True))]
+        if claimed_quality:
+            raise StageBMidiToSoloModelDirectUserListeningReviewFillError(
+                f"unexpected quality claim: {claimed_quality}"
+            )
+    return {
+        "boundary": boundary,
+        "claim_boundary": str(claim.get("boundary") or ""),
+        "review_status": str(review.get("status") or ""),
+        "preferred_rank": _int(review.get("preferred_rank")),
+        "relative_preference_recorded": bool(review.get("relative_preference_recorded", False)),
+        "overall_decision": str(review.get("overall_decision") or ""),
+        "candidate_decision_for_preferred_rank": str(review.get("candidate_decision_for_preferred_rank") or ""),
+        "timing": str(review.get("timing") or ""),
+        "phrase": str(review.get("phrase") or ""),
+        "vocabulary": str(review.get("vocabulary") or ""),
+        "primary_failure": str(review.get("primary_failure") or ""),
+        "human_audio_preference_claimed": bool(claim.get("human_audio_preference_claimed", True)),
+        "model_direct_candidate_keep_claimed": bool(claim.get("model_direct_candidate_keep_claimed", True)),
+        "midi_to_solo_musical_quality_claimed": bool(
+            claim.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "reviewed_candidate_count": len(_list(report.get("reviewed_candidates"))),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    review = report["user_listening_review"]
+    claim = report["claim_boundary"]
+    decision = report["decision"]
+    lines = [
+        "# Stage B MIDI-to-Solo Model-Direct User Listening Review Fill",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- claim boundary: `{claim['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- review status: `{review['status']}`",
+        f"- preferred rank: `{review['preferred_rank']}`",
+        f"- overall decision: `{review['overall_decision']}`",
+        f"- primary failure: `{review['primary_failure']}`",
+        f"- timing: `{review['timing']}`",
+        f"- phrase: `{review['phrase']}`",
+        f"- vocabulary: `{review['vocabulary']}`",
+        f"- human/audio preference claimed: `{_bool_token(claim['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(claim['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Assessment",
+        "",
+        f"- {review['assessment']}",
+        f"- notes: {review['notes']}",
+        "",
+        "## Candidate Reviews",
+        "",
+        "| rank | decision | relative best | musical acceptance | primary failure |",
+        "|---:|---|---|---|---|",
+    ]
+    for item in review.get("candidate_reviews", []):
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(item["rank"]),
+                    f"`{item['decision']}`",
+                    f"`{_bool_token(item['relative_best'])}`",
+                    f"`{item['musical_acceptance']}`",
+                    f"`{item['primary_failure']}`",
+                ]
+            )
+            + " |"
+        )
+    lines.extend(["", "## Reviewed Files", ""])
+    for item in report.get("reviewed_candidates", []):
+        lines.append(f"- rank `{item['rank']}`: `{item['wav_path']}`")
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Fill model-direct user listening review")
+    parser.add_argument("--listening_review_package", type=str, required=True)
+    parser.add_argument("--input_guard_report", type=str, default="")
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_model_direct_user_listening_review_fill",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--reviewer", type=str, required=True)
+    parser.add_argument("--preferred_rank", type=int, required=True)
+    parser.add_argument("--overall_decision", type=str, required=True)
+    parser.add_argument("--candidate_decision", type=str, required=True)
+    parser.add_argument("--timing", type=str, required=True)
+    parser.add_argument("--phrase", type=str, required=True)
+    parser.add_argument("--vocabulary", type=str, required=True)
+    parser.add_argument("--primary_failure", type=str, required=True)
+    parser.add_argument("--assessment", type=str, required=True)
+    parser.add_argument("--notes", type=str, default="")
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--expected_overall_decision", type=str, default="")
+    parser.add_argument("--expected_preferred_rank", type=int, default=0)
+    parser.add_argument("--require_review_completed", action="store_true")
+    parser.add_argument("--require_no_keep_claim", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    output_dir.mkdir(parents=True, exist_ok=True)
+    guard_report = read_json(Path(args.input_guard_report)) if args.input_guard_report else None
+    report = build_user_listening_review_fill(
+        read_json(Path(args.listening_review_package)),
+        output_dir=output_dir,
+        reviewer=str(args.reviewer),
+        preferred_rank=int(args.preferred_rank),
+        overall_decision=str(args.overall_decision),
+        candidate_decision=str(args.candidate_decision),
+        timing=str(args.timing),
+        phrase=str(args.phrase),
+        vocabulary=str(args.vocabulary),
+        primary_failure=str(args.primary_failure),
+        assessment=str(args.assessment),
+        notes=str(args.notes or ""),
+        guard_report=guard_report,
+    )
+    summary = validate_user_listening_review_fill(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        expected_overall_decision=str(args.expected_overall_decision or ""),
+        expected_preferred_rank=int(args.expected_preferred_rank) if int(args.expected_preferred_rank) else None,
+        require_review_completed=bool(args.require_review_completed),
+        require_no_keep_claim=bool(args.require_no_keep_claim),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    write_json(output_dir / "stage_b_midi_to_solo_model_direct_user_listening_review_fill.json", report)
+    write_json(
+        output_dir / "stage_b_midi_to_solo_model_direct_user_listening_review_fill_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_midi_to_solo_model_direct_user_listening_review_fill.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_model_direct_user_listening_review_fill.py
+++ b/tests/test_stage_b_midi_to_solo_model_direct_user_listening_review_fill.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.fill_stage_b_midi_to_solo_model_direct_user_listening_review import (
+    BOUNDARY,
+    CLAIM_BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloModelDirectUserListeningReviewFillError,
+    build_user_listening_review_fill,
+    validate_user_listening_review_fill,
+)
+
+
+def listening_review_package(*, preference_claimed: bool = False) -> dict:
+    return {
+        "schema_version": "stage_b_midi_to_solo_model_direct_listening_review_package_v1",
+        "listening_review_package_boundary": {
+            "boundary": "stage_b_midi_to_solo_model_direct_listening_review_package",
+            "source_boundary": "stage_b_midi_to_solo_model_direct_timing_phrase_repair",
+            "candidate_count": 3,
+            "midi_file_count": 3,
+            "rendered_audio_file_count": 3,
+            "technical_wav_validation": True,
+            "review_input_template_written": True,
+            "listening_review_completed": False,
+            "human_audio_preference_claimed": preference_claimed,
+            "model_direct_generation_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "next_boundary": "stage_b_midi_to_solo_model_direct_user_listening_review_fill",
+            "critical_user_input_required": False,
+        },
+        "rendered_audio_files": [
+            {
+                "rank": 1,
+                "sample_index": 1,
+                "package_midi_path": "rank_01.mid",
+                "source_note_count": 32,
+                "source_unique_pitch_count": 13,
+                "source_max_interval": 9,
+                "source_dead_air_ratio": 0.2258,
+                "source_diagnostic_flags": [],
+                "wav_file": {
+                    "path": "rank_01.wav",
+                    "exists": True,
+                    "duration_seconds": 19.030,
+                    "sample_rate": 44100,
+                    "sha256": "a" * 64,
+                },
+            },
+            {
+                "rank": 2,
+                "sample_index": 2,
+                "package_midi_path": "rank_02.mid",
+                "source_note_count": 32,
+                "source_unique_pitch_count": 15,
+                "source_max_interval": 9,
+                "source_dead_air_ratio": 0.2258,
+                "source_diagnostic_flags": [],
+                "wav_file": {
+                    "path": "rank_02.wav",
+                    "exists": True,
+                    "duration_seconds": 19.001,
+                    "sample_rate": 44100,
+                    "sha256": "b" * 64,
+                },
+            },
+            {
+                "rank": 3,
+                "sample_index": 3,
+                "package_midi_path": "rank_03.mid",
+                "source_note_count": 32,
+                "source_unique_pitch_count": 14,
+                "source_max_interval": 8,
+                "source_dead_air_ratio": 0.2258,
+                "source_diagnostic_flags": [],
+                "wav_file": {
+                    "path": "rank_03.wav",
+                    "exists": True,
+                    "duration_seconds": 18.926,
+                    "sample_rate": 44100,
+                    "sha256": "c" * 64,
+                },
+            },
+        ],
+    }
+
+
+def input_guard_report() -> dict:
+    return {
+        "boundary": "stage_b_midi_to_solo_model_direct_user_listening_review_input_guard",
+        "guard_result": {
+            "validated_review_input_present": False,
+            "preference_fill_allowed": False,
+            "pending_status_field_count": 4,
+            "pending_candidate_decision_count": 3,
+            "pending_candidate_field_count": 9,
+        },
+        "readiness": {
+            "human_audio_preference_claimed": False,
+        },
+    }
+
+
+class StageBMidiToSoloModelDirectUserListeningReviewFillTest(unittest.TestCase):
+    def test_records_rank_three_relative_best_reject_all_without_quality_claim(self) -> None:
+        report = build_user_listening_review_fill(
+            listening_review_package(),
+            output_dir=Path("outputs/review_fill"),
+            reviewer="user",
+            preferred_rank=3,
+            overall_decision="reject_all",
+            candidate_decision="relative_best_needs_followup",
+            timing="songlike_not_soloing",
+            phrase="songlike_not_soloing",
+            vocabulary="songlike_not_soloing",
+            primary_failure="songlike_melody_not_soloing",
+            assessment="rank 3 is relatively best, but all candidates sound like simple song melody rather than jazz soloing",
+            notes="single user listening review of three rendered WAV files",
+            guard_report=input_guard_report(),
+        )
+        summary = validate_user_listening_review_fill(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=NEXT_BOUNDARY,
+            expected_overall_decision="reject_all",
+            expected_preferred_rank=3,
+            require_review_completed=True,
+            require_no_keep_claim=True,
+            require_no_quality_claim=True,
+        )
+
+        self.assertEqual(summary["claim_boundary"], CLAIM_BOUNDARY)
+        self.assertEqual(summary["reviewed_candidate_count"], 3)
+        self.assertEqual(summary["candidate_decision_for_preferred_rank"], "relative_best_needs_followup")
+        self.assertEqual(summary["primary_failure"], "songlike_melody_not_soloing")
+        self.assertFalse(summary["human_audio_preference_claimed"])
+        self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+        candidate_reviews = report["user_listening_review"]["candidate_reviews"]
+        self.assertTrue(candidate_reviews[2]["relative_best"])
+        self.assertEqual(candidate_reviews[2]["musical_acceptance"], "reject")
+
+    def test_rejects_source_package_with_existing_preference_claim(self) -> None:
+        with self.assertRaises(StageBMidiToSoloModelDirectUserListeningReviewFillError):
+            build_user_listening_review_fill(
+                listening_review_package(preference_claimed=True),
+                output_dir=Path("outputs/review_fill"),
+                reviewer="user",
+                preferred_rank=3,
+                overall_decision="reject_all",
+                candidate_decision="relative_best_needs_followup",
+                timing="songlike_not_soloing",
+                phrase="songlike_not_soloing",
+                vocabulary="songlike_not_soloing",
+                primary_failure="songlike_melody_not_soloing",
+                assessment="all candidates need follow-up",
+                notes="",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- #516 user listening review fill boundary 추가
- rank 3 relative best 입력 기록
- current model-direct WAV candidates 전체 reject 기록
- primary failure: `songlike_melody_not_soloing`
- human/audio keep claim 및 MIDI-to-solo musical quality claim 차단

## Context

- #512 listening review package: candidates `3`, rendered WAV `3`, duration range `18.926s-19.030s`
- #514 input guard: validated input `false`, preference fill allowed `false`
- user listening input: rank `3` relative best, all candidates rejected as songlike melody rather than jazz soloing

## Scope

- user listening review fill script 추가
- reject_all / relative best rank validation 추가
- harness mode 추가
- current status, core plan, handoff 문서 갱신

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_direct_user_listening_review_fill tests.test_stage_b_midi_to_solo_model_direct_user_listening_review_input_guard tests.test_stage_b_midi_to_solo_model_direct_listening_review_package`
- `.venv/bin/python -m py_compile scripts/fill_stage_b_midi_to_solo_model_direct_user_listening_review.py scripts/guard_stage_b_midi_to_solo_model_direct_user_listening_review_input.py scripts/build_stage_b_midi_to_solo_model_direct_listening_review_package.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-user-listening-review-fill`
- `bash scripts/agent_harness.sh quick`

## Risk

- single-user listening review only
- no broad model quality claim
- no human/audio keep preference claim

Closes #516

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project status tracking and workflow documentation reflecting current execution phase advancement.
  * Added new assessment documentation capturing user listening review outcomes and findings.

* **Chores**
  * Implemented new automation stage for processing user listening review submissions.

* **Tests**
  * Added validation test coverage for user listening review processing and claims enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->