### PR TITLE
Stage B MIDI-to-solo phrase-bank listening review package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #634, Stage B MIDI-to-solo phrase-bank audio render package.
+- Latest functional issue completed: Issue #636, Stage B MIDI-to-solo phrase-bank listening review package.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo phrase-bank listening review package.
+- Recommended next issue: Stage B MIDI-to-solo phrase-bank listening review input guard.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1108,6 +1108,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-audio-render-pack
 ```
 
 This harness renders phrase-bank ranked MIDI exports to WAV and records technical audio metadata without claiming musical quality.
+
+For Stage B MIDI-to-solo phrase-bank listening review package changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-listening-review-package
+```
+
+This harness packages phrase-bank MIDI/WAV review items and keeps preference pending without claiming musical quality.
 
 For Stage B MIDI-to-solo model-direct user listening review fill changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_phrase_bank_audio_render_package`
-- current evidence boundary: `stage_b_midi_to_solo_phrase_bank_audio_render_package`
+- latest evidence boundary: `stage_b_midi_to_solo_phrase_bank_listening_review_package`
+- current evidence boundary: `stage_b_midi_to_solo_phrase_bank_listening_review_package`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
 - selected quality gap target: `model_conditioned_input_path_quality_alignment`
@@ -27,6 +27,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - phrase-bank best notes / unique pitches / max simultaneous: `64 / 22 / 1`
 - phrase-bank rendered WAV files: `3`
 - phrase-bank audio technical validation: `true`
+- phrase-bank listening review package ready: `true`
+- phrase-bank listening review items: `3`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -49,6 +51,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned ranked WAV technical render 가능
 - 입력 MIDI context 기반 phrase-bank retrieval 후보 export 가능
 - phrase-bank 후보의 WAV technical render 가능
+- phrase-bank 후보의 listening review package 생성 가능
 
 현재 README가 주장하지 않는 것.
 
@@ -157,6 +160,15 @@ Phrase-bank audio render package.
 - rank 3 duration / sample rate / sha256 prefix: `18.997s / 44100 / d3550541fe41`
 - audio rendered quality claimed: `false`
 - human/audio preference claimed: `false`
+
+Phrase-bank listening review package.
+
+- package ready: `true`
+- review item count: `3`
+- validated review input: `false`
+- review WAV files: `rank_01_seed_635.wav`, `rank_02_seed_632.wav`, `rank_03_seed_638.wav`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
 
 MIDI-to-solo input contract.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -2332,6 +2332,42 @@ Issue #634는 Issue #632 phrase-bank retrieval baseline MIDI 후보를 WAV로 re
 
 - `Stage B MIDI-to-solo phrase-bank listening review package`
 
+## 9.9 Stage B MIDI-to-solo phrase-bank listening review package
+
+Issue #636은 Issue #634 phrase-bank WAV/MIDI 후보를 listening review package로 묶고, preference 입력 전 claim boundary를 고정한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_phrase_bank_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_listening_review_input_guard`
+- listening review package ready: `true`
+- review item count: `3`
+- validated review input: `false`
+- human review required now: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+Review WAV:
+
+- rank 1: `outputs/stage_b_midi_to_solo_phrase_bank_audio_render_package/harness_stage_b_midi_to_solo_phrase_bank_audio_render_package/audio/rank_01_seed_635.wav`
+- rank 2: `outputs/stage_b_midi_to_solo_phrase_bank_audio_render_package/harness_stage_b_midi_to_solo_phrase_bank_audio_render_package/audio/rank_02_seed_632.wav`
+- rank 3: `outputs/stage_b_midi_to_solo_phrase_bank_audio_render_package/harness_stage_b_midi_to_solo_phrase_bank_audio_render_package/audio/rank_03_seed_638.wav`
+
+판단:
+
+- WAV/MIDI review artifact 접근 경로 확보.
+- preference와 musical quality claim은 review input 전 pending 유지.
+- 다음 작업은 review input 없이 preference fill이 불가능하도록 guard 추가다.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_phrase_bank_listening_review_package`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-listening-review-package`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo phrase-bank listening review input guard`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #634, Stage B MIDI-to-solo phrase-bank audio render package
-- 다음 권장 이슈: `Stage B MIDI-to-solo phrase-bank listening review package`
+- latest functional result: Issue #636, Stage B MIDI-to-solo phrase-bank listening review package
+- 다음 권장 이슈: `Stage B MIDI-to-solo phrase-bank listening review input guard`
 
 현재 범위가 아닌 것:
 
@@ -34,7 +34,53 @@
 - checkpoint 직접 생성 품질 claim 제외
 - phrase-bank retrieval baseline을 품질 하한 후보 경로로 사용
 - phrase-bank audio render technical validation 완료
-- 청음 review는 다음 작업으로 분리
+- phrase-bank listening review package 준비 완료
+- review input validation guard는 다음 작업으로 분리
+
+## Stage B MIDI-to-Solo Phrase-Bank Listening Review Package Result
+
+Issue #636은 Issue #634 phrase-bank WAV/MIDI 후보를 listening review package로 묶고, preference 입력 전 claim boundary를 고정한 작업이다.
+
+변경:
+
+- phrase-bank audio render report source validation 추가
+- WAV/MIDI review item manifest 생성
+- required review input fields 정의
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_LISTENING_REVIEW_PACKAGE_2026-06-05.md`
+- boundary: `stage_b_midi_to_solo_phrase_bank_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_listening_review_input_guard`
+- listening review package ready: `true`
+- review item count: `3`
+- validated review input: `false`
+- human review required now: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+Review WAV:
+
+- rank 1: `outputs/stage_b_midi_to_solo_phrase_bank_audio_render_package/harness_stage_b_midi_to_solo_phrase_bank_audio_render_package/audio/rank_01_seed_635.wav`
+- rank 2: `outputs/stage_b_midi_to_solo_phrase_bank_audio_render_package/harness_stage_b_midi_to_solo_phrase_bank_audio_render_package/audio/rank_02_seed_632.wav`
+- rank 3: `outputs/stage_b_midi_to_solo_phrase_bank_audio_render_package/harness_stage_b_midi_to_solo_phrase_bank_audio_render_package/audio/rank_03_seed_638.wav`
+
+판단:
+
+- WAV/MIDI review artifact 접근 경로 확보
+- preference와 musical quality claim은 review input 전 pending 유지
+- 다음 작업은 review input 없이 preference fill이 불가능하도록 guard 추가
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_phrase_bank_listening_review_package`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-listening-review-package`
+
+다음:
+
+- `Stage B MIDI-to-solo phrase-bank listening review input guard`
 
 ## Stage B MIDI-to-Solo Phrase-Bank Audio Render Package Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_LISTENING_REVIEW_PACKAGE_2026-06-05.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_LISTENING_REVIEW_PACKAGE_2026-06-05.md
@@ -1,0 +1,34 @@
+# Stage B MIDI-to-Solo Phrase-Bank Listening Review Package
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_phrase_bank_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_listening_review_input_guard`
+- package ready: `true`
+- review item count: `3`
+- validated review input: `false`
+- human/audio preference claimed: `false`
+
+## Review Items
+
+- rank `1` mode `data_motif_rhythm_phrase_variation` seed `635`: WAV `outputs/stage_b_midi_to_solo_phrase_bank_audio_render_package/harness_stage_b_midi_to_solo_phrase_bank_audio_render_package/audio/rank_01_seed_635.wav`, MIDI `outputs/stage_b_midi_to_solo_phrase_bank_retrieval_baseline/harness_stage_b_midi_to_solo_phrase_bank_retrieval_baseline/midi/rank_01_data-motif-rhythm-phrase-variation_seed_635.mid`, duration `18.985`
+- rank `2` mode `data_motif_rhythm_phrase_variation` seed `632`: WAV `outputs/stage_b_midi_to_solo_phrase_bank_audio_render_package/harness_stage_b_midi_to_solo_phrase_bank_audio_render_package/audio/rank_02_seed_632.wav`, MIDI `outputs/stage_b_midi_to_solo_phrase_bank_retrieval_baseline/harness_stage_b_midi_to_solo_phrase_bank_retrieval_baseline/midi/rank_02_data-motif-rhythm-phrase-variation_seed_632.mid`, duration `18.984`
+- rank `3` mode `data_motif_rhythm_phrase_variation` seed `638`: WAV `outputs/stage_b_midi_to_solo_phrase_bank_audio_render_package/harness_stage_b_midi_to_solo_phrase_bank_audio_render_package/audio/rank_03_seed_638.wav`, MIDI `outputs/stage_b_midi_to_solo_phrase_bank_retrieval_baseline/harness_stage_b_midi_to_solo_phrase_bank_retrieval_baseline/midi/rank_03_data-motif-rhythm-phrase-variation_seed_638.mid`, duration `18.997`
+
+## Required Input Fields
+
+- `candidate_rank`
+- `listening_status`
+- `preference`
+- `issue_notes`
+
+## Claim Boundary
+
+- MIDI-to-solo musical quality claimed: `false`
+- audio rendered quality claimed: `false`
+- phrase-bank musical quality claimed: `false`
+- broad trained-model quality claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo phrase-bank listening review input guard`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -202,6 +202,8 @@ Modes:
                 Export ranked MIDI-to-solo candidates from input context and data-derived phrase-bank templates.
   stage-b-midi-to-solo-phrase-bank-audio-render-package
                 Render phrase-bank MIDI-to-solo candidates to local WAV files.
+  stage-b-midi-to-solo-phrase-bank-listening-review-package
+                Package phrase-bank MIDI/WAV candidates for pending listening review.
   stage-b-midi-to-solo-candidate-audio-render-package
                 Render exported MIDI-to-solo candidates to local WAV files.
   stage-b-midi-to-solo-mvp-execution-consolidation
@@ -3665,6 +3667,25 @@ run_stage_b_midi_to_solo_phrase_bank_audio_render_package() {
     --expected_boundary stage_b_midi_to_solo_phrase_bank_audio_render_package \
     --expected_next_boundary stage_b_midi_to_solo_phrase_bank_listening_review_package \
     --require_phrase_bank_audio_path \
+    --require_no_quality_claim
+}
+
+run_stage_b_midi_to_solo_phrase_bank_listening_review_package() {
+  local audio_run_id="${AUDIO_RUN_ID:-harness_stage_b_midi_to_solo_phrase_bank_audio_render_package}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_phrase_bank_listening_review_package}"
+  local audio_render_report="outputs/stage_b_midi_to_solo_phrase_bank_audio_render_package/${audio_run_id}/stage_b_midi_to_solo_phrase_bank_audio_render_package.json"
+  if [[ ! -f "$audio_render_report" ]]; then
+    print_header "Stage B MIDI-to-solo phrase-bank audio render package"
+    RUN_ID="$audio_run_id" run_stage_b_midi_to_solo_phrase_bank_audio_render_package
+  fi
+  print_header "Stage B MIDI-to-solo phrase-bank listening review package"
+  "$PYTHON_BIN" scripts/build_stage_b_midi_to_solo_phrase_bank_listening_review_package.py \
+    --run_id "$run_id" \
+    --audio_render_report "$audio_render_report" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_LISTENING_REVIEW_PACKAGE_2026-06-05.md \
+    --expected_boundary stage_b_midi_to_solo_phrase_bank_listening_review_package \
+    --expected_next_boundary stage_b_midi_to_solo_phrase_bank_listening_review_input_guard \
+    --require_package_ready \
     --require_no_quality_claim
 }
 
@@ -7133,6 +7154,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-phrase-bank-audio-render-package)
     run_stage_b_midi_to_solo_phrase_bank_audio_render_package
+    ;;
+  stage-b-midi-to-solo-phrase-bank-listening-review-package)
+    run_stage_b_midi_to_solo_phrase_bank_listening_review_package
     ;;
   stage-b-midi-to-solo-candidate-audio-render-package)
     run_stage_b_midi_to_solo_candidate_audio_render_package

--- a/scripts/build_stage_b_midi_to_solo_phrase_bank_listening_review_package.py
+++ b/scripts/build_stage_b_midi_to_solo_phrase_bank_listening_review_package.py
@@ -1,0 +1,337 @@
+"""Build a listening review package for phrase-bank MIDI-to-solo output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.render_stage_b_midi_to_solo_phrase_bank_audio import (  # noqa: E402
+    BOUNDARY as AUDIO_RENDER_BOUNDARY,
+    NEXT_BOUNDARY as AUDIO_RENDER_NEXT_BOUNDARY,
+)
+
+
+class StageBMidiToSoloPhraseBankListeningReviewPackageError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_phrase_bank_listening_review_package"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_phrase_bank_listening_review_input_guard"
+SCHEMA_VERSION = "stage_b_midi_to_solo_phrase_bank_listening_review_package_v1"
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "phrase_bank_musical_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _path_exists(path_text: str) -> bool:
+    return bool(path_text and Path(path_text).exists())
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloPhraseBankListeningReviewPackageError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_audio_render_report(report: dict[str, Any], *, expected_count: int) -> list[dict[str, Any]]:
+    boundary = _dict(report.get("audio_render_boundary"))
+    decision = _dict(report.get("decision"))
+    if str(boundary.get("boundary") or "") != AUDIO_RENDER_BOUNDARY:
+        raise StageBMidiToSoloPhraseBankListeningReviewPackageError("phrase-bank audio render boundary required")
+    if str(decision.get("next_boundary") or "") != AUDIO_RENDER_NEXT_BOUNDARY:
+        raise StageBMidiToSoloPhraseBankListeningReviewPackageError("audio render report must route to listening review")
+    required_true = [
+        "technical_wav_validation",
+        "phrase_bank_ranked_audio_render_completed",
+        "phrase_bank_listening_review_package_required",
+    ]
+    missing = [name for name in required_true if not bool(boundary.get(name, False))]
+    if missing:
+        raise StageBMidiToSoloPhraseBankListeningReviewPackageError(f"missing audio render readiness: {missing}")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPhraseBankListeningReviewPackageError("critical user input should not be required")
+    _require_no_quality_claim(boundary, label="audio render boundary")
+    items = [_dict(item) for item in _list(report.get("rendered_audio_files"))]
+    if len(items) < int(expected_count):
+        raise StageBMidiToSoloPhraseBankListeningReviewPackageError("rendered audio file count below expected")
+    review_items: list[dict[str, Any]] = []
+    for item in items[: int(expected_count)]:
+        wav = _dict(item.get("wav_file"))
+        wav_path = str(wav.get("path") or "")
+        midi_path = str(item.get("source_midi_path") or "")
+        if not _path_exists(wav_path) or not _path_exists(midi_path):
+            raise StageBMidiToSoloPhraseBankListeningReviewPackageError("review item MIDI/WAV artifact required")
+        review_items.append(
+            {
+                "rank": _int(item.get("rank")),
+                "mode": str(item.get("mode") or ""),
+                "sample_index": _int(item.get("sample_index")),
+                "sample_seed": _int(item.get("sample_seed")),
+                "midi_path": midi_path,
+                "wav_path": wav_path,
+                "duration_seconds": _float(wav.get("duration_seconds")),
+                "sample_rate": _int(wav.get("sample_rate")),
+                "size_bytes": _int(wav.get("size_bytes")),
+                "sha256": str(wav.get("sha256") or ""),
+                "source_note_count": _int(item.get("source_note_count")),
+                "source_unique_pitch_count": _int(item.get("source_unique_pitch_count")),
+                "source_dead_air_ratio": _float(item.get("source_dead_air_ratio")),
+                "source_phrase_coverage_ratio": _float(item.get("source_phrase_coverage_ratio")),
+                "review_status": "pending",
+            }
+        )
+    return review_items
+
+
+def build_listening_review_package_report(
+    *,
+    audio_render_report: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+    expected_count: int,
+) -> dict[str, Any]:
+    review_items = validate_audio_render_report(audio_render_report, expected_count=expected_count)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundaries": {
+            "audio_render": AUDIO_RENDER_BOUNDARY,
+        },
+        "review_package": {
+            "package_ready": True,
+            "review_item_count": int(len(review_items)),
+            "review_basis": "human_audio_listening_pending",
+            "validated_review_input": False,
+            "required_input_fields": [
+                "candidate_rank",
+                "listening_status",
+                "preference",
+                "issue_notes",
+            ],
+        },
+        "review_items": review_items,
+        "readiness": {
+            "boundary": BOUNDARY,
+            "listening_review_package_ready": True,
+            "review_item_count": int(len(review_items)),
+            "validated_review_input": False,
+            "human_review_required_now": False,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "phrase_bank_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "phrase-bank WAV/MIDI review items are packaged; preference remains pending until validated listening input",
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "audio_rendered_quality",
+            "phrase_bank_musical_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": "Stage B MIDI-to-solo phrase-bank listening review input guard",
+    }
+
+
+def validate_listening_review_package_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    expected_review_item_count: int,
+    require_package_ready: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloPhraseBankListeningReviewPackageError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloPhraseBankListeningReviewPackageError("unexpected next boundary")
+    if require_package_ready and not bool(readiness.get("listening_review_package_ready", False)):
+        raise StageBMidiToSoloPhraseBankListeningReviewPackageError("listening review package should be ready")
+    if _int(readiness.get("review_item_count")) != int(expected_review_item_count):
+        raise StageBMidiToSoloPhraseBankListeningReviewPackageError("review item count mismatch")
+    if bool(readiness.get("validated_review_input", True)):
+        raise StageBMidiToSoloPhraseBankListeningReviewPackageError("review input should remain pending")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPhraseBankListeningReviewPackageError("critical user input should not be required")
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="listening package readiness")
+    return {
+        "boundary": boundary,
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "listening_review_package_ready": bool(readiness.get("listening_review_package_ready", False)),
+        "review_item_count": _int(readiness.get("review_item_count")),
+        "validated_review_input": bool(readiness.get("validated_review_input", True)),
+        "human_review_required_now": bool(readiness.get("human_review_required_now", True)),
+        "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "wav_paths": [str(_dict(item).get("wav_path") or "") for item in _list(report.get("review_items"))],
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    package = report["review_package"]
+    lines = [
+        "# Stage B MIDI-to-Solo Phrase-Bank Listening Review Package",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- package ready: `{_bool_token(package['package_ready'])}`",
+        f"- review item count: `{package['review_item_count']}`",
+        f"- validated review input: `{_bool_token(package['validated_review_input'])}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        "",
+        "## Review Items",
+        "",
+    ]
+    for item in report["review_items"]:
+        lines.append(
+            f"- rank `{item['rank']}` mode `{item['mode']}` seed `{item['sample_seed']}`: "
+            f"WAV `{item['wav_path']}`, MIDI `{item['midi_path']}`, duration `{item['duration_seconds']:.3f}`"
+        )
+    lines.extend(["", "## Required Input Fields", ""])
+    for field in package["required_input_fields"]:
+        lines.append(f"- `{field}`")
+    lines.extend(
+        [
+            "",
+            "## Claim Boundary",
+            "",
+            f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+            f"- audio rendered quality claimed: `{_bool_token(readiness['audio_rendered_quality_claimed'])}`",
+            f"- phrase-bank musical quality claimed: `{_bool_token(readiness['phrase_bank_musical_quality_claimed'])}`",
+            f"- broad trained-model quality claimed: `{_bool_token(readiness['broad_trained_model_quality_claimed'])}`",
+            "",
+            "## Next",
+            "",
+            f"- `{report['next_recommended_issue']}`",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build phrase-bank listening review package")
+    parser.add_argument("--audio_render_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_phrase_bank_listening_review_package",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=636)
+    parser.add_argument("--expected_review_item_count", type=int, default=3)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_package_ready", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_listening_review_package_report(
+        audio_render_report=read_json(Path(args.audio_render_report)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+        expected_count=int(args.expected_review_item_count),
+    )
+    summary = validate_listening_review_package_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        expected_review_item_count=int(args.expected_review_item_count),
+        require_package_ready=bool(args.require_package_ready),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "stage_b_midi_to_solo_phrase_bank_listening_review_package.json", report)
+    write_json(
+        output_dir / "stage_b_midi_to_solo_phrase_bank_listening_review_package_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_midi_to_solo_phrase_bank_listening_review_package.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_phrase_bank_listening_review_package.py
+++ b/tests/test_stage_b_midi_to_solo_phrase_bank_listening_review_package.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.build_stage_b_midi_to_solo_phrase_bank_listening_review_package import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloPhraseBankListeningReviewPackageError,
+    build_listening_review_package_report,
+    validate_listening_review_package_report,
+)
+from scripts.render_stage_b_midi_to_solo_phrase_bank_audio import (
+    BOUNDARY as AUDIO_RENDER_BOUNDARY,
+    NEXT_BOUNDARY as AUDIO_RENDER_NEXT_BOUNDARY,
+)
+
+
+def touch_file(root: Path, name: str) -> str:
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"artifact")
+    return str(path)
+
+
+def audio_render_report(root: Path, *, quality_claim: bool = False) -> dict:
+    files = [
+        {
+            "rank": index,
+            "mode": "data_motif_rhythm_phrase_variation",
+            "sample_index": index,
+            "sample_seed": 632 + index,
+            "source_midi_path": touch_file(root, f"midi/rank_{index}.mid"),
+            "source_note_count": 64,
+            "source_unique_pitch_count": 20 + index,
+            "source_dead_air_ratio": 0.58,
+            "source_phrase_coverage_ratio": 1.0,
+            "wav_file": {
+                "path": touch_file(root, f"audio/rank_{index}.wav"),
+                "exists": True,
+                "duration_seconds": 18.9 + index,
+                "sample_rate": 44100,
+                "size_bytes": 1000,
+                "sha256": f"sha-{index}",
+            },
+        }
+        for index in range(1, 4)
+    ]
+    return {
+        "audio_render_boundary": {
+            "boundary": AUDIO_RENDER_BOUNDARY,
+            "technical_wav_validation": True,
+            "phrase_bank_ranked_audio_render_completed": True,
+            "phrase_bank_listening_review_package_required": True,
+            "human_audio_preference_claimed": quality_claim,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "phrase_bank_musical_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "next_boundary": AUDIO_RENDER_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+        "rendered_audio_files": files,
+    }
+
+
+class StageBMidiToSoloPhraseBankListeningReviewPackageTest(unittest.TestCase):
+    def test_builds_pending_listening_review_package(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            report = build_listening_review_package_report(
+                audio_render_report=audio_render_report(root),
+                output_dir=root / "out",
+                issue_number=636,
+                expected_count=3,
+            )
+            summary = validate_listening_review_package_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                expected_review_item_count=3,
+                require_package_ready=True,
+                require_no_quality_claim=True,
+            )
+
+        self.assertTrue(summary["listening_review_package_ready"])
+        self.assertEqual(summary["review_item_count"], 3)
+        self.assertFalse(summary["validated_review_input"])
+        self.assertFalse(summary["human_audio_preference_claimed"])
+        self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+        self.assertEqual(len(summary["wav_paths"]), 3)
+
+    def test_rejects_audio_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaises(StageBMidiToSoloPhraseBankListeningReviewPackageError):
+                build_listening_review_package_report(
+                    audio_render_report=audio_render_report(root, quality_claim=True),
+                    output_dir=root / "out",
+                    issue_number=636,
+                    expected_count=3,
+                )
+
+    def test_rejects_missing_review_item_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            audio = audio_render_report(root)
+            audio["rendered_audio_files"][0]["wav_file"]["path"] = "missing.wav"
+            with self.assertRaises(StageBMidiToSoloPhraseBankListeningReviewPackageError):
+                build_listening_review_package_report(
+                    audio_render_report=audio,
+                    output_dir=root / "out",
+                    issue_number=636,
+                    expected_count=3,
+                )
+
+    def test_boundary_constants_are_stable(self) -> None:
+        self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_phrase_bank_listening_review_package")
+        self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_phrase_bank_listening_review_input_guard")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- phrase-bank WAV/MIDI 후보의 listening review package 추가
- review item manifest와 required input fields 기록
- preference와 musical quality claim pending 유지

## Context

- Issue #634 결과: phrase-bank audio render package 완료
- rendered audio file count: `3`
- technical WAV validation: `true`
- phrase-bank ranked audio render completed: `true`
- audio rendered quality claim: `false`
- human/audio preference claim: `false`

## Scope

- `scripts/build_stage_b_midi_to_solo_phrase_bank_listening_review_package.py` 추가
- `stage-b-midi-to-solo-phrase-bank-listening-review-package` harness mode 추가
- phrase-bank listening review package unit test 추가
- README, current status, core plan, handoff 갱신

## Result

- listening review package ready: `true`
- review item count: `3`
- validated review input: `false`
- human review required now: `false`
- human/audio preference claimed: `false`
- MIDI-to-solo musical quality claimed: `false`

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_phrase_bank_listening_review_package`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-listening-review-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- 청음 품질 claim 제외
- human/audio preference claim 제외
- review input 없이 preference fill 금지
- 다음 검증 대상: phrase-bank listening review input guard

Closes #636
