### PR TITLE
Stage B MIDI-to-solo jazz phrase repair listening review boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #524, Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair audio package.
+- Latest functional issue completed: Issue #526, Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair listening review boundary.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair listening review.
+- Recommended next issue: Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair objective-only next decision.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -907,6 +907,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-jazz-phrase-voca
 ```
 
 This harness renders repaired MIDI candidates to local WAV files and validates technical WAV metadata without claiming listening quality.
+
+For Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair listening review changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-jazz-phrase-vocabulary-repair-listening-review
+```
+
+This harness prepares pending listening review input and blocks preference fill while review input is missing.
 
 For Stage B generic jazz base readiness audit changes, run:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -152,8 +152,14 @@ MVP가 끝났다고 볼 수 있는 조건:
 - model-direct jazz phrase vocabulary repair audio package listening review completed: `false`
 - model-direct jazz phrase vocabulary repair audio package human/audio preference claim: `false`
 - model-direct jazz phrase vocabulary repair audio package MIDI-to-solo musical quality claim: `false`
-- next review target: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review`
-- 근거 문서: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_JAZZ_PHRASE_VOCABULARY_REPAIR_AUDIO_PACKAGE_2026-06-04.md`
+- model-direct jazz phrase vocabulary repair listening review input template written: `true`
+- model-direct jazz phrase vocabulary repair listening review validated input: `false`
+- model-direct jazz phrase vocabulary repair listening review preference fill allowed: `false`
+- model-direct jazz phrase vocabulary repair listening review pending status/candidate decision/candidate field: `4/3/9`
+- model-direct jazz phrase vocabulary repair listening review human/audio preference claim: `false`
+- model-direct jazz phrase vocabulary repair listening review MIDI-to-solo musical quality claim: `false`
+- next review target: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_only_next_decision`
+- 근거 문서: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_JAZZ_PHRASE_VOCABULARY_REPAIR_LISTENING_REVIEW_2026-06-04.md`
 - margin-recovered timing/repetition focused listening notes 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_NOTES_2026-05-28.md`
 - margin-recovered timing/repetition focused listening fill 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_FILL_2026-05-28.md`
 - margin-recovered phrase/vocabulary repair 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_REPAIR_2026-05-28.md`
@@ -353,6 +359,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo model-direct jazz phrase vocabulary repair decision: target count `6`, distinct rhythm signatures required `true`, max allowed interval `12`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe`
 - MIDI-to-solo model-direct jazz phrase vocabulary repair probe: target passed `true`, generated MIDI `3`, fixed-density/four-note/duration/IOI/interval-cap/four-bar-cycle flags `0/0/0/0/0/0`, shared rhythm signature `1`, max interval `12`, no overlap `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package`
 - MIDI-to-solo model-direct jazz phrase vocabulary repair audio package: rendered WAV `3`, duration range `18.975s-18.988s`, technical validation `true`, listening review/preference/quality claim `false`, next boundary `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review`
+- MIDI-to-solo model-direct jazz phrase vocabulary repair listening review: template `true`, validated input `false`, preference fill `false`, pending fields `4/3/9`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_only_next_decision`
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
 - generic base readiness audit: phase4 prep ready `true`, broad training execution ready `false`, broad quality/Brad adaptation claim `false`
 - generic base manifest contract: generic split `2433/270`, Brad split `47/11/14`, leakage/overlap `0`, broad training execution ready `false`

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #524, Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair audio package
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair listening review`
+- latest functional result: Issue #526, Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair listening review boundary
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair objective-only next decision`
 
 현재 범위가 아닌 것:
 
@@ -1051,6 +1051,58 @@ Rendered WAV:
 다음:
 
 - `Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair listening review`
+
+## Stage B MIDI-to-Solo Model-Direct Jazz Phrase Vocabulary Repair Listening Review Boundary Result
+
+Issue #526은 #524 repaired WAV 후보 3개에 대한 listening review 입력 템플릿과 pending guard를 기록한 작업이다.
+
+변경:
+
+- jazz phrase vocabulary repair listening review boundary script 추가
+- #524 audio package report 검증
+- 후보별 review input template 생성
+- pending review input summary 기록
+- 입력 미작성 상태에서 preference fill 및 quality claim 차단
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_JAZZ_PHRASE_VOCABULARY_REPAIR_LISTENING_REVIEW_2026-06-04.md`
+- boundary: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review`
+- source boundary: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package`
+- next boundary: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_only_next_decision`
+- candidate count: `3`
+- rendered audio file count: `3`
+- review input template written: `true`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- pending status fields: `4`
+- pending candidate decisions: `3`
+- pending candidate fields: `9`
+- listening review completed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+Review input:
+
+- `outputs/stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review/harness_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review/review/jazz_phrase_repair_listening_review_input.md`
+
+판단:
+
+- #524 WAV 후보는 review 입력 템플릿까지 준비됨
+- 실제 청음 입력이 없으므로 preference fill 차단
+- 다음 검토 대상은 사용자 선호 claim 없이 MIDI/objective evidence 기준 next decision
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review tests.test_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review.py scripts/build_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package.py`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-jazz-phrase-vocabulary-repair-listening-review`
+
+다음:
+
+- `Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair objective-only next decision`
 
 ## Previous Model Decision
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_JAZZ_PHRASE_VOCABULARY_REPAIR_LISTENING_REVIEW_2026-06-04.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_JAZZ_PHRASE_VOCABULARY_REPAIR_LISTENING_REVIEW_2026-06-04.md
@@ -1,0 +1,34 @@
+# Stage B MIDI-to-Solo Model-Direct Jazz Phrase Vocabulary Repair Listening Review
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review`
+- source boundary: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package`
+- next boundary: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_only_next_decision`
+- candidate count: `3`
+- rendered audio file count: `3`
+- review input template written: `true`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- listening review completed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Pending Fields
+
+- pending status fields: `4`
+- pending candidate decisions: `3`
+- pending candidate fields: `9`
+
+## Review Input
+
+- template: `outputs/stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review/harness_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review/review/jazz_phrase_repair_listening_review_input.md`
+
+## Not Proven
+
+- `listening_review_completed`
+- `human_audio_preference`
+- `model_direct_generation_quality`
+- `midi_to_solo_musical_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -4201,6 +4201,27 @@ run_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_packag
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review() {
+  local audio_package_run_id="${AUDIO_PACKAGE_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package}"
+  local repair_probe_run_id="${REPAIR_PROBE_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review}"
+  local audio_package="outputs/stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package/${audio_package_run_id}/stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package.json"
+  if [[ ! -f "$audio_package" ]]; then
+    print_header "Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair audio package"
+    RUN_ID="$audio_package_run_id" REPAIR_PROBE_RUN_ID="$repair_probe_run_id" run_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package
+  fi
+  print_header "Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair listening review"
+  "$PYTHON_BIN" scripts/build_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review.py \
+    --run_id "$run_id" \
+    --audio_package "$audio_package" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_JAZZ_PHRASE_VOCABULARY_REPAIR_LISTENING_REVIEW_2026-06-04.md \
+    --expected_boundary stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review \
+    --expected_next_boundary stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_only_next_decision \
+    --expected_file_count 3 \
+    --require_pending_review \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -5647,6 +5668,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-model-direct-jazz-phrase-vocabulary-repair-audio-package)
     run_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package
+    ;;
+  stage-b-midi-to-solo-model-direct-jazz-phrase-vocabulary-repair-listening-review)
+    run_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/build_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review.py
+++ b/scripts/build_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review.py
@@ -1,0 +1,409 @@
+"""Build pending listening review boundary for jazz phrase repair WAV candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+from scripts.build_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+)
+from scripts.guard_stage_b_midi_to_solo_model_direct_user_listening_review_input import (  # noqa: E402
+    parse_review_input,
+)
+
+
+class StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairListeningReviewError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_only_next_decision"
+SCHEMA_VERSION = "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review_v1"
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairListeningReviewError(f"report missing: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def compact_rendered_candidate(item: dict[str, Any]) -> dict[str, Any]:
+    wav_file = _dict(item.get("wav_file"))
+    wav_path = Path(str(wav_file.get("path") or ""))
+    if not bool(wav_file.get("exists", False)) or not wav_path.exists():
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairListeningReviewError(
+            f"missing WAV for rank {item.get('rank')}"
+        )
+    return {
+        "rank": _int(item.get("rank")),
+        "midi_path": str(item.get("midi_path") or ""),
+        "midi_sha256": str(item.get("midi_sha256") or ""),
+        "wav_path": str(wav_path),
+        "wav_sha256": str(wav_file.get("sha256") or ""),
+        "duration_seconds": _float(wav_file.get("duration_seconds")),
+        "sample_rate": _int(wav_file.get("sample_rate")),
+        "size_bytes": _int(wav_file.get("size_bytes")),
+        "note_count": _int(item.get("note_count")),
+        "bar_count": _int(item.get("bar_count")),
+        "max_abs_interval": _int(item.get("max_abs_interval")),
+        "duration_most_common_ratio": _float(item.get("duration_most_common_ratio")),
+        "ioi_most_common_ratio": _float(item.get("ioi_most_common_ratio")),
+        "analysis_flags": _list(item.get("analysis_flags")),
+        "density_pattern": _list(item.get("density_pattern")),
+        "phrase_vocabulary_source": str(item.get("phrase_vocabulary_source") or ""),
+    }
+
+
+def validate_audio_package(audio_package: dict[str, Any], expected_count: int) -> list[dict[str, Any]]:
+    boundary = _dict(audio_package.get("audio_package_boundary"))
+    decision = _dict(audio_package.get("decision"))
+    if str(boundary.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairListeningReviewError(
+            "jazz phrase repair audio package boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != BOUNDARY:
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairListeningReviewError(
+            "audio package must route to listening review boundary"
+        )
+    if not bool(boundary.get("technical_wav_validation", False)):
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairListeningReviewError(
+            "technical WAV validation required"
+        )
+    blocked_claims = [
+        "listening_review_completed",
+        "audio_rendered_quality_claimed",
+        "human_audio_preference_claimed",
+        "model_direct_generation_quality_claimed",
+        "midi_to_solo_musical_quality_claimed",
+        "broad_trained_model_quality_claimed",
+        "brad_style_adaptation_claimed",
+    ]
+    claimed = [name for name in blocked_claims if bool(boundary.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairListeningReviewError(
+            f"unexpected upstream claim: {claimed}"
+        )
+    candidates = [
+        compact_rendered_candidate(item)
+        for item in _list(audio_package.get("rendered_audio_files"))
+        if isinstance(item, dict)
+    ]
+    if len(candidates) != int(expected_count):
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairListeningReviewError(
+            "unexpected rendered candidate count"
+        )
+    return candidates
+
+
+def listening_review_template(candidates: list[dict[str, Any]]) -> str:
+    lines = [
+        "# Stage B MIDI-to-Solo Jazz Phrase Repair Listening Review Input",
+        "",
+        "## Review Status",
+        "",
+        "- reviewer: `pending`",
+        "- reviewed_at: `pending`",
+        "- preferred_rank: `pending`",
+        "- reject_all: `pending`",
+        "- broad_model_quality_claim_allowed: `false`",
+        "",
+        "## Candidates",
+        "",
+        "| rank | midi | wav | note count | max interval | duration ratio | IOI ratio | decision |",
+        "|---:|---|---|---:|---:|---:|---:|---|",
+    ]
+    for item in candidates:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(item["rank"]),
+                    item["midi_path"],
+                    item["wav_path"],
+                    str(item["note_count"]),
+                    str(item["max_abs_interval"]),
+                    f"{float(item['duration_most_common_ratio']):.4f}",
+                    f"{float(item['ioi_most_common_ratio']):.4f}",
+                    "`pending`",
+                ]
+            )
+            + " |"
+        )
+    lines.extend(["", "## Per-Candidate Notes", ""])
+    for item in candidates:
+        lines.extend(
+            [
+                f"### Rank {int(item['rank'])}",
+                "",
+                "- musical_acceptance: `pending`",
+                "- issue_tags: `pending`",
+                "- short_note: `pending`",
+                "",
+            ]
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_listening_review_report(
+    audio_package: dict[str, Any],
+    *,
+    output_dir: Path,
+    expected_file_count: int,
+) -> dict[str, Any]:
+    candidates = validate_audio_package(audio_package, expected_count=expected_file_count)
+    review_input_path = output_dir / "review" / "jazz_phrase_repair_listening_review_input.md"
+    write_text(review_input_path, listening_review_template(candidates))
+    parsed = parse_review_input(review_input_path.read_text(encoding="utf-8"))
+    validated_review_input = bool(parsed.get("validated_review_input_present", False))
+    boundary = {
+        "boundary": BOUNDARY,
+        "source_boundary": SOURCE_BOUNDARY,
+        "candidate_count": len(candidates),
+        "rendered_audio_file_count": len(candidates),
+        "review_input_template_written": True,
+        "validated_review_input_present": validated_review_input,
+        "preference_fill_allowed": validated_review_input,
+        "listening_review_completed": False,
+        "human_audio_preference_claimed": False,
+        "model_direct_generation_quality_claimed": False,
+        "midi_to_solo_musical_quality_claimed": False,
+        "broad_trained_model_quality_claimed": False,
+        "brad_style_adaptation_claimed": False,
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "boundary": BOUNDARY,
+        "source_boundary": SOURCE_BOUNDARY,
+        "review_candidates": candidates,
+        "review_input_template_path": str(review_input_path),
+        "review_input_summary": parsed,
+        "listening_review_boundary": boundary,
+        "readiness": {
+            "boundary": BOUNDARY,
+            "listening_review_boundary_prepared": True,
+            "validated_review_input_present": validated_review_input,
+            "preference_fill_allowed": validated_review_input,
+            "listening_review_completed": False,
+            "human_audio_preference_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "listening review input remains pending; route to objective-only next decision without preference claim",
+        },
+        "not_proven": [
+            "listening_review_completed",
+            "human_audio_preference",
+            "model_direct_generation_quality",
+            "midi_to_solo_musical_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": "Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair objective-only next decision",
+    }
+
+
+def validate_listening_review_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    expected_file_count: int,
+    require_pending_review: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = _dict(report.get("listening_review_boundary"))
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    if expected_boundary and str(boundary.get("boundary") or "") != expected_boundary:
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairListeningReviewError(
+            f"expected boundary {expected_boundary}, got {boundary.get('boundary')}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairListeningReviewError(
+            "unexpected next boundary"
+        )
+    if _int(boundary.get("candidate_count")) != int(expected_file_count):
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairListeningReviewError(
+            "unexpected candidate count"
+        )
+    if not Path(str(report.get("review_input_template_path") or "")).exists():
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairListeningReviewError(
+            "review input template missing"
+        )
+    if require_pending_review and bool(boundary.get("validated_review_input_present", True)):
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairListeningReviewError(
+            "review input should remain pending"
+        )
+    if require_no_quality_claim:
+        blocked = [
+            "listening_review_completed",
+            "human_audio_preference_claimed",
+            "model_direct_generation_quality_claimed",
+            "midi_to_solo_musical_quality_claimed",
+            "broad_trained_model_quality_claimed",
+            "brad_style_adaptation_claimed",
+        ]
+        claimed = [name for name in blocked if bool(readiness.get(name, True))]
+        if claimed:
+            raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairListeningReviewError(
+                f"unexpected quality claim: {claimed}"
+            )
+    review_summary = _dict(report.get("review_input_summary"))
+    return {
+        "boundary": str(boundary.get("boundary") or ""),
+        "source_boundary": str(boundary.get("source_boundary") or ""),
+        "candidate_count": _int(boundary.get("candidate_count")),
+        "rendered_audio_file_count": _int(boundary.get("rendered_audio_file_count")),
+        "review_input_template_written": bool(boundary.get("review_input_template_written", False)),
+        "validated_review_input_present": bool(boundary.get("validated_review_input_present", True)),
+        "preference_fill_allowed": bool(boundary.get("preference_fill_allowed", True)),
+        "pending_status_field_count": len(_list(review_summary.get("pending_status_fields"))),
+        "pending_candidate_decision_count": len(_list(review_summary.get("pending_candidate_decisions"))),
+        "pending_candidate_field_count": len(_list(review_summary.get("pending_candidate_fields"))),
+        "listening_review_completed": bool(readiness.get("listening_review_completed", True)),
+        "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "review_input_template_path": str(report.get("review_input_template_path") or ""),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    boundary = report["listening_review_boundary"]
+    decision = report["decision"]
+    summary = report["review_input_summary"]
+    lines = [
+        "# Stage B MIDI-to-Solo Model-Direct Jazz Phrase Vocabulary Repair Listening Review",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{boundary['boundary']}`",
+        f"- source boundary: `{boundary['source_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- candidate count: `{boundary['candidate_count']}`",
+        f"- rendered audio file count: `{boundary['rendered_audio_file_count']}`",
+        f"- review input template written: `{_bool_token(boundary['review_input_template_written'])}`",
+        f"- validated review input present: `{_bool_token(boundary['validated_review_input_present'])}`",
+        f"- preference fill allowed: `{_bool_token(boundary['preference_fill_allowed'])}`",
+        f"- listening review completed: `{_bool_token(boundary['listening_review_completed'])}`",
+        f"- human/audio preference claimed: `{_bool_token(boundary['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(boundary['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Pending Fields",
+        "",
+        f"- pending status fields: `{len(_list(summary.get('pending_status_fields')))}`",
+        f"- pending candidate decisions: `{len(_list(summary.get('pending_candidate_decisions')))}`",
+        f"- pending candidate fields: `{len(_list(summary.get('pending_candidate_fields')))}`",
+        "",
+        "## Review Input",
+        "",
+        f"- template: `{report['review_input_template_path']}`",
+        "",
+        "## Not Proven",
+        "",
+    ]
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build jazz phrase repair listening review boundary")
+    parser.add_argument("--audio_package", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--expected_file_count", type=int, default=3)
+    parser.add_argument("--require_pending_review", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report = build_listening_review_report(
+        read_json(Path(args.audio_package)),
+        output_dir=output_dir,
+        expected_file_count=int(args.expected_file_count),
+    )
+    summary = validate_listening_review_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        expected_file_count=int(args.expected_file_count),
+        require_pending_review=bool(args.require_pending_review),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    write_json(output_dir / "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review.json", report)
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review.py
+++ b/tests/test_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.build_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairListeningReviewError,
+    build_listening_review_report,
+    validate_listening_review_report,
+)
+
+
+def fake_wav(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"RIFF" + (b"\x00" * 128))
+
+
+def audio_package(root: Path, *, quality_claim: bool = False, technical_valid: bool = True) -> dict:
+    rendered = []
+    for rank in range(1, 4):
+        wav_path = root / f"rank_{rank:02d}.wav"
+        fake_wav(wav_path)
+        rendered.append(
+            {
+                "rank": rank,
+                "midi_path": str(root / f"rank_{rank:02d}.mid"),
+                "midi_sha256": str(rank) * 64,
+                "density_pattern": [5, 3, 6, 4, 5, 4, 6, 3],
+                "phrase_vocabulary_source": "repair_probe_data_guided_phrase_cells",
+                "note_count": 36,
+                "bar_count": 8,
+                "max_abs_interval": 12,
+                "duration_most_common_ratio": 0.25,
+                "ioi_most_common_ratio": 0.28,
+                "analysis_flags": [],
+                "wav_file": {
+                    "path": str(wav_path),
+                    "exists": True,
+                    "duration_seconds": 18.98,
+                    "sample_rate": 44100,
+                    "size_bytes": wav_path.stat().st_size,
+                    "sha256": str(rank) * 64,
+                },
+            }
+        )
+    return {
+        "schema_version": "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package_v1",
+        "audio_package_boundary": {
+            "boundary": "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package",
+            "source_boundary": "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe",
+            "candidate_count": 3,
+            "rendered_audio_file_count": 3,
+            "technical_wav_validation": technical_valid,
+            "listening_review_completed": False,
+            "audio_rendered_quality_claimed": False,
+            "human_audio_preference_claimed": False,
+            "model_direct_generation_quality_claimed": quality_claim,
+            "midi_to_solo_musical_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "next_boundary": BOUNDARY,
+            "critical_user_input_required": False,
+        },
+        "rendered_audio_files": rendered,
+    }
+
+
+class StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairListeningReviewTest(unittest.TestCase):
+    def test_builds_pending_listening_review_without_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            report = build_listening_review_report(
+                audio_package(root),
+                output_dir=root / "review",
+                expected_file_count=3,
+            )
+            summary = validate_listening_review_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                expected_file_count=3,
+                require_pending_review=True,
+                require_no_quality_claim=True,
+            )
+
+        self.assertEqual(summary["candidate_count"], 3)
+        self.assertTrue(summary["review_input_template_written"])
+        self.assertFalse(summary["validated_review_input_present"])
+        self.assertFalse(summary["preference_fill_allowed"])
+        self.assertGreater(summary["pending_status_field_count"], 0)
+        self.assertGreater(summary["pending_candidate_decision_count"], 0)
+        self.assertGreater(summary["pending_candidate_field_count"], 0)
+        self.assertFalse(summary["human_audio_preference_claimed"])
+        self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+        self.assertFalse(summary["critical_user_input_required"])
+        self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
+
+    def test_rejects_upstream_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with self.assertRaises(StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairListeningReviewError):
+                build_listening_review_report(
+                    audio_package(root, quality_claim=True),
+                    output_dir=root / "review",
+                    expected_file_count=3,
+                )
+
+    def test_rejects_missing_technical_wav_validation(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with self.assertRaises(StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairListeningReviewError):
+                build_listening_review_report(
+                    audio_package(root, technical_valid=False),
+                    output_dir=root / "review",
+                    expected_file_count=3,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary
- #524 repaired WAV 후보 3개 listening review boundary 추가
- review input template 생성
- 입력 미작성 상태에서 preference fill 및 quality claim 차단

Context
- #524 결과: rendered WAV 3개, technical WAV validation true
- listening review completed: false
- human/audio preference claim: false
- MIDI-to-solo musical quality claim: false
- 현재 범위: review input 준비와 pending guard 기록

Scope
- audio package report 검증
- 후보별 review input template 생성
- pending review input field count 기록
- objective-only next decision boundary 연결
- CURRENT_STATUS_AND_PLAN, CORE_PLAN, AGENTS handoff 갱신

Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review tests.test_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package
- .venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review.py scripts/build_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-jazz-phrase-vocabulary-repair-listening-review
- bash scripts/agent_harness.sh quick

Risk
- validated review input present: false
- preference fill allowed: false
- human/audio preference claim: false
- MIDI-to-solo musical quality claim: false

Follow-up
- Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair objective-only next decision

Closes #526