### PR TITLE
Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour decision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #694, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair objective next decision.
+- Latest functional issue completed: Issue #696, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour decision.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour decision.
+- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour probe.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1140,6 +1140,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-
 ```
 
 This harness selects the next objective repair boundary after repaired dead-air/timing audio evidence without claiming musical quality.
+
+For Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour decision changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-decision
+```
+
+This harness defines the pitch-contour repair target after repaired dead-air/timing objective evidence without claiming musical quality.
 
 For Stage B MIDI-to-solo phrase-bank retrieval baseline changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision`
+- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -44,6 +44,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned dead-air timing repair objective next decision completed: `true`
 - model-conditioned wide-interval follow-up required: `true`
 - model-conditioned dead-air target supported: `true`
+- model-conditioned pitch-contour repair decision completed: `true`
+- model-conditioned pitch-contour selected target: `wide_interval_pitch_contour_repair`
+- model-conditioned pitch-contour required interval reduction min: `50`
+- model-conditioned pitch-contour repair probe required: `true`
 - phrase-bank retrieval baseline completed: `true`
 - phrase-bank source records / motifs: `56 / 803`
 - phrase-bank exported / qualified MIDI candidates: `3 / 3`
@@ -83,7 +87,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - MVP completion audit completed: `true`
 - quality gap decision completed: `true`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -128,6 +132,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned ranked MIDI/WAV listening review package 생성 가능
 - model-conditioned ranked MIDI 후보의 dead-air/timing repair probe 가능
 - model-conditioned dead-air/timing repaired MIDI 후보의 WAV technical render 가능
+- model-conditioned dead-air/timing repaired evidence 기준 pitch-contour repair target 정의 가능
 - model-conditioned dead-air/timing repaired MIDI/WAV objective next decision 가능
 
 현재 README가 주장하지 않는 것.
@@ -354,6 +359,25 @@ Model-conditioned input path dead-air timing repair objective next decision.
 - max repaired interval: `62`
 - max interval threshold: `12`
 - wide-interval follow-up required: `true`
+- current evidence consolidation ready: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+Model-conditioned input path dead-air timing repair pitch contour decision.
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe`
+- selected target: `wide_interval_pitch_contour_repair`
+- technical WAV validation: `true`
+- dead-air target supported: `true`
+- source repaired dead-air max: `0.0000`
+- target dead-air max: `0.3500`
+- source max added-note ratio: `0.9167`
+- added-note ratio review required: `true`
+- source max interval: `62`
+- target max interval: `12`
+- required interval reduction min: `50`
+- repair probe required: `true`
 - current evidence consolidation ready: `false`
 - human/audio preference claimed: `false`
 - MIDI-to-solo musical quality claimed: `false`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -407,6 +407,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo model-conditioned input path dead-air timing repair probe: repaired/pass `3/3`, dead-air max `0.6522 -> 0.0000`, max added-note ratio `0.9167`, max interval `62`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package`
 - MIDI-to-solo model-conditioned input path dead-air timing repair audio package: rendered WAV `3`, technical validation `true`, repaired dead-air max `0.0000`, max interval `62`, remaining wide-interval risk `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision`
 - MIDI-to-solo model-conditioned input path dead-air timing repair objective next decision: dead-air target supported `true`, max interval `62`, wide-interval follow-up `true`, current evidence consolidation `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision`
+- MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour decision: target `wide_interval_pitch_contour_repair`, interval target `62 -> 12`, required reduction `50`, repair probe `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe`
 - model-core portfolio bullet refresh: resume bullet `6`, short bullet `3`, generic base checkpoint repeatability `9/9/9`, unsupported claim guard 유지
 - Muzig application wording refresh: resume project bullet `5`, short bullet `3`, 자기소개 section `3`, AI 음악 실험/검증 claim만 사용
 - Muzig application final review package: long bullet `5`, short bullet `3`, 자기소개 paragraph `3`, 지원 동기 paragraph `2`, 최종 claim check 포함
@@ -486,6 +487,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - Stage B MIDI-to-solo model-conditioned input path dead-air timing repair probe: repaired/pass `3/3`, dead-air max `0.6522 -> 0.0000`, removal ratio `0.0000`, added-note ratio `0.9167`, max simultaneous `1`, max interval `62`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_audio_package`
 - Stage B MIDI-to-solo model-conditioned input path dead-air timing repair audio package: rendered WAV `3`, technical validation `true`, duration `19.585s-22.390s`, remaining wide-interval risk `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision`
 - Stage B MIDI-to-solo model-conditioned input path dead-air timing repair objective next decision: technical WAV `true`, dead-air target supported `true`, added-note ratio review `true`, max interval `62`, pitch-contour follow-up `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision`
+- Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour decision: technical WAV `true`, dead-air target supported `true`, selected target `wide_interval_pitch_contour_repair`, required interval reduction `50`, repair probe `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe`
 - Stage B MIDI-to-solo controlled scale checkpoint dead-air repeatability temperature guard audio review package: candidate/rendered `3/3`, sample rate `44100`, duration `6.747s-6.861s`, technical validation `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_dead_air_repeatability_temperature_guard_listening_review`
 - Stage B MIDI-to-solo controlled scale checkpoint dead-air repeatability temperature guard listening review: candidate/rendered `3/3`, validated review input `false`, pending fields `4/3/9`, preference fill `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_dead_air_repeatability_temperature_guard_objective_only_next_decision`
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
@@ -3383,6 +3385,46 @@ Issue #694는 Issue #692 audio package 결과를 source로 사용해 repaired MI
 다음 작업:
 
 - `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour decision`
+
+## 9.39 Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour decision
+
+Issue #696은 Issue #694 objective next decision 결과를 source로 사용해 pitch-contour repair target과 다음 probe 경계를 정의한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe`
+- selected target: `wide_interval_pitch_contour_repair`
+- technical WAV validation: `true`
+- dead-air target supported: `true`
+- source repaired dead-air max: `0.0000`
+- target dead-air max: `0.3500`
+- source max added-note ratio: `0.9167`
+- added-note ratio review required: `true`
+- source max interval: `62`
+- target max interval: `12`
+- required interval reduction min: `50`
+- repair probe required: `true`
+- current evidence consolidation ready: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- dead-air target은 유지 대상.
+- max interval `62`를 threshold `12` 이하로 줄이는 repair probe 필요.
+- added-note ratio `0.9167`은 review 신호로 유지.
+- 음악적 품질 claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-decision`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour probe`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -1,6 +1,6 @@
 # Current Status and Plan
 
-작성일: 2026-06-08
+작성일: 2026-06-09
 
 ## Current Focus
 
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #694, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair objective next decision
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour decision`
+- latest functional result: Issue #696, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour decision
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour probe`
 
 현재 범위가 아닌 것:
 
@@ -64,6 +64,58 @@
 - model-conditioned input path dead-air/timing repair probe 기준 repaired 후보 3개 objective target 통과
 - model-conditioned input path dead-air/timing repaired 후보 3개 WAV technical render 완료
 - model-conditioned input path dead-air/timing repaired evidence 기준 pitch-contour follow-up 필요 판정
+- model-conditioned input path dead-air/timing repaired evidence 기준 pitch-contour repair target 정의 완료
+
+## Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Pitch Contour Decision Result
+
+Issue #696은 Issue #694 objective next decision 결과를 source로 사용해 pitch-contour repair target과 다음 probe 경계를 정의한 작업이다.
+
+변경:
+
+- model-conditioned input path dead-air timing repair pitch contour decision script 추가
+- source max interval과 target max interval 기준 interval reduction target 기록
+- dead-air 유지, max simultaneous 유지, added-note ratio review guardrail 기록
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_PITCH_CONTOUR_DECISION_2026-06-09.md`
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe`
+- selected target: `wide_interval_pitch_contour_repair`
+- technical WAV validation: `true`
+- dead-air target supported: `true`
+- source repaired dead-air max: `0.0000`
+- target dead-air max: `0.3500`
+- source max added-note ratio: `0.9167`
+- added-note ratio review required: `true`
+- source max interval: `62`
+- target max interval: `12`
+- required interval reduction min: `50`
+- repair probe required: `true`
+- current evidence consolidation ready: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- dead-air target은 유지 대상.
+- max interval `62`를 threshold `12` 이하로 줄이는 repair probe 필요.
+- added-note ratio `0.9167`은 review 신호로 유지.
+- 음악적 품질 claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-decision`
+
+다음:
+
+- `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour probe`
 
 ## Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Objective Next Decision Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_PITCH_CONTOUR_DECISION_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_PITCH_CONTOUR_DECISION_2026-06-09.md
@@ -1,0 +1,44 @@
+# Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Pitch Contour Decision
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe`
+- selected target: `wide_interval_pitch_contour_repair`
+- technical WAV validation: `true`
+- dead-air target supported: `true`
+- source repaired dead-air max: `0.0000`
+- target dead-air max: `0.3500`
+- source max added-note ratio: `0.9167`
+- added-note ratio review required: `true`
+- source max interval: `62`
+- target max interval: `12`
+- required interval reduction min: `50`
+- repair probe required: `true`
+- current evidence consolidation ready: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Guardrails
+
+- preserve dead-air target: `true`
+- min repaired candidate count: `3`
+- max simultaneous notes: `1`
+- keep note count and unique pitch review: `true`
+
+## Decision
+
+- reason: `wide-interval pitch-contour repair target selected from objective evidence`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour probe`
+
+## Claim Boundary
+
+- `human_audio_preference`
+- `audio_rendered_quality`
+- `midi_to_solo_musical_quality`
+- `model_checkpoint_generation_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -254,6 +254,8 @@ Modes:
                 Render repaired model-conditioned dead-air/timing MIDI candidates to WAV.
   stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-objective-next
                 Select the next objective boundary after repaired dead-air/timing audio evidence.
+  stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-decision
+                Define the pitch-contour repair target after repaired dead-air/timing objective evidence.
   stage-b-midi-to-solo-model-direct-generation-repair
                 Define the model-direct generation repair boundary from sequence budget evidence.
   stage-b-midi-to-solo-model-direct-sequence-budget-repair-smoke
@@ -6260,6 +6262,32 @@ run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_obj
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision() {
+  local objective_next_run_id="${OBJECTIVE_NEXT_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision}"
+  local objective_next_report="outputs/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision/${objective_next_run_id}/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision.json"
+  if [[ ! -f "$objective_next_report" ]]; then
+    print_header "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair objective next decision"
+    RUN_ID="$objective_next_run_id" run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next
+  fi
+  print_header "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour decision"
+  "$PYTHON_BIN" scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour.py \
+    --run_id "$run_id" \
+    --objective_next_report "$objective_next_report" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_PITCH_CONTOUR_DECISION_2026-06-09.md \
+    --issue_number 696 \
+    --target_max_interval 12 \
+    --target_dead_air_max 0.35 \
+    --min_repaired_candidate_count 3 \
+    --max_simultaneous_notes 1 \
+    --max_added_note_ratio_review_threshold 0.75 \
+    --expected_boundary stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision \
+    --expected_next_boundary stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe \
+    --require_pitch_contour_decision \
+    --require_repair_probe \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -7925,6 +7953,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-objective-next)
     run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next
+    ;;
+  stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-decision)
+    run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour.py
+++ b/scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour.py
@@ -1,0 +1,442 @@
+"""Define the pitch-contour repair target after dead-air timing repair evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+    PITCH_CONTOUR_NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+    validate_objective_next_report,
+)
+
+
+class StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourError(
+    ValueError
+):
+    pass
+
+
+BOUNDARY = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_pitch_contour_decision"
+)
+NEXT_BOUNDARY = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_pitch_contour_probe"
+)
+SCHEMA_VERSION = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_pitch_contour_decision_v1"
+)
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_objective_next_source(
+    report: dict[str, Any],
+    *,
+    target_max_interval: int,
+) -> dict[str, Any]:
+    try:
+        summary = validate_objective_next_report(
+            report,
+            expected_boundary=SOURCE_BOUNDARY,
+            expected_next_boundary=SOURCE_NEXT_BOUNDARY,
+            require_objective_decision=True,
+            require_wide_interval_followup=True,
+            require_no_quality_claim=True,
+        )
+    except ValueError as exc:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourError(
+            str(exc)
+        ) from exc
+    if not bool(summary["technical_wav_validation"]):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourError(
+            "technical WAV validation required"
+        )
+    if not bool(summary["dead_air_target_supported"]):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourError(
+            "dead-air target support required before pitch-contour decision"
+        )
+    if bool(summary["current_evidence_consolidation_ready"]):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourError(
+            "current evidence consolidation should remain blocked"
+        )
+    if _int(summary["max_repaired_interval"]) <= int(target_max_interval):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourError(
+            "pitch-contour repair target requires max interval above threshold"
+        )
+    return summary
+
+
+def build_pitch_contour_decision_report(
+    *,
+    objective_next_report: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+    target_max_interval: int,
+    target_dead_air_max: float,
+    min_repaired_candidate_count: int,
+    max_simultaneous_notes: int,
+    max_added_note_ratio_review_threshold: float,
+) -> dict[str, Any]:
+    source = validate_objective_next_source(
+        objective_next_report,
+        target_max_interval=int(target_max_interval),
+    )
+    source_max_interval = _int(source["max_repaired_interval"])
+    required_interval_reduction_min = max(0, source_max_interval - int(target_max_interval))
+    source_dead_air_max = _float(source["repaired_dead_air_max"])
+    source_added_note_ratio = _float(source["max_added_note_ratio"])
+    added_note_ratio_review_required = source_added_note_ratio >= float(
+        max_added_note_ratio_review_threshold
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace(
+            "+00:00", "Z"
+        ),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundary": SOURCE_BOUNDARY,
+        "source_objective_summary": {
+            "rendered_audio_file_count": _int(source["rendered_audio_file_count"]),
+            "technical_wav_validation": bool(source["technical_wav_validation"]),
+            "dead_air_target_supported": bool(source["dead_air_target_supported"]),
+            "repaired_dead_air_max": source_dead_air_max,
+            "max_added_note_ratio": source_added_note_ratio,
+            "added_note_ratio_review_required": bool(added_note_ratio_review_required),
+            "max_repaired_interval": source_max_interval,
+            "remaining_wide_interval_risk": bool(source["remaining_wide_interval_risk"]),
+            "wide_interval_followup_required": bool(source["wide_interval_followup_required"]),
+            "current_evidence_consolidation_ready": bool(
+                source["current_evidence_consolidation_ready"]
+            ),
+        },
+        "selected_repair_target": {
+            "target": "wide_interval_pitch_contour_repair",
+            "primary_metric": "max_repaired_interval",
+            "source_max_interval": source_max_interval,
+            "target_max_interval": int(target_max_interval),
+            "required_interval_reduction_min": int(required_interval_reduction_min),
+            "repair_probe_boundary": NEXT_BOUNDARY,
+            "reason": "max repaired interval remains above objective contour threshold after dead-air timing repair",
+        },
+        "repair_guardrails": {
+            "preserve_dead_air_target": True,
+            "source_repaired_dead_air_max": source_dead_air_max,
+            "target_dead_air_max": float(target_dead_air_max),
+            "min_repaired_candidate_count": int(min_repaired_candidate_count),
+            "max_simultaneous_notes": int(max_simultaneous_notes),
+            "keep_note_count_and_unique_pitch_review": True,
+            "max_added_note_ratio_review_threshold": float(
+                max_added_note_ratio_review_threshold
+            ),
+            "source_max_added_note_ratio": source_added_note_ratio,
+            "added_note_ratio_review_required": bool(added_note_ratio_review_required),
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "pitch_contour_decision_completed": True,
+            "repair_probe_required": True,
+            "technical_wav_validation": bool(source["technical_wav_validation"]),
+            "dead_air_target_supported": bool(source["dead_air_target_supported"]),
+            "wide_interval_followup_required": bool(source["wide_interval_followup_required"]),
+            "current_evidence_consolidation_ready": False,
+            "human_audio_preference_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "wide-interval pitch-contour repair target selected from objective evidence",
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "audio_rendered_quality",
+            "midi_to_solo_musical_quality",
+            "model_checkpoint_generation_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo model-conditioned input path "
+            "dead-air timing repair pitch contour probe"
+        ),
+    }
+
+
+def validate_pitch_contour_decision_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_pitch_contour_decision: bool,
+    require_repair_probe: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    source = _dict(report.get("source_objective_summary"))
+    target = _dict(report.get("selected_repair_target"))
+    guardrails = _dict(report.get("repair_guardrails"))
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourError(
+            "unexpected next boundary"
+        )
+    if require_pitch_contour_decision and not bool(
+        readiness.get("pitch_contour_decision_completed", False)
+    ):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourError(
+            "pitch-contour decision completion required"
+        )
+    if require_repair_probe and not bool(readiness.get("repair_probe_required", False)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourError(
+            "repair probe should be required"
+        )
+    if _int(target.get("source_max_interval")) <= _int(target.get("target_max_interval")):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourError(
+            "source max interval must exceed target max interval"
+        )
+    if _int(target.get("required_interval_reduction_min")) <= 0:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourError(
+            "positive interval reduction target required"
+        )
+    if not bool(guardrails.get("preserve_dead_air_target", False)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourError(
+            "dead-air guardrail required"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourError(
+            "critical user input should not be required"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="pitch-contour decision readiness")
+    return {
+        "boundary": boundary,
+        "source_boundary": str(report.get("source_boundary") or ""),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "pitch_contour_decision_completed": bool(
+            readiness.get("pitch_contour_decision_completed", False)
+        ),
+        "repair_probe_required": bool(readiness.get("repair_probe_required", False)),
+        "technical_wav_validation": bool(source.get("technical_wav_validation", False)),
+        "dead_air_target_supported": bool(source.get("dead_air_target_supported", False)),
+        "source_repaired_dead_air_max": _float(source.get("repaired_dead_air_max")),
+        "target_dead_air_max": _float(guardrails.get("target_dead_air_max")),
+        "source_max_added_note_ratio": _float(guardrails.get("source_max_added_note_ratio")),
+        "added_note_ratio_review_required": bool(
+            guardrails.get("added_note_ratio_review_required", False)
+        ),
+        "source_max_interval": _int(target.get("source_max_interval")),
+        "target_max_interval": _int(target.get("target_max_interval")),
+        "required_interval_reduction_min": _int(
+            target.get("required_interval_reduction_min")
+        ),
+        "current_evidence_consolidation_ready": bool(
+            readiness.get("current_evidence_consolidation_ready", True)
+        ),
+        "human_audio_preference_claimed": bool(
+            readiness.get("human_audio_preference_claimed", True)
+        ),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    source = report["source_objective_summary"]
+    target = report["selected_repair_target"]
+    guardrails = report["repair_guardrails"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    lines = [
+        "# Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Pitch Contour Decision",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- source boundary: `{report['source_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- selected target: `{target['target']}`",
+        f"- technical WAV validation: `{_bool_token(source['technical_wav_validation'])}`",
+        f"- dead-air target supported: `{_bool_token(source['dead_air_target_supported'])}`",
+        f"- source repaired dead-air max: `{source['repaired_dead_air_max']:.4f}`",
+        f"- target dead-air max: `{guardrails['target_dead_air_max']:.4f}`",
+        f"- source max added-note ratio: `{guardrails['source_max_added_note_ratio']:.4f}`",
+        f"- added-note ratio review required: `{_bool_token(guardrails['added_note_ratio_review_required'])}`",
+        f"- source max interval: `{target['source_max_interval']}`",
+        f"- target max interval: `{target['target_max_interval']}`",
+        f"- required interval reduction min: `{target['required_interval_reduction_min']}`",
+        f"- repair probe required: `{_bool_token(readiness['repair_probe_required'])}`",
+        f"- current evidence consolidation ready: `{_bool_token(readiness['current_evidence_consolidation_ready'])}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Guardrails",
+        "",
+        f"- preserve dead-air target: `{_bool_token(guardrails['preserve_dead_air_target'])}`",
+        f"- min repaired candidate count: `{guardrails['min_repaired_candidate_count']}`",
+        f"- max simultaneous notes: `{guardrails['max_simultaneous_notes']}`",
+        f"- keep note count and unique pitch review: `{_bool_token(guardrails['keep_note_count_and_unique_pitch_review'])}`",
+        "",
+        "## Decision",
+        "",
+        f"- reason: `{decision['reason']}`",
+        f"- auto progress allowed: `{_bool_token(decision['auto_progress_allowed'])}`",
+        f"- critical user input required: `{_bool_token(decision['critical_user_input_required'])}`",
+        f"- next recommended issue: `{report['next_recommended_issue']}`",
+        "",
+        "## Claim Boundary",
+        "",
+    ]
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Define the pitch-contour repair target after dead-air timing repair evidence"
+    )
+    parser.add_argument("--objective_next_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=(
+            "outputs/stage_b_midi_to_solo_model_conditioned_input_path_"
+            "dead_air_timing_repair_pitch_contour_decision"
+        ),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=696)
+    parser.add_argument("--target_max_interval", type=int, default=12)
+    parser.add_argument("--target_dead_air_max", type=float, default=0.35)
+    parser.add_argument("--min_repaired_candidate_count", type=int, default=3)
+    parser.add_argument("--max_simultaneous_notes", type=int, default=1)
+    parser.add_argument("--max_added_note_ratio_review_threshold", type=float, default=0.75)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_pitch_contour_decision", action="store_true")
+    parser.add_argument("--require_repair_probe", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_pitch_contour_decision_report(
+        objective_next_report=read_json(Path(args.objective_next_report)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+        target_max_interval=int(args.target_max_interval),
+        target_dead_air_max=float(args.target_dead_air_max),
+        min_repaired_candidate_count=int(args.min_repaired_candidate_count),
+        max_simultaneous_notes=int(args.max_simultaneous_notes),
+        max_added_note_ratio_review_threshold=float(
+            args.max_added_note_ratio_review_threshold
+        ),
+    )
+    summary = validate_pitch_contour_decision_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_pitch_contour_decision=bool(args.require_pitch_contour_decision),
+        require_repair_probe=bool(args.require_repair_probe),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision.py
+++ b/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next import (
+    BOUNDARY as SOURCE_BOUNDARY,
+    PITCH_CONTOUR_NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+from scripts.decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourError,
+    build_pitch_contour_decision_report,
+    validate_pitch_contour_decision_report,
+)
+
+
+def objective_next_source(
+    *,
+    max_interval: int = 62,
+    quality_claim: bool = False,
+    wide_interval_followup: bool = True,
+) -> dict:
+    next_boundary = (
+        SOURCE_NEXT_BOUNDARY
+        if wide_interval_followup
+        else "stage_b_midi_to_solo_mvp_current_evidence_consolidation"
+    )
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "source_boundary": (
+            "stage_b_midi_to_solo_model_conditioned_input_path_"
+            "dead_air_timing_repair_audio_package"
+        ),
+        "objective_summary": {
+            "rendered_audio_file_count": 3,
+            "technical_wav_validation": True,
+            "repaired_candidate_count": 3,
+            "repaired_dead_air_max": 0.0,
+            "max_added_note_ratio": 0.9166666666666666,
+            "max_postprocess_removal_ratio": 0.0,
+            "max_repaired_interval": max_interval,
+            "max_interval_threshold": 12,
+            "remaining_wide_interval_risk": wide_interval_followup,
+            "wide_interval_followup_required": wide_interval_followup,
+            "added_note_ratio_review_threshold": 0.75,
+            "added_note_ratio_review_required": True,
+        },
+        "selected_next_target": {
+            "target": (
+                "wide_interval_pitch_contour_repair"
+                if wide_interval_followup
+                else "current_evidence_consolidation"
+            ),
+            "next_boundary": next_boundary,
+        },
+        "readiness": {
+            "boundary": SOURCE_BOUNDARY,
+            "objective_next_decision_completed": True,
+            "technical_wav_validation": True,
+            "dead_air_target_supported": True,
+            "wide_interval_followup_required": wide_interval_followup,
+            "current_evidence_consolidation_ready": not wide_interval_followup,
+            "human_audio_preference_claimed": quality_claim,
+            "audio_rendered_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": SOURCE_BOUNDARY,
+            "next_boundary": next_boundary,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+        },
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo model-conditioned input path "
+            "dead-air timing repair pitch contour decision"
+        ),
+    }
+
+
+class StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourTest(
+    unittest.TestCase
+):
+    def test_defines_pitch_contour_repair_probe_boundary(self) -> None:
+        report = build_pitch_contour_decision_report(
+            objective_next_report=objective_next_source(),
+            output_dir="out",
+            issue_number=696,
+            target_max_interval=12,
+            target_dead_air_max=0.35,
+            min_repaired_candidate_count=3,
+            max_simultaneous_notes=1,
+            max_added_note_ratio_review_threshold=0.75,
+        )
+        summary = validate_pitch_contour_decision_report(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=NEXT_BOUNDARY,
+            require_pitch_contour_decision=True,
+            require_repair_probe=True,
+            require_no_quality_claim=True,
+        )
+
+        self.assertTrue(summary["pitch_contour_decision_completed"])
+        self.assertTrue(summary["repair_probe_required"])
+        self.assertTrue(summary["technical_wav_validation"])
+        self.assertTrue(summary["dead_air_target_supported"])
+        self.assertEqual(summary["source_max_interval"], 62)
+        self.assertEqual(summary["target_max_interval"], 12)
+        self.assertEqual(summary["required_interval_reduction_min"], 50)
+        self.assertTrue(summary["added_note_ratio_review_required"])
+        self.assertFalse(summary["current_evidence_consolidation_ready"])
+        self.assertFalse(summary["human_audio_preference_claimed"])
+
+    def test_rejects_source_without_wide_interval_followup(self) -> None:
+        with self.assertRaises(
+            StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourError
+        ):
+            build_pitch_contour_decision_report(
+                objective_next_report=objective_next_source(
+                    max_interval=9,
+                    wide_interval_followup=False,
+                ),
+                output_dir="out",
+                issue_number=696,
+                target_max_interval=12,
+                target_dead_air_max=0.35,
+                min_repaired_candidate_count=3,
+                max_simultaneous_notes=1,
+                max_added_note_ratio_review_threshold=0.75,
+            )
+
+    def test_rejects_quality_claim(self) -> None:
+        with self.assertRaises(
+            StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourError
+        ):
+            build_pitch_contour_decision_report(
+                objective_next_report=objective_next_source(quality_claim=True),
+                output_dir="out",
+                issue_number=696,
+                target_max_interval=12,
+                target_dead_air_max=0.35,
+                min_repaired_candidate_count=3,
+                max_simultaneous_notes=1,
+                max_added_note_ratio_review_threshold=0.75,
+            )
+
+    def test_boundary_constants_are_stable(self) -> None:
+        self.assertEqual(
+            BOUNDARY,
+            "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision",
+        )
+        self.assertEqual(
+            NEXT_BOUNDARY,
+            "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- pitch-contour repair target decision 추가
- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe`
- Closes #696

## Context

- #694 objective next decision 결과 기준
- technical WAV validation: `true`
- dead-air target supported: `true`
- source repaired dead-air max: `0.0000`
- source max interval: `62`
- target max interval: `12`
- current evidence consolidation ready: `false`
- human/audio preference, audio quality, MIDI-to-solo musical quality claim 제외

## Scope

- pitch-contour decision script 추가
- source max interval과 target max interval 기반 required interval reduction 기록
- dead-air 유지, max simultaneous 유지, added-note ratio review guardrail 기록
- 전용 harness mode와 unit test 추가
- README, CORE_PLAN, CURRENT_STATUS, AGENTS handoff 갱신

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-decision`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- decision boundary 한정
- pitch-contour repair 구현은 후속 issue 범위
- 음악적 품질 claim 제외

## Follow-up

- Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour probe