### PR TITLE
Stage B MIDI-to-solo model-conditioned input path dead-air timing repair audio package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #690, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair probe.
+- Latest functional issue completed: Issue #692, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair audio package.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path dead-air timing repair audio package.
+- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path dead-air timing repair objective next decision.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1124,6 +1124,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-
 ```
 
 This harness repairs ranked model-conditioned MIDI candidate timing gaps and verifies objective dead-air guardrails without claiming musical quality.
+
+For Stage B MIDI-to-solo model-conditioned input path dead-air timing repair audio package changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-audio-package
+```
+
+This harness renders repaired model-conditioned dead-air/timing MIDI candidates to WAV and verifies technical audio metadata without claiming musical quality.
 
 For Stage B MIDI-to-solo phrase-bank retrieval baseline changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe`
+- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -38,6 +38,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned dead-air max: `0.6522 -> 0.0000`
 - model-conditioned max added-note ratio: `0.9167`
 - model-conditioned max repaired interval: `62`
+- model-conditioned dead-air timing repair WAV files: `3`
+- model-conditioned dead-air timing repair WAV technical validation: `true`
+- model-conditioned remaining wide-interval risk: `true`
 - phrase-bank retrieval baseline completed: `true`
 - phrase-bank source records / motifs: `56 / 803`
 - phrase-bank exported / qualified MIDI candidates: `3 / 3`
@@ -77,7 +80,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - MVP completion audit completed: `true`
 - quality gap decision completed: `true`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -121,6 +124,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned ranked MIDI/WAV technical replacement consolidation 가능
 - model-conditioned ranked MIDI/WAV listening review package 생성 가능
 - model-conditioned ranked MIDI 후보의 dead-air/timing repair probe 가능
+- model-conditioned dead-air/timing repaired MIDI 후보의 WAV technical render 가능
 
 현재 README가 주장하지 않는 것.
 
@@ -315,6 +319,21 @@ Model-conditioned input path dead-air timing repair probe.
 - max postprocess removal ratio: `0.0000`
 - max repaired simultaneous notes: `1`
 - max repaired interval: `62`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+Model-conditioned input path dead-air timing repair audio package.
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision`
+- rendered audio file count: `3`
+- technical WAV validation: `true`
+- repaired dead-air max: `0.0000`
+- max added-note ratio: `0.9167`
+- max postprocess removal ratio: `0.0000`
+- max repaired interval: `62`
+- remaining wide-interval risk: `true`
+- audio rendered quality claimed: `false`
 - human/audio preference claimed: `false`
 - MIDI-to-solo musical quality claimed: `false`
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -405,6 +405,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo model-conditioned input path objective-only next decision: technical path `true`, dead-air failure `3/3`, repair required `true`, current evidence consolidation `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision`
 - MIDI-to-solo model-conditioned input path dead-air timing repair decision: target `dead_air_timing_continuity`, target dead-air max `0.3500`, required gain `0.3022`, repair probe required `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe`
 - MIDI-to-solo model-conditioned input path dead-air timing repair probe: repaired/pass `3/3`, dead-air max `0.6522 -> 0.0000`, max added-note ratio `0.9167`, max interval `62`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package`
+- MIDI-to-solo model-conditioned input path dead-air timing repair audio package: rendered WAV `3`, technical validation `true`, repaired dead-air max `0.0000`, max interval `62`, remaining wide-interval risk `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision`
 - model-core portfolio bullet refresh: resume bullet `6`, short bullet `3`, generic base checkpoint repeatability `9/9/9`, unsupported claim guard 유지
 - Muzig application wording refresh: resume project bullet `5`, short bullet `3`, 자기소개 section `3`, AI 음악 실험/검증 claim만 사용
 - Muzig application final review package: long bullet `5`, short bullet `3`, 자기소개 paragraph `3`, 지원 동기 paragraph `2`, 최종 claim check 포함
@@ -482,6 +483,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - Stage B MIDI-to-solo model-conditioned input path objective-only next decision: candidate/export/render `3/3/3`, dead-air failure `3`, dead-air range `0.6522/0.6522`, repair required `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_decision`
 - Stage B MIDI-to-solo model-conditioned input path dead-air timing repair decision: source dead-air failure `3`, target dead-air max `0.3500`, required gain `0.3022`, guardrail max postprocess removal `0.2500`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe`
 - Stage B MIDI-to-solo model-conditioned input path dead-air timing repair probe: repaired/pass `3/3`, dead-air max `0.6522 -> 0.0000`, removal ratio `0.0000`, added-note ratio `0.9167`, max simultaneous `1`, max interval `62`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package`
+- Stage B MIDI-to-solo model-conditioned input path dead-air timing repair audio package: rendered WAV `3`, technical validation `true`, duration `19.585s-22.390s`, remaining wide-interval risk `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision`
 - Stage B MIDI-to-solo controlled scale checkpoint dead-air repeatability temperature guard audio review package: candidate/rendered `3/3`, sample rate `44100`, duration `6.747s-6.861s`, technical validation `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_dead_air_repeatability_temperature_guard_listening_review`
 - Stage B MIDI-to-solo controlled scale checkpoint dead-air repeatability temperature guard listening review: candidate/rendered `3/3`, validated review input `false`, pending fields `4/3/9`, preference fill `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_dead_air_repeatability_temperature_guard_objective_only_next_decision`
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
@@ -3307,6 +3309,40 @@ Issue #690은 Issue #688 repair decision과 ranked MIDI candidate export 결과�
 다음 작업:
 
 - `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair audio package`
+
+## 9.37 Stage B MIDI-to-solo model-conditioned input path dead-air timing repair audio package
+
+Issue #692는 Issue #690 repair probe 결과의 repaired MIDI 3개를 WAV로 렌더링하고 technical metadata를 검증한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision`
+- rendered audio file count: `3`
+- technical WAV validation: `true`
+- repaired dead-air max: `0.0000`
+- max added-note ratio: `0.9167`
+- max postprocess removal ratio: `0.0000`
+- max repaired interval: `62`
+- remaining wide-interval risk: `true`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- repaired MIDI 3개 WAV technical render 완료.
+- max repaired interval `62` 잔존으로 objective next decision 필요.
+- audio render quality와 human/audio preference claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-audio-package`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair objective next decision`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #690, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair probe
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair audio package`
+- latest functional result: Issue #692, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair audio package
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair objective next decision`
 
 현재 범위가 아닌 것:
 
@@ -62,6 +62,52 @@
 - model-conditioned input path objective-only 기준 dead-air/timing repair 필요 판정
 - model-conditioned input path dead-air/timing repair target 정의 완료
 - model-conditioned input path dead-air/timing repair probe 기준 repaired 후보 3개 objective target 통과
+- model-conditioned input path dead-air/timing repaired 후보 3개 WAV technical render 완료
+
+## Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Audio Package Result
+
+Issue #692는 Issue #690 repair probe 결과의 repaired MIDI 3개를 WAV로 렌더링하고 technical metadata를 검증한 작업이다.
+
+변경:
+
+- model-conditioned input path dead-air timing repair audio package script 추가
+- repaired MIDI 3개 대상 WAV render 및 metadata 기록
+- renderer, soundfont, WAV sample rate, frame count, sha256 검증
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_AUDIO_PACKAGE_2026-06-08.md`
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision`
+- rendered audio file count: `3`
+- technical WAV validation: `true`
+- repaired dead-air max: `0.0000`
+- max added-note ratio: `0.9167`
+- max postprocess removal ratio: `0.0000`
+- max repaired interval: `62`
+- remaining wide-interval risk: `true`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- repaired MIDI 3개 WAV technical render 완료.
+- max repaired interval `62` 잔존으로 objective next decision 필요.
+- audio render quality와 human/audio preference claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio`
+- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-audio-package`
+
+다음:
+
+- `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair objective next decision`
 
 ## Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Probe Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_AUDIO_PACKAGE_2026-06-08.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_AUDIO_PACKAGE_2026-06-08.md
@@ -1,0 +1,35 @@
+# Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Audio Package
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision`
+- render attempted: `true`
+- rendered audio file count: `3`
+- technical WAV validation: `true`
+- repaired dead-air max: `0.0000`
+- max added-note ratio: `0.9167`
+- max postprocess removal ratio: `0.0000`
+- max repaired interval: `62`
+- remaining wide-interval risk: `true`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+
+## Rendered Files
+
+- rank `1` sample `1` seed `497`: `outputs/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package/harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package/audio/rank_01_sample_01_dead_air_timing_repair.wav`, duration `22.390`, sample rate `44100`, size `3949612`, sha256 `bffb0a7d40c2`
+- rank `2` sample `2` seed `498`: `outputs/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package/harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package/audio/rank_02_sample_02_dead_air_timing_repair.wav`, duration `21.355`, sample rate `44100`, size `3767084`, sha256 `512c2ead20c5`
+- rank `3` sample `3` seed `499`: `outputs/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package/harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package/audio/rank_03_sample_03_dead_air_timing_repair.wav`, duration `19.585`, sample rate `44100`, size `3454764`, sha256 `9718df73f088`
+
+## Claim Boundary
+
+- `audio_rendered_quality`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `model_checkpoint_generation_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`
+
+## Next
+
+- `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair objective next decision`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -250,6 +250,8 @@ Modes:
                 Decide the dead-air/timing repair target after model-conditioned objective evidence.
   stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-probe
                 Repair dead-air/timing gaps in ranked model-conditioned MIDI candidates.
+  stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-audio-package
+                Render repaired model-conditioned dead-air/timing MIDI candidates to WAV.
   stage-b-midi-to-solo-model-direct-generation-repair
                 Define the model-direct generation repair boundary from sequence budget evidence.
   stage-b-midi-to-solo-model-direct-sequence-budget-repair-smoke
@@ -6211,6 +6213,27 @@ run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pro
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package() {
+  local repair_probe_run_id="${REPAIR_PROBE_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package}"
+  local repair_probe_report="outputs/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe/${repair_probe_run_id}/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe.json"
+  if [[ ! -f "$repair_probe_report" ]]; then
+    print_header "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair probe"
+    RUN_ID="$repair_probe_run_id" run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe
+  fi
+  print_header "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair audio package"
+  "$PYTHON_BIN" scripts/render_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio.py \
+    --run_id "$run_id" \
+    --repair_probe_report "$repair_probe_report" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_AUDIO_PACKAGE_2026-06-08.md \
+    --expected_boundary stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package \
+    --expected_next_boundary stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision \
+    --expected_file_count 3 \
+    --sample_rate 44100 \
+    --require_audio_package_completed \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -7870,6 +7893,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-probe)
     run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe
+    ;;
+  stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-audio-package)
+    run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/render_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio.py
+++ b/scripts/render_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio.py
@@ -1,0 +1,542 @@
+"""Render repaired model-conditioned dead-air/timing MIDI candidates to WAV."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.render_stage_b_midi_to_solo_candidate_audio import (  # noqa: E402
+    resolve_soundfont,
+    sha256_file,
+    wav_meta,
+)
+from scripts.run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+class StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError(
+    ValueError
+):
+    pass
+
+
+BOUNDARY = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_audio_package"
+)
+NEXT_BOUNDARY = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_objective_next_decision"
+)
+SCHEMA_VERSION = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_audio_package_v1"
+)
+CommandRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _path_exists(path_text: str) -> bool:
+    return bool(path_text and Path(path_text).exists())
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_source_report(report: dict[str, Any], *, expected_count: int) -> list[dict[str, Any]]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("summary"))
+    if str(report.get("boundary") or readiness.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError(
+            "dead-air timing repair probe boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError(
+            "repair probe must route to audio package"
+        )
+    required_true = [
+        "dead_air_timing_repair_probe_completed",
+        "repaired_ranked_midi_written",
+        "dead_air_timing_repair_passed",
+        "dead_air_timing_audio_render_required",
+    ]
+    missing = [name for name in required_true if not bool(readiness.get(name, False))]
+    if missing:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError(
+            f"missing repair probe readiness: {missing}"
+        )
+    if _int(summary.get("repaired_pass_count")) < int(expected_count):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError(
+            "repaired pass count below expected count"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError(
+            "critical user input should not be required"
+        )
+    _require_no_quality_claim(readiness, label="repair probe readiness")
+    rows = [_dict(item) for item in _list(report.get("candidate_repairs"))]
+    if len(rows) < int(expected_count):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError(
+            "candidate repair count below expected count"
+        )
+    compacted: list[dict[str, Any]] = []
+    for row in rows[: int(expected_count)]:
+        repaired_midi_path = str(row.get("repaired_midi_path") or "")
+        if not _path_exists(repaired_midi_path):
+            raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError(
+                f"repaired MIDI missing: {repaired_midi_path}"
+            )
+        if not bool(row.get("candidate_repair_passed", False)):
+            raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError(
+                "candidate repair should pass before audio render"
+            )
+        repaired_metrics = _dict(row.get("repaired_metrics"))
+        repair_stats = _dict(row.get("repair_stats"))
+        compacted.append(
+            {
+                "rank": _int(row.get("rank")),
+                "sample_index": _int(row.get("sample_index")),
+                "sample_seed": _int(row.get("sample_seed")),
+                "source_midi_path": str(row.get("source_midi_path") or ""),
+                "repaired_midi_path": repaired_midi_path,
+                "source_dead_air_ratio": _float(
+                    _dict(row.get("source_metrics")).get("dead_air_ratio")
+                ),
+                "repaired_dead_air_ratio": _float(repaired_metrics.get("dead_air_ratio")),
+                "repaired_note_count": _int(repaired_metrics.get("note_count")),
+                "repaired_unique_pitch_count": _int(
+                    repaired_metrics.get("unique_pitch_count")
+                ),
+                "repaired_max_simultaneous_notes": _int(
+                    repaired_metrics.get("max_simultaneous_notes")
+                ),
+                "repaired_max_interval": _int(repaired_metrics.get("max_interval")),
+                "added_note_ratio": _float(repair_stats.get("added_note_ratio")),
+                "postprocess_removal_ratio": _float(
+                    repair_stats.get("postprocess_removal_ratio")
+                ),
+            }
+        )
+    return compacted
+
+
+def build_render_plan(
+    candidates: list[dict[str, Any]],
+    *,
+    output_dir: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+) -> list[dict[str, Any]]:
+    renderer = Path(renderer_path)
+    soundfont = Path(soundfont_path).expanduser()
+    if not renderer.exists():
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError(
+            f"renderer not found: {renderer}"
+        )
+    if not soundfont.exists():
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError(
+            f"soundfont not found: {soundfont}"
+        )
+    plan: list[dict[str, Any]] = []
+    for item in candidates:
+        wav_path = output_dir / "audio" / (
+            f"rank_{int(item['rank']):02d}_sample_{int(item['sample_index']):02d}_"
+            "dead_air_timing_repair.wav"
+        )
+        plan.append(
+            {
+                **item,
+                "wav_path": str(wav_path),
+                "command": [
+                    str(renderer),
+                    "-ni",
+                    "-F",
+                    str(wav_path),
+                    "-r",
+                    str(sample_rate),
+                    str(soundfont),
+                    str(item["repaired_midi_path"]),
+                ],
+            }
+        )
+    return plan
+
+
+def default_runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(list(command), check=False, text=True, capture_output=True)
+
+
+def execute_render_plan(
+    plan: list[dict[str, Any]],
+    *,
+    runner: CommandRunner = default_runner,
+) -> list[dict[str, Any]]:
+    rendered: list[dict[str, Any]] = []
+    for item in plan:
+        wav_path = Path(str(item["wav_path"]))
+        wav_path.parent.mkdir(parents=True, exist_ok=True)
+        completed = runner(item["command"])
+        if completed.returncode != 0:
+            raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError(
+                f"render failed for rank {item['rank']}: {completed.stderr or completed.stdout}"
+            )
+        rendered.append(
+            {
+                "rank": item["rank"],
+                "sample_index": item["sample_index"],
+                "sample_seed": item["sample_seed"],
+                "source_midi_path": item["source_midi_path"],
+                "repaired_midi_path": item["repaired_midi_path"],
+                "repaired_note_count": item["repaired_note_count"],
+                "repaired_unique_pitch_count": item["repaired_unique_pitch_count"],
+                "repaired_dead_air_ratio": item["repaired_dead_air_ratio"],
+                "repaired_max_simultaneous_notes": item["repaired_max_simultaneous_notes"],
+                "repaired_max_interval": item["repaired_max_interval"],
+                "added_note_ratio": item["added_note_ratio"],
+                "postprocess_removal_ratio": item["postprocess_removal_ratio"],
+                "wav_file": wav_meta(wav_path),
+                "command": list(item["command"]),
+                "stdout_tail": (completed.stdout or "")[-1000:],
+                "stderr_tail": (completed.stderr or "")[-1000:],
+            }
+        )
+    return rendered
+
+
+def build_audio_render_report(
+    source_report: dict[str, Any],
+    *,
+    output_dir: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+    expected_file_count: int,
+    runner: CommandRunner = default_runner,
+) -> dict[str, Any]:
+    candidates = validate_source_report(source_report, expected_count=expected_file_count)
+    resolved_renderer = renderer_path or shutil.which("fluidsynth") or ""
+    resolved_soundfont = resolve_soundfont(soundfont_path)
+    plan = build_render_plan(
+        candidates,
+        output_dir=output_dir,
+        renderer_path=resolved_renderer,
+        soundfont_path=resolved_soundfont,
+        sample_rate=int(sample_rate),
+    )
+    rendered = execute_render_plan(plan, runner=runner)
+    repaired_dead_air_values = [_float(item.get("repaired_dead_air_ratio")) for item in candidates]
+    repaired_interval_values = [_int(item.get("repaired_max_interval")) for item in candidates]
+    added_ratios = [_float(item.get("added_note_ratio")) for item in candidates]
+    removal_ratios = [_float(item.get("postprocess_removal_ratio")) for item in candidates]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "source_boundary": SOURCE_BOUNDARY,
+        "source_summary": _dict(source_report.get("summary")),
+        "renderer": {
+            "name": "fluidsynth",
+            "path": resolved_renderer,
+        },
+        "soundfont": {
+            "path": str(Path(resolved_soundfont).expanduser()),
+            "sha256": sha256_file(Path(resolved_soundfont).expanduser()),
+        },
+        "rendered_audio_files": rendered,
+        "summary": {
+            "rendered_audio_file_count": int(len(rendered)),
+            "technical_wav_validation": True,
+            "repaired_candidate_count": int(len(candidates)),
+            "repaired_dead_air_max": max(repaired_dead_air_values, default=0.0),
+            "max_added_note_ratio": max(added_ratios, default=0.0),
+            "max_postprocess_removal_ratio": max(removal_ratios, default=0.0),
+            "max_repaired_interval": max(repaired_interval_values, default=0),
+            "remaining_wide_interval_risk": max(repaired_interval_values, default=0) >= 12,
+        },
+        "audio_render_boundary": {
+            "boundary": BOUNDARY,
+            "render_attempted": True,
+            "rendered_audio_file_count": int(len(rendered)),
+            "technical_wav_validation": True,
+            "dead_air_timing_repair_audio_package_completed": True,
+            "human_audio_preference_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": (
+                "repaired dead-air/timing MIDI rendered to WAV; next boundary should review objective remaining risks without claiming quality"
+            ),
+        },
+        "not_proven": [
+            "audio_rendered_quality",
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "model_checkpoint_generation_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair objective next decision"
+        ),
+    }
+
+
+def validate_audio_render_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    expected_file_count: int,
+    expected_sample_rate: int,
+    require_audio_package_completed: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = _dict(report.get("audio_render_boundary"))
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("summary"))
+    if expected_boundary and str(boundary.get("boundary") or "") != expected_boundary:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError(
+            "unexpected boundary"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError(
+            "unexpected next boundary"
+        )
+    files = [_dict(item) for item in _list(report.get("rendered_audio_files"))]
+    if len(files) != int(expected_file_count):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError(
+            f"expected {expected_file_count} rendered files"
+        )
+    for item in files:
+        wav_file = _dict(item.get("wav_file"))
+        if not bool(wav_file.get("exists", False)) or not _path_exists(str(wav_file.get("path") or "")):
+            raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError(
+                "missing rendered WAV"
+            )
+        if _int(wav_file.get("sample_rate")) != int(expected_sample_rate):
+            raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError(
+                "unexpected sample rate"
+            )
+        if _int(wav_file.get("frame_count")) <= 0:
+            raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError(
+                "empty WAV"
+            )
+        if _int(wav_file.get("size_bytes")) <= 44:
+            raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError(
+                "invalid WAV size"
+            )
+    if require_audio_package_completed and not bool(
+        boundary.get("dead_air_timing_repair_audio_package_completed", False)
+    ):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError(
+            "audio package completion required"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError(
+            "critical user input should not be required"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(boundary, label="audio render boundary")
+    return {
+        "boundary": str(boundary.get("boundary") or ""),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "render_attempted": bool(boundary.get("render_attempted", False)),
+        "rendered_audio_file_count": _int(boundary.get("rendered_audio_file_count")),
+        "technical_wav_validation": bool(boundary.get("technical_wav_validation", False)),
+        "dead_air_timing_repair_audio_package_completed": bool(
+            boundary.get("dead_air_timing_repair_audio_package_completed", False)
+        ),
+        "repaired_candidate_count": _int(summary.get("repaired_candidate_count")),
+        "repaired_dead_air_max": _float(summary.get("repaired_dead_air_max")),
+        "max_added_note_ratio": _float(summary.get("max_added_note_ratio")),
+        "max_postprocess_removal_ratio": _float(summary.get("max_postprocess_removal_ratio")),
+        "max_repaired_interval": _int(summary.get("max_repaired_interval")),
+        "remaining_wide_interval_risk": bool(summary.get("remaining_wide_interval_risk", False)),
+        "audio_rendered_quality_claimed": bool(boundary.get("audio_rendered_quality_claimed", True)),
+        "human_audio_preference_claimed": bool(boundary.get("human_audio_preference_claimed", True)),
+        "midi_to_solo_musical_quality_claimed": bool(
+            boundary.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "wav_paths": [str(_dict(item.get("wav_file")).get("path") or "") for item in files],
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    boundary = report["audio_render_boundary"]
+    decision = report["decision"]
+    summary = report["summary"]
+    lines = [
+        "# Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Audio Package",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{boundary['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- render attempted: `{_bool_token(boundary['render_attempted'])}`",
+        f"- rendered audio file count: `{boundary['rendered_audio_file_count']}`",
+        f"- technical WAV validation: `{_bool_token(boundary['technical_wav_validation'])}`",
+        f"- repaired dead-air max: `{summary['repaired_dead_air_max']:.4f}`",
+        f"- max added-note ratio: `{summary['max_added_note_ratio']:.4f}`",
+        f"- max postprocess removal ratio: `{summary['max_postprocess_removal_ratio']:.4f}`",
+        f"- max repaired interval: `{summary['max_repaired_interval']}`",
+        f"- remaining wide-interval risk: `{_bool_token(summary['remaining_wide_interval_risk'])}`",
+        f"- audio rendered quality claimed: `{_bool_token(boundary['audio_rendered_quality_claimed'])}`",
+        f"- human/audio preference claimed: `{_bool_token(boundary['human_audio_preference_claimed'])}`",
+        "",
+        "## Rendered Files",
+        "",
+    ]
+    for item in report.get("rendered_audio_files", []):
+        wav_file = item["wav_file"]
+        lines.append(
+            f"- rank `{item['rank']}` sample `{item['sample_index']}` seed `{item['sample_seed']}`: "
+            f"`{wav_file['path']}`, duration `{float(wav_file['duration_seconds']):.3f}`, "
+            f"sample rate `{wav_file['sample_rate']}`, size `{wav_file['size_bytes']}`, "
+            f"sha256 `{str(wav_file['sha256'])[:12]}`"
+        )
+    lines.extend(["", "## Claim Boundary", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    lines.extend(["", "## Next", "", f"- `{report['next_recommended_issue']}`"])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Render model-conditioned dead-air timing repair WAV files"
+    )
+    parser.add_argument("--repair_probe_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=(
+            "outputs/stage_b_midi_to_solo_model_conditioned_input_path_"
+            "dead_air_timing_repair_audio_package"
+        ),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--renderer", type=str, default=shutil.which("fluidsynth") or "")
+    parser.add_argument("--soundfont", type=str, default="")
+    parser.add_argument("--sample_rate", type=int, default=44100)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--expected_file_count", type=int, default=3)
+    parser.add_argument("--require_audio_package_completed", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_audio_render_report(
+        read_json(Path(args.repair_probe_report)),
+        output_dir=output_dir,
+        renderer_path=str(args.renderer or ""),
+        soundfont_path=str(args.soundfont or ""),
+        sample_rate=int(args.sample_rate),
+        expected_file_count=int(args.expected_file_count),
+    )
+    summary = validate_audio_render_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        expected_file_count=int(args.expected_file_count),
+        expected_sample_rate=int(args.sample_rate),
+        require_audio_package_completed=bool(args.require_audio_package_completed),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio.py
+++ b/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+import wave
+from pathlib import Path
+from typing import Sequence
+
+from scripts.render_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError,
+    build_audio_render_report,
+    validate_audio_render_report,
+)
+from scripts.run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe import (
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+def write_wav(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(2)
+        handle.setsampwidth(2)
+        handle.setframerate(44100)
+        handle.writeframes(b"\x00\x00" * 2 * 1000)
+
+
+def fake_runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    wav_path = Path(str(command[3]))
+    write_wav(wav_path)
+    return subprocess.CompletedProcess(list(command), 0, stdout="rendered", stderr="")
+
+
+def touch_file(root: Path, name: str) -> str:
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"midi")
+    return str(path)
+
+
+def source_report(root: Path, *, quality_claim: bool = False) -> dict:
+    rows = []
+    for index in range(1, 4):
+        rows.append(
+            {
+                "rank": index,
+                "sample_index": index,
+                "sample_seed": 690 + index,
+                "source_midi_path": touch_file(root, f"source/rank_{index}.mid"),
+                "repaired_midi_path": touch_file(root, f"repaired/rank_{index}.mid"),
+                "source_metrics": {
+                    "dead_air_ratio": 0.6521739130434783,
+                },
+                "repaired_metrics": {
+                    "note_count": 46,
+                    "unique_pitch_count": 30 + index,
+                    "max_simultaneous_notes": 1,
+                    "dead_air_ratio": 0.0,
+                    "max_interval": 62,
+                },
+                "repair_stats": {
+                    "added_note_ratio": 0.9166666666666666,
+                    "postprocess_removal_ratio": 0.0,
+                },
+                "candidate_repair_passed": True,
+            }
+        )
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "summary": {
+            "repaired_pass_count": 3,
+            "repaired_candidate_count": 3,
+            "repaired_dead_air_max": 0.0,
+            "max_added_note_ratio": 0.9166666666666666,
+            "max_postprocess_removal_ratio": 0.0,
+            "max_repaired_interval": 62,
+        },
+        "candidate_repairs": rows,
+        "readiness": {
+            "dead_air_timing_repair_probe_completed": True,
+            "repaired_ranked_midi_written": True,
+            "dead_air_timing_repair_passed": True,
+            "dead_air_timing_audio_render_required": True,
+            "human_audio_preference_claimed": quality_claim,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": SOURCE_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioTest(
+    unittest.TestCase
+):
+    def test_renders_repaired_midi_to_wav_without_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = touch_file(root, "bin/fluidsynth")
+            soundfont = touch_file(root, "sf/general.sf2")
+            report = build_audio_render_report(
+                source_report(root),
+                output_dir=root / "out",
+                renderer_path=renderer,
+                soundfont_path=soundfont,
+                sample_rate=44100,
+                expected_file_count=3,
+                runner=fake_runner,
+            )
+            summary = validate_audio_render_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                expected_file_count=3,
+                expected_sample_rate=44100,
+                require_audio_package_completed=True,
+                require_no_quality_claim=True,
+            )
+
+        self.assertTrue(summary["render_attempted"])
+        self.assertEqual(summary["rendered_audio_file_count"], 3)
+        self.assertTrue(summary["technical_wav_validation"])
+        self.assertTrue(summary["dead_air_timing_repair_audio_package_completed"])
+        self.assertEqual(summary["repaired_candidate_count"], 3)
+        self.assertEqual(summary["repaired_dead_air_max"], 0.0)
+        self.assertEqual(summary["max_repaired_interval"], 62)
+        self.assertTrue(summary["remaining_wide_interval_risk"])
+        self.assertFalse(summary["audio_rendered_quality_claimed"])
+        self.assertFalse(summary["human_audio_preference_claimed"])
+
+    def test_rejects_source_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = touch_file(root, "bin/fluidsynth")
+            soundfont = touch_file(root, "sf/general.sf2")
+            with self.assertRaises(
+                StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError
+            ):
+                build_audio_render_report(
+                    source_report(root, quality_claim=True),
+                    output_dir=root / "out",
+                    renderer_path=renderer,
+                    soundfont_path=soundfont,
+                    sample_rate=44100,
+                    expected_file_count=3,
+                    runner=fake_runner,
+                )
+
+    def test_rejects_missing_repaired_midi(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = touch_file(root, "bin/fluidsynth")
+            soundfont = touch_file(root, "sf/general.sf2")
+            source = source_report(root)
+            source["candidate_repairs"][0]["repaired_midi_path"] = "missing.mid"
+            with self.assertRaises(
+                StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairAudioError
+            ):
+                build_audio_render_report(
+                    source,
+                    output_dir=root / "out",
+                    renderer_path=renderer,
+                    soundfont_path=soundfont,
+                    sample_rate=44100,
+                    expected_file_count=3,
+                    runner=fake_runner,
+                )
+
+    def test_boundary_constants_are_stable(self) -> None:
+        self.assertEqual(
+            BOUNDARY,
+            "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package",
+        )
+        self.assertEqual(
+            NEXT_BOUNDARY,
+            "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- repaired model-conditioned MIDI 후보 3개 WAV render package 추가
- rendered WAV `3`, technical validation `true` 기록
- repaired dead-air max `0.0000`, max added-note ratio `0.9167`, max interval `62` 기록
- remaining wide-interval risk `true` 기준 objective next decision 경계 지정
- audio quality, human/audio preference, musical quality claim 제외 유지

## Context

- #690 repair probe 결과: repaired/pass `3/3`
- source dead-air max `0.6522`, repaired dead-air max `0.0000`
- max postprocess removal ratio `0.0000`
- max repaired simultaneous notes `1`
- max repaired interval `62`
- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package`

## Scope

- `scripts/render_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio.py`
- `tests/test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio.py`
- `scripts/agent_harness.sh` mode 추가
- README, current status, core plan, handoff 문서 갱신

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio`
- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-audio-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- technical WAV validation 한정
- max repaired interval `62` 잔존
- human/audio preference 미검증
- 음악적 품질 claim 제외

Closes #692