### PR TITLE
Stage B MIDI-to-solo phrase-bank CLI audio render smoke

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #654, Stage B MIDI-to-solo phrase-bank CLI user-input smoke.
+- Latest functional issue completed: Issue #656, Stage B MIDI-to-solo phrase-bank CLI audio render smoke.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo phrase-bank CLI audio render smoke.
+- Recommended next issue: Stage B MIDI-to-solo phrase-bank CLI listening review package.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1188,6 +1188,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-cli-user-input-sm
 ```
 
 This harness validates the phrase-bank CLI package with an explicit input MIDI path and keeps listening preference unclaimed.
+
+For Stage B MIDI-to-solo phrase-bank CLI audio render smoke changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-cli-audio-render-smoke
+```
+
+This harness renders explicit-input phrase-bank CLI MIDI candidates to WAV and records technical metadata without claiming audio quality.
 
 For Stage B MIDI-to-solo model-direct user listening review fill changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke`
-- current evidence boundary: `stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke`
+- latest evidence boundary: `stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke`
+- current evidence boundary: `stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
 - selected quality gap target: `model_conditioned_input_path_quality_alignment`
@@ -46,6 +46,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - phrase-bank CLI MVP repaired MIDI candidates: `3`
 - phrase-bank CLI explicit input smoke completed: `true`
 - phrase-bank CLI explicit input context bars: `228`
+- phrase-bank CLI explicit input WAV files: `3`
+- phrase-bank CLI audio technical validation: `true`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -75,6 +77,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - phrase-bank repaired 후보의 listening review package 생성 가능
 - 입력 MIDI 기반 phrase-bank CLI package와 repaired MIDI 후보 export 가능
 - 명시적 `--input_midi` 경로 기준 phrase-bank CLI smoke 가능
+- 명시적 `--input_midi` 경로 기준 phrase-bank CLI WAV technical render 가능
 
 현재 README가 주장하지 않는 것.
 
@@ -297,6 +300,19 @@ Phrase-bank CLI user-input smoke.
 - human/audio preference claimed: `false`
 - MIDI-to-solo musical quality claimed: `false`
 - next boundary: `stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke`
+
+Phrase-bank CLI audio render smoke.
+
+- render attempted: `true`
+- rendered audio file count: `3`
+- technical WAV validation: `true`
+- CLI user-input audio render completed: `true`
+- WAV files: `rank_01_seed_635.wav`, `rank_02_seed_632.wav`, `rank_03_seed_638.wav`
+- sample rate: `44100`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_cli_listening_review_package`
 
 MIDI-to-solo input contract.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -2667,6 +2667,39 @@ Issue #654는 Issue #652 CLI package를 fixture 자동 생성이 아닌 명시�
 
 - `Stage B MIDI-to-solo phrase-bank CLI audio render smoke`
 
+## 9.19 Stage B MIDI-to-solo phrase-bank CLI audio render smoke
+
+Issue #656은 Issue #654 user-input smoke 결과의 repaired MIDI 후보 3개를 WAV로 렌더하고 technical metadata를 검증한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke`
+- source boundary: `stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_cli_listening_review_package`
+- rendered audio file count: `3`
+- technical WAV validation: `true`
+- sample rate: `44100`
+- WAV files: `rank_01_seed_635.wav`, `rank_02_seed_632.wav`, `rank_03_seed_638.wav`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- 명시적 input MIDI 기반 CLI output WAV 생성 확인.
+- WAV metadata 기준 technical render 검증 완료.
+- 청음 preference와 musical quality claim 제외 유지.
+- 다음 작업은 CLI listening review package.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_phrase_bank_cli_audio_smoke`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-cli-audio-render-smoke`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo phrase-bank CLI listening review package`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #654, Stage B MIDI-to-solo phrase-bank CLI user-input smoke
-- 다음 권장 이슈: `Stage B MIDI-to-solo phrase-bank CLI audio render smoke`
+- latest functional result: Issue #656, Stage B MIDI-to-solo phrase-bank CLI audio render smoke
+- 다음 권장 이슈: `Stage B MIDI-to-solo phrase-bank CLI listening review package`
 
 현재 범위가 아닌 것:
 
@@ -44,6 +44,49 @@
 - objective-only 기준 repaired 후보 3개 CLI MVP package ready
 - 입력 MIDI fixture 기준 CLI package와 repaired MIDI 후보 3개 생성 완료
 - 실제 MIDI 입력 경로 기준 CLI smoke 완료
+- 실제 MIDI 입력 CLI 후보 3개 WAV technical render 완료
+
+## Stage B MIDI-to-Solo Phrase-Bank CLI Audio Render Smoke Result
+
+Issue #656은 Issue #654 user-input smoke에서 생성된 repaired MIDI 후보를 WAV로 렌더하고 technical metadata를 검증한 작업이다.
+
+변경:
+
+- CLI user-input smoke report source validation 추가
+- repaired MIDI candidate WAV render 추가
+- renderer/soundfont metadata, WAV duration/sample rate/sha256 기록
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_CLI_AUDIO_RENDER_SMOKE_2026-06-08.md`
+- boundary: `stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke`
+- source boundary: `stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_cli_listening_review_package`
+- rendered audio file count: `3`
+- technical WAV validation: `true`
+- sample rate: `44100`
+- WAV files: `rank_01_seed_635.wav`, `rank_02_seed_632.wav`, `rank_03_seed_638.wav`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- 명시적 input MIDI 기반 CLI output WAV 생성 확인
+- WAV metadata 기준 technical render 검증 완료
+- 청음 preference와 musical quality claim 제외 유지
+- 다음 작업은 CLI listening review package
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_phrase_bank_cli_audio_smoke`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-cli-audio-render-smoke`
+
+다음:
+
+- `Stage B MIDI-to-solo phrase-bank CLI listening review package`
 
 ## Stage B MIDI-to-Solo Phrase-Bank CLI User-Input Smoke Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_CLI_AUDIO_RENDER_SMOKE_2026-06-08.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_CLI_AUDIO_RENDER_SMOKE_2026-06-08.md
@@ -1,0 +1,34 @@
+# Stage B MIDI-to-Solo Phrase-Bank CLI Audio Render Smoke
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke`
+- source boundary: `stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_cli_listening_review_package`
+- input MIDI: `midi_dataset/midi/studio/Geri Allen/Home Grown/Alone Together.midi`
+- render attempted: `true`
+- rendered audio file count: `3`
+- technical WAV validation: `true`
+- CLI user-input audio render completed: `true`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+
+## Rendered Files
+
+- rank `1` seed `635`: `outputs/stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke/harness_stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke/audio/rank_01_seed_635.wav`, duration `18.987`, sample rate `44100`, size `3349292`, sha256 `635e8ffaae55`
+- rank `2` seed `632`: `outputs/stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke/harness_stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke/audio/rank_02_seed_632.wav`, duration `18.987`, sample rate `44100`, size `3349292`, sha256 `370637bb617f`
+- rank `3` seed `638`: `outputs/stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke/harness_stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke/audio/rank_03_seed_638.wav`, duration `18.997`, sample rate `44100`, size `3351084`, sha256 `3f9c39a2a58a`
+
+## Claim Boundary
+
+- `audio_rendered_quality`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `phrase_bank_musical_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`
+- `production_ready`
+
+## Next
+
+- `Stage B MIDI-to-solo phrase-bank CLI listening review package`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -222,6 +222,8 @@ Modes:
                 Build a runnable input-MIDI to repaired ranked MIDI package manifest.
   stage-b-midi-to-solo-phrase-bank-cli-user-input-smoke
                 Validate the phrase-bank CLI package with an explicit input MIDI path.
+  stage-b-midi-to-solo-phrase-bank-cli-audio-render-smoke
+                Render explicit-input phrase-bank CLI MIDI candidates to WAV.
   stage-b-midi-to-solo-candidate-audio-render-package
                 Render exported MIDI-to-solo candidates to local WAV files.
   stage-b-midi-to-solo-mvp-execution-consolidation
@@ -3914,6 +3916,26 @@ run_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke() {
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke() {
+  local smoke_run_id="${SMOKE_RUN_ID:-harness_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke}"
+  local smoke_report="outputs/stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke/${smoke_run_id}/stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke.json"
+  if [[ ! -f "$smoke_report" ]]; then
+    print_header "Stage B MIDI-to-solo phrase-bank CLI user-input smoke"
+    RUN_ID="$smoke_run_id" run_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke
+  fi
+  print_header "Stage B MIDI-to-solo phrase-bank CLI audio render smoke"
+  "$PYTHON_BIN" scripts/render_stage_b_midi_to_solo_phrase_bank_cli_audio_smoke.py \
+    --run_id "$run_id" \
+    --user_input_smoke_report "$smoke_report" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_CLI_AUDIO_RENDER_SMOKE_2026-06-08.md \
+    --expected_boundary stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke \
+    --expected_next_boundary stage_b_midi_to_solo_phrase_bank_cli_listening_review_package \
+    --expected_file_count 3 \
+    --sample_rate 44100 \
+    --require_no_quality_claim
+}
+
 run_stage_b_midi_to_solo_candidate_audio_render_package() {
   local generation_run_id="${GENERATION_RUN_ID:-harness_stage_b_midi_to_solo_conditioned_generation_probe}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_candidate_audio_render_package}"
@@ -7409,6 +7431,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-phrase-bank-cli-user-input-smoke)
     run_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke
+    ;;
+  stage-b-midi-to-solo-phrase-bank-cli-audio-render-smoke)
+    run_stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke
     ;;
   stage-b-midi-to-solo-candidate-audio-render-package)
     run_stage_b_midi_to_solo_candidate_audio_render_package

--- a/scripts/render_stage_b_midi_to_solo_phrase_bank_cli_audio_smoke.py
+++ b/scripts/render_stage_b_midi_to_solo_phrase_bank_cli_audio_smoke.py
@@ -1,0 +1,323 @@
+"""Render phrase-bank CLI user-input smoke MIDI candidates to WAV."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.check_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+from scripts.render_stage_b_midi_to_solo_candidate_audio import resolve_soundfont, sha256_file  # noqa: E402
+from scripts.render_stage_b_midi_to_solo_phrase_bank_audio import (  # noqa: E402
+    build_render_plan,
+    execute_render_plan,
+    validate_audio_render_report as validate_generic_audio_render_report,
+)
+
+
+class StageBMidiToSoloPhraseBankCliAudioSmokeError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_phrase_bank_cli_listening_review_package"
+SCHEMA_VERSION = "stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke_v1"
+CommandRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "phrase_bank_musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloPhraseBankCliAudioSmokeError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_source_report(report: dict[str, Any], *, expected_count: int) -> list[dict[str, Any]]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    if str(report.get("boundary") or readiness.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloPhraseBankCliAudioSmokeError("CLI user-input smoke boundary required")
+    if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
+        raise StageBMidiToSoloPhraseBankCliAudioSmokeError("CLI smoke must route to audio render smoke")
+    if not bool(readiness.get("user_input_smoke_completed", False)):
+        raise StageBMidiToSoloPhraseBankCliAudioSmokeError("user-input smoke completion required")
+    if not bool(readiness.get("explicit_input_path_used", False)):
+        raise StageBMidiToSoloPhraseBankCliAudioSmokeError("explicit input path smoke required")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPhraseBankCliAudioSmokeError("critical user input should not be required")
+    _require_no_quality_claim(readiness, label="CLI user-input smoke readiness")
+    candidates = [_dict(item) for item in _list(report.get("candidate_manifest"))]
+    if len(candidates) < int(expected_count):
+        raise StageBMidiToSoloPhraseBankCliAudioSmokeError("not enough smoke MIDI candidates")
+    compacted: list[dict[str, Any]] = []
+    for item in candidates[: int(expected_count)]:
+        midi_path = str(item.get("repaired_midi_path") or "")
+        if not midi_path or not Path(midi_path).exists():
+            raise StageBMidiToSoloPhraseBankCliAudioSmokeError(f"repaired MIDI missing: {midi_path}")
+        if not bool(item.get("objective_supported", False)):
+            raise StageBMidiToSoloPhraseBankCliAudioSmokeError("candidate objective support required")
+        compacted.append(
+            {
+                "rank": _int(item.get("rank")),
+                "mode": "cli_user_input_smoke",
+                "sample_index": _int(item.get("rank")),
+                "sample_seed": _int(item.get("sample_seed")),
+                "midi_path": midi_path,
+                "note_count": _int(item.get("note_count")),
+                "unique_pitch_count": _int(item.get("unique_pitch_count")),
+                "dead_air_ratio": _float(item.get("dead_air_ratio")),
+                "phrase_coverage_ratio": _float(item.get("phrase_coverage_ratio")),
+            }
+        )
+    return compacted
+
+
+def build_audio_smoke_report(
+    source_report: dict[str, Any],
+    *,
+    output_dir: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+    expected_file_count: int,
+    runner: CommandRunner | None = None,
+) -> dict[str, Any]:
+    candidates = validate_source_report(source_report, expected_count=expected_file_count)
+    resolved_renderer = renderer_path or shutil.which("fluidsynth") or ""
+    resolved_soundfont = resolve_soundfont(soundfont_path)
+    plan = build_render_plan(
+        candidates,
+        output_dir=output_dir,
+        renderer_path=resolved_renderer,
+        soundfont_path=resolved_soundfont,
+        sample_rate=sample_rate,
+    )
+    rendered = execute_render_plan(plan, runner=runner) if runner else execute_render_plan(plan)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_boundary": SOURCE_BOUNDARY,
+        "source_input": _dict(source_report.get("input")),
+        "renderer": {
+            "name": "fluidsynth",
+            "path": resolved_renderer,
+        },
+        "soundfont": {
+            "path": str(Path(resolved_soundfont).expanduser()),
+            "sha256": sha256_file(Path(resolved_soundfont).expanduser()),
+        },
+        "rendered_audio_files": rendered,
+        "audio_render_boundary": {
+            "boundary": BOUNDARY,
+            "render_attempted": True,
+            "rendered_audio_file_count": int(len(rendered)),
+            "technical_wav_validation": True,
+            "cli_user_input_audio_render_completed": True,
+            "phrase_bank_ranked_audio_render_completed": True,
+            "phrase_bank_listening_review_package_required": True,
+            "audio_output_claimed": True,
+            "audio_rendered_quality_claimed": False,
+            "human_audio_preference_claimed": False,
+            "musical_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "phrase_bank_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "explicit-input CLI repaired MIDI candidates rendered to WAV; listening preference remains unclaimed",
+        },
+        "not_proven": [
+            "audio_rendered_quality",
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "phrase_bank_musical_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "production_ready",
+        ],
+        "next_recommended_issue": "Stage B MIDI-to-solo phrase-bank CLI listening review package",
+    }
+
+
+def validate_audio_smoke_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    expected_file_count: int,
+    expected_sample_rate: int,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    summary = validate_generic_audio_render_report(
+        report,
+        expected_boundary=expected_boundary,
+        expected_next_boundary=expected_next_boundary,
+        expected_file_count=int(expected_file_count),
+        expected_sample_rate=int(expected_sample_rate),
+        require_phrase_bank_audio_path=True,
+        require_no_quality_claim=require_no_quality_claim,
+    )
+    boundary = _dict(report.get("audio_render_boundary"))
+    if not bool(boundary.get("cli_user_input_audio_render_completed", False)):
+        raise StageBMidiToSoloPhraseBankCliAudioSmokeError("CLI audio smoke completion required")
+    summary["source_boundary"] = str(report.get("source_boundary") or "")
+    summary["cli_user_input_audio_render_completed"] = bool(
+        boundary.get("cli_user_input_audio_render_completed", False)
+    )
+    return summary
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    boundary = report["audio_render_boundary"]
+    decision = report["decision"]
+    source_input = report["source_input"]
+    lines = [
+        "# Stage B MIDI-to-Solo Phrase-Bank CLI Audio Render Smoke",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{boundary['boundary']}`",
+        f"- source boundary: `{report['source_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- input MIDI: `{source_input.get('midi_path', '')}`",
+        f"- render attempted: `{_bool_token(boundary['render_attempted'])}`",
+        f"- rendered audio file count: `{boundary['rendered_audio_file_count']}`",
+        f"- technical WAV validation: `{_bool_token(boundary['technical_wav_validation'])}`",
+        f"- CLI user-input audio render completed: `{_bool_token(boundary['cli_user_input_audio_render_completed'])}`",
+        f"- audio rendered quality claimed: `{_bool_token(boundary['audio_rendered_quality_claimed'])}`",
+        f"- human/audio preference claimed: `{_bool_token(boundary['human_audio_preference_claimed'])}`",
+        "",
+        "## Rendered Files",
+        "",
+    ]
+    for item in report.get("rendered_audio_files", []):
+        wav_file = item["wav_file"]
+        lines.append(
+            f"- rank `{item['rank']}` seed `{item['sample_seed']}`: "
+            f"`{wav_file['path']}`, duration `{float(wav_file['duration_seconds']):.3f}`, "
+            f"sample rate `{wav_file['sample_rate']}`, size `{wav_file['size_bytes']}`, "
+            f"sha256 `{str(wav_file['sha256'])[:12]}`"
+        )
+    lines.extend(["", "## Claim Boundary", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    lines.extend(["", "## Next", "", f"- `{report['next_recommended_issue']}`", ""])
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Render explicit-input phrase-bank CLI smoke WAV files")
+    parser.add_argument("--user_input_smoke_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--renderer", type=str, default=shutil.which("fluidsynth") or "")
+    parser.add_argument("--soundfont", type=str, default="")
+    parser.add_argument("--sample_rate", type=int, default=44100)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--expected_file_count", type=int, default=3)
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_audio_smoke_report(
+        read_json(Path(args.user_input_smoke_report)),
+        output_dir=output_dir,
+        renderer_path=str(args.renderer or ""),
+        soundfont_path=str(args.soundfont or ""),
+        sample_rate=int(args.sample_rate),
+        expected_file_count=int(args.expected_file_count),
+    )
+    summary = validate_audio_smoke_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        expected_file_count=int(args.expected_file_count),
+        expected_sample_rate=int(args.sample_rate),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke.json", report)
+    write_json(
+        output_dir / "stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_phrase_bank_cli_audio_smoke.py
+++ b/tests/test_stage_b_midi_to_solo_phrase_bank_cli_audio_smoke.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+import wave
+from pathlib import Path
+from typing import Sequence
+
+from scripts.check_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke import (
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+from scripts.render_stage_b_midi_to_solo_phrase_bank_cli_audio_smoke import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloPhraseBankCliAudioSmokeError,
+    build_audio_smoke_report,
+    validate_audio_smoke_report,
+)
+
+
+def write_wav(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(2)
+        handle.setsampwidth(2)
+        handle.setframerate(44100)
+        handle.writeframes(b"\x00\x00" * 2 * 1000)
+
+
+def fake_runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    wav_path = Path(str(command[3]))
+    write_wav(wav_path)
+    return subprocess.CompletedProcess(list(command), 0, stdout="rendered", stderr="")
+
+
+def touch_file(root: Path, name: str) -> str:
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"midi")
+    return str(path)
+
+
+def smoke_report(root: Path, *, quality_claim: bool = False) -> dict:
+    candidates = []
+    for rank in range(1, 4):
+        candidates.append(
+            {
+                "rank": rank,
+                "sample_seed": 630 + rank,
+                "repaired_midi_path": touch_file(root, f"midi/rank_{rank}.mid"),
+                "objective_supported": True,
+                "note_count": 96,
+                "unique_pitch_count": 20 + rank,
+                "max_simultaneous_notes": 1,
+                "dead_air_ratio": 0.2,
+                "phrase_coverage_ratio": 1.0,
+            }
+        )
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "input": {
+            "midi_path": touch_file(root, "input/source.mid"),
+            "explicit_input_used": True,
+        },
+        "candidate_manifest": candidates,
+        "readiness": {
+            "user_input_smoke_completed": True,
+            "explicit_input_path_used": True,
+            "ranked_repaired_midi_exported": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": quality_claim,
+            "phrase_bank_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": SOURCE_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class StageBMidiToSoloPhraseBankCliAudioSmokeTest(unittest.TestCase):
+    def test_renders_cli_smoke_candidates_to_wav(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = touch_file(root, "bin/fluidsynth")
+            soundfont = touch_file(root, "sf/general.sf2")
+            report = build_audio_smoke_report(
+                smoke_report(root),
+                output_dir=root / "out",
+                renderer_path=renderer,
+                soundfont_path=soundfont,
+                sample_rate=44100,
+                expected_file_count=3,
+                runner=fake_runner,
+            )
+            summary = validate_audio_smoke_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                expected_file_count=3,
+                expected_sample_rate=44100,
+                require_no_quality_claim=True,
+            )
+
+            self.assertEqual(summary["rendered_audio_file_count"], 3)
+            self.assertTrue(summary["technical_wav_validation"])
+            self.assertTrue(summary["cli_user_input_audio_render_completed"])
+            self.assertFalse(summary["human_audio_preference_claimed"])
+
+    def test_rejects_upstream_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = touch_file(root, "bin/fluidsynth")
+            soundfont = touch_file(root, "sf/general.sf2")
+
+            with self.assertRaises(StageBMidiToSoloPhraseBankCliAudioSmokeError):
+                build_audio_smoke_report(
+                    smoke_report(root, quality_claim=True),
+                    output_dir=root / "out",
+                    renderer_path=renderer,
+                    soundfont_path=soundfont,
+                    sample_rate=44100,
+                    expected_file_count=3,
+                    runner=fake_runner,
+                )
+
+    def test_boundary_constants_are_stable(self) -> None:
+        self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke")
+        self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_phrase_bank_cli_listening_review_package")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- phrase-bank CLI user-input smoke 후보 WAV render 추가
- repaired MIDI 후보 3개 technical WAV metadata 검증
- renderer/soundfont, duration/sample rate/sha256 기록

## Context
- Issue #654 user-input smoke 완료
- input MIDI: `midi_dataset/midi/studio/Geri Allen/Home Grown/Alone Together.midi`
- repaired MIDI file count: `3`
- objective supported candidates: `3 / 3`
- rendered WAV file count: `3`
- technical WAV validation: `true`
- audio rendered quality claim: `false`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Scope
- CLI audio render smoke script 추가
- 전용 unit test 추가
- harness mode 추가
- README, current status, core plan, handoff scope 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_phrase_bank_cli_audio_smoke`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-cli-audio-render-smoke`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- WAV metadata 검증만 포함
- 청음 preference와 음악적 품질 미주장
- listening review package는 다음 boundary

Closes #656