### PR TITLE
Stage B MIDI-to-solo model-conditioned input path objective-only next decision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #684, Stage B MIDI-to-solo model-conditioned input path listening review input guard.
+- Latest functional issue completed: Issue #686, Stage B MIDI-to-solo model-conditioned input path objective-only next decision.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path objective-only next decision.
+- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path dead-air timing repair decision.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1100,6 +1100,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-
 ```
 
 This harness blocks model-conditioned input-path preference fill while listening review input is pending.
+
+For Stage B MIDI-to-solo model-conditioned input path objective-only next decision changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-objective-next
+```
+
+This harness selects the next model-conditioned input-path boundary from objective MIDI/WAV evidence only.
 
 For Stage B MIDI-to-solo phrase-bank retrieval baseline changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard`
+- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -27,6 +27,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - listening review package ready: `true`
 - model-conditioned listening review input guard completed: `true`
 - model-conditioned preference fill allowed: `false`
+- model-conditioned objective-only next decision completed: `true`
+- model-conditioned dead-air failure count: `3 / 3`
+- model-conditioned dead-air timing repair required: `true`
 - phrase-bank retrieval baseline completed: `true`
 - phrase-bank source records / motifs: `56 / 803`
 - phrase-bank exported / qualified MIDI candidates: `3 / 3`
@@ -66,7 +69,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - MVP completion audit completed: `true`
 - quality gap decision completed: `true`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -255,6 +258,22 @@ Model-conditioned input path listening review input guard.
 - CLI candidate / rendered WAV: `3 / 3`
 - CLI input context bars: `228`
 - CLI preference fill allowed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+Model-conditioned input path objective-only next decision.
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision`
+- model-conditioned technical path ready: `true`
+- candidate / exported / rendered: `3 / 3 / 3`
+- technical WAV validation: `true`
+- dead-air threshold: `0.5000`
+- dead-air failure count: `3`
+- dead-air min / max: `0.6522 / 0.6522`
+- dead-air timing repair required: `true`
+- current evidence consolidation ready: `false`
+- preference fill allowed: `false`
 - human/audio preference claimed: `false`
 - MIDI-to-solo musical quality claimed: `false`
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -402,6 +402,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo model-conditioned input path replacement consolidation: ranked MIDI/WAV `true/true`, exported/rendered `3/3`, technical replacement ready `true`, listening review package required `true`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_package`
 - MIDI-to-solo model-conditioned input path listening review package: package ready `true`, review items `3`, validated input `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard`
 - MIDI-to-solo model-conditioned input path listening review input guard: validated input `false`, preference fill `false`, review items `3`, required input fields `4`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`
+- MIDI-to-solo model-conditioned input path objective-only next decision: technical path `true`, dead-air failure `3/3`, repair required `true`, current evidence consolidation `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision`
 - model-core portfolio bullet refresh: resume bullet `6`, short bullet `3`, generic base checkpoint repeatability `9/9/9`, unsupported claim guard 유지
 - Muzig application wording refresh: resume project bullet `5`, short bullet `3`, 자기소개 section `3`, AI 음악 실험/검증 claim만 사용
 - Muzig application final review package: long bullet `5`, short bullet `3`, 자기소개 paragraph `3`, 지원 동기 paragraph `2`, 최종 claim check 포함
@@ -476,6 +477,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - Stage B MIDI-to-solo model-conditioned input path replacement consolidation: input ranked MIDI/WAV `true/true`, path match `true`, listening review package required `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_package`
 - Stage B MIDI-to-solo model-conditioned input path listening review package: review item count `3`, validated review input `false`, human/audio preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard`
 - Stage B MIDI-to-solo model-conditioned input path listening review input guard: review item count `3`, validated review input `false`, preference fill allowed `false`, CLI technical evidence `3/3/228`, human/audio preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`
+- Stage B MIDI-to-solo model-conditioned input path objective-only next decision: candidate/export/render `3/3/3`, dead-air failure `3`, dead-air range `0.6522/0.6522`, repair required `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision`
 - Stage B MIDI-to-solo controlled scale checkpoint dead-air repeatability temperature guard audio review package: candidate/rendered `3/3`, sample rate `44100`, duration `6.747s-6.861s`, technical validation `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_dead_air_repeatability_temperature_guard_listening_review`
 - Stage B MIDI-to-solo controlled scale checkpoint dead-air repeatability temperature guard listening review: candidate/rendered `3/3`, validated review input `false`, pending fields `4/3/9`, preference fill `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_dead_air_repeatability_temperature_guard_objective_only_next_decision`
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
@@ -3194,6 +3196,43 @@ Issue #684는 Issue #682 listening review package 결과를 source로 사용해 
 다음 작업:
 
 - `Stage B MIDI-to-solo model-conditioned input path objective-only next decision`
+
+## 9.34 Stage B MIDI-to-solo model-conditioned input path objective-only next decision
+
+Issue #686은 Issue #684 input guard와 model-conditioned candidate/audio evidence를 source로 사용해 청음 입력 없이 다음 자동 경계를 결정한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision`
+- model-conditioned technical path ready: `true`
+- candidate / exported / rendered: `3 / 3 / 3`
+- technical WAV validation: `true`
+- dead-air threshold: `0.5000`
+- dead-air failure count: `3`
+- dead-air min / max: `0.6522 / 0.6522`
+- dead-air timing repair required: `true`
+- current evidence consolidation ready: `false`
+- preference fill allowed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- ranked MIDI/WAV technical path ready.
+- candidate 3개 모두 dead-air threshold 초과.
+- current evidence consolidation 보류.
+- dead-air/timing repair decision 필요.
+- musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_objective_next`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-objective-next`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair decision`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #684, Stage B MIDI-to-solo model-conditioned input path listening review input guard
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path objective-only next decision`
+- latest functional result: Issue #686, Stage B MIDI-to-solo model-conditioned input path objective-only next decision
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair decision`
 
 현재 범위가 아닌 것:
 
@@ -59,6 +59,55 @@
 - model-conditioned input path replacement consolidation 완료
 - model-conditioned input path listening review package 완료
 - model-conditioned input path review input pending 상태에서 preference fill 차단 완료
+- model-conditioned input path objective-only 기준 dead-air/timing repair 필요 판정
+
+## Stage B MIDI-to-Solo Model-Conditioned Input Path Objective-Only Next Decision Result
+
+Issue #686은 Issue #684 input guard와 model-conditioned candidate/audio evidence를 source로 사용해, 청음 입력 없이 다음 자동 경계를 결정한 작업이다.
+
+변경:
+
+- model-conditioned input path objective-only next decision script 추가
+- input guard, candidate export, audio render source evidence 검증
+- dead-air threshold 기반 repair 필요 여부 판정
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_OBJECTIVE_NEXT_DECISION_2026-06-08.md`
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision`
+- model-conditioned technical path ready: `true`
+- candidate / exported / rendered: `3 / 3 / 3`
+- technical WAV validation: `true`
+- dead-air threshold: `0.5000`
+- dead-air failure count: `3`
+- dead-air min / max: `0.6522 / 0.6522`
+- dead-air timing repair required: `true`
+- current evidence consolidation ready: `false`
+- preference fill allowed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- ranked MIDI/WAV technical path ready.
+- candidate 3개 모두 dead-air threshold 초과.
+- current evidence consolidation 보류.
+- dead-air/timing repair decision 필요.
+- musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_objective_next`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_objective_next.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-objective-next`
+
+다음:
+
+- `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair decision`
 
 ## Stage B MIDI-to-Solo Model-Conditioned Input Path Listening Review Input Guard Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_OBJECTIVE_NEXT_DECISION_2026-06-08.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_OBJECTIVE_NEXT_DECISION_2026-06-08.md
@@ -1,0 +1,75 @@
+# Stage B MIDI-to-Solo Model-Conditioned Input Path Objective-Only Next Decision
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision`
+- model-conditioned technical path ready: `true`
+- candidate / exported / rendered: `3 / 3 / 3`
+- technical WAV validation: `true`
+- dead-air threshold: `0.5000`
+- dead-air failure count: `3`
+- dead-air min / max: `0.6522 / 0.6522`
+- dead-air timing repair required: `true`
+- current evidence consolidation ready: `false`
+- preference fill allowed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Source Evidence
+
+- phrase-bank CLI technical path completed: `true`
+- CLI candidate / rendered WAV: `3` / `3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+
+## Candidate Review
+
+### Rank 1
+
+- seed: `497`
+- MIDI: `outputs/stage_b_midi_to_solo_model_conditioned_input_path_candidate_export/harness_stage_b_midi_to_solo_model_conditioned_input_path_candidate_export/midi/rank_01_sample_01.mid`
+- WAV: `outputs/stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package/harness_stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package/audio/rank_01_sample_01.wav`
+- notes / unique pitches / max simultaneous: `24 / 20 / 1`
+- chord-tone / dead-air / phrase coverage: `0.6667 / 0.6522 / 0.9688`
+- position span / postprocess removal: `0.9453 / 0.0000`
+- dead-air failure: `true`
+- WAV duration / sample rate / sha256 prefix: `22.390s / 44100 / fd78ec4d6fdb`
+
+### Rank 2
+
+- seed: `498`
+- MIDI: `outputs/stage_b_midi_to_solo_model_conditioned_input_path_candidate_export/harness_stage_b_midi_to_solo_model_conditioned_input_path_candidate_export/midi/rank_02_sample_02.mid`
+- WAV: `outputs/stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package/harness_stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package/audio/rank_02_sample_02.wav`
+- notes / unique pitches / max simultaneous: `24 / 20 / 1`
+- chord-tone / dead-air / phrase coverage: `0.5417 / 0.6522 / 0.9453`
+- position span / postprocess removal: `0.9453 / 0.0000`
+- dead-air failure: `true`
+- WAV duration / sample rate / sha256 prefix: `21.355s / 44100 / 683ba60bd525`
+
+### Rank 3
+
+- seed: `499`
+- MIDI: `outputs/stage_b_midi_to_solo_model_conditioned_input_path_candidate_export/harness_stage_b_midi_to_solo_model_conditioned_input_path_candidate_export/midi/rank_03_sample_03.mid`
+- WAV: `outputs/stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package/harness_stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package/audio/rank_03_sample_03.wav`
+- notes / unique pitches / max simultaneous: `24 / 19 / 1`
+- chord-tone / dead-air / phrase coverage: `0.5417 / 0.6522 / 0.9922`
+- position span / postprocess removal: `0.9453 / 0.0000`
+- dead-air failure: `true`
+- WAV duration / sample rate / sha256 prefix: `19.585s / 44100 / c0f273d5e926`
+
+## Decision
+
+- auto progress allowed: `true`
+- critical user input required: `false`
+- reason: `model-conditioned ranked MIDI/WAV technical path is ready; dead-air objective risk requires repair`
+- next recommended issue: `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair decision`
+
+## Claim Boundary
+
+- `listening_review_completed`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -244,6 +244,8 @@ Modes:
                 Decide model-conditioned input-path alignment requirements and next probe target.
   stage-b-midi-to-solo-model-conditioned-input-path-listening-review-input-guard
                 Block model-conditioned input-path preference fill while listening review input is pending.
+  stage-b-midi-to-solo-model-conditioned-input-path-objective-next
+                Select the next model-conditioned input-path boundary from objective MIDI/WAV evidence only.
   stage-b-midi-to-solo-model-direct-generation-repair
                 Define the model-direct generation repair boundary from sequence budget evidence.
   stage-b-midi-to-solo-model-direct-sequence-budget-repair-smoke
@@ -6113,6 +6115,41 @@ run_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_gua
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_model_conditioned_input_path_objective_next() {
+  local input_guard_run_id="${INPUT_GUARD_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard}"
+  local candidate_export_run_id="${CANDIDATE_EXPORT_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_candidate_export}"
+  local audio_render_run_id="${AUDIO_RENDER_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision}"
+  local input_guard="outputs/stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard/${input_guard_run_id}/stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard.json"
+  local candidate_export="outputs/stage_b_midi_to_solo_model_conditioned_input_path_candidate_export/${candidate_export_run_id}/stage_b_midi_to_solo_model_conditioned_input_path_candidate_export.json"
+  local audio_render="outputs/stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package/${audio_render_run_id}/stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package.json"
+  if [[ ! -f "$input_guard" ]]; then
+    print_header "Stage B MIDI-to-solo model-conditioned input path listening review input guard"
+    RUN_ID="$input_guard_run_id" run_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard
+  fi
+  if [[ ! -f "$candidate_export" ]]; then
+    print_header "Stage B MIDI-to-solo model-conditioned input path candidate export"
+    RUN_ID="$candidate_export_run_id" run_stage_b_midi_to_solo_model_conditioned_input_path_candidate_export
+  fi
+  if [[ ! -f "$audio_render" ]]; then
+    print_header "Stage B MIDI-to-solo model-conditioned input path audio render package"
+    RUN_ID="$audio_render_run_id" CANDIDATE_EXPORT_RUN_ID="$candidate_export_run_id" run_stage_b_midi_to_solo_model_conditioned_input_path_audio_render_package
+  fi
+  print_header "Stage B MIDI-to-solo model-conditioned input path objective-only next decision"
+  "$PYTHON_BIN" scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_objective_next.py \
+    --run_id "$run_id" \
+    --input_guard_report "$input_guard" \
+    --candidate_export_report "$candidate_export" \
+    --audio_render_report "$audio_render" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_OBJECTIVE_NEXT_DECISION_2026-06-08.md \
+    --issue_number 686 \
+    --expected_boundary stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision \
+    --expected_next_boundary stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision \
+    --require_objective_decision \
+    --require_repair_required \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -7763,6 +7800,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-model-conditioned-input-path-listening-review-input-guard)
     run_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard
+    ;;
+  stage-b-midi-to-solo-model-conditioned-input-path-objective-next)
+    run_stage_b_midi_to_solo_model_conditioned_input_path_objective_next
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_objective_next.py
+++ b/scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_objective_next.py
@@ -1,0 +1,593 @@
+"""Select the next step after model-conditioned input-path evidence without listening input."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.export_stage_b_midi_to_solo_model_conditioned_input_path_candidates import (  # noqa: E402
+    BOUNDARY as CANDIDATE_EXPORT_BOUNDARY,
+)
+from scripts.guard_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input import (  # noqa: E402
+    BOUNDARY as INPUT_GUARD_BOUNDARY,
+    OBJECTIVE_NEXT_BOUNDARY as INPUT_GUARD_NEXT_BOUNDARY,
+)
+from scripts.render_stage_b_midi_to_solo_model_conditioned_input_path_audio import (  # noqa: E402
+    BOUNDARY as AUDIO_RENDER_BOUNDARY,
+)
+
+
+class StageBMidiToSoloModelConditionedInputPathObjectiveNextError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision"
+REPAIR_NEXT_BOUNDARY = "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision"
+CURRENT_EVIDENCE_NEXT_BOUNDARY = "stage_b_midi_to_solo_mvp_current_evidence_consolidation"
+SCHEMA_VERSION = "stage_b_midi_to_solo_model_conditioned_input_path_objective_next_v1"
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def _validate_cli_source(source: dict[str, Any], *, label: str) -> dict[str, Any]:
+    if not bool(source.get("phrase_bank_cli_technical_path_completed", False)):
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            f"{label} phrase-bank CLI technical path completion required"
+        )
+    if _int(source.get("cli_candidate_count")) < 3:
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            f"{label} CLI candidate count below 3"
+        )
+    if _int(source.get("cli_rendered_audio_file_count")) < 3:
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            f"{label} CLI rendered WAV count below 3"
+        )
+    if _int(source.get("cli_input_context_bars")) <= 0:
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            f"{label} CLI input context bars required"
+        )
+    if bool(source.get("cli_preference_fill_allowed", True)):
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            f"{label} CLI preference fill should remain blocked"
+        )
+    return {
+        "phrase_bank_cli_technical_path_completed": True,
+        "cli_candidate_count": _int(source.get("cli_candidate_count")),
+        "cli_rendered_audio_file_count": _int(source.get("cli_rendered_audio_file_count")),
+        "cli_input_context_bars": _int(source.get("cli_input_context_bars")),
+        "cli_preference_fill_allowed": bool(source.get("cli_preference_fill_allowed", True)),
+    }
+
+
+def validate_input_guard_report(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    guard = _dict(report.get("guard_result"))
+    source = _validate_cli_source(_dict(guard.get("source_evidence")), label="input guard source")
+    if str(report.get("boundary") or "") != INPUT_GUARD_BOUNDARY:
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            "model-conditioned input guard boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != INPUT_GUARD_NEXT_BOUNDARY:
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            "input guard must route to objective-only next decision"
+        )
+    if not bool(readiness.get("listening_review_input_guard_completed", False)):
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            "input guard completion required"
+        )
+    if bool(guard.get("validated_review_input_present", True)):
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            "objective-only decision requires pending review input"
+        )
+    if bool(guard.get("preference_fill_allowed", True)):
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            "preference fill must remain blocked"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            "critical user input should not be required"
+        )
+    _require_no_quality_claim(readiness, label="input guard readiness")
+    return {
+        "boundary": INPUT_GUARD_BOUNDARY,
+        "review_item_count": _int(guard.get("review_item_count")),
+        "required_input_field_count": _int(guard.get("required_input_field_count")),
+        "validated_review_input_present": bool(guard.get("validated_review_input_present", False)),
+        "preference_fill_allowed": bool(guard.get("preference_fill_allowed", False)),
+        "source_evidence": source,
+    }
+
+
+def validate_candidate_export_report(report: dict[str, Any], *, expected_count: int) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    summary = _dict(report.get("summary"))
+    source = _validate_cli_source(_dict(report.get("probe_source")), label="candidate export source")
+    candidates = [_dict(item) for item in _list(report.get("top_candidates"))]
+    if str(report.get("boundary") or readiness.get("boundary") or "") != CANDIDATE_EXPORT_BOUNDARY:
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            "candidate export boundary required"
+        )
+    required_true = [
+        "model_conditioned_input_path_candidate_export_completed",
+        "ranked_midi_candidates_exported",
+        "model_conditioned_ranked_input_path_contract_matched",
+        "fallback_replacement_candidate_export_ready",
+    ]
+    missing = [name for name in required_true if not bool(readiness.get(name, False))]
+    if missing:
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            f"missing candidate export readiness: {missing}"
+        )
+    if _int(summary.get("exported_candidate_count")) < int(expected_count):
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            "exported candidate count below expected"
+        )
+    if len(candidates) < int(expected_count):
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            "top candidate rows below expected"
+        )
+    _require_no_quality_claim(readiness, label="candidate export readiness")
+    return {
+        "boundary": CANDIDATE_EXPORT_BOUNDARY,
+        "exported_candidate_count": _int(summary.get("exported_candidate_count")),
+        "best_note_count": _int(summary.get("best_note_count")),
+        "best_unique_pitch_count": _int(summary.get("best_unique_pitch_count")),
+        "best_dead_air_ratio": _float(summary.get("best_dead_air_ratio")),
+        "top_candidates": candidates[: int(expected_count)],
+        "source_evidence": source,
+    }
+
+
+def validate_audio_render_report(report: dict[str, Any], *, expected_count: int) -> dict[str, Any]:
+    boundary = _dict(report.get("audio_render_boundary"))
+    decision = _dict(report.get("decision"))
+    source = _validate_cli_source(_dict(report.get("candidate_export_source")), label="audio render source")
+    if str(report.get("source_boundary") or "") != CANDIDATE_EXPORT_BOUNDARY:
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            "audio render source must be candidate export"
+        )
+    if str(boundary.get("boundary") or "") != AUDIO_RENDER_BOUNDARY:
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            "audio render boundary required"
+        )
+    required_true = [
+        "render_attempted",
+        "technical_wav_validation",
+        "model_conditioned_ranked_audio_render_completed",
+        "fallback_replacement_candidate_export_ready",
+        "fallback_replacement_technical_path_ready",
+        "fallback_replacement_ready",
+    ]
+    missing = [name for name in required_true if not bool(boundary.get(name, False))]
+    if missing:
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            f"missing audio render readiness: {missing}"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            "critical user input should not be required"
+        )
+    _require_no_quality_claim(boundary, label="audio render boundary")
+    rows = [_dict(item) for item in _list(report.get("rendered_audio_files"))]
+    if len(rows) < int(expected_count):
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            "rendered audio rows below expected"
+        )
+    return {
+        "boundary": AUDIO_RENDER_BOUNDARY,
+        "rendered_audio_file_count": _int(boundary.get("rendered_audio_file_count")),
+        "technical_wav_validation": bool(boundary.get("technical_wav_validation", False)),
+        "rendered_audio_files": rows[: int(expected_count)],
+        "source_evidence": source,
+    }
+
+
+def build_candidate_rows(
+    *,
+    candidate_export: dict[str, Any],
+    audio_render: dict[str, Any],
+    dead_air_threshold: float,
+) -> list[dict[str, Any]]:
+    audio_by_rank = {
+        _int(item.get("rank")): item for item in _list(audio_render.get("rendered_audio_files"))
+    }
+    rows: list[dict[str, Any]] = []
+    for candidate in _list(candidate_export.get("top_candidates")):
+        rank = _int(candidate.get("rank"))
+        audio = _dict(audio_by_rank.get(rank))
+        wav = _dict(audio.get("wav_file"))
+        dead_air = max(
+            _float(candidate.get("dead_air_ratio")),
+            _float(audio.get("source_dead_air_ratio")),
+        )
+        rows.append(
+            {
+                "rank": rank,
+                "sample_index": _int(candidate.get("sample_index")),
+                "sample_seed": _int(candidate.get("sample_seed")),
+                "midi_path": str(candidate.get("export_midi_path") or audio.get("source_midi_path") or ""),
+                "wav_path": str(wav.get("path") or ""),
+                "note_count": _int(candidate.get("note_count") or audio.get("source_note_count")),
+                "unique_pitch_count": _int(
+                    candidate.get("unique_pitch_count") or audio.get("source_unique_pitch_count")
+                ),
+                "max_simultaneous_notes": _int(candidate.get("max_simultaneous_notes")),
+                "chord_tone_ratio": _float(
+                    candidate.get("chord_tone_ratio") or audio.get("source_chord_tone_ratio")
+                ),
+                "dead_air_ratio": dead_air,
+                "phrase_coverage_ratio": _float(candidate.get("phrase_coverage_ratio")),
+                "position_span_ratio": _float(candidate.get("position_span_ratio")),
+                "postprocess_removal_ratio": _float(candidate.get("postprocess_removal_ratio")),
+                "wav_duration_seconds": _float(wav.get("duration_seconds")),
+                "wav_sample_rate": _int(wav.get("sample_rate")),
+                "wav_sha256_prefix": str(wav.get("sha256") or "")[:12],
+                "dead_air_failure": dead_air >= float(dead_air_threshold),
+            }
+        )
+    return rows
+
+
+def build_objective_next_report(
+    *,
+    input_guard_report: dict[str, Any],
+    candidate_export_report: dict[str, Any],
+    audio_render_report: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+    expected_count: int,
+    dead_air_threshold: float,
+) -> dict[str, Any]:
+    input_guard = validate_input_guard_report(input_guard_report)
+    candidate_export = validate_candidate_export_report(
+        candidate_export_report,
+        expected_count=int(expected_count),
+    )
+    audio_render = validate_audio_render_report(audio_render_report, expected_count=int(expected_count))
+    if input_guard["source_evidence"] != candidate_export["source_evidence"]:
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            "input guard and candidate export source evidence mismatch"
+        )
+    if candidate_export["source_evidence"] != audio_render["source_evidence"]:
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            "candidate export and audio render source evidence mismatch"
+        )
+    candidate_rows = build_candidate_rows(
+        candidate_export=candidate_export,
+        audio_render=audio_render,
+        dead_air_threshold=float(dead_air_threshold),
+    )
+    dead_air_values = [_float(item["dead_air_ratio"]) for item in candidate_rows]
+    dead_air_failure_count = sum(1 for item in candidate_rows if bool(item["dead_air_failure"]))
+    repair_required = dead_air_failure_count > 0
+    next_boundary = REPAIR_NEXT_BOUNDARY if repair_required else CURRENT_EVIDENCE_NEXT_BOUNDARY
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundaries": {
+            "input_guard": input_guard["boundary"],
+            "candidate_export": candidate_export["boundary"],
+            "audio_render": audio_render["boundary"],
+        },
+        "source_evidence": input_guard["source_evidence"],
+        "objective_summary": {
+            "model_conditioned_technical_path_ready": True,
+            "candidate_count": int(len(candidate_rows)),
+            "exported_candidate_count": _int(candidate_export["exported_candidate_count"]),
+            "rendered_audio_file_count": _int(audio_render["rendered_audio_file_count"]),
+            "technical_wav_validation": bool(audio_render["technical_wav_validation"]),
+            "dead_air_threshold": float(dead_air_threshold),
+            "dead_air_failure_count": int(dead_air_failure_count),
+            "all_candidates_dead_air_failure": dead_air_failure_count == len(candidate_rows),
+            "dead_air_min": min(dead_air_values) if dead_air_values else 0.0,
+            "dead_air_max": max(dead_air_values) if dead_air_values else 0.0,
+            "best_note_count": _int(candidate_export["best_note_count"]),
+            "best_unique_pitch_count": _int(candidate_export["best_unique_pitch_count"]),
+            "validated_review_input_present": bool(input_guard["validated_review_input_present"]),
+            "preference_fill_allowed": bool(input_guard["preference_fill_allowed"]),
+            "dead_air_timing_repair_required": bool(repair_required),
+            "current_evidence_consolidation_ready": not bool(repair_required),
+        },
+        "candidate_reviews": candidate_rows,
+        "readiness": {
+            "boundary": BOUNDARY,
+            "objective_only_next_decision_completed": True,
+            "model_conditioned_technical_path_ready": True,
+            "dead_air_timing_repair_required": bool(repair_required),
+            "current_evidence_consolidation_ready": not bool(repair_required),
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": next_boundary,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": (
+                "model-conditioned ranked MIDI/WAV technical path is ready; dead-air objective risk requires repair"
+                if repair_required
+                else "model-conditioned ranked MIDI/WAV technical path has no dead-air repair trigger"
+            ),
+        },
+        "not_proven": [
+            "listening_review_completed",
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "audio_rendered_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair decision"
+            if repair_required
+            else "Stage B MIDI-to-solo MVP current evidence consolidation"
+        ),
+    }
+
+
+def validate_objective_next_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_objective_decision: bool,
+    require_repair_required: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("objective_summary"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError("unexpected next boundary")
+    if require_objective_decision and not bool(readiness.get("objective_only_next_decision_completed", False)):
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            "objective decision completion required"
+        )
+    if require_repair_required and not bool(summary.get("dead_air_timing_repair_required", False)):
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            "dead-air timing repair should be required"
+        )
+    if bool(summary.get("preference_fill_allowed", True)):
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            "preference fill must remain blocked"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloModelConditionedInputPathObjectiveNextError(
+            "critical user input should not be required"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="objective-next readiness")
+    return {
+        "boundary": boundary,
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "model_conditioned_technical_path_ready": bool(
+            summary.get("model_conditioned_technical_path_ready", False)
+        ),
+        "candidate_count": _int(summary.get("candidate_count")),
+        "exported_candidate_count": _int(summary.get("exported_candidate_count")),
+        "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
+        "technical_wav_validation": bool(summary.get("technical_wav_validation", False)),
+        "dead_air_threshold": _float(summary.get("dead_air_threshold")),
+        "dead_air_failure_count": _int(summary.get("dead_air_failure_count")),
+        "all_candidates_dead_air_failure": bool(summary.get("all_candidates_dead_air_failure", False)),
+        "dead_air_min": _float(summary.get("dead_air_min")),
+        "dead_air_max": _float(summary.get("dead_air_max")),
+        "validated_review_input_present": bool(summary.get("validated_review_input_present", True)),
+        "preference_fill_allowed": bool(summary.get("preference_fill_allowed", True)),
+        "dead_air_timing_repair_required": bool(summary.get("dead_air_timing_repair_required", False)),
+        "current_evidence_consolidation_ready": bool(
+            summary.get("current_evidence_consolidation_ready", True)
+        ),
+        "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["objective_summary"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    source = report["source_evidence"]
+    lines = [
+        "# Stage B MIDI-to-Solo Model-Conditioned Input Path Objective-Only Next Decision",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- model-conditioned technical path ready: `{_bool_token(summary['model_conditioned_technical_path_ready'])}`",
+        f"- candidate / exported / rendered: `{summary['candidate_count']} / {summary['exported_candidate_count']} / {summary['rendered_audio_file_count']}`",
+        f"- technical WAV validation: `{_bool_token(summary['technical_wav_validation'])}`",
+        f"- dead-air threshold: `{summary['dead_air_threshold']:.4f}`",
+        f"- dead-air failure count: `{summary['dead_air_failure_count']}`",
+        f"- dead-air min / max: `{summary['dead_air_min']:.4f} / {summary['dead_air_max']:.4f}`",
+        f"- dead-air timing repair required: `{_bool_token(summary['dead_air_timing_repair_required'])}`",
+        f"- current evidence consolidation ready: `{_bool_token(summary['current_evidence_consolidation_ready'])}`",
+        f"- preference fill allowed: `{_bool_token(summary['preference_fill_allowed'])}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Source Evidence",
+        "",
+        f"- phrase-bank CLI technical path completed: `{_bool_token(source['phrase_bank_cli_technical_path_completed'])}`",
+        f"- CLI candidate / rendered WAV: `{source['cli_candidate_count']}` / `{source['cli_rendered_audio_file_count']}`",
+        f"- CLI input context bars: `{source['cli_input_context_bars']}`",
+        f"- CLI preference fill allowed: `{_bool_token(source['cli_preference_fill_allowed'])}`",
+        "",
+        "## Candidate Review",
+        "",
+    ]
+    for item in report["candidate_reviews"]:
+        lines.extend(
+            [
+                f"### Rank {item['rank']}",
+                "",
+                f"- seed: `{item['sample_seed']}`",
+                f"- MIDI: `{item['midi_path']}`",
+                f"- WAV: `{item['wav_path']}`",
+                f"- notes / unique pitches / max simultaneous: `{item['note_count']} / {item['unique_pitch_count']} / {item['max_simultaneous_notes']}`",
+                f"- chord-tone / dead-air / phrase coverage: `{item['chord_tone_ratio']:.4f} / {item['dead_air_ratio']:.4f} / {item['phrase_coverage_ratio']:.4f}`",
+                f"- position span / postprocess removal: `{item['position_span_ratio']:.4f} / {item['postprocess_removal_ratio']:.4f}`",
+                f"- dead-air failure: `{_bool_token(item['dead_air_failure'])}`",
+                f"- WAV duration / sample rate / sha256 prefix: `{item['wav_duration_seconds']:.3f}s / {item['wav_sample_rate']} / {item['wav_sha256_prefix']}`",
+                "",
+            ]
+        )
+    lines.extend(
+        [
+            "## Decision",
+            "",
+            f"- auto progress allowed: `{_bool_token(decision['auto_progress_allowed'])}`",
+            f"- critical user input required: `{_bool_token(decision['critical_user_input_required'])}`",
+            f"- reason: `{decision['reason']}`",
+            f"- next recommended issue: `{report['next_recommended_issue']}`",
+            "",
+            "## Claim Boundary",
+            "",
+        ]
+    )
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Decide model-conditioned input-path objective-only next step"
+    )
+    parser.add_argument("--input_guard_report", type=str, required=True)
+    parser.add_argument("--candidate_export_report", type=str, required=True)
+    parser.add_argument("--audio_render_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=686)
+    parser.add_argument("--expected_count", type=int, default=3)
+    parser.add_argument("--dead_air_threshold", type=float, default=0.5)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_objective_decision", action="store_true")
+    parser.add_argument("--require_repair_required", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_objective_next_report(
+        input_guard_report=read_json(Path(args.input_guard_report)),
+        candidate_export_report=read_json(Path(args.candidate_export_report)),
+        audio_render_report=read_json(Path(args.audio_render_report)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+        expected_count=int(args.expected_count),
+        dead_air_threshold=float(args.dead_air_threshold),
+    )
+    summary = validate_objective_next_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_objective_decision=bool(args.require_objective_decision),
+        require_repair_required=bool(args.require_repair_required),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir / "stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir / "stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_objective_next.py
+++ b/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_objective_next.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.decide_stage_b_midi_to_solo_model_conditioned_input_path_objective_next import (
+    BOUNDARY,
+    CURRENT_EVIDENCE_NEXT_BOUNDARY,
+    REPAIR_NEXT_BOUNDARY,
+    StageBMidiToSoloModelConditionedInputPathObjectiveNextError,
+    build_objective_next_report,
+    validate_objective_next_report,
+)
+from scripts.export_stage_b_midi_to_solo_model_conditioned_input_path_candidates import (
+    BOUNDARY as CANDIDATE_EXPORT_BOUNDARY,
+)
+from scripts.guard_stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input import (
+    BOUNDARY as INPUT_GUARD_BOUNDARY,
+    OBJECTIVE_NEXT_BOUNDARY as INPUT_GUARD_NEXT_BOUNDARY,
+)
+from scripts.render_stage_b_midi_to_solo_model_conditioned_input_path_audio import (
+    BOUNDARY as AUDIO_RENDER_BOUNDARY,
+)
+
+
+SOURCE_EVIDENCE = {
+    "phrase_bank_cli_technical_path_completed": True,
+    "cli_candidate_count": 3,
+    "cli_rendered_audio_file_count": 3,
+    "cli_input_context_bars": 228,
+    "cli_preference_fill_allowed": False,
+}
+
+
+def input_guard(*, preference_fill_allowed: bool = False, quality_claim: bool = False) -> dict:
+    return {
+        "boundary": INPUT_GUARD_BOUNDARY,
+        "guard_result": {
+            "validated_review_input_present": False,
+            "preference_fill_allowed": preference_fill_allowed,
+            "review_item_count": 3,
+            "required_input_field_count": 4,
+            "source_evidence": dict(SOURCE_EVIDENCE),
+        },
+        "readiness": {
+            "listening_review_input_guard_completed": True,
+            "human_audio_preference_claimed": quality_claim,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": INPUT_GUARD_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+def candidate_export(*, dead_air: float = 0.6522) -> dict:
+    rows = [
+        {
+            "rank": index,
+            "sample_index": index,
+            "sample_seed": 496 + index,
+            "export_midi_path": f"midi/rank_{index:02d}.mid",
+            "note_count": 24,
+            "unique_pitch_count": 20,
+            "max_simultaneous_notes": 1,
+            "chord_tone_ratio": 0.6,
+            "dead_air_ratio": dead_air,
+            "phrase_coverage_ratio": 0.96,
+            "position_span_ratio": 0.94,
+            "postprocess_removal_ratio": 0.0,
+        }
+        for index in range(1, 4)
+    ]
+    return {
+        "boundary": CANDIDATE_EXPORT_BOUNDARY,
+        "probe_source": dict(SOURCE_EVIDENCE),
+        "top_candidates": rows,
+        "summary": {
+            "exported_candidate_count": 3,
+            "best_note_count": 24,
+            "best_unique_pitch_count": 20,
+            "best_dead_air_ratio": dead_air,
+        },
+        "readiness": {
+            "model_conditioned_input_path_candidate_export_completed": True,
+            "ranked_midi_candidates_exported": True,
+            "model_conditioned_ranked_input_path_contract_matched": True,
+            "fallback_replacement_candidate_export_ready": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+    }
+
+
+def audio_render(*, dead_air: float = 0.6522) -> dict:
+    return {
+        "source_boundary": CANDIDATE_EXPORT_BOUNDARY,
+        "candidate_export_source": dict(SOURCE_EVIDENCE),
+        "audio_render_boundary": {
+            "boundary": AUDIO_RENDER_BOUNDARY,
+            "render_attempted": True,
+            "rendered_audio_file_count": 3,
+            "technical_wav_validation": True,
+            "model_conditioned_ranked_audio_render_completed": True,
+            "fallback_replacement_candidate_export_ready": True,
+            "fallback_replacement_technical_path_ready": True,
+            "fallback_replacement_ready": True,
+            "audio_rendered_quality_claimed": False,
+            "human_audio_preference_claimed": False,
+            "musical_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+        },
+        "decision": {
+            "critical_user_input_required": False,
+        },
+        "rendered_audio_files": [
+            {
+                "rank": index,
+                "sample_index": index,
+                "sample_seed": 496 + index,
+                "source_midi_path": f"midi/rank_{index:02d}.mid",
+                "source_note_count": 24,
+                "source_unique_pitch_count": 20,
+                "source_chord_tone_ratio": 0.6,
+                "source_dead_air_ratio": dead_air,
+                "wav_file": {
+                    "path": f"audio/rank_{index:02d}.wav",
+                    "duration_seconds": 20.0,
+                    "sample_rate": 44100,
+                    "sha256": f"hash{index}",
+                },
+            }
+            for index in range(1, 4)
+        ],
+    }
+
+
+class StageBMidiToSoloModelConditionedInputPathObjectiveNextTest(unittest.TestCase):
+    def test_routes_to_repair_when_dead_air_threshold_fails(self) -> None:
+        report = build_objective_next_report(
+            input_guard_report=input_guard(),
+            candidate_export_report=candidate_export(),
+            audio_render_report=audio_render(),
+            output_dir="out",
+            issue_number=686,
+            expected_count=3,
+            dead_air_threshold=0.5,
+        )
+        summary = validate_objective_next_report(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=REPAIR_NEXT_BOUNDARY,
+            require_objective_decision=True,
+            require_repair_required=True,
+            require_no_quality_claim=True,
+        )
+
+        self.assertTrue(summary["model_conditioned_technical_path_ready"])
+        self.assertEqual(summary["dead_air_failure_count"], 3)
+        self.assertTrue(summary["all_candidates_dead_air_failure"])
+        self.assertTrue(summary["dead_air_timing_repair_required"])
+        self.assertFalse(summary["current_evidence_consolidation_ready"])
+        self.assertFalse(summary["preference_fill_allowed"])
+
+    def test_routes_to_current_evidence_when_dead_air_threshold_passes(self) -> None:
+        report = build_objective_next_report(
+            input_guard_report=input_guard(),
+            candidate_export_report=candidate_export(dead_air=0.2),
+            audio_render_report=audio_render(dead_air=0.2),
+            output_dir="out",
+            issue_number=686,
+            expected_count=3,
+            dead_air_threshold=0.5,
+        )
+        summary = validate_objective_next_report(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=CURRENT_EVIDENCE_NEXT_BOUNDARY,
+            require_objective_decision=True,
+            require_repair_required=False,
+            require_no_quality_claim=True,
+        )
+
+        self.assertFalse(summary["dead_air_timing_repair_required"])
+        self.assertTrue(summary["current_evidence_consolidation_ready"])
+
+    def test_rejects_preference_fill_allowed(self) -> None:
+        with self.assertRaises(StageBMidiToSoloModelConditionedInputPathObjectiveNextError):
+            build_objective_next_report(
+                input_guard_report=input_guard(preference_fill_allowed=True),
+                candidate_export_report=candidate_export(),
+                audio_render_report=audio_render(),
+                output_dir="out",
+                issue_number=686,
+                expected_count=3,
+                dead_air_threshold=0.5,
+            )
+
+    def test_rejects_upstream_quality_claim(self) -> None:
+        with self.assertRaises(StageBMidiToSoloModelConditionedInputPathObjectiveNextError):
+            build_objective_next_report(
+                input_guard_report=input_guard(quality_claim=True),
+                candidate_export_report=candidate_export(),
+                audio_render_report=audio_render(),
+                output_dir="out",
+                issue_number=686,
+                expected_count=3,
+                dead_air_threshold=0.5,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- model-conditioned input path objective-only next decision 추가
- listening review input pending 상태의 자동 진행 경계 정의
- ranked MIDI/WAV technical path와 dead-air objective risk 분리
- dead-air timing repair decision 라우팅

## Context

- #684 input guard 결과, validated review input 없음
- review item count: `3`
- preference fill allowed: `false`
- model-conditioned ranked MIDI/WAV technical path ready
- candidate / exported / rendered: `3 / 3 / 3`
- technical WAV validation: `true`
- dead-air threshold: `0.5000`
- dead-air failure count: `3`
- dead-air min / max: `0.6522 / 0.6522`
- current evidence consolidation ready: `false`
- human/audio preference, MIDI-to-solo musical quality claim 제외
- 현재 문제 지점: 기술 경로 ready와 음악 품질 ready의 분리 필요
- 이번 검토 대상: objective-only next decision, dead-air/timing repair 필요 여부, 다음 repair boundary

## Scope

- `decide_stage_b_midi_to_solo_model_conditioned_input_path_objective_next.py` 추가
- unit test 추가
- `agent_harness.sh` mode 추가
- generated objective decision doc 추가
- handoff/status docs 최신 경계 갱신

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_objective_next`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_objective_next.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-objective-next`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- `git diff -- . | rg -n 'Codex|codex|코덱스'` → no matches\n\n## Risk\n\n- human/audio preference 미기록\n- MIDI-to-solo musical quality claim 제외 유지\n- 다음 경계: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision`\n\nCloses #686

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added objective next-decision boundary for model-conditioned input path, evaluating dead-air metrics and determining timing repair requirements.

* **Documentation**
  * Updated workflow records and decision logs with latest objective decision results and corresponding next boundary routing.

* **Tests**
  * Added verification tests for new objective decision routing logic and upstream condition validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->