### PR TITLE
Stage B MIDI-to-solo model-conditioned input path dead-air timing repair probe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #688, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair decision.
+- Latest functional issue completed: Issue #690, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair probe.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path dead-air timing repair probe.
+- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path dead-air timing repair audio package.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1116,6 +1116,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-
 ```
 
 This harness defines the dead-air/timing repair target and guardrails after objective-only evidence.
+
+For Stage B MIDI-to-solo model-conditioned input path dead-air timing repair probe changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-probe
+```
+
+This harness repairs ranked model-conditioned MIDI candidate timing gaps and verifies objective dead-air guardrails without claiming musical quality.
 
 For Stage B MIDI-to-solo phrase-bank retrieval baseline changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision`
+- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -33,6 +33,11 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned dead-air timing repair decision completed: `true`
 - model-conditioned target dead-air max: `0.3500`
 - model-conditioned required dead-air gain min: `0.3022`
+- model-conditioned dead-air timing repair probe completed: `true`
+- model-conditioned repaired / passed candidates: `3 / 3`
+- model-conditioned dead-air max: `0.6522 -> 0.0000`
+- model-conditioned max added-note ratio: `0.9167`
+- model-conditioned max repaired interval: `62`
 - phrase-bank retrieval baseline completed: `true`
 - phrase-bank source records / motifs: `56 / 803`
 - phrase-bank exported / qualified MIDI candidates: `3 / 3`
@@ -72,7 +77,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - MVP completion audit completed: `true`
 - quality gap decision completed: `true`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -115,6 +120,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned ranked MIDI WAV render 가능
 - model-conditioned ranked MIDI/WAV technical replacement consolidation 가능
 - model-conditioned ranked MIDI/WAV listening review package 생성 가능
+- model-conditioned ranked MIDI 후보의 dead-air/timing repair probe 가능
 
 현재 README가 주장하지 않는 것.
 
@@ -293,6 +299,22 @@ Model-conditioned input path dead-air timing repair decision.
 - required dead-air gain min: `0.3022`
 - strategy: `timing_gap_fill_and_duration_compaction`
 - max postprocess removal ratio: `0.2500`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+Model-conditioned input path dead-air timing repair probe.
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package`
+- repaired / passed candidates: `3 / 3`
+- source dead-air max: `0.6522`
+- repaired dead-air max: `0.0000`
+- dead-air gain max: `0.6522`
+- target dead-air max: `0.3500`
+- max added-note ratio: `0.9167`
+- max postprocess removal ratio: `0.0000`
+- max repaired simultaneous notes: `1`
+- max repaired interval: `62`
 - human/audio preference claimed: `false`
 - MIDI-to-solo musical quality claimed: `false`
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -404,6 +404,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo model-conditioned input path listening review input guard: validated input `false`, preference fill `false`, review items `3`, required input fields `4`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`
 - MIDI-to-solo model-conditioned input path objective-only next decision: technical path `true`, dead-air failure `3/3`, repair required `true`, current evidence consolidation `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision`
 - MIDI-to-solo model-conditioned input path dead-air timing repair decision: target `dead_air_timing_continuity`, target dead-air max `0.3500`, required gain `0.3022`, repair probe required `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe`
+- MIDI-to-solo model-conditioned input path dead-air timing repair probe: repaired/pass `3/3`, dead-air max `0.6522 -> 0.0000`, max added-note ratio `0.9167`, max interval `62`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package`
 - model-core portfolio bullet refresh: resume bullet `6`, short bullet `3`, generic base checkpoint repeatability `9/9/9`, unsupported claim guard 유지
 - Muzig application wording refresh: resume project bullet `5`, short bullet `3`, 자기소개 section `3`, AI 음악 실험/검증 claim만 사용
 - Muzig application final review package: long bullet `5`, short bullet `3`, 자기소개 paragraph `3`, 지원 동기 paragraph `2`, 최종 claim check 포함
@@ -480,6 +481,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - Stage B MIDI-to-solo model-conditioned input path listening review input guard: review item count `3`, validated review input `false`, preference fill allowed `false`, CLI technical evidence `3/3/228`, human/audio preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_objective_only_next_decision`
 - Stage B MIDI-to-solo model-conditioned input path objective-only next decision: candidate/export/render `3/3/3`, dead-air failure `3`, dead-air range `0.6522/0.6522`, repair required `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision`
 - Stage B MIDI-to-solo model-conditioned input path dead-air timing repair decision: source dead-air failure `3`, target dead-air max `0.3500`, required gain `0.3022`, guardrail max postprocess removal `0.2500`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe`
+- Stage B MIDI-to-solo model-conditioned input path dead-air timing repair probe: repaired/pass `3/3`, dead-air max `0.6522 -> 0.0000`, removal ratio `0.0000`, added-note ratio `0.9167`, max simultaneous `1`, max interval `62`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package`
 - Stage B MIDI-to-solo controlled scale checkpoint dead-air repeatability temperature guard audio review package: candidate/rendered `3/3`, sample rate `44100`, duration `6.747s-6.861s`, technical validation `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_dead_air_repeatability_temperature_guard_listening_review`
 - Stage B MIDI-to-solo controlled scale checkpoint dead-air repeatability temperature guard listening review: candidate/rendered `3/3`, validated review input `false`, pending fields `4/3/9`, preference fill `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_dead_air_repeatability_temperature_guard_objective_only_next_decision`
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
@@ -3270,6 +3272,41 @@ Issue #688은 Issue #686 objective-only next decision 결과를 source로 사용
 다음 작업:
 
 - `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair probe`
+
+## 9.36 Stage B MIDI-to-solo model-conditioned input path dead-air timing repair probe
+
+Issue #690은 Issue #688 repair decision과 ranked MIDI candidate export 결과를 source로 사용해, model-conditioned 후보의 dead-air/timing gap repair를 검증한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package`
+- repaired / passed candidates: `3 / 3`
+- source dead-air max: `0.6522`
+- repaired dead-air max: `0.0000`
+- dead-air gain max: `0.6522`
+- target dead-air max: `0.3500`
+- max added-note ratio: `0.9167`
+- max postprocess removal ratio: `0.0000`
+- max repaired simultaneous notes: `1`
+- max repaired interval: `62`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- dead-air/timing objective target 통과.
+- repaired MIDI technical audio render 필요.
+- max repaired interval `62` 잔존. 음악적 품질 claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-probe`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair audio package`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #688, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair decision
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair probe`
+- latest functional result: Issue #690, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair probe
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair audio package`
 
 현재 범위가 아닌 것:
 
@@ -61,6 +61,53 @@
 - model-conditioned input path review input pending 상태에서 preference fill 차단 완료
 - model-conditioned input path objective-only 기준 dead-air/timing repair 필요 판정
 - model-conditioned input path dead-air/timing repair target 정의 완료
+- model-conditioned input path dead-air/timing repair probe 기준 repaired 후보 3개 objective target 통과
+
+## Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Probe Result
+
+Issue #690은 Issue #688 repair decision과 ranked MIDI candidate export 결과를 source로 사용해, model-conditioned 후보의 dead-air/timing gap repair를 검증한 작업이다.
+
+변경:
+
+- model-conditioned input path dead-air timing repair probe script 추가
+- exported ranked MIDI 3개 대상 timing gap fill 및 duration compaction 적용
+- note count, unique pitch count, max simultaneous notes, postprocess removal ratio guard 검증
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_PROBE_2026-06-08.md`
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package`
+- repaired / passed candidates: `3 / 3`
+- source dead-air max: `0.6522`
+- repaired dead-air max: `0.0000`
+- dead-air gain max: `0.6522`
+- target dead-air max: `0.3500`
+- max added-note ratio: `0.9167`
+- max postprocess removal ratio: `0.0000`
+- max repaired simultaneous notes: `1`
+- max repaired interval: `62`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- dead-air/timing objective target 통과.
+- repaired MIDI technical audio render 필요.
+- max repaired interval `62` 잔존. 음악적 품질 claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-probe`
+
+다음:
+
+- `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair audio package`
 
 ## Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Decision Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_PROBE_2026-06-08.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_PROBE_2026-06-08.md
@@ -1,0 +1,53 @@
+# Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Probe
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package`
+- repair passed: `true`
+- source candidate count: `3`
+- repaired candidate count: `3`
+- repaired pass count: `3`
+- source dead-air max: `0.6522`
+- repaired dead-air max: `0.0000`
+- dead-air gain max: `0.6522`
+- max added-note ratio: `0.9167`
+- max postprocess removal ratio: `0.0000`
+- max repaired simultaneous notes: `1`
+- max repaired interval: `62`
+
+## Repair Config
+
+- strategy: `timing_gap_fill_and_duration_compaction`
+- dead-air threshold seconds: `0.5000`
+- max start gap seconds: `0.4900`
+- fill note duration seconds: `0.1800`
+- preferred fill pitch range: `48`-`88`
+
+## Guardrails
+
+- target dead-air max: `0.3500`
+- required dead-air gain min: `0.3022`
+- min note count: `24`
+- min unique pitch count: `8`
+- max simultaneous notes: `1`
+- max postprocess removal ratio: `0.2500`
+
+## Repaired MIDI
+
+- rank `1` sample `1`: `outputs/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe/harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe/midi/rank_01_sample_01_dead_air_timing_repair.mid`, dead-air `0.6522` -> `0.0000`, notes `24` -> `46`, added ratio `0.9167`, pass `true`
+- rank `2` sample `2`: `outputs/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe/harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe/midi/rank_02_sample_02_dead_air_timing_repair.mid`, dead-air `0.6522` -> `0.0000`, notes `24` -> `46`, added ratio `0.9167`, pass `true`
+- rank `3` sample `3`: `outputs/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe/harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe/midi/rank_03_sample_03_dead_air_timing_repair.mid`, dead-air `0.6522` -> `0.0000`, notes `24` -> `46`, added ratio `0.9167`, pass `true`
+
+## Claim Boundary
+
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- audio-rendered quality claimed: `false`
+- model checkpoint generation quality claimed: `false`
+
+## Decision
+
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair audio package`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -248,6 +248,8 @@ Modes:
                 Select the next model-conditioned input-path boundary from objective MIDI/WAV evidence only.
   stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-decision
                 Decide the dead-air/timing repair target after model-conditioned objective evidence.
+  stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-probe
+                Repair dead-air/timing gaps in ranked model-conditioned MIDI candidates.
   stage-b-midi-to-solo-model-direct-generation-repair
                 Define the model-direct generation repair boundary from sequence budget evidence.
   stage-b-midi-to-solo-model-direct-sequence-budget-repair-smoke
@@ -6175,6 +6177,40 @@ run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_dec
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe() {
+  local decision_run_id="${DECISION_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision}"
+  local candidate_export_run_id="${CANDIDATE_EXPORT_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_candidate_export}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe}"
+  local decision_report="outputs/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision/${decision_run_id}/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision.json"
+  local candidate_export="outputs/stage_b_midi_to_solo_model_conditioned_input_path_candidate_export/${candidate_export_run_id}/stage_b_midi_to_solo_model_conditioned_input_path_candidate_export.json"
+  if [[ ! -f "$decision_report" ]]; then
+    print_header "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair decision"
+    RUN_ID="$decision_run_id" run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision
+  fi
+  if [[ ! -f "$candidate_export" ]]; then
+    print_header "Stage B MIDI-to-solo model-conditioned input path candidate export"
+    RUN_ID="$candidate_export_run_id" run_stage_b_midi_to_solo_model_conditioned_input_path_candidate_export
+  fi
+  print_header "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair probe"
+  "$PYTHON_BIN" scripts/run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe.py \
+    --run_id "$run_id" \
+    --repair_decision_report "$decision_report" \
+    --candidate_export_report "$candidate_export" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_PROBE_2026-06-08.md \
+    --issue_number 690 \
+    --min_repaired_candidates 3 \
+    --dead_air_threshold_seconds 0.5 \
+    --max_start_gap_seconds 0.49 \
+    --fill_note_duration_seconds 0.18 \
+    --min_note_duration_seconds 0.04 \
+    --preferred_pitch_min 48 \
+    --preferred_pitch_max 88 \
+    --expected_boundary stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe \
+    --expected_next_boundary stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package \
+    --require_repair_passed \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -7831,6 +7867,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-decision)
     run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision
+    ;;
+  stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-probe)
+    run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe.py
+++ b/scripts/run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe.py
@@ -1,0 +1,855 @@
+"""Run dead-air/timing repair probe for model-conditioned input-path MIDI candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pretty_midi
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision import (  # noqa: E402
+    BOUNDARY as DECISION_BOUNDARY,
+    NEXT_BOUNDARY as DECISION_NEXT_BOUNDARY,
+)
+from scripts.diagnose_stage_b_midi_to_solo_model_direct_phrase_quality import (  # noqa: E402
+    note_metrics_for_path,
+)
+from scripts.export_stage_b_midi_to_solo_model_conditioned_input_path_candidates import (  # noqa: E402
+    BOUNDARY as CANDIDATE_EXPORT_BOUNDARY,
+)
+
+
+class StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError(
+    ValueError
+):
+    pass
+
+
+BOUNDARY = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_probe"
+)
+NEXT_BOUNDARY = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_audio_package"
+)
+FAIL_NEXT_BOUNDARY = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_followup"
+)
+SCHEMA_VERSION = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_probe_v1"
+)
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def max_simultaneous_notes(notes: list[pretty_midi.Note]) -> int:
+    events: list[tuple[float, int]] = []
+    for note in notes:
+        events.append((float(note.start), 1))
+        events.append((float(note.end), -1))
+    active = 0
+    maximum = 0
+    for _time, delta in sorted(events, key=lambda item: (item[0], item[1])):
+        active = max(0, active + delta)
+        maximum = max(maximum, active)
+    return maximum
+
+
+def load_midi_notes(path: str | Path) -> list[pretty_midi.Note]:
+    midi = pretty_midi.PrettyMIDI(str(path))
+    notes: list[pretty_midi.Note] = []
+    for instrument in midi.instruments:
+        if not instrument.is_drum:
+            notes.extend(instrument.notes)
+    return sorted(notes, key=lambda note: (float(note.start), int(note.pitch), float(note.end)))
+
+
+def objective_metrics_for_path(
+    path: str | Path,
+    *,
+    dead_air_threshold_seconds: float,
+) -> dict[str, Any]:
+    metrics = dict(
+        note_metrics_for_path(
+            path,
+            dead_air_threshold_seconds=float(dead_air_threshold_seconds),
+        )
+    )
+    notes = load_midi_notes(path)
+    metrics["max_simultaneous_notes"] = max_simultaneous_notes(notes)
+    return metrics
+
+
+def map_pitch_to_preferred_range(
+    pitch: int,
+    *,
+    preferred_pitch_min: int,
+    preferred_pitch_max: int,
+) -> int:
+    mapped = int(pitch)
+    while mapped < int(preferred_pitch_min):
+        mapped += 12
+    while mapped > int(preferred_pitch_max):
+        mapped -= 12
+    return mapped
+
+
+def repair_candidate_midi(
+    source_midi_path: str | Path,
+    repaired_midi_path: str | Path,
+    *,
+    bpm: float,
+    max_start_gap_seconds: float,
+    min_note_duration_seconds: float,
+    fill_note_duration_seconds: float,
+    preferred_pitch_min: int,
+    preferred_pitch_max: int,
+) -> dict[str, Any]:
+    source_midi_path = Path(source_midi_path)
+    repaired_midi_path = Path(repaired_midi_path)
+    source = pretty_midi.PrettyMIDI(str(source_midi_path))
+    source_notes: list[pretty_midi.Note] = []
+    for instrument in source.instruments:
+        if not instrument.is_drum:
+            source_notes.extend(instrument.notes)
+    source_notes.sort(key=lambda note: (float(note.start), int(note.pitch), float(note.end)))
+    if not source_notes:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError(
+            f"source MIDI has no notes: {source_midi_path}"
+        )
+
+    repaired = pretty_midi.PrettyMIDI(initial_tempo=float(bpm))
+    program = 0
+    for instrument in source.instruments:
+        if not instrument.is_drum:
+            program = int(instrument.program)
+            break
+    repaired_instrument = pretty_midi.Instrument(
+        program=program,
+        is_drum=False,
+        name="dead_air_timing_repaired_solo",
+    )
+
+    repaired_notes: list[pretty_midi.Note] = [
+        pretty_midi.Note(
+            velocity=max(1, min(127, int(note.velocity or 80))),
+            pitch=int(note.pitch),
+            start=float(note.start),
+            end=float(note.end),
+        )
+        for note in source_notes
+        if float(note.end) > float(note.start)
+    ]
+    added_notes: list[pretty_midi.Note] = []
+    for previous_note, next_note in zip(source_notes, source_notes[1:]):
+        gap = float(next_note.start) - float(previous_note.start)
+        if gap <= float(max_start_gap_seconds):
+            continue
+        insert_count = max(1, int(math.ceil(gap / float(max_start_gap_seconds))) - 1)
+        for insert_index in range(1, insert_count + 1):
+            fraction = float(insert_index) / float(insert_count + 1)
+            start = float(previous_note.start) + (gap * fraction)
+            if start <= float(previous_note.start) + 0.03:
+                continue
+            if start >= float(next_note.start) - 0.03:
+                continue
+            interpolated_pitch = round(
+                int(previous_note.pitch)
+                + ((int(next_note.pitch) - int(previous_note.pitch)) * fraction)
+            )
+            pitch = map_pitch_to_preferred_range(
+                int(interpolated_pitch),
+                preferred_pitch_min=int(preferred_pitch_min),
+                preferred_pitch_max=int(preferred_pitch_max),
+            )
+            duration = min(
+                float(fill_note_duration_seconds),
+                max(float(min_note_duration_seconds), (gap / float(insert_count + 1)) * 0.75),
+            )
+            end = min(float(next_note.start) - 0.01, start + duration)
+            if end <= start:
+                continue
+            velocity = round((int(previous_note.velocity or 80) + int(next_note.velocity or 80)) / 2)
+            added_notes.append(
+                pretty_midi.Note(
+                    velocity=max(1, min(127, int(velocity))),
+                    pitch=int(pitch),
+                    start=float(start),
+                    end=float(end),
+                )
+            )
+
+    all_notes = sorted(
+        repaired_notes + added_notes,
+        key=lambda note: (float(note.start), int(note.pitch), float(note.end)),
+    )
+    final_notes: list[pretty_midi.Note] = []
+    overlap_adjusted_count = 0
+    for index, note in enumerate(all_notes):
+        start = float(note.start)
+        end = float(note.end)
+        if index + 1 < len(all_notes):
+            next_start = float(all_notes[index + 1].start)
+            if end > next_start - 0.005:
+                adjusted_end = max(start + 0.005, next_start - 0.005)
+                if adjusted_end < end:
+                    overlap_adjusted_count += 1
+                end = adjusted_end
+        if end - start < 0.005:
+            continue
+        final_notes.append(
+            pretty_midi.Note(
+                velocity=int(note.velocity),
+                pitch=int(note.pitch),
+                start=start,
+                end=end,
+            )
+        )
+
+    repaired_instrument.notes = final_notes
+    repaired.instruments.append(repaired_instrument)
+    repaired_midi_path.parent.mkdir(parents=True, exist_ok=True)
+    repaired.write(str(repaired_midi_path))
+
+    removed_note_count = max(0, len(repaired_notes) + len(added_notes) - len(final_notes))
+    return {
+        "source_note_count": int(len(source_notes)),
+        "added_note_count": int(len(added_notes)),
+        "removed_note_count": int(removed_note_count),
+        "repaired_note_count": int(len(final_notes)),
+        "overlap_adjusted_note_count": int(overlap_adjusted_count),
+        "added_note_ratio": float(len(added_notes) / max(1, len(source_notes))),
+        "postprocess_removal_ratio": float(removed_note_count / max(1, len(source_notes))),
+    }
+
+
+def validate_repair_decision(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    target = _dict(report.get("repair_target"))
+    guardrails = _dict(report.get("guardrails"))
+    source = _dict(report.get("source_objective_summary"))
+    if str(report.get("boundary") or "") != DECISION_BOUNDARY:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError(
+            "dead-air timing repair decision boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != DECISION_NEXT_BOUNDARY:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError(
+            "decision must route to repair probe"
+        )
+    if str(target.get("selected_target") or "") != "dead_air_timing_continuity":
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError(
+            "dead-air timing continuity target required"
+        )
+    if not bool(target.get("repair_probe_required", False)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError(
+            "repair probe requirement missing"
+        )
+    if _int(target.get("source_dead_air_failure_count")) <= 0:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError(
+            "source dead-air failures required"
+        )
+    if _float(target.get("required_dead_air_gain_min")) <= 0:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError(
+            "positive dead-air gain requirement required"
+        )
+    if bool(source.get("preference_fill_allowed", True)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError(
+            "preference fill must remain blocked"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError(
+            "critical user input should not be required"
+        )
+    _require_no_quality_claim(readiness, label="repair decision readiness")
+    return {
+        "boundary": DECISION_BOUNDARY,
+        "target_dead_air_max": _float(target.get("target_dead_air_max")),
+        "required_dead_air_gain_min": _float(target.get("required_dead_air_gain_min")),
+        "source_dead_air_failure_count": _int(target.get("source_dead_air_failure_count")),
+        "source_dead_air_max": _float(target.get("source_dead_air_max")),
+        "min_note_count": _int(guardrails.get("min_note_count")),
+        "min_unique_pitch_count": _int(guardrails.get("min_unique_pitch_count")),
+        "max_simultaneous_notes": _int(guardrails.get("max_simultaneous_notes")),
+        "max_postprocess_removal_ratio": _float(
+            guardrails.get("max_postprocess_removal_ratio")
+        ),
+        "require_preference_fill_blocked": bool(
+            guardrails.get("require_preference_fill_blocked", False)
+        ),
+    }
+
+
+def validate_candidate_export(report: dict[str, Any], *, min_count: int) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    context = _dict(report.get("input_context"))
+    top_candidates = [_dict(item) for item in _list(report.get("top_candidates"))]
+    if str(report.get("boundary") or "") != CANDIDATE_EXPORT_BOUNDARY:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError(
+            "candidate export boundary required"
+        )
+    required_true = [
+        "model_conditioned_input_path_candidate_export_completed",
+        "ranked_midi_candidates_exported",
+        "model_conditioned_ranked_input_path_contract_matched",
+    ]
+    missing = [name for name in required_true if not bool(readiness.get(name, False))]
+    if missing:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError(
+            f"missing candidate export readiness: {missing}"
+        )
+    if bool(decision.get("critical_user_input_required", False)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError(
+            "critical user input should not be required"
+        )
+    if len(top_candidates) < int(min_count):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError(
+            "top candidate count below minimum"
+        )
+    for row in top_candidates[: int(min_count)]:
+        export_path = Path(str(row.get("export_midi_path") or ""))
+        if not export_path.exists():
+            raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError(
+                f"exported MIDI missing: {export_path}"
+            )
+        if not bool(row.get("contract_gate_passed", False)):
+            raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError(
+                "candidate contract gate must be passed"
+            )
+    _require_no_quality_claim(readiness, label="candidate export readiness")
+    return {
+        "boundary": CANDIDATE_EXPORT_BOUNDARY,
+        "bpm": _float(context.get("bpm")) or 120.0,
+        "bars": _int(context.get("bars")),
+        "chord_progression": list(_list(context.get("chord_progression"))),
+        "top_candidates": top_candidates[: int(min_count)],
+    }
+
+
+def build_dead_air_timing_repair_probe_report(
+    *,
+    repair_decision_report: dict[str, Any],
+    candidate_export_report: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+    min_repaired_candidates: int,
+    dead_air_threshold_seconds: float,
+    max_start_gap_seconds: float,
+    fill_note_duration_seconds: float,
+    min_note_duration_seconds: float,
+    preferred_pitch_min: int,
+    preferred_pitch_max: int,
+) -> dict[str, Any]:
+    decision_source = validate_repair_decision(repair_decision_report)
+    export_source = validate_candidate_export(
+        candidate_export_report,
+        min_count=int(min_repaired_candidates),
+    )
+    repaired_dir = output_dir / "midi"
+    candidate_repairs: list[dict[str, Any]] = []
+    for row in export_source["top_candidates"]:
+        rank = _int(row.get("rank"))
+        sample_index = _int(row.get("sample_index"))
+        source_path = Path(str(row.get("export_midi_path") or ""))
+        repaired_path = repaired_dir / (
+            f"rank_{rank:02d}_sample_{sample_index:02d}_dead_air_timing_repair.mid"
+        )
+        before = objective_metrics_for_path(
+            source_path,
+            dead_air_threshold_seconds=float(dead_air_threshold_seconds),
+        )
+        repair_stats = repair_candidate_midi(
+            source_path,
+            repaired_path,
+            bpm=float(export_source["bpm"]),
+            max_start_gap_seconds=float(max_start_gap_seconds),
+            min_note_duration_seconds=float(min_note_duration_seconds),
+            fill_note_duration_seconds=float(fill_note_duration_seconds),
+            preferred_pitch_min=int(preferred_pitch_min),
+            preferred_pitch_max=int(preferred_pitch_max),
+        )
+        after = objective_metrics_for_path(
+            repaired_path,
+            dead_air_threshold_seconds=float(dead_air_threshold_seconds),
+        )
+        candidate_passed = bool(
+            _float(after.get("dead_air_ratio")) <= _float(decision_source["target_dead_air_max"])
+            and _int(after.get("note_count")) >= _int(decision_source["min_note_count"])
+            and _int(after.get("unique_pitch_count"))
+            >= _int(decision_source["min_unique_pitch_count"])
+            and _int(after.get("max_simultaneous_notes"))
+            <= _int(decision_source["max_simultaneous_notes"])
+            and _float(repair_stats.get("postprocess_removal_ratio"))
+            <= _float(decision_source["max_postprocess_removal_ratio"])
+        )
+        candidate_repairs.append(
+            {
+                "rank": rank,
+                "sample_index": sample_index,
+                "sample_seed": _int(row.get("sample_seed")),
+                "source_midi_path": str(source_path),
+                "repaired_midi_path": str(repaired_path),
+                "source_metrics": {
+                    "note_count": _int(before.get("note_count")),
+                    "unique_pitch_count": _int(before.get("unique_pitch_count")),
+                    "max_simultaneous_notes": _int(before.get("max_simultaneous_notes")),
+                    "dead_air_ratio": _float(before.get("dead_air_ratio")),
+                    "max_interval": _int(before.get("max_interval")),
+                    "pitch_span": _int(before.get("pitch_span")),
+                },
+                "repaired_metrics": {
+                    "note_count": _int(after.get("note_count")),
+                    "unique_pitch_count": _int(after.get("unique_pitch_count")),
+                    "max_simultaneous_notes": _int(after.get("max_simultaneous_notes")),
+                    "dead_air_ratio": _float(after.get("dead_air_ratio")),
+                    "max_interval": _int(after.get("max_interval")),
+                    "pitch_span": _int(after.get("pitch_span")),
+                },
+                "repair_stats": repair_stats,
+                "dead_air_gain": _float(before.get("dead_air_ratio"))
+                - _float(after.get("dead_air_ratio")),
+                "candidate_repair_passed": bool(candidate_passed),
+            }
+        )
+
+    source_dead_air_values = [
+        _float(row.get("source_metrics", {}).get("dead_air_ratio")) for row in candidate_repairs
+    ]
+    repaired_dead_air_values = [
+        _float(row.get("repaired_metrics", {}).get("dead_air_ratio"))
+        for row in candidate_repairs
+    ]
+    repaired_pass_count = sum(
+        1 for row in candidate_repairs if bool(row.get("candidate_repair_passed", False))
+    )
+    source_dead_air_max = max(source_dead_air_values) if source_dead_air_values else 0.0
+    repaired_dead_air_max = max(repaired_dead_air_values) if repaired_dead_air_values else 0.0
+    dead_air_gain_max = source_dead_air_max - repaired_dead_air_max
+    target_met = bool(
+        repaired_pass_count >= int(min_repaired_candidates)
+        and repaired_dead_air_max <= _float(decision_source["target_dead_air_max"])
+        and dead_air_gain_max >= _float(decision_source["required_dead_air_gain_min"])
+    )
+    next_boundary = NEXT_BOUNDARY if target_met else FAIL_NEXT_BOUNDARY
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundaries": {
+            "repair_decision": DECISION_BOUNDARY,
+            "candidate_export": CANDIDATE_EXPORT_BOUNDARY,
+        },
+        "repair_config": {
+            "strategy": "timing_gap_fill_and_duration_compaction",
+            "dead_air_threshold_seconds": float(dead_air_threshold_seconds),
+            "max_start_gap_seconds": float(max_start_gap_seconds),
+            "fill_note_duration_seconds": float(fill_note_duration_seconds),
+            "min_note_duration_seconds": float(min_note_duration_seconds),
+            "preferred_fill_pitch_min": int(preferred_pitch_min),
+            "preferred_fill_pitch_max": int(preferred_pitch_max),
+            "min_repaired_candidates": int(min_repaired_candidates),
+        },
+        "guardrails": {
+            "target_dead_air_max": _float(decision_source["target_dead_air_max"]),
+            "required_dead_air_gain_min": _float(decision_source["required_dead_air_gain_min"]),
+            "min_note_count": _int(decision_source["min_note_count"]),
+            "min_unique_pitch_count": _int(decision_source["min_unique_pitch_count"]),
+            "max_simultaneous_notes": _int(decision_source["max_simultaneous_notes"]),
+            "max_postprocess_removal_ratio": _float(
+                decision_source["max_postprocess_removal_ratio"]
+            ),
+        },
+        "input_context": {
+            "bars": _int(export_source["bars"]),
+            "bpm": _float(export_source["bpm"]),
+            "chord_progression": list(export_source["chord_progression"]),
+        },
+        "candidate_repairs": candidate_repairs,
+        "summary": {
+            "source_candidate_count": int(len(candidate_repairs)),
+            "repaired_candidate_count": int(len(candidate_repairs)),
+            "repaired_pass_count": int(repaired_pass_count),
+            "source_dead_air_max": float(source_dead_air_max),
+            "repaired_dead_air_max": float(repaired_dead_air_max),
+            "dead_air_gain_max": float(dead_air_gain_max),
+            "target_dead_air_max": _float(decision_source["target_dead_air_max"]),
+            "required_dead_air_gain_min": _float(decision_source["required_dead_air_gain_min"]),
+            "required_dead_air_gain_met": bool(
+                dead_air_gain_max >= _float(decision_source["required_dead_air_gain_min"])
+            ),
+            "max_added_note_ratio": max(
+                (
+                    _float(row.get("repair_stats", {}).get("added_note_ratio"))
+                    for row in candidate_repairs
+                ),
+                default=0.0,
+            ),
+            "max_postprocess_removal_ratio": max(
+                (
+                    _float(row.get("repair_stats", {}).get("postprocess_removal_ratio"))
+                    for row in candidate_repairs
+                ),
+                default=0.0,
+            ),
+            "max_repaired_simultaneous_notes": max(
+                (
+                    _int(row.get("repaired_metrics", {}).get("max_simultaneous_notes"))
+                    for row in candidate_repairs
+                ),
+                default=0,
+            ),
+            "max_repaired_interval": max(
+                (
+                    _int(row.get("repaired_metrics", {}).get("max_interval"))
+                    for row in candidate_repairs
+                ),
+                default=0,
+            ),
+            "dead_air_timing_repair_passed": bool(target_met),
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "dead_air_timing_repair_probe_completed": True,
+            "repaired_ranked_midi_written": bool(len(candidate_repairs) >= int(min_repaired_candidates)),
+            "dead_air_timing_repair_passed": bool(target_met),
+            "dead_air_timing_audio_render_required": bool(target_met),
+            "current_evidence_consolidation_ready": False,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": next_boundary,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": (
+                "repaired ranked MIDI candidates pass the dead-air/timing objective gate; render repaired MIDI to WAV next"
+                if target_met
+                else "dead-air/timing repair objective gate still requires follow-up"
+            ),
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "audio_rendered_quality",
+            "model_checkpoint_generation_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair audio package"
+            if target_met
+            else "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair follow-up"
+        ),
+    }
+
+
+def validate_dead_air_timing_repair_probe_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    min_repaired_candidates: int,
+    require_repair_passed: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("summary"))
+    candidate_repairs = [_dict(item) for item in _list(report.get("candidate_repairs"))]
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError(
+            "unexpected next boundary"
+        )
+    if len(candidate_repairs) < int(min_repaired_candidates):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError(
+            "candidate repair count below threshold"
+        )
+    for row in candidate_repairs[: int(min_repaired_candidates)]:
+        if not Path(str(row.get("repaired_midi_path") or "")).exists():
+            raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError(
+                "repaired MIDI path missing"
+            )
+        if not bool(row.get("candidate_repair_passed", False)) and require_repair_passed:
+            raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError(
+                "candidate repair should pass"
+            )
+    if require_repair_passed and not bool(
+        readiness.get("dead_air_timing_repair_passed", False)
+    ):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError(
+            "dead-air timing repair should pass"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError(
+            "critical user input should not be required"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="repair probe readiness")
+    return {
+        "boundary": boundary,
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "dead_air_timing_repair_probe_completed": bool(
+            readiness.get("dead_air_timing_repair_probe_completed", False)
+        ),
+        "repaired_ranked_midi_written": bool(
+            readiness.get("repaired_ranked_midi_written", False)
+        ),
+        "dead_air_timing_repair_passed": bool(
+            readiness.get("dead_air_timing_repair_passed", False)
+        ),
+        "dead_air_timing_audio_render_required": bool(
+            readiness.get("dead_air_timing_audio_render_required", False)
+        ),
+        "source_candidate_count": _int(summary.get("source_candidate_count")),
+        "repaired_candidate_count": _int(summary.get("repaired_candidate_count")),
+        "repaired_pass_count": _int(summary.get("repaired_pass_count")),
+        "source_dead_air_max": _float(summary.get("source_dead_air_max")),
+        "repaired_dead_air_max": _float(summary.get("repaired_dead_air_max")),
+        "dead_air_gain_max": _float(summary.get("dead_air_gain_max")),
+        "target_dead_air_max": _float(summary.get("target_dead_air_max")),
+        "required_dead_air_gain_met": bool(summary.get("required_dead_air_gain_met", False)),
+        "max_added_note_ratio": _float(summary.get("max_added_note_ratio")),
+        "max_postprocess_removal_ratio": _float(
+            summary.get("max_postprocess_removal_ratio")
+        ),
+        "max_repaired_simultaneous_notes": _int(summary.get("max_repaired_simultaneous_notes")),
+        "max_repaired_interval": _int(summary.get("max_repaired_interval")),
+        "human_audio_preference_claimed": bool(
+            readiness.get("human_audio_preference_claimed", True)
+        ),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    config = report["repair_config"]
+    guardrails = report["guardrails"]
+    lines = [
+        "# Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Probe",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- repair passed: `{_bool_token(summary['dead_air_timing_repair_passed'])}`",
+        f"- source candidate count: `{summary['source_candidate_count']}`",
+        f"- repaired candidate count: `{summary['repaired_candidate_count']}`",
+        f"- repaired pass count: `{summary['repaired_pass_count']}`",
+        f"- source dead-air max: `{summary['source_dead_air_max']:.4f}`",
+        f"- repaired dead-air max: `{summary['repaired_dead_air_max']:.4f}`",
+        f"- dead-air gain max: `{summary['dead_air_gain_max']:.4f}`",
+        f"- max added-note ratio: `{summary['max_added_note_ratio']:.4f}`",
+        f"- max postprocess removal ratio: `{summary['max_postprocess_removal_ratio']:.4f}`",
+        f"- max repaired simultaneous notes: `{summary['max_repaired_simultaneous_notes']}`",
+        f"- max repaired interval: `{summary['max_repaired_interval']}`",
+        "",
+        "## Repair Config",
+        "",
+        f"- strategy: `{config['strategy']}`",
+        f"- dead-air threshold seconds: `{config['dead_air_threshold_seconds']:.4f}`",
+        f"- max start gap seconds: `{config['max_start_gap_seconds']:.4f}`",
+        f"- fill note duration seconds: `{config['fill_note_duration_seconds']:.4f}`",
+        f"- preferred fill pitch range: `{config['preferred_fill_pitch_min']}`-`{config['preferred_fill_pitch_max']}`",
+        "",
+        "## Guardrails",
+        "",
+        f"- target dead-air max: `{guardrails['target_dead_air_max']:.4f}`",
+        f"- required dead-air gain min: `{guardrails['required_dead_air_gain_min']:.4f}`",
+        f"- min note count: `{guardrails['min_note_count']}`",
+        f"- min unique pitch count: `{guardrails['min_unique_pitch_count']}`",
+        f"- max simultaneous notes: `{guardrails['max_simultaneous_notes']}`",
+        f"- max postprocess removal ratio: `{guardrails['max_postprocess_removal_ratio']:.4f}`",
+        "",
+        "## Repaired MIDI",
+        "",
+    ]
+    for row in report["candidate_repairs"]:
+        source = row["source_metrics"]
+        repaired = row["repaired_metrics"]
+        stats = row["repair_stats"]
+        lines.append(
+            f"- rank `{row['rank']}` sample `{row['sample_index']}`: "
+            f"`{row['repaired_midi_path']}`, dead-air `{source['dead_air_ratio']:.4f}` -> "
+            f"`{repaired['dead_air_ratio']:.4f}`, notes `{source['note_count']}` -> "
+            f"`{repaired['note_count']}`, added ratio `{stats['added_note_ratio']:.4f}`, "
+            f"pass `{_bool_token(row['candidate_repair_passed'])}`"
+        )
+    lines.extend(
+        [
+            "",
+            "## Claim Boundary",
+            "",
+            f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+            f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+            f"- audio-rendered quality claimed: `{_bool_token(readiness['audio_rendered_quality_claimed'])}`",
+            f"- model checkpoint generation quality claimed: `{_bool_token(readiness['model_checkpoint_generation_quality_claimed'])}`",
+            "",
+            "## Decision",
+            "",
+            f"- auto progress allowed: `{_bool_token(decision['auto_progress_allowed'])}`",
+            f"- critical user input required: `{_bool_token(decision['critical_user_input_required'])}`",
+            f"- next recommended issue: `{report['next_recommended_issue']}`",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run model-conditioned input-path dead-air timing repair probe"
+    )
+    parser.add_argument("--repair_decision_report", type=str, required=True)
+    parser.add_argument("--candidate_export_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=(
+            "outputs/stage_b_midi_to_solo_model_conditioned_input_path_"
+            "dead_air_timing_repair_probe"
+        ),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=690)
+    parser.add_argument("--min_repaired_candidates", type=int, default=3)
+    parser.add_argument("--dead_air_threshold_seconds", type=float, default=0.5)
+    parser.add_argument("--max_start_gap_seconds", type=float, default=0.49)
+    parser.add_argument("--fill_note_duration_seconds", type=float, default=0.18)
+    parser.add_argument("--min_note_duration_seconds", type=float, default=0.04)
+    parser.add_argument("--preferred_pitch_min", type=int, default=48)
+    parser.add_argument("--preferred_pitch_max", type=int, default=88)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_repair_passed", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_dead_air_timing_repair_probe_report(
+        repair_decision_report=read_json(Path(args.repair_decision_report)),
+        candidate_export_report=read_json(Path(args.candidate_export_report)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+        min_repaired_candidates=int(args.min_repaired_candidates),
+        dead_air_threshold_seconds=float(args.dead_air_threshold_seconds),
+        max_start_gap_seconds=float(args.max_start_gap_seconds),
+        fill_note_duration_seconds=float(args.fill_note_duration_seconds),
+        min_note_duration_seconds=float(args.min_note_duration_seconds),
+        preferred_pitch_min=int(args.preferred_pitch_min),
+        preferred_pitch_max=int(args.preferred_pitch_max),
+    )
+    summary = validate_dead_air_timing_repair_probe_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        min_repaired_candidates=int(args.min_repaired_candidates),
+        require_repair_passed=bool(args.require_repair_passed),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe.py
+++ b/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import pretty_midi
+
+from scripts.decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision import (
+    BOUNDARY as DECISION_BOUNDARY,
+    NEXT_BOUNDARY as DECISION_NEXT_BOUNDARY,
+)
+from scripts.export_stage_b_midi_to_solo_model_conditioned_input_path_candidates import (
+    BOUNDARY as CANDIDATE_EXPORT_BOUNDARY,
+)
+from scripts.run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError,
+    build_dead_air_timing_repair_probe_report,
+    objective_metrics_for_path,
+    repair_candidate_midi,
+    validate_dead_air_timing_repair_probe_report,
+)
+
+
+def write_sparse_midi(path: Path, *, pitch_offset: int = 0) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    midi = pretty_midi.PrettyMIDI(initial_tempo=120)
+    piano = pretty_midi.Instrument(program=0, is_drum=False, name="solo")
+    starts = [
+        0.0,
+        0.125,
+        1.0,
+        2.0,
+        2.125,
+        3.0,
+        4.0,
+        4.125,
+        5.0,
+        6.0,
+        6.125,
+        7.0,
+        8.0,
+        8.125,
+        9.0,
+        10.0,
+        10.125,
+        11.0,
+        12.0,
+        12.125,
+        13.0,
+        14.0,
+        14.125,
+        15.0,
+    ]
+    pitches = [
+        52,
+        59,
+        81,
+        36,
+        43,
+        74,
+        100,
+        38,
+        65,
+        26,
+        71,
+        28,
+        62,
+        52,
+        59,
+        76,
+        71,
+        35,
+        48,
+        108,
+        26,
+        105,
+        60,
+        95,
+    ]
+    for start, pitch in zip(starts, pitches):
+        piano.notes.append(
+            pretty_midi.Note(
+                velocity=84,
+                pitch=int(pitch + pitch_offset),
+                start=float(start),
+                end=float(start + 0.125),
+            )
+        )
+    midi.instruments.append(piano)
+    midi.write(str(path))
+    return str(path)
+
+
+def repair_decision(*, quality_claim: bool = False) -> dict:
+    return {
+        "boundary": DECISION_BOUNDARY,
+        "source_objective_summary": {
+            "preference_fill_allowed": False,
+        },
+        "repair_target": {
+            "selected_target": "dead_air_timing_continuity",
+            "source_dead_air_failure_count": 3,
+            "source_dead_air_max": 0.6521739130434783,
+            "target_dead_air_max": 0.35,
+            "required_dead_air_gain_min": 0.3021739130434783,
+            "repair_probe_required": True,
+        },
+        "guardrails": {
+            "min_note_count": 24,
+            "min_unique_pitch_count": 8,
+            "max_simultaneous_notes": 1,
+            "max_postprocess_removal_ratio": 0.25,
+            "require_preference_fill_blocked": True,
+        },
+        "readiness": {
+            "dead_air_timing_repair_decision_completed": True,
+            "human_audio_preference_claimed": quality_claim,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": DECISION_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+def candidate_export(root: Path) -> dict:
+    rows = []
+    for index in range(1, 4):
+        path = write_sparse_midi(root / f"midi/rank_{index:02d}.mid", pitch_offset=index - 1)
+        rows.append(
+            {
+                "rank": index,
+                "sample_index": index,
+                "sample_seed": 690 + index,
+                "export_midi_path": path,
+                "contract_gate_passed": True,
+                "note_count": 24,
+                "unique_pitch_count": 19,
+                "max_simultaneous_notes": 1,
+                "dead_air_ratio": 0.6521739130434783,
+            }
+        )
+    return {
+        "boundary": CANDIDATE_EXPORT_BOUNDARY,
+        "input_context": {
+            "bpm": 120,
+            "bars": 8,
+            "chord_progression": ["Cmaj7", "F7", "G7", "Cmaj7"] * 2,
+        },
+        "top_candidates": rows,
+        "readiness": {
+            "model_conditioned_input_path_candidate_export_completed": True,
+            "ranked_midi_candidates_exported": True,
+            "model_conditioned_ranked_input_path_contract_matched": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeTest(
+    unittest.TestCase
+):
+    def test_repair_candidate_reduces_dead_air_without_overlap(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = Path(write_sparse_midi(root / "source.mid"))
+            repaired = root / "repaired.mid"
+            stats = repair_candidate_midi(
+                source,
+                repaired,
+                bpm=120,
+                max_start_gap_seconds=0.49,
+                min_note_duration_seconds=0.04,
+                fill_note_duration_seconds=0.18,
+                preferred_pitch_min=48,
+                preferred_pitch_max=88,
+            )
+            before = objective_metrics_for_path(source, dead_air_threshold_seconds=0.5)
+            after = objective_metrics_for_path(repaired, dead_air_threshold_seconds=0.5)
+
+        self.assertEqual(before["note_count"], 24)
+        self.assertGreater(stats["added_note_count"], 0)
+        self.assertEqual(stats["removed_note_count"], 0)
+        self.assertLess(after["dead_air_ratio"], before["dead_air_ratio"])
+        self.assertEqual(after["dead_air_ratio"], 0.0)
+        self.assertEqual(after["max_simultaneous_notes"], 1)
+
+    def test_builds_repair_probe_and_routes_audio_package(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            report = build_dead_air_timing_repair_probe_report(
+                repair_decision_report=repair_decision(),
+                candidate_export_report=candidate_export(root),
+                output_dir=root / "out",
+                issue_number=690,
+                min_repaired_candidates=3,
+                dead_air_threshold_seconds=0.5,
+                max_start_gap_seconds=0.49,
+                fill_note_duration_seconds=0.18,
+                min_note_duration_seconds=0.04,
+                preferred_pitch_min=48,
+                preferred_pitch_max=88,
+            )
+            summary = validate_dead_air_timing_repair_probe_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                min_repaired_candidates=3,
+                require_repair_passed=True,
+                require_no_quality_claim=True,
+            )
+
+        self.assertTrue(summary["dead_air_timing_repair_probe_completed"])
+        self.assertTrue(summary["dead_air_timing_repair_passed"])
+        self.assertTrue(summary["dead_air_timing_audio_render_required"])
+        self.assertEqual(summary["source_candidate_count"], 3)
+        self.assertEqual(summary["repaired_candidate_count"], 3)
+        self.assertEqual(summary["repaired_pass_count"], 3)
+        self.assertGreater(summary["dead_air_gain_max"], 0.3)
+        self.assertEqual(summary["repaired_dead_air_max"], 0.0)
+        self.assertLessEqual(summary["max_repaired_simultaneous_notes"], 1)
+        self.assertFalse(summary["human_audio_preference_claimed"])
+        self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+
+    def test_rejects_repair_decision_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaises(
+                StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairProbeError
+            ):
+                build_dead_air_timing_repair_probe_report(
+                    repair_decision_report=repair_decision(quality_claim=True),
+                    candidate_export_report=candidate_export(root),
+                    output_dir=root / "out",
+                    issue_number=690,
+                    min_repaired_candidates=3,
+                    dead_air_threshold_seconds=0.5,
+                    max_start_gap_seconds=0.49,
+                    fill_note_duration_seconds=0.18,
+                    min_note_duration_seconds=0.04,
+                    preferred_pitch_min=48,
+                    preferred_pitch_max=88,
+                )
+
+    def test_boundary_constants_are_stable(self) -> None:
+        self.assertEqual(
+            BOUNDARY,
+            "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe",
+        )
+        self.assertEqual(
+            NEXT_BOUNDARY,
+            "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- ranked model-conditioned MIDI 후보 3개 대상 dead-air/timing repair probe 추가
- timing gap fill 및 duration compaction 기반 repaired MIDI export
- dead-air max `0.6522 -> 0.0000`, repaired/pass `3/3` 기록
- max added-note ratio `0.9167`, max repaired interval `62` 리스크 기록
- 음악적 품질, human/audio preference, broad training claim 제외 유지

## Context

- #688 decision 결과: selected target `dead_air_timing_continuity`
- source candidate dead-air failure count: `3`
- source dead-air min/max: `0.6522 / 0.6522`
- target dead-air max: `0.3500`
- required dead-air gain min: `0.3022`
- excluded claim: human/audio preference, MIDI-to-solo musical quality, broad trained-model quality, Brad style adaptation

## Scope

- `scripts/run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe.py`
- `tests/test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe.py`
- `scripts/agent_harness.sh` mode 추가
- README, current status, core plan, handoff 문서 갱신

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe`
- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-probe`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- objective MIDI 지표 기준 통과
- max added-note ratio `0.9167`
- max repaired interval `62` 잔존
- repaired MIDI WAV technical validation 미진행
- listening preference claim 없음

Closes #690