### PR TITLE
Stage B MIDI-to-solo model-conditioned input path probe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #672, Stage B MIDI-to-solo model-conditioned input path quality alignment.
+- Latest functional issue completed: Issue #674, Stage B MIDI-to-solo model-conditioned input path probe.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path probe.
+- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path candidate export.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment`
+- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_probe`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -14,11 +14,13 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned input path aligned: `false`
 - model-conditioned candidate source available: `true`
 - model-conditioned audio technical path available: `true`
-- model-conditioned ranked input-path export contract matched: `true`
-- fallback replacement candidate export ready: `true`
+- model-conditioned input path probe completed: `true`
+- model-conditioned ranked input-path export contract matched: `false`
+- fallback replacement candidate export ready: `false`
 - model-conditioned ranked audio render completed: `true`
 - fallback replacement technical path ready: `true`
-- fallback replacement ready: `true`
+- fallback replacement ready: `false`
+- candidate export required: `true`
 - listening review package required: `true`
 - listening review package ready: `true`
 - phrase-bank retrieval baseline completed: `true`
@@ -60,7 +62,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - MVP completion audit completed: `true`
 - quality gap decision completed: `true`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_probe`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_candidate_export`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -98,6 +100,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - README 첫 상태 영역에 current evidence와 claim boundary 반영 완료
 - technical model-core MVP 완료 범위 audit 가능
 - model-conditioned input path alignment decision 가능
+- model-conditioned input path probe 가능
 
 현재 README가 주장하지 않는 것.
 
@@ -151,6 +154,8 @@ Model-conditioned input path alignment.
 
 Model-conditioned input path probe.
 
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_probe`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_candidate_export`
 - model-conditioned source: `model_checkpoint_direct_constrained`
 - model-conditioned candidate source available: `true`
 - model-conditioned audio technical path available: `true`
@@ -158,6 +163,10 @@ Model-conditioned input path probe.
 - ranked input-path export contract matched: `false`
 - fallback replacement ready: `false`
 - candidate export required: `true`
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3 / 3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
 
 Model-conditioned input path candidate export.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -2970,6 +2970,44 @@ Issue #672는 Issue #670 quality gap decision 이후 fallback replacement probe 
 
 - `Stage B MIDI-to-solo model-conditioned input path probe`
 
+## 9.28 Stage B MIDI-to-solo model-conditioned input path probe
+
+Issue #674는 Issue #672 alignment decision 이후 fallback path와 model-conditioned path를 같은 input context 기준으로 비교한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_probe`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_candidate_export`
+- model-conditioned candidate source available: `true`
+- model-conditioned audio technical path available: `true`
+- same input context as fallback: `true`
+- ranked input-path export contract matched: `false`
+- fallback replacement ready: `false`
+- candidate export required: `true`
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3 / 3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- human review required now: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- model-conditioned strict MIDI/WAV technical evidence 확인.
+- fallback path와 같은 input context 사용 확인.
+- ranked input-path export contract 미충족.
+- 다음 작업은 model-conditioned candidate export.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_probe`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-probe`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo model-conditioned input path candidate export`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #672, Stage B MIDI-to-solo model-conditioned input path quality alignment
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path probe`
+- latest functional result: Issue #674, Stage B MIDI-to-solo model-conditioned input path probe
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path candidate export`
 
 현재 범위가 아닌 것:
 
@@ -53,6 +53,53 @@
 - technical model-core MVP completion audit 완료
 - quality gap target 결정 완료
 - model-conditioned input path alignment decision 완료
+- model-conditioned input path probe 완료
+
+## Stage B MIDI-to-Solo Model-Conditioned Input Path Probe Result
+
+Issue #674는 Issue #672 alignment decision을 받아 fallback path와 model-conditioned path를 같은 input context 기준으로 비교한 작업이다.
+
+변경:
+
+- probe alignment source 검증에 phrase-bank CLI technical path evidence 추가
+- CLI candidate/rendered WAV/input context/preference guard 검증 추가
+- generated probe doc와 status docs 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_PROBE_2026-06-05.md`
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_probe`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_candidate_export`
+- model-conditioned candidate source available: `true`
+- model-conditioned audio technical path available: `true`
+- same input context as fallback: `true`
+- ranked input-path export contract matched: `false`
+- fallback replacement ready: `false`
+- candidate export required: `true`
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3 / 3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- human review required now: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- model-conditioned strict MIDI/WAV technical evidence 확인
+- fallback path와 같은 input context 사용 확인
+- ranked input-path export contract 미충족
+- 다음 작업은 model-conditioned candidate export
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_probe`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-probe`
+
+다음:
+
+- `Stage B MIDI-to-solo model-conditioned input path candidate export`
 
 ## Stage B MIDI-to-Solo Model-Conditioned Input Path Quality Alignment Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_PROBE_2026-06-05.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_PROBE_2026-06-05.md
@@ -10,6 +10,13 @@
 - fallback replacement ready: `false`
 - candidate export required: `true`
 
+## Alignment Source
+
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3` / `3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+
 ## Fallback Input Path
 
 - generation source: `context_conditioned_fallback`

--- a/scripts/probe_stage_b_midi_to_solo_model_conditioned_input_path.py
+++ b/scripts/probe_stage_b_midi_to_solo_model_conditioned_input_path.py
@@ -99,6 +99,7 @@ def validate_alignment_report(report: dict[str, Any]) -> dict[str, Any]:
     readiness = _dict(report.get("readiness"))
     decision = _dict(report.get("decision"))
     alignment = _dict(report.get("alignment_decision"))
+    source = _dict(report.get("alignment_source"))
     if str(report.get("boundary") or readiness.get("boundary") or "") != ALIGNMENT_BOUNDARY:
         raise StageBMidiToSoloModelConditionedInputPathProbeError(
             "model-conditioned input path alignment boundary required"
@@ -121,6 +122,20 @@ def validate_alignment_report(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloModelConditionedInputPathProbeError(
             "critical user input should not be required"
         )
+    if not bool(source.get("phrase_bank_cli_technical_path_completed", False)):
+        raise StageBMidiToSoloModelConditionedInputPathProbeError(
+            "phrase-bank CLI technical path completion required"
+        )
+    if _int(source.get("cli_candidate_count")) < 3:
+        raise StageBMidiToSoloModelConditionedInputPathProbeError("CLI candidate count below 3")
+    if _int(source.get("cli_rendered_audio_file_count")) < 3:
+        raise StageBMidiToSoloModelConditionedInputPathProbeError("CLI rendered WAV count below 3")
+    if _int(source.get("cli_input_context_bars")) <= 0:
+        raise StageBMidiToSoloModelConditionedInputPathProbeError("CLI input context bars required")
+    if bool(source.get("cli_preference_fill_allowed", True)):
+        raise StageBMidiToSoloModelConditionedInputPathProbeError(
+            "CLI preference fill should remain blocked"
+        )
     _require_no_quality_claim(readiness, label="alignment readiness")
     return {
         "boundary": ALIGNMENT_BOUNDARY,
@@ -129,6 +144,11 @@ def validate_alignment_report(report: dict[str, Any]) -> dict[str, Any]:
         "alignment_decision_probe_required": bool(
             alignment.get("fallback_replacement_probe_required", False)
         ),
+        "phrase_bank_cli_technical_path_completed": True,
+        "cli_candidate_count": _int(source.get("cli_candidate_count")),
+        "cli_rendered_audio_file_count": _int(source.get("cli_rendered_audio_file_count")),
+        "cli_input_context_bars": _int(source.get("cli_input_context_bars")),
+        "cli_preference_fill_allowed": bool(source.get("cli_preference_fill_allowed", True)),
         "human_review_required_now": bool(readiness.get("human_review_required_now", False)),
     }
 
@@ -517,6 +537,17 @@ def validate_probe_report(
         ),
         "fallback_replacement_ready": bool(readiness.get("fallback_replacement_ready", True)),
         "candidate_export_required": bool(readiness.get("candidate_export_required", False)),
+        "phrase_bank_cli_technical_path_completed": bool(
+            _dict(report.get("alignment_source")).get("phrase_bank_cli_technical_path_completed", False)
+        ),
+        "cli_candidate_count": _int(_dict(report.get("alignment_source")).get("cli_candidate_count")),
+        "cli_rendered_audio_file_count": _int(
+            _dict(report.get("alignment_source")).get("cli_rendered_audio_file_count")
+        ),
+        "cli_input_context_bars": _int(_dict(report.get("alignment_source")).get("cli_input_context_bars")),
+        "cli_preference_fill_allowed": bool(
+            _dict(report.get("alignment_source")).get("cli_preference_fill_allowed", True)
+        ),
         "human_review_required_now": bool(readiness.get("human_review_required_now", True)),
         "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
         "midi_to_solo_musical_quality_claimed": bool(
@@ -532,6 +563,7 @@ def validate_probe_report(
 
 
 def markdown_report(report: dict[str, Any]) -> str:
+    alignment = report["alignment_source"]
     fallback = report["fallback_input_path"]
     model_probe = report["model_conditioned_probe"]
     readiness = report["readiness"]
@@ -548,6 +580,13 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- ranked input-path export contract matched: `{_bool_token(readiness['model_conditioned_ranked_input_path_contract_matched'])}`",
         f"- fallback replacement ready: `{_bool_token(readiness['fallback_replacement_ready'])}`",
         f"- candidate export required: `{_bool_token(readiness['candidate_export_required'])}`",
+        "",
+        "## Alignment Source",
+        "",
+        f"- phrase-bank CLI technical path completed: `{_bool_token(alignment['phrase_bank_cli_technical_path_completed'])}`",
+        f"- CLI candidate / rendered WAV: `{alignment['cli_candidate_count']}` / `{alignment['cli_rendered_audio_file_count']}`",
+        f"- CLI input context bars: `{alignment['cli_input_context_bars']}`",
+        f"- CLI preference fill allowed: `{_bool_token(alignment['cli_preference_fill_allowed'])}`",
         "",
         "## Fallback Input Path",
         "",

--- a/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_probe.py
+++ b/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_probe.py
@@ -33,6 +33,13 @@ def alignment_report() -> dict:
         "alignment_decision": {
             "fallback_replacement_probe_required": True,
         },
+        "alignment_source": {
+            "phrase_bank_cli_technical_path_completed": True,
+            "cli_candidate_count": 3,
+            "cli_rendered_audio_file_count": 3,
+            "cli_input_context_bars": 228,
+            "cli_preference_fill_allowed": False,
+        },
         "readiness": {
             "boundary": ALIGNMENT_BOUNDARY,
             "model_conditioned_input_path_quality_alignment_decision_completed": True,
@@ -213,6 +220,11 @@ class StageBMidiToSoloModelConditionedInputPathProbeTest(unittest.TestCase):
         self.assertTrue(summary["candidate_export_required"])
         self.assertTrue(summary["missing_ranked_export_contract"])
         self.assertEqual(summary["selected_next_boundary"], NEXT_BOUNDARY)
+        self.assertTrue(summary["phrase_bank_cli_technical_path_completed"])
+        self.assertEqual(summary["cli_candidate_count"], 3)
+        self.assertEqual(summary["cli_rendered_audio_file_count"], 3)
+        self.assertEqual(summary["cli_input_context_bars"], 228)
+        self.assertFalse(summary["cli_preference_fill_allowed"])
         self.assertFalse(summary["human_audio_preference_claimed"])
         self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
 


### PR DESCRIPTION
## Summary
- model-conditioned input path probe에 alignment source CLI evidence 연결
- fallback path와 model-conditioned path 비교 결과 재검증
- candidate export required 상태 유지

## Context
- Issue #672 alignment decision completed true
- phrase-bank CLI technical path completed true
- CLI candidate/rendered WAV: 3 / 3
- model-conditioned candidate/audio technical evidence true / true
- ranked input-path export contract matched false

## Scope
- probe validator alignment source CLI fields 검증 추가
- generated probe doc, README, CURRENT_STATUS, CORE_PLAN, handoff 갱신
- 다음 boundary를 model-conditioned input path candidate export로 기록

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_probe
- bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-probe
- bash scripts/agent_harness.sh quick
- git diff --check

## Risk
- fallback replacement ready claim 없음
- musical quality claim 없음
- 다음 검증 대상: Stage B MIDI-to-solo model-conditioned input path candidate export

Closes #674