### PR TITLE
Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour probe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #696, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour decision.
+- Latest functional issue completed: Issue #698, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour probe.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour probe.
+- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour audio package.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1148,6 +1148,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-
 ```
 
 This harness defines the pitch-contour repair target after repaired dead-air/timing objective evidence without claiming musical quality.
+
+For Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour probe changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-probe
+```
+
+This harness repairs wide pitch intervals in dead-air/timing repaired model-conditioned MIDI candidates without claiming musical quality.
 
 For Stage B MIDI-to-solo phrase-bank retrieval baseline changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision`
+- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -48,6 +48,12 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned pitch-contour selected target: `wide_interval_pitch_contour_repair`
 - model-conditioned pitch-contour required interval reduction min: `50`
 - model-conditioned pitch-contour repair probe required: `true`
+- model-conditioned pitch-contour repair probe completed: `true`
+- model-conditioned pitch-contour repaired / passed candidates: `3 / 3`
+- model-conditioned pitch-contour max interval: `62 -> 11`
+- model-conditioned pitch-contour interval reduction: `51`
+- model-conditioned pitch-contour repaired dead-air max: `0.0000`
+- model-conditioned pitch-contour max pitch changed ratio: `0.7174`
 - phrase-bank retrieval baseline completed: `true`
 - phrase-bank source records / motifs: `56 / 803`
 - phrase-bank exported / qualified MIDI candidates: `3 / 3`
@@ -87,7 +93,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - MVP completion audit completed: `true`
 - quality gap decision completed: `true`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_audio_package`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -133,6 +139,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned ranked MIDI 후보의 dead-air/timing repair probe 가능
 - model-conditioned dead-air/timing repaired MIDI 후보의 WAV technical render 가능
 - model-conditioned dead-air/timing repaired evidence 기준 pitch-contour repair target 정의 가능
+- model-conditioned dead-air/timing repaired MIDI 후보의 pitch-contour objective repair 가능
 - model-conditioned dead-air/timing repaired MIDI/WAV objective next decision 가능
 
 현재 README가 주장하지 않는 것.
@@ -379,6 +386,23 @@ Model-conditioned input path dead-air timing repair pitch contour decision.
 - required interval reduction min: `50`
 - repair probe required: `true`
 - current evidence consolidation ready: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+Model-conditioned input path dead-air timing repair pitch contour probe.
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_audio_package`
+- repaired / passed candidates: `3 / 3`
+- source max interval: `62`
+- repaired max interval: `11`
+- target max interval: `12`
+- interval reduction: `51`
+- required interval reduction min: `50`
+- source dead-air max: `0.0000`
+- repaired dead-air max: `0.0000`
+- min repaired unique pitch count: `22`
+- max pitch changed ratio: `0.7174`
 - human/audio preference claimed: `false`
 - MIDI-to-solo musical quality claimed: `false`
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -408,6 +408,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo model-conditioned input path dead-air timing repair audio package: rendered WAV `3`, technical validation `true`, repaired dead-air max `0.0000`, max interval `62`, remaining wide-interval risk `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision`
 - MIDI-to-solo model-conditioned input path dead-air timing repair objective next decision: dead-air target supported `true`, max interval `62`, wide-interval follow-up `true`, current evidence consolidation `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision`
 - MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour decision: target `wide_interval_pitch_contour_repair`, interval target `62 -> 12`, required reduction `50`, repair probe `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe`
+- MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour probe: repaired/pass `3/3`, max interval `62 -> 11`, interval reduction `51`, dead-air max `0.0000`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_audio_package`
 - model-core portfolio bullet refresh: resume bullet `6`, short bullet `3`, generic base checkpoint repeatability `9/9/9`, unsupported claim guard 유지
 - Muzig application wording refresh: resume project bullet `5`, short bullet `3`, 자기소개 section `3`, AI 음악 실험/검증 claim만 사용
 - Muzig application final review package: long bullet `5`, short bullet `3`, 자기소개 paragraph `3`, 지원 동기 paragraph `2`, 최종 claim check 포함
@@ -488,6 +489,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - Stage B MIDI-to-solo model-conditioned input path dead-air timing repair audio package: rendered WAV `3`, technical validation `true`, duration `19.585s-22.390s`, remaining wide-interval risk `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_objective_next_decision`
 - Stage B MIDI-to-solo model-conditioned input path dead-air timing repair objective next decision: technical WAV `true`, dead-air target supported `true`, added-note ratio review `true`, max interval `62`, pitch-contour follow-up `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision`
 - Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour decision: technical WAV `true`, dead-air target supported `true`, selected target `wide_interval_pitch_contour_repair`, required interval reduction `50`, repair probe `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe`
+- Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour probe: repaired/pass `3/3`, max interval `62 -> 11`, target max interval `12`, dead-air max `0.0000`, max pitch changed ratio `0.7174`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_audio_package`
 - Stage B MIDI-to-solo controlled scale checkpoint dead-air repeatability temperature guard audio review package: candidate/rendered `3/3`, sample rate `44100`, duration `6.747s-6.861s`, technical validation `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_dead_air_repeatability_temperature_guard_listening_review`
 - Stage B MIDI-to-solo controlled scale checkpoint dead-air repeatability temperature guard listening review: candidate/rendered `3/3`, validated review input `false`, pending fields `4/3/9`, preference fill `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_dead_air_repeatability_temperature_guard_objective_only_next_decision`
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
@@ -3425,6 +3427,45 @@ Issue #696은 Issue #694 objective next decision 결과를 source로 사용해 p
 다음 작업:
 
 - `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour probe`
+
+## 9.40 Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour probe
+
+Issue #698은 Issue #696 pitch-contour decision 결과와 Issue #690 dead-air timing repair MIDI를 source로 사용해 wide interval objective repair를 실행한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_audio_package`
+- repaired / passed candidates: `3 / 3`
+- source max interval: `62`
+- repaired max interval: `11`
+- target max interval: `12`
+- interval reduction: `51`
+- required interval reduction min: `50`
+- source dead-air max: `0.0000`
+- repaired dead-air max: `0.0000`
+- max simultaneous notes: `1`
+- min repaired unique pitch count: `22`
+- max pitch changed ratio: `0.7174`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- max interval target 통과.
+- dead-air target 유지.
+- monophonic gate 유지.
+- pitch changed ratio `0.7174`로 audio review 필요.
+- 음악적 품질 claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-probe`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour audio package`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #696, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour decision
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour probe`
+- latest functional result: Issue #698, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour probe
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour audio package`
 
 현재 범위가 아닌 것:
 
@@ -65,6 +65,57 @@
 - model-conditioned input path dead-air/timing repaired 후보 3개 WAV technical render 완료
 - model-conditioned input path dead-air/timing repaired evidence 기준 pitch-contour follow-up 필요 판정
 - model-conditioned input path dead-air/timing repaired evidence 기준 pitch-contour repair target 정의 완료
+- model-conditioned input path dead-air/timing repaired 후보 3개 pitch-contour objective repair 통과
+
+## Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Pitch Contour Probe Result
+
+Issue #698은 Issue #696 pitch-contour decision 결과와 Issue #690 dead-air timing repair MIDI를 source로 사용해 wide interval objective repair를 실행한 작업이다.
+
+변경:
+
+- model-conditioned input path dead-air timing repair pitch contour probe script 추가
+- pitch class 유지 + octave contour fold 기반 repaired MIDI export
+- max interval, dead-air, monophonic, unique pitch guardrail 검증
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_PITCH_CONTOUR_PROBE_2026-06-09.md`
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_audio_package`
+- repaired / passed candidates: `3 / 3`
+- source max interval: `62`
+- repaired max interval: `11`
+- target max interval: `12`
+- interval reduction: `51`
+- required interval reduction min: `50`
+- source dead-air max: `0.0000`
+- repaired dead-air max: `0.0000`
+- max simultaneous notes: `1`
+- min repaired unique pitch count: `22`
+- max pitch changed ratio: `0.7174`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- max interval target 통과.
+- dead-air target 유지.
+- monophonic gate 유지.
+- pitch changed ratio `0.7174`로 audio review 필요.
+- 음악적 품질 claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-probe`
+
+다음:
+
+- `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour audio package`
 
 ## Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Pitch Contour Decision Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_PITCH_CONTOUR_PROBE_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_PITCH_CONTOUR_PROBE_2026-06-09.md
@@ -1,0 +1,46 @@
+# Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Pitch Contour Probe
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_audio_package`
+- repair passed: `true`
+- source candidate count: `3`
+- repaired candidate count: `3`
+- repaired pass count: `3`
+- source max interval: `62`
+- repaired max interval: `11`
+- target max interval: `12`
+- interval reduction: `51`
+- required interval reduction min: `50`
+- source dead-air max: `0.0000`
+- repaired dead-air max: `0.0000`
+- min repaired unique pitch count: `22`
+- max pitch changed ratio: `0.7174`
+
+## Repair Config
+
+- strategy: `pitch_class_octave_contour_fold`
+- preferred pitch range: `48`-`88`
+- max adjacent interval: `12`
+- min unique pitch count: `8`
+
+## Guardrails
+
+- target max interval: `12`
+- target dead-air max: `0.3500`
+- max simultaneous notes: `1`
+- source max added-note ratio: `0.9167`
+- added-note ratio review required: `true`
+
+## Repaired MIDI
+
+- rank `1` sample `1`: `outputs/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe/harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe/midi/rank_01_sample_01_pitch_contour_repair.mid`, max interval `62` -> `9`, unique pitch `31` -> `23`, pitch changed ratio `0.6957`, pass `true`
+- rank `2` sample `2`: `outputs/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe/harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe/midi/rank_02_sample_02_pitch_contour_repair.mid`, max interval `51` -> `11`, unique pitch `30` -> `26`, pitch changed ratio `0.6522`, pass `true`
+- rank `3` sample `3`: `outputs/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe/harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe/midi/rank_03_sample_03_pitch_contour_repair.mid`, max interval `35` -> `6`, unique pitch `31` -> `22`, pitch changed ratio `0.7174`, pass `true`
+
+## Claim Boundary
+
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- audio rendered quality claimed: `false`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -256,6 +256,8 @@ Modes:
                 Select the next objective boundary after repaired dead-air/timing audio evidence.
   stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-decision
                 Define the pitch-contour repair target after repaired dead-air/timing objective evidence.
+  stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-probe
+                Repair wide pitch intervals in dead-air/timing repaired model-conditioned MIDI candidates.
   stage-b-midi-to-solo-model-direct-generation-repair
                 Define the model-direct generation repair boundary from sequence budget evidence.
   stage-b-midi-to-solo-model-direct-sequence-budget-repair-smoke
@@ -6288,6 +6290,39 @@ run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pit
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe() {
+  local pitch_contour_decision_run_id="${PITCH_CONTOUR_DECISION_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision}"
+  local dead_air_repair_probe_run_id="${DEAD_AIR_REPAIR_PROBE_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe}"
+  local pitch_contour_decision_report="outputs/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision/${pitch_contour_decision_run_id}/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision.json"
+  local dead_air_repair_probe_report="outputs/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe/${dead_air_repair_probe_run_id}/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe.json"
+  if [[ ! -f "$pitch_contour_decision_report" ]]; then
+    print_header "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour decision"
+    RUN_ID="$pitch_contour_decision_run_id" run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision
+  fi
+  if [[ ! -f "$dead_air_repair_probe_report" ]]; then
+    print_header "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair probe"
+    RUN_ID="$dead_air_repair_probe_run_id" run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe
+  fi
+  print_header "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour probe"
+  "$PYTHON_BIN" scripts/run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe.py \
+    --run_id "$run_id" \
+    --pitch_contour_decision_report "$pitch_contour_decision_report" \
+    --dead_air_repair_probe_report "$dead_air_repair_probe_report" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_PITCH_CONTOUR_PROBE_2026-06-09.md \
+    --issue_number 698 \
+    --min_repaired_candidates 3 \
+    --dead_air_threshold_seconds 0.5 \
+    --preferred_pitch_min 48 \
+    --preferred_pitch_max 88 \
+    --max_adjacent_interval 12 \
+    --min_unique_pitch_count 8 \
+    --expected_boundary stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe \
+    --expected_next_boundary stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_audio_package \
+    --require_repair_passed \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -7956,6 +7991,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-decision)
     run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_decision
+    ;;
+  stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-probe)
+    run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe.py
+++ b/scripts/run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe.py
@@ -1,0 +1,747 @@
+"""Run pitch-contour repair probe for dead-air/timing repaired MIDI candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pretty_midi
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour import (  # noqa: E402
+    BOUNDARY as DECISION_BOUNDARY,
+    NEXT_BOUNDARY as DECISION_NEXT_BOUNDARY,
+    validate_pitch_contour_decision_report,
+)
+from scripts.run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe import (  # noqa: E402
+    BOUNDARY as DEAD_AIR_REPAIR_BOUNDARY,
+    load_midi_notes,
+    max_simultaneous_notes,
+    objective_metrics_for_path,
+)
+
+
+class StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourProbeError(
+    ValueError
+):
+    pass
+
+
+BOUNDARY = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_pitch_contour_probe"
+)
+NEXT_BOUNDARY = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_pitch_contour_audio_package"
+)
+FAIL_NEXT_BOUNDARY = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_pitch_contour_followup"
+)
+SCHEMA_VERSION = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_pitch_contour_probe_v1"
+)
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourProbeError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_pitch_contour_decision_source(report: dict[str, Any]) -> dict[str, Any]:
+    try:
+        summary = validate_pitch_contour_decision_report(
+            report,
+            expected_boundary=DECISION_BOUNDARY,
+            expected_next_boundary=DECISION_NEXT_BOUNDARY,
+            require_pitch_contour_decision=True,
+            require_repair_probe=True,
+            require_no_quality_claim=True,
+        )
+    except ValueError as exc:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourProbeError(
+            str(exc)
+        ) from exc
+    if _int(summary["source_max_interval"]) <= _int(summary["target_max_interval"]):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourProbeError(
+            "pitch-contour repair source must exceed target interval"
+        )
+    return summary
+
+
+def validate_dead_air_repair_probe_source(
+    report: dict[str, Any],
+    *,
+    min_candidate_count: int,
+) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("summary"))
+    candidate_repairs = [_dict(item) for item in _list(report.get("candidate_repairs"))]
+    if str(report.get("boundary") or "") != DEAD_AIR_REPAIR_BOUNDARY:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourProbeError(
+            "dead-air timing repair probe boundary required"
+        )
+    if not bool(readiness.get("dead_air_timing_repair_passed", False)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourProbeError(
+            "dead-air timing repair pass required"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourProbeError(
+            "critical user input should not be required"
+        )
+    if len(candidate_repairs) < int(min_candidate_count):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourProbeError(
+            "candidate repair count below minimum"
+        )
+    for row in candidate_repairs[: int(min_candidate_count)]:
+        repaired_path = Path(str(row.get("repaired_midi_path") or ""))
+        if not repaired_path.exists():
+            raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourProbeError(
+                f"dead-air repaired MIDI missing: {repaired_path}"
+            )
+        if not bool(row.get("candidate_repair_passed", False)):
+            raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourProbeError(
+                "dead-air repaired candidate must pass"
+            )
+    _require_no_quality_claim(readiness, label="dead-air repair probe readiness")
+    return {
+        "boundary": DEAD_AIR_REPAIR_BOUNDARY,
+        "candidate_repairs": candidate_repairs[: int(min_candidate_count)],
+        "source_max_interval": _int(summary.get("max_repaired_interval")),
+        "source_dead_air_max": _float(summary.get("repaired_dead_air_max")),
+        "max_added_note_ratio": _float(summary.get("max_added_note_ratio")),
+        "max_postprocess_removal_ratio": _float(summary.get("max_postprocess_removal_ratio")),
+        "max_repaired_simultaneous_notes": _int(summary.get("max_repaired_simultaneous_notes")),
+    }
+
+
+def map_to_preferred_range(
+    pitch: int,
+    *,
+    preferred_pitch_min: int,
+    preferred_pitch_max: int,
+) -> int:
+    mapped = int(pitch)
+    while mapped < int(preferred_pitch_min):
+        mapped += 12
+    while mapped > int(preferred_pitch_max):
+        mapped -= 12
+    return max(int(preferred_pitch_min), min(int(preferred_pitch_max), int(mapped)))
+
+
+def choose_contour_pitch(
+    original_pitch: int,
+    *,
+    previous_pitch: int | None,
+    preferred_pitch_min: int,
+    preferred_pitch_max: int,
+    max_adjacent_interval: int,
+) -> int:
+    base = map_to_preferred_range(
+        int(original_pitch),
+        preferred_pitch_min=int(preferred_pitch_min),
+        preferred_pitch_max=int(preferred_pitch_max),
+    )
+    if previous_pitch is None:
+        return int(base)
+    candidates: list[int] = []
+    for octave_shift in range(-8, 9):
+        candidate = int(original_pitch) + (12 * octave_shift)
+        if int(preferred_pitch_min) <= candidate <= int(preferred_pitch_max):
+            candidates.append(candidate)
+    if not candidates:
+        candidates.append(base)
+    candidates.sort(
+        key=lambda candidate: (
+            abs(candidate - int(previous_pitch)),
+            abs(candidate - int(original_pitch)),
+            candidate,
+        )
+    )
+    best = candidates[0]
+    if abs(best - int(previous_pitch)) <= int(max_adjacent_interval):
+        return int(best)
+    direction = 1 if best >= int(previous_pitch) else -1
+    bounded = int(previous_pitch) + (direction * int(max_adjacent_interval))
+    return map_to_preferred_range(
+        bounded,
+        preferred_pitch_min=int(preferred_pitch_min),
+        preferred_pitch_max=int(preferred_pitch_max),
+    )
+
+
+def write_pitch_contour_repaired_midi(
+    source_midi_path: str | Path,
+    repaired_midi_path: str | Path,
+    *,
+    preferred_pitch_min: int,
+    preferred_pitch_max: int,
+    max_adjacent_interval: int,
+) -> dict[str, Any]:
+    source_midi_path = Path(source_midi_path)
+    repaired_midi_path = Path(repaired_midi_path)
+    source = pretty_midi.PrettyMIDI(str(source_midi_path))
+    source_notes = load_midi_notes(source_midi_path)
+    if not source_notes:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourProbeError(
+            f"source MIDI has no notes: {source_midi_path}"
+        )
+    repaired = pretty_midi.PrettyMIDI(initial_tempo=float(source.estimate_tempo() or 120.0))
+    program = 0
+    for instrument in source.instruments:
+        if not instrument.is_drum:
+            program = int(instrument.program)
+            break
+    repaired_instrument = pretty_midi.Instrument(
+        program=program,
+        is_drum=False,
+        name="pitch_contour_repaired_solo",
+    )
+    previous_pitch: int | None = None
+    changed_note_count = 0
+    max_pitch_shift_abs = 0
+    repaired_notes: list[pretty_midi.Note] = []
+    for note in source_notes:
+        pitch = choose_contour_pitch(
+            int(note.pitch),
+            previous_pitch=previous_pitch,
+            preferred_pitch_min=int(preferred_pitch_min),
+            preferred_pitch_max=int(preferred_pitch_max),
+            max_adjacent_interval=int(max_adjacent_interval),
+        )
+        if pitch != int(note.pitch):
+            changed_note_count += 1
+            max_pitch_shift_abs = max(max_pitch_shift_abs, abs(pitch - int(note.pitch)))
+        repaired_notes.append(
+            pretty_midi.Note(
+                velocity=max(1, min(127, int(note.velocity or 80))),
+                pitch=int(pitch),
+                start=float(note.start),
+                end=float(note.end),
+            )
+        )
+        previous_pitch = int(pitch)
+    repaired_instrument.notes = repaired_notes
+    repaired.instruments.append(repaired_instrument)
+    repaired_midi_path.parent.mkdir(parents=True, exist_ok=True)
+    repaired.write(str(repaired_midi_path))
+    return {
+        "source_note_count": int(len(source_notes)),
+        "repaired_note_count": int(len(repaired_notes)),
+        "changed_note_count": int(changed_note_count),
+        "pitch_changed_ratio": float(changed_note_count / max(1, len(source_notes))),
+        "max_pitch_shift_abs": int(max_pitch_shift_abs),
+    }
+
+
+def build_pitch_contour_probe_report(
+    *,
+    pitch_contour_decision_report: dict[str, Any],
+    dead_air_repair_probe_report: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+    min_repaired_candidates: int,
+    dead_air_threshold_seconds: float,
+    preferred_pitch_min: int,
+    preferred_pitch_max: int,
+    max_adjacent_interval: int,
+    min_unique_pitch_count: int,
+) -> dict[str, Any]:
+    decision_source = validate_pitch_contour_decision_source(pitch_contour_decision_report)
+    dead_air_source = validate_dead_air_repair_probe_source(
+        dead_air_repair_probe_report,
+        min_candidate_count=int(min_repaired_candidates),
+    )
+    repaired_dir = output_dir / "midi"
+    candidate_repairs: list[dict[str, Any]] = []
+    for row in dead_air_source["candidate_repairs"]:
+        rank = _int(row.get("rank"))
+        sample_index = _int(row.get("sample_index"))
+        source_path = Path(str(row.get("repaired_midi_path") or ""))
+        repaired_path = repaired_dir / (
+            f"rank_{rank:02d}_sample_{sample_index:02d}_pitch_contour_repair.mid"
+        )
+        before = objective_metrics_for_path(
+            source_path,
+            dead_air_threshold_seconds=float(dead_air_threshold_seconds),
+        )
+        pitch_stats = write_pitch_contour_repaired_midi(
+            source_path,
+            repaired_path,
+            preferred_pitch_min=int(preferred_pitch_min),
+            preferred_pitch_max=int(preferred_pitch_max),
+            max_adjacent_interval=int(max_adjacent_interval),
+        )
+        after = objective_metrics_for_path(
+            repaired_path,
+            dead_air_threshold_seconds=float(dead_air_threshold_seconds),
+        )
+        repaired_notes = load_midi_notes(repaired_path)
+        candidate_passed = bool(
+            _int(after.get("max_interval")) <= _int(decision_source["target_max_interval"])
+            and _float(after.get("dead_air_ratio")) <= _float(decision_source["target_dead_air_max"])
+            and _int(after.get("note_count")) >= _int(before.get("note_count"))
+            and _int(after.get("unique_pitch_count")) >= int(min_unique_pitch_count)
+            and max_simultaneous_notes(repaired_notes) <= 1
+        )
+        candidate_repairs.append(
+            {
+                "rank": rank,
+                "sample_index": sample_index,
+                "sample_seed": _int(row.get("sample_seed")),
+                "source_midi_path": str(source_path),
+                "repaired_midi_path": str(repaired_path),
+                "source_metrics": {
+                    "note_count": _int(before.get("note_count")),
+                    "unique_pitch_count": _int(before.get("unique_pitch_count")),
+                    "max_simultaneous_notes": _int(before.get("max_simultaneous_notes")),
+                    "dead_air_ratio": _float(before.get("dead_air_ratio")),
+                    "max_interval": _int(before.get("max_interval")),
+                    "pitch_span": _int(before.get("pitch_span")),
+                },
+                "repaired_metrics": {
+                    "note_count": _int(after.get("note_count")),
+                    "unique_pitch_count": _int(after.get("unique_pitch_count")),
+                    "max_simultaneous_notes": max_simultaneous_notes(repaired_notes),
+                    "dead_air_ratio": _float(after.get("dead_air_ratio")),
+                    "max_interval": _int(after.get("max_interval")),
+                    "pitch_span": _int(after.get("pitch_span")),
+                },
+                "pitch_repair_stats": pitch_stats,
+                "candidate_repair_passed": bool(candidate_passed),
+            }
+        )
+
+    repaired_pass_count = sum(
+        1 for row in candidate_repairs if bool(row.get("candidate_repair_passed", False))
+    )
+    source_max_interval = max(
+        (_int(row.get("source_metrics", {}).get("max_interval")) for row in candidate_repairs),
+        default=0,
+    )
+    repaired_max_interval = max(
+        (_int(row.get("repaired_metrics", {}).get("max_interval")) for row in candidate_repairs),
+        default=0,
+    )
+    repaired_dead_air_max = max(
+        (_float(row.get("repaired_metrics", {}).get("dead_air_ratio")) for row in candidate_repairs),
+        default=0.0,
+    )
+    pitch_contour_target_met = bool(
+        repaired_pass_count >= int(min_repaired_candidates)
+        and repaired_max_interval <= _int(decision_source["target_max_interval"])
+        and repaired_dead_air_max <= _float(decision_source["target_dead_air_max"])
+    )
+    next_boundary = NEXT_BOUNDARY if pitch_contour_target_met else FAIL_NEXT_BOUNDARY
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace(
+            "+00:00", "Z"
+        ),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundaries": {
+            "pitch_contour_decision": DECISION_BOUNDARY,
+            "dead_air_repair_probe": DEAD_AIR_REPAIR_BOUNDARY,
+        },
+        "repair_config": {
+            "strategy": "pitch_class_octave_contour_fold",
+            "dead_air_threshold_seconds": float(dead_air_threshold_seconds),
+            "preferred_pitch_min": int(preferred_pitch_min),
+            "preferred_pitch_max": int(preferred_pitch_max),
+            "max_adjacent_interval": int(max_adjacent_interval),
+            "min_repaired_candidates": int(min_repaired_candidates),
+            "min_unique_pitch_count": int(min_unique_pitch_count),
+        },
+        "guardrails": {
+            "target_max_interval": _int(decision_source["target_max_interval"]),
+            "source_decision_max_interval": _int(decision_source["source_max_interval"]),
+            "required_interval_reduction_min": _int(
+                decision_source["required_interval_reduction_min"]
+            ),
+            "target_dead_air_max": _float(decision_source["target_dead_air_max"]),
+            "source_dead_air_max": _float(dead_air_source["source_dead_air_max"]),
+            "max_simultaneous_notes": 1,
+            "min_unique_pitch_count": int(min_unique_pitch_count),
+            "source_max_added_note_ratio": _float(decision_source["source_max_added_note_ratio"]),
+            "added_note_ratio_review_required": bool(
+                decision_source["added_note_ratio_review_required"]
+            ),
+        },
+        "candidate_repairs": candidate_repairs,
+        "summary": {
+            "source_candidate_count": int(len(candidate_repairs)),
+            "repaired_candidate_count": int(len(candidate_repairs)),
+            "repaired_pass_count": int(repaired_pass_count),
+            "source_max_interval": int(source_max_interval),
+            "repaired_max_interval": int(repaired_max_interval),
+            "target_max_interval": _int(decision_source["target_max_interval"]),
+            "interval_reduction": int(source_max_interval - repaired_max_interval),
+            "required_interval_reduction_min": _int(
+                decision_source["required_interval_reduction_min"]
+            ),
+            "source_dead_air_max": _float(dead_air_source["source_dead_air_max"]),
+            "repaired_dead_air_max": float(repaired_dead_air_max),
+            "target_dead_air_max": _float(decision_source["target_dead_air_max"]),
+            "max_repaired_simultaneous_notes": max(
+                (
+                    _int(row.get("repaired_metrics", {}).get("max_simultaneous_notes"))
+                    for row in candidate_repairs
+                ),
+                default=0,
+            ),
+            "min_repaired_unique_pitch_count": min(
+                (
+                    _int(row.get("repaired_metrics", {}).get("unique_pitch_count"))
+                    for row in candidate_repairs
+                ),
+                default=0,
+            ),
+            "max_pitch_changed_ratio": max(
+                (
+                    _float(row.get("pitch_repair_stats", {}).get("pitch_changed_ratio"))
+                    for row in candidate_repairs
+                ),
+                default=0.0,
+            ),
+            "pitch_contour_repair_passed": bool(pitch_contour_target_met),
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "pitch_contour_repair_probe_completed": True,
+            "repaired_ranked_midi_written": bool(len(candidate_repairs) >= int(min_repaired_candidates)),
+            "pitch_contour_repair_passed": bool(pitch_contour_target_met),
+            "pitch_contour_audio_render_required": bool(pitch_contour_target_met),
+            "current_evidence_consolidation_ready": False,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": next_boundary,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": (
+                "pitch-contour objective target passed; render repaired MIDI to WAV next"
+                if pitch_contour_target_met
+                else "pitch-contour objective target still requires follow-up"
+            ),
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "audio_rendered_quality",
+            "model_checkpoint_generation_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour audio package"
+            if pitch_contour_target_met
+            else "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour follow-up"
+        ),
+    }
+
+
+def validate_pitch_contour_probe_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    min_repaired_candidates: int,
+    require_repair_passed: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("summary"))
+    candidate_repairs = [_dict(item) for item in _list(report.get("candidate_repairs"))]
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourProbeError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourProbeError(
+            "unexpected next boundary"
+        )
+    if len(candidate_repairs) < int(min_repaired_candidates):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourProbeError(
+            "candidate repair count below threshold"
+        )
+    for row in candidate_repairs[: int(min_repaired_candidates)]:
+        if not Path(str(row.get("repaired_midi_path") or "")).exists():
+            raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourProbeError(
+                "repaired MIDI path missing"
+            )
+        if require_repair_passed and not bool(row.get("candidate_repair_passed", False)):
+            raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourProbeError(
+                "candidate repair should pass"
+            )
+    if require_repair_passed and not bool(readiness.get("pitch_contour_repair_passed", False)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourProbeError(
+            "pitch-contour repair should pass"
+        )
+    if _int(summary.get("repaired_max_interval")) > _int(summary.get("target_max_interval")):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourProbeError(
+            "repaired max interval exceeds target"
+        )
+    if _float(summary.get("repaired_dead_air_max")) > _float(summary.get("target_dead_air_max")):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourProbeError(
+            "repaired dead-air exceeds target"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourProbeError(
+            "critical user input should not be required"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="pitch-contour probe readiness")
+    return {
+        "boundary": boundary,
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "pitch_contour_repair_probe_completed": bool(
+            readiness.get("pitch_contour_repair_probe_completed", False)
+        ),
+        "repaired_ranked_midi_written": bool(
+            readiness.get("repaired_ranked_midi_written", False)
+        ),
+        "pitch_contour_repair_passed": bool(
+            readiness.get("pitch_contour_repair_passed", False)
+        ),
+        "pitch_contour_audio_render_required": bool(
+            readiness.get("pitch_contour_audio_render_required", False)
+        ),
+        "source_candidate_count": _int(summary.get("source_candidate_count")),
+        "repaired_candidate_count": _int(summary.get("repaired_candidate_count")),
+        "repaired_pass_count": _int(summary.get("repaired_pass_count")),
+        "source_max_interval": _int(summary.get("source_max_interval")),
+        "repaired_max_interval": _int(summary.get("repaired_max_interval")),
+        "target_max_interval": _int(summary.get("target_max_interval")),
+        "interval_reduction": _int(summary.get("interval_reduction")),
+        "required_interval_reduction_min": _int(summary.get("required_interval_reduction_min")),
+        "source_dead_air_max": _float(summary.get("source_dead_air_max")),
+        "repaired_dead_air_max": _float(summary.get("repaired_dead_air_max")),
+        "target_dead_air_max": _float(summary.get("target_dead_air_max")),
+        "max_repaired_simultaneous_notes": _int(
+            summary.get("max_repaired_simultaneous_notes")
+        ),
+        "min_repaired_unique_pitch_count": _int(
+            summary.get("min_repaired_unique_pitch_count")
+        ),
+        "max_pitch_changed_ratio": _float(summary.get("max_pitch_changed_ratio")),
+        "human_audio_preference_claimed": bool(
+            readiness.get("human_audio_preference_claimed", True)
+        ),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    config = report["repair_config"]
+    guardrails = report["guardrails"]
+    lines = [
+        "# Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Pitch Contour Probe",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- repair passed: `{_bool_token(summary['pitch_contour_repair_passed'])}`",
+        f"- source candidate count: `{summary['source_candidate_count']}`",
+        f"- repaired candidate count: `{summary['repaired_candidate_count']}`",
+        f"- repaired pass count: `{summary['repaired_pass_count']}`",
+        f"- source max interval: `{summary['source_max_interval']}`",
+        f"- repaired max interval: `{summary['repaired_max_interval']}`",
+        f"- target max interval: `{summary['target_max_interval']}`",
+        f"- interval reduction: `{summary['interval_reduction']}`",
+        f"- required interval reduction min: `{summary['required_interval_reduction_min']}`",
+        f"- source dead-air max: `{summary['source_dead_air_max']:.4f}`",
+        f"- repaired dead-air max: `{summary['repaired_dead_air_max']:.4f}`",
+        f"- min repaired unique pitch count: `{summary['min_repaired_unique_pitch_count']}`",
+        f"- max pitch changed ratio: `{summary['max_pitch_changed_ratio']:.4f}`",
+        "",
+        "## Repair Config",
+        "",
+        f"- strategy: `{config['strategy']}`",
+        f"- preferred pitch range: `{config['preferred_pitch_min']}`-`{config['preferred_pitch_max']}`",
+        f"- max adjacent interval: `{config['max_adjacent_interval']}`",
+        f"- min unique pitch count: `{config['min_unique_pitch_count']}`",
+        "",
+        "## Guardrails",
+        "",
+        f"- target max interval: `{guardrails['target_max_interval']}`",
+        f"- target dead-air max: `{guardrails['target_dead_air_max']:.4f}`",
+        f"- max simultaneous notes: `{guardrails['max_simultaneous_notes']}`",
+        f"- source max added-note ratio: `{guardrails['source_max_added_note_ratio']:.4f}`",
+        f"- added-note ratio review required: `{_bool_token(guardrails['added_note_ratio_review_required'])}`",
+        "",
+        "## Repaired MIDI",
+        "",
+    ]
+    for row in report["candidate_repairs"]:
+        source = row["source_metrics"]
+        repaired = row["repaired_metrics"]
+        stats = row["pitch_repair_stats"]
+        lines.append(
+            f"- rank `{row['rank']}` sample `{row['sample_index']}`: "
+            f"`{row['repaired_midi_path']}`, max interval `{source['max_interval']}` -> "
+            f"`{repaired['max_interval']}`, unique pitch `{source['unique_pitch_count']}` -> "
+            f"`{repaired['unique_pitch_count']}`, pitch changed ratio "
+            f"`{stats['pitch_changed_ratio']:.4f}`, pass `{_bool_token(row['candidate_repair_passed'])}`"
+        )
+    lines.extend(
+        [
+            "",
+            "## Claim Boundary",
+            "",
+            f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+            f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+            f"- audio rendered quality claimed: `{_bool_token(readiness['audio_rendered_quality_claimed'])}`",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run pitch-contour repair probe for dead-air/timing repaired MIDI candidates"
+    )
+    parser.add_argument("--pitch_contour_decision_report", type=str, required=True)
+    parser.add_argument("--dead_air_repair_probe_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=(
+            "outputs/stage_b_midi_to_solo_model_conditioned_input_path_"
+            "dead_air_timing_repair_pitch_contour_probe"
+        ),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=698)
+    parser.add_argument("--min_repaired_candidates", type=int, default=3)
+    parser.add_argument("--dead_air_threshold_seconds", type=float, default=0.5)
+    parser.add_argument("--preferred_pitch_min", type=int, default=48)
+    parser.add_argument("--preferred_pitch_max", type=int, default=88)
+    parser.add_argument("--max_adjacent_interval", type=int, default=12)
+    parser.add_argument("--min_unique_pitch_count", type=int, default=8)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_repair_passed", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_pitch_contour_probe_report(
+        pitch_contour_decision_report=read_json(Path(args.pitch_contour_decision_report)),
+        dead_air_repair_probe_report=read_json(Path(args.dead_air_repair_probe_report)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+        min_repaired_candidates=int(args.min_repaired_candidates),
+        dead_air_threshold_seconds=float(args.dead_air_threshold_seconds),
+        preferred_pitch_min=int(args.preferred_pitch_min),
+        preferred_pitch_max=int(args.preferred_pitch_max),
+        max_adjacent_interval=int(args.max_adjacent_interval),
+        min_unique_pitch_count=int(args.min_unique_pitch_count),
+    )
+    summary = validate_pitch_contour_probe_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        min_repaired_candidates=int(args.min_repaired_candidates),
+        require_repair_passed=bool(args.require_repair_passed),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe.py
+++ b/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import pretty_midi
+
+from scripts.decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour import (
+    BOUNDARY as DECISION_BOUNDARY,
+    NEXT_BOUNDARY as DECISION_NEXT_BOUNDARY,
+)
+from scripts.run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourProbeError,
+    build_pitch_contour_probe_report,
+    choose_contour_pitch,
+    validate_pitch_contour_probe_report,
+)
+from scripts.run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_probe import (
+    BOUNDARY as DEAD_AIR_REPAIR_BOUNDARY,
+)
+
+
+def write_wide_interval_midi(path: Path, pitches: list[int]) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    midi = pretty_midi.PrettyMIDI(initial_tempo=120)
+    piano = pretty_midi.Instrument(program=0, is_drum=False, name="solo")
+    for index, pitch in enumerate(pitches):
+        start = index * 0.25
+        piano.notes.append(
+            pretty_midi.Note(
+                velocity=84,
+                pitch=int(pitch),
+                start=float(start),
+                end=float(start + 0.18),
+            )
+        )
+    midi.instruments.append(piano)
+    midi.write(str(path))
+    return str(path)
+
+
+def pitch_contour_decision_source() -> dict:
+    return {
+        "boundary": DECISION_BOUNDARY,
+        "source_boundary": (
+            "stage_b_midi_to_solo_model_conditioned_input_path_"
+            "dead_air_timing_repair_objective_next_decision"
+        ),
+        "source_objective_summary": {
+            "rendered_audio_file_count": 3,
+            "technical_wav_validation": True,
+            "dead_air_target_supported": True,
+            "repaired_dead_air_max": 0.0,
+            "max_added_note_ratio": 0.9166666666666666,
+            "added_note_ratio_review_required": True,
+            "max_repaired_interval": 62,
+            "remaining_wide_interval_risk": True,
+            "wide_interval_followup_required": True,
+            "current_evidence_consolidation_ready": False,
+        },
+        "selected_repair_target": {
+            "target": "wide_interval_pitch_contour_repair",
+            "primary_metric": "max_repaired_interval",
+            "source_max_interval": 62,
+            "target_max_interval": 12,
+            "required_interval_reduction_min": 50,
+            "repair_probe_boundary": DECISION_NEXT_BOUNDARY,
+        },
+        "repair_guardrails": {
+            "preserve_dead_air_target": True,
+            "source_repaired_dead_air_max": 0.0,
+            "target_dead_air_max": 0.35,
+            "min_repaired_candidate_count": 3,
+            "max_simultaneous_notes": 1,
+            "keep_note_count_and_unique_pitch_review": True,
+            "max_added_note_ratio_review_threshold": 0.75,
+            "source_max_added_note_ratio": 0.9166666666666666,
+            "added_note_ratio_review_required": True,
+        },
+        "readiness": {
+            "boundary": DECISION_BOUNDARY,
+            "pitch_contour_decision_completed": True,
+            "repair_probe_required": True,
+            "technical_wav_validation": True,
+            "dead_air_target_supported": True,
+            "wide_interval_followup_required": True,
+            "current_evidence_consolidation_ready": False,
+            "human_audio_preference_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": DECISION_BOUNDARY,
+            "next_boundary": DECISION_NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+def dead_air_repair_probe_source(root: Path) -> dict:
+    midi_paths = [
+        write_wide_interval_midi(root / "rank_01_dead_air.mid", [48, 84, 50, 86, 52, 88]),
+        write_wide_interval_midi(root / "rank_02_dead_air.mid", [55, 88, 57, 84, 59, 86]),
+        write_wide_interval_midi(root / "rank_03_dead_air.mid", [60, 88, 62, 84, 64, 86]),
+    ]
+    return {
+        "boundary": DEAD_AIR_REPAIR_BOUNDARY,
+        "summary": {
+            "repaired_candidate_count": 3,
+            "repaired_pass_count": 3,
+            "repaired_dead_air_max": 0.0,
+            "max_added_note_ratio": 0.9166666666666666,
+            "max_postprocess_removal_ratio": 0.0,
+            "max_repaired_simultaneous_notes": 1,
+            "max_repaired_interval": 62,
+            "dead_air_timing_repair_passed": True,
+        },
+        "candidate_repairs": [
+            {
+                "rank": index,
+                "sample_index": index,
+                "sample_seed": 490 + index,
+                "repaired_midi_path": path,
+                "candidate_repair_passed": True,
+            }
+            for index, path in enumerate(midi_paths, start=1)
+        ],
+        "readiness": {
+            "dead_air_timing_repair_passed": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "critical_user_input_required": False,
+            "next_boundary": (
+                "stage_b_midi_to_solo_model_conditioned_input_path_"
+                "dead_air_timing_repair_audio_package"
+            ),
+        },
+    }
+
+
+class StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourProbeTest(
+    unittest.TestCase
+):
+    def test_choose_contour_pitch_preserves_pitch_class_with_small_interval(self) -> None:
+        self.assertEqual(
+            choose_contour_pitch(
+                84,
+                previous_pitch=48,
+                preferred_pitch_min=48,
+                preferred_pitch_max=88,
+                max_adjacent_interval=12,
+            ),
+            48,
+        )
+
+    def test_repairs_wide_intervals_and_routes_audio_package(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            report = build_pitch_contour_probe_report(
+                pitch_contour_decision_report=pitch_contour_decision_source(),
+                dead_air_repair_probe_report=dead_air_repair_probe_source(root / "source"),
+                output_dir=root / "out",
+                issue_number=698,
+                min_repaired_candidates=3,
+                dead_air_threshold_seconds=0.5,
+                preferred_pitch_min=48,
+                preferred_pitch_max=88,
+                max_adjacent_interval=12,
+                min_unique_pitch_count=3,
+            )
+            summary = validate_pitch_contour_probe_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                min_repaired_candidates=3,
+                require_repair_passed=True,
+                require_no_quality_claim=True,
+            )
+
+        self.assertTrue(summary["pitch_contour_repair_probe_completed"])
+        self.assertTrue(summary["pitch_contour_repair_passed"])
+        self.assertEqual(summary["repaired_pass_count"], 3)
+        self.assertGreater(summary["source_max_interval"], 12)
+        self.assertLessEqual(summary["repaired_max_interval"], 12)
+        self.assertLessEqual(summary["repaired_dead_air_max"], 0.35)
+        self.assertFalse(summary["human_audio_preference_claimed"])
+
+    def test_rejects_quality_claim_in_decision_source(self) -> None:
+        source = pitch_contour_decision_source()
+        source["readiness"]["human_audio_preference_claimed"] = True
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with self.assertRaises(
+                StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourProbeError
+            ):
+                build_pitch_contour_probe_report(
+                    pitch_contour_decision_report=source,
+                    dead_air_repair_probe_report=dead_air_repair_probe_source(root / "source"),
+                    output_dir=root / "out",
+                    issue_number=698,
+                    min_repaired_candidates=3,
+                    dead_air_threshold_seconds=0.5,
+                    preferred_pitch_min=48,
+                    preferred_pitch_max=88,
+                    max_adjacent_interval=12,
+                    min_unique_pitch_count=4,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- pitch-contour objective repair probe 추가
- max interval: `62 -> 11`
- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_audio_package`
- Closes #698

## Context

- #696 pitch-contour decision 결과 기준
- source max interval: `62`
- target max interval: `12`
- required interval reduction min: `50`
- source dead-air max: `0.0000`
- current evidence consolidation ready: `false`
- human/audio preference, audio quality, MIDI-to-solo musical quality claim 제외

## Scope

- dead-air/timing repaired MIDI 후보 3개 대상 pitch-contour repair probe 구현
- pitch class 유지 + octave contour fold 기반 repaired MIDI export
- max interval, dead-air, monophonic, unique pitch guardrail 검증
- 전용 harness mode와 unit test 추가
- README, CORE_PLAN, CURRENT_STATUS, AGENTS handoff 갱신

## Result

- repaired / passed candidates: `3 / 3`
- repaired max interval: `11`
- interval reduction: `51`
- repaired dead-air max: `0.0000`
- max simultaneous notes: `1`
- min repaired unique pitch count: `22`
- max pitch changed ratio: `0.7174`

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe`
- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-probe`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- objective MIDI repair 한정
- pitch changed ratio `0.7174`로 audio review 필요
- 음악적 품질 claim 제외

## Follow-up

- Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour audio package