### PR TITLE
Stage B MIDI-to-solo model-conditioned input path dead-air timing repair objective next decision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #692, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair audio package.
+- Latest functional issue completed: Issue #694, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair objective next decision.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path dead-air timing repair objective next decision.
+- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour decision.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1132,6 +1132,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-
 ```
 
 This harness renders repaired model-conditioned dead-air/timing MIDI candidates to WAV and verifies technical audio metadata without claiming musical quality.
+
+For Stage B MIDI-to-solo model-conditioned input path dead-air timing repair objective next decision changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-objective-next
+```
+
+This harness selects the next objective repair boundary after repaired dead-air/timing audio evidence without claiming musical quality.
 
 For Stage B MIDI-to-solo phrase-bank retrieval baseline changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package`
+- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -41,6 +41,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned dead-air timing repair WAV files: `3`
 - model-conditioned dead-air timing repair WAV technical validation: `true`
 - model-conditioned remaining wide-interval risk: `true`
+- model-conditioned dead-air timing repair objective next decision completed: `true`
+- model-conditioned wide-interval follow-up required: `true`
+- model-conditioned dead-air target supported: `true`
 - phrase-bank retrieval baseline completed: `true`
 - phrase-bank source records / motifs: `56 / 803`
 - phrase-bank exported / qualified MIDI candidates: `3 / 3`
@@ -80,7 +83,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - MVP completion audit completed: `true`
 - quality gap decision completed: `true`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -125,6 +128,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned ranked MIDI/WAV listening review package 생성 가능
 - model-conditioned ranked MIDI 후보의 dead-air/timing repair probe 가능
 - model-conditioned dead-air/timing repaired MIDI 후보의 WAV technical render 가능
+- model-conditioned dead-air/timing repaired MIDI/WAV objective next decision 가능
 
 현재 README가 주장하지 않는 것.
 
@@ -334,6 +338,23 @@ Model-conditioned input path dead-air timing repair audio package.
 - max repaired interval: `62`
 - remaining wide-interval risk: `true`
 - audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+Model-conditioned input path dead-air timing repair objective next decision.
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision`
+- selected target: `wide_interval_pitch_contour_repair`
+- technical WAV validation: `true`
+- rendered audio file count: `3`
+- repaired dead-air max: `0.0000`
+- max added-note ratio: `0.9167`
+- added-note ratio review required: `true`
+- max repaired interval: `62`
+- max interval threshold: `12`
+- wide-interval follow-up required: `true`
+- current evidence consolidation ready: `false`
 - human/audio preference claimed: `false`
 - MIDI-to-solo musical quality claimed: `false`
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -406,6 +406,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo model-conditioned input path dead-air timing repair decision: target `dead_air_timing_continuity`, target dead-air max `0.3500`, required gain `0.3022`, repair probe required `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe`
 - MIDI-to-solo model-conditioned input path dead-air timing repair probe: repaired/pass `3/3`, dead-air max `0.6522 -> 0.0000`, max added-note ratio `0.9167`, max interval `62`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package`
 - MIDI-to-solo model-conditioned input path dead-air timing repair audio package: rendered WAV `3`, technical validation `true`, repaired dead-air max `0.0000`, max interval `62`, remaining wide-interval risk `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision`
+- MIDI-to-solo model-conditioned input path dead-air timing repair objective next decision: dead-air target supported `true`, max interval `62`, wide-interval follow-up `true`, current evidence consolidation `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision`
 - model-core portfolio bullet refresh: resume bullet `6`, short bullet `3`, generic base checkpoint repeatability `9/9/9`, unsupported claim guard 유지
 - Muzig application wording refresh: resume project bullet `5`, short bullet `3`, 자기소개 section `3`, AI 음악 실험/검증 claim만 사용
 - Muzig application final review package: long bullet `5`, short bullet `3`, 자기소개 paragraph `3`, 지원 동기 paragraph `2`, 최종 claim check 포함
@@ -484,6 +485,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - Stage B MIDI-to-solo model-conditioned input path dead-air timing repair decision: source dead-air failure `3`, target dead-air max `0.3500`, required gain `0.3022`, guardrail max postprocess removal `0.2500`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe`
 - Stage B MIDI-to-solo model-conditioned input path dead-air timing repair probe: repaired/pass `3/3`, dead-air max `0.6522 -> 0.0000`, removal ratio `0.0000`, added-note ratio `0.9167`, max simultaneous `1`, max interval `62`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package`
 - Stage B MIDI-to-solo model-conditioned input path dead-air timing repair audio package: rendered WAV `3`, technical validation `true`, duration `19.585s-22.390s`, remaining wide-interval risk `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision`
+- Stage B MIDI-to-solo model-conditioned input path dead-air timing repair objective next decision: technical WAV `true`, dead-air target supported `true`, added-note ratio review `true`, max interval `62`, pitch-contour follow-up `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision`
 - Stage B MIDI-to-solo controlled scale checkpoint dead-air repeatability temperature guard audio review package: candidate/rendered `3/3`, sample rate `44100`, duration `6.747s-6.861s`, technical validation `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_dead_air_repeatability_temperature_guard_listening_review`
 - Stage B MIDI-to-solo controlled scale checkpoint dead-air repeatability temperature guard listening review: candidate/rendered `3/3`, validated review input `false`, pending fields `4/3/9`, preference fill `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_dead_air_repeatability_temperature_guard_objective_only_next_decision`
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
@@ -3343,6 +3345,44 @@ Issue #692는 Issue #690 repair probe 결과의 repaired MIDI 3개를 WAV로 렌
 다음 작업:
 
 - `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair objective next decision`
+
+## 9.38 Stage B MIDI-to-solo model-conditioned input path dead-air timing repair objective next decision
+
+Issue #694는 Issue #692 audio package 결과를 source로 사용해 repaired MIDI/WAV objective evidence의 다음 경계를 결정한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision`
+- selected target: `wide_interval_pitch_contour_repair`
+- technical WAV validation: `true`
+- rendered audio file count: `3`
+- repaired dead-air max: `0.0000`
+- max added-note ratio: `0.9167`
+- added-note ratio review required: `true`
+- max repaired interval: `62`
+- max interval threshold: `12`
+- wide-interval follow-up required: `true`
+- current evidence consolidation ready: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- dead-air target은 objective 기준 통과.
+- max repaired interval `62`가 threshold `12`를 초과해 pitch-contour follow-up 필요.
+- 현재 evidence consolidation 제외.
+- 음악적 품질 claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-objective-next`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour decision`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #692, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair audio package
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair objective next decision`
+- latest functional result: Issue #694, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair objective next decision
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour decision`
 
 현재 범위가 아닌 것:
 
@@ -63,6 +63,56 @@
 - model-conditioned input path dead-air/timing repair target 정의 완료
 - model-conditioned input path dead-air/timing repair probe 기준 repaired 후보 3개 objective target 통과
 - model-conditioned input path dead-air/timing repaired 후보 3개 WAV technical render 완료
+- model-conditioned input path dead-air/timing repaired evidence 기준 pitch-contour follow-up 필요 판정
+
+## Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Objective Next Decision Result
+
+Issue #694는 Issue #692 audio package 결과를 source로 사용해 repaired MIDI/WAV objective evidence의 다음 경계를 결정한 작업이다.
+
+변경:
+
+- model-conditioned input path dead-air timing repair objective next decision script 추가
+- repaired dead-air support와 wide interval follow-up 필요 여부 분리
+- added-note ratio review 신호 기록
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_OBJECTIVE_NEXT_DECISION_2026-06-08.md`
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision`
+- selected target: `wide_interval_pitch_contour_repair`
+- technical WAV validation: `true`
+- rendered audio file count: `3`
+- repaired dead-air max: `0.0000`
+- max added-note ratio: `0.9167`
+- added-note ratio review required: `true`
+- max repaired interval: `62`
+- max interval threshold: `12`
+- wide-interval follow-up required: `true`
+- current evidence consolidation ready: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- dead-air target은 objective 기준 통과.
+- max repaired interval `62`가 threshold `12`를 초과해 pitch-contour follow-up 필요.
+- 현재 evidence consolidation 제외.
+- 음악적 품질 claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-objective-next`
+
+다음:
+
+- `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour decision`
 
 ## Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Audio Package Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_OBJECTIVE_NEXT_DECISION_2026-06-08.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_OBJECTIVE_NEXT_DECISION_2026-06-08.md
@@ -1,0 +1,35 @@
+# Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Objective Next Decision
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision`
+- selected target: `wide_interval_pitch_contour_repair`
+- technical WAV validation: `true`
+- rendered audio file count: `3`
+- repaired dead-air max: `0.0000`
+- max added-note ratio: `0.9167`
+- added-note ratio review required: `true`
+- max repaired interval: `62`
+- max interval threshold: `12`
+- wide-interval follow-up required: `true`
+- current evidence consolidation ready: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Decision
+
+- reason: `repaired dead-air target passed, but max repaired interval still exceeds objective contour threshold`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour decision`
+
+## Claim Boundary
+
+- `human_audio_preference`
+- `audio_rendered_quality`
+- `midi_to_solo_musical_quality`
+- `model_checkpoint_generation_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -252,6 +252,8 @@ Modes:
                 Repair dead-air/timing gaps in ranked model-conditioned MIDI candidates.
   stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-audio-package
                 Render repaired model-conditioned dead-air/timing MIDI candidates to WAV.
+  stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-objective-next
+                Select the next objective boundary after repaired dead-air/timing audio evidence.
   stage-b-midi-to-solo-model-direct-generation-repair
                 Define the model-direct generation repair boundary from sequence budget evidence.
   stage-b-midi-to-solo-model-direct-sequence-budget-repair-smoke
@@ -6234,6 +6236,30 @@ run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_aud
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next() {
+  local audio_package_run_id="${AUDIO_PACKAGE_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision}"
+  local audio_package_report="outputs/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package/${audio_package_run_id}/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package.json"
+  if [[ ! -f "$audio_package_report" ]]; then
+    print_header "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair audio package"
+    RUN_ID="$audio_package_run_id" run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package
+  fi
+  print_header "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair objective next decision"
+  "$PYTHON_BIN" scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next.py \
+    --run_id "$run_id" \
+    --audio_package_report "$audio_package_report" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_OBJECTIVE_NEXT_DECISION_2026-06-08.md \
+    --issue_number 694 \
+    --expected_count 3 \
+    --max_interval_threshold 12 \
+    --max_added_note_ratio_review_threshold 0.75 \
+    --expected_boundary stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision \
+    --expected_next_boundary stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision \
+    --require_objective_decision \
+    --require_wide_interval_followup \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -7896,6 +7922,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-audio-package)
     run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package
+    ;;
+  stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-objective-next)
+    run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next.py
+++ b/scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next.py
@@ -1,0 +1,418 @@
+"""Select the next boundary after repaired model-conditioned audio evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.render_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+class StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairObjectiveNextError(
+    ValueError
+):
+    pass
+
+
+BOUNDARY = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_objective_next_decision"
+)
+PITCH_CONTOUR_NEXT_BOUNDARY = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_pitch_contour_decision"
+)
+CURRENT_EVIDENCE_NEXT_BOUNDARY = "stage_b_midi_to_solo_mvp_current_evidence_consolidation"
+SCHEMA_VERSION = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_objective_next_v1"
+)
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairObjectiveNextError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_audio_package(report: dict[str, Any], *, expected_count: int) -> dict[str, Any]:
+    boundary = _dict(report.get("audio_render_boundary"))
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("summary"))
+    if str(boundary.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairObjectiveNextError(
+            "dead-air timing repair audio package boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairObjectiveNextError(
+            "audio package must route to objective next decision"
+        )
+    required_true = [
+        "render_attempted",
+        "technical_wav_validation",
+        "dead_air_timing_repair_audio_package_completed",
+    ]
+    missing = [name for name in required_true if not bool(boundary.get(name, False))]
+    if missing:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairObjectiveNextError(
+            f"missing audio package readiness: {missing}"
+        )
+    if _int(boundary.get("rendered_audio_file_count")) < int(expected_count):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairObjectiveNextError(
+            "rendered audio count below expected"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairObjectiveNextError(
+            "critical user input should not be required"
+        )
+    _require_no_quality_claim(boundary, label="audio package boundary")
+    files = [_dict(item) for item in _list(report.get("rendered_audio_files"))]
+    if len(files) < int(expected_count):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairObjectiveNextError(
+            "rendered audio rows below expected"
+        )
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "rendered_audio_file_count": _int(boundary.get("rendered_audio_file_count")),
+        "technical_wav_validation": bool(boundary.get("technical_wav_validation", False)),
+        "repaired_candidate_count": _int(summary.get("repaired_candidate_count")),
+        "repaired_dead_air_max": _float(summary.get("repaired_dead_air_max")),
+        "max_added_note_ratio": _float(summary.get("max_added_note_ratio")),
+        "max_postprocess_removal_ratio": _float(summary.get("max_postprocess_removal_ratio")),
+        "max_repaired_interval": _int(summary.get("max_repaired_interval")),
+        "remaining_wide_interval_risk": bool(summary.get("remaining_wide_interval_risk", False)),
+        "rendered_audio_files": files[: int(expected_count)],
+    }
+
+
+def build_objective_next_report(
+    *,
+    audio_package_report: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+    expected_count: int,
+    max_interval_threshold: int,
+    max_added_note_ratio_review_threshold: float,
+) -> dict[str, Any]:
+    source = validate_audio_package(audio_package_report, expected_count=int(expected_count))
+    wide_interval_followup_required = bool(
+        source["remaining_wide_interval_risk"]
+        or _int(source["max_repaired_interval"]) >= int(max_interval_threshold)
+    )
+    added_note_ratio_review_required = bool(
+        _float(source["max_added_note_ratio"]) >= float(max_added_note_ratio_review_threshold)
+    )
+    next_boundary = (
+        PITCH_CONTOUR_NEXT_BOUNDARY
+        if wide_interval_followup_required
+        else CURRENT_EVIDENCE_NEXT_BOUNDARY
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundary": source["boundary"],
+        "objective_summary": {
+            "rendered_audio_file_count": _int(source["rendered_audio_file_count"]),
+            "technical_wav_validation": bool(source["technical_wav_validation"]),
+            "repaired_candidate_count": _int(source["repaired_candidate_count"]),
+            "repaired_dead_air_max": _float(source["repaired_dead_air_max"]),
+            "max_added_note_ratio": _float(source["max_added_note_ratio"]),
+            "max_postprocess_removal_ratio": _float(source["max_postprocess_removal_ratio"]),
+            "max_repaired_interval": _int(source["max_repaired_interval"]),
+            "max_interval_threshold": int(max_interval_threshold),
+            "remaining_wide_interval_risk": bool(source["remaining_wide_interval_risk"]),
+            "wide_interval_followup_required": bool(wide_interval_followup_required),
+            "added_note_ratio_review_threshold": float(max_added_note_ratio_review_threshold),
+            "added_note_ratio_review_required": bool(added_note_ratio_review_required),
+        },
+        "selected_next_target": {
+            "target": (
+                "wide_interval_pitch_contour_repair"
+                if wide_interval_followup_required
+                else "current_evidence_consolidation"
+            ),
+            "next_boundary": next_boundary,
+            "reason": (
+                "repaired dead-air target passed, but max repaired interval still exceeds objective contour threshold"
+                if wide_interval_followup_required
+                else "repaired dead-air audio evidence has no objective follow-up blocker"
+            ),
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "objective_next_decision_completed": True,
+            "technical_wav_validation": bool(source["technical_wav_validation"]),
+            "dead_air_target_supported": _float(source["repaired_dead_air_max"]) <= 0.35,
+            "wide_interval_followup_required": bool(wide_interval_followup_required),
+            "current_evidence_consolidation_ready": not bool(wide_interval_followup_required),
+            "human_audio_preference_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": next_boundary,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "objective MIDI/WAV evidence selected the next repair boundary without quality claim",
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "audio_rendered_quality",
+            "midi_to_solo_musical_quality",
+            "model_checkpoint_generation_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour decision"
+            if wide_interval_followup_required
+            else "Stage B MIDI-to-solo MVP current evidence consolidation"
+        ),
+    }
+
+
+def validate_objective_next_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_objective_decision: bool,
+    require_wide_interval_followup: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("objective_summary"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairObjectiveNextError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairObjectiveNextError(
+            "unexpected next boundary"
+        )
+    if require_objective_decision and not bool(
+        readiness.get("objective_next_decision_completed", False)
+    ):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairObjectiveNextError(
+            "objective next decision completion required"
+        )
+    if require_wide_interval_followup and not bool(
+        readiness.get("wide_interval_followup_required", False)
+    ):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairObjectiveNextError(
+            "wide-interval follow-up should be required"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairObjectiveNextError(
+            "critical user input should not be required"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="objective next readiness")
+    return {
+        "boundary": boundary,
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "objective_next_decision_completed": bool(
+            readiness.get("objective_next_decision_completed", False)
+        ),
+        "technical_wav_validation": bool(readiness.get("technical_wav_validation", False)),
+        "dead_air_target_supported": bool(readiness.get("dead_air_target_supported", False)),
+        "wide_interval_followup_required": bool(
+            readiness.get("wide_interval_followup_required", False)
+        ),
+        "current_evidence_consolidation_ready": bool(
+            readiness.get("current_evidence_consolidation_ready", False)
+        ),
+        "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
+        "repaired_dead_air_max": _float(summary.get("repaired_dead_air_max")),
+        "max_added_note_ratio": _float(summary.get("max_added_note_ratio")),
+        "added_note_ratio_review_required": bool(
+            summary.get("added_note_ratio_review_required", False)
+        ),
+        "max_repaired_interval": _int(summary.get("max_repaired_interval")),
+        "remaining_wide_interval_risk": bool(summary.get("remaining_wide_interval_risk", False)),
+        "human_audio_preference_claimed": bool(
+            readiness.get("human_audio_preference_claimed", True)
+        ),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    summary = report["objective_summary"]
+    target = report["selected_next_target"]
+    lines = [
+        "# Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Objective Next Decision",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- source boundary: `{report['source_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- selected target: `{target['target']}`",
+        f"- technical WAV validation: `{_bool_token(summary['technical_wav_validation'])}`",
+        f"- rendered audio file count: `{summary['rendered_audio_file_count']}`",
+        f"- repaired dead-air max: `{summary['repaired_dead_air_max']:.4f}`",
+        f"- max added-note ratio: `{summary['max_added_note_ratio']:.4f}`",
+        f"- added-note ratio review required: `{_bool_token(summary['added_note_ratio_review_required'])}`",
+        f"- max repaired interval: `{summary['max_repaired_interval']}`",
+        f"- max interval threshold: `{summary['max_interval_threshold']}`",
+        f"- wide-interval follow-up required: `{_bool_token(summary['wide_interval_followup_required'])}`",
+        f"- current evidence consolidation ready: `{_bool_token(readiness['current_evidence_consolidation_ready'])}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Decision",
+        "",
+        f"- reason: `{target['reason']}`",
+        f"- auto progress allowed: `{_bool_token(decision['auto_progress_allowed'])}`",
+        f"- critical user input required: `{_bool_token(decision['critical_user_input_required'])}`",
+        f"- next recommended issue: `{report['next_recommended_issue']}`",
+        "",
+        "## Claim Boundary",
+        "",
+    ]
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Select the next boundary after repaired model-conditioned audio evidence"
+    )
+    parser.add_argument("--audio_package_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=(
+            "outputs/stage_b_midi_to_solo_model_conditioned_input_path_"
+            "dead_air_timing_repair_objective_next_decision"
+        ),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=694)
+    parser.add_argument("--expected_count", type=int, default=3)
+    parser.add_argument("--max_interval_threshold", type=int, default=12)
+    parser.add_argument("--max_added_note_ratio_review_threshold", type=float, default=0.75)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_objective_decision", action="store_true")
+    parser.add_argument("--require_wide_interval_followup", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_objective_next_report(
+        audio_package_report=read_json(Path(args.audio_package_report)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+        expected_count=int(args.expected_count),
+        max_interval_threshold=int(args.max_interval_threshold),
+        max_added_note_ratio_review_threshold=float(args.max_added_note_ratio_review_threshold),
+    )
+    summary = validate_objective_next_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_objective_decision=bool(args.require_objective_decision),
+        require_wide_interval_followup=bool(args.require_wide_interval_followup),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next.py
+++ b/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next import (
+    BOUNDARY,
+    CURRENT_EVIDENCE_NEXT_BOUNDARY,
+    PITCH_CONTOUR_NEXT_BOUNDARY,
+    StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairObjectiveNextError,
+    build_objective_next_report,
+    validate_objective_next_report,
+)
+from scripts.render_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio import (
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+def audio_package(
+    *,
+    max_interval: int = 62,
+    quality_claim: bool = False,
+) -> dict:
+    return {
+        "summary": {
+            "rendered_audio_file_count": 3,
+            "technical_wav_validation": True,
+            "repaired_candidate_count": 3,
+            "repaired_dead_air_max": 0.0,
+            "max_added_note_ratio": 0.9166666666666666,
+            "max_postprocess_removal_ratio": 0.0,
+            "max_repaired_interval": max_interval,
+            "remaining_wide_interval_risk": max_interval >= 12,
+        },
+        "audio_render_boundary": {
+            "boundary": SOURCE_BOUNDARY,
+            "render_attempted": True,
+            "rendered_audio_file_count": 3,
+            "technical_wav_validation": True,
+            "dead_air_timing_repair_audio_package_completed": True,
+            "human_audio_preference_claimed": quality_claim,
+            "audio_rendered_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "rendered_audio_files": [
+            {
+                "rank": index,
+                "wav_file": {
+                    "path": f"audio/rank_{index}.wav",
+                    "exists": True,
+                    "sample_rate": 44100,
+                    "frame_count": 1000,
+                    "size_bytes": 4044,
+                },
+            }
+            for index in range(1, 4)
+        ],
+        "decision": {
+            "next_boundary": SOURCE_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairObjectiveNextTest(
+    unittest.TestCase
+):
+    def test_routes_to_pitch_contour_when_wide_interval_remains(self) -> None:
+        report = build_objective_next_report(
+            audio_package_report=audio_package(),
+            output_dir="out",
+            issue_number=694,
+            expected_count=3,
+            max_interval_threshold=12,
+            max_added_note_ratio_review_threshold=0.75,
+        )
+        summary = validate_objective_next_report(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=PITCH_CONTOUR_NEXT_BOUNDARY,
+            require_objective_decision=True,
+            require_wide_interval_followup=True,
+            require_no_quality_claim=True,
+        )
+
+        self.assertTrue(summary["objective_next_decision_completed"])
+        self.assertTrue(summary["technical_wav_validation"])
+        self.assertTrue(summary["dead_air_target_supported"])
+        self.assertTrue(summary["wide_interval_followup_required"])
+        self.assertFalse(summary["current_evidence_consolidation_ready"])
+        self.assertTrue(summary["added_note_ratio_review_required"])
+        self.assertEqual(summary["max_repaired_interval"], 62)
+        self.assertFalse(summary["human_audio_preference_claimed"])
+
+    def test_routes_to_current_evidence_without_wide_interval_risk(self) -> None:
+        report = build_objective_next_report(
+            audio_package_report=audio_package(max_interval=9),
+            output_dir="out",
+            issue_number=694,
+            expected_count=3,
+            max_interval_threshold=12,
+            max_added_note_ratio_review_threshold=0.75,
+        )
+        summary = validate_objective_next_report(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=CURRENT_EVIDENCE_NEXT_BOUNDARY,
+            require_objective_decision=True,
+            require_wide_interval_followup=False,
+            require_no_quality_claim=True,
+        )
+
+        self.assertFalse(summary["wide_interval_followup_required"])
+        self.assertTrue(summary["current_evidence_consolidation_ready"])
+
+    def test_rejects_audio_quality_claim(self) -> None:
+        with self.assertRaises(
+            StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairObjectiveNextError
+        ):
+            build_objective_next_report(
+                audio_package_report=audio_package(quality_claim=True),
+                output_dir="out",
+                issue_number=694,
+                expected_count=3,
+                max_interval_threshold=12,
+                max_added_note_ratio_review_threshold=0.75,
+            )
+
+    def test_boundary_constants_are_stable(self) -> None:
+        self.assertEqual(
+            BOUNDARY,
+            "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision",
+        )
+        self.assertEqual(
+            PITCH_CONTOUR_NEXT_BOUNDARY,
+            "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- repaired MIDI/WAV objective next decision 추가
- dead-air target support `true`와 wide interval follow-up `true` 분리
- max repaired interval `62`, max interval threshold `12` 기록
- added-note ratio review required `true` 기록
- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision`
- human/audio preference, audio quality, musical quality claim 제외 유지

## Context

- #692 audio package 결과: rendered WAV `3`, technical validation `true`
- repaired dead-air max `0.0000`
- max added-note ratio `0.9167`
- max repaired interval `62`
- remaining wide-interval risk `true`

## Scope

- `scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next.py`
- `tests/test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next.py`
- `scripts/agent_harness.sh` mode 추가
- README, current status, core plan, handoff 문서 갱신

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-objective-next`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- objective evidence 기반 판단 한정
- pitch-contour repair는 후속 경계
- human/audio preference 미검증
- 음악적 품질 claim 제외

Closes #694

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated project status documentation to reflect completion of Issue `#694` (dead-air timing repair objective decision stage).
  * Added comprehensive documentation for the objective next decision process, including validation criteria and recommended next steps.
  * Advanced project boundary markers and evidence tracking in the Stage B MIDI-to-solo pipeline.

* **Chores**
  * Added automation support for the new objective next decision workflow stage.
  * Implemented validation and decision-routing for pitch-contour follow-up determination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->