### PR TITLE
Stage B MIDI-to-solo model-conditioned input path candidate export

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #674, Stage B MIDI-to-solo model-conditioned input path probe.
+- Latest functional issue completed: Issue #676, Stage B MIDI-to-solo model-conditioned input path candidate export.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path candidate export.
+- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path audio render package.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_probe`
+- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_candidate_export`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -15,14 +15,15 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned candidate source available: `true`
 - model-conditioned audio technical path available: `true`
 - model-conditioned input path probe completed: `true`
-- model-conditioned ranked input-path export contract matched: `false`
-- fallback replacement candidate export ready: `false`
-- model-conditioned ranked audio render completed: `true`
-- fallback replacement technical path ready: `true`
+- model-conditioned ranked input-path export contract matched: `true`
+- fallback replacement candidate export ready: `true`
+- model-conditioned ranked audio render completed: `false`
+- fallback replacement technical path ready: `false`
 - fallback replacement ready: `false`
-- candidate export required: `true`
-- listening review package required: `true`
-- listening review package ready: `true`
+- model-conditioned input path candidate export completed: `true`
+- candidate audio render required: `true`
+- listening review package required: `false`
+- listening review package ready: `false`
 - phrase-bank retrieval baseline completed: `true`
 - phrase-bank source records / motifs: `56 / 803`
 - phrase-bank exported / qualified MIDI candidates: `3 / 3`
@@ -62,7 +63,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - MVP completion audit completed: `true`
 - quality gap decision completed: `true`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_candidate_export`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -101,6 +102,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - technical model-core MVP 완료 범위 audit 가능
 - model-conditioned input path alignment decision 가능
 - model-conditioned input path probe 가능
+- model-conditioned ranked input-path candidate export 가능
 
 현재 README가 주장하지 않는 것.
 
@@ -170,6 +172,8 @@ Model-conditioned input path probe.
 
 Model-conditioned input path candidate export.
 
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_candidate_export`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package`
 - generation source: `model_checkpoint_direct_constrained`
 - ranked MIDI candidates exported: `true`
 - ranked input-path export contract matched: `true`
@@ -178,6 +182,10 @@ Model-conditioned input path candidate export.
 - fallback replacement candidate export ready: `true`
 - fallback replacement ready: `false`
 - candidate audio render required: `true`
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3 / 3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
 
 Model-conditioned input path audio render package.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -3008,6 +3008,44 @@ Issue #674는 Issue #672 alignment decision 이후 fallback path와 model-condit
 
 - `Stage B MIDI-to-solo model-conditioned input path candidate export`
 
+## 9.29 Stage B MIDI-to-solo model-conditioned input path candidate export
+
+Issue #676은 Issue #674 probe 결과의 ranked export contract gap을 model-conditioned 후보 export로 닫은 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_candidate_export`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package`
+- ranked MIDI candidates exported: `true`
+- ranked input-path export contract matched: `true`
+- fallback replacement candidate export ready: `true`
+- fallback replacement ready: `false`
+- candidate audio render required: `true`
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3 / 3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- exported candidate count: `3`
+- best note / unique pitch / max simultaneous: `24 / 20 / 1`
+- human review required now: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- model-conditioned strict MIDI 후보가 ranked input-path export contract 충족.
+- audio render package는 아직 미완료.
+- fallback replacement ready는 ranked WAV render 후 판단.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_candidate_export`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-candidate-export`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo model-conditioned input path audio render package`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #674, Stage B MIDI-to-solo model-conditioned input path probe
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path candidate export`
+- latest functional result: Issue #676, Stage B MIDI-to-solo model-conditioned input path candidate export
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path audio render package`
 
 현재 범위가 아닌 것:
 
@@ -54,6 +54,53 @@
 - quality gap target 결정 완료
 - model-conditioned input path alignment decision 완료
 - model-conditioned input path probe 완료
+- model-conditioned input path candidate export 완료
+
+## Stage B MIDI-to-Solo Model-Conditioned Input Path Candidate Export Result
+
+Issue #676은 Issue #674 probe 결과의 ranked export contract gap을 model-conditioned 후보 export로 닫은 작업이다.
+
+변경:
+
+- candidate export probe source 검증에 phrase-bank CLI technical path evidence 추가
+- model-conditioned ranked MIDI 후보 3개 export
+- generated candidate export doc와 status docs 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_CANDIDATE_EXPORT_2026-06-05.md`
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_candidate_export`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package`
+- ranked MIDI candidates exported: `true`
+- ranked input-path export contract matched: `true`
+- fallback replacement candidate export ready: `true`
+- fallback replacement ready: `false`
+- candidate audio render required: `true`
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3 / 3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- exported candidate count: `3`
+- best note / unique pitch / max simultaneous: `24 / 20 / 1`
+- human review required now: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- model-conditioned strict MIDI 후보가 ranked input-path export contract 충족
+- audio render package는 아직 미완료
+- fallback replacement ready는 ranked WAV render 후 판단
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_candidate_export`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-candidate-export`
+
+다음:
+
+- `Stage B MIDI-to-solo model-conditioned input path audio render package`
 
 ## Stage B MIDI-to-Solo Model-Conditioned Input Path Probe Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_CANDIDATE_EXPORT_2026-06-05.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_CANDIDATE_EXPORT_2026-06-05.md
@@ -11,6 +11,13 @@
 - fallback replacement ready: `false`
 - candidate audio render required: `true`
 
+## Probe Source
+
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3` / `3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+
 ## Input Context
 
 - chord progression: `Cmaj7, F7, G7, Cmaj7, Cmaj7, Cmaj7, Cmaj7, Cmaj7`

--- a/scripts/export_stage_b_midi_to_solo_model_conditioned_input_path_candidates.py
+++ b/scripts/export_stage_b_midi_to_solo_model_conditioned_input_path_candidates.py
@@ -85,6 +85,7 @@ def validate_probe_report(report: dict[str, Any]) -> dict[str, Any]:
     readiness = _dict(report.get("readiness"))
     decision = _dict(report.get("decision"))
     replacement = _dict(report.get("replacement_decision"))
+    source = _dict(report.get("alignment_source"))
     if str(report.get("boundary") or readiness.get("boundary") or "") != PROBE_BOUNDARY:
         raise StageBMidiToSoloModelConditionedInputPathCandidateExportError(
             "model-conditioned input path probe boundary required"
@@ -121,6 +122,20 @@ def validate_probe_report(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloModelConditionedInputPathCandidateExportError(
             "critical user input should not be required"
         )
+    if not bool(source.get("phrase_bank_cli_technical_path_completed", False)):
+        raise StageBMidiToSoloModelConditionedInputPathCandidateExportError(
+            "phrase-bank CLI technical path completion required"
+        )
+    if _int(source.get("cli_candidate_count")) < 3:
+        raise StageBMidiToSoloModelConditionedInputPathCandidateExportError("CLI candidate count below 3")
+    if _int(source.get("cli_rendered_audio_file_count")) < 3:
+        raise StageBMidiToSoloModelConditionedInputPathCandidateExportError("CLI rendered WAV count below 3")
+    if _int(source.get("cli_input_context_bars")) <= 0:
+        raise StageBMidiToSoloModelConditionedInputPathCandidateExportError("CLI input context bars required")
+    if bool(source.get("cli_preference_fill_allowed", True)):
+        raise StageBMidiToSoloModelConditionedInputPathCandidateExportError(
+            "CLI preference fill should remain blocked"
+        )
     _require_no_quality_claim(readiness, label="probe readiness")
     return {
         "boundary": PROBE_BOUNDARY,
@@ -128,6 +143,11 @@ def validate_probe_report(report: dict[str, Any]) -> dict[str, Any]:
         "model_conditioned_audio_technical_path_available": True,
         "same_input_context_as_fallback": True,
         "candidate_export_required": True,
+        "phrase_bank_cli_technical_path_completed": True,
+        "cli_candidate_count": _int(source.get("cli_candidate_count")),
+        "cli_rendered_audio_file_count": _int(source.get("cli_rendered_audio_file_count")),
+        "cli_input_context_bars": _int(source.get("cli_input_context_bars")),
+        "cli_preference_fill_allowed": bool(source.get("cli_preference_fill_allowed", True)),
     }
 
 
@@ -466,6 +486,17 @@ def validate_candidate_export_report(
         ),
         "fallback_replacement_ready": bool(readiness.get("fallback_replacement_ready", True)),
         "candidate_audio_render_required": bool(readiness.get("candidate_audio_render_required", False)),
+        "phrase_bank_cli_technical_path_completed": bool(
+            _dict(report.get("probe_source")).get("phrase_bank_cli_technical_path_completed", False)
+        ),
+        "cli_candidate_count": _int(_dict(report.get("probe_source")).get("cli_candidate_count")),
+        "cli_rendered_audio_file_count": _int(
+            _dict(report.get("probe_source")).get("cli_rendered_audio_file_count")
+        ),
+        "cli_input_context_bars": _int(_dict(report.get("probe_source")).get("cli_input_context_bars")),
+        "cli_preference_fill_allowed": bool(
+            _dict(report.get("probe_source")).get("cli_preference_fill_allowed", True)
+        ),
         "candidate_count": _int(summary.get("candidate_count")),
         "exported_candidate_count": _int(summary.get("exported_candidate_count")),
         "best_note_count": _int(summary.get("best_note_count")),
@@ -482,6 +513,7 @@ def validate_candidate_export_report(
 
 
 def markdown_report(report: dict[str, Any]) -> str:
+    probe = report["probe_source"]
     summary = report["summary"]
     readiness = report["readiness"]
     decision = report["decision"]
@@ -500,6 +532,13 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- fallback replacement candidate export ready: `{_bool_token(readiness['fallback_replacement_candidate_export_ready'])}`",
         f"- fallback replacement ready: `{_bool_token(readiness['fallback_replacement_ready'])}`",
         f"- candidate audio render required: `{_bool_token(readiness['candidate_audio_render_required'])}`",
+        "",
+        "## Probe Source",
+        "",
+        f"- phrase-bank CLI technical path completed: `{_bool_token(probe['phrase_bank_cli_technical_path_completed'])}`",
+        f"- CLI candidate / rendered WAV: `{probe['cli_candidate_count']}` / `{probe['cli_rendered_audio_file_count']}`",
+        f"- CLI input context bars: `{probe['cli_input_context_bars']}`",
+        f"- CLI preference fill allowed: `{_bool_token(probe['cli_preference_fill_allowed'])}`",
         "",
         "## Input Context",
         "",

--- a/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_candidate_export.py
+++ b/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_candidate_export.py
@@ -31,6 +31,13 @@ def probe_report() -> dict:
         "replacement_decision": {
             "selected_next_boundary": PROBE_NEXT_BOUNDARY,
         },
+        "alignment_source": {
+            "phrase_bank_cli_technical_path_completed": True,
+            "cli_candidate_count": 3,
+            "cli_rendered_audio_file_count": 3,
+            "cli_input_context_bars": 228,
+            "cli_preference_fill_allowed": False,
+        },
         "readiness": {
             "model_conditioned_input_path_probe_completed": True,
             "model_conditioned_candidate_source_available": True,
@@ -161,6 +168,11 @@ class StageBMidiToSoloModelConditionedInputPathCandidateExportTest(unittest.Test
         self.assertTrue(summary["fallback_replacement_candidate_export_ready"])
         self.assertFalse(summary["fallback_replacement_ready"])
         self.assertTrue(summary["candidate_audio_render_required"])
+        self.assertTrue(summary["phrase_bank_cli_technical_path_completed"])
+        self.assertEqual(summary["cli_candidate_count"], 3)
+        self.assertEqual(summary["cli_rendered_audio_file_count"], 3)
+        self.assertEqual(summary["cli_input_context_bars"], 228)
+        self.assertFalse(summary["cli_preference_fill_allowed"])
         self.assertEqual(summary["exported_candidate_count"], 3)
         self.assertEqual(summary["best_max_simultaneous_notes"], 1)
         self.assertFalse(summary["human_audio_preference_claimed"])


### PR DESCRIPTION
## Summary
- model-conditioned input path candidate export에 probe source CLI evidence 연결
- ranked MIDI export contract matched 상태 기록
- 다음 audio render package boundary로 진행

## Context
- Issue #674 probe 결과: candidate export required true
- model-conditioned candidate/audio technical evidence true / true
- ranked input-path export contract matched false
- phrase-bank CLI technical path completed true

## Scope
- candidate export validator probe source CLI fields 검증 추가
- model-conditioned ranked MIDI 후보 3개 export evidence 갱신
- generated candidate export doc, README, CURRENT_STATUS, CORE_PLAN, handoff 갱신

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_candidate_export
- bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-candidate-export
- bash scripts/agent_harness.sh quick
- git diff --check

## Risk
- ranked WAV render 미완료
- fallback replacement ready claim 없음
- musical quality claim 없음

Closes #676