### PR TITLE
Stage B MIDI-to-solo model-conditioned input path replacement consolidation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #678, Stage B MIDI-to-solo model-conditioned input path audio render package.
+- Latest functional issue completed: Issue #680, Stage B MIDI-to-solo model-conditioned input path replacement consolidation.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path replacement consolidation.
+- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path listening review package.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package`
+- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_replacement_consolidation`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -22,7 +22,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - fallback replacement ready: `true`
 - model-conditioned input path candidate export completed: `true`
 - model-conditioned input path audio render completed: `true`
-- listening review package required: `false`
+- model-conditioned input path replacement consolidated: `true`
+- listening review package required: `true`
 - listening review package ready: `false`
 - phrase-bank retrieval baseline completed: `true`
 - phrase-bank source records / motifs: `56 / 803`
@@ -63,7 +64,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - MVP completion audit completed: `true`
 - quality gap decision completed: `true`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_replacement_consolidation`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_package`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -104,6 +105,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned input path probe 가능
 - model-conditioned ranked input-path candidate export 가능
 - model-conditioned ranked MIDI WAV render 가능
+- model-conditioned ranked MIDI/WAV technical replacement consolidation 가능
 
 현재 README가 주장하지 않는 것.
 
@@ -207,11 +209,19 @@ Model-conditioned input path audio render package.
 
 Model-conditioned input path replacement consolidation.
 
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_replacement_consolidation`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_package`
 - model-conditioned input to ranked MIDI completed: `true`
 - model-conditioned input to ranked WAV completed: `true`
 - fallback replacement technical path ready: `true`
+- fallback replacement ready: `true`
 - listening review package required: `true`
 - exported/rendered count: `3 / 3`
+- WAV duration range: `19.585s - 22.390s`
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3 / 3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
 - human/audio preference claimed: `false`
 - MIDI-to-solo musical quality claimed: `false`
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -3084,6 +3084,45 @@ Issue #678은 Issue #676 candidate export 결과의 ranked MIDI 후보를 WAV로
 
 - `Stage B MIDI-to-solo model-conditioned input path replacement consolidation`
 
+## 9.31 Stage B MIDI-to-solo model-conditioned input path replacement consolidation
+
+Issue #680은 Issue #676 candidate export와 Issue #678 audio render 결과를 단일 technical replacement evidence로 통합한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_replacement_consolidation`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_package`
+- replacement consolidated: `true`
+- input to ranked MIDI completed: `true`
+- input to ranked WAV completed: `true`
+- fallback replacement technical path ready: `true`
+- fallback replacement ready: `true`
+- listening review package required: `true`
+- exported/rendered count: `3 / 3`
+- WAV duration range: `19.585s - 22.390s`
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3 / 3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- human review required now: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- ranked MIDI/WAV technical replacement evidence 통합 완료.
+- listening review package 필요.
+- 청음 품질과 사용자 선호 claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_replacement_consolidation`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-replacement-consolidation`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo model-conditioned input path listening review package`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #678, Stage B MIDI-to-solo model-conditioned input path audio render package
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path replacement consolidation`
+- latest functional result: Issue #680, Stage B MIDI-to-solo model-conditioned input path replacement consolidation
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path listening review package`
 
 현재 범위가 아닌 것:
 
@@ -56,6 +56,54 @@
 - model-conditioned input path probe 완료
 - model-conditioned input path candidate export 완료
 - model-conditioned input path audio render package 완료
+- model-conditioned input path replacement consolidation 완료
+
+## Stage B MIDI-to-Solo Model-Conditioned Input Path Replacement Consolidation Result
+
+Issue #680은 Issue #676 candidate export와 Issue #678 audio render 결과를 단일 technical replacement evidence로 통합한 작업이다.
+
+변경:
+
+- candidate export source와 audio render source CLI evidence 일치 검증 추가
+- ranked MIDI export path와 audio render source path 일치 검증 유지
+- generated consolidation doc와 status docs 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_REPLACEMENT_CONSOLIDATION_2026-06-05.md`
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_replacement_consolidation`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_package`
+- replacement consolidated: `true`
+- input to ranked MIDI completed: `true`
+- input to ranked WAV completed: `true`
+- fallback replacement technical path ready: `true`
+- fallback replacement ready: `true`
+- listening review package required: `true`
+- exported/rendered count: `3 / 3`
+- WAV duration range: `19.585s - 22.390s`
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3 / 3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- human review required now: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- ranked MIDI/WAV technical replacement evidence 통합 완료
+- listening review package 필요
+- 청음 품질과 사용자 선호 claim 제외 유지
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_replacement_consolidation`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-replacement-consolidation`
+
+다음:
+
+- `Stage B MIDI-to-solo model-conditioned input path listening review package`
 
 ## Stage B MIDI-to-Solo Model-Conditioned Input Path Audio Render Package Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_REPLACEMENT_CONSOLIDATION_2026-06-05.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_REPLACEMENT_CONSOLIDATION_2026-06-05.md
@@ -16,6 +16,10 @@
 - rendered audio file count: `3`
 - WAV duration range: `19.585s - 22.390s`
 - best note / unique pitch / max simultaneous: `24 / 20 / 1`
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3` / `3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
 
 ## Claim Boundary
 

--- a/scripts/consolidate_stage_b_midi_to_solo_model_conditioned_input_path_replacement.py
+++ b/scripts/consolidate_stage_b_midi_to_solo_model_conditioned_input_path_replacement.py
@@ -81,9 +81,40 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
         )
 
 
+def validate_cli_source(source: dict[str, Any], *, label: str) -> dict[str, Any]:
+    if not bool(source.get("phrase_bank_cli_technical_path_completed", False)):
+        raise StageBMidiToSoloModelConditionedInputPathReplacementConsolidationError(
+            f"{label} phrase-bank CLI technical path completion required"
+        )
+    if _int(source.get("cli_candidate_count")) < 3:
+        raise StageBMidiToSoloModelConditionedInputPathReplacementConsolidationError(
+            f"{label} CLI candidate count below 3"
+        )
+    if _int(source.get("cli_rendered_audio_file_count")) < 3:
+        raise StageBMidiToSoloModelConditionedInputPathReplacementConsolidationError(
+            f"{label} CLI rendered WAV count below 3"
+        )
+    if _int(source.get("cli_input_context_bars")) <= 0:
+        raise StageBMidiToSoloModelConditionedInputPathReplacementConsolidationError(
+            f"{label} CLI input context bars required"
+        )
+    if bool(source.get("cli_preference_fill_allowed", True)):
+        raise StageBMidiToSoloModelConditionedInputPathReplacementConsolidationError(
+            f"{label} CLI preference fill should remain blocked"
+        )
+    return {
+        "phrase_bank_cli_technical_path_completed": True,
+        "cli_candidate_count": _int(source.get("cli_candidate_count")),
+        "cli_rendered_audio_file_count": _int(source.get("cli_rendered_audio_file_count")),
+        "cli_input_context_bars": _int(source.get("cli_input_context_bars")),
+        "cli_preference_fill_allowed": bool(source.get("cli_preference_fill_allowed", True)),
+    }
+
+
 def validate_candidate_export(report: dict[str, Any], *, expected_count: int) -> dict[str, Any]:
     readiness = _dict(report.get("readiness"))
     summary = _dict(report.get("summary"))
+    source = validate_cli_source(_dict(report.get("probe_source")), label="candidate export source")
     if str(report.get("boundary") or readiness.get("boundary") or "") != CANDIDATE_EXPORT_BOUNDARY:
         raise StageBMidiToSoloModelConditionedInputPathReplacementConsolidationError(
             "candidate export boundary required"
@@ -119,12 +150,14 @@ def validate_candidate_export(report: dict[str, Any], *, expected_count: int) ->
         "best_max_simultaneous_notes": _int(summary.get("best_max_simultaneous_notes")),
         "best_dead_air_ratio": _float(summary.get("best_dead_air_ratio")),
         "midi_paths": midi_paths,
+        "source_evidence": source,
     }
 
 
 def validate_audio_render(report: dict[str, Any], *, expected_count: int) -> dict[str, Any]:
     boundary = _dict(report.get("audio_render_boundary"))
     decision = _dict(report.get("decision"))
+    source = validate_cli_source(_dict(report.get("candidate_export_source")), label="audio render source")
     if str(boundary.get("boundary") or "") != AUDIO_RENDER_BOUNDARY:
         raise StageBMidiToSoloModelConditionedInputPathReplacementConsolidationError(
             "audio render boundary required"
@@ -182,6 +215,7 @@ def validate_audio_render(report: dict[str, Any], *, expected_count: int) -> dic
         "wav_duration_max_seconds": max(durations) if durations else 0.0,
         "wav_paths": wav_paths,
         "source_midi_paths": source_midi_paths,
+        "source_evidence": source,
     }
 
 
@@ -200,6 +234,10 @@ def build_replacement_consolidation_report(
         raise StageBMidiToSoloModelConditionedInputPathReplacementConsolidationError(
             "ranked MIDI export paths must match audio render source paths"
         )
+    if candidate["source_evidence"] != audio["source_evidence"]:
+        raise StageBMidiToSoloModelConditionedInputPathReplacementConsolidationError(
+            "candidate export and audio render source evidence must match"
+        )
     return {
         "schema_version": SCHEMA_VERSION,
         "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
@@ -212,6 +250,7 @@ def build_replacement_consolidation_report(
         },
         "candidate_export": candidate,
         "audio_render": audio,
+        "source_evidence": candidate["source_evidence"],
         "replacement_consolidation": {
             "model_conditioned_input_to_ranked_midi_completed": True,
             "model_conditioned_input_to_ranked_wav_completed": True,
@@ -327,6 +366,17 @@ def validate_replacement_consolidation_report(
         "rendered_audio_file_count": _int(audio.get("rendered_audio_file_count")),
         "wav_duration_min_seconds": _float(audio.get("wav_duration_min_seconds")),
         "wav_duration_max_seconds": _float(audio.get("wav_duration_max_seconds")),
+        "phrase_bank_cli_technical_path_completed": bool(
+            _dict(report.get("source_evidence")).get("phrase_bank_cli_technical_path_completed", False)
+        ),
+        "cli_candidate_count": _int(_dict(report.get("source_evidence")).get("cli_candidate_count")),
+        "cli_rendered_audio_file_count": _int(
+            _dict(report.get("source_evidence")).get("cli_rendered_audio_file_count")
+        ),
+        "cli_input_context_bars": _int(_dict(report.get("source_evidence")).get("cli_input_context_bars")),
+        "cli_preference_fill_allowed": bool(
+            _dict(report.get("source_evidence")).get("cli_preference_fill_allowed", True)
+        ),
         "human_review_required_now": bool(readiness.get("human_review_required_now", True)),
         "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
         "midi_to_solo_musical_quality_claimed": bool(
@@ -342,6 +392,7 @@ def markdown_report(report: dict[str, Any]) -> str:
     decision = report["decision"]
     candidate = report["candidate_export"]
     audio = report["audio_render"]
+    source = report["source_evidence"]
     lines = [
         "# Stage B MIDI-to-Solo Model-Conditioned Input Path Replacement Consolidation",
         "",
@@ -361,6 +412,10 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- rendered audio file count: `{audio['rendered_audio_file_count']}`",
         f"- WAV duration range: `{audio['wav_duration_min_seconds']:.3f}s - {audio['wav_duration_max_seconds']:.3f}s`",
         f"- best note / unique pitch / max simultaneous: `{candidate['best_note_count']} / {candidate['best_unique_pitch_count']} / {candidate['best_max_simultaneous_notes']}`",
+        f"- phrase-bank CLI technical path completed: `{_bool_token(source['phrase_bank_cli_technical_path_completed'])}`",
+        f"- CLI candidate / rendered WAV: `{source['cli_candidate_count']}` / `{source['cli_rendered_audio_file_count']}`",
+        f"- CLI input context bars: `{source['cli_input_context_bars']}`",
+        f"- CLI preference fill allowed: `{_bool_token(source['cli_preference_fill_allowed'])}`",
         "",
         "## Claim Boundary",
         "",

--- a/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_replacement_consolidation.py
+++ b/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_replacement_consolidation.py
@@ -44,6 +44,13 @@ def candidate_export_report(root: Path) -> dict:
             "best_max_simultaneous_notes": 1,
             "best_dead_air_ratio": 0.65,
         },
+        "probe_source": {
+            "phrase_bank_cli_technical_path_completed": True,
+            "cli_candidate_count": 3,
+            "cli_rendered_audio_file_count": 3,
+            "cli_input_context_bars": 228,
+            "cli_preference_fill_allowed": False,
+        },
         "top_candidates": top,
         "readiness": {
             "model_conditioned_input_path_candidate_export_completed": True,
@@ -96,6 +103,13 @@ def audio_render_report(root: Path, midi_paths: list[str], *, quality_claim: boo
             "next_boundary": AUDIO_RENDER_NEXT_BOUNDARY,
             "critical_user_input_required": False,
         },
+        "candidate_export_source": {
+            "phrase_bank_cli_technical_path_completed": True,
+            "cli_candidate_count": 3,
+            "cli_rendered_audio_file_count": 3,
+            "cli_input_context_bars": 228,
+            "cli_preference_fill_allowed": False,
+        },
         "rendered_audio_files": files,
     }
 
@@ -130,6 +144,11 @@ class StageBMidiToSoloModelConditionedInputPathReplacementConsolidationTest(unit
         self.assertTrue(summary["listening_review_package_required"])
         self.assertEqual(summary["exported_candidate_count"], 3)
         self.assertEqual(summary["rendered_audio_file_count"], 3)
+        self.assertTrue(summary["phrase_bank_cli_technical_path_completed"])
+        self.assertEqual(summary["cli_candidate_count"], 3)
+        self.assertEqual(summary["cli_rendered_audio_file_count"], 3)
+        self.assertEqual(summary["cli_input_context_bars"], 228)
+        self.assertFalse(summary["cli_preference_fill_allowed"])
         self.assertFalse(summary["human_audio_preference_claimed"])
         self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
 


### PR DESCRIPTION
## Summary
- model-conditioned ranked MIDI/WAV technical replacement evidence 통합
- candidate export와 audio render source CLI evidence 일치 검증
- listening review package boundary로 진행

## Context
- Issue #678 audio render 결과: rendered WAV 3개, technical WAV validation true
- fallback replacement technical path ready true
- fallback replacement ready true
- audio quality/preference claim false

## Scope
- replacement consolidation validator source CLI evidence 검증 추가
- ranked MIDI export path와 audio source path 일치 검증 유지
- generated consolidation doc, README, CURRENT_STATUS, CORE_PLAN, handoff 갱신

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_replacement_consolidation
- bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-replacement-consolidation
- bash scripts/agent_harness.sh quick
- git diff --check

## Risk
- listening review package 미완료
- human/audio preference claim 없음
- MIDI-to-solo musical quality claim 없음

Closes #680