### PR TITLE
Stage B MIDI-to-solo phrase-bank audio render package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #632, Stage B MIDI-to-solo phrase-bank retrieval baseline.
+- Latest functional issue completed: Issue #634, Stage B MIDI-to-solo phrase-bank audio render package.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo phrase-bank audio render package.
+- Recommended next issue: Stage B MIDI-to-solo phrase-bank listening review package.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1092,6 +1092,22 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-
 ```
 
 This harness packages ranked WAV/MIDI review items and keeps human/audio preference pending without claiming musical quality.
+
+For Stage B MIDI-to-solo phrase-bank retrieval baseline changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-retrieval-baseline
+```
+
+This harness extracts data-derived phrase/motif templates, exports ranked MIDI candidates, and keeps musical quality claims excluded.
+
+For Stage B MIDI-to-solo phrase-bank audio render package changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-audio-render-package
+```
+
+This harness renders phrase-bank ranked MIDI exports to WAV and records technical audio metadata without claiming musical quality.
 
 For Stage B MIDI-to-solo model-direct user listening review fill changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_phrase_bank_retrieval_baseline`
-- current evidence boundary: `stage_b_midi_to_solo_phrase_bank_retrieval_baseline`
+- latest evidence boundary: `stage_b_midi_to_solo_phrase_bank_audio_render_package`
+- current evidence boundary: `stage_b_midi_to_solo_phrase_bank_audio_render_package`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
 - selected quality gap target: `model_conditioned_input_path_quality_alignment`
@@ -25,6 +25,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - phrase-bank source records / motifs: `56 / 803`
 - phrase-bank exported / qualified MIDI candidates: `3 / 3`
 - phrase-bank best notes / unique pitches / max simultaneous: `64 / 22 / 1`
+- phrase-bank rendered WAV files: `3`
+- phrase-bank audio technical validation: `true`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -46,6 +48,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned ranked MIDI candidate export 가능
 - model-conditioned ranked WAV technical render 가능
 - 입력 MIDI context 기반 phrase-bank retrieval 후보 export 가능
+- phrase-bank 후보의 WAV technical render 가능
 
 현재 README가 주장하지 않는 것.
 
@@ -143,6 +146,16 @@ Phrase-bank retrieval baseline.
 - best note / unique pitch / max simultaneous: `64 / 22 / 1`
 - best dead-air / phrase coverage: `0.5873015873015873 / 1.0`
 - MIDI-to-solo MVP claimed: `false`
+- human/audio preference claimed: `false`
+
+Phrase-bank audio render package.
+
+- rendered WAV files: `3`
+- technical WAV validation: `true`
+- rank 1 duration / sample rate / sha256 prefix: `18.985s / 44100 / 07a95cfe5c4b`
+- rank 2 duration / sample rate / sha256 prefix: `18.984s / 44100 / a3a3efc8a9e1`
+- rank 3 duration / sample rate / sha256 prefix: `18.997s / 44100 / d3550541fe41`
+- audio rendered quality claimed: `false`
 - human/audio preference claimed: `false`
 
 MIDI-to-solo input contract.

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -2299,6 +2299,39 @@ Issue #632는 model-conditioned direct path의 청음 품질 claim 없이, 입�
 
 - `Stage B MIDI-to-solo phrase-bank audio render package`
 
+## 9.8 Stage B MIDI-to-solo phrase-bank audio render package
+
+Issue #634는 Issue #632 phrase-bank retrieval baseline MIDI 후보를 WAV로 render하고 technical metadata를 검증한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_phrase_bank_audio_render_package`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_listening_review_package`
+- rendered audio file count: `3`
+- technical WAV validation: `true`
+- phrase-bank ranked audio render completed: `true`
+- rank 1 duration / sample rate / sha256 prefix: `18.985s / 44100 / 07a95cfe5c4b`
+- rank 2 duration / sample rate / sha256 prefix: `18.984s / 44100 / a3a3efc8a9e1`
+- rank 3 duration / sample rate / sha256 prefix: `18.997s / 44100 / d3550541fe41`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+
+판단:
+
+- phrase-bank 후보의 review-ready WAV artifact 생성 완료.
+- 현재 검증 범위는 renderer execution과 WAV metadata다.
+- 청음 품질, phrase-bank musical quality, human/audio preference claim 제외.
+- 다음 작업은 phrase-bank listening review package다.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_phrase_bank_audio_render`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-audio-render-package`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo phrase-bank listening review package`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #632, Stage B MIDI-to-solo phrase-bank retrieval baseline
-- 다음 권장 이슈: `Stage B MIDI-to-solo phrase-bank audio render package`
+- latest functional result: Issue #634, Stage B MIDI-to-solo phrase-bank audio render package
+- 다음 권장 이슈: `Stage B MIDI-to-solo phrase-bank listening review package`
 
 현재 범위가 아닌 것:
 
@@ -33,7 +33,53 @@
 
 - checkpoint 직접 생성 품질 claim 제외
 - phrase-bank retrieval baseline을 품질 하한 후보 경로로 사용
-- audio render와 청음 review는 다음 작업으로 분리
+- phrase-bank audio render technical validation 완료
+- 청음 review는 다음 작업으로 분리
+
+## Stage B MIDI-to-Solo Phrase-Bank Audio Render Package Result
+
+Issue #634는 Issue #632 phrase-bank retrieval baseline MIDI 후보를 WAV로 render하고 technical metadata를 검증한 작업이다.
+
+변경:
+
+- phrase-bank retrieval report source validation 추가
+- exported top MIDI 후보 3개 WAV render 추가
+- sample rate, frame count, file size, sha256 metadata 검증 추가
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_AUDIO_RENDER_PACKAGE_2026-06-05.md`
+- boundary: `stage_b_midi_to_solo_phrase_bank_audio_render_package`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_listening_review_package`
+- rendered audio file count: `3`
+- technical WAV validation: `true`
+- phrase-bank ranked audio render completed: `true`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- critical user input required: `false`
+
+Rendered WAV:
+
+- rank 1: `outputs/stage_b_midi_to_solo_phrase_bank_audio_render_package/harness_stage_b_midi_to_solo_phrase_bank_audio_render_package/audio/rank_01_seed_635.wav`
+- rank 2: `outputs/stage_b_midi_to_solo_phrase_bank_audio_render_package/harness_stage_b_midi_to_solo_phrase_bank_audio_render_package/audio/rank_02_seed_632.wav`
+- rank 3: `outputs/stage_b_midi_to_solo_phrase_bank_audio_render_package/harness_stage_b_midi_to_solo_phrase_bank_audio_render_package/audio/rank_03_seed_638.wav`
+
+판단:
+
+- phrase-bank MIDI 후보의 review-ready WAV artifact 생성 완료
+- 현재 검증 범위는 renderer execution과 WAV metadata
+- 청음 품질, human/audio preference, phrase-bank musical quality claim 제외
+- 다음 작업은 phrase-bank listening review package
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_phrase_bank_audio_render`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-audio-render-package`
+
+다음:
+
+- `Stage B MIDI-to-solo phrase-bank listening review package`
 
 ## Stage B MIDI-to-Solo Phrase-Bank Retrieval Baseline Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_AUDIO_RENDER_PACKAGE_2026-06-05.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_AUDIO_RENDER_PACKAGE_2026-06-05.md
@@ -1,0 +1,31 @@
+# Stage B MIDI-to-Solo Phrase-Bank Audio Render Package
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_phrase_bank_audio_render_package`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_listening_review_package`
+- render attempted: `true`
+- rendered audio file count: `3`
+- technical WAV validation: `true`
+- phrase-bank ranked audio render completed: `true`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+
+## Rendered Files
+
+- rank `1` mode `data_motif_rhythm_phrase_variation` seed `635`: `outputs/stage_b_midi_to_solo_phrase_bank_audio_render_package/harness_stage_b_midi_to_solo_phrase_bank_audio_render_package/audio/rank_01_seed_635.wav`, duration `18.985`, sample rate `44100`, size `3349036`, sha256 `07a95cfe5c4b`
+- rank `2` mode `data_motif_rhythm_phrase_variation` seed `632`: `outputs/stage_b_midi_to_solo_phrase_bank_audio_render_package/harness_stage_b_midi_to_solo_phrase_bank_audio_render_package/audio/rank_02_seed_632.wav`, duration `18.984`, sample rate `44100`, size `3348780`, sha256 `a3a3efc8a9e1`
+- rank `3` mode `data_motif_rhythm_phrase_variation` seed `638`: `outputs/stage_b_midi_to_solo_phrase_bank_audio_render_package/harness_stage_b_midi_to_solo_phrase_bank_audio_render_package/audio/rank_03_seed_638.wav`, duration `18.997`, sample rate `44100`, size `3351084`, sha256 `d3550541fe41`
+
+## Claim Boundary
+
+- `audio_rendered_quality`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `phrase_bank_musical_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`
+
+## Next
+
+- `Stage B MIDI-to-solo phrase-bank listening review package`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -200,6 +200,8 @@ Modes:
                 Export ranked context-conditioned MIDI-to-solo candidates.
   stage-b-midi-to-solo-phrase-bank-retrieval-baseline
                 Export ranked MIDI-to-solo candidates from input context and data-derived phrase-bank templates.
+  stage-b-midi-to-solo-phrase-bank-audio-render-package
+                Render phrase-bank MIDI-to-solo candidates to local WAV files.
   stage-b-midi-to-solo-candidate-audio-render-package
                 Render exported MIDI-to-solo candidates to local WAV files.
   stage-b-midi-to-solo-mvp-execution-consolidation
@@ -3645,6 +3647,25 @@ run_stage_b_midi_to_solo_phrase_bank_retrieval_baseline() {
     --expected_next_boundary stage_b_midi_to_solo_phrase_bank_audio_render_package \
     --require_exported_candidates \
     --require_no_final_claim
+}
+
+run_stage_b_midi_to_solo_phrase_bank_audio_render_package() {
+  local phrase_bank_run_id="${PHRASE_BANK_RUN_ID:-harness_stage_b_midi_to_solo_phrase_bank_retrieval_baseline}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_phrase_bank_audio_render_package}"
+  local phrase_bank_report="outputs/stage_b_midi_to_solo_phrase_bank_retrieval_baseline/${phrase_bank_run_id}/stage_b_midi_to_solo_phrase_bank_retrieval_baseline.json"
+  if [[ ! -f "$phrase_bank_report" ]]; then
+    print_header "Stage B MIDI-to-solo phrase-bank retrieval baseline"
+    RUN_ID="$phrase_bank_run_id" run_stage_b_midi_to_solo_phrase_bank_retrieval_baseline
+  fi
+  print_header "Stage B MIDI-to-solo phrase-bank audio render package"
+  "$PYTHON_BIN" scripts/render_stage_b_midi_to_solo_phrase_bank_audio.py \
+    --run_id "$run_id" \
+    --phrase_bank_report "$phrase_bank_report" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_AUDIO_RENDER_PACKAGE_2026-06-05.md \
+    --expected_boundary stage_b_midi_to_solo_phrase_bank_audio_render_package \
+    --expected_next_boundary stage_b_midi_to_solo_phrase_bank_listening_review_package \
+    --require_phrase_bank_audio_path \
+    --require_no_quality_claim
 }
 
 run_stage_b_midi_to_solo_candidate_audio_render_package() {
@@ -7109,6 +7130,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-phrase-bank-retrieval-baseline)
     run_stage_b_midi_to_solo_phrase_bank_retrieval_baseline
+    ;;
+  stage-b-midi-to-solo-phrase-bank-audio-render-package)
+    run_stage_b_midi_to_solo_phrase_bank_audio_render_package
     ;;
   stage-b-midi-to-solo-candidate-audio-render-package)
     run_stage_b_midi_to_solo_candidate_audio_render_package

--- a/scripts/render_stage_b_midi_to_solo_phrase_bank_audio.py
+++ b/scripts/render_stage_b_midi_to_solo_phrase_bank_audio.py
@@ -1,0 +1,431 @@
+"""Render phrase-bank MIDI-to-solo candidates to WAV files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.render_stage_b_midi_to_solo_candidate_audio import (  # noqa: E402
+    resolve_soundfont,
+    sha256_file,
+    wav_meta,
+)
+from scripts.run_stage_b_midi_to_solo_phrase_bank_retrieval_baseline import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+class StageBMidiToSoloPhraseBankAudioRenderError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_phrase_bank_audio_render_package"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_phrase_bank_listening_review_package"
+SCHEMA_VERSION = "stage_b_midi_to_solo_phrase_bank_audio_render_package_v1"
+CommandRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "phrase_bank_musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _path_exists(path_text: str) -> bool:
+    return bool(path_text and Path(path_text).exists())
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloPhraseBankAudioRenderError(f"unexpected quality claim in {label}: {claimed}")
+
+
+def validate_source_report(report: dict[str, Any], *, expected_count: int) -> list[dict[str, Any]]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    if str(report.get("boundary") or readiness.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloPhraseBankAudioRenderError("phrase-bank retrieval boundary required")
+    if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
+        raise StageBMidiToSoloPhraseBankAudioRenderError("phrase-bank report must route to audio render")
+    required_true = [
+        "phrase_bank_template_extracted",
+        "phrase_bank_retrieval_baseline_completed",
+        "ranked_midi_candidates_exported",
+    ]
+    missing = [name for name in required_true if not bool(readiness.get(name, False))]
+    if missing:
+        raise StageBMidiToSoloPhraseBankAudioRenderError(f"missing phrase-bank readiness: {missing}")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPhraseBankAudioRenderError("critical user input should not be required")
+    _require_no_quality_claim(readiness, label="phrase-bank readiness")
+    candidates = [_dict(item) for item in _list(report.get("top_candidates"))]
+    if len(candidates) < int(expected_count):
+        raise StageBMidiToSoloPhraseBankAudioRenderError("not enough top candidates")
+    compacted: list[dict[str, Any]] = []
+    for row in candidates[: int(expected_count)]:
+        midi_path = str(row.get("export_midi_path") or "")
+        if not _path_exists(midi_path):
+            raise StageBMidiToSoloPhraseBankAudioRenderError(f"ranked MIDI export missing: {midi_path}")
+        if str(row.get("generation_source") or "") != "phrase_bank_data_motif_retrieval":
+            raise StageBMidiToSoloPhraseBankAudioRenderError("phrase-bank candidate source mismatch")
+        if not bool(row.get("export_contract_gate_passed", False)):
+            raise StageBMidiToSoloPhraseBankAudioRenderError("phrase-bank candidate export gate failed")
+        metrics = _dict(row.get("exported_metrics"))
+        compacted.append(
+            {
+                "rank": _int(row.get("rank")),
+                "mode": str(row.get("mode") or ""),
+                "sample_index": _int(row.get("sample_index")),
+                "sample_seed": _int(row.get("sample_seed")),
+                "midi_path": midi_path,
+                "note_count": _int(metrics.get("note_count")),
+                "unique_pitch_count": _int(metrics.get("unique_pitch_count")),
+                "dead_air_ratio": _float(metrics.get("dead_air_ratio")),
+                "phrase_coverage_ratio": _float(metrics.get("phrase_coverage_ratio")),
+            }
+        )
+    return compacted
+
+
+def build_render_plan(
+    candidates: list[dict[str, Any]],
+    *,
+    output_dir: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+) -> list[dict[str, Any]]:
+    renderer = Path(renderer_path)
+    soundfont = Path(soundfont_path).expanduser()
+    if not renderer.exists():
+        raise StageBMidiToSoloPhraseBankAudioRenderError(f"renderer not found: {renderer}")
+    if not soundfont.exists():
+        raise StageBMidiToSoloPhraseBankAudioRenderError(f"soundfont not found: {soundfont}")
+    plan: list[dict[str, Any]] = []
+    for item in candidates:
+        wav_path = output_dir / "audio" / f"rank_{int(item['rank']):02d}_seed_{int(item['sample_seed'])}.wav"
+        plan.append(
+            {
+                **item,
+                "wav_path": str(wav_path),
+                "command": [
+                    str(renderer),
+                    "-ni",
+                    "-F",
+                    str(wav_path),
+                    "-r",
+                    str(sample_rate),
+                    str(soundfont),
+                    str(item["midi_path"]),
+                ],
+            }
+        )
+    return plan
+
+
+def default_runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(list(command), check=False, text=True, capture_output=True)
+
+
+def execute_render_plan(
+    plan: list[dict[str, Any]],
+    *,
+    runner: CommandRunner = default_runner,
+) -> list[dict[str, Any]]:
+    rendered: list[dict[str, Any]] = []
+    for item in plan:
+        wav_path = Path(str(item["wav_path"]))
+        wav_path.parent.mkdir(parents=True, exist_ok=True)
+        completed = runner(item["command"])
+        if completed.returncode != 0:
+            raise StageBMidiToSoloPhraseBankAudioRenderError(
+                f"render failed for rank {item['rank']}: {completed.stderr or completed.stdout}"
+            )
+        rendered.append(
+            {
+                "rank": item["rank"],
+                "mode": item["mode"],
+                "sample_index": item["sample_index"],
+                "sample_seed": item["sample_seed"],
+                "source_midi_path": item["midi_path"],
+                "source_note_count": item["note_count"],
+                "source_unique_pitch_count": item["unique_pitch_count"],
+                "source_dead_air_ratio": item["dead_air_ratio"],
+                "source_phrase_coverage_ratio": item["phrase_coverage_ratio"],
+                "wav_file": wav_meta(wav_path),
+                "command": list(item["command"]),
+                "stdout_tail": (completed.stdout or "")[-1000:],
+                "stderr_tail": (completed.stderr or "")[-1000:],
+            }
+        )
+    return rendered
+
+
+def build_audio_render_report(
+    source_report: dict[str, Any],
+    *,
+    output_dir: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+    expected_file_count: int,
+    runner: CommandRunner = default_runner,
+) -> dict[str, Any]:
+    candidates = validate_source_report(source_report, expected_count=expected_file_count)
+    resolved_renderer = renderer_path or shutil.which("fluidsynth") or ""
+    resolved_soundfont = resolve_soundfont(soundfont_path)
+    plan = build_render_plan(
+        candidates,
+        output_dir=output_dir,
+        renderer_path=resolved_renderer,
+        soundfont_path=resolved_soundfont,
+        sample_rate=sample_rate,
+    )
+    rendered = execute_render_plan(plan, runner=runner)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_boundary": SOURCE_BOUNDARY,
+        "source_generation_summary": _dict(source_report.get("summary")),
+        "renderer": {
+            "name": "fluidsynth",
+            "path": resolved_renderer,
+        },
+        "soundfont": {
+            "path": str(Path(resolved_soundfont).expanduser()),
+            "sha256": sha256_file(Path(resolved_soundfont).expanduser()),
+        },
+        "rendered_audio_files": rendered,
+        "audio_render_boundary": {
+            "boundary": BOUNDARY,
+            "render_attempted": True,
+            "rendered_audio_file_count": int(len(rendered)),
+            "technical_wav_validation": True,
+            "phrase_bank_ranked_audio_render_completed": True,
+            "phrase_bank_listening_review_package_required": True,
+            "audio_output_claimed": True,
+            "audio_rendered_quality_claimed": False,
+            "human_audio_preference_claimed": False,
+            "musical_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "phrase_bank_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "phrase-bank ranked MIDI exports rendered to WAV; listening review package remains separate",
+        },
+        "not_proven": [
+            "audio_rendered_quality",
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "phrase_bank_musical_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": "Stage B MIDI-to-solo phrase-bank listening review package",
+    }
+
+
+def validate_audio_render_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    expected_file_count: int,
+    expected_sample_rate: int,
+    require_phrase_bank_audio_path: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = _dict(report.get("audio_render_boundary"))
+    decision = _dict(report.get("decision"))
+    if expected_boundary and str(boundary.get("boundary") or "") != expected_boundary:
+        raise StageBMidiToSoloPhraseBankAudioRenderError("unexpected boundary")
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloPhraseBankAudioRenderError("unexpected next boundary")
+    files = [_dict(item) for item in _list(report.get("rendered_audio_files"))]
+    if len(files) != int(expected_file_count):
+        raise StageBMidiToSoloPhraseBankAudioRenderError(f"expected {expected_file_count} rendered files")
+    for item in files:
+        wav_file = _dict(item.get("wav_file"))
+        if not bool(wav_file.get("exists", False)) or not _path_exists(str(wav_file.get("path") or "")):
+            raise StageBMidiToSoloPhraseBankAudioRenderError("missing rendered WAV")
+        if _int(wav_file.get("sample_rate")) != int(expected_sample_rate):
+            raise StageBMidiToSoloPhraseBankAudioRenderError("unexpected sample rate")
+        if _int(wav_file.get("frame_count")) <= 0:
+            raise StageBMidiToSoloPhraseBankAudioRenderError("empty WAV")
+        if _int(wav_file.get("size_bytes")) <= 44:
+            raise StageBMidiToSoloPhraseBankAudioRenderError("invalid WAV size")
+    if require_phrase_bank_audio_path and not bool(boundary.get("phrase_bank_ranked_audio_render_completed", False)):
+        raise StageBMidiToSoloPhraseBankAudioRenderError("phrase-bank ranked audio render should be completed")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPhraseBankAudioRenderError("critical user input should not be required")
+    if require_no_quality_claim:
+        _require_no_quality_claim(boundary, label="audio render boundary")
+    return {
+        "boundary": str(boundary.get("boundary") or ""),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "render_attempted": bool(boundary.get("render_attempted", False)),
+        "rendered_audio_file_count": _int(boundary.get("rendered_audio_file_count")),
+        "technical_wav_validation": bool(boundary.get("technical_wav_validation", False)),
+        "phrase_bank_ranked_audio_render_completed": bool(
+            boundary.get("phrase_bank_ranked_audio_render_completed", False)
+        ),
+        "phrase_bank_listening_review_package_required": bool(
+            boundary.get("phrase_bank_listening_review_package_required", False)
+        ),
+        "audio_rendered_quality_claimed": bool(boundary.get("audio_rendered_quality_claimed", True)),
+        "human_audio_preference_claimed": bool(boundary.get("human_audio_preference_claimed", True)),
+        "midi_to_solo_musical_quality_claimed": bool(
+            boundary.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "wav_paths": [str(_dict(item.get("wav_file")).get("path") or "") for item in files],
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    boundary = report["audio_render_boundary"]
+    decision = report["decision"]
+    lines = [
+        "# Stage B MIDI-to-Solo Phrase-Bank Audio Render Package",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{boundary['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- render attempted: `{_bool_token(boundary['render_attempted'])}`",
+        f"- rendered audio file count: `{boundary['rendered_audio_file_count']}`",
+        f"- technical WAV validation: `{_bool_token(boundary['technical_wav_validation'])}`",
+        f"- phrase-bank ranked audio render completed: `{_bool_token(boundary['phrase_bank_ranked_audio_render_completed'])}`",
+        f"- audio rendered quality claimed: `{_bool_token(boundary['audio_rendered_quality_claimed'])}`",
+        f"- human/audio preference claimed: `{_bool_token(boundary['human_audio_preference_claimed'])}`",
+        "",
+        "## Rendered Files",
+        "",
+    ]
+    for item in report.get("rendered_audio_files", []):
+        wav_file = item["wav_file"]
+        lines.append(
+            f"- rank `{item['rank']}` mode `{item['mode']}` seed `{item['sample_seed']}`: "
+            f"`{wav_file['path']}`, duration `{float(wav_file['duration_seconds']):.3f}`, "
+            f"sample rate `{wav_file['sample_rate']}`, size `{wav_file['size_bytes']}`, "
+            f"sha256 `{str(wav_file['sha256'])[:12]}`"
+        )
+    lines.extend(["", "## Claim Boundary", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    lines.extend(["", "## Next", "", f"- `{report['next_recommended_issue']}`"])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Render phrase-bank MIDI-to-solo WAV files")
+    parser.add_argument("--phrase_bank_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_phrase_bank_audio_render_package",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--renderer", type=str, default=shutil.which("fluidsynth") or "")
+    parser.add_argument("--soundfont", type=str, default="")
+    parser.add_argument("--sample_rate", type=int, default=44100)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--expected_file_count", type=int, default=3)
+    parser.add_argument("--require_phrase_bank_audio_path", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_audio_render_report(
+        read_json(Path(args.phrase_bank_report)),
+        output_dir=output_dir,
+        renderer_path=str(args.renderer or ""),
+        soundfont_path=str(args.soundfont or ""),
+        sample_rate=int(args.sample_rate),
+        expected_file_count=int(args.expected_file_count),
+    )
+    summary = validate_audio_render_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        expected_file_count=int(args.expected_file_count),
+        expected_sample_rate=int(args.sample_rate),
+        require_phrase_bank_audio_path=bool(args.require_phrase_bank_audio_path),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "stage_b_midi_to_solo_phrase_bank_audio_render_package.json", report)
+    write_json(
+        output_dir / "stage_b_midi_to_solo_phrase_bank_audio_render_package_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_midi_to_solo_phrase_bank_audio_render_package.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_phrase_bank_audio_render.py
+++ b/tests/test_stage_b_midi_to_solo_phrase_bank_audio_render.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+import wave
+from pathlib import Path
+from typing import Sequence
+
+from scripts.render_stage_b_midi_to_solo_phrase_bank_audio import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloPhraseBankAudioRenderError,
+    build_audio_render_report,
+    validate_audio_render_report,
+)
+from scripts.run_stage_b_midi_to_solo_phrase_bank_retrieval_baseline import (
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+def write_wav(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(2)
+        handle.setsampwidth(2)
+        handle.setframerate(44100)
+        handle.writeframes(b"\x00\x00" * 2 * 1000)
+
+
+def fake_runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    wav_path = Path(str(command[3]))
+    write_wav(wav_path)
+    return subprocess.CompletedProcess(list(command), 0, stdout="rendered", stderr="")
+
+
+def touch_file(root: Path, name: str) -> str:
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"midi")
+    return str(path)
+
+
+def phrase_bank_report(root: Path, *, quality_claim: bool = False) -> dict:
+    top_candidates = [
+        {
+            "rank": index,
+            "mode": "data_motif_rhythm_phrase_variation",
+            "sample_index": index,
+            "sample_seed": 632 + index,
+            "export_midi_path": touch_file(root, f"midi/rank_{index}.mid"),
+            "generation_source": "phrase_bank_data_motif_retrieval",
+            "export_contract_gate_passed": True,
+            "exported_metrics": {
+                "note_count": 64,
+                "unique_pitch_count": 20 + index,
+                "max_simultaneous_notes": 1,
+                "dead_air_ratio": 0.58,
+                "phrase_coverage_ratio": 1.0,
+            },
+        }
+        for index in range(1, 4)
+    ]
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "summary": {
+            "candidate_count": 9,
+            "exported_candidate_count": 3,
+            "exported_qualified_candidate_count": 3,
+        },
+        "top_candidates": top_candidates,
+        "readiness": {
+            "phrase_bank_template_extracted": True,
+            "phrase_bank_retrieval_baseline_completed": True,
+            "ranked_midi_candidates_exported": True,
+            "midi_to_solo_mvp_claimed": False,
+            "phrase_bank_musical_quality_claimed": quality_claim,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "human_audio_preference_claimed": False,
+        },
+        "decision": {
+            "next_boundary": SOURCE_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class StageBMidiToSoloPhraseBankAudioRenderTest(unittest.TestCase):
+    def test_renders_phrase_bank_candidates_to_wav_without_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = touch_file(root, "bin/fluidsynth")
+            soundfont = touch_file(root, "sf/general.sf2")
+            report = build_audio_render_report(
+                phrase_bank_report(root),
+                output_dir=root / "out",
+                renderer_path=renderer,
+                soundfont_path=soundfont,
+                sample_rate=44100,
+                expected_file_count=3,
+                runner=fake_runner,
+            )
+            summary = validate_audio_render_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                expected_file_count=3,
+                expected_sample_rate=44100,
+                require_phrase_bank_audio_path=True,
+                require_no_quality_claim=True,
+            )
+
+        self.assertTrue(summary["render_attempted"])
+        self.assertEqual(summary["rendered_audio_file_count"], 3)
+        self.assertTrue(summary["technical_wav_validation"])
+        self.assertTrue(summary["phrase_bank_ranked_audio_render_completed"])
+        self.assertTrue(summary["phrase_bank_listening_review_package_required"])
+        self.assertFalse(summary["human_audio_preference_claimed"])
+        self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+
+    def test_rejects_phrase_bank_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = touch_file(root, "bin/fluidsynth")
+            soundfont = touch_file(root, "sf/general.sf2")
+            with self.assertRaises(StageBMidiToSoloPhraseBankAudioRenderError):
+                build_audio_render_report(
+                    phrase_bank_report(root, quality_claim=True),
+                    output_dir=root / "out",
+                    renderer_path=renderer,
+                    soundfont_path=soundfont,
+                    sample_rate=44100,
+                    expected_file_count=3,
+                    runner=fake_runner,
+                )
+
+    def test_rejects_missing_phrase_bank_midi_export(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = touch_file(root, "bin/fluidsynth")
+            soundfont = touch_file(root, "sf/general.sf2")
+            source = phrase_bank_report(root)
+            source["top_candidates"][0]["export_midi_path"] = "missing.mid"
+            with self.assertRaises(StageBMidiToSoloPhraseBankAudioRenderError):
+                build_audio_render_report(
+                    source,
+                    output_dir=root / "out",
+                    renderer_path=renderer,
+                    soundfont_path=soundfont,
+                    sample_rate=44100,
+                    expected_file_count=3,
+                    runner=fake_runner,
+                )
+
+    def test_boundary_constants_are_stable(self) -> None:
+        self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_phrase_bank_audio_render_package")
+        self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_phrase_bank_listening_review_package")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- phrase-bank retrieval baseline MIDI 후보의 WAV render package 추가
- local renderer/soundfont 기반 technical WAV validation 추가
- 청음 품질 claim 없이 review-ready audio artifact 생성

## Context

- Issue #632 결과: phrase-bank retrieval baseline completed
- source records / motif count: `56 / 803`
- exported / exported qualified MIDI candidates: `3 / 3`
- best note / unique pitch / max simultaneous: `64 / 22 / 1`
- human/audio preference claim: `false`
- phrase-bank musical quality claim: `false`

## Scope

- `scripts/render_stage_b_midi_to_solo_phrase_bank_audio.py` 추가
- `stage-b-midi-to-solo-phrase-bank-audio-render-package` harness mode 추가
- phrase-bank audio render unit test 추가
- README, current status, core plan, handoff 갱신

## Result

- rendered audio file count: `3`
- technical WAV validation: `true`
- phrase-bank ranked audio render completed: `true`
- rank 1 duration / sample rate / sha256 prefix: `18.985s / 44100 / 07a95cfe5c4b`
- rank 2 duration / sample rate / sha256 prefix: `18.984s / 44100 / a3a3efc8a9e1`
- rank 3 duration / sample rate / sha256 prefix: `18.997s / 44100 / d3550541fe41`
- audio rendered quality claimed: `false`
- human/audio preference claimed: `false`

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_phrase_bank_audio_render`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-audio-render-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- 청음 품질 claim 제외
- broad trained-model quality claim 제외
- Brad style adaptation claim 제외
- 다음 검증 대상: phrase-bank listening review package

Closes #634
