### PR TITLE
Stage B MIDI-to-solo model-conditioned input path audio render package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #676, Stage B MIDI-to-solo model-conditioned input path candidate export.
+- Latest functional issue completed: Issue #678, Stage B MIDI-to-solo model-conditioned input path audio render package.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path audio render package.
+- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path replacement consolidation.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_candidate_export`
+- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -17,11 +17,11 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned input path probe completed: `true`
 - model-conditioned ranked input-path export contract matched: `true`
 - fallback replacement candidate export ready: `true`
-- model-conditioned ranked audio render completed: `false`
-- fallback replacement technical path ready: `false`
-- fallback replacement ready: `false`
+- model-conditioned ranked audio render completed: `true`
+- fallback replacement technical path ready: `true`
+- fallback replacement ready: `true`
 - model-conditioned input path candidate export completed: `true`
-- candidate audio render required: `true`
+- model-conditioned input path audio render completed: `true`
 - listening review package required: `false`
 - listening review package ready: `false`
 - phrase-bank retrieval baseline completed: `true`
@@ -63,7 +63,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - MVP completion audit completed: `true`
 - quality gap decision completed: `true`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_replacement_consolidation`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -103,6 +103,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned input path alignment decision 가능
 - model-conditioned input path probe 가능
 - model-conditioned ranked input-path candidate export 가능
+- model-conditioned ranked MIDI WAV render 가능
 
 현재 README가 주장하지 않는 것.
 
@@ -189,12 +190,18 @@ Model-conditioned input path candidate export.
 
 Model-conditioned input path audio render package.
 
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_replacement_consolidation`
 - rendered audio file count: `3`
 - technical WAV validation: `true`
 - model-conditioned ranked audio render completed: `true`
 - fallback replacement technical path ready: `true`
 - fallback replacement ready: `true`
 - WAV duration range: `19.585s - 22.390s`
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3 / 3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
 - audio rendered quality claimed: `false`
 - human/audio preference claimed: `false`
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -3046,6 +3046,44 @@ Issue #676은 Issue #674 probe 결과의 ranked export contract gap을 model-con
 
 - `Stage B MIDI-to-solo model-conditioned input path audio render package`
 
+## 9.30 Stage B MIDI-to-solo model-conditioned input path audio render package
+
+Issue #678은 Issue #676 candidate export 결과의 ranked MIDI 후보를 WAV로 렌더한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_replacement_consolidation`
+- render attempted: `true`
+- rendered audio file count: `3`
+- technical WAV validation: `true`
+- model-conditioned ranked audio render completed: `true`
+- fallback replacement candidate export ready: `true`
+- fallback replacement technical path ready: `true`
+- fallback replacement ready: `true`
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3 / 3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- ranked MIDI -> WAV technical path 확인.
+- fallback replacement technical path ready.
+- 청음 품질과 사용자 선호 claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_audio_render`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-audio-render-package`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo model-conditioned input path replacement consolidation`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #676, Stage B MIDI-to-solo model-conditioned input path candidate export
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path audio render package`
+- latest functional result: Issue #678, Stage B MIDI-to-solo model-conditioned input path audio render package
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path replacement consolidation`
 
 현재 범위가 아닌 것:
 
@@ -55,6 +55,53 @@
 - model-conditioned input path alignment decision 완료
 - model-conditioned input path probe 완료
 - model-conditioned input path candidate export 완료
+- model-conditioned input path audio render package 완료
+
+## Stage B MIDI-to-Solo Model-Conditioned Input Path Audio Render Package Result
+
+Issue #678은 Issue #676 candidate export 결과의 ranked MIDI 후보를 WAV로 렌더한 작업이다.
+
+변경:
+
+- audio render source 검증에 candidate export CLI evidence 추가
+- model-conditioned ranked MIDI 후보 3개 WAV render
+- generated audio render doc와 status docs 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_AUDIO_RENDER_PACKAGE_2026-06-05.md`
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_replacement_consolidation`
+- render attempted: `true`
+- rendered audio file count: `3`
+- technical WAV validation: `true`
+- model-conditioned ranked audio render completed: `true`
+- fallback replacement candidate export ready: `true`
+- fallback replacement technical path ready: `true`
+- fallback replacement ready: `true`
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3 / 3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- ranked MIDI -> WAV technical path 확인
+- fallback replacement technical path ready
+- 청음 품질과 사용자 선호 claim 제외 유지
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_audio_render`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-audio-render-package`
+
+다음:
+
+- `Stage B MIDI-to-solo model-conditioned input path replacement consolidation`
 
 ## Stage B MIDI-to-Solo Model-Conditioned Input Path Candidate Export Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_AUDIO_RENDER_PACKAGE_2026-06-05.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_AUDIO_RENDER_PACKAGE_2026-06-05.md
@@ -12,6 +12,13 @@
 - audio rendered quality claimed: `false`
 - human/audio preference claimed: `false`
 
+## Candidate Export Source
+
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3` / `3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+
 ## Rendered Files
 
 - rank `1` sample `1` seed `497`: `outputs/stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package/harness_stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package/audio/rank_01_sample_01.wav`, duration `22.390`, sample rate `44100`, size `3949612`, sha256 `fd78ec4d6fdb`

--- a/scripts/render_stage_b_midi_to_solo_model_conditioned_input_path_audio.py
+++ b/scripts/render_stage_b_midi_to_solo_model_conditioned_input_path_audio.py
@@ -149,6 +149,31 @@ def validate_source_report(report: dict[str, Any], *, expected_count: int) -> li
     return compacted
 
 
+def validate_source_cli_evidence(report: dict[str, Any]) -> dict[str, Any]:
+    source = _dict(report.get("probe_source"))
+    if not bool(source.get("phrase_bank_cli_technical_path_completed", False)):
+        raise StageBMidiToSoloModelConditionedInputPathAudioRenderError(
+            "phrase-bank CLI technical path completion required"
+        )
+    if _int(source.get("cli_candidate_count")) < 3:
+        raise StageBMidiToSoloModelConditionedInputPathAudioRenderError("CLI candidate count below 3")
+    if _int(source.get("cli_rendered_audio_file_count")) < 3:
+        raise StageBMidiToSoloModelConditionedInputPathAudioRenderError("CLI rendered WAV count below 3")
+    if _int(source.get("cli_input_context_bars")) <= 0:
+        raise StageBMidiToSoloModelConditionedInputPathAudioRenderError("CLI input context bars required")
+    if bool(source.get("cli_preference_fill_allowed", True)):
+        raise StageBMidiToSoloModelConditionedInputPathAudioRenderError(
+            "CLI preference fill should remain blocked"
+        )
+    return {
+        "phrase_bank_cli_technical_path_completed": True,
+        "cli_candidate_count": _int(source.get("cli_candidate_count")),
+        "cli_rendered_audio_file_count": _int(source.get("cli_rendered_audio_file_count")),
+        "cli_input_context_bars": _int(source.get("cli_input_context_bars")),
+        "cli_preference_fill_allowed": bool(source.get("cli_preference_fill_allowed", True)),
+    }
+
+
 def build_render_plan(
     candidates: list[dict[str, Any]],
     *,
@@ -234,6 +259,7 @@ def build_audio_render_report(
     runner: CommandRunner = default_runner,
 ) -> dict[str, Any]:
     candidates = validate_source_report(source_report, expected_count=expected_file_count)
+    source_cli_evidence = validate_source_cli_evidence(source_report)
     resolved_renderer = renderer_path or shutil.which("fluidsynth") or ""
     resolved_soundfont = resolve_soundfont(soundfont_path)
     plan = build_render_plan(
@@ -250,6 +276,7 @@ def build_audio_render_report(
         "output_dir": str(output_dir),
         "source_boundary": SOURCE_BOUNDARY,
         "source_generation_summary": _dict(source_report.get("summary")),
+        "candidate_export_source": source_cli_evidence,
         "renderer": {
             "name": "fluidsynth",
             "path": resolved_renderer,
@@ -357,6 +384,17 @@ def validate_audio_render_report(
             boundary.get("fallback_replacement_technical_path_ready", False)
         ),
         "fallback_replacement_ready": bool(boundary.get("fallback_replacement_ready", False)),
+        "phrase_bank_cli_technical_path_completed": bool(
+            _dict(report.get("candidate_export_source")).get("phrase_bank_cli_technical_path_completed", False)
+        ),
+        "cli_candidate_count": _int(_dict(report.get("candidate_export_source")).get("cli_candidate_count")),
+        "cli_rendered_audio_file_count": _int(
+            _dict(report.get("candidate_export_source")).get("cli_rendered_audio_file_count")
+        ),
+        "cli_input_context_bars": _int(_dict(report.get("candidate_export_source")).get("cli_input_context_bars")),
+        "cli_preference_fill_allowed": bool(
+            _dict(report.get("candidate_export_source")).get("cli_preference_fill_allowed", True)
+        ),
         "audio_rendered_quality_claimed": bool(boundary.get("audio_rendered_quality_claimed", True)),
         "human_audio_preference_claimed": bool(boundary.get("human_audio_preference_claimed", True)),
         "midi_to_solo_musical_quality_claimed": bool(
@@ -371,6 +409,7 @@ def validate_audio_render_report(
 def markdown_report(report: dict[str, Any]) -> str:
     boundary = report["audio_render_boundary"]
     decision = report["decision"]
+    source = report["candidate_export_source"]
     lines = [
         "# Stage B MIDI-to-Solo Model-Conditioned Input Path Audio Render Package",
         "",
@@ -385,6 +424,13 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- fallback replacement ready: `{_bool_token(boundary['fallback_replacement_ready'])}`",
         f"- audio rendered quality claimed: `{_bool_token(boundary['audio_rendered_quality_claimed'])}`",
         f"- human/audio preference claimed: `{_bool_token(boundary['human_audio_preference_claimed'])}`",
+        "",
+        "## Candidate Export Source",
+        "",
+        f"- phrase-bank CLI technical path completed: `{_bool_token(source['phrase_bank_cli_technical_path_completed'])}`",
+        f"- CLI candidate / rendered WAV: `{source['cli_candidate_count']}` / `{source['cli_rendered_audio_file_count']}`",
+        f"- CLI input context bars: `{source['cli_input_context_bars']}`",
+        f"- CLI preference fill allowed: `{_bool_token(source['cli_preference_fill_allowed'])}`",
         "",
         "## Rendered Files",
         "",

--- a/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_audio_render.py
+++ b/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_audio_render.py
@@ -66,6 +66,13 @@ def candidate_export_report(root: Path, *, quality_claim: bool = False) -> dict:
             "candidate_count": 3,
             "exported_candidate_count": 3,
         },
+        "probe_source": {
+            "phrase_bank_cli_technical_path_completed": True,
+            "cli_candidate_count": 3,
+            "cli_rendered_audio_file_count": 3,
+            "cli_input_context_bars": 228,
+            "cli_preference_fill_allowed": False,
+        },
         "top_candidates": top_candidates,
         "readiness": {
             "model_conditioned_input_path_candidate_export_completed": True,
@@ -119,6 +126,11 @@ class StageBMidiToSoloModelConditionedInputPathAudioRenderTest(unittest.TestCase
         self.assertTrue(summary["model_conditioned_ranked_audio_render_completed"])
         self.assertTrue(summary["fallback_replacement_technical_path_ready"])
         self.assertTrue(summary["fallback_replacement_ready"])
+        self.assertTrue(summary["phrase_bank_cli_technical_path_completed"])
+        self.assertEqual(summary["cli_candidate_count"], 3)
+        self.assertEqual(summary["cli_rendered_audio_file_count"], 3)
+        self.assertEqual(summary["cli_input_context_bars"], 228)
+        self.assertFalse(summary["cli_preference_fill_allowed"])
         self.assertFalse(summary["human_audio_preference_claimed"])
         self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
 


### PR DESCRIPTION
## Summary
- model-conditioned ranked MIDI 후보를 WAV로 렌더
- candidate export source CLI evidence를 audio render package에 연결
- replacement consolidation boundary로 진행

## Context
- Issue #676 candidate export 결과: ranked MIDI candidates exported true
- ranked input-path export contract matched true
- candidate audio render required true
- phrase-bank CLI technical path completed true

## Scope
- audio render validator candidate export source CLI fields 검증 추가
- rendered WAV 3개 technical metadata 검증
- generated audio render doc, README, CURRENT_STATUS, CORE_PLAN, handoff 갱신

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_audio_render
- bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-audio-render-package
- bash scripts/agent_harness.sh quick
- git diff --check

## Risk
- audio quality claim 없음
- human/audio preference claim 없음
- 다음 검증 대상: Stage B MIDI-to-solo model-conditioned input path replacement consolidation

Closes #678