### PR TITLE
Stage B MIDI-to-solo README evidence refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #664, Stage B MIDI-to-solo MVP current evidence consolidation.
+- Latest functional issue completed: Issue #666, Stage B MIDI-to-solo README evidence refresh.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo README evidence refresh.
+- Recommended next issue: Stage B MIDI-to-solo MVP completion audit.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - phrase-bank CLI technical MIDI-to-solo path ready: `true`
 - phrase-bank CLI MVP current evidence consolidation ready: `true`
 - phrase-bank CLI technical path included in current evidence: `true`
+- README evidence refreshed: `true`
+- next boundary: `stage_b_midi_to_solo_mvp_completion_audit`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -90,6 +92,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - 명시적 `--input_midi` 경로 기준 phrase-bank CLI review input pending 상태에서 preference fill 차단 가능
 - 명시적 `--input_midi` 경로 기준 phrase-bank CLI technical path objective decision 가능
 - selected-scale objective path와 phrase-bank CLI technical path를 current evidence로 통합 가능
+- README 첫 상태 영역에 current evidence와 claim boundary 반영 완료
 
 현재 README가 주장하지 않는 것.
 
@@ -380,6 +383,15 @@ MVP current evidence consolidation.
 - human/audio preference claimed: `false`
 - MIDI-to-solo musical quality claimed: `false`
 - next boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
+
+README evidence refresh.
+
+- latest evidence boundary reflected: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- technical execution evidence supported: `true`
+- selected-scale objective path complete: `true`
+- phrase-bank CLI technical path ready: `true`
+- quality/preference claim excluded: `true`
+- next boundary: `stage_b_midi_to_solo_mvp_completion_audit`
 
 MIDI-to-solo input contract.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -2837,6 +2837,34 @@ Issue #664는 기존 current evidence consolidation에 CLI phrase-bank objective
 
 - `Stage B MIDI-to-solo README evidence refresh`
 
+## 9.24 Stage B MIDI-to-solo README evidence refresh
+
+Issue #666은 Issue #664 current evidence를 README 첫 상태 영역과 claim boundary에 반영하고, 다음 boundary를 MVP completion audit으로 넘긴 문서 작업이다.
+
+결과:
+
+- latest evidence boundary reflected: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- technical execution evidence supported: `true`
+- selected-scale objective path complete: `true`
+- phrase-bank CLI technical path ready: `true`
+- quality/preference claim excluded: `true`
+- next boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+
+판단:
+
+- README 첫 상태 영역에서 technical current evidence 확인 가능.
+- 청음 preference와 musical quality claim 제외 유지.
+- 다음 작업은 MVP completion audit.
+
+검증:
+
+- `git diff --check`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo MVP completion audit`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #664, Stage B MIDI-to-solo MVP current evidence consolidation
-- 다음 권장 이슈: `Stage B MIDI-to-solo README evidence refresh`
+- latest functional result: Issue #666, Stage B MIDI-to-solo README evidence refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo MVP completion audit`
 
 현재 범위가 아닌 것:
 
@@ -49,6 +49,42 @@
 - 실제 MIDI 입력 CLI review input pending 상태에서 preference fill 차단 완료
 - 실제 MIDI 입력 CLI technical path objective decision 완료
 - selected-scale objective path와 실제 MIDI 입력 CLI technical path current evidence 통합 완료
+- README current evidence와 claim boundary refresh 완료
+
+## Stage B MIDI-to-Solo README Evidence Refresh Result
+
+Issue #666은 Issue #664 current evidence를 README 첫 상태 영역과 claim boundary에 반영하고, 다음 boundary를 MVP completion audit으로 넘긴 문서 작업이다.
+
+변경:
+
+- README latest/current evidence boundary 확인
+- selected-scale objective path와 phrase-bank CLI technical path status 반영
+- README evidence refresh 완료 상태 추가
+- current status, core plan, handoff scope 갱신
+
+결과:
+
+- latest evidence boundary reflected: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- technical execution evidence supported: `true`
+- selected-scale objective path complete: `true`
+- phrase-bank CLI technical path ready: `true`
+- quality/preference claim excluded: `true`
+- next boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+
+판단:
+
+- README 첫 상태 영역에서 technical current evidence 확인 가능
+- 청음 preference와 musical quality claim 제외 유지
+- 다음 작업은 MVP completion audit
+
+검증:
+
+- `git diff --check`
+- `bash scripts/agent_harness.sh quick`
+
+다음:
+
+- `Stage B MIDI-to-solo MVP completion audit`
 
 ## Stage B MIDI-to-Solo MVP Current Evidence Consolidation Result
 


### PR DESCRIPTION
## Summary
- README current evidence section을 #664 기준으로 갱신
- selected-scale objective path와 CLI technical path를 첫 상태 영역에 반영
- 다음 boundary를 MVP completion audit으로 연결

## Context
- Issue #664 결과: current MVP evidence supported `true`
- selected-scale objective path complete: `true`
- phrase-bank CLI technical path ready: `true`
- preference fill allowed: `false`
- human/audio preference와 MIDI-to-solo musical quality claim 제외 유지

## Scope
- README 상태와 claim boundary refresh
- current status, core plan, handoff scope 갱신

## Validation
- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk
- human/audio preference: 미주장
- MIDI-to-solo musical quality: 미주장
- 다음 작업: MVP completion audit

Closes #666