### PR TITLE
Stage B MIDI-to-solo phrase-bank dead-air density repair audio package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #642, Stage B MIDI-to-solo phrase-bank dead-air density repair probe.
+- Latest functional issue completed: Issue #644, Stage B MIDI-to-solo phrase-bank dead-air density repair audio package.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo phrase-bank dead-air density repair audio package.
+- Recommended next issue: Stage B MIDI-to-solo phrase-bank dead-air density repair listening review package.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1140,6 +1140,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-dead-air-density-
 ```
 
 This harness repairs phrase-bank candidates for dead-air and density variation, then routes objective-supported repaired MIDI candidates to audio packaging without claiming musical quality.
+
+For Stage B MIDI-to-solo phrase-bank dead-air density repair audio package changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-dead-air-density-repair-audio-package
+```
+
+This harness renders dead-air/density repaired MIDI candidates to local WAV files and records technical audio metadata without claiming listening preference.
 
 For Stage B MIDI-to-solo model-direct user listening review fill changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_probe`
-- current evidence boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_probe`
+- latest evidence boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio_package`
+- current evidence boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio_package`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
 - selected quality gap target: `model_conditioned_input_path_quality_alignment`
@@ -36,6 +36,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - phrase-bank repaired / qualified candidates: `3 / 3`
 - phrase-bank repaired dead-air range: `0.1895 - 0.2211`
 - phrase-bank min dead-air gain: `0.3768`
+- phrase-bank repaired WAV files: `3`
+- phrase-bank repaired audio technical validation: `true`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -61,6 +63,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - phrase-bank 후보의 listening review package 생성 가능
 - phrase-bank 후보의 objective-only 실패 신호 분리 가능
 - phrase-bank 후보의 dead-air/density objective repair 가능
+- phrase-bank repaired MIDI 후보의 WAV technical render 가능
 
 현재 README가 주장하지 않는 것.
 
@@ -213,6 +216,18 @@ Phrase-bank dead-air density repair probe.
 - human/audio preference claimed: `false`
 - MIDI-to-solo musical quality claimed: `false`
 - next boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio_package`
+
+Phrase-bank dead-air density repair audio package.
+
+- rendered WAV files: `3`
+- technical WAV validation: `true`
+- rank 1 duration / sample rate / sha256 prefix: `18.985s / 44100 / 4ac7b2dc9f80`
+- rank 2 duration / sample rate / sha256 prefix: `18.984s / 44100 / eb6402477bf3`
+- rank 3 duration / sample rate / sha256 prefix: `18.997s / 44100 / 9991eb5b673c`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_package`
 
 MIDI-to-solo input contract.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -2469,6 +2469,39 @@ Issue #642는 Issue #640 objective-only decision의 repair target을 받아 phra
 
 - `Stage B MIDI-to-solo phrase-bank dead-air density repair audio package`
 
+## 9.13 Stage B MIDI-to-solo phrase-bank dead-air density repair audio package
+
+Issue #644는 Issue #642 repaired MIDI 후보 3개를 WAV로 render하고 technical metadata를 검증한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio_package`
+- source boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_probe`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_package`
+- rendered audio file count: `3`
+- technical WAV validation: `true`
+- rank 1 duration / sample rate / sha256 prefix: `18.985s / 44100 / 4ac7b2dc9f80`
+- rank 2 duration / sample rate / sha256 prefix: `18.984s / 44100 / eb6402477bf3`
+- rank 3 duration / sample rate / sha256 prefix: `18.997s / 44100 / 9991eb5b673c`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- dead-air/density repaired MIDI 후보의 WAV artifact 생성 완료.
+- 현재 검증 범위는 renderer execution과 WAV metadata.
+- 청음 품질 claim 제외.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-dead-air-density-repair-audio-package`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo phrase-bank dead-air density repair listening review package`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #642, Stage B MIDI-to-solo phrase-bank dead-air density repair probe
-- 다음 권장 이슈: `Stage B MIDI-to-solo phrase-bank dead-air density repair audio package`
+- latest functional result: Issue #644, Stage B MIDI-to-solo phrase-bank dead-air density repair audio package
+- 다음 권장 이슈: `Stage B MIDI-to-solo phrase-bank dead-air density repair listening review package`
 
 현재 범위가 아닌 것:
 
@@ -38,6 +38,49 @@
 - review input pending 상태에서 preference fill 차단 완료
 - objective-only 지표 기준 phrase-bank 후보 3개 모두 repair 필요
 - dead-air/density repair probe 기준 repaired 후보 3개 모두 objective target 통과
+- dead-air/density repaired MIDI 후보 3개 WAV technical render 완료
+
+## Stage B MIDI-to-Solo Phrase-Bank Dead-Air Density Repair Audio Package Result
+
+Issue #644는 Issue #642 repaired MIDI 후보 3개를 WAV로 render하고 technical metadata를 검증한 작업이다.
+
+변경:
+
+- dead-air/density repair report source validation 추가
+- repaired MIDI 후보 3개 WAV render 추가
+- WAV duration, sample rate, size, sha256 metadata 기록
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_DEAD_AIR_DENSITY_REPAIR_AUDIO_PACKAGE_2026-06-05.md`
+- boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio_package`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_package`
+- rendered audio file count: `3`
+- technical WAV validation: `true`
+- rank 1 duration / sample rate / sha256 prefix: `18.985s / 44100 / 4ac7b2dc9f80`
+- rank 2 duration / sample rate / sha256 prefix: `18.984s / 44100 / eb6402477bf3`
+- rank 3 duration / sample rate / sha256 prefix: `18.997s / 44100 / 9991eb5b673c`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- repaired MIDI 후보의 local WAV artifact 생성 완료
+- 현재 검증 범위는 renderer execution과 WAV metadata
+- 청음 품질, human/audio preference, phrase-bank musical quality claim 제외
+- 다음 작업은 repaired 후보 listening review package
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-dead-air-density-repair-audio-package`
+
+다음:
+
+- `Stage B MIDI-to-solo phrase-bank dead-air density repair listening review package`
 
 ## Stage B MIDI-to-Solo Phrase-Bank Dead-Air Density Repair Probe Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_DEAD_AIR_DENSITY_REPAIR_AUDIO_PACKAGE_2026-06-05.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_DEAD_AIR_DENSITY_REPAIR_AUDIO_PACKAGE_2026-06-05.md
@@ -1,0 +1,32 @@
+# Stage B MIDI-to-Solo Phrase-Bank Dead-Air Density Repair Audio Package
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio_package`
+- source boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_probe`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_package`
+- render attempted: `true`
+- rendered audio file count: `3`
+- technical WAV validation: `true`
+- repaired ranked audio render completed: `true`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+
+## Rendered Files
+
+- rank `1` mode `dead_air_density_repair` seed `635`: `outputs/stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio_package/harness_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio_package/audio/rank_01_seed_635.wav`, duration `18.985`, sample rate `44100`, size `3349036`, sha256 `4ac7b2dc9f80`
+- rank `2` mode `dead_air_density_repair` seed `632`: `outputs/stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio_package/harness_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio_package/audio/rank_02_seed_632.wav`, duration `18.984`, sample rate `44100`, size `3348780`, sha256 `eb6402477bf3`
+- rank `3` mode `dead_air_density_repair` seed `638`: `outputs/stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio_package/harness_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio_package/audio/rank_03_seed_638.wav`, duration `18.997`, sample rate `44100`, size `3351084`, sha256 `9991eb5b673c`
+
+## Claim Boundary
+
+- `audio_rendered_quality`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `phrase_bank_musical_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`
+
+## Next
+
+- `Stage B MIDI-to-solo phrase-bank dead-air density repair listening review package`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -210,6 +210,8 @@ Modes:
                 Select the next phrase-bank boundary from objective MIDI/WAV evidence only.
   stage-b-midi-to-solo-phrase-bank-dead-air-density-repair-probe
                 Repair phrase-bank candidates for dead-air and density variation.
+  stage-b-midi-to-solo-phrase-bank-dead-air-density-repair-audio-package
+                Render dead-air/density repaired phrase-bank MIDI candidates to WAV files.
   stage-b-midi-to-solo-candidate-audio-render-package
                 Render exported MIDI-to-solo candidates to local WAV files.
   stage-b-midi-to-solo-mvp-execution-consolidation
@@ -3769,6 +3771,26 @@ run_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_probe() {
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio_package() {
+  local repair_run_id="${REPAIR_RUN_ID:-harness_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_probe}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio_package}"
+  local repair_report="outputs/stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_probe/${repair_run_id}/stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_probe.json"
+  if [[ ! -f "$repair_report" ]]; then
+    print_header "Stage B MIDI-to-solo phrase-bank dead-air density repair probe"
+    RUN_ID="$repair_run_id" run_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_probe
+  fi
+  print_header "Stage B MIDI-to-solo phrase-bank dead-air density repair audio package"
+  "$PYTHON_BIN" scripts/render_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio.py \
+    --run_id "$run_id" \
+    --repair_report "$repair_report" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_DEAD_AIR_DENSITY_REPAIR_AUDIO_PACKAGE_2026-06-05.md \
+    --expected_boundary stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio_package \
+    --expected_next_boundary stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_package \
+    --expected_file_count 3 \
+    --require_repaired_audio_path \
+    --require_no_quality_claim
+}
+
 run_stage_b_midi_to_solo_candidate_audio_render_package() {
   local generation_run_id="${GENERATION_RUN_ID:-harness_stage_b_midi_to_solo_conditioned_generation_probe}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_candidate_audio_render_package}"
@@ -7246,6 +7268,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-phrase-bank-dead-air-density-repair-probe)
     run_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_probe
+    ;;
+  stage-b-midi-to-solo-phrase-bank-dead-air-density-repair-audio-package)
+    run_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio_package
     ;;
   stage-b-midi-to-solo-candidate-audio-render-package)
     run_stage_b_midi_to_solo_candidate_audio_render_package

--- a/scripts/render_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio.py
+++ b/scripts/render_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio.py
@@ -1,0 +1,322 @@
+"""Render dead-air/density repaired phrase-bank MIDI candidates to WAV."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.render_stage_b_midi_to_solo_candidate_audio import resolve_soundfont, sha256_file  # noqa: E402
+from scripts.render_stage_b_midi_to_solo_phrase_bank_audio import (  # noqa: E402
+    build_render_plan,
+    execute_render_plan,
+    validate_audio_render_report as validate_generic_audio_render_report,
+)
+from scripts.run_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_probe import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+class StageBMidiToSoloPhraseBankDeadAirDensityRepairAudioError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio_package"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_package"
+SCHEMA_VERSION = "stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio_package_v1"
+CommandRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "phrase_bank_musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _path_exists(path_text: str) -> bool:
+    return bool(path_text and Path(path_text).exists())
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloPhraseBankDeadAirDensityRepairAudioError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_source_report(report: dict[str, Any], *, expected_count: int) -> list[dict[str, Any]]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("summary"))
+    if str(report.get("boundary") or readiness.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloPhraseBankDeadAirDensityRepairAudioError("repair probe boundary required")
+    if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
+        raise StageBMidiToSoloPhraseBankDeadAirDensityRepairAudioError("repair probe must route to audio package")
+    if not bool(readiness.get("dead_air_density_repair_probe_completed", False)):
+        raise StageBMidiToSoloPhraseBankDeadAirDensityRepairAudioError("repair probe completion required")
+    if not bool(summary.get("repair_probe_target_passed", False)):
+        raise StageBMidiToSoloPhraseBankDeadAirDensityRepairAudioError("repair probe target pass required")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPhraseBankDeadAirDensityRepairAudioError("critical user input should not be required")
+    _require_no_quality_claim(readiness, label="repair probe readiness")
+    candidates = [_dict(item) for item in _list(report.get("repaired_candidates"))]
+    if len(candidates) < int(expected_count):
+        raise StageBMidiToSoloPhraseBankDeadAirDensityRepairAudioError("not enough repaired candidates")
+    compacted: list[dict[str, Any]] = []
+    for item in candidates[: int(expected_count)]:
+        gate = _dict(item.get("repair_gate"))
+        midi_path = str(item.get("repaired_midi_path") or "")
+        if not bool(gate.get("qualified", False)):
+            raise StageBMidiToSoloPhraseBankDeadAirDensityRepairAudioError("unqualified repaired candidate")
+        if not _path_exists(midi_path):
+            raise StageBMidiToSoloPhraseBankDeadAirDensityRepairAudioError(f"repaired MIDI missing: {midi_path}")
+        metrics = _dict(item.get("repaired_metrics"))
+        compacted.append(
+            {
+                "rank": _int(item.get("rank")),
+                "mode": "dead_air_density_repair",
+                "sample_index": _int(item.get("rank")),
+                "sample_seed": _int(item.get("sample_seed")),
+                "midi_path": midi_path,
+                "note_count": _int(metrics.get("note_count")),
+                "unique_pitch_count": _int(metrics.get("unique_pitch_count")),
+                "dead_air_ratio": _float(metrics.get("dead_air_ratio")),
+                "phrase_coverage_ratio": _float(metrics.get("phrase_coverage_ratio")),
+            }
+        )
+    return compacted
+
+
+def build_audio_render_report(
+    source_report: dict[str, Any],
+    *,
+    output_dir: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+    expected_file_count: int,
+    runner: CommandRunner | None = None,
+) -> dict[str, Any]:
+    candidates = validate_source_report(source_report, expected_count=expected_file_count)
+    resolved_renderer = renderer_path or shutil.which("fluidsynth") or ""
+    resolved_soundfont = resolve_soundfont(soundfont_path)
+    plan = build_render_plan(
+        candidates,
+        output_dir=output_dir,
+        renderer_path=resolved_renderer,
+        soundfont_path=resolved_soundfont,
+        sample_rate=sample_rate,
+    )
+    rendered = execute_render_plan(plan, runner=runner) if runner else execute_render_plan(plan)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_boundary": SOURCE_BOUNDARY,
+        "source_repair_summary": _dict(source_report.get("summary")),
+        "renderer": {
+            "name": "fluidsynth",
+            "path": resolved_renderer,
+        },
+        "soundfont": {
+            "path": str(Path(resolved_soundfont).expanduser()),
+            "sha256": sha256_file(Path(resolved_soundfont).expanduser()),
+        },
+        "rendered_audio_files": rendered,
+        "audio_render_boundary": {
+            "boundary": BOUNDARY,
+            "render_attempted": True,
+            "rendered_audio_file_count": int(len(rendered)),
+            "technical_wav_validation": True,
+            "phrase_bank_ranked_audio_render_completed": True,
+            "phrase_bank_listening_review_package_required": True,
+            "audio_output_claimed": True,
+            "audio_rendered_quality_claimed": False,
+            "human_audio_preference_claimed": False,
+            "musical_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "phrase_bank_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "dead-air/density repaired MIDI exports rendered to WAV; listening review package remains separate",
+        },
+        "not_proven": [
+            "audio_rendered_quality",
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "phrase_bank_musical_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": "Stage B MIDI-to-solo phrase-bank dead-air density repair listening review package",
+    }
+
+
+def validate_audio_render_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    expected_file_count: int,
+    expected_sample_rate: int,
+    require_repaired_audio_path: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    summary = validate_generic_audio_render_report(
+        report,
+        expected_boundary=expected_boundary,
+        expected_next_boundary=expected_next_boundary,
+        expected_file_count=expected_file_count,
+        expected_sample_rate=expected_sample_rate,
+        require_phrase_bank_audio_path=require_repaired_audio_path,
+        require_no_quality_claim=require_no_quality_claim,
+    )
+    summary["source_boundary"] = str(report.get("source_boundary") or "")
+    return summary
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    boundary = report["audio_render_boundary"]
+    decision = report["decision"]
+    lines = [
+        "# Stage B MIDI-to-Solo Phrase-Bank Dead-Air Density Repair Audio Package",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{boundary['boundary']}`",
+        f"- source boundary: `{report['source_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- render attempted: `{_bool_token(boundary['render_attempted'])}`",
+        f"- rendered audio file count: `{boundary['rendered_audio_file_count']}`",
+        f"- technical WAV validation: `{_bool_token(boundary['technical_wav_validation'])}`",
+        f"- repaired ranked audio render completed: `{_bool_token(boundary['phrase_bank_ranked_audio_render_completed'])}`",
+        f"- audio rendered quality claimed: `{_bool_token(boundary['audio_rendered_quality_claimed'])}`",
+        f"- human/audio preference claimed: `{_bool_token(boundary['human_audio_preference_claimed'])}`",
+        "",
+        "## Rendered Files",
+        "",
+    ]
+    for item in report.get("rendered_audio_files", []):
+        wav_file = item["wav_file"]
+        lines.append(
+            f"- rank `{item['rank']}` mode `{item['mode']}` seed `{item['sample_seed']}`: "
+            f"`{wav_file['path']}`, duration `{float(wav_file['duration_seconds']):.3f}`, "
+            f"sample rate `{wav_file['sample_rate']}`, size `{wav_file['size_bytes']}`, "
+            f"sha256 `{str(wav_file['sha256'])[:12]}`"
+        )
+    lines.extend(["", "## Claim Boundary", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    lines.extend(["", "## Next", "", f"- `{report['next_recommended_issue']}`"])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Render dead-air/density repaired phrase-bank MIDI-to-solo WAV files")
+    parser.add_argument("--repair_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio_package",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--renderer", type=str, default=shutil.which("fluidsynth") or "")
+    parser.add_argument("--soundfont", type=str, default="")
+    parser.add_argument("--sample_rate", type=int, default=44100)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--expected_file_count", type=int, default=3)
+    parser.add_argument("--require_repaired_audio_path", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_audio_render_report(
+        read_json(Path(args.repair_report)),
+        output_dir=output_dir,
+        renderer_path=str(args.renderer or ""),
+        soundfont_path=str(args.soundfont or ""),
+        sample_rate=int(args.sample_rate),
+        expected_file_count=int(args.expected_file_count),
+    )
+    summary = validate_audio_render_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        expected_file_count=int(args.expected_file_count),
+        expected_sample_rate=int(args.sample_rate),
+        require_repaired_audio_path=bool(args.require_repaired_audio_path),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio_package.json", report)
+    write_json(
+        output_dir / "stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio_package_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio_package.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio.py
+++ b/tests/test_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+import wave
+from pathlib import Path
+from typing import Sequence
+
+import pretty_midi
+
+from scripts.render_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloPhraseBankDeadAirDensityRepairAudioError,
+    build_audio_render_report,
+    validate_audio_render_report,
+)
+from scripts.run_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_probe import (
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+def write_midi(path: Path) -> None:
+    midi = pretty_midi.PrettyMIDI(initial_tempo=120)
+    instrument = pretty_midi.Instrument(program=0, is_drum=False)
+    instrument.notes.append(pretty_midi.Note(velocity=80, pitch=60, start=0.0, end=0.2))
+    midi.instruments.append(instrument)
+    midi.write(str(path))
+
+
+def write_wav(path: Path, sample_rate: int = 44100) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(2)
+        handle.setsampwidth(2)
+        handle.setframerate(sample_rate)
+        handle.writeframes(b"\x00\x00\x00\x00" * sample_rate)
+
+
+def fake_runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    wav_path = Path(command[3])
+    write_wav(wav_path, sample_rate=int(command[5]))
+    return subprocess.CompletedProcess(list(command), 0, stdout="rendered", stderr="")
+
+
+def repair_report(tmp_path: Path, *, quality_claim: bool = False) -> dict:
+    midi_paths: list[Path] = []
+    for rank in range(1, 4):
+        path = tmp_path / f"rank_{rank}.mid"
+        write_midi(path)
+        midi_paths.append(path)
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "summary": {
+            "repair_probe_target_passed": True,
+        },
+        "readiness": {
+            "dead_air_density_repair_probe_completed": True,
+            "human_audio_preference_claimed": quality_claim,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "phrase_bank_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "next_boundary": SOURCE_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+        "repaired_candidates": [
+            {
+                "rank": rank,
+                "sample_seed": 630 + rank,
+                "repaired_midi_path": str(path),
+                "repaired_metrics": {
+                    "note_count": 96,
+                    "unique_pitch_count": 20,
+                    "dead_air_ratio": 0.2,
+                    "phrase_coverage_ratio": 1.0,
+                },
+                "repair_gate": {"qualified": True, "flags": []},
+            }
+            for rank, path in enumerate(midi_paths, start=1)
+        ],
+    }
+
+
+class StageBMidiToSoloPhraseBankDeadAirDensityRepairAudioTest(unittest.TestCase):
+    def test_renders_repaired_midi_to_wav_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            renderer = tmp_path / "fluidsynth"
+            soundfont = tmp_path / "soundfont.sf2"
+            renderer.write_text("", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+
+            report = build_audio_render_report(
+                repair_report(tmp_path),
+                output_dir=tmp_path / "out",
+                renderer_path=str(renderer),
+                soundfont_path=str(soundfont),
+                sample_rate=44100,
+                expected_file_count=3,
+                runner=fake_runner,
+            )
+            summary = validate_audio_render_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                expected_file_count=3,
+                expected_sample_rate=44100,
+                require_repaired_audio_path=True,
+                require_no_quality_claim=True,
+            )
+
+            self.assertEqual(summary["rendered_audio_file_count"], 3)
+            self.assertTrue(summary["technical_wav_validation"])
+            self.assertFalse(summary["human_audio_preference_claimed"])
+
+    def test_rejects_upstream_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            renderer = tmp_path / "fluidsynth"
+            soundfont = tmp_path / "soundfont.sf2"
+            renderer.write_text("", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+
+            with self.assertRaises(StageBMidiToSoloPhraseBankDeadAirDensityRepairAudioError):
+                build_audio_render_report(
+                    repair_report(tmp_path, quality_claim=True),
+                    output_dir=tmp_path / "out",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(soundfont),
+                    sample_rate=44100,
+                    expected_file_count=3,
+                    runner=fake_runner,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- dead-air/density repaired MIDI 후보 WAV render package 추가
- repaired 후보 3개 technical WAV metadata 기록
- listening preference와 musical quality claim 제외 유지

## Context

- #642 결과: repaired candidate count `3`, qualified repaired candidate count `3`
- repaired dead-air range: `0.1895 - 0.2211`
- next boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio_package`
- human/audio preference, MIDI-to-solo musical quality claim 제외

## Changes

- `scripts/render_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio.py`
  - dead-air/density repair report source validation
  - repaired MIDI 후보 3개 WAV render
  - WAV duration, sample rate, size, sha256 metadata 기록
- `tests/test_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio.py`
  - fake runner 기반 WAV metadata 검증
  - upstream quality claim 차단 검증
- `scripts/agent_harness.sh`
  - `stage-b-midi-to-solo-phrase-bank-dead-air-density-repair-audio-package` mode 추가
- README, current status, core plan, handoff 문서 동기화

## Result

- rendered audio file count: `3`
- technical WAV validation: `true`
- rank 1 duration / sample rate / sha256 prefix: `18.985s / 44100 / 4ac7b2dc9f80`
- rank 2 duration / sample rate / sha256 prefix: `18.984s / 44100 / eb6402477bf3`
- rank 3 duration / sample rate / sha256 prefix: `18.997s / 44100 / 9991eb5b673c`
- next boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_package`

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_audio`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-dead-air-density-repair-audio-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- 변경 파일 기준 `Codex|codex|코덱스` 미검출

## Risk

- technical audio render 범위
- audio rendered quality claim 없음
- human/audio preference claim 없음
- MIDI-to-solo musical quality claim 없음

Closes #644
