### PR TITLE
Stage B MIDI-to-solo phrase-bank CLI user-input smoke

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #652, Stage B MIDI-to-solo phrase-bank CLI MVP package.
+- Latest functional issue completed: Issue #654, Stage B MIDI-to-solo phrase-bank CLI user-input smoke.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo phrase-bank CLI user-input smoke.
+- Recommended next issue: Stage B MIDI-to-solo phrase-bank CLI audio render smoke.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1180,6 +1180,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-cli-mvp-package
 ```
 
 This harness builds a runnable input-MIDI to repaired ranked MIDI package manifest without claiming listening preference or musical quality.
+
+For Stage B MIDI-to-solo phrase-bank CLI user-input smoke changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-cli-user-input-smoke
+```
+
+This harness validates the phrase-bank CLI package with an explicit input MIDI path and keeps listening preference unclaimed.
 
 For Stage B MIDI-to-solo model-direct user listening review fill changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_phrase_bank_cli_mvp_package`
-- current evidence boundary: `stage_b_midi_to_solo_phrase_bank_cli_mvp_package`
+- latest evidence boundary: `stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke`
+- current evidence boundary: `stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
 - selected quality gap target: `model_conditioned_input_path_quality_alignment`
@@ -44,6 +44,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - phrase-bank repaired objective supported candidates: `3 / 3`
 - phrase-bank CLI MVP package ready: `true`
 - phrase-bank CLI MVP repaired MIDI candidates: `3`
+- phrase-bank CLI explicit input smoke completed: `true`
+- phrase-bank CLI explicit input context bars: `228`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -72,6 +74,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - phrase-bank repaired MIDI 후보의 WAV technical render 가능
 - phrase-bank repaired 후보의 listening review package 생성 가능
 - 입력 MIDI 기반 phrase-bank CLI package와 repaired MIDI 후보 export 가능
+- 명시적 `--input_midi` 경로 기준 phrase-bank CLI smoke 가능
 
 현재 README가 주장하지 않는 것.
 
@@ -281,6 +284,19 @@ Phrase-bank CLI MVP package.
 - human/audio preference claimed: `false`
 - MIDI-to-solo musical quality claimed: `false`
 - next boundary: `stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke`
+
+Phrase-bank CLI user-input smoke.
+
+- input MIDI: `midi_dataset/midi/studio/Geri Allen/Home Grown/Alone Together.midi`
+- explicit input used: `true`
+- candidate count: `3`
+- objective supported candidate count: `3`
+- repaired MIDI file count: `3`
+- input context bars: `228`
+- dead-air range: `0.1895 - 0.2211`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke`
 
 MIDI-to-solo input contract.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -2632,6 +2632,41 @@ Issue #652는 입력 MIDI에서 context extraction, phrase-bank retrieval, dead-
 
 - `Stage B MIDI-to-solo phrase-bank CLI user-input smoke`
 
+## 9.18 Stage B MIDI-to-solo phrase-bank CLI user-input smoke
+
+Issue #654는 Issue #652 CLI package를 fixture 자동 생성이 아닌 명시적 `--input_midi` 경로로 실행하고 결과를 검증한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke`
+- input MIDI: `midi_dataset/midi/studio/Geri Allen/Home Grown/Alone Together.midi`
+- explicit input used: `true`
+- candidate count: `3`
+- objective supported candidate count: `3`
+- all candidates objective supported: `true`
+- repaired MIDI file count: `3`
+- input context bars: `228`
+- dead-air range: `0.1895 - 0.2211`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- 명시적 입력 MIDI path 검증 완료.
+- ranked repaired MIDI 후보 3개 export 확인.
+- audio render와 청음 preference는 별도 boundary로 유지.
+- 다음 작업은 CLI output audio render smoke.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-cli-user-input-smoke`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo phrase-bank CLI audio render smoke`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #652, Stage B MIDI-to-solo phrase-bank CLI MVP package
-- 다음 권장 이슈: `Stage B MIDI-to-solo phrase-bank CLI user-input smoke`
+- latest functional result: Issue #654, Stage B MIDI-to-solo phrase-bank CLI user-input smoke
+- 다음 권장 이슈: `Stage B MIDI-to-solo phrase-bank CLI audio render smoke`
 
 현재 범위가 아닌 것:
 
@@ -43,6 +43,51 @@
 - repaired review input pending 상태에서 preference fill 차단 완료
 - objective-only 기준 repaired 후보 3개 CLI MVP package ready
 - 입력 MIDI fixture 기준 CLI package와 repaired MIDI 후보 3개 생성 완료
+- 실제 MIDI 입력 경로 기준 CLI smoke 완료
+
+## Stage B MIDI-to-Solo Phrase-Bank CLI User-Input Smoke Result
+
+Issue #654는 Issue #652 CLI package를 fixture 자동 생성이 아닌 명시적 `--input_midi` 경로로 검증한 작업이다.
+
+변경:
+
+- CLI package report source validation 추가
+- 명시적 input MIDI path 검증
+- repaired MIDI candidate manifest 검증
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_CLI_USER_INPUT_SMOKE_2026-06-08.md`
+- boundary: `stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke`
+- input MIDI: `midi_dataset/midi/studio/Geri Allen/Home Grown/Alone Together.midi`
+- explicit input used: `true`
+- candidate count: `3`
+- objective supported candidate count: `3`
+- all candidates objective supported: `true`
+- repaired MIDI file count: `3`
+- input context bars: `228`
+- dead-air range: `0.1895 - 0.2211`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- fixture 자동 생성 경로와 명시적 입력 경로 분리 확인
+- 실제 MIDI 입력 기준 ranked repaired MIDI 후보 3개 export 확인
+- 청음 preference와 musical quality claim 제외 유지
+- 다음 작업은 CLI output audio render smoke
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-cli-user-input-smoke`
+
+다음:
+
+- `Stage B MIDI-to-solo phrase-bank CLI audio render smoke`
 
 ## Stage B MIDI-to-Solo Phrase-Bank CLI MVP Package Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_CLI_USER_INPUT_SMOKE_2026-06-08.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_CLI_USER_INPUT_SMOKE_2026-06-08.md
@@ -1,0 +1,55 @@
+# Stage B MIDI-to-Solo Phrase-Bank CLI User-Input Smoke
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke`
+- input MIDI: `midi_dataset/midi/studio/Geri Allen/Home Grown/Alone Together.midi`
+- explicit input used: `true`
+- candidate count: `3`
+- objective supported candidate count: `3`
+- repaired MIDI file count: `3`
+- input context bars: `228`
+- dead-air range: `0.1895 - 0.2211`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Candidate Manifest
+
+### Rank 1
+
+- seed: `635`
+- objective supported: `true`
+- notes / unique pitches / max simultaneous: `96 / 22 / 1`
+- dead-air / phrase coverage: `0.1895 / 1.0000`
+- repaired MIDI: `outputs/stage_b_midi_to_solo_phrase_bank_cli_mvp_package/harness_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke_package/midi/rank_01_seed_635_dead_air_density_repair.mid`
+
+### Rank 2
+
+- seed: `632`
+- objective supported: `true`
+- notes / unique pitches / max simultaneous: `96 / 22 / 1`
+- dead-air / phrase coverage: `0.2105 / 1.0000`
+- repaired MIDI: `outputs/stage_b_midi_to_solo_phrase_bank_cli_mvp_package/harness_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke_package/midi/rank_02_seed_632_dead_air_density_repair.mid`
+
+### Rank 3
+
+- seed: `638`
+- objective supported: `true`
+- notes / unique pitches / max simultaneous: `96 / 22 / 1`
+- dead-air / phrase coverage: `0.2211 / 1.0000`
+- repaired MIDI: `outputs/stage_b_midi_to_solo_phrase_bank_cli_mvp_package/harness_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke_package/midi/rank_03_seed_638_dead_air_density_repair.mid`
+
+## Claim Boundary
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `phrase_bank_musical_quality`
+- `audio_rendered_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`
+- `production_ready`
+
+## Next
+
+- `Stage B MIDI-to-solo phrase-bank CLI audio render smoke`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -220,6 +220,8 @@ Modes:
                 Select the next repaired phrase-bank boundary from objective MIDI/WAV evidence only.
   stage-b-midi-to-solo-phrase-bank-cli-mvp-package
                 Build a runnable input-MIDI to repaired ranked MIDI package manifest.
+  stage-b-midi-to-solo-phrase-bank-cli-user-input-smoke
+                Validate the phrase-bank CLI package with an explicit input MIDI path.
   stage-b-midi-to-solo-candidate-audio-render-package
                 Render exported MIDI-to-solo candidates to local WAV files.
   stage-b-midi-to-solo-mvp-execution-consolidation
@@ -3885,6 +3887,33 @@ run_stage_b_midi_to_solo_phrase_bank_cli_mvp_package() {
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke() {
+  local input_midi="${INPUT_MIDI:-midi_dataset/midi/studio/Geri Allen/Home Grown/Alone Together.midi}"
+  local package_run_id="${PACKAGE_RUN_ID:-harness_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke_package}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke}"
+  local package_report="outputs/stage_b_midi_to_solo_phrase_bank_cli_mvp_package/${package_run_id}/stage_b_midi_to_solo_phrase_bank_cli_mvp_package.json"
+  if [[ ! -f "$package_report" ]]; then
+    print_header "Stage B MIDI-to-solo phrase-bank CLI MVP package explicit input"
+    "$PYTHON_BIN" scripts/run_stage_b_midi_to_solo_phrase_bank_cli_mvp_package.py \
+      --input_midi "$input_midi" \
+      --run_id "$package_run_id" \
+      --expected_boundary stage_b_midi_to_solo_phrase_bank_cli_mvp_package \
+      --expected_next_boundary stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke \
+      --require_cli_ready \
+      --require_no_quality_claim
+  fi
+  print_header "Stage B MIDI-to-solo phrase-bank CLI user-input smoke"
+  "$PYTHON_BIN" scripts/check_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke.py \
+    --run_id "$run_id" \
+    --cli_package_report "$package_report" \
+    --expected_input_midi "$input_midi" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_CLI_USER_INPUT_SMOKE_2026-06-08.md \
+    --expected_boundary stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke \
+    --expected_next_boundary stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke \
+    --require_explicit_input \
+    --require_no_quality_claim
+}
+
 run_stage_b_midi_to_solo_candidate_audio_render_package() {
   local generation_run_id="${GENERATION_RUN_ID:-harness_stage_b_midi_to_solo_conditioned_generation_probe}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_candidate_audio_render_package}"
@@ -7377,6 +7406,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-phrase-bank-cli-mvp-package)
     run_stage_b_midi_to_solo_phrase_bank_cli_mvp_package
+    ;;
+  stage-b-midi-to-solo-phrase-bank-cli-user-input-smoke)
+    run_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke
     ;;
   stage-b-midi-to-solo-candidate-audio-render-package)
     run_stage_b_midi_to_solo_candidate_audio_render_package

--- a/scripts/check_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke.py
+++ b/scripts/check_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke.py
@@ -1,0 +1,387 @@
+"""Validate a phrase-bank CLI package built from an explicit input MIDI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.run_stage_b_midi_to_solo_phrase_bank_cli_mvp_package import (  # noqa: E402
+    BOUNDARY as CLI_PACKAGE_BOUNDARY,
+    NEXT_BOUNDARY as CLI_PACKAGE_NEXT_BOUNDARY,
+)
+
+
+class StageBMidiToSoloPhraseBankCliUserInputSmokeError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke"
+SCHEMA_VERSION = "stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke_v1"
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "phrase_bank_musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloPhraseBankCliUserInputSmokeError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def resolve_path(path_text: str) -> Path:
+    return Path(path_text).expanduser().resolve()
+
+
+def is_fixture_auto_input(path_text: str) -> bool:
+    normalized = str(path_text).replace("\\", "/")
+    return normalized.endswith("/input/fixture.mid")
+
+
+def validate_cli_package_source(
+    report: dict[str, Any],
+    *,
+    expected_input_midi: Path | None,
+    min_candidate_count: int,
+    require_explicit_input: bool,
+) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("objective_summary"))
+    input_info = _dict(report.get("input"))
+    candidates = [_dict(item) for item in _list(report.get("candidate_manifest"))]
+    if str(report.get("boundary") or "") != CLI_PACKAGE_BOUNDARY:
+        raise StageBMidiToSoloPhraseBankCliUserInputSmokeError("CLI package boundary required")
+    if str(decision.get("next_boundary") or "") != CLI_PACKAGE_NEXT_BOUNDARY:
+        raise StageBMidiToSoloPhraseBankCliUserInputSmokeError("CLI package must route to user-input smoke")
+    input_midi = str(input_info.get("midi_path") or "")
+    if not input_midi:
+        raise StageBMidiToSoloPhraseBankCliUserInputSmokeError("input MIDI path required")
+    if not Path(input_midi).exists():
+        raise StageBMidiToSoloPhraseBankCliUserInputSmokeError(f"input MIDI missing: {input_midi}")
+    if expected_input_midi is not None and resolve_path(input_midi) != resolve_path(str(expected_input_midi)):
+        raise StageBMidiToSoloPhraseBankCliUserInputSmokeError("unexpected input MIDI path")
+    if require_explicit_input and is_fixture_auto_input(input_midi):
+        raise StageBMidiToSoloPhraseBankCliUserInputSmokeError("explicit input path required")
+    if not bool(readiness.get("cli_mvp_package_completed", False)):
+        raise StageBMidiToSoloPhraseBankCliUserInputSmokeError("CLI package completion required")
+    if not bool(readiness.get("ranked_repaired_midi_exported", False)):
+        raise StageBMidiToSoloPhraseBankCliUserInputSmokeError("ranked repaired MIDI export required")
+    if _int(summary.get("candidate_count")) < int(min_candidate_count):
+        raise StageBMidiToSoloPhraseBankCliUserInputSmokeError("candidate count below threshold")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPhraseBankCliUserInputSmokeError("critical user input should not be required")
+    _require_no_quality_claim(readiness, label="CLI package readiness")
+    for item in candidates[: int(min_candidate_count)]:
+        midi_path = str(item.get("repaired_midi_path") or "")
+        if not Path(midi_path).exists():
+            raise StageBMidiToSoloPhraseBankCliUserInputSmokeError(f"repaired MIDI missing: {midi_path}")
+        if not bool(item.get("objective_supported", False)):
+            raise StageBMidiToSoloPhraseBankCliUserInputSmokeError("candidate objective support required")
+    return {
+        "input_midi": input_midi,
+        "explicit_input_used": not is_fixture_auto_input(input_midi),
+        "candidate_count": _int(summary.get("candidate_count")),
+        "objective_supported_candidate_count": _int(summary.get("objective_supported_candidate_count")),
+        "all_candidates_objective_supported": bool(summary.get("all_candidates_objective_supported", False)),
+        "min_dead_air_ratio": _float(summary.get("min_dead_air_ratio")),
+        "max_dead_air_ratio": _float(summary.get("max_dead_air_ratio")),
+        "input_context_bars": _int(summary.get("input_context_bars")),
+        "phrase_bank_exported_candidate_count": _int(summary.get("phrase_bank_exported_candidate_count")),
+        "candidate_manifest": candidates,
+    }
+
+
+def build_user_input_smoke_report(
+    *,
+    cli_package_report: dict[str, Any],
+    package_report_path: Path,
+    output_dir: Path,
+    issue_number: int,
+    expected_input_midi: Path | None,
+    min_candidate_count: int,
+    require_explicit_input: bool,
+) -> dict[str, Any]:
+    source = validate_cli_package_source(
+        cli_package_report,
+        expected_input_midi=expected_input_midi,
+        min_candidate_count=int(min_candidate_count),
+        require_explicit_input=bool(require_explicit_input),
+    )
+    candidates = source["candidate_manifest"][: int(min_candidate_count)]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundary": CLI_PACKAGE_BOUNDARY,
+        "source_report": str(package_report_path),
+        "input": {
+            "midi_path": source["input_midi"],
+            "explicit_input_used": bool(source["explicit_input_used"]),
+        },
+        "objective_summary": {
+            "candidate_count": _int(source["candidate_count"]),
+            "objective_supported_candidate_count": _int(source["objective_supported_candidate_count"]),
+            "all_candidates_objective_supported": bool(source["all_candidates_objective_supported"]),
+            "min_dead_air_ratio": _float(source["min_dead_air_ratio"]),
+            "max_dead_air_ratio": _float(source["max_dead_air_ratio"]),
+            "input_context_bars": _int(source["input_context_bars"]),
+            "phrase_bank_exported_candidate_count": _int(source["phrase_bank_exported_candidate_count"]),
+            "repaired_midi_file_count": len(candidates),
+        },
+        "candidate_manifest": [
+            {
+                "rank": _int(item.get("rank")),
+                "sample_seed": _int(item.get("sample_seed")),
+                "repaired_midi_path": str(item.get("repaired_midi_path") or ""),
+                "objective_supported": bool(item.get("objective_supported", False)),
+                "note_count": _int(item.get("note_count")),
+                "unique_pitch_count": _int(item.get("unique_pitch_count")),
+                "max_simultaneous_notes": _int(item.get("max_simultaneous_notes")),
+                "dead_air_ratio": _float(item.get("dead_air_ratio")),
+                "phrase_coverage_ratio": _float(item.get("phrase_coverage_ratio")),
+            }
+            for item in candidates
+        ],
+        "readiness": {
+            "boundary": BOUNDARY,
+            "user_input_smoke_completed": True,
+            "explicit_input_path_used": bool(source["explicit_input_used"]),
+            "ranked_repaired_midi_exported": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "phrase_bank_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "explicit input MIDI path produced ranked repaired MIDI candidates without quality claim",
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "phrase_bank_musical_quality",
+            "audio_rendered_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "production_ready",
+        ],
+        "next_recommended_issue": "Stage B MIDI-to-solo phrase-bank CLI audio render smoke",
+    }
+
+
+def validate_user_input_smoke_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    min_candidate_count: int,
+    require_explicit_input: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("objective_summary"))
+    candidates = [_dict(item) for item in _list(report.get("candidate_manifest"))]
+    boundary = str(report.get("boundary") or "")
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloPhraseBankCliUserInputSmokeError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloPhraseBankCliUserInputSmokeError("unexpected next boundary")
+    if require_explicit_input and not bool(readiness.get("explicit_input_path_used", False)):
+        raise StageBMidiToSoloPhraseBankCliUserInputSmokeError("explicit input smoke required")
+    if _int(summary.get("candidate_count")) < int(min_candidate_count):
+        raise StageBMidiToSoloPhraseBankCliUserInputSmokeError("candidate count below threshold")
+    if _int(summary.get("repaired_midi_file_count")) < int(min_candidate_count):
+        raise StageBMidiToSoloPhraseBankCliUserInputSmokeError("repaired MIDI file count below threshold")
+    for item in candidates[: int(min_candidate_count)]:
+        midi_path = str(item.get("repaired_midi_path") or "")
+        if not Path(midi_path).exists():
+            raise StageBMidiToSoloPhraseBankCliUserInputSmokeError(f"repaired MIDI missing: {midi_path}")
+        if not bool(item.get("objective_supported", False)):
+            raise StageBMidiToSoloPhraseBankCliUserInputSmokeError("candidate objective support required")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPhraseBankCliUserInputSmokeError("critical user input should not be required")
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="user-input smoke readiness")
+    return {
+        "boundary": boundary,
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "input_midi": str(_dict(report.get("input")).get("midi_path") or ""),
+        "explicit_input_used": bool(readiness.get("explicit_input_path_used", False)),
+        "candidate_count": _int(summary.get("candidate_count")),
+        "objective_supported_candidate_count": _int(summary.get("objective_supported_candidate_count")),
+        "all_candidates_objective_supported": bool(summary.get("all_candidates_objective_supported", False)),
+        "min_dead_air_ratio": _float(summary.get("min_dead_air_ratio")),
+        "max_dead_air_ratio": _float(summary.get("max_dead_air_ratio")),
+        "input_context_bars": _int(summary.get("input_context_bars")),
+        "repaired_midi_file_count": _int(summary.get("repaired_midi_file_count")),
+        "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["objective_summary"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    lines = [
+        "# Stage B MIDI-to-Solo Phrase-Bank CLI User-Input Smoke",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- input MIDI: `{report['input']['midi_path']}`",
+        f"- explicit input used: `{_bool_token(readiness['explicit_input_path_used'])}`",
+        f"- candidate count: `{summary['candidate_count']}`",
+        f"- objective supported candidate count: `{summary['objective_supported_candidate_count']}`",
+        f"- repaired MIDI file count: `{summary['repaired_midi_file_count']}`",
+        f"- input context bars: `{summary['input_context_bars']}`",
+        f"- dead-air range: `{summary['min_dead_air_ratio']:.4f} - {summary['max_dead_air_ratio']:.4f}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Candidate Manifest",
+        "",
+    ]
+    for item in report["candidate_manifest"]:
+        lines.extend(
+            [
+                f"### Rank {item['rank']}",
+                "",
+                f"- seed: `{item['sample_seed']}`",
+                f"- objective supported: `{_bool_token(item['objective_supported'])}`",
+                f"- notes / unique pitches / max simultaneous: `{item['note_count']} / {item['unique_pitch_count']} / {item['max_simultaneous_notes']}`",
+                f"- dead-air / phrase coverage: `{item['dead_air_ratio']:.4f} / {item['phrase_coverage_ratio']:.4f}`",
+                f"- repaired MIDI: `{item['repaired_midi_path']}`",
+                "",
+            ]
+        )
+    lines.extend(["## Claim Boundary", ""])
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    lines.extend(["", "## Next", "", f"- `{report['next_recommended_issue']}`", ""])
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Validate explicit input MIDI CLI smoke package")
+    parser.add_argument("--cli_package_report", type=str, required=True)
+    parser.add_argument("--expected_input_midi", type=str, default="")
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=654)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--min_candidate_count", type=int, default=3)
+    parser.add_argument("--require_explicit_input", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    expected_input_midi = Path(args.expected_input_midi) if args.expected_input_midi else None
+    package_report_path = Path(args.cli_package_report)
+    report = build_user_input_smoke_report(
+        cli_package_report=read_json(package_report_path),
+        package_report_path=package_report_path,
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+        expected_input_midi=expected_input_midi,
+        min_candidate_count=int(args.min_candidate_count),
+        require_explicit_input=bool(args.require_explicit_input),
+    )
+    summary = validate_user_input_smoke_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        min_candidate_count=int(args.min_candidate_count),
+        require_explicit_input=bool(args.require_explicit_input),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke.json", report)
+    write_json(
+        output_dir / "stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke.py
+++ b/tests/test_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import pretty_midi
+
+from scripts.check_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloPhraseBankCliUserInputSmokeError,
+    build_user_input_smoke_report,
+    validate_user_input_smoke_report,
+)
+from scripts.run_stage_b_midi_to_solo_phrase_bank_cli_mvp_package import (
+    BOUNDARY as CLI_PACKAGE_BOUNDARY,
+    NEXT_BOUNDARY as CLI_PACKAGE_NEXT_BOUNDARY,
+)
+
+
+def write_test_midi(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    midi = pretty_midi.PrettyMIDI(initial_tempo=120)
+    instrument = pretty_midi.Instrument(program=0, is_drum=False, name="solo")
+    for index in range(4):
+        start = index * 0.25
+        instrument.notes.append(
+            pretty_midi.Note(velocity=80, pitch=60 + index, start=start, end=start + 0.18)
+        )
+    midi.instruments.append(instrument)
+    midi.write(str(path))
+    return path
+
+
+def package_report(root: Path, *, input_path: Path) -> dict:
+    candidates = []
+    for rank in range(1, 4):
+        midi_path = write_test_midi(root / f"rank_{rank}.mid")
+        candidates.append(
+            {
+                "rank": rank,
+                "sample_seed": 630 + rank,
+                "repaired_midi_path": str(midi_path),
+                "objective_supported": True,
+                "note_count": 96,
+                "unique_pitch_count": 20,
+                "max_simultaneous_notes": 1,
+                "dead_air_ratio": 0.2 + rank * 0.01,
+                "phrase_coverage_ratio": 1.0,
+            }
+        )
+    return {
+        "boundary": CLI_PACKAGE_BOUNDARY,
+        "input": {"midi_path": str(input_path)},
+        "objective_summary": {
+            "candidate_count": 3,
+            "objective_supported_candidate_count": 3,
+            "all_candidates_objective_supported": True,
+            "min_dead_air_ratio": 0.21,
+            "max_dead_air_ratio": 0.23,
+            "input_context_bars": 12,
+            "phrase_bank_exported_candidate_count": 3,
+        },
+        "candidate_manifest": candidates,
+        "readiness": {
+            "cli_mvp_package_completed": True,
+            "ranked_repaired_midi_exported": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "phrase_bank_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": CLI_PACKAGE_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class StageBMidiToSoloPhraseBankCliUserInputSmokeTest(unittest.TestCase):
+    def test_builds_user_input_smoke_report(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            input_path = write_test_midi(root / "external_input.mid")
+            report = build_user_input_smoke_report(
+                cli_package_report=package_report(root, input_path=input_path),
+                package_report_path=root / "package.json",
+                output_dir=root / "smoke",
+                issue_number=654,
+                expected_input_midi=input_path,
+                min_candidate_count=3,
+                require_explicit_input=True,
+            )
+            summary = validate_user_input_smoke_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                min_candidate_count=3,
+                require_explicit_input=True,
+                require_no_quality_claim=True,
+            )
+
+            self.assertEqual(summary["candidate_count"], 3)
+            self.assertTrue(summary["explicit_input_used"])
+            self.assertEqual(summary["repaired_midi_file_count"], 3)
+            self.assertFalse(summary["human_audio_preference_claimed"])
+
+    def test_rejects_auto_fixture_when_explicit_input_required(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixture_path = write_test_midi(root / "input" / "fixture.mid")
+
+            with self.assertRaises(StageBMidiToSoloPhraseBankCliUserInputSmokeError):
+                build_user_input_smoke_report(
+                    cli_package_report=package_report(root, input_path=fixture_path),
+                    package_report_path=root / "package.json",
+                    output_dir=root / "smoke",
+                    issue_number=654,
+                    expected_input_midi=fixture_path,
+                    min_candidate_count=3,
+                    require_explicit_input=True,
+                )
+
+    def test_boundary_constants_are_stable(self) -> None:
+        self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke")
+        self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- phrase-bank CLI package 명시적 input MIDI smoke 추가
- fixture 자동 생성 경로와 실제 `--input_midi` 경로 분리 검증
- repaired MIDI candidate manifest 검증

## Context
- Issue #652 CLI MVP package 완료
- default fixture 기준 CLI package ready: `true`
- 실제 입력: `midi_dataset/midi/studio/Geri Allen/Home Grown/Alone Together.midi`
- explicit input used: `true`
- candidate count: `3`
- objective supported candidates: `3 / 3`
- input context bars: `228`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Scope
- user-input smoke validation script 추가
- 전용 unit test 추가
- harness mode 추가
- README, current status, core plan, handoff scope 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-cli-user-input-smoke`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- 음악적 품질 미주장
- audio render는 다음 boundary
- input MIDI smoke는 단일 파일 기준

Closes #654