### PR TITLE
Stage B MIDI-to-solo phrase-bank dead-air density repair listening review input guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #646, Stage B MIDI-to-solo phrase-bank dead-air density repair listening review package.
+- Latest functional issue completed: Issue #648, Stage B MIDI-to-solo phrase-bank dead-air density repair listening review input guard.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo phrase-bank dead-air density repair listening review input guard.
+- Recommended next issue: Stage B MIDI-to-solo phrase-bank dead-air density repair objective-only next decision.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1156,6 +1156,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-dead-air-density-
 ```
 
 This harness packages dead-air/density repaired MIDI/WAV candidates for pending listening review without claiming human/audio preference.
+
+For Stage B MIDI-to-solo phrase-bank dead-air density repair listening review input guard changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-dead-air-density-repair-listening-review-input-guard
+```
+
+This harness blocks preference fill while repaired phrase-bank listening review input is pending and routes to the objective-only next decision.
 
 For Stage B MIDI-to-solo model-direct user listening review fill changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_package`
-- current evidence boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_package`
+- latest evidence boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input_guard`
+- current evidence boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input_guard`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
 - selected quality gap target: `model_conditioned_input_path_quality_alignment`
@@ -40,6 +40,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - phrase-bank repaired audio technical validation: `true`
 - phrase-bank repaired listening review package ready: `true`
 - phrase-bank repaired listening review items: `3`
+- phrase-bank repaired preference fill allowed: `false`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -241,6 +242,16 @@ Phrase-bank dead-air density repair listening review package.
 - human/audio preference claimed: `false`
 - MIDI-to-solo musical quality claimed: `false`
 - next boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input_guard`
+
+Phrase-bank dead-air density repair listening review input guard.
+
+- validated review input present: `false`
+- preference fill allowed: `false`
+- review item count: `3`
+- required input fields: `candidate_rank`, `listening_status`, `preference`, `issue_notes`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_objective_only_next_decision`
 
 MIDI-to-solo input contract.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -2533,6 +2533,37 @@ Issue #646은 Issue #644 repaired WAV/MIDI 후보를 listening review package로
 
 - `Stage B MIDI-to-solo phrase-bank dead-air density repair listening review input guard`
 
+## 9.15 Stage B MIDI-to-solo phrase-bank dead-air density repair listening review input guard
+
+Issue #648은 Issue #646 listening review package의 pending input 상태를 검증하고, review input 없이 preference fill이 진행되지 않도록 막은 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input_guard`
+- source boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_objective_only_next_decision`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- review item count: `3`
+- required input field count: `4`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- review input 없는 상태에서 preference fill 차단.
+- human/audio preference와 musical quality claim 제외 유지.
+- 다음 작업은 repaired 후보 objective-only next decision.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input_guard`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-dead-air-density-repair-listening-review-input-guard`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo phrase-bank dead-air density repair objective-only next decision`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #646, Stage B MIDI-to-solo phrase-bank dead-air density repair listening review package
-- 다음 권장 이슈: `Stage B MIDI-to-solo phrase-bank dead-air density repair listening review input guard`
+- latest functional result: Issue #648, Stage B MIDI-to-solo phrase-bank dead-air density repair listening review input guard
+- 다음 권장 이슈: `Stage B MIDI-to-solo phrase-bank dead-air density repair objective-only next decision`
 
 현재 범위가 아닌 것:
 
@@ -40,6 +40,47 @@
 - dead-air/density repair probe 기준 repaired 후보 3개 모두 objective target 통과
 - dead-air/density repaired MIDI 후보 3개 WAV technical render 완료
 - dead-air/density repaired 후보 listening review package 준비 완료
+- repaired review input pending 상태에서 preference fill 차단 완료
+
+## Stage B MIDI-to-Solo Phrase-Bank Dead-Air Density Repair Listening Review Input Guard Result
+
+Issue #648은 Issue #646 listening review package의 pending input 상태를 검증하고, review input 없이 preference fill이 진행되지 않도록 막은 작업이다.
+
+변경:
+
+- repaired listening review package source validation 추가
+- `validated_review_input=false` 상태 검증
+- preference fill allowed false 기록
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_DEAD_AIR_DENSITY_REPAIR_LISTENING_REVIEW_INPUT_GUARD_2026-06-08.md`
+- boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input_guard`
+- source boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_objective_only_next_decision`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- review item count: `3`
+- required input field count: `4`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- review input 없는 상태에서 preference fill 차단
+- human/audio preference와 musical quality claim 제외 유지
+- 다음 작업은 repaired 후보 objective-only next decision
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input_guard`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-dead-air-density-repair-listening-review-input-guard`
+
+다음:
+
+- `Stage B MIDI-to-solo phrase-bank dead-air density repair objective-only next decision`
 
 ## Stage B MIDI-to-Solo Phrase-Bank Dead-Air Density Repair Listening Review Package Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_DEAD_AIR_DENSITY_REPAIR_LISTENING_REVIEW_INPUT_GUARD_2026-06-08.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_DEAD_AIR_DENSITY_REPAIR_LISTENING_REVIEW_INPUT_GUARD_2026-06-08.md
@@ -1,0 +1,28 @@
+# Stage B MIDI-to-Solo Phrase-Bank Dead-Air Density Repair Listening Review Input Guard
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input_guard`
+- source boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_objective_only_next_decision`
+- review item count: `3`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Decision
+
+- auto progress allowed: `true`
+- critical user input required: `false`
+- reason: `listening review input pending; preference fill blocked`
+- next recommended issue: `Stage B MIDI-to-solo phrase-bank dead-air density repair objective-only next decision`
+
+## Claim Boundary
+
+- `listening_review_completed`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `phrase_bank_musical_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -214,6 +214,8 @@ Modes:
                 Render dead-air/density repaired phrase-bank MIDI candidates to WAV files.
   stage-b-midi-to-solo-phrase-bank-dead-air-density-repair-listening-review-package
                 Package dead-air/density repaired MIDI/WAV candidates for pending listening review.
+  stage-b-midi-to-solo-phrase-bank-dead-air-density-repair-listening-review-input-guard
+                Guard repaired phrase-bank preference fill while listening review input is pending.
   stage-b-midi-to-solo-candidate-audio-render-package
                 Render exported MIDI-to-solo candidates to local WAV files.
   stage-b-midi-to-solo-mvp-execution-consolidation
@@ -3813,6 +3815,26 @@ run_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_pa
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input_guard() {
+  local package_run_id="${PACKAGE_RUN_ID:-harness_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_package}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input_guard}"
+  local source_package="outputs/stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_package/${package_run_id}/stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_package.json"
+  if [[ ! -f "$source_package" ]]; then
+    print_header "Stage B MIDI-to-solo phrase-bank dead-air density repair listening review package"
+    RUN_ID="$package_run_id" run_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_package
+  fi
+  print_header "Stage B MIDI-to-solo phrase-bank dead-air density repair listening review input guard"
+  "$PYTHON_BIN" scripts/guard_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input.py \
+    --run_id "$run_id" \
+    --source_package "$source_package" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_DEAD_AIR_DENSITY_REPAIR_LISTENING_REVIEW_INPUT_GUARD_2026-06-08.md \
+    --expected_boundary stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input_guard \
+    --expected_next_boundary stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_objective_only_next_decision \
+    --require_guard_completed \
+    --require_pending_input \
+    --require_no_quality_claim
+}
+
 run_stage_b_midi_to_solo_candidate_audio_render_package() {
   local generation_run_id="${GENERATION_RUN_ID:-harness_stage_b_midi_to_solo_conditioned_generation_probe}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_candidate_audio_render_package}"
@@ -7296,6 +7318,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-phrase-bank-dead-air-density-repair-listening-review-package)
     run_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_package
+    ;;
+  stage-b-midi-to-solo-phrase-bank-dead-air-density-repair-listening-review-input-guard)
+    run_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input_guard
     ;;
   stage-b-midi-to-solo-candidate-audio-render-package)
     run_stage_b_midi_to_solo_candidate_audio_render_package

--- a/scripts/guard_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input.py
+++ b/scripts/guard_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input.py
@@ -1,0 +1,313 @@
+"""Guard repaired phrase-bank listening preference fill against missing review input."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.build_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_package import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+class StageBMidiToSoloPhraseBankDeadAirDensityRepairListeningInputGuardError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input_guard"
+FILL_BOUNDARY = "stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_fill"
+OBJECTIVE_NEXT_BOUNDARY = (
+    "stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_objective_only_next_decision"
+)
+SCHEMA_VERSION = "stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input_guard_v1"
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "phrase_bank_musical_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloPhraseBankDeadAirDensityRepairListeningInputGuardError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_source_package(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    package = _dict(report.get("review_package"))
+    if str(report.get("boundary") or readiness.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloPhraseBankDeadAirDensityRepairListeningInputGuardError(
+            "repaired listening review package boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
+        raise StageBMidiToSoloPhraseBankDeadAirDensityRepairListeningInputGuardError(
+            "review package must route to repaired input guard"
+        )
+    if not bool(readiness.get("listening_review_package_ready", False)):
+        raise StageBMidiToSoloPhraseBankDeadAirDensityRepairListeningInputGuardError(
+            "listening review package readiness required"
+        )
+    if _int(readiness.get("review_item_count")) <= 0:
+        raise StageBMidiToSoloPhraseBankDeadAirDensityRepairListeningInputGuardError("review items required")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPhraseBankDeadAirDensityRepairListeningInputGuardError(
+            "critical user input should not be required"
+        )
+    _require_no_quality_claim(readiness, label="listening review package readiness")
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "review_item_count": _int(readiness.get("review_item_count")),
+        "validated_review_input": bool(readiness.get("validated_review_input", False)),
+        "required_input_fields": [str(item) for item in _list(package.get("required_input_fields"))],
+        "wav_paths": [str(_dict(item).get("wav_path") or "") for item in _list(report.get("review_items"))],
+    }
+
+
+def build_listening_review_input_guard_report(
+    source_package: dict[str, Any],
+    *,
+    output_dir: Path,
+    issue_number: int,
+) -> dict[str, Any]:
+    source = validate_source_package(source_package)
+    validated_input = bool(source["validated_review_input"])
+    next_boundary = FILL_BOUNDARY if validated_input else OBJECTIVE_NEXT_BOUNDARY
+    reason = (
+        "validated listening review input present; preference fill allowed"
+        if validated_input
+        else "listening review input pending; preference fill blocked"
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundary": source["boundary"],
+        "source_package_summary": source,
+        "guard_result": {
+            "validated_review_input_present": bool(validated_input),
+            "preference_fill_allowed": bool(validated_input),
+            "review_item_count": int(source["review_item_count"]),
+            "required_input_field_count": len(source["required_input_fields"]),
+            "missing_validated_input_reason": "" if validated_input else "validated_review_input=false",
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "listening_review_input_guard_completed": True,
+            "validated_review_input_present": bool(validated_input),
+            "preference_fill_allowed": bool(validated_input),
+            "listening_review_completed": False,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "phrase_bank_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": next_boundary,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": reason,
+        },
+        "not_proven": [
+            "listening_review_completed",
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "phrase_bank_musical_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo phrase-bank dead-air density repair listening review fill"
+            if validated_input
+            else "Stage B MIDI-to-solo phrase-bank dead-air density repair objective-only next decision"
+        ),
+    }
+
+
+def validate_listening_review_input_guard_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_guard_completed: bool,
+    require_pending_input: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    guard = _dict(report.get("guard_result"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloPhraseBankDeadAirDensityRepairListeningInputGuardError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloPhraseBankDeadAirDensityRepairListeningInputGuardError("unexpected next boundary")
+    if require_guard_completed and not bool(readiness.get("listening_review_input_guard_completed", False)):
+        raise StageBMidiToSoloPhraseBankDeadAirDensityRepairListeningInputGuardError(
+            "guard completion required"
+        )
+    if require_pending_input and bool(guard.get("validated_review_input_present", True)):
+        raise StageBMidiToSoloPhraseBankDeadAirDensityRepairListeningInputGuardError(
+            "review input should remain pending"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="input guard readiness")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPhraseBankDeadAirDensityRepairListeningInputGuardError(
+            "critical user input should not be required"
+        )
+    return {
+        "boundary": boundary,
+        "source_boundary": str(report.get("source_boundary") or ""),
+        "validated_review_input_present": bool(guard.get("validated_review_input_present", True)),
+        "preference_fill_allowed": bool(guard.get("preference_fill_allowed", True)),
+        "review_item_count": _int(guard.get("review_item_count")),
+        "required_input_field_count": _int(guard.get("required_input_field_count")),
+        "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    guard = report["guard_result"]
+    lines = [
+        "# Stage B MIDI-to-Solo Phrase-Bank Dead-Air Density Repair Listening Review Input Guard",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- source boundary: `{report['source_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- review item count: `{guard['review_item_count']}`",
+        f"- validated review input present: `{_bool_token(guard['validated_review_input_present'])}`",
+        f"- preference fill allowed: `{_bool_token(guard['preference_fill_allowed'])}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Decision",
+        "",
+        f"- auto progress allowed: `{_bool_token(decision['auto_progress_allowed'])}`",
+        f"- critical user input required: `{_bool_token(decision['critical_user_input_required'])}`",
+        f"- reason: `{decision['reason']}`",
+        f"- next recommended issue: `{report['next_recommended_issue']}`",
+        "",
+        "## Claim Boundary",
+        "",
+    ]
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Guard repaired phrase-bank listening review input")
+    parser.add_argument("--source_package", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input_guard",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=648)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_guard_completed", action="store_true")
+    parser.add_argument("--require_pending_input", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_listening_review_input_guard_report(
+        read_json(Path(args.source_package)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+    )
+    summary = validate_listening_review_input_guard_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_guard_completed=bool(args.require_guard_completed),
+        require_pending_input=bool(args.require_pending_input),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir / "stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input_guard.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input_guard_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir / "stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input_guard.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input_guard.py
+++ b/tests/test_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input_guard.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.build_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_package import (
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+from scripts.guard_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input import (
+    BOUNDARY,
+    FILL_BOUNDARY,
+    OBJECTIVE_NEXT_BOUNDARY,
+    StageBMidiToSoloPhraseBankDeadAirDensityRepairListeningInputGuardError,
+    build_listening_review_input_guard_report,
+    validate_listening_review_input_guard_report,
+)
+
+
+def source_package(*, validated_review_input: bool = False, quality_claim: bool = False) -> dict:
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "review_package": {
+            "package_ready": True,
+            "review_item_count": 3,
+            "validated_review_input": validated_review_input,
+            "required_input_fields": [
+                "candidate_rank",
+                "listening_status",
+                "preference",
+                "issue_notes",
+            ],
+        },
+        "review_items": [
+            {"rank": index, "wav_path": f"audio/rank_{index}.wav"} for index in range(1, 4)
+        ],
+        "readiness": {
+            "listening_review_package_ready": True,
+            "review_item_count": 3,
+            "validated_review_input": validated_review_input,
+            "human_audio_preference_claimed": quality_claim,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "phrase_bank_musical_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "next_boundary": SOURCE_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class StageBMidiToSoloPhraseBankDeadAirDensityRepairListeningInputGuardTest(unittest.TestCase):
+    def test_blocks_preference_fill_when_review_input_pending(self) -> None:
+        report = build_listening_review_input_guard_report(
+            source_package(),
+            output_dir="out",
+            issue_number=648,
+        )
+        summary = validate_listening_review_input_guard_report(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=OBJECTIVE_NEXT_BOUNDARY,
+            require_guard_completed=True,
+            require_pending_input=True,
+            require_no_quality_claim=True,
+        )
+
+        self.assertFalse(summary["validated_review_input_present"])
+        self.assertFalse(summary["preference_fill_allowed"])
+        self.assertEqual(summary["review_item_count"], 3)
+        self.assertEqual(summary["required_input_field_count"], 4)
+        self.assertFalse(summary["human_audio_preference_claimed"])
+
+    def test_routes_to_fill_when_validated_input_present(self) -> None:
+        report = build_listening_review_input_guard_report(
+            source_package(validated_review_input=True),
+            output_dir="out",
+            issue_number=648,
+        )
+        summary = validate_listening_review_input_guard_report(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=FILL_BOUNDARY,
+            require_guard_completed=True,
+            require_pending_input=False,
+            require_no_quality_claim=True,
+        )
+
+        self.assertTrue(summary["validated_review_input_present"])
+        self.assertTrue(summary["preference_fill_allowed"])
+
+    def test_rejects_upstream_quality_claim(self) -> None:
+        with self.assertRaises(StageBMidiToSoloPhraseBankDeadAirDensityRepairListeningInputGuardError):
+            build_listening_review_input_guard_report(
+                source_package(quality_claim=True),
+                output_dir="out",
+                issue_number=648,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- repaired listening review input guard 추가
- review input pending 상태에서 preference fill 차단
- objective-only next decision boundary 라우팅

## Context

- #646 결과: listening review package ready `true`, review item count `3`
- validated review input: `false`
- human/audio preference, MIDI-to-solo musical quality claim 제외
- next boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input_guard`

## Changes

- `scripts/guard_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input.py`
  - repaired listening review package source validation
  - pending input 상태에서 preference fill allowed false 기록
  - objective-only next decision boundary 라우팅
- `tests/test_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input_guard.py`
  - pending input 차단 검증
  - validated input fill route 검증
  - upstream quality claim 차단 검증
- `scripts/agent_harness.sh`
  - `stage-b-midi-to-solo-phrase-bank-dead-air-density-repair-listening-review-input-guard` mode 추가
- README, current status, core plan, handoff 문서 동기화

## Result

- validated review input present: `false`
- preference fill allowed: `false`
- review item count: `3`
- required input field count: `4`
- human/audio preference claimed: `false`
- MIDI-to-solo musical quality claimed: `false`
- next boundary: `stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_objective_only_next_decision`

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_phrase_bank_dead_air_density_repair_listening_review_input_guard`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-dead-air-density-repair-listening-review-input-guard`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- 변경 파일 기준 `Codex|codex|코덱스` 미검출

## Risk

- listening input guard 범위
- human/audio preference claim 없음
- MIDI-to-solo musical quality claim 없음

Closes #648
