### PR TITLE
Stage B MIDI-to-solo quality gap decision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #668, Stage B MIDI-to-solo MVP completion audit.
+- Latest functional issue completed: Issue #670, Stage B MIDI-to-solo quality gap decision.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo quality gap decision.
+- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path quality alignment.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- latest evidence boundary: `stage_b_midi_to_solo_quality_gap_decision`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -58,8 +58,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - phrase-bank CLI technical path included in current evidence: `true`
 - README evidence refreshed: `true`
 - MVP completion audit completed: `true`
-- quality gap decision required: `true`
-- next boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- quality gap decision completed: `true`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -123,9 +123,15 @@ MVP completion audit.
 
 Quality gap decision.
 
+- boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment`
 - selected target: `model_conditioned_input_path_quality_alignment`
 - fallback path active: `true`
 - model-conditioned input path alignment required: `true`
+- phrase-bank CLI technical path completed: `true`
+- musical quality MVP completed: `false`
+- CLI candidate / rendered WAV: `3 / 3`
+- CLI preference fill allowed: `false`
 - human review required now: `false`
 
 Model-conditioned input path alignment.

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -2899,6 +2899,42 @@ Issue #668은 Issue #664 current evidence와 Issue #666 README refresh를 기준
 
 - `Stage B MIDI-to-solo quality gap decision`
 
+## 9.26 Stage B MIDI-to-solo quality gap decision
+
+Issue #670은 Issue #668 MVP completion audit 이후 남은 quality gap을 다음 자동 구현 타깃으로 분리한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment`
+- selected target: `model_conditioned_input_path_quality_alignment`
+- fallback path active: `true`
+- model-conditioned input path alignment required: `true`
+- technical model-core MVP completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- musical quality MVP completed: `false`
+- CLI candidate / rendered WAV: `3 / 3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- human review required now: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- 기술 경로 완료와 음악 품질 gap 분리 유지.
+- 현재 generation source가 `context_conditioned_fallback`이므로 model-conditioned input path alignment를 다음 target으로 유지.
+- human review 없이 자동 진행 가능.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_gap_decision`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-gap-decision`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo model-conditioned input path quality alignment`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #668, Stage B MIDI-to-solo MVP completion audit
-- 다음 권장 이슈: `Stage B MIDI-to-solo quality gap decision`
+- latest functional result: Issue #670, Stage B MIDI-to-solo quality gap decision
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path quality alignment`
 
 현재 범위가 아닌 것:
 
@@ -51,6 +51,51 @@
 - selected-scale objective path와 실제 MIDI 입력 CLI technical path current evidence 통합 완료
 - README current evidence와 claim boundary refresh 완료
 - technical model-core MVP completion audit 완료
+- quality gap target 결정 완료
+
+## Stage B MIDI-to-Solo Quality Gap Decision Result
+
+Issue #670은 Issue #668 MVP completion audit 이후 남은 quality gap을 다음 자동 구현 타깃으로 분리한 작업이다.
+
+변경:
+
+- quality gap decision script에 CLI completion fields 추가
+- MVP completion audit report 검증에 CLI technical path 반영
+- generated decision doc와 status docs 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_2026-06-05.md`
+- boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment`
+- selected target: `model_conditioned_input_path_quality_alignment`
+- fallback path active: `true`
+- model-conditioned input path alignment required: `true`
+- technical model-core MVP completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- musical quality MVP completed: `false`
+- CLI candidate / rendered WAV: `3 / 3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- human review required now: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- 기술 경로 완료와 음악 품질 gap 분리 유지
+- 현재 generation source가 `context_conditioned_fallback`이므로 model-conditioned input path alignment를 다음 target으로 유지
+- human review 없이 자동 진행 가능
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_gap_decision`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-gap-decision`
+
+다음:
+
+- `Stage B MIDI-to-solo model-conditioned input path quality alignment`
 
 ## Stage B MIDI-to-Solo MVP Completion Audit Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_2026-06-05.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_2026-06-05.md
@@ -11,12 +11,16 @@
 ## Evidence
 
 - technical model-core MVP completed: `true`
+- phrase-bank CLI technical path completed: `true`
 - musical quality MVP completed: `false`
 - generation source: `context_conditioned_fallback`
 - exported candidates: `3`
 - rendered WAV files: `3`
 - objective strict/sample: `9` / `9`
 - objective dead-air failure: `0`
+- CLI candidate / rendered WAV: `3` / `3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
 
 ## Claim Boundary
 

--- a/scripts/decide_stage_b_midi_to_solo_quality_gap.py
+++ b/scripts/decide_stage_b_midi_to_solo_quality_gap.py
@@ -69,10 +69,20 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloQualityGapDecisionError("human/audio preference should remain incomplete")
     if bool(audit.get("product_mvp_completed", True)):
         raise StageBMidiToSoloQualityGapDecisionError("product MVP should remain incomplete")
+    if not bool(audit.get("phrase_bank_cli_technical_path_completed", False)):
+        raise StageBMidiToSoloQualityGapDecisionError("phrase-bank CLI technical path completion required")
     if _int(evidence.get("exported_candidate_count")) < 3:
         raise StageBMidiToSoloQualityGapDecisionError("exported candidate count below 3")
     if _int(evidence.get("rendered_audio_file_count")) < 3:
         raise StageBMidiToSoloQualityGapDecisionError("rendered WAV count below 3")
+    if not bool(evidence.get("phrase_bank_cli_technical_path_ready", False)):
+        raise StageBMidiToSoloQualityGapDecisionError("phrase-bank CLI technical path readiness required")
+    if _int(evidence.get("cli_candidate_count")) < 3:
+        raise StageBMidiToSoloQualityGapDecisionError("CLI candidate count below 3")
+    if _int(evidence.get("cli_rendered_audio_file_count")) < 3:
+        raise StageBMidiToSoloQualityGapDecisionError("CLI rendered WAV count below 3")
+    if bool(evidence.get("cli_preference_fill_allowed", True)):
+        raise StageBMidiToSoloQualityGapDecisionError("CLI preference fill should remain blocked")
     if _int(evidence.get("objective_strict_valid_sample_count")) != _int(evidence.get("objective_sample_count")):
         raise StageBMidiToSoloQualityGapDecisionError("objective strict valid count must match sample count")
     blocked_claims = [
@@ -87,6 +97,7 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloQualityGapDecisionError(f"unexpected quality claim: {claimed}")
     return {
         "technical_model_core_mvp_completed": True,
+        "phrase_bank_cli_technical_path_completed": True,
         "musical_quality_mvp_completed": False,
         "human_audio_preference_completed": False,
         "product_mvp_completed": False,
@@ -102,6 +113,13 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
         "objective_target_avg_postprocess_removal_ratio": _float(
             evidence.get("objective_target_avg_postprocess_removal_ratio")
         ),
+        "phrase_bank_cli_technical_path_ready": bool(
+            evidence.get("phrase_bank_cli_technical_path_ready", False)
+        ),
+        "cli_candidate_count": _int(evidence.get("cli_candidate_count")),
+        "cli_rendered_audio_file_count": _int(evidence.get("cli_rendered_audio_file_count")),
+        "cli_input_context_bars": _int(evidence.get("cli_input_context_bars")),
+        "cli_preference_fill_allowed": bool(evidence.get("cli_preference_fill_allowed", True)),
     }
 
 
@@ -111,7 +129,7 @@ def select_quality_gap_target(audit_summary: dict[str, Any]) -> dict[str, Any]:
     target = SELECTED_TARGET if fallback_path_active else "listening_review_quality_gap"
     next_boundary = NEXT_BOUNDARY if fallback_path_active else "stage_b_midi_to_solo_listening_review_quality_gap"
     reason = (
-        "input-to-WAV path still uses context_conditioned_fallback while selected-scale objective repair is separate"
+        "input-to-WAV path still uses context_conditioned_fallback while selected-scale and CLI paths are technical evidence, not model-conditioned quality"
         if fallback_path_active
         else "model-conditioned path is available; listening review gap remains"
     )
@@ -142,6 +160,7 @@ def build_quality_gap_decision_report(
         "mvp_completion_summary": audit_summary,
         "quality_gap": {
             "technical_model_core_mvp_completed": True,
+            "phrase_bank_cli_technical_path_completed": True,
             "musical_quality_mvp_completed": False,
             "human_audio_preference_completed": False,
             "product_mvp_completed": False,
@@ -229,7 +248,18 @@ def validate_quality_gap_decision_report(
         "technical_model_core_mvp_completed": bool(
             quality_gap.get("technical_model_core_mvp_completed", False)
         ),
+        "phrase_bank_cli_technical_path_completed": bool(
+            quality_gap.get("phrase_bank_cli_technical_path_completed", False)
+        ),
         "musical_quality_mvp_completed": bool(quality_gap.get("musical_quality_mvp_completed", True)),
+        "cli_candidate_count": _int(_dict(report.get("mvp_completion_summary")).get("cli_candidate_count")),
+        "cli_rendered_audio_file_count": _int(
+            _dict(report.get("mvp_completion_summary")).get("cli_rendered_audio_file_count")
+        ),
+        "cli_input_context_bars": _int(_dict(report.get("mvp_completion_summary")).get("cli_input_context_bars")),
+        "cli_preference_fill_allowed": bool(
+            _dict(report.get("mvp_completion_summary")).get("cli_preference_fill_allowed", True)
+        ),
         "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
         "midi_to_solo_musical_quality_claimed": bool(
             readiness.get("midi_to_solo_musical_quality_claimed", True)
@@ -259,12 +289,16 @@ def markdown_report(report: dict[str, Any]) -> str:
         "## Evidence",
         "",
         f"- technical model-core MVP completed: `{_bool_token(summary['technical_model_core_mvp_completed'])}`",
+        f"- phrase-bank CLI technical path completed: `{_bool_token(summary['phrase_bank_cli_technical_path_completed'])}`",
         f"- musical quality MVP completed: `{_bool_token(summary['musical_quality_mvp_completed'])}`",
         f"- generation source: `{summary['generation_source']}`",
         f"- exported candidates: `{summary['exported_candidate_count']}`",
         f"- rendered WAV files: `{summary['rendered_audio_file_count']}`",
         f"- objective strict/sample: `{summary['objective_strict_valid_sample_count']}` / `{summary['objective_sample_count']}`",
         f"- objective dead-air failure: `{summary['objective_dead_air_failure_count']}`",
+        f"- CLI candidate / rendered WAV: `{summary['cli_candidate_count']}` / `{summary['cli_rendered_audio_file_count']}`",
+        f"- CLI input context bars: `{summary['cli_input_context_bars']}`",
+        f"- CLI preference fill allowed: `{_bool_token(summary['cli_preference_fill_allowed'])}`",
         "",
         "## Claim Boundary",
         "",

--- a/tests/test_stage_b_midi_to_solo_quality_gap_decision.py
+++ b/tests/test_stage_b_midi_to_solo_quality_gap_decision.py
@@ -40,6 +40,7 @@ def mvp_completion_audit(
             "input_to_ranked_midi_completed": True,
             "input_to_rendered_wav_completed": True,
             "selected_scale_objective_repair_completed": True,
+            "phrase_bank_cli_technical_path_completed": True,
             "readme_evidence_boundary_refreshed": True,
             "musical_quality_mvp_completed": musical_complete,
             "human_audio_preference_completed": False,
@@ -56,6 +57,11 @@ def mvp_completion_audit(
             "objective_dead_air_failure_count": 0,
             "objective_avg_postprocess_removal_ratio": 0.2176,
             "objective_target_avg_postprocess_removal_ratio": 0.3,
+            "phrase_bank_cli_technical_path_ready": True,
+            "cli_candidate_count": 3,
+            "cli_rendered_audio_file_count": 3,
+            "cli_input_context_bars": 228,
+            "cli_preference_fill_allowed": False,
         },
         "decision": {
             "next_boundary": "stage_b_midi_to_solo_quality_gap_decision",
@@ -85,6 +91,11 @@ class StageBMidiToSoloQualityGapDecisionTest(unittest.TestCase):
         self.assertTrue(summary["model_conditioned_input_path_alignment_required"])
         self.assertFalse(summary["human_review_required_now"])
         self.assertTrue(summary["technical_model_core_mvp_completed"])
+        self.assertTrue(summary["phrase_bank_cli_technical_path_completed"])
+        self.assertEqual(summary["cli_candidate_count"], 3)
+        self.assertEqual(summary["cli_rendered_audio_file_count"], 3)
+        self.assertEqual(summary["cli_input_context_bars"], 228)
+        self.assertFalse(summary["cli_preference_fill_allowed"])
         self.assertFalse(summary["musical_quality_mvp_completed"])
         self.assertFalse(summary["human_audio_preference_claimed"])
         self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])


### PR DESCRIPTION
## Summary
- quality gap decision에 phrase-bank CLI technical path 완료 evidence 반영
- 다음 자동 작업 boundary를 model-conditioned input path quality alignment로 기록
- human/audio preference와 musical quality claim 미완료 상태 유지

## Context
- Issue #668 MVP completion audit 결과: technical model-core MVP completed true
- phrase-bank CLI technical path: candidate 3개, rendered WAV 3개, input context bars 228
- preference fill allowed false, human/audio preference claimed false
- 현재 generation source: context_conditioned_fallback

## Scope
- quality gap decision validator CLI fields 추가
- generated decision doc, README, CURRENT_STATUS, CORE_PLAN, AGENTS handoff 갱신
- completion evidence와 quality gap target 분리

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_gap_decision
- bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-gap-decision
- bash scripts/agent_harness.sh quick
- git diff --check

## Risk
- 음악 품질 claim 없음
- model-conditioned input path alignment 미완료
- 다음 검증 대상: Stage B MIDI-to-solo model-conditioned input path quality alignment

Closes #670