### PR TITLE
Stage B MIDI-to-solo phrase-bank objective-only next decision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #638, Stage B MIDI-to-solo phrase-bank listening review input guard.
+- Latest functional issue completed: Issue #640, Stage B MIDI-to-solo phrase-bank objective-only next decision.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo phrase-bank objective-only next decision.
+- Recommended next issue: Stage B MIDI-to-solo phrase-bank dead-air density repair probe.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1124,6 +1124,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-listening-review-
 ```
 
 This harness blocks preference fill while phrase-bank listening review input is pending and routes to the objective-only next decision.
+
+For Stage B MIDI-to-solo phrase-bank objective-only next decision changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-objective-only-next-decision
+```
+
+This harness selects the next phrase-bank boundary from objective MIDI/WAV evidence only, without claiming human/audio preference or musical quality.
 
 For Stage B MIDI-to-solo model-direct user listening review fill changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_phrase_bank_listening_review_input_guard`
-- current evidence boundary: `stage_b_midi_to_solo_phrase_bank_listening_review_input_guard`
+- latest evidence boundary: `stage_b_midi_to_solo_phrase_bank_objective_only_next_decision`
+- current evidence boundary: `stage_b_midi_to_solo_phrase_bank_objective_only_next_decision`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
 - selected quality gap target: `model_conditioned_input_path_quality_alignment`
@@ -30,6 +30,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - phrase-bank listening review package ready: `true`
 - phrase-bank listening review items: `3`
 - phrase-bank preference fill allowed: `false`
+- phrase-bank objective keep candidates: `0 / 3`
+- phrase-bank repair required candidates: `3 / 3`
+- phrase-bank dead-air range: `0.5873 - 0.6032`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -53,6 +56,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - 입력 MIDI context 기반 phrase-bank retrieval 후보 export 가능
 - phrase-bank 후보의 WAV technical render 가능
 - phrase-bank 후보의 listening review package 생성 가능
+- phrase-bank 후보의 objective-only 실패 신호 분리 가능
 
 현재 README가 주장하지 않는 것.
 
@@ -179,6 +183,19 @@ Phrase-bank listening review input guard.
 - required input fields: `candidate_rank`, `listening_status`, `preference`, `issue_notes`
 - human/audio preference claimed: `false`
 - next boundary: `stage_b_midi_to_solo_phrase_bank_objective_only_next_decision`
+
+Phrase-bank objective-only next decision.
+
+- review basis: `objective_midi_and_wav_metadata_only`
+- candidate count: `3`
+- objective keep candidate count: `0`
+- repair required candidate count: `3`
+- all candidates require repair: `true`
+- dead-air range: `0.5873 - 0.6032`
+- primary risk flags: `dead_air_ratio_above_review_threshold`, `uniform_bar_note_density`, `low_duration_diversity`, `low_ioi_diversity`, `low_approach_resolution`, `high_pitch_reuse_ratio`, `no_leap_motion`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_probe`
 
 MIDI-to-solo input contract.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -2399,6 +2399,41 @@ Issue #638은 Issue #636 listening review package의 pending input 상태를 검
 
 - `Stage B MIDI-to-solo phrase-bank objective-only next decision`
 
+## 9.11 Stage B MIDI-to-solo phrase-bank objective-only next decision
+
+Issue #640은 Issue #638 input guard 이후 사용자 청음 없이 진행 가능한 objective-only decision을 추가한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_phrase_bank_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_phrase_bank_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_probe`
+- review basis: `objective_midi_and_wav_metadata_only`
+- candidate count: `3`
+- objective keep candidate count: `0`
+- repair required candidate count: `3`
+- all candidates require repair: `true`
+- dead-air range: `0.5873 - 0.6032`
+- preference fill allowed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- phrase-bank 후보 3개 모두 기존 export gate 통과.
+- 3개 모두 solo keep 기준 objective risk 존재.
+- 공통 risk: dead-air 초과, uniform bar note density, duration/IOI diversity 부족, approach resolution 부족, pitch reuse 과다, leap motion 부재.
+- 현재 후보를 CLI MVP keep 후보로 포장하지 않고 dead-air/density repair 대상으로 분리.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_phrase_bank_objective_only_next_decision`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-objective-only-next-decision`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo phrase-bank dead-air density repair probe`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #638, Stage B MIDI-to-solo phrase-bank listening review input guard
-- 다음 권장 이슈: `Stage B MIDI-to-solo phrase-bank objective-only next decision`
+- latest functional result: Issue #640, Stage B MIDI-to-solo phrase-bank objective-only next decision
+- 다음 권장 이슈: `Stage B MIDI-to-solo phrase-bank dead-air density repair probe`
 
 현재 범위가 아닌 것:
 
@@ -36,6 +36,50 @@
 - phrase-bank audio render technical validation 완료
 - phrase-bank listening review package 준비 완료
 - review input pending 상태에서 preference fill 차단 완료
+- objective-only 지표 기준 phrase-bank 후보 3개 모두 repair 필요
+
+## Stage B MIDI-to-Solo Phrase-Bank Objective-Only Next Decision Result
+
+Issue #640은 Issue #638 input guard 이후 사용자 청음 없이 진행 가능한 objective-only decision을 추가한 작업이다.
+
+변경:
+
+- input guard, phrase-bank retrieval, audio render report source validation 추가
+- review input 없는 preference fill 차단 유지
+- MIDI/WAV metadata 기반 후보별 risk flag 기록
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-05.md`
+- boundary: `stage_b_midi_to_solo_phrase_bank_objective_only_next_decision`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_probe`
+- review basis: `objective_midi_and_wav_metadata_only`
+- candidate count: `3`
+- objective keep candidate count: `0`
+- repair required candidate count: `3`
+- all candidates require repair: `true`
+- dead-air range: `0.5873 - 0.6032`
+- preference fill allowed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- 3개 후보 모두 기존 export gate는 통과
+- solo keep 기준 objective risk 존재
+- 공통 risk: dead-air 초과, uniform bar note density, duration/IOI diversity 부족, approach resolution 부족, pitch reuse 과다, leap motion 부재
+- CLI MVP package 전 dead-air/density repair 필요
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_phrase_bank_objective_only_next_decision`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-objective-only-next-decision`
+
+다음:
+
+- `Stage B MIDI-to-solo phrase-bank dead-air density repair probe`
 
 ## Stage B MIDI-to-Solo Phrase-Bank Listening Review Input Guard Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-05.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-05.md
@@ -1,0 +1,62 @@
+# Stage B MIDI-to-Solo Phrase-Bank Objective-Only Next Decision
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_phrase_bank_objective_only_next_decision`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_probe`
+- review basis: `objective_midi_and_wav_metadata_only`
+- candidate count: `3`
+- objective keep candidate count: `0`
+- repair required candidate count: `3`
+- all candidates require repair: `true`
+- dead-air range: `0.5873 - 0.6032`
+- preference fill allowed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Candidate Objective Review
+
+### Rank 1
+
+- seed: `635`
+- notes / unique pitches / max simultaneous: `64 / 22 / 1`
+- dead-air / phrase coverage: `0.5873 / 1.0000`
+- duration diversity / IOI diversity: `0.0938 / 0.0952`
+- approach resolution / repeated pitch ratio: `0.3529 / 0.6562`
+- repair required: `true`
+- risk flags: `dead_air_ratio_above_review_threshold, uniform_bar_note_density, low_duration_diversity, low_ioi_diversity, low_approach_resolution, high_pitch_reuse_ratio, no_leap_motion`
+
+### Rank 2
+
+- seed: `632`
+- notes / unique pitches / max simultaneous: `64 / 21 / 1`
+- dead-air / phrase coverage: `0.5873 / 1.0000`
+- duration diversity / IOI diversity: `0.0938 / 0.0952`
+- approach resolution / repeated pitch ratio: `0.3714 / 0.6719`
+- repair required: `true`
+- risk flags: `dead_air_ratio_above_review_threshold, uniform_bar_note_density, low_duration_diversity, low_ioi_diversity, low_approach_resolution, high_pitch_reuse_ratio, no_leap_motion`
+
+### Rank 3
+
+- seed: `638`
+- notes / unique pitches / max simultaneous: `64 / 22 / 1`
+- dead-air / phrase coverage: `0.6032 / 1.0000`
+- duration diversity / IOI diversity: `0.0781 / 0.0952`
+- approach resolution / repeated pitch ratio: `0.3056 / 0.6562`
+- repair required: `true`
+- risk flags: `dead_air_ratio_above_review_threshold, uniform_bar_note_density, low_duration_diversity, low_ioi_diversity, low_approach_resolution, high_pitch_reuse_ratio, no_leap_motion`
+
+## Decision
+
+- auto progress allowed: `true`
+- critical user input required: `false`
+- reason: `phrase-bank candidates require objective repair before CLI MVP packaging`
+- next recommended issue: `Stage B MIDI-to-solo phrase-bank dead-air density repair probe`
+
+## Not Proven
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `phrase_bank_musical_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -206,6 +206,8 @@ Modes:
                 Package phrase-bank MIDI/WAV candidates for pending listening review.
   stage-b-midi-to-solo-phrase-bank-listening-review-input-guard
                 Guard phrase-bank preference fill while listening review input is pending.
+  stage-b-midi-to-solo-phrase-bank-objective-only-next-decision
+                Select the next phrase-bank boundary from objective MIDI/WAV evidence only.
   stage-b-midi-to-solo-candidate-audio-render-package
                 Render exported MIDI-to-solo candidates to local WAV files.
   stage-b-midi-to-solo-mvp-execution-consolidation
@@ -3711,6 +3713,40 @@ run_stage_b_midi_to_solo_phrase_bank_listening_review_input_guard() {
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_phrase_bank_objective_only_next_decision() {
+  local phrase_bank_run_id="${PHRASE_BANK_RUN_ID:-harness_stage_b_midi_to_solo_phrase_bank_retrieval_baseline}"
+  local audio_run_id="${AUDIO_RUN_ID:-harness_stage_b_midi_to_solo_phrase_bank_audio_render_package}"
+  local input_guard_run_id="${INPUT_GUARD_RUN_ID:-harness_stage_b_midi_to_solo_phrase_bank_listening_review_input_guard}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_phrase_bank_objective_only_next_decision}"
+  local phrase_bank_report="outputs/stage_b_midi_to_solo_phrase_bank_retrieval_baseline/${phrase_bank_run_id}/stage_b_midi_to_solo_phrase_bank_retrieval_baseline.json"
+  local audio_render_report="outputs/stage_b_midi_to_solo_phrase_bank_audio_render_package/${audio_run_id}/stage_b_midi_to_solo_phrase_bank_audio_render_package.json"
+  local input_guard_report="outputs/stage_b_midi_to_solo_phrase_bank_listening_review_input_guard/${input_guard_run_id}/stage_b_midi_to_solo_phrase_bank_listening_review_input_guard.json"
+  if [[ ! -f "$phrase_bank_report" ]]; then
+    print_header "Stage B MIDI-to-solo phrase-bank retrieval baseline"
+    RUN_ID="$phrase_bank_run_id" run_stage_b_midi_to_solo_phrase_bank_retrieval_baseline
+  fi
+  if [[ ! -f "$audio_render_report" ]]; then
+    print_header "Stage B MIDI-to-solo phrase-bank audio render package"
+    RUN_ID="$audio_run_id" PHRASE_BANK_RUN_ID="$phrase_bank_run_id" run_stage_b_midi_to_solo_phrase_bank_audio_render_package
+  fi
+  if [[ ! -f "$input_guard_report" ]]; then
+    print_header "Stage B MIDI-to-solo phrase-bank listening review input guard"
+    RUN_ID="$input_guard_run_id" AUDIO_RUN_ID="$audio_run_id" PHRASE_BANK_RUN_ID="$phrase_bank_run_id" run_stage_b_midi_to_solo_phrase_bank_listening_review_input_guard
+  fi
+  print_header "Stage B MIDI-to-solo phrase-bank objective-only next decision"
+  "$PYTHON_BIN" scripts/decide_stage_b_midi_to_solo_phrase_bank_objective_next.py \
+    --run_id "$run_id" \
+    --input_guard_report "$input_guard_report" \
+    --phrase_bank_report "$phrase_bank_report" \
+    --audio_render_report "$audio_render_report" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-05.md \
+    --expected_boundary stage_b_midi_to_solo_phrase_bank_objective_only_next_decision \
+    --expected_next_boundary stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_probe \
+    --require_objective_decision \
+    --require_repair_required \
+    --require_no_quality_claim
+}
+
 run_stage_b_midi_to_solo_candidate_audio_render_package() {
   local generation_run_id="${GENERATION_RUN_ID:-harness_stage_b_midi_to_solo_conditioned_generation_probe}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_candidate_audio_render_package}"
@@ -7182,6 +7218,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-phrase-bank-listening-review-input-guard)
     run_stage_b_midi_to_solo_phrase_bank_listening_review_input_guard
+    ;;
+  stage-b-midi-to-solo-phrase-bank-objective-only-next-decision)
+    run_stage_b_midi_to_solo_phrase_bank_objective_only_next_decision
     ;;
   stage-b-midi-to-solo-candidate-audio-render-package)
     run_stage_b_midi_to_solo_candidate_audio_render_package

--- a/scripts/decide_stage_b_midi_to_solo_phrase_bank_objective_next.py
+++ b/scripts/decide_stage_b_midi_to_solo_phrase_bank_objective_next.py
@@ -1,0 +1,504 @@
+"""Select the next phrase-bank MIDI-to-solo step from objective evidence only."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.guard_stage_b_midi_to_solo_phrase_bank_listening_review_input import (  # noqa: E402
+    BOUNDARY as INPUT_GUARD_BOUNDARY,
+    OBJECTIVE_NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+from scripts.render_stage_b_midi_to_solo_phrase_bank_audio import (  # noqa: E402
+    BOUNDARY as AUDIO_RENDER_BOUNDARY,
+)
+from scripts.run_stage_b_midi_to_solo_phrase_bank_retrieval_baseline import (  # noqa: E402
+    BOUNDARY as PHRASE_BANK_BOUNDARY,
+)
+
+
+class StageBMidiToSoloPhraseBankObjectiveNextError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_phrase_bank_objective_only_next_decision"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_probe"
+SCHEMA_VERSION = "stage_b_midi_to_solo_phrase_bank_objective_only_next_decision_v1"
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "phrase_bank_musical_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloPhraseBankObjectiveNextError(f"unexpected quality claim in {label}: {claimed}")
+
+
+def validate_input_guard_report(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    guard = _dict(report.get("guard_result"))
+    if str(report.get("boundary") or "") != INPUT_GUARD_BOUNDARY:
+        raise StageBMidiToSoloPhraseBankObjectiveNextError("phrase-bank input guard boundary required")
+    if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
+        raise StageBMidiToSoloPhraseBankObjectiveNextError("input guard must route to objective-only next decision")
+    if not bool(readiness.get("listening_review_input_guard_completed", False)):
+        raise StageBMidiToSoloPhraseBankObjectiveNextError("input guard completion required")
+    if bool(guard.get("validated_review_input_present", True)):
+        raise StageBMidiToSoloPhraseBankObjectiveNextError("objective-only decision requires pending review input")
+    if bool(guard.get("preference_fill_allowed", True)):
+        raise StageBMidiToSoloPhraseBankObjectiveNextError("preference fill must remain blocked")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPhraseBankObjectiveNextError("critical user input should not be required")
+    _require_no_quality_claim(readiness, label="input guard readiness")
+    return {
+        "boundary": INPUT_GUARD_BOUNDARY,
+        "validated_review_input_present": bool(guard.get("validated_review_input_present", False)),
+        "preference_fill_allowed": bool(guard.get("preference_fill_allowed", False)),
+        "review_item_count": _int(guard.get("review_item_count")),
+    }
+
+
+def validate_phrase_bank_report(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    summary = _dict(report.get("summary"))
+    if str(report.get("boundary") or "") != PHRASE_BANK_BOUNDARY:
+        raise StageBMidiToSoloPhraseBankObjectiveNextError("phrase-bank retrieval boundary required")
+    if not bool(readiness.get("phrase_bank_retrieval_baseline_completed", False)):
+        raise StageBMidiToSoloPhraseBankObjectiveNextError("phrase-bank retrieval completion required")
+    if _int(summary.get("exported_candidate_count")) <= 0:
+        raise StageBMidiToSoloPhraseBankObjectiveNextError("exported phrase-bank candidates required")
+    _require_no_quality_claim(readiness, label="phrase-bank readiness")
+    candidates = [_dict(item) for item in _list(report.get("top_candidates"))]
+    if not candidates:
+        raise StageBMidiToSoloPhraseBankObjectiveNextError("top phrase-bank candidates required")
+    return {
+        "boundary": PHRASE_BANK_BOUNDARY,
+        "summary": summary,
+        "objective_gate": _dict(report.get("objective_gate")),
+        "top_candidates": candidates,
+    }
+
+
+def validate_audio_render_report(report: dict[str, Any]) -> dict[str, Any]:
+    boundary = _dict(report.get("audio_render_boundary"))
+    if str(report.get("source_boundary") or "") != PHRASE_BANK_BOUNDARY:
+        raise StageBMidiToSoloPhraseBankObjectiveNextError("audio render source must be phrase-bank retrieval")
+    if str(boundary.get("boundary") or "") != AUDIO_RENDER_BOUNDARY:
+        raise StageBMidiToSoloPhraseBankObjectiveNextError("phrase-bank audio render boundary required")
+    if not bool(boundary.get("technical_wav_validation", False)):
+        raise StageBMidiToSoloPhraseBankObjectiveNextError("technical WAV validation required")
+    if _int(boundary.get("rendered_audio_file_count")) <= 0:
+        raise StageBMidiToSoloPhraseBankObjectiveNextError("rendered WAV files required")
+    _require_no_quality_claim(boundary, label="audio render boundary")
+    rendered = [_dict(item) for item in _list(report.get("rendered_audio_files"))]
+    if not rendered:
+        raise StageBMidiToSoloPhraseBankObjectiveNextError("rendered audio items required")
+    return {
+        "boundary": AUDIO_RENDER_BOUNDARY,
+        "rendered_audio_files": rendered,
+        "technical_wav_validation": bool(boundary.get("technical_wav_validation", False)),
+    }
+
+
+def same_bar_density_pattern(candidate: dict[str, Any]) -> bool:
+    per_bar = _dict(_dict(candidate.get("collapse")).get("per_bar_note_counts"))
+    values = [_int(value) for value in per_bar.values()]
+    return bool(values) and len(set(values)) == 1
+
+
+def candidate_risk_flags(
+    candidate: dict[str, Any],
+    *,
+    dead_air_review_max: float,
+    min_rhythm_diversity: float,
+    min_approach_resolution: float,
+    max_pitch_reuse_ratio: float,
+) -> list[str]:
+    metrics = _dict(candidate.get("metrics"))
+    rhythm = _dict(candidate.get("rhythm_profile"))
+    approach = _dict(candidate.get("approach_resolution"))
+    contour = _dict(candidate.get("phrase_contour"))
+    collapse = _dict(candidate.get("collapse"))
+    flags: list[str] = []
+    if _float(metrics.get("dead_air_ratio")) >= float(dead_air_review_max):
+        flags.append("dead_air_ratio_above_review_threshold")
+    if same_bar_density_pattern(candidate):
+        flags.append("uniform_bar_note_density")
+    if _float(rhythm.get("duration_diversity_ratio")) < float(min_rhythm_diversity):
+        flags.append("low_duration_diversity")
+    if _float(rhythm.get("ioi_diversity_ratio")) < float(min_rhythm_diversity):
+        flags.append("low_ioi_diversity")
+    if _float(approach.get("approach_resolution_ratio")) < float(min_approach_resolution):
+        flags.append("low_approach_resolution")
+    if _float(collapse.get("repeated_pitch_ratio")) > float(max_pitch_reuse_ratio):
+        flags.append("high_pitch_reuse_ratio")
+    if _float(contour.get("leap_motion_ratio")) <= 0.0:
+        flags.append("no_leap_motion")
+    return flags
+
+
+def build_candidate_reviews(
+    *,
+    phrase_bank: dict[str, Any],
+    audio_render: dict[str, Any],
+    dead_air_review_max: float,
+    min_rhythm_diversity: float,
+    min_approach_resolution: float,
+    max_pitch_reuse_ratio: float,
+) -> list[dict[str, Any]]:
+    rendered_by_seed = {
+        _int(item.get("sample_seed")): item for item in _list(audio_render.get("rendered_audio_files"))
+    }
+    reviews: list[dict[str, Any]] = []
+    for rank, candidate in enumerate(_list(phrase_bank.get("top_candidates")), start=1):
+        seed = _int(candidate.get("sample_seed"))
+        metrics = _dict(candidate.get("metrics"))
+        rhythm = _dict(candidate.get("rhythm_profile"))
+        approach = _dict(candidate.get("approach_resolution"))
+        contour = _dict(candidate.get("phrase_contour"))
+        collapse = _dict(candidate.get("collapse"))
+        audio_item = _dict(rendered_by_seed.get(seed))
+        wav = _dict(audio_item.get("wav_file"))
+        flags = candidate_risk_flags(
+            candidate,
+            dead_air_review_max=dead_air_review_max,
+            min_rhythm_diversity=min_rhythm_diversity,
+            min_approach_resolution=min_approach_resolution,
+            max_pitch_reuse_ratio=max_pitch_reuse_ratio,
+        )
+        reviews.append(
+            {
+                "rank": rank,
+                "sample_seed": seed,
+                "mode": str(audio_item.get("mode") or ""),
+                "midi_path": str(audio_item.get("source_midi_path") or candidate.get("midi_path") or ""),
+                "wav_path": str(wav.get("path") or ""),
+                "objective_metrics": {
+                    "note_count": _int(metrics.get("note_count")),
+                    "unique_pitch_count": _int(metrics.get("unique_pitch_count")),
+                    "max_simultaneous_notes": _int(metrics.get("max_simultaneous_notes")),
+                    "dead_air_ratio": _float(metrics.get("dead_air_ratio")),
+                    "phrase_coverage_ratio": _float(metrics.get("phrase_coverage_ratio")),
+                    "note_density": _float(metrics.get("note_density")),
+                    "duration_seconds": _float(wav.get("duration_seconds")),
+                    "duration_diversity_ratio": _float(rhythm.get("duration_diversity_ratio")),
+                    "ioi_diversity_ratio": _float(rhythm.get("ioi_diversity_ratio")),
+                    "repeated_pitch_ratio": _float(collapse.get("repeated_pitch_ratio")),
+                    "max_same_pitch_repeats": _int(collapse.get("max_same_pitch_repeats")),
+                    "leap_motion_ratio": _float(contour.get("leap_motion_ratio")),
+                    "approach_resolution_ratio": _float(approach.get("approach_resolution_ratio")),
+                },
+                "risk_flags": flags,
+                "objective_keep_candidate": not flags,
+                "repair_required": bool(flags),
+            }
+        )
+    return reviews
+
+
+def build_objective_next_report(
+    *,
+    input_guard_report: dict[str, Any],
+    phrase_bank_report: dict[str, Any],
+    audio_render_report: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+    dead_air_review_max: float,
+    min_rhythm_diversity: float,
+    min_approach_resolution: float,
+    max_pitch_reuse_ratio: float,
+) -> dict[str, Any]:
+    input_guard = validate_input_guard_report(input_guard_report)
+    phrase_bank = validate_phrase_bank_report(phrase_bank_report)
+    audio_render = validate_audio_render_report(audio_render_report)
+    candidate_reviews = build_candidate_reviews(
+        phrase_bank=phrase_bank,
+        audio_render=audio_render,
+        dead_air_review_max=dead_air_review_max,
+        min_rhythm_diversity=min_rhythm_diversity,
+        min_approach_resolution=min_approach_resolution,
+        max_pitch_reuse_ratio=max_pitch_reuse_ratio,
+    )
+    keep_count = sum(1 for item in candidate_reviews if bool(item["objective_keep_candidate"]))
+    repair_count = sum(1 for item in candidate_reviews if bool(item["repair_required"]))
+    dead_air_values = [
+        _float(_dict(item.get("objective_metrics")).get("dead_air_ratio")) for item in candidate_reviews
+    ]
+    next_boundary = NEXT_BOUNDARY if repair_count else "stage_b_midi_to_solo_phrase_bank_cli_mvp_package"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundaries": {
+            "input_guard": input_guard["boundary"],
+            "phrase_bank": phrase_bank["boundary"],
+            "audio_render": audio_render["boundary"],
+        },
+        "review_policy": {
+            "basis": "objective_midi_and_wav_metadata_only",
+            "dead_air_review_max": float(dead_air_review_max),
+            "min_rhythm_diversity": float(min_rhythm_diversity),
+            "min_approach_resolution": float(min_approach_resolution),
+            "max_pitch_reuse_ratio": float(max_pitch_reuse_ratio),
+            "human_audio_preference_allowed": False,
+        },
+        "objective_summary": {
+            "candidate_count": len(candidate_reviews),
+            "objective_keep_candidate_count": keep_count,
+            "repair_required_candidate_count": repair_count,
+            "all_candidates_require_repair": repair_count == len(candidate_reviews),
+            "max_dead_air_ratio": max(dead_air_values) if dead_air_values else 0.0,
+            "min_dead_air_ratio": min(dead_air_values) if dead_air_values else 0.0,
+            "technical_wav_validation": bool(audio_render["technical_wav_validation"]),
+            "validated_review_input_present": bool(input_guard["validated_review_input_present"]),
+            "preference_fill_allowed": bool(input_guard["preference_fill_allowed"]),
+        },
+        "candidate_reviews": candidate_reviews,
+        "readiness": {
+            "boundary": BOUNDARY,
+            "objective_only_next_decision_completed": True,
+            "objective_keep_candidate_available": keep_count > 0,
+            "phrase_bank_repair_required": repair_count > 0,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "phrase_bank_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": next_boundary,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": (
+                "phrase-bank candidates require objective repair before CLI MVP packaging"
+                if repair_count
+                else "phrase-bank objective candidate available for CLI MVP packaging"
+            ),
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "phrase_bank_musical_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo phrase-bank dead-air density repair probe"
+            if repair_count
+            else "Stage B MIDI-to-solo phrase-bank CLI MVP package"
+        ),
+    }
+
+
+def validate_objective_next_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_objective_decision: bool,
+    require_repair_required: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("objective_summary"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloPhraseBankObjectiveNextError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloPhraseBankObjectiveNextError("unexpected next boundary")
+    if require_objective_decision and not bool(readiness.get("objective_only_next_decision_completed", False)):
+        raise StageBMidiToSoloPhraseBankObjectiveNextError("objective-only decision completion required")
+    if require_repair_required and not bool(readiness.get("phrase_bank_repair_required", False)):
+        raise StageBMidiToSoloPhraseBankObjectiveNextError("phrase-bank repair requirement expected")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPhraseBankObjectiveNextError("critical user input should not be required")
+    if bool(summary.get("preference_fill_allowed", True)):
+        raise StageBMidiToSoloPhraseBankObjectiveNextError("preference fill must remain blocked")
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="objective-next readiness")
+    return {
+        "boundary": boundary,
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "candidate_count": _int(summary.get("candidate_count")),
+        "objective_keep_candidate_count": _int(summary.get("objective_keep_candidate_count")),
+        "repair_required_candidate_count": _int(summary.get("repair_required_candidate_count")),
+        "all_candidates_require_repair": bool(summary.get("all_candidates_require_repair", False)),
+        "max_dead_air_ratio": _float(summary.get("max_dead_air_ratio")),
+        "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["objective_summary"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    policy = report["review_policy"]
+    lines = [
+        "# Stage B MIDI-to-Solo Phrase-Bank Objective-Only Next Decision",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- review basis: `{policy['basis']}`",
+        f"- candidate count: `{summary['candidate_count']}`",
+        f"- objective keep candidate count: `{summary['objective_keep_candidate_count']}`",
+        f"- repair required candidate count: `{summary['repair_required_candidate_count']}`",
+        f"- all candidates require repair: `{_bool_token(summary['all_candidates_require_repair'])}`",
+        f"- dead-air range: `{summary['min_dead_air_ratio']:.4f} - {summary['max_dead_air_ratio']:.4f}`",
+        f"- preference fill allowed: `{_bool_token(summary['preference_fill_allowed'])}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Candidate Objective Review",
+        "",
+    ]
+    for item in report["candidate_reviews"]:
+        metrics = item["objective_metrics"]
+        lines.extend(
+            [
+                f"### Rank {item['rank']}",
+                "",
+                f"- seed: `{item['sample_seed']}`",
+                f"- notes / unique pitches / max simultaneous: `{metrics['note_count']} / {metrics['unique_pitch_count']} / {metrics['max_simultaneous_notes']}`",
+                f"- dead-air / phrase coverage: `{metrics['dead_air_ratio']:.4f} / {metrics['phrase_coverage_ratio']:.4f}`",
+                f"- duration diversity / IOI diversity: `{metrics['duration_diversity_ratio']:.4f} / {metrics['ioi_diversity_ratio']:.4f}`",
+                f"- approach resolution / repeated pitch ratio: `{metrics['approach_resolution_ratio']:.4f} / {metrics['repeated_pitch_ratio']:.4f}`",
+                f"- repair required: `{_bool_token(item['repair_required'])}`",
+                f"- risk flags: `{', '.join(item['risk_flags'])}`",
+                "",
+            ]
+        )
+    lines.extend(
+        [
+            "## Decision",
+            "",
+            f"- auto progress allowed: `{_bool_token(decision['auto_progress_allowed'])}`",
+            f"- critical user input required: `{_bool_token(decision['critical_user_input_required'])}`",
+            f"- reason: `{decision['reason']}`",
+            f"- next recommended issue: `{report['next_recommended_issue']}`",
+            "",
+            "## Not Proven",
+            "",
+        ]
+    )
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run_id", default="harness_stage_b_midi_to_solo_phrase_bank_objective_next")
+    parser.add_argument("--output_root", type=Path, default=Path("outputs/stage_b_midi_to_solo_phrase_bank_objective_only_next_decision"))
+    parser.add_argument("--input_guard_report", type=Path, required=True)
+    parser.add_argument("--phrase_bank_report", type=Path, required=True)
+    parser.add_argument("--audio_render_report", type=Path, required=True)
+    parser.add_argument("--doc_path", type=Path)
+    parser.add_argument("--issue_number", type=int, default=640)
+    parser.add_argument("--dead_air_review_max", type=float, default=0.45)
+    parser.add_argument("--min_rhythm_diversity", type=float, default=0.12)
+    parser.add_argument("--min_approach_resolution", type=float, default=0.40)
+    parser.add_argument("--max_pitch_reuse_ratio", type=float, default=0.60)
+    parser.add_argument("--expected_boundary")
+    parser.add_argument("--expected_next_boundary")
+    parser.add_argument("--require_objective_decision", action="store_true")
+    parser.add_argument("--require_repair_required", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    output_dir = args.output_root / args.run_id
+    report = build_objective_next_report(
+        input_guard_report=read_json(args.input_guard_report),
+        phrase_bank_report=read_json(args.phrase_bank_report),
+        audio_render_report=read_json(args.audio_render_report),
+        output_dir=output_dir,
+        issue_number=args.issue_number,
+        dead_air_review_max=args.dead_air_review_max,
+        min_rhythm_diversity=args.min_rhythm_diversity,
+        min_approach_resolution=args.min_approach_resolution,
+        max_pitch_reuse_ratio=args.max_pitch_reuse_ratio,
+    )
+    summary = validate_objective_next_report(
+        report,
+        expected_boundary=args.expected_boundary,
+        expected_next_boundary=args.expected_next_boundary,
+        require_objective_decision=args.require_objective_decision,
+        require_repair_required=args.require_repair_required,
+        require_no_quality_claim=args.require_no_quality_claim,
+    )
+    json_path = output_dir / "stage_b_midi_to_solo_phrase_bank_objective_only_next_decision.json"
+    md_path = output_dir / "stage_b_midi_to_solo_phrase_bank_objective_only_next_decision.md"
+    validation_path = output_dir / "stage_b_midi_to_solo_phrase_bank_objective_only_next_decision_validation_summary.json"
+    write_json(json_path, report)
+    write_text(md_path, markdown_report(report))
+    write_json(validation_path, summary)
+    if args.doc_path:
+        write_text(args.doc_path, markdown_report(report))
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_stage_b_midi_to_solo_phrase_bank_objective_only_next_decision.py
+++ b/tests/test_stage_b_midi_to_solo_phrase_bank_objective_only_next_decision.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.decide_stage_b_midi_to_solo_phrase_bank_objective_next import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloPhraseBankObjectiveNextError,
+    build_objective_next_report,
+    validate_objective_next_report,
+)
+from scripts.guard_stage_b_midi_to_solo_phrase_bank_listening_review_input import (
+    BOUNDARY as INPUT_GUARD_BOUNDARY,
+    OBJECTIVE_NEXT_BOUNDARY as INPUT_GUARD_NEXT_BOUNDARY,
+)
+from scripts.render_stage_b_midi_to_solo_phrase_bank_audio import BOUNDARY as AUDIO_RENDER_BOUNDARY
+from scripts.run_stage_b_midi_to_solo_phrase_bank_retrieval_baseline import (
+    BOUNDARY as PHRASE_BANK_BOUNDARY,
+)
+
+
+def input_guard_report(*, quality_claim: bool = False) -> dict:
+    return {
+        "boundary": INPUT_GUARD_BOUNDARY,
+        "guard_result": {
+            "validated_review_input_present": False,
+            "preference_fill_allowed": False,
+            "review_item_count": 3,
+        },
+        "readiness": {
+            "listening_review_input_guard_completed": True,
+            "human_audio_preference_claimed": quality_claim,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "phrase_bank_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "next_boundary": INPUT_GUARD_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+def candidate(seed: int, dead_air: float, duration_diversity: float = 0.09) -> dict:
+    return {
+        "sample_seed": seed,
+        "metrics": {
+            "note_count": 64,
+            "unique_pitch_count": 22,
+            "max_simultaneous_notes": 1,
+            "dead_air_ratio": dead_air,
+            "phrase_coverage_ratio": 1.0,
+            "note_density": 4.0,
+        },
+        "collapse": {
+            "per_bar_note_counts": {str(index): 8 for index in range(8)},
+            "repeated_pitch_ratio": 0.65,
+            "max_same_pitch_repeats": 7,
+        },
+        "rhythm_profile": {
+            "duration_diversity_ratio": duration_diversity,
+            "ioi_diversity_ratio": 0.09,
+        },
+        "approach_resolution": {
+            "approach_resolution_ratio": 0.35,
+        },
+        "phrase_contour": {
+            "leap_motion_ratio": 0.0,
+        },
+    }
+
+
+def phrase_bank_report() -> dict:
+    return {
+        "boundary": PHRASE_BANK_BOUNDARY,
+        "summary": {
+            "exported_candidate_count": 3,
+        },
+        "objective_gate": {
+            "max_dead_air_ratio": 0.65,
+        },
+        "top_candidates": [
+            candidate(635, 0.5873),
+            candidate(632, 0.5873),
+            candidate(638, 0.6032),
+        ],
+        "readiness": {
+            "phrase_bank_retrieval_baseline_completed": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "phrase_bank_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+    }
+
+
+def audio_render_report() -> dict:
+    return {
+        "source_boundary": PHRASE_BANK_BOUNDARY,
+        "audio_render_boundary": {
+            "boundary": AUDIO_RENDER_BOUNDARY,
+            "technical_wav_validation": True,
+            "rendered_audio_file_count": 3,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "phrase_bank_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "rendered_audio_files": [
+            {
+                "rank": index,
+                "sample_seed": seed,
+                "mode": "data_motif_rhythm_phrase_variation",
+                "source_midi_path": f"midi/rank_{index}.mid",
+                "wav_file": {"path": f"audio/rank_{index}.wav", "duration_seconds": 18.9},
+            }
+            for index, seed in enumerate([635, 632, 638], start=1)
+        ],
+    }
+
+
+class StageBMidiToSoloPhraseBankObjectiveNextTest(unittest.TestCase):
+    def test_routes_to_repair_when_objective_risks_remain(self) -> None:
+        report = build_objective_next_report(
+            input_guard_report=input_guard_report(),
+            phrase_bank_report=phrase_bank_report(),
+            audio_render_report=audio_render_report(),
+            output_dir="out",
+            issue_number=640,
+            dead_air_review_max=0.45,
+            min_rhythm_diversity=0.12,
+            min_approach_resolution=0.40,
+            max_pitch_reuse_ratio=0.60,
+        )
+        summary = validate_objective_next_report(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=NEXT_BOUNDARY,
+            require_objective_decision=True,
+            require_repair_required=True,
+            require_no_quality_claim=True,
+        )
+
+        self.assertEqual(summary["candidate_count"], 3)
+        self.assertEqual(summary["objective_keep_candidate_count"], 0)
+        self.assertEqual(summary["repair_required_candidate_count"], 3)
+        self.assertTrue(summary["all_candidates_require_repair"])
+        self.assertFalse(summary["human_audio_preference_claimed"])
+
+    def test_rejects_upstream_quality_claim(self) -> None:
+        with self.assertRaises(StageBMidiToSoloPhraseBankObjectiveNextError):
+            build_objective_next_report(
+                input_guard_report=input_guard_report(quality_claim=True),
+                phrase_bank_report=phrase_bank_report(),
+                audio_render_report=audio_render_report(),
+                output_dir="out",
+                issue_number=640,
+                dead_air_review_max=0.45,
+                min_rhythm_diversity=0.12,
+                min_approach_resolution=0.40,
+                max_pitch_reuse_ratio=0.60,
+            )
+
+    def test_boundary_constants_are_stable(self) -> None:
+        self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_phrase_bank_objective_only_next_decision")
+        self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_probe")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- phrase-bank objective-only next decision 추가
- review input pending 상태에서 preference fill 차단 유지
- MIDI/WAV metadata 기반 후보별 repair 필요 여부 기록

## Context

- #638 결과: `validated_review_input_present=false`, `preference_fill_allowed=false`
- phrase-bank 후보 3개 technical WAV validation 완료
- 후보 dead-air ratio: `0.5873 / 0.5873 / 0.6032`
- 후보 phrase coverage ratio: `1.0 / 1.0 / 1.0`
- 후보 note count: `64 / 64 / 64`
- human/audio preference, MIDI-to-solo musical quality claim 제외

## Changes

- `scripts/decide_stage_b_midi_to_solo_phrase_bank_objective_next.py`
  - input guard, phrase-bank retrieval, audio render source validation
  - candidate risk flags: dead-air, uniform density, rhythm diversity, approach resolution, pitch reuse, leap motion
  - next boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_probe`
- `tests/test_stage_b_midi_to_solo_phrase_bank_objective_only_next_decision.py`
  - repair-required route 검증
  - upstream quality claim 차단 검증
- `scripts/agent_harness.sh`
  - `stage-b-midi-to-solo-phrase-bank-objective-only-next-decision` mode 추가
- README, current status, core plan, handoff 문서 동기화

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_phrase_bank_objective_only_next_decision`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-objective-only-next-decision`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- 변경 파일 기준 `Codex|codex|코덱스` 미검출

## Risk

- objective-only 판단 범위
- human/audio preference claim 없음
- musical quality claim 없음

Closes #640
