### PR TITLE
Stage B MIDI-to-solo controlled checkpoint generation probe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #552, Stage B MIDI-to-solo controlled training scale smoke.
+- Latest functional issue completed: Issue #554, Stage B MIDI-to-solo controlled scale checkpoint generation probe.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo controlled scale checkpoint generation probe.
+- Recommended next issue: Stage B MIDI-to-solo controlled scale checkpoint repair decision.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1011,6 +1011,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-controlled-training-scale-smo
 ```
 
 This harness runs the bounded `512/128`, `max_sequence=160` local training smoke and summarizes checkpoint readiness without claiming model quality.
+
+For Stage B MIDI-to-solo controlled scale checkpoint generation probe changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-controlled-scale-checkpoint-generation-probe
+```
+
+This harness probes generation/decode from the controlled MIDI-to-solo scale checkpoint and records the strict gate boundary without claiming model quality.
 
 For Stage B generic jazz base readiness audit changes, run:
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 모델의 학습, 생성, 디�
 |---|---|
 | pipeline MVP | 완료 |
 | MIDI-to-solo execution path | 입력 MIDI -> context -> ranked MIDI -> WAV technical path 검증 |
-| current evidence boundary | `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_contour_phrase_shape_repeatability_objective_path_complete` |
-| generation source | `model_checkpoint_direct_constrained` |
+| current evidence boundary | `stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe` |
+| generation source | `controlled_scale_checkpoint_generation_probe` |
 | full generic window preparation | train `154136` / val `21845` tokenized records |
 | scale checkpoint training smoke | train `128` / val `32`, best validation loss `5.9031`, checkpoint `1` |
 | sequence budget repair | max sequence `96 -> 160`, direct note capacity `17 -> 33` |
@@ -22,6 +22,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 모델의 학습, 생성, 디�
 | rendered review WAV | `6` files, duration `18.865s-19.000s` |
 | listening review input | pending fields `4 / 6 / 18` |
 | controlled training scale smoke | train / val `512 / 128`, max sequence `160`, best validation loss `5.1061`, checkpoint `1` |
+| controlled scale checkpoint generation probe | sample `3`, valid / strict / grammar `0 / 0 / 3`, collapse warning `3`, repair decision 필요 |
 | human/audio preference | 미검증 |
 | MIDI-to-solo musical quality | 미검증 |
 | broad trained-model quality | 미주장 |
@@ -30,9 +31,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 모델의 학습, 생성, 디�
 
 최신 판단:
 
-- evidence boundary: `stage_b_midi_to_solo_model_direct_jazz_phrase_vocabulary_contour_phrase_shape_repeatability_objective_path_complete`
-- documentation status: `stage_b_model_core_evidence_readme_refresh`
-- next engineering boundary: `stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe`
+- evidence boundary: `stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe`
+- documentation status: `stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe`
+- next engineering boundary: `stage_b_midi_to_solo_controlled_scale_checkpoint_repair_decision`
 - objective MIDI repeatability path support: `true`
 - controlled training scale smoke ready: `true`
 - input MIDI to ranked candidate technical path: `true`
@@ -82,6 +83,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 모델의 학습, 생성, 디�
 | dead-air 잔여 병목 | dead-air failure `1`, sustained coverage regression 관측 | sustained coverage/dead-air repair, constrained note groups per bar `8` | repair valid/strict/grammar `3/3/3`, dead-air/long-note `0/0` |
 | 단일 seed 과장 위험 | objective gate support가 single seed set에 한정 | objective gate repeatability sweep 추가 | seeds `44/52/60`, valid/strict/grammar `9/9/9`, failure reasons none |
 | MIDI-to-solo 반복성 과장 위험 | contour phrase candidate 3개만으로는 반복성 부족 | repeatability sweep과 consolidation 추가 | generated/qualified `6/6`, flags/overlap `0/0`, pass rate `1.0000` |
+| controlled checkpoint raw generation 실패 | sample `3`, valid/strict/grammar `0/0/3`, collapse warning rate `1.0`, avg/max postprocess removal `0.8090/0.8636` | generation probe와 repair decision 경계 분리 | note count `3-4 < 6`, quality claim 제외 |
 | 음악 품질 claim 과장 위험 | objective MIDI gate와 청감 품질의 분리 필요 | listening review guard와 claim boundary 문서화 | pending fields `4/6/18`, musical quality/human preference/broad quality claim `false` |
 
 ## 주요 검증 결과
@@ -118,6 +120,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 모델의 학습, 생성, 디�
 | controlled scale smoke max sequence | `160` |
 | controlled scale smoke best validation loss | `5.1061` |
 | controlled scale smoke checkpoint count | `1` |
+| controlled checkpoint generation probe | sample `3`, valid/strict/grammar `0/0/3` |
+| controlled checkpoint collapse warning | count/rate `3/1.0` |
+| controlled checkpoint avg/max postprocess removal | `0.809042809042809 / 0.8636363636363636` |
 | raw generation probe | sample `3`, valid/strict/grammar `0/0/0` |
 | density/coverage repair | valid/strict/grammar `1/1/3`, note-count failure delta `3` |
 | duration/long-note repair | valid/strict/grammar `2/2/3`, long-note failure delta `2` |
@@ -139,6 +144,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 모델의 학습, 생성, 디�
 | model-direct 8-bar candidate generation | objective gate 범위 검증 |
 | model-direct contour phrase repeatability | generated/qualified `6/6` 범위 검증 |
 | controlled training scale smoke | `512/128`, max_sequence `160`, checkpoint `1` 범위 검증 |
+| controlled scale checkpoint generation/decode path | sample `3`, grammar `3/3` 범위 검증 |
+| controlled scale checkpoint review gate | valid/strict `0/0`, repair decision 필요 |
 | `.mid` 파일 존재 기반 성공 판정 제거 | 검증 |
 | one-note / long sustain / chord block 실패 감지 | 검증 |
 | human/audio preference | 미검증 |
@@ -184,4 +191,10 @@ MIDI-to-solo controlled training scale smoke:
 
 ```bash
 bash scripts/agent_harness.sh stage-b-midi-to-solo-controlled-training-scale-smoke
+```
+
+MIDI-to-solo controlled scale checkpoint generation probe:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-controlled-scale-checkpoint-generation-probe
 ```

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -362,6 +362,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - model-core evidence README refresh: MIDI-to-solo repeatability objective path 기준 README 갱신, generated/qualified `6/6`, flags/overlap `0/0`, quality claim `false`, next boundary `stage_b_midi_to_solo_training_scale_expansion_decision`
 - MIDI-to-solo training scale expansion decision: selected train/val `512/128`, max_sequence `160`, objective generated/qualified `6/6`, GPU/cloud spend required `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_training_scale_smoke`
 - MIDI-to-solo controlled training scale smoke: train/val `512/128`, max_sequence `160`, best validation loss `5.1061`, checkpoint `1`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe`
+- MIDI-to-solo controlled scale checkpoint generation probe: sample `3`, valid/strict/grammar `0/0/3`, collapse warning rate `1.0`, avg/max postprocess removal `0.8090/0.8636`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_repair_decision`
 - model-core portfolio bullet refresh: resume bullet `6`, short bullet `3`, generic base checkpoint repeatability `9/9/9`, unsupported claim guard 유지
 - Muzig application wording refresh: resume project bullet `5`, short bullet `3`, 자기소개 section `3`, AI 음악 실험/검증 claim만 사용
 - Muzig application final review package: long bullet `5`, short bullet `3`, 자기소개 paragraph `3`, 지원 동기 paragraph `2`, 최종 claim check 포함
@@ -398,6 +399,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - Stage B model-core evidence README refresh: evidence boundary를 MIDI-to-solo objective path로 갱신, rendered WAV `6`, pending fields `4/6/18`, quality claim `false`, next boundary `stage_b_midi_to_solo_training_scale_expansion_decision`
 - Stage B MIDI-to-solo training scale expansion decision: selected train/val `512/128`, prior `128/32`, max_sequence `160`, controlled smoke ready `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_training_scale_smoke`
 - Stage B MIDI-to-solo controlled training scale smoke: returncode `0`, best validation loss `5.1061`, checkpoint `1`, vocab fit `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe`
+- Stage B MIDI-to-solo controlled scale checkpoint generation probe: generation returncode `0`, sample `3`, valid/strict/grammar `0/0/3`, note count failure `3/3`, collapse warning `3/3`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_repair_decision`
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
 - generic base readiness audit: phase4 prep ready `true`, broad training execution ready `false`, broad quality/Brad adaptation claim `false`
 - generic base manifest contract: generic split `2433/270`, Brad split `47/11/14`, leakage/overlap `0`, broad training execution ready `false`

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #552, Stage B MIDI-to-solo controlled training scale smoke
-- 다음 권장 이슈: `Stage B MIDI-to-solo controlled scale checkpoint generation probe`
+- latest functional result: Issue #554, Stage B MIDI-to-solo controlled scale checkpoint generation probe
+- 다음 권장 이슈: `Stage B MIDI-to-solo controlled scale checkpoint repair decision`
 
 현재 범위가 아닌 것:
 
@@ -1754,6 +1754,51 @@ Issue #552는 #550 decision에서 정의한 selected `512/128`, `max_sequence=16
 다음:
 
 - `Stage B MIDI-to-solo controlled scale checkpoint generation probe`
+
+## Stage B MIDI-to-Solo Controlled Scale Checkpoint Generation Probe Result
+
+Issue #554는 #552 controlled `512/128`, `max_sequence=160` checkpoint로 generation/decode probe를 실행한 작업이다.
+
+변경:
+
+- controlled scale checkpoint generation probe harness mode 추가
+- existing generic scale checkpoint generation probe를 MIDI-to-solo controlled checkpoint 입력으로 실행
+- controlled training smoke와 generation probe 결과를 MIDI-to-solo boundary로 요약하는 summary script 추가
+- generation command returncode, grammar gate, collapse warning, postprocess removal ratio 전달
+- 전용 unit test와 문서 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_CONTROLLED_SCALE_CHECKPOINT_GENERATION_PROBE_2026-06-04.md`
+- boundary: `stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe`
+- next boundary: `stage_b_midi_to_solo_controlled_scale_checkpoint_repair_decision`
+- train / val records: `512` / `128`
+- best validation loss: `5.1061`
+- sample count: `3`
+- valid / strict / grammar: `0` / `0` / `3`
+- collapse warning sample count / rate: `3` / `1.0`
+- avg onset / sustained coverage ratio: `0.08333333333333333` / `0.16666666666666666`
+- max longest sustained empty run steps: `32`
+- avg / max postprocess removal ratio: `0.809042809042809` / `0.8636363636363636`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- checkpoint load와 generation/decode 실행 경로 동작
+- grammar gate는 통과했지만 MIDI review gate는 note count `3-4 < 6`과 collapse warning으로 실패
+- controlled training smoke 성공은 generation quality claim으로 연결 불가
+- 다음 작업은 repair decision에서 note density, collapse, postprocess removal 원인 분리
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe tests.test_stage_b_midi_to_solo_controlled_training_scale_smoke tests.test_stage_b_generic_base_scale_checkpoint_generation_probe`
+- `.venv/bin/python -m py_compile scripts/summarize_stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe.py scripts/run_stage_b_generic_base_scale_checkpoint_generation_probe.py`
+- `bash -n scripts/agent_harness.sh`
+- `FORCE_GENERATION_PROBE=1 bash scripts/agent_harness.sh stage-b-midi-to-solo-controlled-scale-checkpoint-generation-probe`
+
+다음:
+
+- `Stage B MIDI-to-solo controlled scale checkpoint repair decision`
 
 ## Previous Model Decision
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_CONTROLLED_SCALE_CHECKPOINT_GENERATION_PROBE_2026-06-04.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_CONTROLLED_SCALE_CHECKPOINT_GENERATION_PROBE_2026-06-04.md
@@ -1,0 +1,30 @@
+# Stage B MIDI-to-Solo Controlled Scale Checkpoint Generation Probe
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe`
+- next boundary: `stage_b_midi_to_solo_controlled_scale_checkpoint_repair_decision`
+- train / val records: `512` / `128`
+- best validation loss: `5.1061`
+- sample count: `3`
+- valid / strict / grammar: `0` / `0` / `3`
+- collapse warning sample count / rate: `3` / `1.0`
+- avg onset / sustained coverage ratio: `0.08333333333333333` / `0.16666666666666666`
+- max longest sustained empty run steps: `32`
+- avg / max postprocess removal ratio: `0.809042809042809` / `0.8636363636363636`
+- raw generation quality ready: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Failure Reasons
+
+- `note count too low: 4 < 6; collapse=postprocess_removed_majority`: `1`
+- `note count too low: 3 < 6; collapse=repeated_position_pitch,postprocess_removed_majority`: `1`
+- `note count too low: 3 < 6; collapse=postprocess_removed_majority`: `1`
+
+## Not Proven
+
+- `checkpoint_generation_repeatability`
+- `midi_to_solo_musical_quality`
+- `human_audio_preference`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -210,6 +210,8 @@ Modes:
                 Decide the next bounded MIDI-to-solo training scale smoke after objective path support.
   stage-b-midi-to-solo-controlled-training-scale-smoke
                 Run the bounded 512/128 max_sequence 160 MIDI-to-solo training scale smoke.
+  stage-b-midi-to-solo-controlled-scale-checkpoint-generation-probe
+                Probe generation/decode from the controlled MIDI-to-solo scale checkpoint.
   stage-b-midi-to-solo-model-direct-8bar-generation-probe
                 Run fallback-free model-direct 8-bar MIDI generation and record review gate evidence.
   stage-b-midi-to-solo-model-direct-monophonic-overlap-repair
@@ -4594,6 +4596,48 @@ run_stage_b_midi_to_solo_controlled_training_scale_smoke() {
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe() {
+  local controlled_training_run_id="${CONTROLLED_TRAINING_RUN_ID:-harness_stage_b_midi_to_solo_controlled_training_scale_smoke}"
+  local training_run_id="${TRAINING_RUN_ID:-controlled_512_128_maxseq160}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe}"
+  local generation_probe_run_id="${GENERATION_PROBE_RUN_ID:-controlled_scale_checkpoint}"
+  local output_root="outputs/stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe"
+  local controlled_training="outputs/stage_b_midi_to_solo_controlled_training_scale_smoke/${controlled_training_run_id}/stage_b_midi_to_solo_controlled_training_scale_smoke.json"
+  local training_scale_smoke="outputs/stage_b_midi_to_solo_controlled_training_scale_smoke/${controlled_training_run_id}/training_smoke/${training_run_id}/stage_b_generic_base_training_scale_smoke.json"
+  local generic_output_root="${output_root}/${run_id}/generic_generation_probe"
+  local generation_probe="${generic_output_root}/${generation_probe_run_id}/stage_b_generic_base_scale_checkpoint_generation_probe.json"
+  if [[ ! -f "$controlled_training" || ! -f "$training_scale_smoke" ]]; then
+    print_header "Stage B MIDI-to-solo controlled training scale smoke"
+    RUN_ID="$controlled_training_run_id" TRAINING_RUN_ID="$training_run_id" run_stage_b_midi_to_solo_controlled_training_scale_smoke
+  fi
+  if [[ "${FORCE_GENERATION_PROBE:-0}" == "1" || ! -f "$generation_probe" ]]; then
+    print_header "Stage B MIDI-to-solo controlled scale checkpoint raw generation probe"
+    "$PYTHON_BIN" scripts/run_stage_b_generic_base_scale_checkpoint_generation_probe.py \
+      --run_id "$generation_probe_run_id" \
+      --output_root "$generic_output_root" \
+      --training_scale_smoke "$training_scale_smoke" \
+      --issue_number 554 \
+      --max_sequence 160 \
+      --num_samples 3 \
+      --seed 43 \
+      --max_simultaneous_notes 1 \
+      --expected_boundary stage_b_generic_base_scale_checkpoint_generation_probe \
+      --require_probe_completed \
+      --require_no_broad_quality_claim \
+      --require_no_brad_style_claim
+  fi
+  print_header "Stage B MIDI-to-solo controlled scale checkpoint generation probe"
+  "$PYTHON_BIN" scripts/summarize_stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe.py \
+    --run_id "$run_id" \
+    --controlled_training "$controlled_training" \
+    --generation_probe "$generation_probe" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_CONTROLLED_SCALE_CHECKPOINT_GENERATION_PROBE_2026-06-04.md \
+    --expected_boundary stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe \
+    --min_sample_count 1 \
+    --require_generation_executable \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -6079,6 +6123,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-controlled-training-scale-smoke)
     run_stage_b_midi_to_solo_controlled_training_scale_smoke
+    ;;
+  stage-b-midi-to-solo-controlled-scale-checkpoint-generation-probe)
+    run_stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/run_stage_b_generic_base_scale_checkpoint_generation_probe.py
+++ b/scripts/run_stage_b_generic_base_scale_checkpoint_generation_probe.py
@@ -138,6 +138,15 @@ def build_probe_report(
             "diagnostic_failure_reasons": _dict(summary.get("diagnostic_failure_reasons")),
             "collapse_warning_sample_count": _int(summary.get("collapse_warning_sample_count")),
             "collapse_warning_sample_rate": _float(summary.get("collapse_warning_sample_rate")),
+            "passed_collapse_rate_gate": bool(summary.get("passed_collapse_rate_gate", False)),
+            "avg_repeated_position_pitch_pair_ratio": _float(
+                summary.get("avg_repeated_position_pitch_pair_ratio")
+            ),
+            "max_repeated_position_pitch_pair_ratio": _float(
+                summary.get("max_repeated_position_pitch_pair_ratio")
+            ),
+            "avg_postprocess_removal_ratio": _float(summary.get("avg_postprocess_removal_ratio")),
+            "max_postprocess_removal_ratio": _float(summary.get("max_postprocess_removal_ratio")),
             "avg_onset_coverage_ratio": _float(summary.get("avg_onset_coverage_ratio")),
             "avg_sustained_coverage_ratio": _float(summary.get("avg_sustained_coverage_ratio")),
             "max_longest_sustained_empty_run_steps": _int(
@@ -278,6 +287,8 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- strict valid sample count: `{generation['strict_valid_sample_count']}`",
         f"- grammar gate sample count: `{generation['grammar_gate_sample_count']}`",
         f"- collapse warning sample rate: `{generation['collapse_warning_sample_rate']}`",
+        f"- passed collapse rate gate: `{_bool_token(generation['passed_collapse_rate_gate'])}`",
+        f"- avg / max postprocess removal ratio: `{generation['avg_postprocess_removal_ratio']}` / `{generation['max_postprocess_removal_ratio']}`",
         f"- avg onset coverage ratio: `{generation['avg_onset_coverage_ratio']}`",
         f"- avg sustained coverage ratio: `{generation['avg_sustained_coverage_ratio']}`",
         f"- max longest sustained empty run steps: `{generation['max_longest_sustained_empty_run_steps']}`",

--- a/scripts/summarize_stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe.py
+++ b/scripts/summarize_stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe.py
@@ -1,0 +1,309 @@
+"""Summarize generation behavior from the controlled MIDI-to-solo scale checkpoint."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+from scripts.run_stage_b_generic_base_scale_checkpoint_generation_probe import (  # noqa: E402
+    BOUNDARY as GENERIC_GENERATION_BOUNDARY,
+)
+from scripts.summarize_stage_b_midi_to_solo_controlled_training_scale_smoke import (  # noqa: E402
+    BOUNDARY as CONTROLLED_TRAINING_BOUNDARY,
+)
+
+
+class StageBMidiToSoloControlledScaleCheckpointGenerationProbeSummaryError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe"
+PASS_NEXT_BOUNDARY = "stage_b_midi_to_solo_controlled_scale_checkpoint_repeatability_probe"
+FAIL_NEXT_BOUNDARY = "stage_b_midi_to_solo_controlled_scale_checkpoint_repair_decision"
+SCHEMA_VERSION = "stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe_v1"
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise StageBMidiToSoloControlledScaleCheckpointGenerationProbeSummaryError(f"report missing: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def validate_controlled_training(report: dict[str, Any]) -> dict[str, Any]:
+    if str(report.get("boundary") or "") != CONTROLLED_TRAINING_BOUNDARY:
+        raise StageBMidiToSoloControlledScaleCheckpointGenerationProbeSummaryError("controlled training boundary required")
+    readiness = _dict(report.get("readiness"))
+    training = _dict(report.get("training_result"))
+    if not bool(readiness.get("checkpoint_generation_probe_ready", False)):
+        raise StageBMidiToSoloControlledScaleCheckpointGenerationProbeSummaryError("checkpoint probe readiness required")
+    if _int(training.get("checkpoint_count")) < 1:
+        raise StageBMidiToSoloControlledScaleCheckpointGenerationProbeSummaryError("checkpoint count required")
+    return {
+        "selected_train_records": _int(training.get("selected_train_records")),
+        "selected_val_records": _int(training.get("selected_val_records")),
+        "max_sequence": _int(training.get("max_sequence")),
+        "best_validation_loss": _float(training.get("best_validation_loss")),
+        "checkpoint_count": _int(training.get("checkpoint_count")),
+    }
+
+
+def validate_generation_probe(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    command = _dict(report.get("generation_command"))
+    summary = _dict(report.get("generation_summary"))
+    if str(readiness.get("boundary") or "") != GENERIC_GENERATION_BOUNDARY:
+        raise StageBMidiToSoloControlledScaleCheckpointGenerationProbeSummaryError("generation probe boundary required")
+    if not bool(readiness.get("generation_path_executable", False)):
+        raise StageBMidiToSoloControlledScaleCheckpointGenerationProbeSummaryError("generation path should be executable")
+    if _int(command.get("returncode")) != 0:
+        raise StageBMidiToSoloControlledScaleCheckpointGenerationProbeSummaryError("generation command must succeed")
+    if _int(summary.get("sample_count")) <= 0:
+        raise StageBMidiToSoloControlledScaleCheckpointGenerationProbeSummaryError("generated sample count required")
+    blocked_claims = [
+        "broad_trained_model_quality_claimed",
+        "brad_style_adaptation_claimed",
+        "human_audio_preference_claimed",
+        "production_ready_improviser_claimed",
+    ]
+    claimed = [name for name in blocked_claims if bool(readiness.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloControlledScaleCheckpointGenerationProbeSummaryError(f"unexpected generation claim: {claimed}")
+    return {
+        "source_next_boundary": str(decision.get("next_boundary") or ""),
+        "command_returncode": _int(command.get("returncode")),
+        "sample_count": _int(summary.get("sample_count")),
+        "valid_sample_count": _int(summary.get("valid_sample_count")),
+        "strict_valid_sample_count": _int(summary.get("strict_valid_sample_count")),
+        "grammar_gate_sample_count": _int(summary.get("grammar_gate_sample_count")),
+        "passed_generation_gate": bool(summary.get("passed_generation_gate", False)),
+        "passed_grammar_gate": bool(summary.get("passed_grammar_gate", False)),
+        "passed_strict_review_gate": bool(summary.get("passed_strict_review_gate", False)),
+        "collapse_warning_sample_count": _int(summary.get("collapse_warning_sample_count")),
+        "collapse_warning_sample_rate": _float(summary.get("collapse_warning_sample_rate")),
+        "avg_onset_coverage_ratio": _float(summary.get("avg_onset_coverage_ratio")),
+        "avg_sustained_coverage_ratio": _float(summary.get("avg_sustained_coverage_ratio")),
+        "max_longest_sustained_empty_run_steps": _int(summary.get("max_longest_sustained_empty_run_steps")),
+        "avg_postprocess_removal_ratio": _float(summary.get("avg_postprocess_removal_ratio")),
+        "max_postprocess_removal_ratio": _float(summary.get("max_postprocess_removal_ratio")),
+        "failure_reasons": _dict(summary.get("failure_reasons")),
+        "strict_failure_reasons": _dict(summary.get("strict_failure_reasons")),
+        "diagnostic_failure_reasons": _dict(summary.get("diagnostic_failure_reasons")),
+    }
+
+
+def build_controlled_generation_probe_summary(
+    controlled_training: dict[str, Any],
+    generation_probe: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> dict[str, Any]:
+    training = validate_controlled_training(controlled_training)
+    generation = validate_generation_probe(generation_probe)
+    passed_strict = bool(generation.get("passed_strict_review_gate", False))
+    next_boundary = PASS_NEXT_BOUNDARY if passed_strict else FAIL_NEXT_BOUNDARY
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "boundary": BOUNDARY,
+        "source_boundaries": {
+            "controlled_training": CONTROLLED_TRAINING_BOUNDARY,
+            "generation_probe": GENERIC_GENERATION_BOUNDARY,
+        },
+        "training_source": training,
+        "generation_summary": generation,
+        "readiness": {
+            "boundary": BOUNDARY,
+            "controlled_scale_checkpoint_generation_probe_completed": True,
+            "generation_path_executable": True,
+            "raw_generation_quality_ready": passed_strict,
+            "model_direct_generation_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "human_audio_preference_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": next_boundary,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "controlled scale checkpoint generation probe completed; next boundary selected by strict gate outcome",
+        },
+        "not_proven": [
+            "checkpoint_generation_repeatability",
+            "midi_to_solo_musical_quality",
+            "human_audio_preference",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo controlled scale checkpoint repeatability probe"
+            if passed_strict
+            else "Stage B MIDI-to-solo controlled scale checkpoint repair decision"
+        ),
+    }
+
+
+def validate_controlled_generation_probe_summary(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    min_sample_count: int,
+    require_generation_executable: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    generation = _dict(report.get("generation_summary"))
+    training = _dict(report.get("training_source"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloControlledScaleCheckpointGenerationProbeSummaryError("unexpected boundary")
+    if _int(generation.get("sample_count")) < int(min_sample_count):
+        raise StageBMidiToSoloControlledScaleCheckpointGenerationProbeSummaryError("sample count below requirement")
+    if require_generation_executable and not bool(readiness.get("generation_path_executable", False)):
+        raise StageBMidiToSoloControlledScaleCheckpointGenerationProbeSummaryError("generation executable required")
+    if require_no_quality_claim:
+        blocked = [
+            "model_direct_generation_quality_claimed",
+            "midi_to_solo_musical_quality_claimed",
+            "human_audio_preference_claimed",
+            "broad_trained_model_quality_claimed",
+            "brad_style_adaptation_claimed",
+        ]
+        claimed = [name for name in blocked if bool(readiness.get(name, True))]
+        if claimed:
+            raise StageBMidiToSoloControlledScaleCheckpointGenerationProbeSummaryError(f"unexpected quality claim: {claimed}")
+    return {
+        "boundary": boundary,
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "selected_train_records": _int(training.get("selected_train_records")),
+        "selected_val_records": _int(training.get("selected_val_records")),
+        "best_validation_loss": _float(training.get("best_validation_loss")),
+        "sample_count": _int(generation.get("sample_count")),
+        "valid_sample_count": _int(generation.get("valid_sample_count")),
+        "strict_valid_sample_count": _int(generation.get("strict_valid_sample_count")),
+        "grammar_gate_sample_count": _int(generation.get("grammar_gate_sample_count")),
+        "raw_generation_quality_ready": bool(readiness.get("raw_generation_quality_ready", False)),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "midi_to_solo_musical_quality_claimed": bool(readiness.get("midi_to_solo_musical_quality_claimed", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    training = report["training_source"]
+    generation = report["generation_summary"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    lines = [
+        "# Stage B MIDI-to-Solo Controlled Scale Checkpoint Generation Probe",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- train / val records: `{training['selected_train_records']}` / `{training['selected_val_records']}`",
+        f"- best validation loss: `{training['best_validation_loss']}`",
+        f"- sample count: `{generation['sample_count']}`",
+        f"- valid / strict / grammar: `{generation['valid_sample_count']}` / `{generation['strict_valid_sample_count']}` / `{generation['grammar_gate_sample_count']}`",
+        f"- collapse warning sample count / rate: `{generation['collapse_warning_sample_count']}` / `{generation['collapse_warning_sample_rate']}`",
+        f"- avg onset / sustained coverage ratio: `{generation['avg_onset_coverage_ratio']}` / `{generation['avg_sustained_coverage_ratio']}`",
+        f"- max longest sustained empty run steps: `{generation['max_longest_sustained_empty_run_steps']}`",
+        f"- avg / max postprocess removal ratio: `{generation['avg_postprocess_removal_ratio']}` / `{generation['max_postprocess_removal_ratio']}`",
+        f"- raw generation quality ready: `{_bool_token(readiness['raw_generation_quality_ready'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Failure Reasons",
+        "",
+    ]
+    for reason, count in generation["diagnostic_failure_reasons"].items():
+        lines.append(f"- `{reason}`: `{count}`")
+    lines.extend([
+        "",
+        "## Not Proven",
+        "",
+    ])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Summarize controlled scale checkpoint generation probe")
+    parser.add_argument("--controlled_training", type=str, required=True)
+    parser.add_argument("--generation_probe", type=str, required=True)
+    parser.add_argument("--output_root", type=str, default="outputs/stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe")
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--min_sample_count", type=int, default=1)
+    parser.add_argument("--require_generation_executable", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report = build_controlled_generation_probe_summary(
+        read_json(Path(args.controlled_training)),
+        read_json(Path(args.generation_probe)),
+        output_dir=output_dir,
+    )
+    summary = validate_controlled_generation_probe_summary(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        min_sample_count=int(args.min_sample_count),
+        require_generation_executable=bool(args.require_generation_executable),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    write_json(output_dir / "stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe.json", report)
+    write_json(
+        output_dir / "stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_generic_base_scale_checkpoint_generation_probe.py
+++ b/tests/test_stage_b_generic_base_scale_checkpoint_generation_probe.py
@@ -139,6 +139,8 @@ class StageBGenericBaseScaleCheckpointGenerationProbeTest(unittest.TestCase):
                         "valid_sample_count": 0,
                         "strict_valid_sample_count": 0,
                         "grammar_gate_sample_count": 0,
+                        "avg_postprocess_removal_ratio": 0.82,
+                        "max_postprocess_removal_ratio": 0.9,
                         "diagnostic_failure_reasons": {"Stage B generated samples did not satisfy gate": 3},
                     },
                 },
@@ -146,6 +148,8 @@ class StageBGenericBaseScaleCheckpointGenerationProbeTest(unittest.TestCase):
             )
 
         self.assertEqual(report["decision"]["next_boundary"], FAIL_NEXT_BOUNDARY)
+        self.assertEqual(report["generation_summary"]["avg_postprocess_removal_ratio"], 0.82)
+        self.assertEqual(report["generation_summary"]["max_postprocess_removal_ratio"], 0.9)
         self.assertFalse(report["readiness"]["raw_generation_quality_ready"])
         self.assertFalse(report["readiness"]["broad_trained_model_quality_claimed"])
 

--- a/tests/test_stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe.py
+++ b/tests/test_stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.run_stage_b_generic_base_scale_checkpoint_generation_probe import (
+    BOUNDARY as GENERIC_GENERATION_BOUNDARY,
+)
+from scripts.summarize_stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe import (
+    BOUNDARY,
+    FAIL_NEXT_BOUNDARY,
+    PASS_NEXT_BOUNDARY,
+    StageBMidiToSoloControlledScaleCheckpointGenerationProbeSummaryError,
+    build_controlled_generation_probe_summary,
+    validate_controlled_generation_probe_summary,
+)
+from scripts.summarize_stage_b_midi_to_solo_controlled_training_scale_smoke import (
+    BOUNDARY as CONTROLLED_TRAINING_BOUNDARY,
+)
+
+
+def controlled_training_report(*, checkpoint_count: int = 1) -> dict:
+    return {
+        "boundary": CONTROLLED_TRAINING_BOUNDARY,
+        "training_result": {
+            "selected_train_records": 512,
+            "selected_val_records": 128,
+            "max_sequence": 160,
+            "best_validation_loss": 5.1061,
+            "checkpoint_count": checkpoint_count,
+        },
+        "readiness": {
+            "checkpoint_generation_probe_ready": True,
+            "midi_to_solo_musical_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+    }
+
+
+def generation_probe_report(
+    *,
+    sample_count: int = 3,
+    strict_count: int = 0,
+    command_returncode: int = 0,
+    broad_claim: bool = False,
+) -> dict:
+    passed_strict = strict_count > 0
+    return {
+        "readiness": {
+            "boundary": GENERIC_GENERATION_BOUNDARY,
+            "generation_path_executable": command_returncode == 0 and sample_count > 0,
+            "broad_trained_model_quality_claimed": broad_claim,
+            "brad_style_adaptation_claimed": False,
+            "human_audio_preference_claimed": False,
+            "production_ready_improviser_claimed": False,
+        },
+        "decision": {
+            "next_boundary": (
+                "stage_b_generic_base_scale_checkpoint_repeatability_probe"
+                if passed_strict
+                else "stage_b_generic_base_scale_checkpoint_grammar_representation_decision"
+            ),
+            "critical_user_input_required": False,
+        },
+        "generation_command": {
+            "returncode": command_returncode,
+        },
+        "generation_summary": {
+            "sample_count": sample_count,
+            "valid_sample_count": sample_count if sample_count else 0,
+            "strict_valid_sample_count": strict_count,
+            "grammar_gate_sample_count": sample_count if sample_count else 0,
+            "passed_generation_gate": sample_count > 0,
+            "passed_grammar_gate": sample_count > 0,
+            "passed_strict_review_gate": passed_strict,
+            "collapse_warning_sample_count": 0,
+            "avg_onset_coverage_ratio": 0.75,
+            "avg_sustained_coverage_ratio": 0.5,
+            "max_longest_sustained_empty_run_steps": 8,
+        },
+    }
+
+
+class StageBMidiToSoloControlledScaleCheckpointGenerationProbeTest(unittest.TestCase):
+    def test_summarizes_generation_probe_without_quality_claim(self) -> None:
+        report = build_controlled_generation_probe_summary(
+            controlled_training_report(),
+            generation_probe_report(sample_count=3, strict_count=0),
+            output_dir=Path("outputs/controlled_scale_checkpoint_generation_probe"),
+        )
+        summary = validate_controlled_generation_probe_summary(
+            report,
+            expected_boundary=BOUNDARY,
+            min_sample_count=1,
+            require_generation_executable=True,
+            require_no_quality_claim=True,
+        )
+
+        self.assertEqual(summary["selected_train_records"], 512)
+        self.assertEqual(summary["selected_val_records"], 128)
+        self.assertEqual(summary["sample_count"], 3)
+        self.assertEqual(summary["valid_sample_count"], 3)
+        self.assertEqual(summary["strict_valid_sample_count"], 0)
+        self.assertEqual(summary["next_boundary"], FAIL_NEXT_BOUNDARY)
+        self.assertFalse(summary["raw_generation_quality_ready"])
+        self.assertFalse(summary["critical_user_input_required"])
+        self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+
+    def test_routes_strict_gate_pass_to_repeatability(self) -> None:
+        report = build_controlled_generation_probe_summary(
+            controlled_training_report(),
+            generation_probe_report(sample_count=3, strict_count=2),
+            output_dir=Path("outputs/controlled_scale_checkpoint_generation_probe"),
+        )
+
+        self.assertEqual(report["decision"]["next_boundary"], PASS_NEXT_BOUNDARY)
+        self.assertTrue(report["readiness"]["raw_generation_quality_ready"])
+
+    def test_rejects_missing_training_checkpoint(self) -> None:
+        with self.assertRaises(StageBMidiToSoloControlledScaleCheckpointGenerationProbeSummaryError):
+            build_controlled_generation_probe_summary(
+                controlled_training_report(checkpoint_count=0),
+                generation_probe_report(),
+                output_dir=Path("outputs/controlled_scale_checkpoint_generation_probe"),
+            )
+
+    def test_rejects_generation_command_failure(self) -> None:
+        with self.assertRaises(StageBMidiToSoloControlledScaleCheckpointGenerationProbeSummaryError):
+            build_controlled_generation_probe_summary(
+                controlled_training_report(),
+                generation_probe_report(command_returncode=1),
+                output_dir=Path("outputs/controlled_scale_checkpoint_generation_probe"),
+            )
+
+    def test_rejects_broad_quality_claim(self) -> None:
+        with self.assertRaises(StageBMidiToSoloControlledScaleCheckpointGenerationProbeSummaryError):
+            build_controlled_generation_probe_summary(
+                controlled_training_report(),
+                generation_probe_report(broad_claim=True),
+                output_dir=Path("outputs/controlled_scale_checkpoint_generation_probe"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- controlled scale checkpoint generation/decode probe 추가
- #552 controlled `512/128`, `max_sequence=160` checkpoint 기반 raw generation 결과 기록
- generation path 실행 성공과 MIDI review gate 실패 경계 분리
- closes #554

## Context

- #552 controlled training smoke 결과: train/val `512/128`, best validation loss `5.1061`, checkpoint `1`
- 다음 검토 대상: checkpoint가 실제 generation/decode 경로에서 MIDI 후보를 생성하는지 여부
- 제외 claim: MIDI-to-solo musical quality, human/audio preference, broad trained-model quality, Brad style adaptation

## Scope

- controlled checkpoint generation probe summary script 추가
- existing generic scale checkpoint generation probe에 collapse/postprocess metrics 전달 추가
- dedicated harness mode 추가
- README, CURRENT_STATUS_AND_PLAN, CORE_PLAN, AGENTS handoff 갱신

## Result

- generation returncode: `0`
- sample count: `3`
- valid / strict / grammar: `0 / 0 / 3`
- collapse warning sample count / rate: `3 / 1.0`
- avg / max postprocess removal ratio: `0.809042809042809 / 0.8636363636363636`
- primary failure: note count `3-4 < 6`
- next boundary: `stage_b_midi_to_solo_controlled_scale_checkpoint_repair_decision`

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe tests.test_stage_b_midi_to_solo_controlled_training_scale_smoke tests.test_stage_b_generic_base_scale_checkpoint_generation_probe`
- `.venv/bin/python -m py_compile scripts/summarize_stage_b_midi_to_solo_controlled_scale_checkpoint_generation_probe.py scripts/run_stage_b_generic_base_scale_checkpoint_generation_probe.py`
- `bash -n scripts/agent_harness.sh`
- `FORCE_GENERATION_PROBE=1 bash scripts/agent_harness.sh stage-b-midi-to-solo-controlled-scale-checkpoint-generation-probe`
- `bash scripts/agent_harness.sh quick`

## Risk

- strict gate failure is an expected report outcome, not a command failure
- musical quality claim remains false
- next repair decision required before repeatability or listening review