### PR TITLE
Stage B MIDI-to-solo model-conditioned input path dead-air timing repair decision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #686, Stage B MIDI-to-solo model-conditioned input path objective-only next decision.
+- Latest functional issue completed: Issue #688, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair decision.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path dead-air timing repair decision.
+- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path dead-air timing repair probe.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1108,6 +1108,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-
 ```
 
 This harness selects the next model-conditioned input-path boundary from objective MIDI/WAV evidence only.
+
+For Stage B MIDI-to-solo model-conditioned input path dead-air timing repair decision changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-decision
+```
+
+This harness defines the dead-air/timing repair target and guardrails after objective-only evidence.
 
 For Stage B MIDI-to-solo phrase-bank retrieval baseline changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`
+- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -30,6 +30,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned objective-only next decision completed: `true`
 - model-conditioned dead-air failure count: `3 / 3`
 - model-conditioned dead-air timing repair required: `true`
+- model-conditioned dead-air timing repair decision completed: `true`
+- model-conditioned target dead-air max: `0.3500`
+- model-conditioned required dead-air gain min: `0.3022`
 - phrase-bank retrieval baseline completed: `true`
 - phrase-bank source records / motifs: `56 / 803`
 - phrase-bank exported / qualified MIDI candidates: `3 / 3`
@@ -69,7 +72,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - MVP completion audit completed: `true`
 - quality gap decision completed: `true`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -274,6 +277,22 @@ Model-conditioned input path objective-only next decision.
 - dead-air timing repair required: `true`
 - current evidence consolidation ready: `false`
 - preference fill allowed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+Model-conditioned input path dead-air timing repair decision.
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe`
+- selected target: `dead_air_timing_continuity`
+- repair probe required: `true`
+- source dead-air failure count: `3`
+- source dead-air min / max: `0.6522 / 0.6522`
+- target dead-air max: `0.3500`
+- required dead-air gain min: `0.3022`
+- strategy: `timing_gap_fill_and_duration_compaction`
+- max postprocess removal ratio: `0.2500`
 - human/audio preference claimed: `false`
 - MIDI-to-solo musical quality claimed: `false`
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -403,6 +403,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo model-conditioned input path listening review package: package ready `true`, review items `3`, validated input `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard`
 - MIDI-to-solo model-conditioned input path listening review input guard: validated input `false`, preference fill `false`, review items `3`, required input fields `4`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`
 - MIDI-to-solo model-conditioned input path objective-only next decision: technical path `true`, dead-air failure `3/3`, repair required `true`, current evidence consolidation `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision`
+- MIDI-to-solo model-conditioned input path dead-air timing repair decision: target `dead_air_timing_continuity`, target dead-air max `0.3500`, required gain `0.3022`, repair probe required `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe`
 - model-core portfolio bullet refresh: resume bullet `6`, short bullet `3`, generic base checkpoint repeatability `9/9/9`, unsupported claim guard 유지
 - Muzig application wording refresh: resume project bullet `5`, short bullet `3`, 자기소개 section `3`, AI 음악 실험/검증 claim만 사용
 - Muzig application final review package: long bullet `5`, short bullet `3`, 자기소개 paragraph `3`, 지원 동기 paragraph `2`, 최종 claim check 포함
@@ -478,6 +479,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - Stage B MIDI-to-solo model-conditioned input path listening review package: review item count `3`, validated review input `false`, human/audio preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_listening_review_input_guard`
 - Stage B MIDI-to-solo model-conditioned input path listening review input guard: review item count `3`, validated review input `false`, preference fill allowed `false`, CLI technical evidence `3/3/228`, human/audio preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`
 - Stage B MIDI-to-solo model-conditioned input path objective-only next decision: candidate/export/render `3/3/3`, dead-air failure `3`, dead-air range `0.6522/0.6522`, repair required `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision`
+- Stage B MIDI-to-solo model-conditioned input path dead-air timing repair decision: source dead-air failure `3`, target dead-air max `0.3500`, required gain `0.3022`, guardrail max postprocess removal `0.2500`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe`
 - Stage B MIDI-to-solo controlled scale checkpoint dead-air repeatability temperature guard audio review package: candidate/rendered `3/3`, sample rate `44100`, duration `6.747s-6.861s`, technical validation `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_dead_air_repeatability_temperature_guard_listening_review`
 - Stage B MIDI-to-solo controlled scale checkpoint dead-air repeatability temperature guard listening review: candidate/rendered `3/3`, validated review input `false`, pending fields `4/3/9`, preference fill `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_dead_air_repeatability_temperature_guard_objective_only_next_decision`
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
@@ -3233,6 +3235,41 @@ Issue #686은 Issue #684 input guard와 model-conditioned candidate/audio eviden
 다음 작업:
 
 - `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair decision`
+
+## 9.35 Stage B MIDI-to-solo model-conditioned input path dead-air timing repair decision
+
+Issue #688은 Issue #686 objective-only next decision 결과를 source로 사용해 dead-air/timing repair target과 guardrail을 정의한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe`
+- selected target: `dead_air_timing_continuity`
+- repair probe required: `true`
+- source dead-air failure count: `3`
+- source dead-air min / max: `0.6522 / 0.6522`
+- target dead-air max: `0.3500`
+- required dead-air gain min: `0.3022`
+- strategy: `timing_gap_fill_and_duration_compaction`
+- max postprocess removal ratio: `0.2500`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- selected candidate 3개 모두 dead-air threshold 초과.
+- 다음 경계에서 timing gap fill과 duration compaction repair probe 필요.
+- repair success와 musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-decision`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair probe`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #686, Stage B MIDI-to-solo model-conditioned input path objective-only next decision
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair decision`
+- latest functional result: Issue #688, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair decision
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair probe`
 
 현재 범위가 아닌 것:
 
@@ -60,6 +60,53 @@
 - model-conditioned input path listening review package 완료
 - model-conditioned input path review input pending 상태에서 preference fill 차단 완료
 - model-conditioned input path objective-only 기준 dead-air/timing repair 필요 판정
+- model-conditioned input path dead-air/timing repair target 정의 완료
+
+## Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Decision Result
+
+Issue #688은 Issue #686 objective-only next decision 결과를 source로 사용해 dead-air/timing repair target과 guardrail을 정의한 작업이다.
+
+변경:
+
+- model-conditioned input path dead-air timing repair decision script 추가
+- objective-only next decision report 검증
+- target dead-air max와 guardrail 정의
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_DECISION_2026-06-08.md`
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe`
+- selected target: `dead_air_timing_continuity`
+- repair probe required: `true`
+- source dead-air failure count: `3`
+- source dead-air min / max: `0.6522 / 0.6522`
+- target dead-air max: `0.3500`
+- required dead-air gain min: `0.3022`
+- strategy: `timing_gap_fill_and_duration_compaction`
+- max postprocess removal ratio: `0.2500`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- selected candidate 3개 모두 dead-air threshold 초과.
+- 다음 경계에서 timing gap fill과 duration compaction repair probe 필요.
+- repair success와 musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-decision`
+
+다음:
+
+- `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair probe`
 
 ## Stage B MIDI-to-Solo Model-Conditioned Input Path Objective-Only Next Decision Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_DECISION_2026-06-08.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_DECISION_2026-06-08.md
@@ -1,0 +1,50 @@
+# Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Decision
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe`
+- selected target: `dead_air_timing_continuity`
+- repair probe required: `true`
+- source dead-air failure count: `3`
+- source dead-air min / max: `0.6522 / 0.6522`
+- target dead-air max: `0.3500`
+- required dead-air gain min: `0.3022`
+- strategy: `timing_gap_fill_and_duration_compaction`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Source Objective Evidence
+
+- candidate / exported / rendered: `3 / 3 / 3`
+- technical WAV validation: `true`
+- validated review input present: `false`
+- preference fill allowed: `false`
+
+## Guardrails
+
+- min note count: `24`
+- min unique pitch count: `8`
+- max simultaneous notes: `1`
+- max postprocess removal ratio: `0.2500`
+- require ranked MIDI export: `true`
+- require technical WAV validation: `true`
+- require preference fill blocked: `true`
+
+## Decision
+
+- auto progress allowed: `true`
+- critical user input required: `false`
+- reason: `all selected model-conditioned candidates fail the dead-air threshold; repair probe target defined`
+- next recommended issue: `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair probe`
+
+## Claim Boundary
+
+- `dead_air_repair_success`
+- `listening_review_completed`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -246,6 +246,8 @@ Modes:
                 Block model-conditioned input-path preference fill while listening review input is pending.
   stage-b-midi-to-solo-model-conditioned-input-path-objective-next
                 Select the next model-conditioned input-path boundary from objective MIDI/WAV evidence only.
+  stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-decision
+                Decide the dead-air/timing repair target after model-conditioned objective evidence.
   stage-b-midi-to-solo-model-direct-generation-repair
                 Define the model-direct generation repair boundary from sequence budget evidence.
   stage-b-midi-to-solo-model-direct-sequence-budget-repair-smoke
@@ -6150,6 +6152,29 @@ run_stage_b_midi_to_solo_model_conditioned_input_path_objective_next() {
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision() {
+  local objective_next_run_id="${OBJECTIVE_NEXT_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision}"
+  local objective_next="outputs/stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision/${objective_next_run_id}/stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision.json"
+  if [[ ! -f "$objective_next" ]]; then
+    print_header "Stage B MIDI-to-solo model-conditioned input path objective-only next decision"
+    RUN_ID="$objective_next_run_id" run_stage_b_midi_to_solo_model_conditioned_input_path_objective_next
+  fi
+  print_header "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair decision"
+  "$PYTHON_BIN" scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision.py \
+    --run_id "$run_id" \
+    --objective_next_report "$objective_next" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_DECISION_2026-06-08.md \
+    --issue_number 688 \
+    --target_dead_air_max 0.35 \
+    --max_postprocess_removal_ratio 0.25 \
+    --expected_boundary stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision \
+    --expected_next_boundary stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe \
+    --require_decision_completed \
+    --require_repair_probe \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -7803,6 +7828,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-model-conditioned-input-path-objective-next)
     run_stage_b_midi_to_solo_model_conditioned_input_path_objective_next
+    ;;
+  stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-decision)
+    run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision.py
+++ b/scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision.py
@@ -1,0 +1,399 @@
+"""Decide model-conditioned input-path dead-air/timing repair target."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.decide_stage_b_midi_to_solo_model_conditioned_input_path_objective_next import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+    REPAIR_NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+class StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairDecisionError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe"
+SCHEMA_VERSION = "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision_v1"
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairDecisionError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_source_objective_next(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("objective_summary"))
+    if str(report.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairDecisionError(
+            "objective-only next decision boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairDecisionError(
+            "objective-only decision must route to dead-air timing repair decision"
+        )
+    if not bool(readiness.get("objective_only_next_decision_completed", False)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairDecisionError(
+            "objective-only decision completion required"
+        )
+    if not bool(readiness.get("dead_air_timing_repair_required", False)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairDecisionError(
+            "dead-air timing repair should be required"
+        )
+    if bool(readiness.get("current_evidence_consolidation_ready", True)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairDecisionError(
+            "current evidence consolidation should remain blocked"
+        )
+    if _int(summary.get("dead_air_failure_count")) <= 0:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairDecisionError(
+            "dead-air failure count required"
+        )
+    if not bool(summary.get("all_candidates_dead_air_failure", False)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairDecisionError(
+            "all selected candidates should fail the current dead-air threshold"
+        )
+    if bool(summary.get("preference_fill_allowed", True)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairDecisionError(
+            "preference fill must remain blocked"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairDecisionError(
+            "critical user input should not be required"
+        )
+    _require_no_quality_claim(readiness, label="objective-next readiness")
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "candidate_count": _int(summary.get("candidate_count")),
+        "exported_candidate_count": _int(summary.get("exported_candidate_count")),
+        "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
+        "technical_wav_validation": bool(summary.get("technical_wav_validation", False)),
+        "dead_air_threshold": _float(summary.get("dead_air_threshold")),
+        "dead_air_failure_count": _int(summary.get("dead_air_failure_count")),
+        "dead_air_min": _float(summary.get("dead_air_min")),
+        "dead_air_max": _float(summary.get("dead_air_max")),
+        "best_note_count": _int(summary.get("best_note_count")),
+        "best_unique_pitch_count": _int(summary.get("best_unique_pitch_count")),
+        "validated_review_input_present": bool(summary.get("validated_review_input_present", True)),
+        "preference_fill_allowed": bool(summary.get("preference_fill_allowed", True)),
+        "candidate_reviews": [_dict(item) for item in _list(report.get("candidate_reviews"))],
+    }
+
+
+def build_dead_air_timing_repair_decision_report(
+    *,
+    objective_next_report: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+    target_dead_air_max: float,
+    max_postprocess_removal_ratio: float,
+) -> dict[str, Any]:
+    source = validate_source_objective_next(objective_next_report)
+    source_dead_air_max = _float(source["dead_air_max"])
+    required_gain = max(0.0, source_dead_air_max - float(target_dead_air_max))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundary": source["boundary"],
+        "source_objective_summary": source,
+        "repair_target": {
+            "selected_target": "dead_air_timing_continuity",
+            "source_dead_air_failure_count": _int(source["dead_air_failure_count"]),
+            "source_dead_air_min": _float(source["dead_air_min"]),
+            "source_dead_air_max": source_dead_air_max,
+            "target_dead_air_max": float(target_dead_air_max),
+            "required_dead_air_gain_min": float(required_gain),
+            "strategy": "timing_gap_fill_and_duration_compaction",
+            "repair_probe_required": True,
+        },
+        "guardrails": {
+            "min_note_count": 24,
+            "min_unique_pitch_count": 8,
+            "max_simultaneous_notes": 1,
+            "max_postprocess_removal_ratio": float(max_postprocess_removal_ratio),
+            "require_ranked_midi_export": True,
+            "require_technical_wav_validation": True,
+            "require_preference_fill_blocked": True,
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "dead_air_timing_repair_decision_completed": True,
+            "repair_probe_required": True,
+            "model_conditioned_technical_path_ready": True,
+            "current_evidence_consolidation_ready": False,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "all selected model-conditioned candidates fail the dead-air threshold; repair probe target defined",
+        },
+        "not_proven": [
+            "dead_air_repair_success",
+            "listening_review_completed",
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "audio_rendered_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair probe",
+    }
+
+
+def validate_dead_air_timing_repair_decision_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_decision_completed: bool,
+    require_repair_probe: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    target = _dict(report.get("repair_target"))
+    guardrails = _dict(report.get("guardrails"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairDecisionError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairDecisionError(
+            "unexpected next boundary"
+        )
+    if require_decision_completed and not bool(
+        readiness.get("dead_air_timing_repair_decision_completed", False)
+    ):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairDecisionError(
+            "repair decision completion required"
+        )
+    if require_repair_probe and not bool(target.get("repair_probe_required", False)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairDecisionError(
+            "repair probe should be required"
+        )
+    if _float(target.get("required_dead_air_gain_min")) <= 0:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairDecisionError(
+            "required dead-air gain should be positive"
+        )
+    if not bool(guardrails.get("require_preference_fill_blocked", False)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairDecisionError(
+            "preference fill block guardrail required"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairDecisionError(
+            "critical user input should not be required"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="repair decision readiness")
+    return {
+        "boundary": boundary,
+        "source_boundary": str(report.get("source_boundary") or ""),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "dead_air_timing_repair_decision_completed": bool(
+            readiness.get("dead_air_timing_repair_decision_completed", False)
+        ),
+        "repair_probe_required": bool(target.get("repair_probe_required", False)),
+        "selected_target": str(target.get("selected_target") or ""),
+        "source_dead_air_failure_count": _int(target.get("source_dead_air_failure_count")),
+        "source_dead_air_max": _float(target.get("source_dead_air_max")),
+        "target_dead_air_max": _float(target.get("target_dead_air_max")),
+        "required_dead_air_gain_min": _float(target.get("required_dead_air_gain_min")),
+        "max_postprocess_removal_ratio": _float(guardrails.get("max_postprocess_removal_ratio")),
+        "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    target = report["repair_target"]
+    guardrails = report["guardrails"]
+    source = report["source_objective_summary"]
+    lines = [
+        "# Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Decision",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- source boundary: `{report['source_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- selected target: `{target['selected_target']}`",
+        f"- repair probe required: `{_bool_token(target['repair_probe_required'])}`",
+        f"- source dead-air failure count: `{target['source_dead_air_failure_count']}`",
+        f"- source dead-air min / max: `{target['source_dead_air_min']:.4f} / {target['source_dead_air_max']:.4f}`",
+        f"- target dead-air max: `{target['target_dead_air_max']:.4f}`",
+        f"- required dead-air gain min: `{target['required_dead_air_gain_min']:.4f}`",
+        f"- strategy: `{target['strategy']}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Source Objective Evidence",
+        "",
+        f"- candidate / exported / rendered: `{source['candidate_count']} / {source['exported_candidate_count']} / {source['rendered_audio_file_count']}`",
+        f"- technical WAV validation: `{_bool_token(source['technical_wav_validation'])}`",
+        f"- validated review input present: `{_bool_token(source['validated_review_input_present'])}`",
+        f"- preference fill allowed: `{_bool_token(source['preference_fill_allowed'])}`",
+        "",
+        "## Guardrails",
+        "",
+        f"- min note count: `{guardrails['min_note_count']}`",
+        f"- min unique pitch count: `{guardrails['min_unique_pitch_count']}`",
+        f"- max simultaneous notes: `{guardrails['max_simultaneous_notes']}`",
+        f"- max postprocess removal ratio: `{guardrails['max_postprocess_removal_ratio']:.4f}`",
+        f"- require ranked MIDI export: `{_bool_token(guardrails['require_ranked_midi_export'])}`",
+        f"- require technical WAV validation: `{_bool_token(guardrails['require_technical_wav_validation'])}`",
+        f"- require preference fill blocked: `{_bool_token(guardrails['require_preference_fill_blocked'])}`",
+        "",
+        "## Decision",
+        "",
+        f"- auto progress allowed: `{_bool_token(decision['auto_progress_allowed'])}`",
+        f"- critical user input required: `{_bool_token(decision['critical_user_input_required'])}`",
+        f"- reason: `{decision['reason']}`",
+        f"- next recommended issue: `{report['next_recommended_issue']}`",
+        "",
+        "## Claim Boundary",
+        "",
+    ]
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Decide model-conditioned input-path dead-air timing repair target"
+    )
+    parser.add_argument("--objective_next_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=688)
+    parser.add_argument("--target_dead_air_max", type=float, default=0.35)
+    parser.add_argument("--max_postprocess_removal_ratio", type=float, default=0.25)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_decision_completed", action="store_true")
+    parser.add_argument("--require_repair_probe", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_dead_air_timing_repair_decision_report(
+        objective_next_report=read_json(Path(args.objective_next_report)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+        target_dead_air_max=float(args.target_dead_air_max),
+        max_postprocess_removal_ratio=float(args.max_postprocess_removal_ratio),
+    )
+    summary = validate_dead_air_timing_repair_decision_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_decision_completed=bool(args.require_decision_completed),
+        require_repair_probe=bool(args.require_repair_probe),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision.py
+++ b/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairDecisionError,
+    build_dead_air_timing_repair_decision_report,
+    validate_dead_air_timing_repair_decision_report,
+)
+from scripts.decide_stage_b_midi_to_solo_model_conditioned_input_path_objective_next import (
+    BOUNDARY as SOURCE_BOUNDARY,
+    REPAIR_NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+def objective_next(
+    *,
+    repair_required: bool = True,
+    quality_claim: bool = False,
+) -> dict:
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "objective_summary": {
+            "candidate_count": 3,
+            "exported_candidate_count": 3,
+            "rendered_audio_file_count": 3,
+            "technical_wav_validation": True,
+            "dead_air_threshold": 0.5,
+            "dead_air_failure_count": 3 if repair_required else 0,
+            "all_candidates_dead_air_failure": repair_required,
+            "dead_air_min": 0.6522 if repair_required else 0.2,
+            "dead_air_max": 0.6522 if repair_required else 0.2,
+            "best_note_count": 24,
+            "best_unique_pitch_count": 20,
+            "validated_review_input_present": False,
+            "preference_fill_allowed": False,
+        },
+        "candidate_reviews": [
+            {
+                "rank": index,
+                "dead_air_ratio": 0.6522,
+            }
+            for index in range(1, 4)
+        ],
+        "readiness": {
+            "objective_only_next_decision_completed": True,
+            "dead_air_timing_repair_required": repair_required,
+            "current_evidence_consolidation_ready": not repair_required,
+            "human_audio_preference_claimed": quality_claim,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": SOURCE_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairDecisionTest(unittest.TestCase):
+    def test_defines_dead_air_timing_repair_target(self) -> None:
+        report = build_dead_air_timing_repair_decision_report(
+            objective_next_report=objective_next(),
+            output_dir="out",
+            issue_number=688,
+            target_dead_air_max=0.35,
+            max_postprocess_removal_ratio=0.25,
+        )
+        summary = validate_dead_air_timing_repair_decision_report(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=NEXT_BOUNDARY,
+            require_decision_completed=True,
+            require_repair_probe=True,
+            require_no_quality_claim=True,
+        )
+
+        self.assertTrue(summary["dead_air_timing_repair_decision_completed"])
+        self.assertTrue(summary["repair_probe_required"])
+        self.assertEqual(summary["selected_target"], "dead_air_timing_continuity")
+        self.assertEqual(summary["source_dead_air_failure_count"], 3)
+        self.assertGreater(summary["required_dead_air_gain_min"], 0.3)
+        self.assertFalse(summary["human_audio_preference_claimed"])
+
+    def test_rejects_source_without_repair_requirement(self) -> None:
+        with self.assertRaises(
+            StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairDecisionError
+        ):
+            build_dead_air_timing_repair_decision_report(
+                objective_next_report=objective_next(repair_required=False),
+                output_dir="out",
+                issue_number=688,
+                target_dead_air_max=0.35,
+                max_postprocess_removal_ratio=0.25,
+            )
+
+    def test_rejects_upstream_quality_claim(self) -> None:
+        with self.assertRaises(
+            StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairDecisionError
+        ):
+            build_dead_air_timing_repair_decision_report(
+                objective_next_report=objective_next(quality_claim=True),
+                output_dir="out",
+                issue_number=688,
+                target_dead_air_max=0.35,
+                max_postprocess_removal_ratio=0.25,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- model-conditioned input path dead-air/timing repair decision 추가
- objective-only next decision 결과의 repair target 정의
- target dead-air max, required gain, guardrail 기록
- 다음 dead-air timing repair probe boundary 연결

## Context

- #686 objective-only next decision 결과, model-conditioned technical path ready
- candidate / exported / rendered: `3 / 3 / 3`
- technical WAV validation: `true`
- dead-air failure count: `3`
- source dead-air min / max: `0.6522 / 0.6522`
- current evidence consolidation ready: `false`
- preference fill allowed: `false`
- human/audio preference, MIDI-to-solo musical quality claim 제외
- 현재 문제 지점: selected candidate 3개 모두 dead-air threshold 초과
- 이번 검토 대상: dead-air/timing repair target, guardrail, 다음 probe boundary

## Scope

- `decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision.py` 추가
- unit test 추가
- `agent_harness.sh` mode 추가
- generated repair decision doc 추가
- handoff/status docs 최신 경계 갱신

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-decision`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- `git diff -- . | rg -n 'Codex|codex|코덱스'` → no matches\n\n## Risk\n\n- actual repair probe 미실행\n- MIDI-to-solo musical quality claim 제외 유지\n- 다음 경계: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe`\n\nCloses #688