### PR TITLE
Stage B MIDI-to-solo jazz phrase repair audio package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #522, Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair probe.
+- Latest functional issue completed: Issue #524, Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair audio package.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair audio package.
+- Recommended next issue: Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair listening review.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -899,6 +899,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-jazz-phrase-voca
 ```
 
 This harness generates repaired MIDI candidates and verifies fixed-density, repeated-rhythm, interval-cap, and overlap guardrails without claiming listening quality.
+
+For Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair audio package changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-jazz-phrase-vocabulary-repair-audio-package
+```
+
+This harness renders repaired MIDI candidates to local WAV files and validates technical WAV metadata without claiming listening quality.
 
 For Stage B generic jazz base readiness audit changes, run:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -146,8 +146,14 @@ MVP가 끝났다고 볼 수 있는 조건:
 - model-direct jazz phrase vocabulary repair probe shared rhythm signature count: `1`
 - model-direct jazz phrase vocabulary repair probe max abs interval max: `12`
 - model-direct jazz phrase vocabulary repair probe no overlap: `true`
-- next review target: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package`
-- 근거 문서: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_JAZZ_PHRASE_VOCABULARY_REPAIR_PROBE_2026-06-04.md`
+- model-direct jazz phrase vocabulary repair audio package rendered WAV files: `3`
+- model-direct jazz phrase vocabulary repair audio package technical WAV validation: `true`
+- model-direct jazz phrase vocabulary repair audio package duration range: `18.975s-18.988s`
+- model-direct jazz phrase vocabulary repair audio package listening review completed: `false`
+- model-direct jazz phrase vocabulary repair audio package human/audio preference claim: `false`
+- model-direct jazz phrase vocabulary repair audio package MIDI-to-solo musical quality claim: `false`
+- next review target: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review`
+- 근거 문서: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_JAZZ_PHRASE_VOCABULARY_REPAIR_AUDIO_PACKAGE_2026-06-04.md`
 - margin-recovered timing/repetition focused listening notes 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_NOTES_2026-05-28.md`
 - margin-recovered timing/repetition focused listening fill 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_FILL_2026-05-28.md`
 - margin-recovered phrase/vocabulary repair 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_REPAIR_2026-05-28.md`
@@ -346,6 +352,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo model-direct songlike melody rejection analysis: uniform density / four-notes template / duration monotony / IOI monotony / interval cap / 4-bar cycle counts `3/3/3/3/3/3`, shared rhythm signature `3`, max interval `9`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_decision`
 - MIDI-to-solo model-direct jazz phrase vocabulary repair decision: target count `6`, distinct rhythm signatures required `true`, max allowed interval `12`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe`
 - MIDI-to-solo model-direct jazz phrase vocabulary repair probe: target passed `true`, generated MIDI `3`, fixed-density/four-note/duration/IOI/interval-cap/four-bar-cycle flags `0/0/0/0/0/0`, shared rhythm signature `1`, max interval `12`, no overlap `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package`
+- MIDI-to-solo model-direct jazz phrase vocabulary repair audio package: rendered WAV `3`, duration range `18.975s-18.988s`, technical validation `true`, listening review/preference/quality claim `false`, next boundary `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review`
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
 - generic base readiness audit: phase4 prep ready `true`, broad training execution ready `false`, broad quality/Brad adaptation claim `false`
 - generic base manifest contract: generic split `2433/270`, Brad split `47/11/14`, leakage/overlap `0`, broad training execution ready `false`

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #522, Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair probe
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair audio package`
+- latest functional result: Issue #524, Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair audio package
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair listening review`
 
 현재 범위가 아닌 것:
 
@@ -1002,6 +1002,55 @@ Generated MIDI:
 다음:
 
 - `Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair audio package`
+
+## Stage B MIDI-to-Solo Model-Direct Jazz Phrase Vocabulary Repair Audio Package Result
+
+Issue #524는 #522 repaired MIDI 후보 3개를 로컬 WAV로 render하고 technical WAV metadata를 검증한 작업이다.
+
+변경:
+
+- jazz phrase vocabulary repair audio package script 추가
+- #522 repaired MIDI 후보 3개 WAV render
+- renderer / soundfont / WAV metadata 검증 추가
+- listening review 전 quality claim 차단 guard 추가
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_JAZZ_PHRASE_VOCABULARY_REPAIR_AUDIO_PACKAGE_2026-06-04.md`
+- boundary: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package`
+- source boundary: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe`
+- next boundary: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review`
+- candidate count: `3`
+- rendered audio file count: `3`
+- technical WAV validation: `true`
+- duration range: `18.975s-18.988s`
+- listening review completed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+Rendered WAV:
+
+- rank 1: `outputs/stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package/harness_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package/audio/jazz_phrase_repair_rank_01.wav`
+- rank 2: `outputs/stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package/harness_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package/audio/jazz_phrase_repair_rank_02.wav`
+- rank 3: `outputs/stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package/harness_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package/audio/jazz_phrase_repair_rank_03.wav`
+
+판단:
+
+- #522 objective repair 후보는 WAV review package까지 연결 가능
+- 현재 결과는 technical audio output evidence이며 청음 품질 claim 아님
+- 다음 검토 대상은 repaired WAV 후보별 listening review 기록과 reject/keep decision boundary
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package tests.test_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package.py scripts/run_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe.py`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-jazz-phrase-vocabulary-repair-audio-package`
+
+다음:
+
+- `Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair listening review`
 
 ## Previous Model Decision
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_JAZZ_PHRASE_VOCABULARY_REPAIR_AUDIO_PACKAGE_2026-06-04.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_JAZZ_PHRASE_VOCABULARY_REPAIR_AUDIO_PACKAGE_2026-06-04.md
@@ -1,0 +1,32 @@
+# Stage B MIDI-to-Solo Model-Direct Jazz Phrase Vocabulary Repair Audio Package
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package`
+- source boundary: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe`
+- next boundary: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review`
+- candidate count: `3`
+- rendered audio file count: `3`
+- technical WAV validation: `true`
+- duration range: `18.975s-18.988s`
+- listening review completed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Rendered Files
+
+| rank | midi path | wav path | duration | sample rate | size | sha256 |
+|---:|---|---|---:|---:|---:|---|
+| 1 | outputs/stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe/harness_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe/midi/jazz_phrase_repair_rank_01.mid | outputs/stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package/harness_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package/audio/jazz_phrase_repair_rank_01.wav | 18.975 | 44100 | 3347244 | 6ffaf59d84ac |
+| 2 | outputs/stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe/harness_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe/midi/jazz_phrase_repair_rank_02.mid | outputs/stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package/harness_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package/audio/jazz_phrase_repair_rank_02.wav | 18.988 | 44100 | 3349548 | b740ef5d8e41 |
+| 3 | outputs/stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe/harness_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe/midi/jazz_phrase_repair_rank_03.mid | outputs/stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package/harness_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package/audio/jazz_phrase_repair_rank_03.wav | 18.984 | 44100 | 3348780 | 07d4ac225f51 |
+
+## Not Proven
+
+- `listening_review_completed`
+- `audio_rendered_quality`
+- `human_audio_keep_preference`
+- `jazz_solo_musical_quality`
+- `model_direct_generation_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -4168,6 +4168,39 @@ run_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe() {
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package() {
+  local repair_probe_run_id="${REPAIR_PROBE_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe}"
+  local repair_decision_run_id="${REPAIR_DECISION_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_decision}"
+  local songlike_analysis_run_id="${SONGLIKE_ANALYSIS_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_songlike_melody_rejection_analysis}"
+  local review_fill_run_id="${REVIEW_FILL_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_user_listening_review_fill}"
+  local review_package_run_id="${REVIEW_PACKAGE_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_listening_review_package}"
+  local input_guard_run_id="${INPUT_GUARD_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_user_listening_review_input_guard}"
+  local timing_repair_run_id="${TIMING_REPAIR_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_timing_phrase_repair}"
+  local pitch_repair_run_id="${PITCH_REPAIR_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_pitch_contour_repair}"
+  local diagnostics_run_id="${DIAGNOSTICS_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_phrase_quality_diagnostics}"
+  local evidence_run_id="${EVIDENCE_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_audio_evidence_consolidation}"
+  local audio_render_run_id="${AUDIO_RENDER_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_audio_render_package}"
+  local overlap_repair_run_id="${OVERLAP_REPAIR_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_monophonic_overlap_repair}"
+  local previous_direct_run_id="${PREVIOUS_DIRECT_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_8bar_generation_probe}"
+  local sequence_budget_run_id="${SEQUENCE_BUDGET_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_sequence_budget_repair_smoke}"
+  local context_run_id="${CONTEXT_RUN_ID:-harness_stage_b_midi_to_solo_context_extraction}"
+  local scale_run_id="${SCALE_RUN_ID:-max_sequence_160}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package}"
+  local repair_probe="outputs/stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe/${repair_probe_run_id}/stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe.json"
+  if [[ ! -f "$repair_probe" ]]; then
+    print_header "Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair probe"
+    RUN_ID="$repair_probe_run_id" REPAIR_DECISION_RUN_ID="$repair_decision_run_id" SONGLIKE_ANALYSIS_RUN_ID="$songlike_analysis_run_id" REVIEW_FILL_RUN_ID="$review_fill_run_id" REVIEW_PACKAGE_RUN_ID="$review_package_run_id" INPUT_GUARD_RUN_ID="$input_guard_run_id" TIMING_REPAIR_RUN_ID="$timing_repair_run_id" PITCH_REPAIR_RUN_ID="$pitch_repair_run_id" DIAGNOSTICS_RUN_ID="$diagnostics_run_id" EVIDENCE_RUN_ID="$evidence_run_id" AUDIO_RENDER_RUN_ID="$audio_render_run_id" OVERLAP_REPAIR_RUN_ID="$overlap_repair_run_id" PREVIOUS_DIRECT_RUN_ID="$previous_direct_run_id" SEQUENCE_BUDGET_RUN_ID="$sequence_budget_run_id" CONTEXT_RUN_ID="$context_run_id" SCALE_RUN_ID="$scale_run_id" run_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe
+  fi
+  print_header "Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair audio package"
+  "$PYTHON_BIN" scripts/build_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package.py \
+    --run_id "$run_id" \
+    --repair_probe "$repair_probe" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_JAZZ_PHRASE_VOCABULARY_REPAIR_AUDIO_PACKAGE_2026-06-04.md \
+    --expected_boundary stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package \
+    --expected_file_count 3 \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -5611,6 +5644,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-model-direct-jazz-phrase-vocabulary-repair-probe)
     run_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe
+    ;;
+  stage-b-midi-to-solo-model-direct-jazz-phrase-vocabulary-repair-audio-package)
+    run_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/build_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package.py
+++ b/scripts/build_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package.py
@@ -1,0 +1,451 @@
+"""Build WAV review package for jazz phrase vocabulary repair probe candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+from scripts.render_stage_b_midi_to_solo_candidate_audio import (  # noqa: E402
+    default_soundfont_candidates,
+    resolve_soundfont,
+    sha256_file,
+    wav_meta,
+)
+from scripts.run_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+)
+
+
+class StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairAudioPackageError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review"
+SCHEMA_VERSION = "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package_v1"
+CommandRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairAudioPackageError(f"report missing: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def default_runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(list(command), check=False, text=True, capture_output=True)
+
+
+def validate_repair_probe(probe_report: dict[str, Any], expected_count: int) -> list[dict[str, Any]]:
+    readiness = _dict(probe_report.get("readiness"))
+    decision = _dict(probe_report.get("decision"))
+    repair_result = _dict(probe_report.get("repair_result"))
+    analysis_by_rank = {
+        _int(_dict(item).get("rank")): _dict(item)
+        for item in _list(probe_report.get("candidate_analyses"))
+        if _int(_dict(item).get("rank")) > 0
+    }
+    if str(probe_report.get("boundary") or readiness.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairAudioPackageError(
+            "repair probe boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != BOUNDARY:
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairAudioPackageError(
+            "repair probe must route to audio package"
+        )
+    if not bool(readiness.get("repair_probe_completed", False)):
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairAudioPackageError("repair probe completion required")
+    if not bool(repair_result.get("target_passed", False)):
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairAudioPackageError("repair target pass required")
+    blocked_claims = [
+        "human_audio_preference_claimed",
+        "model_direct_candidate_keep_claimed",
+        "model_direct_generation_quality_claimed",
+        "midi_to_solo_musical_quality_claimed",
+        "broad_trained_model_quality_claimed",
+        "brad_style_adaptation_claimed",
+    ]
+    claimed = [name for name in blocked_claims if bool(readiness.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairAudioPackageError(
+            f"unexpected upstream claim: {claimed}"
+        )
+    candidates: list[dict[str, Any]] = []
+    for item in _list(probe_report.get("generated_candidates"))[: int(expected_count)]:
+        row = _dict(item)
+        midi_path = Path(str(row.get("midi_path") or ""))
+        if not midi_path.exists():
+            raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairAudioPackageError(
+                f"generated MIDI missing: {midi_path}"
+            )
+        rank = _int(row.get("rank"))
+        analysis = analysis_by_rank.get(rank, {})
+        candidates.append(
+            {
+                "rank": rank,
+                "midi_path": str(midi_path),
+                "midi_sha256": sha256_file(midi_path),
+                "density_pattern": _list(row.get("density_pattern")),
+                "phrase_vocabulary_source": str(row.get("phrase_vocabulary_source") or ""),
+                "note_count": _int(analysis.get("note_count")),
+                "bar_count": _int(analysis.get("bar_count")),
+                "max_abs_interval": _int(analysis.get("max_abs_interval")),
+                "duration_most_common_ratio": _float(analysis.get("duration_most_common_ratio")),
+                "ioi_most_common_ratio": _float(analysis.get("ioi_most_common_ratio")),
+                "analysis_flags": _list(analysis.get("analysis_flags")),
+            }
+        )
+    if len(candidates) != int(expected_count):
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairAudioPackageError("unexpected candidate count")
+    return candidates
+
+
+def build_render_plan(
+    candidates: list[dict[str, Any]],
+    *,
+    output_dir: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+) -> list[dict[str, Any]]:
+    renderer = Path(renderer_path)
+    soundfont = Path(soundfont_path).expanduser()
+    if not renderer.exists():
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairAudioPackageError(f"renderer not found: {renderer}")
+    if not soundfont.exists():
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairAudioPackageError(
+            f"soundfont not found: {soundfont}"
+        )
+    plan: list[dict[str, Any]] = []
+    for item in candidates:
+        wav_path = output_dir / "audio" / f"jazz_phrase_repair_rank_{int(item['rank']):02d}.wav"
+        plan.append(
+            {
+                **item,
+                "wav_path": str(wav_path),
+                "command": [
+                    str(renderer),
+                    "-ni",
+                    "-F",
+                    str(wav_path),
+                    "-r",
+                    str(sample_rate),
+                    str(soundfont),
+                    str(item["midi_path"]),
+                ],
+            }
+        )
+    return plan
+
+
+def execute_render_plan(
+    plan: list[dict[str, Any]],
+    *,
+    runner: CommandRunner = default_runner,
+) -> list[dict[str, Any]]:
+    rendered: list[dict[str, Any]] = []
+    for item in plan:
+        wav_path = Path(str(item["wav_path"]))
+        wav_path.parent.mkdir(parents=True, exist_ok=True)
+        completed = runner(item["command"])
+        if completed.returncode != 0:
+            raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairAudioPackageError(
+                f"render failed for rank {item['rank']}: {completed.stderr or completed.stdout}"
+            )
+        rendered.append(
+            {
+                "rank": item["rank"],
+                "midi_path": item["midi_path"],
+                "midi_sha256": item["midi_sha256"],
+                "density_pattern": item["density_pattern"],
+                "phrase_vocabulary_source": item["phrase_vocabulary_source"],
+                "note_count": item["note_count"],
+                "bar_count": item["bar_count"],
+                "max_abs_interval": item["max_abs_interval"],
+                "duration_most_common_ratio": item["duration_most_common_ratio"],
+                "ioi_most_common_ratio": item["ioi_most_common_ratio"],
+                "analysis_flags": item["analysis_flags"],
+                "wav_file": wav_meta(wav_path),
+                "command": list(item["command"]),
+                "stdout_tail": (completed.stdout or "")[-1000:],
+                "stderr_tail": (completed.stderr or "")[-1000:],
+            }
+        )
+    return rendered
+
+
+def build_repair_audio_package_report(
+    probe_report: dict[str, Any],
+    *,
+    output_dir: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+    expected_file_count: int,
+    runner: CommandRunner = default_runner,
+) -> dict[str, Any]:
+    candidates = validate_repair_probe(probe_report, expected_count=expected_file_count)
+    resolved_renderer = renderer_path or shutil.which("fluidsynth") or ""
+    resolved_soundfont = resolve_soundfont(soundfont_path)
+    plan = build_render_plan(
+        candidates,
+        output_dir=output_dir,
+        renderer_path=resolved_renderer,
+        soundfont_path=resolved_soundfont,
+        sample_rate=int(sample_rate),
+    )
+    rendered = execute_render_plan(plan, runner=runner)
+    durations = [_float(_dict(item.get("wav_file")).get("duration_seconds")) for item in rendered]
+    boundary = {
+        "boundary": BOUNDARY,
+        "source_boundary": SOURCE_BOUNDARY,
+        "candidate_count": int(len(candidates)),
+        "rendered_audio_file_count": int(len(rendered)),
+        "technical_wav_validation": True,
+        "audio_output_claimed": True,
+        "listening_review_completed": False,
+        "audio_rendered_quality_claimed": False,
+        "human_audio_preference_claimed": False,
+        "model_direct_generation_quality_claimed": False,
+        "midi_to_solo_musical_quality_claimed": False,
+        "broad_trained_model_quality_claimed": False,
+        "brad_style_adaptation_claimed": False,
+        "duration_seconds_min": min(durations) if durations else 0.0,
+        "duration_seconds_max": max(durations) if durations else 0.0,
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_boundary": SOURCE_BOUNDARY,
+        "renderer": {
+            "name": "fluidsynth",
+            "path": resolved_renderer,
+        },
+        "soundfont": {
+            "path": str(Path(resolved_soundfont).expanduser()),
+            "sha256": sha256_file(Path(resolved_soundfont).expanduser()),
+            "default_candidates_checked": [str(path) for path in default_soundfont_candidates()],
+        },
+        "rendered_audio_files": rendered,
+        "audio_package_boundary": boundary,
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "repaired MIDI candidates rendered to WAV for listening review without quality claim",
+        },
+        "not_proven": [
+            "listening_review_completed",
+            "audio_rendered_quality",
+            "human_audio_keep_preference",
+            "jazz_solo_musical_quality",
+            "model_direct_generation_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": "Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair listening review",
+    }
+
+
+def validate_repair_audio_package_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_file_count: int,
+    expected_sample_rate: int,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = _dict(report.get("audio_package_boundary"))
+    decision = _dict(report.get("decision"))
+    files = _list(report.get("rendered_audio_files"))
+    if expected_boundary and str(boundary.get("boundary") or "") != expected_boundary:
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairAudioPackageError(
+            f"expected boundary {expected_boundary}, got {boundary.get('boundary')}"
+        )
+    if len(files) != int(expected_file_count):
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairAudioPackageError("unexpected rendered file count")
+    for item in files:
+        wav_file = _dict(_dict(item).get("wav_file"))
+        if not bool(wav_file.get("exists", False)):
+            raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairAudioPackageError("missing rendered WAV")
+        if _int(wav_file.get("sample_rate")) != int(expected_sample_rate):
+            raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairAudioPackageError("unexpected sample rate")
+        if _int(wav_file.get("frame_count")) <= 0:
+            raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairAudioPackageError("empty WAV")
+        if _int(wav_file.get("size_bytes")) <= 44:
+            raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairAudioPackageError("invalid WAV size")
+    if require_no_quality_claim:
+        blocked = [
+            "listening_review_completed",
+            "audio_rendered_quality_claimed",
+            "human_audio_preference_claimed",
+            "model_direct_generation_quality_claimed",
+            "midi_to_solo_musical_quality_claimed",
+            "broad_trained_model_quality_claimed",
+            "brad_style_adaptation_claimed",
+        ]
+        claimed = [name for name in blocked if bool(boundary.get(name, True))]
+        if claimed:
+            raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairAudioPackageError(
+                f"unexpected quality claim: {claimed}"
+            )
+    return {
+        "boundary": str(boundary.get("boundary") or ""),
+        "source_boundary": str(boundary.get("source_boundary") or ""),
+        "candidate_count": _int(boundary.get("candidate_count")),
+        "rendered_audio_file_count": _int(boundary.get("rendered_audio_file_count")),
+        "technical_wav_validation": bool(boundary.get("technical_wav_validation", False)),
+        "listening_review_completed": bool(boundary.get("listening_review_completed", True)),
+        "human_audio_preference_claimed": bool(boundary.get("human_audio_preference_claimed", True)),
+        "midi_to_solo_musical_quality_claimed": bool(
+            boundary.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "duration_seconds_min": _float(boundary.get("duration_seconds_min")),
+        "duration_seconds_max": _float(boundary.get("duration_seconds_max")),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "wav_paths": [str(_dict(_dict(item).get("wav_file")).get("path") or "") for item in files],
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    boundary = report["audio_package_boundary"]
+    decision = report["decision"]
+    lines = [
+        "# Stage B MIDI-to-Solo Model-Direct Jazz Phrase Vocabulary Repair Audio Package",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{boundary['boundary']}`",
+        f"- source boundary: `{boundary['source_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- candidate count: `{boundary['candidate_count']}`",
+        f"- rendered audio file count: `{boundary['rendered_audio_file_count']}`",
+        f"- technical WAV validation: `{_bool_token(boundary['technical_wav_validation'])}`",
+        f"- duration range: `{float(boundary['duration_seconds_min']):.3f}s-{float(boundary['duration_seconds_max']):.3f}s`",
+        f"- listening review completed: `{_bool_token(boundary['listening_review_completed'])}`",
+        f"- human/audio preference claimed: `{_bool_token(boundary['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(boundary['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Rendered Files",
+        "",
+        "| rank | midi path | wav path | duration | sample rate | size | sha256 |",
+        "|---:|---|---|---:|---:|---:|---|",
+    ]
+    for item in report.get("rendered_audio_files", []):
+        wav_file = item["wav_file"]
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(item["rank"]),
+                    str(item["midi_path"]),
+                    str(wav_file["path"]),
+                    f"{float(wav_file['duration_seconds']):.3f}",
+                    str(wav_file["sample_rate"]),
+                    str(wav_file["size_bytes"]),
+                    str(wav_file["sha256"][:12]),
+                ]
+            )
+            + " |"
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build repaired jazz phrase WAV package")
+    parser.add_argument("--repair_probe", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--renderer", type=str, default=shutil.which("fluidsynth") or "")
+    parser.add_argument("--soundfont", type=str, default="")
+    parser.add_argument("--sample_rate", type=int, default=44100)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_file_count", type=int, default=3)
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report = build_repair_audio_package_report(
+        read_json(Path(args.repair_probe)),
+        output_dir=output_dir,
+        renderer_path=str(args.renderer or ""),
+        soundfont_path=str(args.soundfont or ""),
+        sample_rate=int(args.sample_rate),
+        expected_file_count=int(args.expected_file_count),
+    )
+    summary = validate_repair_audio_package_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_file_count=int(args.expected_file_count),
+        expected_sample_rate=int(args.sample_rate),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    write_json(output_dir / "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package.json", report)
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package.py
+++ b/tests/test_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+import wave
+from pathlib import Path
+from typing import Sequence
+
+from scripts.build_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairAudioPackageError,
+    build_repair_audio_package_report,
+    validate_repair_audio_package_report,
+)
+
+
+def fake_midi(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"MThd\x00\x00\x00\x06\x00\x00\x00\x01\x00`MTrk\x00\x00\x00\x04\x00\xff/\x00")
+
+
+def write_wav(path: Path, sample_rate: int = 44100) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(2)
+        handle.setsampwidth(2)
+        handle.setframerate(sample_rate)
+        handle.writeframes(b"\x00\x00\x00\x00" * sample_rate)
+
+
+def fake_runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    output_index = list(command).index("-F") + 1
+    write_wav(Path(command[output_index]))
+    return subprocess.CompletedProcess(list(command), 0, stdout="rendered", stderr="")
+
+
+def repair_probe(root: Path, *, quality_claim: bool = False, target_passed: bool = True) -> dict:
+    midi_paths = [root / f"jazz_phrase_repair_rank_{index:02d}.mid" for index in range(1, 4)]
+    for path in midi_paths:
+        fake_midi(path)
+    return {
+        "schema_version": "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe_v1",
+        "boundary": "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe",
+        "generated_candidates": [
+            {
+                "rank": index,
+                "midi_path": str(path),
+                "density_pattern": [5, 3, 6, 4, 5, 4, 6, 3],
+                "phrase_vocabulary_source": "repair_probe_data_guided_phrase_cells",
+            }
+            for index, path in enumerate(midi_paths, start=1)
+        ],
+        "candidate_analyses": [
+            {
+                "rank": index,
+                "note_count": 36,
+                "bar_count": 8,
+                "max_abs_interval": 10 + (index % 2),
+                "duration_most_common_ratio": 0.25,
+                "ioi_most_common_ratio": 0.31,
+                "analysis_flags": [],
+            }
+            for index in range(1, 4)
+        ],
+        "repair_result": {
+            "target_passed": target_passed,
+            "no_overlap": True,
+        },
+        "readiness": {
+            "boundary": "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe",
+            "repair_probe_completed": True,
+            "objective_repair_target_passed": target_passed,
+            "generated_midi_file_count": 3,
+            "human_audio_preference_claimed": False,
+            "model_direct_candidate_keep_claimed": False,
+            "model_direct_generation_quality_claimed": quality_claim,
+            "midi_to_solo_musical_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "next_boundary": BOUNDARY,
+        },
+    }
+
+
+class StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairAudioPackageTest(unittest.TestCase):
+    def test_builds_audio_package_without_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            soundfont = root / "piano.sf2"
+            renderer.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            report = build_repair_audio_package_report(
+                repair_probe(root),
+                output_dir=root / "audio_package",
+                renderer_path=str(renderer),
+                soundfont_path=str(soundfont),
+                sample_rate=44100,
+                expected_file_count=3,
+                runner=fake_runner,
+            )
+            summary = validate_repair_audio_package_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_file_count=3,
+                expected_sample_rate=44100,
+                require_no_quality_claim=True,
+            )
+
+        self.assertEqual(summary["source_boundary"], "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe")
+        self.assertEqual(summary["candidate_count"], 3)
+        self.assertEqual(summary["rendered_audio_file_count"], 3)
+        self.assertTrue(summary["technical_wav_validation"])
+        self.assertFalse(summary["listening_review_completed"])
+        self.assertFalse(summary["human_audio_preference_claimed"])
+        self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+        self.assertFalse(summary["critical_user_input_required"])
+        self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
+        self.assertEqual(len(summary["wav_paths"]), 3)
+
+    def test_rejects_unpassed_probe(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            soundfont = root / "piano.sf2"
+            renderer.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            with self.assertRaises(StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairAudioPackageError):
+                build_repair_audio_package_report(
+                    repair_probe(root, target_passed=False),
+                    output_dir=root / "audio_package",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(soundfont),
+                    sample_rate=44100,
+                    expected_file_count=3,
+                    runner=fake_runner,
+                )
+
+    def test_rejects_upstream_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            soundfont = root / "piano.sf2"
+            renderer.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            with self.assertRaises(StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairAudioPackageError):
+                build_repair_audio_package_report(
+                    repair_probe(root, quality_claim=True),
+                    output_dir=root / "audio_package",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(soundfont),
+                    sample_rate=44100,
+                    expected_file_count=3,
+                    runner=fake_runner,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary
- #522 repaired MIDI 후보 3개 WAV render package 추가
- technical WAV metadata 검증 및 duration range 기록
- listening review 전 human/audio preference, MIDI-to-solo musical quality claim 차단

Context
- #522 objective gate 기준 fixed-density, four-note template, duration/IOI monotony, interval-cap compression 분리
- 남은 검토 대상: repaired 후보의 실제 listening review
- 현재 범위: WAV technical output package, 품질 판정 제외

Scope
- audio package build script 추가
- unit test 추가
- 전용 harness mode 추가
- CURRENT_STATUS_AND_PLAN, CORE_PLAN, AGENTS handoff 갱신

Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package tests.test_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe
- .venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package.py scripts/run_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-jazz-phrase-vocabulary-repair-audio-package
- bash scripts/agent_harness.sh quick

Risk
- WAV technical validation만 완료
- listening review completed: false
- human/audio preference claim: false
- MIDI-to-solo musical quality claim: false

Follow-up
- Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair listening review

Closes #524