### PR TITLE
Stage B MIDI-to-solo model-conditioned input path listening review input guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #682, Stage B MIDI-to-solo model-conditioned input path listening review package.
+- Latest functional issue completed: Issue #684, Stage B MIDI-to-solo model-conditioned input path listening review input guard.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path listening review input guard.
+- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path objective-only next decision.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1092,6 +1092,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-
 ```
 
 This harness packages ranked WAV/MIDI review items and keeps human/audio preference pending without claiming musical quality.
+
+For Stage B MIDI-to-solo model-conditioned input path listening review input guard changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-listening-review-input-guard
+```
+
+This harness blocks model-conditioned input-path preference fill while listening review input is pending.
 
 For Stage B MIDI-to-solo phrase-bank retrieval baseline changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_package`
+- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -25,6 +25,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned input path replacement consolidated: `true`
 - listening review package required: `true`
 - listening review package ready: `true`
+- model-conditioned listening review input guard completed: `true`
+- model-conditioned preference fill allowed: `false`
 - phrase-bank retrieval baseline completed: `true`
 - phrase-bank source records / motifs: `56 / 803`
 - phrase-bank exported / qualified MIDI candidates: `3 / 3`
@@ -64,7 +66,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - MVP completion audit completed: `true`
 - quality gap decision completed: `true`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -239,6 +241,22 @@ Model-conditioned input path listening review package.
 - CLI input context bars: `228`
 - CLI preference fill allowed: `false`
 - human/audio preference claimed: `false`
+
+Model-conditioned input path listening review input guard.
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`
+- review item count: `3`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3 / 3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
 
 Phrase-bank retrieval baseline.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -401,6 +401,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo model-conditioned input path audio render package: rendered WAV `3`, technical validation `true`, fallback replacement technical path ready `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_replacement_consolidation`
 - MIDI-to-solo model-conditioned input path replacement consolidation: ranked MIDI/WAV `true/true`, exported/rendered `3/3`, technical replacement ready `true`, listening review package required `true`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_package`
 - MIDI-to-solo model-conditioned input path listening review package: package ready `true`, review items `3`, validated input `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard`
+- MIDI-to-solo model-conditioned input path listening review input guard: validated input `false`, preference fill `false`, review items `3`, required input fields `4`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`
 - model-core portfolio bullet refresh: resume bullet `6`, short bullet `3`, generic base checkpoint repeatability `9/9/9`, unsupported claim guard 유지
 - Muzig application wording refresh: resume project bullet `5`, short bullet `3`, 자기소개 section `3`, AI 음악 실험/검증 claim만 사용
 - Muzig application final review package: long bullet `5`, short bullet `3`, 자기소개 paragraph `3`, 지원 동기 paragraph `2`, 최종 claim check 포함
@@ -474,6 +475,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - Stage B MIDI-to-solo model-conditioned input path audio render package: rendered WAV `3`, duration `19.585s-22.390s`, technical path ready `true`, human/audio preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_replacement_consolidation`
 - Stage B MIDI-to-solo model-conditioned input path replacement consolidation: input ranked MIDI/WAV `true/true`, path match `true`, listening review package required `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_package`
 - Stage B MIDI-to-solo model-conditioned input path listening review package: review item count `3`, validated review input `false`, human/audio preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard`
+- Stage B MIDI-to-solo model-conditioned input path listening review input guard: review item count `3`, validated review input `false`, preference fill allowed `false`, CLI technical evidence `3/3/228`, human/audio preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`
 - Stage B MIDI-to-solo controlled scale checkpoint dead-air repeatability temperature guard audio review package: candidate/rendered `3/3`, sample rate `44100`, duration `6.747s-6.861s`, technical validation `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_dead_air_repeatability_temperature_guard_listening_review`
 - Stage B MIDI-to-solo controlled scale checkpoint dead-air repeatability temperature guard listening review: candidate/rendered `3/3`, validated review input `false`, pending fields `4/3/9`, preference fill `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_dead_air_repeatability_temperature_guard_objective_only_next_decision`
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
@@ -3156,6 +3158,42 @@ Issue #682는 Issue #680 replacement consolidation 결과를 WAV/MIDI review ite
 다음 작업:
 
 - `Stage B MIDI-to-solo model-conditioned input path listening review input guard`
+
+## 9.33 Stage B MIDI-to-solo model-conditioned input path listening review input guard
+
+Issue #684는 Issue #682 listening review package 결과를 source로 사용해 검증된 청음 입력이 없는 상태의 preference fill을 차단한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`
+- review item count: `3`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3 / 3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- validated listening input 없음.
+- preference fill 차단.
+- musical quality claim 제외 유지.
+- 객관 evidence 기반 다음 경계 진행 가능.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-listening-review-input-guard`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo model-conditioned input path objective-only next decision`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -1,6 +1,6 @@
 # Current Status and Plan
 
-작성일: 2026-06-05
+작성일: 2026-06-08
 
 ## Current Focus
 
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #682, Stage B MIDI-to-solo model-conditioned input path listening review package
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path listening review input guard`
+- latest functional result: Issue #684, Stage B MIDI-to-solo model-conditioned input path listening review input guard
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path objective-only next decision`
 
 현재 범위가 아닌 것:
 
@@ -58,6 +58,54 @@
 - model-conditioned input path audio render package 완료
 - model-conditioned input path replacement consolidation 완료
 - model-conditioned input path listening review package 완료
+- model-conditioned input path review input pending 상태에서 preference fill 차단 완료
+
+## Stage B MIDI-to-Solo Model-Conditioned Input Path Listening Review Input Guard Result
+
+Issue #684는 Issue #682 listening review package 결과를 source로 사용해, 검증된 청음 입력이 없는 상태의 preference fill을 차단한 작업이다.
+
+변경:
+
+- model-conditioned input path listening review input guard script 추가
+- source package boundary와 replacement source CLI evidence 일치 검증
+- pending review input 기준 preference fill 차단
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_LISTENING_REVIEW_INPUT_GUARD_2026-06-08.md`
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`
+- review item count: `3`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3 / 3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- validated listening input 없음.
+- preference fill 차단.
+- musical quality claim 제외 유지.
+- 객관 evidence 기반 다음 경계 진행 가능.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard`
+- `.venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-listening-review-input-guard`
+
+다음:
+
+- `Stage B MIDI-to-solo model-conditioned input path objective-only next decision`
 
 ## Stage B MIDI-to-Solo Model-Conditioned Input Path Listening Review Package Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_LISTENING_REVIEW_INPUT_GUARD_2026-06-08.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_LISTENING_REVIEW_INPUT_GUARD_2026-06-08.md
@@ -1,0 +1,45 @@
+# Stage B MIDI-to-Solo Model-Conditioned Input Path Listening Review Input Guard
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`
+- review item count: `3`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3` / `3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Decision
+
+- auto progress allowed: `true`
+- critical user input required: `false`
+- reason: `listening review input pending; preference fill blocked`
+- next recommended issue: `Stage B MIDI-to-solo model-conditioned input path objective-only next decision`
+
+## Required Input Fields
+
+- `candidate_rank`
+- `listening_status`
+- `preference`
+- `issue_notes`
+
+## Review WAV Paths
+
+- `outputs/stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package/harness_stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package/audio/rank_01_sample_01.wav`
+- `outputs/stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package/harness_stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package/audio/rank_02_sample_02.wav`
+- `outputs/stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package/harness_stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package/audio/rank_03_sample_03.wav`
+
+## Claim Boundary
+
+- `listening_review_completed`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -242,6 +242,8 @@ Modes:
                 Decide the next quality-gap repair target after technical MVP completion.
   stage-b-midi-to-solo-model-conditioned-input-path-quality-alignment
                 Decide model-conditioned input-path alignment requirements and next probe target.
+  stage-b-midi-to-solo-model-conditioned-input-path-listening-review-input-guard
+                Block model-conditioned input-path preference fill while listening review input is pending.
   stage-b-midi-to-solo-model-direct-generation-repair
                 Define the model-direct generation repair boundary from sequence budget evidence.
   stage-b-midi-to-solo-model-direct-sequence-budget-repair-smoke
@@ -6090,6 +6092,27 @@ run_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_package()
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard() {
+  local package_run_id="${PACKAGE_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_package}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard}"
+  local source_package="outputs/stage_b_midi_to_solo_model_conditioned_input_path_listening_review_package/${package_run_id}/stage_b_midi_to_solo_model_conditioned_input_path_listening_review_package.json"
+  if [[ ! -f "$source_package" ]]; then
+    print_header "Stage B MIDI-to-solo model-conditioned input path listening review package"
+    RUN_ID="$package_run_id" run_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_package
+  fi
+  print_header "Stage B MIDI-to-solo model-conditioned input path listening review input guard"
+  "$PYTHON_BIN" scripts/guard_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input.py \
+    --run_id "$run_id" \
+    --source_package "$source_package" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_LISTENING_REVIEW_INPUT_GUARD_2026-06-08.md \
+    --issue_number 684 \
+    --expected_boundary stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard \
+    --expected_next_boundary stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision \
+    --require_guard_completed \
+    --require_pending_input \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -7737,6 +7760,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-model-conditioned-input-path-listening-review-package)
     run_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_package
+    ;;
+  stage-b-midi-to-solo-model-conditioned-input-path-listening-review-input-guard)
+    run_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/guard_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input.py
+++ b/scripts/guard_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input.py
@@ -1,0 +1,387 @@
+"""Guard model-conditioned input-path preference fill against missing review input."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.build_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_package import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+class StageBMidiToSoloModelConditionedInputPathListeningInputGuardError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard"
+FILL_BOUNDARY = "stage_b_midi_to_solo_model_conditioned_input_path_listening_review_fill"
+OBJECTIVE_NEXT_BOUNDARY = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision"
+)
+SCHEMA_VERSION = "stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard_v1"
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloModelConditionedInputPathListeningInputGuardError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def _validate_cli_source(source: dict[str, Any], *, label: str) -> dict[str, Any]:
+    if not bool(source.get("phrase_bank_cli_technical_path_completed", False)):
+        raise StageBMidiToSoloModelConditionedInputPathListeningInputGuardError(
+            f"{label} phrase-bank CLI technical path completion required"
+        )
+    if _int(source.get("cli_candidate_count")) < 3:
+        raise StageBMidiToSoloModelConditionedInputPathListeningInputGuardError(
+            f"{label} CLI candidate count below 3"
+        )
+    if _int(source.get("cli_rendered_audio_file_count")) < 3:
+        raise StageBMidiToSoloModelConditionedInputPathListeningInputGuardError(
+            f"{label} CLI rendered WAV count below 3"
+        )
+    if _int(source.get("cli_input_context_bars")) <= 0:
+        raise StageBMidiToSoloModelConditionedInputPathListeningInputGuardError(
+            f"{label} CLI input context bars required"
+        )
+    if bool(source.get("cli_preference_fill_allowed", True)):
+        raise StageBMidiToSoloModelConditionedInputPathListeningInputGuardError(
+            f"{label} CLI preference fill should remain blocked"
+        )
+    return {
+        "phrase_bank_cli_technical_path_completed": True,
+        "cli_candidate_count": _int(source.get("cli_candidate_count")),
+        "cli_rendered_audio_file_count": _int(source.get("cli_rendered_audio_file_count")),
+        "cli_input_context_bars": _int(source.get("cli_input_context_bars")),
+        "cli_preference_fill_allowed": bool(source.get("cli_preference_fill_allowed", True)),
+    }
+
+
+def validate_source_package(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    package = _dict(report.get("review_package"))
+    package_source = _validate_cli_source(
+        _dict(package.get("source_evidence")),
+        label="listening package source",
+    )
+    replacement_source = _validate_cli_source(
+        _dict(_dict(report.get("replacement_source")).get("source_evidence")),
+        label="replacement source",
+    )
+    if package_source != replacement_source:
+        raise StageBMidiToSoloModelConditionedInputPathListeningInputGuardError(
+            "source evidence mismatch between package and replacement summary"
+        )
+    if str(report.get("boundary") or readiness.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloModelConditionedInputPathListeningInputGuardError(
+            "model-conditioned listening review package boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
+        raise StageBMidiToSoloModelConditionedInputPathListeningInputGuardError(
+            "model-conditioned review package must route to input guard"
+        )
+    if not bool(readiness.get("listening_review_package_ready", False)):
+        raise StageBMidiToSoloModelConditionedInputPathListeningInputGuardError(
+            "listening review package readiness required"
+        )
+    if _int(readiness.get("review_item_count")) <= 0:
+        raise StageBMidiToSoloModelConditionedInputPathListeningInputGuardError(
+            "review items required"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloModelConditionedInputPathListeningInputGuardError(
+            "critical user input should not be required"
+        )
+    _require_no_quality_claim(readiness, label="model-conditioned listening review package readiness")
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "review_item_count": _int(readiness.get("review_item_count")),
+        "validated_review_input": bool(readiness.get("validated_review_input", False)),
+        "human_review_required_now": bool(readiness.get("human_review_required_now", False)),
+        "required_input_fields": [str(item) for item in _list(package.get("required_input_fields"))],
+        "wav_paths": [str(_dict(item).get("wav_path") or "") for item in _list(report.get("review_items"))],
+        "source_evidence": package_source,
+    }
+
+
+def build_listening_review_input_guard_report(
+    source_package: dict[str, Any],
+    *,
+    output_dir: Path,
+    issue_number: int,
+) -> dict[str, Any]:
+    source = validate_source_package(source_package)
+    validated_input = bool(source["validated_review_input"])
+    next_boundary = FILL_BOUNDARY if validated_input else OBJECTIVE_NEXT_BOUNDARY
+    reason = (
+        "validated listening review input present; preference fill allowed"
+        if validated_input
+        else "listening review input pending; preference fill blocked"
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundary": source["boundary"],
+        "source_package_summary": source,
+        "guard_result": {
+            "validated_review_input_present": bool(validated_input),
+            "preference_fill_allowed": bool(validated_input),
+            "review_item_count": int(source["review_item_count"]),
+            "required_input_field_count": len(source["required_input_fields"]),
+            "missing_validated_input_reason": "" if validated_input else "validated_review_input=false",
+            "source_evidence": source["source_evidence"],
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "listening_review_input_guard_completed": True,
+            "validated_review_input_present": bool(validated_input),
+            "preference_fill_allowed": bool(validated_input),
+            "listening_review_completed": False,
+            "human_review_required_now": bool(source["human_review_required_now"]),
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+            **source["source_evidence"],
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": next_boundary,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": reason,
+        },
+        "not_proven": [
+            "listening_review_completed",
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "audio_rendered_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo model-conditioned input path listening review fill"
+            if validated_input
+            else "Stage B MIDI-to-solo model-conditioned input path objective-only next decision"
+        ),
+    }
+
+
+def validate_listening_review_input_guard_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_guard_completed: bool,
+    require_pending_input: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    guard = _dict(report.get("guard_result"))
+    source = _validate_cli_source(_dict(guard.get("source_evidence")), label="guard source")
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloModelConditionedInputPathListeningInputGuardError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloModelConditionedInputPathListeningInputGuardError(
+            "unexpected next boundary"
+        )
+    if require_guard_completed and not bool(readiness.get("listening_review_input_guard_completed", False)):
+        raise StageBMidiToSoloModelConditionedInputPathListeningInputGuardError(
+            "guard completion required"
+        )
+    if require_pending_input and bool(guard.get("validated_review_input_present", True)):
+        raise StageBMidiToSoloModelConditionedInputPathListeningInputGuardError(
+            "review input should remain pending"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="model-conditioned input guard readiness")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloModelConditionedInputPathListeningInputGuardError(
+            "critical user input should not be required"
+        )
+    return {
+        "boundary": boundary,
+        "source_boundary": str(report.get("source_boundary") or ""),
+        "validated_review_input_present": bool(guard.get("validated_review_input_present", True)),
+        "preference_fill_allowed": bool(guard.get("preference_fill_allowed", True)),
+        "review_item_count": _int(guard.get("review_item_count")),
+        "required_input_field_count": _int(guard.get("required_input_field_count")),
+        "phrase_bank_cli_technical_path_completed": bool(
+            source["phrase_bank_cli_technical_path_completed"]
+        ),
+        "cli_candidate_count": _int(source["cli_candidate_count"]),
+        "cli_rendered_audio_file_count": _int(source["cli_rendered_audio_file_count"]),
+        "cli_input_context_bars": _int(source["cli_input_context_bars"]),
+        "cli_preference_fill_allowed": bool(source["cli_preference_fill_allowed"]),
+        "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    guard = report["guard_result"]
+    source = guard["source_evidence"]
+    package = report["source_package_summary"]
+    lines = [
+        "# Stage B MIDI-to-Solo Model-Conditioned Input Path Listening Review Input Guard",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- source boundary: `{report['source_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- review item count: `{guard['review_item_count']}`",
+        f"- validated review input present: `{_bool_token(guard['validated_review_input_present'])}`",
+        f"- preference fill allowed: `{_bool_token(guard['preference_fill_allowed'])}`",
+        f"- phrase-bank CLI technical path completed: `{_bool_token(source['phrase_bank_cli_technical_path_completed'])}`",
+        f"- CLI candidate / rendered WAV: `{source['cli_candidate_count']}` / `{source['cli_rendered_audio_file_count']}`",
+        f"- CLI input context bars: `{source['cli_input_context_bars']}`",
+        f"- CLI preference fill allowed: `{_bool_token(source['cli_preference_fill_allowed'])}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Decision",
+        "",
+        f"- auto progress allowed: `{_bool_token(decision['auto_progress_allowed'])}`",
+        f"- critical user input required: `{_bool_token(decision['critical_user_input_required'])}`",
+        f"- reason: `{decision['reason']}`",
+        f"- next recommended issue: `{report['next_recommended_issue']}`",
+        "",
+        "## Required Input Fields",
+        "",
+    ]
+    for field in package["required_input_fields"]:
+        lines.append(f"- `{field}`")
+    lines.extend(["", "## Review WAV Paths", ""])
+    for path in package["wav_paths"]:
+        lines.append(f"- `{path}`")
+    lines.extend(["", "## Claim Boundary", ""])
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Guard model-conditioned input-path listening review input"
+    )
+    parser.add_argument("--source_package", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=684)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_guard_completed", action="store_true")
+    parser.add_argument("--require_pending_input", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_listening_review_input_guard_report(
+        read_json(Path(args.source_package)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+    )
+    summary = validate_listening_review_input_guard_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_guard_completed=bool(args.require_guard_completed),
+        require_pending_input=bool(args.require_pending_input),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard.py
+++ b/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.build_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_package import (
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+from scripts.guard_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input import (
+    BOUNDARY,
+    FILL_BOUNDARY,
+    OBJECTIVE_NEXT_BOUNDARY,
+    StageBMidiToSoloModelConditionedInputPathListeningInputGuardError,
+    build_listening_review_input_guard_report,
+    validate_listening_review_input_guard_report,
+)
+
+
+SOURCE_EVIDENCE = {
+    "phrase_bank_cli_technical_path_completed": True,
+    "cli_candidate_count": 3,
+    "cli_rendered_audio_file_count": 3,
+    "cli_input_context_bars": 228,
+    "cli_preference_fill_allowed": False,
+}
+
+
+def source_package(
+    *,
+    validated_review_input: bool = False,
+    quality_claim: bool = False,
+    source_evidence: dict | None = None,
+) -> dict:
+    evidence = source_evidence if source_evidence is not None else dict(SOURCE_EVIDENCE)
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "replacement_source": {
+            "source_evidence": dict(evidence),
+        },
+        "review_package": {
+            "package_ready": True,
+            "review_item_count": 3,
+            "review_basis": "human_audio_listening_pending",
+            "validated_review_input": validated_review_input,
+            "source_evidence": dict(evidence),
+            "required_input_fields": [
+                "candidate_rank",
+                "listening_status",
+                "preference",
+                "issue_notes",
+            ],
+        },
+        "review_items": [
+            {"rank": index, "wav_path": f"audio/rank_{index}.wav"} for index in range(1, 4)
+        ],
+        "readiness": {
+            "listening_review_package_ready": True,
+            "review_item_count": 3,
+            "validated_review_input": validated_review_input,
+            "human_review_required_now": False,
+            "human_audio_preference_claimed": quality_claim,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": SOURCE_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class StageBMidiToSoloModelConditionedInputPathListeningInputGuardTest(unittest.TestCase):
+    def test_blocks_preference_fill_when_review_input_pending(self) -> None:
+        report = build_listening_review_input_guard_report(
+            source_package(),
+            output_dir="out",
+            issue_number=684,
+        )
+        summary = validate_listening_review_input_guard_report(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=OBJECTIVE_NEXT_BOUNDARY,
+            require_guard_completed=True,
+            require_pending_input=True,
+            require_no_quality_claim=True,
+        )
+
+        self.assertFalse(summary["validated_review_input_present"])
+        self.assertFalse(summary["preference_fill_allowed"])
+        self.assertEqual(summary["review_item_count"], 3)
+        self.assertEqual(summary["required_input_field_count"], 4)
+        self.assertTrue(summary["phrase_bank_cli_technical_path_completed"])
+        self.assertEqual(summary["cli_input_context_bars"], 228)
+        self.assertFalse(summary["human_audio_preference_claimed"])
+
+    def test_routes_to_fill_when_validated_input_present(self) -> None:
+        report = build_listening_review_input_guard_report(
+            source_package(validated_review_input=True),
+            output_dir="out",
+            issue_number=684,
+        )
+        summary = validate_listening_review_input_guard_report(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=FILL_BOUNDARY,
+            require_guard_completed=True,
+            require_pending_input=False,
+            require_no_quality_claim=True,
+        )
+
+        self.assertTrue(summary["validated_review_input_present"])
+        self.assertTrue(summary["preference_fill_allowed"])
+
+    def test_rejects_upstream_quality_claim(self) -> None:
+        with self.assertRaises(StageBMidiToSoloModelConditionedInputPathListeningInputGuardError):
+            build_listening_review_input_guard_report(
+                source_package(quality_claim=True),
+                output_dir="out",
+                issue_number=684,
+            )
+
+    def test_rejects_missing_cli_source_evidence(self) -> None:
+        broken_evidence = dict(SOURCE_EVIDENCE)
+        broken_evidence["phrase_bank_cli_technical_path_completed"] = False
+
+        with self.assertRaises(StageBMidiToSoloModelConditionedInputPathListeningInputGuardError):
+            build_listening_review_input_guard_report(
+                source_package(source_evidence=broken_evidence),
+                output_dir="out",
+                issue_number=684,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- model-conditioned input path listening review input guard 추가
- validated review input 없음 상태의 preference fill 차단
- source package boundary와 CLI technical evidence 검증
- README, CORE_PLAN, CURRENT_STATUS, AGENTS 최신 경계 갱신

## Context

- #682 listening review package 결과, ranked WAV/MIDI review item 생성 완료
- review item count: `3`
- validated review input: `false`
- phrase-bank CLI technical path completed: `true`
- CLI candidate / rendered WAV: `3 / 3`
- CLI input context bars: `228`
- human/audio preference, MIDI-to-solo musical quality claim 제외 상태
- 현재 문제 지점: 청음 입력 부재 상태에서 preference fill 진행 시 품질 claim 오염 가능
- 이번 검토 대상: input guard, pending review 경계, objective-only next decision 라우팅

## Scope

- `guard_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input.py` 추가
- unit test 추가
- `agent_harness.sh` mode 추가
- generated review input guard doc 추가
- handoff/status docs 최신 경계 갱신

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard`
- `.venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-listening-review-input-guard`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- `git diff -- . | rg -n 'Codex|codex|코덱스'` → no matches\n\n## Risk\n\n- human/audio preference 미기록\n- MIDI-to-solo musical quality claim 제외 유지\n- 다음 경계: `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`\n\nCloses #684