### PR TITLE
Stage B MIDI-to-solo jazz phrase objective-only next decision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #526, Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair listening review boundary.
+- Latest functional issue completed: Issue #528, Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair objective-only next decision.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair objective-only next decision.
+- Recommended next issue: Stage B MIDI-to-solo model-direct jazz phrase vocabulary contour phrase-shape repair.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -915,6 +915,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-jazz-phrase-voca
 ```
 
 This harness prepares pending listening review input and blocks preference fill while review input is missing.
+
+For Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair objective-only next decision changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-jazz-phrase-vocabulary-repair-objective-next
+```
+
+This harness routes pending listening review evidence to the next objective repair target without claiming listening quality.
 
 For Stage B generic jazz base readiness audit changes, run:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -158,8 +158,13 @@ MVP가 끝났다고 볼 수 있는 조건:
 - model-direct jazz phrase vocabulary repair listening review pending status/candidate decision/candidate field: `4/3/9`
 - model-direct jazz phrase vocabulary repair listening review human/audio preference claim: `false`
 - model-direct jazz phrase vocabulary repair listening review MIDI-to-solo musical quality claim: `false`
-- next review target: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_only_next_decision`
-- 근거 문서: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_JAZZ_PHRASE_VOCABULARY_REPAIR_LISTENING_REVIEW_2026-06-04.md`
+- model-direct jazz phrase vocabulary repair objective-only decision completed: `true`
+- model-direct jazz phrase vocabulary repair objective-only stepwise contour bias count: `3`
+- model-direct jazz phrase vocabulary repair objective-only distinct density pattern count: `3`
+- model-direct jazz phrase vocabulary repair objective-only max abs interval max: `12`
+- model-direct jazz phrase vocabulary repair objective-only targets: `reduce_stepwise_contour_bias`, `add_phrase_shape_tension_release`, `add_approach_enclosure_cells`, `preserve_density_variation`, `preserve_interval_guard`, `preserve_no_quality_claim`
+- next review target: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_contour_phrase_shape_repair`
+- 근거 문서: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_JAZZ_PHRASE_VOCABULARY_REPAIR_OBJECTIVE_NEXT_DECISION_2026-06-04.md`
 - margin-recovered timing/repetition focused listening notes 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_NOTES_2026-05-28.md`
 - margin-recovered timing/repetition focused listening fill 문서: `docs/STAGE_B_MARGIN_RECOVERED_TIMING_REPETITION_FOCUSED_LISTENING_FILL_2026-05-28.md`
 - margin-recovered phrase/vocabulary repair 문서: `docs/STAGE_B_MARGIN_RECOVERED_PHRASE_VOCABULARY_REPAIR_2026-05-28.md`
@@ -360,6 +365,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo model-direct jazz phrase vocabulary repair probe: target passed `true`, generated MIDI `3`, fixed-density/four-note/duration/IOI/interval-cap/four-bar-cycle flags `0/0/0/0/0/0`, shared rhythm signature `1`, max interval `12`, no overlap `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package`
 - MIDI-to-solo model-direct jazz phrase vocabulary repair audio package: rendered WAV `3`, duration range `18.975s-18.988s`, technical validation `true`, listening review/preference/quality claim `false`, next boundary `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review`
 - MIDI-to-solo model-direct jazz phrase vocabulary repair listening review: template `true`, validated input `false`, preference fill `false`, pending fields `4/3/9`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_only_next_decision`
+- MIDI-to-solo model-direct jazz phrase vocabulary repair objective-only next decision: stepwise contour bias `3/3`, distinct density pattern `3`, max interval `12`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_contour_phrase_shape_repair`
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
 - generic base readiness audit: phase4 prep ready `true`, broad training execution ready `false`, broad quality/Brad adaptation claim `false`
 - generic base manifest contract: generic split `2433/270`, Brad split `47/11/14`, leakage/overlap `0`, broad training execution ready `false`

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #526, Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair listening review boundary
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair objective-only next decision`
+- latest functional result: Issue #528, Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair objective-only next decision
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-direct jazz phrase vocabulary contour phrase-shape repair`
 
 현재 범위가 아닌 것:
 
@@ -1103,6 +1103,62 @@ Review input:
 다음:
 
 - `Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair objective-only next decision`
+
+## Stage B MIDI-to-Solo Model-Direct Jazz Phrase Vocabulary Repair Objective-Only Next Decision Result
+
+Issue #528은 #526 pending review 상태에서 사용자 선호 claim 없이 MIDI/objective evidence 기준 다음 repair target을 결정한 작업이다.
+
+변경:
+
+- jazz phrase vocabulary repair objective-only next decision script 추가
+- #526 listening review boundary report 검증
+- 후보별 objective flag 집계
+- stepwise contour bias 잔여 신호 기반 repair target 정의
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_JAZZ_PHRASE_VOCABULARY_REPAIR_OBJECTIVE_NEXT_DECISION_2026-06-04.md`
+- boundary: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review`
+- next boundary: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_contour_phrase_shape_repair`
+- candidate count: `3`
+- stepwise contour bias count: `3`
+- all candidates stepwise biased: `true`
+- distinct density pattern count: `3`
+- max abs interval max: `12`
+- selected repair target count: `6`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+Selected repair targets:
+
+- `reduce_stepwise_contour_bias`
+- `add_phrase_shape_tension_release`
+- `add_approach_enclosure_cells`
+- `preserve_density_variation`
+- `preserve_interval_guard`
+- `preserve_no_quality_claim`
+
+판단:
+
+- rhythm density / repeated template failure는 #522 이후 objective 기준으로 분리
+- 청음 입력이 없으므로 preference fill은 계속 차단
+- 남은 objective signal은 후보 3개 모두의 stepwise contour bias
+- 다음 검토 대상은 density variation과 interval guard를 유지하면서 contour/phrase-shape를 보강하는 repair
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_next tests.test_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_next.py scripts/build_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review.py`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-jazz-phrase-vocabulary-repair-objective-next`
+
+다음:
+
+- `Stage B MIDI-to-solo model-direct jazz phrase vocabulary contour phrase-shape repair`
 
 ## Previous Model Decision
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_JAZZ_PHRASE_VOCABULARY_REPAIR_OBJECTIVE_NEXT_DECISION_2026-06-04.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_JAZZ_PHRASE_VOCABULARY_REPAIR_OBJECTIVE_NEXT_DECISION_2026-06-04.md
@@ -1,0 +1,34 @@
+# Stage B MIDI-to-Solo Model-Direct Jazz Phrase Vocabulary Repair Objective-Only Next Decision
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review`
+- next boundary: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_contour_phrase_shape_repair`
+- objective-only decision completed: `true`
+- candidate count: `3`
+- stepwise contour bias count: `3`
+- distinct density pattern count: `3`
+- max abs interval max: `12`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Selected Repair Targets
+
+- `reduce_stepwise_contour_bias`
+- `add_phrase_shape_tension_release`
+- `add_approach_enclosure_cells`
+- `preserve_density_variation`
+- `preserve_interval_guard`
+- `preserve_no_quality_claim`
+
+## Not Proven
+
+- `listening_review_completed`
+- `human_audio_preference`
+- `model_direct_generation_quality`
+- `midi_to_solo_musical_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -4222,6 +4222,29 @@ run_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_re
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_next() {
+  local listening_review_run_id="${LISTENING_REVIEW_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review}"
+  local audio_package_run_id="${AUDIO_PACKAGE_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package}"
+  local repair_probe_run_id="${REPAIR_PROBE_RUN_ID:-harness_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_probe}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_next}"
+  local listening_review="outputs/stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review/${listening_review_run_id}/stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review.json"
+  if [[ ! -f "$listening_review" ]]; then
+    print_header "Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair listening review"
+    RUN_ID="$listening_review_run_id" AUDIO_PACKAGE_RUN_ID="$audio_package_run_id" REPAIR_PROBE_RUN_ID="$repair_probe_run_id" run_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review
+  fi
+  print_header "Stage B MIDI-to-solo model-direct jazz phrase vocabulary repair objective-only next decision"
+  "$PYTHON_BIN" scripts/decide_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_next.py \
+    --run_id "$run_id" \
+    --listening_review "$listening_review" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MODEL_DIRECT_JAZZ_PHRASE_VOCABULARY_REPAIR_OBJECTIVE_NEXT_DECISION_2026-06-04.md \
+    --expected_boundary stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_only_next_decision \
+    --expected_next_boundary stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_contour_phrase_shape_repair \
+    --min_repair_target_count 6 \
+    --require_stepwise_target \
+    --require_pending_review \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -5671,6 +5694,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-model-direct-jazz-phrase-vocabulary-repair-listening-review)
     run_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review
+    ;;
+  stage-b-midi-to-solo-model-direct-jazz-phrase-vocabulary-repair-objective-next)
+    run_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_next
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/decide_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_next.py
+++ b/scripts/decide_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_next.py
@@ -1,0 +1,361 @@
+"""Decide the next objective-only repair after pending jazz phrase listening review."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+from scripts.build_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+)
+
+
+class StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairObjectiveNextError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_only_next_decision"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_contour_phrase_shape_repair"
+SCHEMA_VERSION = "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_next_v1"
+REPAIR_TARGETS = [
+    "reduce_stepwise_contour_bias",
+    "add_phrase_shape_tension_release",
+    "add_approach_enclosure_cells",
+    "preserve_density_variation",
+    "preserve_interval_guard",
+    "preserve_no_quality_claim",
+]
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairObjectiveNextError(f"report missing: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def validate_listening_review_boundary(report: dict[str, Any]) -> list[dict[str, Any]]:
+    boundary = _dict(report.get("listening_review_boundary"))
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    if str(boundary.get("boundary") or report.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairObjectiveNextError(
+            "listening review boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != BOUNDARY:
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairObjectiveNextError(
+            "listening review must route to objective-only decision"
+        )
+    if not bool(readiness.get("listening_review_boundary_prepared", False)):
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairObjectiveNextError(
+            "listening review boundary preparation required"
+        )
+    if bool(readiness.get("validated_review_input_present", True)):
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairObjectiveNextError(
+            "validated review input should be absent for objective-only decision"
+        )
+    blocked_claims = [
+        "listening_review_completed",
+        "human_audio_preference_claimed",
+        "model_direct_generation_quality_claimed",
+        "midi_to_solo_musical_quality_claimed",
+        "broad_trained_model_quality_claimed",
+        "brad_style_adaptation_claimed",
+    ]
+    claimed = [name for name in blocked_claims if bool(readiness.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairObjectiveNextError(
+            f"unexpected upstream claim: {claimed}"
+        )
+    candidates = [_dict(item) for item in _list(report.get("review_candidates")) if isinstance(item, dict)]
+    if len(candidates) < 1:
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairObjectiveNextError(
+            "review candidates required"
+        )
+    return candidates
+
+
+def objective_summary(candidates: list[dict[str, Any]]) -> dict[str, Any]:
+    flag_counter: Counter[str] = Counter()
+    density_patterns: set[tuple[int, ...]] = set()
+    note_counts: list[int] = []
+    max_intervals: list[int] = []
+    duration_ratios: list[float] = []
+    ioi_ratios: list[float] = []
+    for item in candidates:
+        for flag in _list(item.get("analysis_flags")):
+            flag_counter[str(flag)] += 1
+        density_patterns.add(tuple(_int(value) for value in _list(item.get("density_pattern"))))
+        note_counts.append(_int(item.get("note_count")))
+        max_intervals.append(_int(item.get("max_abs_interval")))
+        duration_ratios.append(_float(item.get("duration_most_common_ratio")))
+        ioi_ratios.append(_float(item.get("ioi_most_common_ratio")))
+    candidate_count = len(candidates)
+    return {
+        "candidate_count": candidate_count,
+        "flag_counts": dict(sorted(flag_counter.items())),
+        "stepwise_contour_bias_count": int(flag_counter.get("stepwise_contour_bias", 0)),
+        "all_candidates_stepwise_biased": int(flag_counter.get("stepwise_contour_bias", 0)) == candidate_count,
+        "distinct_density_pattern_count": len(density_patterns),
+        "fixed_density_count": 0 if len(density_patterns) == candidate_count else candidate_count - len(density_patterns),
+        "note_count_min": min(note_counts) if note_counts else 0,
+        "note_count_max": max(note_counts) if note_counts else 0,
+        "max_abs_interval_max": max(max_intervals) if max_intervals else 0,
+        "duration_most_common_ratio_max": max(duration_ratios) if duration_ratios else 0.0,
+        "ioi_most_common_ratio_max": max(ioi_ratios) if ioi_ratios else 0.0,
+    }
+
+
+def build_objective_next_decision_report(
+    listening_review: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> dict[str, Any]:
+    candidates = validate_listening_review_boundary(listening_review)
+    objective = objective_summary(candidates)
+    selected_targets = list(REPAIR_TARGETS)
+    boundary = {
+        "boundary": BOUNDARY,
+        "source_boundary": SOURCE_BOUNDARY,
+        "objective_only_decision_completed": True,
+        "validated_review_input_present": False,
+        "preference_fill_allowed": False,
+        "selected_next_boundary": NEXT_BOUNDARY,
+        "selected_repair_target_count": len(selected_targets),
+        "stepwise_contour_bias_count": _int(objective.get("stepwise_contour_bias_count")),
+        "candidate_count": _int(objective.get("candidate_count")),
+        "human_audio_preference_claimed": False,
+        "model_direct_generation_quality_claimed": False,
+        "midi_to_solo_musical_quality_claimed": False,
+        "broad_trained_model_quality_claimed": False,
+        "brad_style_adaptation_claimed": False,
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "boundary": BOUNDARY,
+        "source_boundary": SOURCE_BOUNDARY,
+        "objective_summary": objective,
+        "selected_repair_targets": selected_targets,
+        "objective_next_decision_boundary": boundary,
+        "readiness": {
+            "boundary": BOUNDARY,
+            "objective_only_decision_completed": True,
+            "validated_review_input_present": False,
+            "preference_fill_allowed": False,
+            "human_audio_preference_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "pending review blocks preference fill; objective flags route to contour and phrase-shape repair",
+        },
+        "not_proven": [
+            "listening_review_completed",
+            "human_audio_preference",
+            "model_direct_generation_quality",
+            "midi_to_solo_musical_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": "Stage B MIDI-to-solo model-direct jazz phrase vocabulary contour phrase-shape repair",
+    }
+
+
+def validate_objective_next_decision_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    min_repair_target_count: int,
+    require_stepwise_target: bool,
+    require_pending_review: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = _dict(report.get("objective_next_decision_boundary"))
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    targets = [str(item) for item in _list(report.get("selected_repair_targets"))]
+    if expected_boundary and str(boundary.get("boundary") or "") != expected_boundary:
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairObjectiveNextError(
+            f"expected boundary {expected_boundary}, got {boundary.get('boundary')}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairObjectiveNextError(
+            "unexpected next boundary"
+        )
+    if len(targets) < int(min_repair_target_count):
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairObjectiveNextError(
+            "not enough selected repair targets"
+        )
+    if require_stepwise_target and "reduce_stepwise_contour_bias" not in targets:
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairObjectiveNextError(
+            "stepwise contour repair target required"
+        )
+    if require_pending_review and bool(readiness.get("validated_review_input_present", True)):
+        raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairObjectiveNextError(
+            "review input should remain pending"
+        )
+    if require_no_quality_claim:
+        blocked = [
+            "human_audio_preference_claimed",
+            "model_direct_generation_quality_claimed",
+            "midi_to_solo_musical_quality_claimed",
+            "broad_trained_model_quality_claimed",
+            "brad_style_adaptation_claimed",
+        ]
+        claimed = [name for name in blocked if bool(readiness.get(name, True))]
+        if claimed:
+            raise StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairObjectiveNextError(
+                f"unexpected quality claim: {claimed}"
+            )
+    objective = _dict(report.get("objective_summary"))
+    return {
+        "boundary": str(boundary.get("boundary") or ""),
+        "source_boundary": str(boundary.get("source_boundary") or ""),
+        "candidate_count": _int(objective.get("candidate_count")),
+        "stepwise_contour_bias_count": _int(objective.get("stepwise_contour_bias_count")),
+        "all_candidates_stepwise_biased": bool(objective.get("all_candidates_stepwise_biased", False)),
+        "distinct_density_pattern_count": _int(objective.get("distinct_density_pattern_count")),
+        "max_abs_interval_max": _int(objective.get("max_abs_interval_max")),
+        "selected_repair_target_count": len(targets),
+        "selected_repair_targets": targets,
+        "validated_review_input_present": bool(readiness.get("validated_review_input_present", True)),
+        "preference_fill_allowed": bool(readiness.get("preference_fill_allowed", True)),
+        "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    boundary = report["objective_next_decision_boundary"]
+    decision = report["decision"]
+    objective = report["objective_summary"]
+    lines = [
+        "# Stage B MIDI-to-Solo Model-Direct Jazz Phrase Vocabulary Repair Objective-Only Next Decision",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{boundary['boundary']}`",
+        f"- source boundary: `{boundary['source_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- objective-only decision completed: `{_bool_token(boundary['objective_only_decision_completed'])}`",
+        f"- candidate count: `{objective['candidate_count']}`",
+        f"- stepwise contour bias count: `{objective['stepwise_contour_bias_count']}`",
+        f"- distinct density pattern count: `{objective['distinct_density_pattern_count']}`",
+        f"- max abs interval max: `{objective['max_abs_interval_max']}`",
+        f"- validated review input present: `{_bool_token(boundary['validated_review_input_present'])}`",
+        f"- preference fill allowed: `{_bool_token(boundary['preference_fill_allowed'])}`",
+        f"- human/audio preference claimed: `{_bool_token(boundary['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(boundary['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Selected Repair Targets",
+        "",
+    ]
+    for target in report.get("selected_repair_targets", []):
+        lines.append(f"- `{target}`")
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Decide objective-only next repair")
+    parser.add_argument("--listening_review", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_next",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--min_repair_target_count", type=int, default=6)
+    parser.add_argument("--require_stepwise_target", action="store_true")
+    parser.add_argument("--require_pending_review", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report = build_objective_next_decision_report(
+        read_json(Path(args.listening_review)),
+        output_dir=output_dir,
+    )
+    summary = validate_objective_next_decision_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        min_repair_target_count=int(args.min_repair_target_count),
+        require_stepwise_target=bool(args.require_stepwise_target),
+        require_pending_review=bool(args.require_pending_review),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    write_json(output_dir / "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_next.json", report)
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_next_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_next.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_next.py
+++ b/tests/test_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_next.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.decide_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_next import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairObjectiveNextError,
+    build_objective_next_decision_report,
+    validate_objective_next_decision_report,
+)
+
+
+def listening_review(*, validated_input: bool = False, quality_claim: bool = False) -> dict:
+    return {
+        "schema_version": "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review_v1",
+        "boundary": "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review",
+        "listening_review_boundary": {
+            "boundary": "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review",
+            "source_boundary": "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_audio_package",
+            "candidate_count": 3,
+            "rendered_audio_file_count": 3,
+            "review_input_template_written": True,
+            "validated_review_input_present": validated_input,
+            "preference_fill_allowed": validated_input,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+        },
+        "readiness": {
+            "boundary": "stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review",
+            "listening_review_boundary_prepared": True,
+            "validated_review_input_present": validated_input,
+            "preference_fill_allowed": validated_input,
+            "listening_review_completed": False,
+            "human_audio_preference_claimed": False,
+            "model_direct_generation_quality_claimed": quality_claim,
+            "midi_to_solo_musical_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "next_boundary": BOUNDARY,
+            "critical_user_input_required": False,
+        },
+        "review_candidates": [
+            {
+                "rank": rank,
+                "note_count": 36,
+                "max_abs_interval": 10 + (rank % 2) * 2,
+                "duration_most_common_ratio": 0.25 + (rank % 2) * 0.0833,
+                "ioi_most_common_ratio": 0.3142 + (rank % 2) * 0.0285,
+                "density_pattern": patterns[rank - 1],
+                "analysis_flags": ["stepwise_contour_bias"],
+            }
+            for rank, patterns in [
+                (1, [[5, 3, 6, 4, 5, 4, 6, 3], [6, 4, 3, 5, 6, 5, 3, 4], [5, 6, 4, 3, 5, 3, 6, 4]]),
+                (2, [[5, 3, 6, 4, 5, 4, 6, 3], [6, 4, 3, 5, 6, 5, 3, 4], [5, 6, 4, 3, 5, 3, 6, 4]]),
+                (3, [[5, 3, 6, 4, 5, 4, 6, 3], [6, 4, 3, 5, 6, 5, 3, 4], [5, 6, 4, 3, 5, 3, 6, 4]]),
+            ]
+        ],
+    }
+
+
+class StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairObjectiveNextTest(unittest.TestCase):
+    def test_routes_pending_review_to_contour_phrase_shape_repair(self) -> None:
+        report = build_objective_next_decision_report(
+            listening_review(),
+            output_dir=Path("outputs/objective_next"),
+        )
+        summary = validate_objective_next_decision_report(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=NEXT_BOUNDARY,
+            min_repair_target_count=6,
+            require_stepwise_target=True,
+            require_pending_review=True,
+            require_no_quality_claim=True,
+        )
+
+        self.assertEqual(summary["candidate_count"], 3)
+        self.assertEqual(summary["stepwise_contour_bias_count"], 3)
+        self.assertTrue(summary["all_candidates_stepwise_biased"])
+        self.assertEqual(summary["distinct_density_pattern_count"], 3)
+        self.assertIn("reduce_stepwise_contour_bias", summary["selected_repair_targets"])
+        self.assertFalse(summary["validated_review_input_present"])
+        self.assertFalse(summary["preference_fill_allowed"])
+        self.assertFalse(summary["human_audio_preference_claimed"])
+        self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+        self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
+
+    def test_rejects_validated_review_input_for_objective_only_path(self) -> None:
+        with self.assertRaises(StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairObjectiveNextError):
+            build_objective_next_decision_report(
+                listening_review(validated_input=True),
+                output_dir=Path("outputs/objective_next"),
+            )
+
+    def test_rejects_upstream_quality_claim(self) -> None:
+        with self.assertRaises(StageBMidiToSoloModelDirectJazzPhraseVocabularyRepairObjectiveNextError):
+            build_objective_next_decision_report(
+                listening_review(quality_claim=True),
+                output_dir=Path("outputs/objective_next"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary
- #526 pending listening review 상태에서 objective-only next decision 추가
- 후보 3개 stepwise contour bias 집계
- 다음 contour/phrase-shape repair boundary 지정

Context
- #526 결과: validated review input false, preference fill allowed false
- #524/#526 후보 3개 모두 quality claim 없음
- objective 지표: stepwise_contour_bias 3/3
- density variation과 interval guard는 유지 대상

Scope
- listening review boundary report 검증
- 후보별 objective flag 집계
- repair target 6개 정의
- CURRENT_STATUS_AND_PLAN, CORE_PLAN, AGENTS handoff 갱신

Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_next tests.test_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review
- .venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_objective_next.py scripts/build_stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_repair_listening_review.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-model-direct-jazz-phrase-vocabulary-repair-objective-next
- bash scripts/agent_harness.sh quick

Risk
- listening review completed: false
- human/audio preference claim: false
- MIDI-to-solo musical quality claim: false
- objective flag 기반 decision이며 실제 청음 대체 아님

Follow-up
- Stage B MIDI-to-solo model-direct jazz phrase vocabulary contour phrase-shape repair

Closes #528