### PR TITLE
Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour listening review input guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #702, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour listening review package.
+- Latest functional issue completed: Issue #704, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour listening review input guard.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour listening review input guard.
+- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour objective-only next decision.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1172,6 +1172,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-
 ```
 
 This harness packages pitch-contour repaired WAV/MIDI candidates for pending listening review without claiming musical quality.
+
+For Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour listening review input guard changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-listening-review-input-guard
+```
+
+This harness blocks pitch-contour preference fill while listening review input is pending.
 
 For Stage B MIDI-to-solo phrase-bank retrieval baseline changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_package`
+- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -61,6 +61,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned pitch-contour listening review package ready: `true`
 - model-conditioned pitch-contour listening review items: `3`
 - model-conditioned pitch-contour validated review input: `false`
+- model-conditioned pitch-contour listening review input guard completed: `true`
+- model-conditioned pitch-contour preference fill allowed: `false`
 - phrase-bank retrieval baseline completed: `true`
 - phrase-bank source records / motifs: `56 / 803`
 - phrase-bank exported / qualified MIDI candidates: `3 / 3`
@@ -100,7 +102,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - MVP completion audit completed: `true`
 - quality gap decision completed: `true`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -149,6 +151,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned dead-air/timing repaired MIDI 후보의 pitch-contour objective repair 가능
 - model-conditioned pitch-contour repaired MIDI 후보의 WAV technical render 가능
 - model-conditioned pitch-contour repaired WAV/MIDI 후보의 listening review package 생성 가능
+- model-conditioned pitch-contour review input pending 상태에서 preference fill 차단 가능
 - model-conditioned dead-air/timing repaired MIDI/WAV objective next decision 가능
 
 현재 README가 주장하지 않는 것.
@@ -439,6 +442,22 @@ Model-conditioned input path dead-air timing repair pitch contour listening revi
 - review item count: `3`
 - validated review input: `false`
 - technical WAV validation: `true`
+- max repaired interval: `11`
+- max pitch changed ratio: `0.7174`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+Model-conditioned input path dead-air timing repair pitch contour listening review input guard.
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision`
+- review item count: `3`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `3`
 - max repaired interval: `11`
 - max pitch changed ratio: `0.7174`
 - human/audio preference claimed: `false`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -411,6 +411,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour probe: repaired/pass `3/3`, max interval `62 -> 11`, interval reduction `51`, dead-air max `0.0000`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_audio_package`
 - MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour audio package: rendered WAV `3`, technical validation `true`, duration `18.422s-18.978s`, max interval `11`, audio review required `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_package`
 - MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour listening review package: review items `3`, validated input `false`, technical WAV `true`, preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard`
+- MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour listening review input guard: validated input `false`, preference fill `false`, technical WAV `true`, max interval `11`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision`
 - model-core portfolio bullet refresh: resume bullet `6`, short bullet `3`, generic base checkpoint repeatability `9/9/9`, unsupported claim guard 유지
 - Muzig application wording refresh: resume project bullet `5`, short bullet `3`, 자기소개 section `3`, AI 음악 실험/검증 claim만 사용
 - Muzig application final review package: long bullet `5`, short bullet `3`, 자기소개 paragraph `3`, 지원 동기 paragraph `2`, 최종 claim check 포함
@@ -494,6 +495,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour probe: repaired/pass `3/3`, max interval `62 -> 11`, target max interval `12`, dead-air max `0.0000`, max pitch changed ratio `0.7174`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_audio_package`
 - Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour audio package: rendered WAV `3`, technical validation `true`, duration `18.422s-18.978s`, audio review required `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_package`
 - Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour listening review package: review items `3`, validated review input `false`, max interval `11`, max pitch changed ratio `0.7174`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard`
+- Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour listening review input guard: review item count `3`, validated review input `false`, preference fill allowed `false`, technical WAV `true`, max interval `11`, human/audio preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision`
 - Stage B MIDI-to-solo controlled scale checkpoint dead-air repeatability temperature guard audio review package: candidate/rendered `3/3`, sample rate `44100`, duration `6.747s-6.861s`, technical validation `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_dead_air_repeatability_temperature_guard_listening_review`
 - Stage B MIDI-to-solo controlled scale checkpoint dead-air repeatability temperature guard listening review: candidate/rendered `3/3`, validated review input `false`, pending fields `4/3/9`, preference fill `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_dead_air_repeatability_temperature_guard_objective_only_next_decision`
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
@@ -3541,6 +3543,43 @@ Issue #702는 Issue #700 pitch-contour WAV/MIDI 후보 3개를 listening review 
 다음 작업:
 
 - `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour listening review input guard`
+
+## 9.43 Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour listening review input guard
+
+Issue #704는 Issue #702 listening review package 결과를 source로 사용해 검증된 청음 입력이 없는 상태의 preference fill을 차단한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision`
+- review item count: `3`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `3`
+- max repaired interval: `11`
+- max pitch changed ratio: `0.7174`
+- audio review required: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- validated listening input 없음.
+- preference fill 차단.
+- musical quality claim 제외 유지.
+- 객관 evidence 기반 다음 경계 진행 가능.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-listening-review-input-guard`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour objective-only next decision`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #702, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour listening review package
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour listening review input guard`
+- latest functional result: Issue #704, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour listening review input guard
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour objective-only next decision`
 
 현재 범위가 아닌 것:
 
@@ -68,6 +68,55 @@
 - model-conditioned input path dead-air/timing repaired 후보 3개 pitch-contour objective repair 통과
 - model-conditioned input path pitch-contour repaired 후보 3개 WAV technical render 완료
 - model-conditioned input path pitch-contour repaired WAV/MIDI 후보 3개 listening review package 준비 완료
+- model-conditioned input path pitch-contour review input pending 상태에서 preference fill 차단 완료
+
+## Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Pitch Contour Listening Review Input Guard Result
+
+Issue #704는 Issue #702 listening review package 결과를 source로 사용해, 검증된 청음 입력이 없는 상태의 preference fill을 차단한 작업이다.
+
+변경:
+
+- model-conditioned input path dead-air timing repair pitch contour listening review input guard script 추가
+- source listening review package boundary와 technical WAV evidence 검증
+- review input pending 상태에서 preference fill 차단
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_PITCH_CONTOUR_LISTENING_REVIEW_INPUT_GUARD_2026-06-09.md`
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision`
+- review item count: `3`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `3`
+- max repaired interval: `11`
+- max pitch changed ratio: `0.7174`
+- audio review required: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- validated listening input 없음.
+- preference fill 차단.
+- musical quality claim 제외 유지.
+- 객관 evidence 기반 다음 경계 진행 가능.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard`
+- `.venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-listening-review-input-guard`
+
+다음:
+
+- `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour objective-only next decision`
 
 ## Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Pitch Contour Listening Review Package Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_PITCH_CONTOUR_LISTENING_REVIEW_INPUT_GUARD_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_PITCH_CONTOUR_LISTENING_REVIEW_INPUT_GUARD_2026-06-09.md
@@ -1,0 +1,47 @@
+# Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Pitch Contour Listening Review Input Guard
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision`
+- review item count: `3`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `3`
+- max repaired interval: `11`
+- max pitch changed ratio: `0.7174`
+- audio review required: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Decision
+
+- auto progress allowed: `true`
+- critical user input required: `false`
+- reason: `listening review input pending; preference fill blocked`
+- next recommended issue: `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour objective-only next decision`
+
+## Required Input Fields
+
+- `candidate_rank`
+- `listening_status`
+- `preference`
+- `issue_notes`
+
+## Review WAV Paths
+
+- `outputs/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_audio_package/harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_audio_package/audio/rank_01_sample_01_pitch_contour_repair.wav`
+- `outputs/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_audio_package/harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_audio_package/audio/rank_02_sample_02_pitch_contour_repair.wav`
+- `outputs/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_audio_package/harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_audio_package/audio/rank_03_sample_03_pitch_contour_repair.wav`
+
+## Claim Boundary
+
+- `listening_review_completed`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -262,6 +262,8 @@ Modes:
                 Render pitch-contour repaired model-conditioned MIDI candidates to WAV.
   stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-listening-review-package
                 Package pitch-contour repaired WAV/MIDI candidates for pending listening review.
+  stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-listening-review-input-guard
+                Block pitch-contour preference fill while listening review input is pending.
   stage-b-midi-to-solo-model-direct-generation-repair
                 Define the model-direct generation repair boundary from sequence budget evidence.
   stage-b-midi-to-solo-model-direct-sequence-budget-repair-smoke
@@ -6369,6 +6371,27 @@ run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pit
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard() {
+  local package_run_id="${PACKAGE_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_package}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard}"
+  local source_package="outputs/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_package/${package_run_id}/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_package.json"
+  if [[ ! -f "$source_package" ]]; then
+    print_header "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour listening review package"
+    RUN_ID="$package_run_id" run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_package
+  fi
+  print_header "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour listening review input guard"
+  "$PYTHON_BIN" scripts/guard_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input.py \
+    --run_id "$run_id" \
+    --source_package "$source_package" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_PITCH_CONTOUR_LISTENING_REVIEW_INPUT_GUARD_2026-06-09.md \
+    --issue_number 704 \
+    --expected_boundary stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard \
+    --expected_next_boundary stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision \
+    --require_guard_completed \
+    --require_preference_blocked \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -8046,6 +8069,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-listening-review-package)
     run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_package
+    ;;
+  stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-listening-review-input-guard)
+    run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/guard_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input.py
+++ b/scripts/guard_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input.py
@@ -1,0 +1,410 @@
+"""Guard pitch-contour listening review preference fill against missing input."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.build_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_package import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+class StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourListeningInputGuardError(
+    ValueError
+):
+    pass
+
+
+BOUNDARY = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_pitch_contour_listening_review_input_guard"
+)
+FILL_BOUNDARY = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_pitch_contour_listening_review_fill"
+)
+OBJECTIVE_NEXT_BOUNDARY = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_pitch_contour_objective_only_next_decision"
+)
+SCHEMA_VERSION = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_pitch_contour_listening_review_input_guard_v1"
+)
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourListeningInputGuardError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_source_package(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    package = _dict(report.get("review_package"))
+    source = _dict(report.get("source_summary"))
+    review_items = [_dict(item) for item in _list(report.get("review_items"))]
+    boundary = str(report.get("boundary") or readiness.get("boundary") or "")
+    if boundary != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourListeningInputGuardError(
+            "pitch-contour listening review package boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourListeningInputGuardError(
+            "pitch-contour listening package must route to input guard"
+        )
+    if not bool(readiness.get("listening_review_package_ready", False)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourListeningInputGuardError(
+            "listening review package readiness required"
+        )
+    if not bool(package.get("package_ready", False)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourListeningInputGuardError(
+            "review package ready flag required"
+        )
+    review_item_count = _int(readiness.get("review_item_count") or package.get("review_item_count"))
+    if review_item_count <= 0 or len(review_items) < review_item_count:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourListeningInputGuardError(
+            "review items required"
+        )
+    if not bool(source.get("technical_wav_validation", False)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourListeningInputGuardError(
+            "technical WAV validation required"
+        )
+    if _int(source.get("rendered_audio_file_count")) < review_item_count:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourListeningInputGuardError(
+            "rendered audio count below review item count"
+        )
+    if not bool(source.get("audio_review_required", False)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourListeningInputGuardError(
+            "audio review requirement should remain recorded"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourListeningInputGuardError(
+            "critical user input should not be required"
+        )
+    _require_no_quality_claim(readiness, label="pitch-contour listening package readiness")
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "review_item_count": review_item_count,
+        "validated_review_input": bool(readiness.get("validated_review_input", False)),
+        "human_review_required_now": bool(readiness.get("human_review_required_now", False)),
+        "required_input_fields": [
+            str(item) for item in _list(package.get("required_input_fields"))
+        ],
+        "wav_paths": [str(item.get("wav_path") or "") for item in review_items],
+        "source_summary": {
+            "technical_wav_validation": bool(source.get("technical_wav_validation", False)),
+            "rendered_audio_file_count": _int(source.get("rendered_audio_file_count")),
+            "max_repaired_interval": _int(source.get("max_repaired_interval")),
+            "max_pitch_changed_ratio": _float(source.get("max_pitch_changed_ratio")),
+            "audio_review_required": bool(source.get("audio_review_required", False)),
+        },
+    }
+
+
+def build_listening_review_input_guard_report(
+    source_package: dict[str, Any],
+    *,
+    output_dir: Path,
+    issue_number: int,
+) -> dict[str, Any]:
+    source = validate_source_package(source_package)
+    validated_input = bool(source["validated_review_input"])
+    next_boundary = FILL_BOUNDARY if validated_input else OBJECTIVE_NEXT_BOUNDARY
+    reason = (
+        "validated listening review input present; preference fill allowed"
+        if validated_input
+        else "listening review input pending; preference fill blocked"
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundary": source["boundary"],
+        "source_package_summary": source,
+        "guard_result": {
+            "validated_review_input_present": bool(validated_input),
+            "preference_fill_allowed": bool(validated_input),
+            "review_item_count": int(source["review_item_count"]),
+            "required_input_field_count": len(source["required_input_fields"]),
+            "missing_validated_input_reason": ""
+            if validated_input
+            else "validated_review_input=false",
+            "source_summary": source["source_summary"],
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "listening_review_input_guard_completed": True,
+            "validated_review_input_present": bool(validated_input),
+            "preference_fill_allowed": bool(validated_input),
+            "listening_review_completed": False,
+            "human_review_required_now": bool(source["human_review_required_now"]),
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+            **source["source_summary"],
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": next_boundary,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": reason,
+        },
+        "not_proven": [
+            "listening_review_completed",
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "audio_rendered_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour listening review fill"
+            if validated_input
+            else "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour objective-only next decision"
+        ),
+    }
+
+
+def validate_listening_review_input_guard_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_guard_completed: bool,
+    require_preference_blocked: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    guard = _dict(report.get("guard_result"))
+    source = _dict(guard.get("source_summary"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourListeningInputGuardError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourListeningInputGuardError(
+            "unexpected next boundary"
+        )
+    if require_guard_completed and not bool(
+        readiness.get("listening_review_input_guard_completed", False)
+    ):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourListeningInputGuardError(
+            "guard completion required"
+        )
+    if require_preference_blocked and bool(guard.get("preference_fill_allowed", True)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourListeningInputGuardError(
+            "preference fill should remain blocked"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourListeningInputGuardError(
+            "critical user input should not be required"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="pitch-contour input guard readiness")
+    return {
+        "boundary": boundary,
+        "source_boundary": str(report.get("source_boundary") or ""),
+        "validated_review_input_present": bool(
+            guard.get("validated_review_input_present", True)
+        ),
+        "preference_fill_allowed": bool(guard.get("preference_fill_allowed", True)),
+        "review_item_count": _int(guard.get("review_item_count")),
+        "required_input_field_count": _int(guard.get("required_input_field_count")),
+        "technical_wav_validation": bool(source.get("technical_wav_validation", False)),
+        "rendered_audio_file_count": _int(source.get("rendered_audio_file_count")),
+        "max_repaired_interval": _int(source.get("max_repaired_interval")),
+        "max_pitch_changed_ratio": _float(source.get("max_pitch_changed_ratio")),
+        "audio_review_required": bool(source.get("audio_review_required", False)),
+        "human_audio_preference_claimed": bool(
+            readiness.get("human_audio_preference_claimed", True)
+        ),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    guard = report["guard_result"]
+    source = guard["source_summary"]
+    package = report["source_package_summary"]
+    lines = [
+        "# Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Pitch Contour Listening Review Input Guard",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- source boundary: `{report['source_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- review item count: `{guard['review_item_count']}`",
+        f"- required input field count: `{guard['required_input_field_count']}`",
+        f"- validated review input present: `{_bool_token(guard['validated_review_input_present'])}`",
+        f"- preference fill allowed: `{_bool_token(guard['preference_fill_allowed'])}`",
+        f"- technical WAV validation: `{_bool_token(source['technical_wav_validation'])}`",
+        f"- rendered audio file count: `{source['rendered_audio_file_count']}`",
+        f"- max repaired interval: `{source['max_repaired_interval']}`",
+        f"- max pitch changed ratio: `{source['max_pitch_changed_ratio']:.4f}`",
+        f"- audio review required: `{_bool_token(source['audio_review_required'])}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Decision",
+        "",
+        f"- auto progress allowed: `{_bool_token(decision['auto_progress_allowed'])}`",
+        f"- critical user input required: `{_bool_token(decision['critical_user_input_required'])}`",
+        f"- reason: `{decision['reason']}`",
+        f"- next recommended issue: `{report['next_recommended_issue']}`",
+        "",
+        "## Required Input Fields",
+        "",
+    ]
+    for field in package["required_input_fields"]:
+        lines.append(f"- `{field}`")
+    lines.extend(["", "## Review WAV Paths", ""])
+    for path in package["wav_paths"]:
+        lines.append(f"- `{path}`")
+    lines.extend(["", "## Claim Boundary", ""])
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Guard pitch-contour listening review input"
+    )
+    parser.add_argument("--source_package", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=(
+            "outputs/stage_b_midi_to_solo_model_conditioned_input_path_"
+            "dead_air_timing_repair_pitch_contour_listening_review_input_guard"
+        ),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=704)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_guard_completed", action="store_true")
+    parser.add_argument("--require_preference_blocked", action="store_true")
+    parser.add_argument("--require_pending_input", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_listening_review_input_guard_report(
+        read_json(Path(args.source_package)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+    )
+    summary = validate_listening_review_input_guard_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_guard_completed=bool(args.require_guard_completed),
+        require_preference_blocked=bool(
+            args.require_preference_blocked or args.require_pending_input
+        ),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard.py
+++ b/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.build_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_package import (
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+from scripts.guard_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input import (
+    BOUNDARY,
+    FILL_BOUNDARY,
+    OBJECTIVE_NEXT_BOUNDARY,
+    StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourListeningInputGuardError,
+    build_listening_review_input_guard_report,
+    validate_listening_review_input_guard_report,
+)
+
+
+SOURCE_SUMMARY = {
+    "technical_wav_validation": True,
+    "rendered_audio_file_count": 3,
+    "max_repaired_interval": 11,
+    "max_pitch_changed_ratio": 0.7174,
+    "audio_review_required": True,
+}
+
+
+def source_package(
+    *,
+    validated_review_input: bool = False,
+    quality_claim: bool = False,
+    source_summary: dict | None = None,
+) -> dict:
+    summary = source_summary if source_summary is not None else dict(SOURCE_SUMMARY)
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "source_summary": dict(summary),
+        "review_package": {
+            "package_ready": True,
+            "review_item_count": 3,
+            "review_basis": "human_audio_listening_pending",
+            "validated_review_input": validated_review_input,
+            "required_input_fields": [
+                "candidate_rank",
+                "listening_status",
+                "preference",
+                "issue_notes",
+            ],
+        },
+        "review_items": [
+            {"rank": index, "wav_path": f"audio/rank_{index}.wav"}
+            for index in range(1, 4)
+        ],
+        "readiness": {
+            "boundary": SOURCE_BOUNDARY,
+            "listening_review_package_ready": True,
+            "review_item_count": 3,
+            "validated_review_input": validated_review_input,
+            "human_review_required_now": False,
+            "human_audio_preference_claimed": quality_claim,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": SOURCE_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourListeningInputGuardTest(
+    unittest.TestCase
+):
+    def test_blocks_preference_fill_when_review_input_pending(self) -> None:
+        report = build_listening_review_input_guard_report(
+            source_package(),
+            output_dir="out",
+            issue_number=704,
+        )
+        summary = validate_listening_review_input_guard_report(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=OBJECTIVE_NEXT_BOUNDARY,
+            require_guard_completed=True,
+            require_preference_blocked=True,
+            require_no_quality_claim=True,
+        )
+
+        self.assertFalse(summary["validated_review_input_present"])
+        self.assertFalse(summary["preference_fill_allowed"])
+        self.assertEqual(summary["review_item_count"], 3)
+        self.assertEqual(summary["required_input_field_count"], 4)
+        self.assertTrue(summary["technical_wav_validation"])
+        self.assertEqual(summary["rendered_audio_file_count"], 3)
+        self.assertEqual(summary["max_repaired_interval"], 11)
+        self.assertAlmostEqual(summary["max_pitch_changed_ratio"], 0.7174)
+        self.assertFalse(summary["human_audio_preference_claimed"])
+
+    def test_routes_to_fill_when_validated_input_present(self) -> None:
+        report = build_listening_review_input_guard_report(
+            source_package(validated_review_input=True),
+            output_dir="out",
+            issue_number=704,
+        )
+        summary = validate_listening_review_input_guard_report(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=FILL_BOUNDARY,
+            require_guard_completed=True,
+            require_preference_blocked=False,
+            require_no_quality_claim=True,
+        )
+
+        self.assertTrue(summary["validated_review_input_present"])
+        self.assertTrue(summary["preference_fill_allowed"])
+
+    def test_rejects_upstream_quality_claim(self) -> None:
+        with self.assertRaises(
+            StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourListeningInputGuardError
+        ):
+            build_listening_review_input_guard_report(
+                source_package(quality_claim=True),
+                output_dir="out",
+                issue_number=704,
+            )
+
+    def test_rejects_missing_technical_wav_validation(self) -> None:
+        broken_summary = dict(SOURCE_SUMMARY)
+        broken_summary["technical_wav_validation"] = False
+
+        with self.assertRaises(
+            StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourListeningInputGuardError
+        ):
+            build_listening_review_input_guard_report(
+                source_package(source_summary=broken_summary),
+                output_dir="out",
+                issue_number=704,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- pitch-contour listening review input guard 추가
- validated review input 부재 시 preference fill 차단
- objective-only next boundary 기록

## Context
- #702 listening review package 완료
- review item count: `3`
- validated review input: `false`
- technical WAV validation: `true`
- max repaired interval: `11`
- max pitch changed ratio: `0.7174`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Scope
- source listening review package boundary 검증
- technical WAV evidence 유지 검증
- preference fill blocked 상태 기록
- harness mode, unit test, README/status docs 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard`
- `.venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-listening-review-input-guard`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- 청음 입력 미검증 상태 유지
- human/audio preference와 musical quality claim 제외

## Follow-up
- Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour objective-only next decision

Closes #704

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a listening review input guard for the pitch-contour repair stage that prevents preference fill until listening review input is validated.

* **Documentation**
  * Updated project tracking and status documentation to reflect the new listening review input guard completion and its blocking behavior during the review phase.

* **Tests**
  * Added test coverage for the listening review input guard validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->