### PR TITLE
Stage B MIDI-to-solo phrase-bank CLI listening review package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #656, Stage B MIDI-to-solo phrase-bank CLI audio render smoke.
+- Latest functional issue completed: Issue #658, Stage B MIDI-to-solo phrase-bank CLI listening review package.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo phrase-bank CLI listening review package.
+- Recommended next issue: Stage B MIDI-to-solo phrase-bank CLI listening review input guard.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1196,6 +1196,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-cli-audio-render-
 ```
 
 This harness renders explicit-input phrase-bank CLI MIDI candidates to WAV and records technical metadata without claiming audio quality.
+
+For Stage B MIDI-to-solo phrase-bank CLI listening review package changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-cli-listening-review-package
+```
+
+This harness packages explicit-input phrase-bank CLI WAV/MIDI candidates for pending listening review without claiming preference.
 
 For Stage B MIDI-to-solo model-direct user listening review fill changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke`
-- current evidence boundary: `stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke`
+- latest evidence boundary: `stage_b_midi_to_solo_phrase_bank_cli_listening_review_package`
+- current evidence boundary: `stage_b_midi_to_solo_phrase_bank_cli_listening_review_package`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
 - selected quality gap target: `model_conditioned_input_path_quality_alignment`
@@ -48,6 +48,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - phrase-bank CLI explicit input context bars: `228`
 - phrase-bank CLI explicit input WAV files: `3`
 - phrase-bank CLI audio technical validation: `true`
+- phrase-bank CLI listening review package ready: `true`
+- phrase-bank CLI listening review items: `3`
+- phrase-bank CLI validated review input: `false`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -78,6 +81,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - 입력 MIDI 기반 phrase-bank CLI package와 repaired MIDI 후보 export 가능
 - 명시적 `--input_midi` 경로 기준 phrase-bank CLI smoke 가능
 - 명시적 `--input_midi` 경로 기준 phrase-bank CLI WAV technical render 가능
+- 명시적 `--input_midi` 경로 기준 phrase-bank CLI listening review package 생성 가능
 
 현재 README가 주장하지 않는 것.
 
@@ -313,6 +317,17 @@ Phrase-bank CLI audio render smoke.
 - human/audio preference claimed: `false`
 - MIDI-to-solo musical quality claimed: `false`
 - next boundary: `stage_b_midi_to_solo_phrase_bank_cli_listening_review_package`
+
+Phrase-bank CLI listening review package.
+
+- package ready: `true`
+- review item count: `3`
+- validated review input: `false`
+- review WAV files: `rank_01_seed_635.wav`, `rank_02_seed_632.wav`, `rank_03_seed_638.wav`
+- required input fields: `candidate_rank`, `listening_status`, `preference`, `issue_notes`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_cli_listening_review_input_guard`
 
 MIDI-to-solo input contract.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -2700,6 +2700,37 @@ Issue #656은 Issue #654 user-input smoke 결과의 repaired MIDI 후보 3개를
 
 - `Stage B MIDI-to-solo phrase-bank CLI listening review package`
 
+## 9.20 Stage B MIDI-to-solo phrase-bank CLI listening review package
+
+Issue #658은 Issue #656 CLI audio render smoke 결과의 WAV/MIDI 후보 3개를 listening review package로 묶고, preference와 musical quality claim을 차단한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_phrase_bank_cli_listening_review_package`
+- source boundary: `stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_cli_listening_review_input_guard`
+- package ready: `true`
+- review item count: `3`
+- validated review input: `false`
+- required input fields: `candidate_rank`, `listening_status`, `preference`, `issue_notes`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- 명시적 input MIDI 기반 CLI output review package 생성 확인.
+- 청음 preference 입력 전 품질 claim 제외 유지.
+- 다음 작업은 CLI listening review input guard.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_phrase_bank_cli_listening_review_package`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-cli-listening-review-package`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo phrase-bank CLI listening review input guard`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #656, Stage B MIDI-to-solo phrase-bank CLI audio render smoke
-- 다음 권장 이슈: `Stage B MIDI-to-solo phrase-bank CLI listening review package`
+- latest functional result: Issue #658, Stage B MIDI-to-solo phrase-bank CLI listening review package
+- 다음 권장 이슈: `Stage B MIDI-to-solo phrase-bank CLI listening review input guard`
 
 현재 범위가 아닌 것:
 
@@ -45,6 +45,47 @@
 - 입력 MIDI fixture 기준 CLI package와 repaired MIDI 후보 3개 생성 완료
 - 실제 MIDI 입력 경로 기준 CLI smoke 완료
 - 실제 MIDI 입력 CLI 후보 3개 WAV technical render 완료
+- 실제 MIDI 입력 CLI WAV/MIDI 후보 3개 listening review package 준비 완료
+
+## Stage B MIDI-to-Solo Phrase-Bank CLI Listening Review Package Result
+
+Issue #658은 Issue #656 audio render smoke 결과의 CLI WAV/MIDI 후보 3개를 listening review package로 묶고, preference와 musical quality claim을 차단한 작업이다.
+
+변경:
+
+- CLI audio render smoke report source validation 추가
+- WAV/MIDI review item manifest 생성
+- pending review input field 정의
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_CLI_LISTENING_REVIEW_PACKAGE_2026-06-08.md`
+- boundary: `stage_b_midi_to_solo_phrase_bank_cli_listening_review_package`
+- source boundary: `stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_cli_listening_review_input_guard`
+- package ready: `true`
+- review item count: `3`
+- validated review input: `false`
+- required input fields: `candidate_rank`, `listening_status`, `preference`, `issue_notes`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- 명시적 input MIDI 기반 CLI output review package 생성 확인
+- 청음 preference 입력 전 품질 claim 제외 유지
+- 다음 작업은 CLI listening review input guard
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_phrase_bank_cli_listening_review_package`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-cli-listening-review-package`
+
+다음:
+
+- `Stage B MIDI-to-solo phrase-bank CLI listening review input guard`
 
 ## Stage B MIDI-to-Solo Phrase-Bank CLI Audio Render Smoke Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_CLI_LISTENING_REVIEW_PACKAGE_2026-06-08.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_CLI_LISTENING_REVIEW_PACKAGE_2026-06-08.md
@@ -1,0 +1,61 @@
+# Stage B MIDI-to-Solo Phrase-Bank CLI Listening Review Package
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_phrase_bank_cli_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_phrase_bank_cli_listening_review_input_guard`
+- package ready: `true`
+- review item count: `3`
+- validated review input: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Review Items
+
+### Rank 1
+
+- seed: `635`
+- MIDI: `outputs/stage_b_midi_to_solo_phrase_bank_cli_mvp_package/harness_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke_package/midi/rank_01_seed_635_dead_air_density_repair.mid`
+- WAV: `outputs/stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke/harness_stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke/audio/rank_01_seed_635.wav`
+- duration / sample rate / sha256: `18.987s / 44100 / 635e8ffaae55`
+- notes / unique pitches / dead-air: `96 / 22 / 0.1895`
+- review status: `pending`
+
+### Rank 2
+
+- seed: `632`
+- MIDI: `outputs/stage_b_midi_to_solo_phrase_bank_cli_mvp_package/harness_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke_package/midi/rank_02_seed_632_dead_air_density_repair.mid`
+- WAV: `outputs/stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke/harness_stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke/audio/rank_02_seed_632.wav`
+- duration / sample rate / sha256: `18.987s / 44100 / 370637bb617f`
+- notes / unique pitches / dead-air: `96 / 22 / 0.2105`
+- review status: `pending`
+
+### Rank 3
+
+- seed: `638`
+- MIDI: `outputs/stage_b_midi_to_solo_phrase_bank_cli_mvp_package/harness_stage_b_midi_to_solo_phrase_bank_cli_user_input_smoke_package/midi/rank_03_seed_638_dead_air_density_repair.mid`
+- WAV: `outputs/stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke/harness_stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke/audio/rank_03_seed_638.wav`
+- duration / sample rate / sha256: `18.997s / 44100 / 3f9c39a2a58a`
+- notes / unique pitches / dead-air: `96 / 22 / 0.2211`
+- review status: `pending`
+
+## Required Review Input
+
+- `candidate_rank`
+- `listening_status`
+- `preference`
+- `issue_notes`
+
+## Claim Boundary
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `phrase_bank_musical_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`
+- `production_ready`
+
+## Next
+
+- `Stage B MIDI-to-solo phrase-bank CLI listening review input guard`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -224,6 +224,8 @@ Modes:
                 Validate the phrase-bank CLI package with an explicit input MIDI path.
   stage-b-midi-to-solo-phrase-bank-cli-audio-render-smoke
                 Render explicit-input phrase-bank CLI MIDI candidates to WAV.
+  stage-b-midi-to-solo-phrase-bank-cli-listening-review-package
+                Package explicit-input phrase-bank CLI WAV/MIDI candidates for pending listening review.
   stage-b-midi-to-solo-candidate-audio-render-package
                 Render exported MIDI-to-solo candidates to local WAV files.
   stage-b-midi-to-solo-mvp-execution-consolidation
@@ -3936,6 +3938,26 @@ run_stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke() {
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_phrase_bank_cli_listening_review_package() {
+  local audio_run_id="${AUDIO_RUN_ID:-harness_stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_phrase_bank_cli_listening_review_package}"
+  local audio_render_report="outputs/stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke/${audio_run_id}/stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke.json"
+  if [[ ! -f "$audio_render_report" ]]; then
+    print_header "Stage B MIDI-to-solo phrase-bank CLI audio render smoke"
+    RUN_ID="$audio_run_id" run_stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke
+  fi
+  print_header "Stage B MIDI-to-solo phrase-bank CLI listening review package"
+  "$PYTHON_BIN" scripts/build_stage_b_midi_to_solo_phrase_bank_cli_listening_review_package.py \
+    --run_id "$run_id" \
+    --audio_render_report "$audio_render_report" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_PHRASE_BANK_CLI_LISTENING_REVIEW_PACKAGE_2026-06-08.md \
+    --expected_boundary stage_b_midi_to_solo_phrase_bank_cli_listening_review_package \
+    --expected_next_boundary stage_b_midi_to_solo_phrase_bank_cli_listening_review_input_guard \
+    --expected_review_item_count 3 \
+    --require_package_ready \
+    --require_no_quality_claim
+}
+
 run_stage_b_midi_to_solo_candidate_audio_render_package() {
   local generation_run_id="${GENERATION_RUN_ID:-harness_stage_b_midi_to_solo_conditioned_generation_probe}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_candidate_audio_render_package}"
@@ -7434,6 +7456,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-phrase-bank-cli-audio-render-smoke)
     run_stage_b_midi_to_solo_phrase_bank_cli_audio_render_smoke
+    ;;
+  stage-b-midi-to-solo-phrase-bank-cli-listening-review-package)
+    run_stage_b_midi_to_solo_phrase_bank_cli_listening_review_package
     ;;
   stage-b-midi-to-solo-candidate-audio-render-package)
     run_stage_b_midi_to_solo_candidate_audio_render_package

--- a/scripts/build_stage_b_midi_to_solo_phrase_bank_cli_listening_review_package.py
+++ b/scripts/build_stage_b_midi_to_solo_phrase_bank_cli_listening_review_package.py
@@ -1,0 +1,340 @@
+"""Build a listening review package for phrase-bank CLI audio smoke output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.render_stage_b_midi_to_solo_phrase_bank_cli_audio_smoke import (  # noqa: E402
+    BOUNDARY as AUDIO_RENDER_BOUNDARY,
+    NEXT_BOUNDARY as AUDIO_RENDER_NEXT_BOUNDARY,
+)
+
+
+class StageBMidiToSoloPhraseBankCliListeningPackageError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_phrase_bank_cli_listening_review_package"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_phrase_bank_cli_listening_review_input_guard"
+SCHEMA_VERSION = "stage_b_midi_to_solo_phrase_bank_cli_listening_review_package_v1"
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "phrase_bank_musical_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _path_exists(path_text: str) -> bool:
+    return bool(path_text and Path(path_text).exists())
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloPhraseBankCliListeningPackageError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_audio_render_report(report: dict[str, Any], *, expected_count: int) -> list[dict[str, Any]]:
+    boundary = _dict(report.get("audio_render_boundary"))
+    decision = _dict(report.get("decision"))
+    if str(boundary.get("boundary") or "") != AUDIO_RENDER_BOUNDARY:
+        raise StageBMidiToSoloPhraseBankCliListeningPackageError("CLI audio render smoke boundary required")
+    if str(decision.get("next_boundary") or "") != AUDIO_RENDER_NEXT_BOUNDARY:
+        raise StageBMidiToSoloPhraseBankCliListeningPackageError("audio smoke must route to listening package")
+    required_true = [
+        "technical_wav_validation",
+        "cli_user_input_audio_render_completed",
+        "phrase_bank_ranked_audio_render_completed",
+        "phrase_bank_listening_review_package_required",
+    ]
+    missing = [name for name in required_true if not bool(boundary.get(name, False))]
+    if missing:
+        raise StageBMidiToSoloPhraseBankCliListeningPackageError(
+            f"missing audio render readiness: {missing}"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPhraseBankCliListeningPackageError("critical user input should not be required")
+    _require_no_quality_claim(boundary, label="audio render boundary")
+    items = [_dict(item) for item in _list(report.get("rendered_audio_files"))]
+    if len(items) < int(expected_count):
+        raise StageBMidiToSoloPhraseBankCliListeningPackageError("rendered audio file count below expected")
+    review_items: list[dict[str, Any]] = []
+    for item in items[: int(expected_count)]:
+        wav = _dict(item.get("wav_file"))
+        wav_path = str(wav.get("path") or "")
+        midi_path = str(item.get("source_midi_path") or "")
+        if not _path_exists(wav_path) or not _path_exists(midi_path):
+            raise StageBMidiToSoloPhraseBankCliListeningPackageError("review item MIDI/WAV artifact required")
+        review_items.append(
+            {
+                "rank": _int(item.get("rank")),
+                "mode": str(item.get("mode") or ""),
+                "sample_index": _int(item.get("sample_index")),
+                "sample_seed": _int(item.get("sample_seed")),
+                "midi_path": midi_path,
+                "wav_path": wav_path,
+                "duration_seconds": _float(wav.get("duration_seconds")),
+                "sample_rate": _int(wav.get("sample_rate")),
+                "size_bytes": _int(wav.get("size_bytes")),
+                "sha256": str(wav.get("sha256") or ""),
+                "source_note_count": _int(item.get("source_note_count")),
+                "source_unique_pitch_count": _int(item.get("source_unique_pitch_count")),
+                "source_dead_air_ratio": _float(item.get("source_dead_air_ratio")),
+                "source_phrase_coverage_ratio": _float(item.get("source_phrase_coverage_ratio")),
+                "review_status": "pending",
+            }
+        )
+    return review_items
+
+
+def build_listening_review_package_report(
+    *,
+    audio_render_report: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+    expected_count: int,
+) -> dict[str, Any]:
+    review_items = validate_audio_render_report(audio_render_report, expected_count=expected_count)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundaries": {
+            "audio_render": AUDIO_RENDER_BOUNDARY,
+        },
+        "review_package": {
+            "package_ready": True,
+            "review_item_count": int(len(review_items)),
+            "review_basis": "human_audio_listening_pending",
+            "validated_review_input": False,
+            "required_input_fields": [
+                "candidate_rank",
+                "listening_status",
+                "preference",
+                "issue_notes",
+            ],
+        },
+        "review_items": review_items,
+        "readiness": {
+            "boundary": BOUNDARY,
+            "listening_review_package_ready": True,
+            "review_item_count": int(len(review_items)),
+            "validated_review_input": False,
+            "human_review_required_now": False,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "phrase_bank_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "CLI WAV/MIDI review items are packaged; preference remains pending until validated listening input",
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "audio_rendered_quality",
+            "phrase_bank_musical_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "production_ready",
+        ],
+        "next_recommended_issue": "Stage B MIDI-to-solo phrase-bank CLI listening review input guard",
+    }
+
+
+def validate_listening_review_package_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    expected_review_item_count: int,
+    require_package_ready: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloPhraseBankCliListeningPackageError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloPhraseBankCliListeningPackageError("unexpected next boundary")
+    if require_package_ready and not bool(readiness.get("listening_review_package_ready", False)):
+        raise StageBMidiToSoloPhraseBankCliListeningPackageError("listening review package should be ready")
+    if _int(readiness.get("review_item_count")) != int(expected_review_item_count):
+        raise StageBMidiToSoloPhraseBankCliListeningPackageError("review item count mismatch")
+    if bool(readiness.get("validated_review_input", True)):
+        raise StageBMidiToSoloPhraseBankCliListeningPackageError("review input should remain pending")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPhraseBankCliListeningPackageError("critical user input should not be required")
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="listening package readiness")
+    return {
+        "boundary": boundary,
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "listening_review_package_ready": bool(readiness.get("listening_review_package_ready", False)),
+        "review_item_count": _int(readiness.get("review_item_count")),
+        "validated_review_input": bool(readiness.get("validated_review_input", True)),
+        "human_review_required_now": bool(readiness.get("human_review_required_now", True)),
+        "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "wav_paths": [str(_dict(item).get("wav_path") or "") for item in _list(report.get("review_items"))],
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    package = report["review_package"]
+    lines = [
+        "# Stage B MIDI-to-Solo Phrase-Bank CLI Listening Review Package",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- package ready: `{_bool_token(package['package_ready'])}`",
+        f"- review item count: `{package['review_item_count']}`",
+        f"- validated review input: `{_bool_token(package['validated_review_input'])}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Review Items",
+        "",
+    ]
+    for item in report["review_items"]:
+        lines.extend(
+            [
+                f"### Rank {item['rank']}",
+                "",
+                f"- seed: `{item['sample_seed']}`",
+                f"- MIDI: `{item['midi_path']}`",
+                f"- WAV: `{item['wav_path']}`",
+                f"- duration / sample rate / sha256: `{item['duration_seconds']:.3f}s / {item['sample_rate']} / {item['sha256'][:12]}`",
+                f"- notes / unique pitches / dead-air: `{item['source_note_count']} / {item['source_unique_pitch_count']} / {item['source_dead_air_ratio']:.4f}`",
+                f"- review status: `{item['review_status']}`",
+                "",
+            ]
+        )
+    lines.extend(["## Required Review Input", ""])
+    for field in package["required_input_fields"]:
+        lines.append(f"- `{field}`")
+    lines.extend(["", "## Claim Boundary", ""])
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    lines.extend(["", "## Next", "", f"- `{report['next_recommended_issue']}`", ""])
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build CLI listening review package from rendered WAV files")
+    parser.add_argument("--audio_render_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_phrase_bank_cli_listening_review_package",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=658)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--expected_review_item_count", type=int, default=3)
+    parser.add_argument("--require_package_ready", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_listening_review_package_report(
+        audio_render_report=read_json(Path(args.audio_render_report)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+        expected_count=int(args.expected_review_item_count),
+    )
+    summary = validate_listening_review_package_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        expected_review_item_count=int(args.expected_review_item_count),
+        require_package_ready=bool(args.require_package_ready),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "stage_b_midi_to_solo_phrase_bank_cli_listening_review_package.json", report)
+    write_json(
+        output_dir / "stage_b_midi_to_solo_phrase_bank_cli_listening_review_package_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_midi_to_solo_phrase_bank_cli_listening_review_package.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_phrase_bank_cli_listening_review_package.py
+++ b/tests/test_stage_b_midi_to_solo_phrase_bank_cli_listening_review_package.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+import wave
+from pathlib import Path
+
+import pretty_midi
+
+from scripts.build_stage_b_midi_to_solo_phrase_bank_cli_listening_review_package import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloPhraseBankCliListeningPackageError,
+    build_listening_review_package_report,
+    validate_listening_review_package_report,
+)
+from scripts.render_stage_b_midi_to_solo_phrase_bank_cli_audio_smoke import (
+    BOUNDARY as AUDIO_BOUNDARY,
+    NEXT_BOUNDARY as AUDIO_NEXT_BOUNDARY,
+)
+
+
+def write_midi(path: Path) -> None:
+    midi = pretty_midi.PrettyMIDI(initial_tempo=120)
+    instrument = pretty_midi.Instrument(program=0, is_drum=False)
+    instrument.notes.append(pretty_midi.Note(velocity=80, pitch=60, start=0.0, end=0.2))
+    midi.instruments.append(instrument)
+    midi.write(str(path))
+
+
+def write_wav(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(2)
+        handle.setsampwidth(2)
+        handle.setframerate(44100)
+        handle.writeframes(b"\x00\x00\x00\x00" * 44100)
+
+
+def audio_report(tmp_path: Path, *, quality_claim: bool = False) -> dict:
+    items = []
+    for rank, seed in enumerate([635, 632, 638], start=1):
+        midi_path = tmp_path / f"rank_{rank}.mid"
+        wav_path = tmp_path / f"rank_{rank}.wav"
+        write_midi(midi_path)
+        write_wav(wav_path)
+        items.append(
+            {
+                "rank": rank,
+                "mode": "cli_user_input_smoke",
+                "sample_index": rank,
+                "sample_seed": seed,
+                "source_midi_path": str(midi_path),
+                "source_note_count": 96,
+                "source_unique_pitch_count": 20,
+                "source_dead_air_ratio": 0.2,
+                "source_phrase_coverage_ratio": 1.0,
+                "wav_file": {
+                    "path": str(wav_path),
+                    "exists": True,
+                    "duration_seconds": 1.0,
+                    "sample_rate": 44100,
+                    "size_bytes": wav_path.stat().st_size,
+                    "sha256": "abc",
+                },
+            }
+        )
+    return {
+        "audio_render_boundary": {
+            "boundary": AUDIO_BOUNDARY,
+            "technical_wav_validation": True,
+            "cli_user_input_audio_render_completed": True,
+            "phrase_bank_ranked_audio_render_completed": True,
+            "phrase_bank_listening_review_package_required": True,
+            "human_audio_preference_claimed": quality_claim,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "phrase_bank_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": AUDIO_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+        "rendered_audio_files": items,
+    }
+
+
+class StageBMidiToSoloPhraseBankCliListeningPackageTest(unittest.TestCase):
+    def test_builds_pending_review_package(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            report = build_listening_review_package_report(
+                audio_render_report=audio_report(Path(tmp)),
+                output_dir=Path(tmp) / "out",
+                issue_number=658,
+                expected_count=3,
+            )
+            summary = validate_listening_review_package_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                expected_review_item_count=3,
+                require_package_ready=True,
+                require_no_quality_claim=True,
+            )
+
+            self.assertTrue(summary["listening_review_package_ready"])
+            self.assertFalse(summary["validated_review_input"])
+            self.assertEqual(summary["review_item_count"], 3)
+            self.assertFalse(summary["human_audio_preference_claimed"])
+
+    def test_rejects_upstream_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(StageBMidiToSoloPhraseBankCliListeningPackageError):
+                build_listening_review_package_report(
+                    audio_render_report=audio_report(Path(tmp), quality_claim=True),
+                    output_dir=Path(tmp) / "out",
+                    issue_number=658,
+                    expected_count=3,
+                )
+
+    def test_boundary_constants_are_stable(self) -> None:
+        self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_phrase_bank_cli_listening_review_package")
+        self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_phrase_bank_cli_listening_review_input_guard")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- CLI audio render smoke 결과의 WAV/MIDI 후보 3개 listening review package 생성
- review item manifest와 pending input field 정의
- preference 및 musical quality claim 제외 유지

## Context
- Issue #656 결과: 명시적 input MIDI 기준 CLI 후보 WAV 3개 technical render 완료
- rendered audio file count: `3`
- technical WAV validation: `true`
- 청음 preference 입력 없음
- 현재 검토 대상: review package readiness와 input guard 연결

## Scope
- `scripts/build_stage_b_midi_to_solo_phrase_bank_cli_listening_review_package.py` 추가
- `stage-b-midi-to-solo-phrase-bank-cli-listening-review-package` harness mode 추가
- unit test 추가
- README, current status, core plan, handoff scope 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_phrase_bank_cli_listening_review_package`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-phrase-bank-cli-listening-review-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- human/audio preference: 미주장
- MIDI-to-solo musical quality: 미주장
- 다음 검증 대상: CLI listening review input guard

Closes #658