### PR TITLE
Stage B MIDI-to-solo MVP current evidence consolidation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #662, Stage B MIDI-to-solo phrase-bank CLI objective-only next decision.
+- Latest functional issue completed: Issue #664, Stage B MIDI-to-solo MVP current evidence consolidation.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo MVP current evidence consolidation.
+- Recommended next issue: Stage B MIDI-to-solo README evidence refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1018,7 +1018,7 @@ For Stage B MIDI-to-solo MVP current evidence consolidation changes, run:
 bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-current-evidence-consolidation
 ```
 
-This harness consolidates the input contract, context extraction, ranked MIDI candidates, technical WAV render path, and selected-scale objective repair boundary without claiming musical quality.
+This harness consolidates the input contract, context extraction, ranked MIDI candidates, technical WAV render path, selected-scale objective repair boundary, and CLI technical path without claiming musical quality.
 
 For Stage B MIDI-to-solo README evidence refresh changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_phrase_bank_cli_objective_only_next_decision`
-- current evidence boundary: `stage_b_midi_to_solo_phrase_bank_cli_objective_only_next_decision`
+- latest evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
 - selected quality gap target: `model_conditioned_input_path_quality_alignment`
@@ -55,6 +55,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - phrase-bank CLI preference fill allowed: `false`
 - phrase-bank CLI technical MIDI-to-solo path ready: `true`
 - phrase-bank CLI MVP current evidence consolidation ready: `true`
+- phrase-bank CLI technical path included in current evidence: `true`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -88,6 +89,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - 명시적 `--input_midi` 경로 기준 phrase-bank CLI listening review package 생성 가능
 - 명시적 `--input_midi` 경로 기준 phrase-bank CLI review input pending 상태에서 preference fill 차단 가능
 - 명시적 `--input_midi` 경로 기준 phrase-bank CLI technical path objective decision 가능
+- selected-scale objective path와 phrase-bank CLI technical path를 current evidence로 통합 가능
 
 현재 README가 주장하지 않는 것.
 
@@ -106,6 +108,7 @@ MVP completion audit.
 - input to ranked MIDI completed: `true`
 - input to rendered WAV completed: `true`
 - selected-scale objective repair completed: `true`
+- phrase-bank CLI technical path included: `true`
 - musical quality MVP completed: `false`
 - human/audio preference completed: `false`
 - product MVP completed: `false`
@@ -361,6 +364,22 @@ Phrase-bank CLI objective-only next decision.
 - human/audio preference claimed: `false`
 - MIDI-to-solo musical quality claimed: `false`
 - next boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+
+MVP current evidence consolidation.
+
+- current MVP evidence supported: `true`
+- technical execution evidence supported: `true`
+- selected-scale objective path complete: `true`
+- phrase-bank CLI technical path ready: `true`
+- generation exported / qualified candidates: `3 / 3`
+- technical audio rendered WAV files: `3`
+- selected-scale objective valid / strict / grammar: `9 / 9 / 9`
+- CLI candidate / rendered WAV files: `3 / 3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- next boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
 
 MIDI-to-solo input contract.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -2800,6 +2800,43 @@ Issue #662는 CLI phrase-bank 경로의 objective-only evidence를 통합하고,
 
 - `Stage B MIDI-to-solo MVP current evidence consolidation`
 
+## 9.23 Stage B MIDI-to-solo MVP current evidence consolidation
+
+Issue #664는 기존 current evidence consolidation에 CLI phrase-bank objective evidence를 추가하고, selected-scale objective path와 명시적 input MIDI CLI technical path를 함께 current evidence로 정리한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- next boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
+- current MVP evidence supported: `true`
+- technical execution evidence supported: `true`
+- selected-scale objective path complete: `true`
+- phrase-bank CLI technical path ready: `true`
+- exported / qualified candidates: `3 / 3`
+- rendered WAV files: `3`
+- selected-scale objective valid / strict / grammar: `9 / 9 / 9`
+- CLI candidate / rendered WAV files: `3 / 3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- 입력 MIDI 기반 context, ranked MIDI export, WAV render 기술 경로 current evidence 유지.
+- selected-scale objective repair path와 명시적 input MIDI CLI technical path 병행 정리.
+- 청음 preference와 musical quality claim 제외 유지.
+- 다음 작업은 README evidence refresh.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-current-evidence-consolidation`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo README evidence refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #662, Stage B MIDI-to-solo phrase-bank CLI objective-only next decision
-- 다음 권장 이슈: `Stage B MIDI-to-solo MVP current evidence consolidation`
+- latest functional result: Issue #664, Stage B MIDI-to-solo MVP current evidence consolidation
+- 다음 권장 이슈: `Stage B MIDI-to-solo README evidence refresh`
 
 현재 범위가 아닌 것:
 
@@ -48,6 +48,54 @@
 - 실제 MIDI 입력 CLI WAV/MIDI 후보 3개 listening review package 준비 완료
 - 실제 MIDI 입력 CLI review input pending 상태에서 preference fill 차단 완료
 - 실제 MIDI 입력 CLI technical path objective decision 완료
+- selected-scale objective path와 실제 MIDI 입력 CLI technical path current evidence 통합 완료
+
+## Stage B MIDI-to-Solo MVP Current Evidence Consolidation Result
+
+Issue #664는 기존 current evidence consolidation에 CLI phrase-bank objective evidence를 추가하고, selected-scale objective path와 명시적 input MIDI CLI technical path를 함께 current evidence로 정리한 작업이다.
+
+변경:
+
+- current evidence consolidation script에 CLI objective report source 추가
+- selected-scale objective path와 phrase-bank CLI technical path 병행 기록
+- readiness와 proven evidence 항목에 CLI technical path 반영
+- harness mode 입력 report 확장
+- unit test와 문서 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MVP_CURRENT_EVIDENCE_CONSOLIDATION_2026-06-05.md`
+- boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- next boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
+- current MVP evidence supported: `true`
+- technical execution evidence supported: `true`
+- selected-scale objective path complete: `true`
+- phrase-bank CLI technical path ready: `true`
+- exported / qualified candidates: `3 / 3`
+- rendered WAV files: `3`
+- selected-scale objective valid / strict / grammar: `9 / 9 / 9`
+- CLI candidate / rendered WAV files: `3 / 3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- 입력 MIDI 기반 context, ranked MIDI export, WAV render 기술 경로 current evidence 유지
+- selected-scale objective repair path와 명시적 input MIDI CLI technical path 병행 정리
+- 청음 preference와 musical quality claim 제외 유지
+- 다음 작업은 README evidence refresh
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-current-evidence-consolidation`
+
+다음:
+
+- `Stage B MIDI-to-solo README evidence refresh`
 
 ## Stage B MIDI-to-Solo Phrase-Bank CLI Objective-Only Next Decision Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MVP_CURRENT_EVIDENCE_CONSOLIDATION_2026-06-05.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MVP_CURRENT_EVIDENCE_CONSOLIDATION_2026-06-05.md
@@ -7,6 +7,7 @@
 - current MVP evidence supported: `true`
 - technical execution evidence supported: `true`
 - selected-scale objective path complete: `true`
+- phrase-bank CLI technical path ready: `true`
 - human/audio preference claimed: `false`
 - MIDI-to-solo musical quality claimed: `false`
 
@@ -44,6 +45,16 @@
 - avg / max postprocess removal ratio: `0.21759259259259262` / `0.2916666666666667`
 - target avg postprocess removal ratio: `0.3`
 - validated review input present: `false`
+- preference fill allowed: `false`
+
+## Phrase-Bank CLI Technical Path
+
+- technical MIDI-to-solo CLI path ready: `true`
+- explicit input used: `true`
+- candidate / objective supported: `3` / `3`
+- repaired MIDI / rendered WAV: `3` / `3`
+- input context bars: `228`
+- dead-air range: `0.1895-0.2211`
 - preference fill allowed: `false`
 
 ## MIDI Paths

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -5821,6 +5821,7 @@ run_stage_b_midi_to_solo_mvp_current_evidence_consolidation() {
   local generation_run_id="${GENERATION_RUN_ID:-harness_stage_b_midi_to_solo_conditioned_generation_probe}"
   local candidate_audio_run_id="${CANDIDATE_AUDIO_RUN_ID:-harness_stage_b_midi_to_solo_candidate_audio_render_package}"
   local objective_next_run_id="${OBJECTIVE_NEXT_RUN_ID:-harness_stage_b_midi_to_solo_controlled_scale_checkpoint_training_scale_postprocess_removal_dead_air_repair_objective_next}"
+  local cli_objective_next_run_id="${CLI_OBJECTIVE_NEXT_RUN_ID:-harness_stage_b_midi_to_solo_phrase_bank_cli_objective_only_next_decision}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_mvp_current_evidence_consolidation}"
   local contract_report="outputs/stage_b_midi_to_solo_mvp_contract/${contract_run_id}/stage_b_midi_to_solo_mvp_contract.json"
   local context_report="outputs/stage_b_midi_to_solo_context_extraction/${context_run_id}/stage_b_midi_to_solo_context_extraction.json"
@@ -5828,6 +5829,7 @@ run_stage_b_midi_to_solo_mvp_current_evidence_consolidation() {
   local generation_probe="outputs/stage_b_midi_to_solo_conditioned_generation_probe/${generation_run_id}/stage_b_midi_to_solo_conditioned_generation_probe.json"
   local candidate_audio="outputs/stage_b_midi_to_solo_candidate_audio_render_package/${candidate_audio_run_id}/stage_b_midi_to_solo_candidate_audio_render_package.json"
   local objective_next="outputs/stage_b_midi_to_solo_controlled_scale_checkpoint_training_scale_postprocess_removal_dead_air_repair_objective_next/${objective_next_run_id}/stage_b_midi_to_solo_controlled_scale_checkpoint_training_scale_postprocess_removal_dead_air_repair_objective_next.json"
+  local cli_objective_next="outputs/stage_b_midi_to_solo_phrase_bank_cli_objective_only_next_decision/${cli_objective_next_run_id}/stage_b_midi_to_solo_phrase_bank_cli_objective_only_next_decision.json"
   if [[ ! -f "$contract_report" ]]; then
     print_header "Stage B MIDI-to-solo MVP input contract"
     RUN_ID="$contract_run_id" run_stage_b_midi_to_solo_mvp_contract
@@ -5852,6 +5854,10 @@ run_stage_b_midi_to_solo_mvp_current_evidence_consolidation() {
     print_header "Stage B MIDI-to-solo controlled scale checkpoint training scale postprocess removal dead-air repair objective-only next decision"
     RUN_ID="$objective_next_run_id" run_stage_b_midi_to_solo_controlled_scale_checkpoint_training_scale_postprocess_removal_dead_air_repair_objective_next
   fi
+  if [[ ! -f "$cli_objective_next" ]]; then
+    print_header "Stage B MIDI-to-solo phrase-bank CLI objective-only next decision"
+    RUN_ID="$cli_objective_next_run_id" run_stage_b_midi_to_solo_phrase_bank_cli_objective_only_next_decision
+  fi
   print_header "Stage B MIDI-to-solo MVP current evidence consolidation"
   "$PYTHON_BIN" scripts/consolidate_stage_b_midi_to_solo_mvp_current_evidence.py \
     --run_id "$run_id" \
@@ -5861,6 +5867,7 @@ run_stage_b_midi_to_solo_mvp_current_evidence_consolidation() {
     --generation_probe "$generation_probe" \
     --audio_render "$candidate_audio" \
     --objective_next "$objective_next" \
+    --cli_objective_next "$cli_objective_next" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_CURRENT_EVIDENCE_CONSOLIDATION_2026-06-05.md \
     --expected_boundary stage_b_midi_to_solo_mvp_current_evidence_consolidation \
     --expected_next_boundary stage_b_midi_to_solo_readme_evidence_refresh \

--- a/scripts/consolidate_stage_b_midi_to_solo_mvp_current_evidence.py
+++ b/scripts/consolidate_stage_b_midi_to_solo_mvp_current_evidence.py
@@ -36,6 +36,7 @@ OBJECTIVE_FINAL_BOUNDARY = (
     "stage_b_midi_to_solo_controlled_scale_checkpoint_training_scale_"
     "postprocess_removal_dead_air_repair_objective_path_complete"
 )
+CLI_OBJECTIVE_BOUNDARY = "stage_b_midi_to_solo_phrase_bank_cli_objective_only_next_decision"
 
 
 def _dict(value: Any) -> dict[str, Any]:
@@ -352,6 +353,81 @@ def validate_objective_next(report: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def validate_cli_objective_next(report: dict[str, Any]) -> dict[str, Any]:
+    if str(report.get("boundary") or "") != CLI_OBJECTIVE_BOUNDARY:
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError("CLI objective boundary required")
+    summary = _dict(report.get("objective_summary"))
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    if str(decision.get("next_boundary") or "") != BOUNDARY:
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "CLI objective next boundary should route to current evidence"
+        )
+    if not bool(readiness.get("cli_objective_only_next_decision_completed", False)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError("CLI objective decision completion required")
+    if not bool(summary.get("technical_midi_to_solo_cli_path_ready", False)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError("CLI technical path readiness required")
+    if not bool(summary.get("mvp_current_evidence_consolidation_ready", False)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "CLI current evidence readiness required"
+        )
+    if not bool(summary.get("explicit_input_used", False)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError("CLI explicit input evidence required")
+    if _int(summary.get("candidate_count")) < 3:
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError("CLI candidate count below 3")
+    if _int(summary.get("objective_supported_candidate_count")) < 3:
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError("CLI objective support below 3")
+    if _int(summary.get("repaired_midi_file_count")) < 3:
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError("CLI repaired MIDI count below 3")
+    if _int(summary.get("rendered_audio_file_count")) < 3:
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError("CLI rendered audio count below 3")
+    if not bool(summary.get("technical_wav_validation", False)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError("CLI technical WAV validation required")
+    if bool(summary.get("validated_review_input_present", True)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "CLI validated review input should remain absent"
+        )
+    if bool(summary.get("preference_fill_allowed", True)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError("CLI preference fill should remain blocked")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError("CLI critical user input should not be required")
+    blocked_claims = [
+        "human_audio_preference_claimed",
+        "midi_to_solo_musical_quality_claimed",
+        "audio_rendered_quality_claimed",
+        "phrase_bank_musical_quality_claimed",
+        "broad_trained_model_quality_claimed",
+        "brad_style_adaptation_claimed",
+        "production_ready_claimed",
+    ]
+    claimed = [name for name in blocked_claims if bool(readiness.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            f"unexpected CLI objective claim: {claimed}"
+        )
+    dead_air = _list(summary.get("dead_air_range"))
+    return {
+        "boundary": CLI_OBJECTIVE_BOUNDARY,
+        "technical_midi_to_solo_cli_path_ready": bool(
+            summary.get("technical_midi_to_solo_cli_path_ready", False)
+        ),
+        "mvp_current_evidence_consolidation_ready": bool(
+            summary.get("mvp_current_evidence_consolidation_ready", False)
+        ),
+        "explicit_input_used": bool(summary.get("explicit_input_used", False)),
+        "candidate_count": _int(summary.get("candidate_count")),
+        "objective_supported_candidate_count": _int(summary.get("objective_supported_candidate_count")),
+        "repaired_midi_file_count": _int(summary.get("repaired_midi_file_count")),
+        "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
+        "technical_wav_validation": bool(summary.get("technical_wav_validation", False)),
+        "input_context_bars": _int(summary.get("input_context_bars")),
+        "min_dead_air_ratio": _float(dead_air[0]) if len(dead_air) >= 1 else 0.0,
+        "max_dead_air_ratio": _float(dead_air[1]) if len(dead_air) >= 2 else 0.0,
+        "validated_review_input_present": bool(summary.get("validated_review_input_present", True)),
+        "preference_fill_allowed": bool(summary.get("preference_fill_allowed", True)),
+    }
+
+
 def build_current_evidence_consolidation_report(
     *,
     contract_report: dict[str, Any],
@@ -360,6 +436,7 @@ def build_current_evidence_consolidation_report(
     generation_probe: dict[str, Any],
     audio_render: dict[str, Any],
     objective_next: dict[str, Any],
+    cli_objective_next: dict[str, Any],
     output_dir: Path,
     issue_number: int,
 ) -> dict[str, Any]:
@@ -369,6 +446,7 @@ def build_current_evidence_consolidation_report(
     generation = validate_generation(generation_probe)
     audio = validate_audio(audio_render)
     objective = validate_objective_next(objective_next)
+    cli_objective = validate_cli_objective_next(cli_objective_next)
     technical_path_supported = (
         bool(resource["midi_to_solo_training_resource_ready"])
         and generation["exported_candidate_count"] >= 3
@@ -377,7 +455,12 @@ def build_current_evidence_consolidation_report(
         and bool(audio["technical_wav_validation"])
     )
     selected_scale_objective_path_complete = bool(objective["objective_path_supported"])
-    current_evidence_supported = bool(technical_path_supported and selected_scale_objective_path_complete)
+    phrase_bank_cli_technical_path_ready = bool(cli_objective["technical_midi_to_solo_cli_path_ready"])
+    current_evidence_supported = bool(
+        technical_path_supported
+        and selected_scale_objective_path_complete
+        and phrase_bank_cli_technical_path_ready
+    )
     return {
         "schema_version": SCHEMA_VERSION,
         "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
@@ -392,6 +475,7 @@ def build_current_evidence_consolidation_report(
             "audio": audio["boundary"],
             "objective_next": objective["boundary"],
             "objective_final": objective["final_boundary"],
+            "phrase_bank_cli_objective_next": cli_objective["boundary"],
         },
         "mvp_contract": contract,
         "context_extraction": context,
@@ -399,6 +483,7 @@ def build_current_evidence_consolidation_report(
         "ranked_midi_generation": generation,
         "technical_audio_render": audio,
         "selected_scale_objective_path": objective,
+        "phrase_bank_cli_technical_path": cli_objective,
         "readiness": {
             "boundary": BOUNDARY,
             "mvp_current_evidence_consolidated": True,
@@ -408,6 +493,7 @@ def build_current_evidence_consolidation_report(
             "ranked_midi_candidates_exported": True,
             "technical_wav_path_ready": True,
             "selected_scale_objective_path_complete": selected_scale_objective_path_complete,
+            "phrase_bank_cli_technical_path_ready": phrase_bank_cli_technical_path_ready,
             "current_mvp_technical_execution_evidence_supported": technical_path_supported,
             "current_mvp_objective_repair_evidence_supported": selected_scale_objective_path_complete,
             "midi_to_solo_mvp_current_evidence_supported": current_evidence_supported,
@@ -435,6 +521,7 @@ def build_current_evidence_consolidation_report(
             "ranked_midi_candidates_exported",
             "technical_wav_render_path_validated",
             "selected_scale_objective_dead_air_repair_path_complete",
+            "explicit_input_cli_ranked_midi_wav_path_validated",
             "quality_claim_guard_preserved",
         ],
         "not_proven": [
@@ -465,6 +552,7 @@ def validate_current_evidence_consolidation_report(
     generation = _dict(report.get("ranked_midi_generation"))
     audio = _dict(report.get("technical_audio_render"))
     objective = _dict(report.get("selected_scale_objective_path"))
+    cli_objective = _dict(report.get("phrase_bank_cli_technical_path"))
     if expected_boundary and boundary != expected_boundary:
         raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
             f"expected boundary {expected_boundary}, got {boundary}"
@@ -483,6 +571,10 @@ def validate_current_evidence_consolidation_report(
         raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError("objective sample count below threshold")
     if not bool(objective.get("objective_path_supported", False)):
         raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError("objective path support required")
+    if not bool(cli_objective.get("technical_midi_to_solo_cli_path_ready", False)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError("CLI technical path support required")
+    if bool(cli_objective.get("preference_fill_allowed", True)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError("CLI preference fill should remain blocked")
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError("critical user input should not be required")
     for item in _list(generation.get("midi_paths")) + _list(audio.get("wav_paths")):
@@ -513,6 +605,13 @@ def validate_current_evidence_consolidation_report(
         "selected_scale_objective_path_complete": bool(
             readiness.get("selected_scale_objective_path_complete", False)
         ),
+        "phrase_bank_cli_technical_path_ready": bool(
+            readiness.get("phrase_bank_cli_technical_path_ready", False)
+        ),
+        "cli_candidate_count": _int(cli_objective.get("candidate_count")),
+        "cli_rendered_audio_file_count": _int(cli_objective.get("rendered_audio_file_count")),
+        "cli_input_context_bars": _int(cli_objective.get("input_context_bars")),
+        "cli_preference_fill_allowed": bool(cli_objective.get("preference_fill_allowed", True)),
         "generation_source": str(generation.get("generation_source") or ""),
         "exported_candidate_count": _int(generation.get("exported_candidate_count")),
         "exported_qualified_candidate_count": _int(generation.get("exported_qualified_candidate_count")),
@@ -550,6 +649,7 @@ def markdown_report(report: dict[str, Any]) -> str:
     generation = report["ranked_midi_generation"]
     audio = report["technical_audio_render"]
     objective = report["selected_scale_objective_path"]
+    cli_objective = report["phrase_bank_cli_technical_path"]
     lines = [
         "# Stage B MIDI-to-Solo MVP Current Evidence Consolidation",
         "",
@@ -560,6 +660,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- current MVP evidence supported: `{_bool_token(readiness['midi_to_solo_mvp_current_evidence_supported'])}`",
         f"- technical execution evidence supported: `{_bool_token(readiness['current_mvp_technical_execution_evidence_supported'])}`",
         f"- selected-scale objective path complete: `{_bool_token(readiness['selected_scale_objective_path_complete'])}`",
+        f"- phrase-bank CLI technical path ready: `{_bool_token(readiness['phrase_bank_cli_technical_path_ready'])}`",
         f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
         f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
         "",
@@ -599,6 +700,16 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- validated review input present: `{_bool_token(objective['validated_review_input_present'])}`",
         f"- preference fill allowed: `{_bool_token(objective['preference_fill_allowed'])}`",
         "",
+        "## Phrase-Bank CLI Technical Path",
+        "",
+        f"- technical MIDI-to-solo CLI path ready: `{_bool_token(cli_objective['technical_midi_to_solo_cli_path_ready'])}`",
+        f"- explicit input used: `{_bool_token(cli_objective['explicit_input_used'])}`",
+        f"- candidate / objective supported: `{cli_objective['candidate_count']}` / `{cli_objective['objective_supported_candidate_count']}`",
+        f"- repaired MIDI / rendered WAV: `{cli_objective['repaired_midi_file_count']}` / `{cli_objective['rendered_audio_file_count']}`",
+        f"- input context bars: `{cli_objective['input_context_bars']}`",
+        f"- dead-air range: `{cli_objective['min_dead_air_ratio']:.4f}-{cli_objective['max_dead_air_ratio']:.4f}`",
+        f"- preference fill allowed: `{_bool_token(cli_objective['preference_fill_allowed'])}`",
+        "",
         "## MIDI Paths",
         "",
     ]
@@ -622,6 +733,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--generation_probe", type=str, required=True)
     parser.add_argument("--audio_render", type=str, required=True)
     parser.add_argument("--objective_next", type=str, required=True)
+    parser.add_argument("--cli_objective_next", type=str, required=True)
     parser.add_argument(
         "--output_root",
         type=str,
@@ -651,6 +763,7 @@ def main() -> int:
         generation_probe=read_json(Path(args.generation_probe)),
         audio_render=read_json(Path(args.audio_render)),
         objective_next=read_json(Path(args.objective_next)),
+        cli_objective_next=read_json(Path(args.cli_objective_next)),
         output_dir=output_dir,
         issue_number=int(args.issue_number),
     )

--- a/tests/test_stage_b_midi_to_solo_mvp_current_evidence_consolidation.py
+++ b/tests/test_stage_b_midi_to_solo_mvp_current_evidence_consolidation.py
@@ -186,6 +186,39 @@ def reports(
                 "critical_user_input_required": False,
             },
         },
+        "cli_objective": {
+            "boundary": "stage_b_midi_to_solo_phrase_bank_cli_objective_only_next_decision",
+            "objective_summary": {
+                "technical_midi_to_solo_cli_path_ready": True,
+                "mvp_current_evidence_consolidation_ready": True,
+                "explicit_input_used": True,
+                "candidate_count": 3,
+                "objective_supported_candidate_count": 3,
+                "repaired_midi_file_count": 3,
+                "rendered_audio_file_count": 3,
+                "technical_wav_validation": True,
+                "input_context_bars": 228,
+                "dead_air_range": [0.1895, 0.2211],
+                "validated_review_input_present": False,
+                "preference_fill_allowed": False,
+            },
+            "readiness": {
+                "cli_objective_only_next_decision_completed": True,
+                "technical_midi_to_solo_cli_path_ready": True,
+                "mvp_current_evidence_consolidation_ready": True,
+                "human_audio_preference_claimed": False,
+                "midi_to_solo_musical_quality_claimed": quality_claim,
+                "audio_rendered_quality_claimed": False,
+                "phrase_bank_musical_quality_claimed": False,
+                "broad_trained_model_quality_claimed": False,
+                "brad_style_adaptation_claimed": False,
+                "production_ready_claimed": False,
+            },
+            "decision": {
+                "next_boundary": "stage_b_midi_to_solo_mvp_current_evidence_consolidation",
+                "critical_user_input_required": False,
+            },
+        },
     }
 
 
@@ -200,6 +233,7 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationTest(unittest.TestCase):
                 generation_probe=data["generation"],
                 audio_render=data["audio"],
                 objective_next=data["objective"],
+                cli_objective_next=data["cli_objective"],
                 output_dir=Path(tmp) / "out",
                 issue_number=612,
             )
@@ -217,9 +251,14 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationTest(unittest.TestCase):
             self.assertTrue(summary["midi_to_solo_mvp_current_evidence_supported"])
             self.assertTrue(summary["technical_execution_evidence_supported"])
             self.assertTrue(summary["selected_scale_objective_path_complete"])
+            self.assertTrue(summary["phrase_bank_cli_technical_path_ready"])
             self.assertEqual(summary["generation_source"], "context_conditioned_fallback")
             self.assertEqual(summary["exported_candidate_count"], 3)
             self.assertEqual(summary["rendered_audio_file_count"], 3)
+            self.assertEqual(summary["cli_candidate_count"], 3)
+            self.assertEqual(summary["cli_rendered_audio_file_count"], 3)
+            self.assertEqual(summary["cli_input_context_bars"], 228)
+            self.assertFalse(summary["cli_preference_fill_allowed"])
             self.assertEqual(summary["objective_sample_count"], 9)
             self.assertEqual(summary["objective_strict_valid_sample_count"], 9)
             self.assertEqual(summary["objective_grammar_gate_sample_count"], 9)
@@ -241,6 +280,7 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationTest(unittest.TestCase):
                     generation_probe=data["generation"],
                     audio_render=data["audio"],
                     objective_next=data["objective"],
+                    cli_objective_next=data["cli_objective"],
                     output_dir=Path(tmp) / "out",
                     issue_number=612,
                 )
@@ -256,6 +296,7 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationTest(unittest.TestCase):
                     generation_probe=data["generation"],
                     audio_render=data["audio"],
                     objective_next=data["objective"],
+                    cli_objective_next=data["cli_objective"],
                     output_dir=Path(tmp) / "out",
                     issue_number=612,
                 )
@@ -271,6 +312,7 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationTest(unittest.TestCase):
                     generation_probe=data["generation"],
                     audio_render=data["audio"],
                     objective_next=data["objective"],
+                    cli_objective_next=data["cli_objective"],
                     output_dir=Path(tmp) / "out",
                     issue_number=612,
                 )
@@ -285,6 +327,7 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationTest(unittest.TestCase):
                     generation_probe=data["generation"],
                     audio_render=data["audio"],
                     objective_next=data["objective"],
+                    cli_objective_next=data["cli_objective"],
                     output_dir=Path(tmp) / "out",
                     issue_number=612,
                 )


### PR DESCRIPTION
## Summary
- MVP current evidence consolidation에 CLI phrase-bank objective evidence 반영
- selected-scale objective path와 명시적 input MIDI CLI technical path 병행 기록
- README evidence refresh boundary 연결 유지

## Context
- Issue #662 결과: CLI technical MIDI-to-solo path ready `true`
- explicit input used: `true`
- candidate/rendered count: `3 / 3`
- input context bars: `228`
- preference fill allowed: `false`
- human/audio preference와 MIDI-to-solo musical quality claim 제외

## Scope
- current evidence consolidation script에 CLI objective report source 추가
- readiness와 proven evidence 항목에 CLI technical path 반영
- harness mode 입력 report 확장
- unit test와 문서 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_current_evidence_consolidation`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-current-evidence-consolidation`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- human/audio preference: 미주장
- MIDI-to-solo musical quality: 미주장
- 다음 작업: README evidence refresh

Closes #664