### PR TITLE
Stage B MIDI-to-solo MVP completion audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #666, Stage B MIDI-to-solo README evidence refresh.
+- Latest functional issue completed: Issue #668, Stage B MIDI-to-solo MVP completion audit.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo MVP completion audit.
+- Recommended next issue: Stage B MIDI-to-solo quality gap decision.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1035,7 +1035,7 @@ For Stage B MIDI-to-solo MVP completion audit changes, run:
 bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit
 ```
 
-This harness audits technical model-core MVP completion and keeps musical quality, human preference, broad model quality, and product readiness claims excluded.
+This harness audits technical model-core MVP completion, including the CLI technical path, and keeps musical quality, human preference, broad model quality, and product readiness claims excluded.
 
 For Stage B MIDI-to-solo quality gap decision changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- latest evidence boundary: `stage_b_midi_to_solo_mvp_completion_audit`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -57,7 +57,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - phrase-bank CLI MVP current evidence consolidation ready: `true`
 - phrase-bank CLI technical path included in current evidence: `true`
 - README evidence refreshed: `true`
-- next boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- MVP completion audit completed: `true`
+- quality gap decision required: `true`
+- next boundary: `stage_b_midi_to_solo_quality_gap_decision`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -93,6 +95,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - 명시적 `--input_midi` 경로 기준 phrase-bank CLI technical path objective decision 가능
 - selected-scale objective path와 phrase-bank CLI technical path를 current evidence로 통합 가능
 - README 첫 상태 영역에 current evidence와 claim boundary 반영 완료
+- technical model-core MVP 완료 범위 audit 가능
 
 현재 README가 주장하지 않는 것.
 
@@ -112,9 +115,11 @@ MVP completion audit.
 - input to rendered WAV completed: `true`
 - selected-scale objective repair completed: `true`
 - phrase-bank CLI technical path included: `true`
+- phrase-bank CLI technical path completed: `true`
 - musical quality MVP completed: `false`
 - human/audio preference completed: `false`
 - product MVP completed: `false`
+- next boundary: `stage_b_midi_to_solo_quality_gap_decision`
 
 Quality gap decision.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -2865,6 +2865,40 @@ Issue #666은 Issue #664 current evidence를 README 첫 상태 영역과 claim b
 
 - `Stage B MIDI-to-solo MVP completion audit`
 
+## 9.25 Stage B MIDI-to-solo MVP completion audit
+
+Issue #668은 Issue #664 current evidence와 Issue #666 README refresh를 기준으로 technical model-core MVP 완료 범위를 audit한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- next boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- technical model-core MVP completed: `true`
+- input to ranked MIDI completed: `true`
+- input to rendered WAV completed: `true`
+- selected-scale objective repair completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- musical quality MVP completed: `false`
+- human/audio preference completed: `false`
+- product MVP completed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- technical model-core MVP 완료 범위 확인.
+- 음악 품질, 사용자 선호, 제품 MVP 완료 claim 제외 유지.
+- 다음 작업은 quality gap decision.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo quality gap decision`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #666, Stage B MIDI-to-solo README evidence refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo MVP completion audit`
+- latest functional result: Issue #668, Stage B MIDI-to-solo MVP completion audit
+- 다음 권장 이슈: `Stage B MIDI-to-solo quality gap decision`
 
 현재 범위가 아닌 것:
 
@@ -50,6 +50,50 @@
 - 실제 MIDI 입력 CLI technical path objective decision 완료
 - selected-scale objective path와 실제 MIDI 입력 CLI technical path current evidence 통합 완료
 - README current evidence와 claim boundary refresh 완료
+- technical model-core MVP completion audit 완료
+
+## Stage B MIDI-to-Solo MVP Completion Audit Result
+
+Issue #668은 Issue #664 current evidence와 Issue #666 README refresh를 기준으로 technical model-core MVP 완료 범위를 audit한 작업이다.
+
+변경:
+
+- completion audit script에 CLI technical path readiness 검증 추가
+- README required snippet에 CLI technical path와 README refresh 상태 추가
+- technical model-core MVP 완료 범위와 quality gap boundary 분리
+- unit test와 generated audit doc 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_2026-06-05.md`
+- boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- next boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- technical model-core MVP completed: `true`
+- input to ranked MIDI completed: `true`
+- input to rendered WAV completed: `true`
+- selected-scale objective repair completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- musical quality MVP completed: `false`
+- human/audio preference completed: `false`
+- product MVP completed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- technical model-core MVP 완료 범위 확인
+- 음악 품질, 사용자 선호, 제품 MVP 완료 claim 제외 유지
+- 다음 작업은 quality gap decision
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit`
+
+다음:
+
+- `Stage B MIDI-to-solo quality gap decision`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_2026-06-05.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_2026-06-05.md
@@ -5,6 +5,7 @@
 - boundary: `stage_b_midi_to_solo_mvp_completion_audit`
 - next boundary: `stage_b_midi_to_solo_quality_gap_decision`
 - technical model-core MVP completed: `true`
+- phrase-bank CLI technical path completed: `true`
 - musical quality MVP completed: `false`
 - human/audio preference completed: `false`
 - product MVP completed: `false`
@@ -20,6 +21,10 @@
 - objective sample / strict / grammar: `9` / `9` / `9`
 - objective dead-air / collapse failure: `0` / `0`
 - objective avg / target postprocess removal: `0.21759259259259262` / `0.3`
+- phrase-bank CLI technical path ready: `true`
+- CLI candidate / rendered WAV: `3` / `3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
 
 ## Claim Boundary
 

--- a/scripts/audit_stage_b_midi_to_solo_mvp_completion.py
+++ b/scripts/audit_stage_b_midi_to_solo_mvp_completion.py
@@ -60,6 +60,7 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
     generation = _dict(report.get("ranked_midi_generation"))
     audio = _dict(report.get("technical_audio_render"))
     objective = _dict(report.get("selected_scale_objective_path"))
+    cli_objective = _dict(report.get("phrase_bank_cli_technical_path"))
     decision = _dict(report.get("decision"))
     required_true = [
         "mvp_current_evidence_consolidated",
@@ -69,6 +70,7 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
         "ranked_midi_candidates_exported",
         "technical_wav_path_ready",
         "selected_scale_objective_path_complete",
+        "phrase_bank_cli_technical_path_ready",
         "current_mvp_technical_execution_evidence_supported",
         "current_mvp_objective_repair_evidence_supported",
         "midi_to_solo_mvp_current_evidence_supported",
@@ -98,6 +100,14 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloMvpCompletionAuditError("objective strict valid count must match sample count")
     if _int(objective.get("dead_air_failure_count")) != 0:
         raise StageBMidiToSoloMvpCompletionAuditError("objective dead-air failure count must be zero")
+    if not bool(cli_objective.get("technical_midi_to_solo_cli_path_ready", False)):
+        raise StageBMidiToSoloMvpCompletionAuditError("CLI technical path support required")
+    if _int(cli_objective.get("candidate_count")) < 3:
+        raise StageBMidiToSoloMvpCompletionAuditError("CLI candidate count below 3")
+    if _int(cli_objective.get("rendered_audio_file_count")) < 3:
+        raise StageBMidiToSoloMvpCompletionAuditError("CLI rendered WAV count below 3")
+    if bool(cli_objective.get("preference_fill_allowed", True)):
+        raise StageBMidiToSoloMvpCompletionAuditError("CLI preference fill should remain blocked")
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloMvpCompletionAuditError("critical user input should not be required")
     return {
@@ -123,6 +133,13 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
         "objective_target_avg_postprocess_removal_ratio": _float(
             objective.get("target_avg_postprocess_removal_ratio")
         ),
+        "phrase_bank_cli_technical_path_ready": bool(
+            cli_objective.get("technical_midi_to_solo_cli_path_ready", False)
+        ),
+        "cli_candidate_count": _int(cli_objective.get("candidate_count")),
+        "cli_rendered_audio_file_count": _int(cli_objective.get("rendered_audio_file_count")),
+        "cli_input_context_bars": _int(cli_objective.get("input_context_bars")),
+        "cli_preference_fill_allowed": bool(cli_objective.get("preference_fill_allowed", True)),
     }
 
 
@@ -132,6 +149,8 @@ def validate_readme_refresh(readme_text: str) -> dict[str, Any]:
         "current_evidence_support": "current MVP evidence support: `true`",
         "technical_path": "input MIDI -> context -> ranked MIDI -> WAV technical path: `true`",
         "objective_path": "selected-scale objective repair path complete: `true`",
+        "cli_path": "phrase-bank CLI technical path included in current evidence: `true`",
+        "readme_refresh": "README evidence refreshed: `true`",
         "human_preference_false": "human/audio preference claim: `false`",
         "musical_quality_false": "MIDI-to-solo musical quality claim: `false`",
         "broad_quality_false": "broad trained-model quality claim: `false`",
@@ -160,6 +179,7 @@ def build_mvp_completion_audit_report(
         evidence["current_evidence_supported"]
         and evidence["technical_execution_evidence_supported"]
         and evidence["selected_scale_objective_path_complete"]
+        and evidence["phrase_bank_cli_technical_path_ready"]
         and readme["readme_current_evidence_refreshed"]
     )
     return {
@@ -176,6 +196,7 @@ def build_mvp_completion_audit_report(
             "input_to_ranked_midi_completed": True,
             "input_to_rendered_wav_completed": True,
             "selected_scale_objective_repair_completed": True,
+            "phrase_bank_cli_technical_path_completed": True,
             "readme_evidence_boundary_refreshed": True,
             "musical_quality_mvp_completed": False,
             "human_audio_preference_completed": False,
@@ -209,6 +230,7 @@ def build_mvp_completion_audit_report(
             "ranked_midi_candidate_export",
             "technical_wav_render_path",
             "selected_scale_objective_repair_path",
+            "phrase_bank_cli_technical_path",
             "readme_current_evidence_refresh",
         ],
         "not_proven": [
@@ -269,6 +291,9 @@ def validate_mvp_completion_audit_report(
         "selected_scale_objective_repair_completed": bool(
             audit.get("selected_scale_objective_repair_completed", False)
         ),
+        "phrase_bank_cli_technical_path_completed": bool(
+            audit.get("phrase_bank_cli_technical_path_completed", False)
+        ),
         "musical_quality_mvp_completed": bool(audit.get("musical_quality_mvp_completed", True)),
         "human_audio_preference_completed": bool(audit.get("human_audio_preference_completed", True)),
         "product_mvp_completed": bool(audit.get("product_mvp_completed", True)),
@@ -280,6 +305,13 @@ def validate_mvp_completion_audit_report(
             evidence.get("objective_strict_valid_sample_count")
         ),
         "objective_dead_air_failure_count": _int(evidence.get("objective_dead_air_failure_count")),
+        "phrase_bank_cli_technical_path_ready": bool(
+            evidence.get("phrase_bank_cli_technical_path_ready", False)
+        ),
+        "cli_candidate_count": _int(evidence.get("cli_candidate_count")),
+        "cli_rendered_audio_file_count": _int(evidence.get("cli_rendered_audio_file_count")),
+        "cli_input_context_bars": _int(evidence.get("cli_input_context_bars")),
+        "cli_preference_fill_allowed": bool(evidence.get("cli_preference_fill_allowed", True)),
         "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
         "midi_to_solo_musical_quality_claimed": bool(
             readiness.get("midi_to_solo_musical_quality_claimed", True)
@@ -302,6 +334,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- boundary: `{report['boundary']}`",
         f"- next boundary: `{decision['next_boundary']}`",
         f"- technical model-core MVP completed: `{_bool_token(audit['technical_model_core_mvp_completed'])}`",
+        f"- phrase-bank CLI technical path completed: `{_bool_token(audit['phrase_bank_cli_technical_path_completed'])}`",
         f"- musical quality MVP completed: `{_bool_token(audit['musical_quality_mvp_completed'])}`",
         f"- human/audio preference completed: `{_bool_token(audit['human_audio_preference_completed'])}`",
         f"- product MVP completed: `{_bool_token(audit['product_mvp_completed'])}`",
@@ -317,6 +350,10 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- objective sample / strict / grammar: `{evidence['objective_sample_count']}` / `{evidence['objective_strict_valid_sample_count']}` / `{evidence['objective_grammar_gate_sample_count']}`",
         f"- objective dead-air / collapse failure: `{evidence['objective_dead_air_failure_count']}` / `{evidence['objective_collapse_warning_sample_count']}`",
         f"- objective avg / target postprocess removal: `{evidence['objective_avg_postprocess_removal_ratio']}` / `{evidence['objective_target_avg_postprocess_removal_ratio']}`",
+        f"- phrase-bank CLI technical path ready: `{_bool_token(evidence['phrase_bank_cli_technical_path_ready'])}`",
+        f"- CLI candidate / rendered WAV: `{evidence['cli_candidate_count']}` / `{evidence['cli_rendered_audio_file_count']}`",
+        f"- CLI input context bars: `{evidence['cli_input_context_bars']}`",
+        f"- CLI preference fill allowed: `{_bool_token(evidence['cli_preference_fill_allowed'])}`",
         "",
         "## Claim Boundary",
         "",

--- a/tests/test_stage_b_midi_to_solo_mvp_completion_audit.py
+++ b/tests/test_stage_b_midi_to_solo_mvp_completion_audit.py
@@ -26,6 +26,7 @@ def current_evidence(*, quality_claim: bool = False, strict_count: int = 9) -> d
             "ranked_midi_candidates_exported": True,
             "technical_wav_path_ready": True,
             "selected_scale_objective_path_complete": True,
+            "phrase_bank_cli_technical_path_ready": True,
             "current_mvp_technical_execution_evidence_supported": True,
             "current_mvp_objective_repair_evidence_supported": True,
             "midi_to_solo_mvp_current_evidence_supported": True,
@@ -56,6 +57,13 @@ def current_evidence(*, quality_claim: bool = False, strict_count: int = 9) -> d
             "avg_postprocess_removal_ratio": 0.2176,
             "target_avg_postprocess_removal_ratio": 0.3,
         },
+        "phrase_bank_cli_technical_path": {
+            "technical_midi_to_solo_cli_path_ready": True,
+            "candidate_count": 3,
+            "rendered_audio_file_count": 3,
+            "input_context_bars": 228,
+            "preference_fill_allowed": False,
+        },
         "decision": {
             "critical_user_input_required": False,
         },
@@ -71,6 +79,8 @@ def readme_text(*, missing_boundary: bool = False) -> str:
             "- current MVP evidence support: `true`",
             "- input MIDI -> context -> ranked MIDI -> WAV technical path: `true`",
             "- selected-scale objective repair path complete: `true`",
+            "- phrase-bank CLI technical path included in current evidence: `true`",
+            "- README evidence refreshed: `true`",
             "- human/audio preference claim: `false`",
             "- MIDI-to-solo musical quality claim: `false`",
             "- broad trained-model quality claim: `false`",
@@ -99,6 +109,7 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
         self.assertTrue(summary["input_to_ranked_midi_completed"])
         self.assertTrue(summary["input_to_rendered_wav_completed"])
         self.assertTrue(summary["selected_scale_objective_repair_completed"])
+        self.assertTrue(summary["phrase_bank_cli_technical_path_completed"])
         self.assertFalse(summary["musical_quality_mvp_completed"])
         self.assertFalse(summary["human_audio_preference_completed"])
         self.assertFalse(summary["product_mvp_completed"])
@@ -108,6 +119,11 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
         self.assertEqual(summary["objective_sample_count"], 9)
         self.assertEqual(summary["objective_strict_valid_sample_count"], 9)
         self.assertEqual(summary["objective_dead_air_failure_count"], 0)
+        self.assertTrue(summary["phrase_bank_cli_technical_path_ready"])
+        self.assertEqual(summary["cli_candidate_count"], 3)
+        self.assertEqual(summary["cli_rendered_audio_file_count"], 3)
+        self.assertEqual(summary["cli_input_context_bars"], 228)
+        self.assertFalse(summary["cli_preference_fill_allowed"])
         self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
 
     def test_rejects_missing_readme_evidence_boundary(self) -> None:


### PR DESCRIPTION
## Summary
- MVP completion audit에 CLI technical path evidence 반영
- README evidence refresh snippet 검증 확장
- technical model-core MVP 완료 범위와 quality gap boundary 분리

## Context
- Issue #664: current evidence에 phrase-bank CLI technical path 포함
- Issue #666: README evidence refresh 완료
- technical model-core MVP claim 가능 범위: input/context/ranked MIDI/WAV/objective guard
- 제외 claim: human/audio preference, MIDI-to-solo musical quality, broad trained model quality

## Scope
- completion audit script CLI readiness 검증 추가
- README required snippet 확장
- unit test, generated audit doc, status docs 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- musical quality MVP: 미완료
- product MVP: 미완료
- 다음 작업: quality gap decision

Closes #668