### PR TITLE
Stage B MIDI-to-solo model-conditioned input path quality alignment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #670, Stage B MIDI-to-solo quality gap decision.
+- Latest functional issue completed: Issue #672, Stage B MIDI-to-solo model-conditioned input path quality alignment.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path quality alignment.
+- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path probe.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -59,7 +59,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - README evidence refreshed: `true`
 - MVP completion audit completed: `true`
 - quality gap decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment`
+- model-conditioned input path quality alignment decision completed: `true`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_probe`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -96,6 +97,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - selected-scale objective path와 phrase-bank CLI technical path를 current evidence로 통합 가능
 - README 첫 상태 영역에 current evidence와 claim boundary 반영 완료
 - technical model-core MVP 완료 범위 audit 가능
+- model-conditioned input path alignment decision 가능
 
 현재 README가 주장하지 않는 것.
 
@@ -136,9 +138,15 @@ Quality gap decision.
 
 Model-conditioned input path alignment.
 
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_probe`
 - selected probe target: `replace_fallback_with_model_conditioned_input_path_probe`
 - model-conditioned input path aligned: `false`
 - fallback replacement probe required: `true`
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3 / 3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
 - human review required now: `false`
 
 Model-conditioned input path probe.

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -2935,6 +2935,41 @@ Issue #670은 Issue #668 MVP completion audit 이후 남은 quality gap을 다�
 
 - `Stage B MIDI-to-solo model-conditioned input path quality alignment`
 
+## 9.27 Stage B MIDI-to-solo model-conditioned input path quality alignment
+
+Issue #672는 Issue #670 quality gap decision 이후 fallback replacement probe 조건을 다시 고정한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_probe`
+- selected probe target: `replace_fallback_with_model_conditioned_input_path_probe`
+- model-conditioned input path aligned: `false`
+- fallback replacement probe required: `true`
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3 / 3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- human review required now: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- quality gap source의 CLI technical path 완료 evidence를 alignment decision source로 유지.
+- 현재 input-to-WAV path는 아직 `context_conditioned_fallback` 경로.
+- 다음 작업은 model-conditioned input path probe.
+- 청음 리뷰와 musical quality claim은 아직 제외.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-quality-alignment`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo model-conditioned input path probe`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #670, Stage B MIDI-to-solo quality gap decision
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path quality alignment`
+- latest functional result: Issue #672, Stage B MIDI-to-solo model-conditioned input path quality alignment
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path probe`
 
 현재 범위가 아닌 것:
 
@@ -52,6 +52,49 @@
 - README current evidence와 claim boundary refresh 완료
 - technical model-core MVP completion audit 완료
 - quality gap target 결정 완료
+- model-conditioned input path alignment decision 완료
+
+## Stage B MIDI-to-Solo Model-Conditioned Input Path Quality Alignment Result
+
+Issue #672는 Issue #670 quality gap decision을 받아 fallback replacement probe 조건을 다시 고정한 작업이다.
+
+변경:
+
+- alignment decision source 검증에 phrase-bank CLI technical path evidence 추가
+- CLI candidate/rendered WAV/input context/preference guard 검증 추가
+- generated decision doc와 status docs 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_QUALITY_ALIGNMENT_2026-06-05.md`
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_probe`
+- selected probe target: `replace_fallback_with_model_conditioned_input_path_probe`
+- model-conditioned input path aligned: `false`
+- fallback replacement probe required: `true`
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3 / 3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- human review required now: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- quality gap source의 CLI technical path 완료 evidence 유지
+- 현재 input-to-WAV path는 아직 `context_conditioned_fallback` 경로
+- 다음 작업은 fallback replacement probe이며 청음 리뷰는 아직 필요하지 않음
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-quality-alignment`
+
+다음:
+
+- `Stage B MIDI-to-solo model-conditioned input path probe`
 
 ## Stage B MIDI-to-Solo Quality Gap Decision Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_QUALITY_ALIGNMENT_2026-06-05.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_QUALITY_ALIGNMENT_2026-06-05.md
@@ -13,6 +13,10 @@
 
 - source boundary: `stage_b_midi_to_solo_quality_gap_decision`
 - technical model-core MVP completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3` / `3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
 - fallback path active: `true`
 - model-conditioned input path alignment required: `true`
 
@@ -22,6 +26,7 @@
 - reuse_selected_scale_objective_repair_guardrails: `True`
 - preserve_ranked_midi_export_min_count: `3`
 - preserve_rendered_wav_min_count: `3`
+- preserve_phrase_bank_cli_technical_path: `True`
 - preserve_objective_strict_sample_support: `True`
 - preserve_no_quality_claim: `True`
 

--- a/scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment.py
+++ b/scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment.py
@@ -38,6 +38,13 @@ def _bool_token(value: Any) -> str:
     return "true" if bool(value) else "false"
 
 
+def _int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def validate_quality_gap_decision(report: dict[str, Any]) -> dict[str, Any]:
     if str(report.get("boundary") or "") != QUALITY_GAP_BOUNDARY:
         raise StageBMidiToSoloModelConditionedInputPathAlignmentError(
@@ -45,6 +52,7 @@ def validate_quality_gap_decision(report: dict[str, Any]) -> dict[str, Any]:
         )
     readiness = _dict(report.get("readiness"))
     quality_gap = _dict(report.get("quality_gap"))
+    summary = _dict(report.get("mvp_completion_summary"))
     selected = _dict(report.get("selected_target"))
     decision = _dict(report.get("decision"))
     if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
@@ -63,6 +71,10 @@ def validate_quality_gap_decision(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloModelConditionedInputPathAlignmentError(
             "technical model-core MVP completion required"
         )
+    if not bool(quality_gap.get("phrase_bank_cli_technical_path_completed", False)):
+        raise StageBMidiToSoloModelConditionedInputPathAlignmentError(
+            "phrase-bank CLI technical path completion required"
+        )
     if not bool(quality_gap.get("fallback_path_active", False)):
         raise StageBMidiToSoloModelConditionedInputPathAlignmentError(
             "fallback path should be active for this alignment boundary"
@@ -74,6 +86,20 @@ def validate_quality_gap_decision(report: dict[str, Any]) -> dict[str, Any]:
     if bool(quality_gap.get("musical_quality_mvp_completed", True)):
         raise StageBMidiToSoloModelConditionedInputPathAlignmentError(
             "musical quality MVP should remain incomplete"
+        )
+    if not bool(summary.get("phrase_bank_cli_technical_path_ready", False)):
+        raise StageBMidiToSoloModelConditionedInputPathAlignmentError(
+            "phrase-bank CLI technical path readiness required"
+        )
+    if _int(summary.get("cli_candidate_count")) < 3:
+        raise StageBMidiToSoloModelConditionedInputPathAlignmentError("CLI candidate count below 3")
+    if _int(summary.get("cli_rendered_audio_file_count")) < 3:
+        raise StageBMidiToSoloModelConditionedInputPathAlignmentError("CLI rendered WAV count below 3")
+    if _int(summary.get("cli_input_context_bars")) <= 0:
+        raise StageBMidiToSoloModelConditionedInputPathAlignmentError("CLI input context bars required")
+    if bool(summary.get("cli_preference_fill_allowed", True)):
+        raise StageBMidiToSoloModelConditionedInputPathAlignmentError(
+            "CLI preference fill should remain blocked"
         )
     blocked_claims = [
         "human_audio_preference_claimed",
@@ -90,6 +116,12 @@ def validate_quality_gap_decision(report: dict[str, Any]) -> dict[str, Any]:
     return {
         "source_boundary": QUALITY_GAP_BOUNDARY,
         "technical_model_core_mvp_completed": True,
+        "phrase_bank_cli_technical_path_completed": True,
+        "phrase_bank_cli_technical_path_ready": True,
+        "cli_candidate_count": _int(summary.get("cli_candidate_count")),
+        "cli_rendered_audio_file_count": _int(summary.get("cli_rendered_audio_file_count")),
+        "cli_input_context_bars": _int(summary.get("cli_input_context_bars")),
+        "cli_preference_fill_allowed": bool(summary.get("cli_preference_fill_allowed", True)),
         "fallback_path_active": True,
         "model_conditioned_input_path_alignment_required": True,
         "selected_quality_gap_target": str(readiness.get("selected_target") or ""),
@@ -117,6 +149,7 @@ def build_alignment_report(
             "reuse_selected_scale_objective_repair_guardrails": True,
             "preserve_ranked_midi_export_min_count": 3,
             "preserve_rendered_wav_min_count": 3,
+            "preserve_phrase_bank_cli_technical_path": True,
             "preserve_objective_strict_sample_support": True,
             "preserve_no_quality_claim": True,
         },
@@ -213,6 +246,17 @@ def validate_alignment_report(
         "fallback_replacement_probe_required": bool(
             readiness.get("fallback_replacement_probe_required", False)
         ),
+        "phrase_bank_cli_technical_path_completed": bool(
+            _dict(report.get("alignment_source")).get("phrase_bank_cli_technical_path_completed", False)
+        ),
+        "cli_candidate_count": _int(_dict(report.get("alignment_source")).get("cli_candidate_count")),
+        "cli_rendered_audio_file_count": _int(
+            _dict(report.get("alignment_source")).get("cli_rendered_audio_file_count")
+        ),
+        "cli_input_context_bars": _int(_dict(report.get("alignment_source")).get("cli_input_context_bars")),
+        "cli_preference_fill_allowed": bool(
+            _dict(report.get("alignment_source")).get("cli_preference_fill_allowed", True)
+        ),
         "human_review_required_now": bool(readiness.get("human_review_required_now", True)),
         "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
         "midi_to_solo_musical_quality_claimed": bool(
@@ -247,6 +291,10 @@ def markdown_report(report: dict[str, Any]) -> str:
         "",
         f"- source boundary: `{source['source_boundary']}`",
         f"- technical model-core MVP completed: `{_bool_token(source['technical_model_core_mvp_completed'])}`",
+        f"- phrase-bank CLI technical path completed: `{_bool_token(source['phrase_bank_cli_technical_path_completed'])}`",
+        f"- CLI candidate / rendered WAV: `{source['cli_candidate_count']}` / `{source['cli_rendered_audio_file_count']}`",
+        f"- CLI input context bars: `{source['cli_input_context_bars']}`",
+        f"- CLI preference fill allowed: `{_bool_token(source['cli_preference_fill_allowed'])}`",
         f"- fallback path active: `{_bool_token(source['fallback_path_active'])}`",
         f"- model-conditioned input path alignment required: `{_bool_token(source['model_conditioned_input_path_alignment_required'])}`",
         "",

--- a/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment.py
+++ b/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment.py
@@ -28,12 +28,21 @@ def quality_gap_decision(
         "boundary": QUALITY_GAP_BOUNDARY,
         "quality_gap": {
             "technical_model_core_mvp_completed": True,
+            "phrase_bank_cli_technical_path_completed": True,
             "musical_quality_mvp_completed": False,
             "human_audio_preference_completed": False,
             "product_mvp_completed": False,
             "fallback_path_active": fallback_active,
             "model_conditioned_input_path_alignment_required": fallback_active,
             "human_review_required_now": False,
+        },
+        "mvp_completion_summary": {
+            "phrase_bank_cli_technical_path_completed": True,
+            "phrase_bank_cli_technical_path_ready": True,
+            "cli_candidate_count": 3,
+            "cli_rendered_audio_file_count": 3,
+            "cli_input_context_bars": 228,
+            "cli_preference_fill_allowed": False,
         },
         "selected_target": {
             "selected_target": selected_target,
@@ -80,6 +89,11 @@ class StageBMidiToSoloModelConditionedInputPathAlignmentTest(unittest.TestCase):
         self.assertFalse(summary["model_conditioned_input_path_aligned"])
         self.assertTrue(summary["fallback_replacement_probe_required"])
         self.assertTrue(summary["fallback_replacement_probe_required_from_decision"])
+        self.assertTrue(summary["phrase_bank_cli_technical_path_completed"])
+        self.assertEqual(summary["cli_candidate_count"], 3)
+        self.assertEqual(summary["cli_rendered_audio_file_count"], 3)
+        self.assertEqual(summary["cli_input_context_bars"], 228)
+        self.assertFalse(summary["cli_preference_fill_allowed"])
         self.assertFalse(summary["human_review_required_now"])
         self.assertFalse(summary["human_audio_preference_claimed"])
         self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])


### PR DESCRIPTION
## Summary
- model-conditioned input path alignment decision에 phrase-bank CLI technical path evidence 반영
- fallback replacement probe required 상태 유지
- no-quality-claim 경계와 다음 probe boundary 기록

## Context
- Issue #670 quality gap decision completed true
- technical model-core MVP completed true
- phrase-bank CLI technical path completed true
- CLI candidate/rendered WAV: 3 / 3
- CLI input context bars: 228
- 현재 input-to-WAV generation source: context_conditioned_fallback

## Scope
- alignment source validation에 CLI evidence 추가
- generated decision doc, README, CURRENT_STATUS, CORE_PLAN, handoff 갱신
- 다음 boundary를 model-conditioned input path probe로 기록

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment
- bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-quality-alignment
- bash scripts/agent_harness.sh quick
- git diff --check

## Risk
- model-conditioned input path quality claim 없음
- human/audio preference claim 없음
- 다음 검증 대상: Stage B MIDI-to-solo model-conditioned input path probe

Closes #672