### PR TITLE
Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour objective-only next decision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #704, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour listening review input guard.
+- Latest functional issue completed: Issue #706, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour objective-only next decision.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour objective-only next decision.
+- Recommended next issue: Stage B MIDI-to-solo MVP current evidence consolidation.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1180,6 +1180,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-
 ```
 
 This harness blocks pitch-contour preference fill while listening review input is pending.
+
+For Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour objective-only next decision changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-objective-next
+```
+
+This harness selects the next boundary after pitch-contour objective evidence without claiming musical quality.
 
 For Stage B MIDI-to-solo phrase-bank retrieval baseline changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard`
+- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -63,6 +63,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned pitch-contour validated review input: `false`
 - model-conditioned pitch-contour listening review input guard completed: `true`
 - model-conditioned pitch-contour preference fill allowed: `false`
+- model-conditioned pitch-contour objective-only next decision completed: `true`
+- model-conditioned pitch-contour target supported: `true`
+- model-conditioned pitch-contour current evidence consolidation ready: `true`
+- model-conditioned pitch-contour changed-ratio review required: `true`
 - phrase-bank retrieval baseline completed: `true`
 - phrase-bank source records / motifs: `56 / 803`
 - phrase-bank exported / qualified MIDI candidates: `3 / 3`
@@ -102,7 +106,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - MVP completion audit completed: `true`
 - quality gap decision completed: `true`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision`
+- next boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -152,6 +156,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned pitch-contour repaired MIDI 후보의 WAV technical render 가능
 - model-conditioned pitch-contour repaired WAV/MIDI 후보의 listening review package 생성 가능
 - model-conditioned pitch-contour review input pending 상태에서 preference fill 차단 가능
+- model-conditioned pitch-contour objective evidence 기준 current evidence consolidation 경계 결정 가능
 - model-conditioned dead-air/timing repaired MIDI/WAV objective next decision 가능
 
 현재 README가 주장하지 않는 것.
@@ -460,6 +465,26 @@ Model-conditioned input path dead-air timing repair pitch contour listening revi
 - rendered audio file count: `3`
 - max repaired interval: `11`
 - max pitch changed ratio: `0.7174`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+Model-conditioned input path dead-air timing repair pitch contour objective-only next decision.
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- review item count: `3`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `3`
+- max repaired interval: `11`
+- max interval threshold: `12`
+- pitch-contour target supported: `true`
+- max pitch changed ratio: `0.7174`
+- pitch changed ratio review required: `true`
+- audio review required: `true`
+- current evidence consolidation ready: `true`
 - human/audio preference claimed: `false`
 - MIDI-to-solo musical quality claimed: `false`
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -412,6 +412,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour audio package: rendered WAV `3`, technical validation `true`, duration `18.422s-18.978s`, max interval `11`, audio review required `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_package`
 - MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour listening review package: review items `3`, validated input `false`, technical WAV `true`, preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard`
 - MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour listening review input guard: validated input `false`, preference fill `false`, technical WAV `true`, max interval `11`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision`
+- MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour objective-only next decision: target supported `true`, max interval `11/12`, pitch changed ratio review `true`, current evidence consolidation ready `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - model-core portfolio bullet refresh: resume bullet `6`, short bullet `3`, generic base checkpoint repeatability `9/9/9`, unsupported claim guard 유지
 - Muzig application wording refresh: resume project bullet `5`, short bullet `3`, 자기소개 section `3`, AI 음악 실험/검증 claim만 사용
 - Muzig application final review package: long bullet `5`, short bullet `3`, 자기소개 paragraph `3`, 지원 동기 paragraph `2`, 최종 claim check 포함
@@ -496,6 +497,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour audio package: rendered WAV `3`, technical validation `true`, duration `18.422s-18.978s`, audio review required `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_package`
 - Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour listening review package: review items `3`, validated review input `false`, max interval `11`, max pitch changed ratio `0.7174`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard`
 - Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour listening review input guard: review item count `3`, validated review input `false`, preference fill allowed `false`, technical WAV `true`, max interval `11`, human/audio preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision`
+- Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour objective-only next decision: target supported `true`, max interval `11/12`, max pitch changed ratio `0.7174`, current evidence consolidation ready `true`, human/audio preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - Stage B MIDI-to-solo controlled scale checkpoint dead-air repeatability temperature guard audio review package: candidate/rendered `3/3`, sample rate `44100`, duration `6.747s-6.861s`, technical validation `true`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_dead_air_repeatability_temperature_guard_listening_review`
 - Stage B MIDI-to-solo controlled scale checkpoint dead-air repeatability temperature guard listening review: candidate/rendered `3/3`, validated review input `false`, pending fields `4/3/9`, preference fill `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_dead_air_repeatability_temperature_guard_objective_only_next_decision`
 - Muzig application resume wording: long bullet `7`, short bullet `3`, self-introduction sections `3`, unsupported claim guard 유지
@@ -3580,6 +3582,47 @@ Issue #704는 Issue #702 listening review package 결과를 source로 사용해 
 다음 작업:
 
 - `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour objective-only next decision`
+
+## 9.44 Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour objective-only next decision
+
+Issue #706은 Issue #704 input guard 결과를 source로 사용해 청음 입력 없이 objective evidence 기준 다음 경계를 결정한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- review item count: `3`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `3`
+- max repaired interval: `11`
+- max interval threshold: `12`
+- pitch-contour target supported: `true`
+- max pitch changed ratio: `0.7174`
+- pitch changed ratio review required: `true`
+- audio review required: `true`
+- current evidence consolidation ready: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- max interval target 통과.
+- preference fill 차단 유지.
+- pitch changed ratio review 필요 상태 유지.
+- musical quality claim 제외 유지.
+- 다음 boundary는 current evidence consolidation.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_next`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-objective-next`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo MVP current evidence consolidation`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #704, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour listening review input guard
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour objective-only next decision`
+- latest functional result: Issue #706, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour objective-only next decision
+- 다음 권장 이슈: `Stage B MIDI-to-solo MVP current evidence consolidation`
 
 현재 범위가 아닌 것:
 
@@ -69,6 +69,59 @@
 - model-conditioned input path pitch-contour repaired 후보 3개 WAV technical render 완료
 - model-conditioned input path pitch-contour repaired WAV/MIDI 후보 3개 listening review package 준비 완료
 - model-conditioned input path pitch-contour review input pending 상태에서 preference fill 차단 완료
+- model-conditioned input path pitch-contour objective-only 기준 current evidence consolidation 준비 완료
+
+## Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Pitch Contour Objective-Only Next Decision Result
+
+Issue #706은 Issue #704 input guard 결과를 source로 사용해 청음 입력 없이 objective evidence 기준 다음 경계를 결정한 작업이다.
+
+변경:
+
+- model-conditioned input path dead-air timing repair pitch contour objective-only next decision script 추가
+- max interval target 통과 여부 검증
+- pitch changed ratio review 필요 상태 기록
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_PITCH_CONTOUR_OBJECTIVE_NEXT_DECISION_2026-06-09.md`
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- review item count: `3`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `3`
+- max repaired interval: `11`
+- max interval threshold: `12`
+- pitch-contour target supported: `true`
+- max pitch changed ratio: `0.7174`
+- pitch changed ratio review required: `true`
+- audio review required: `true`
+- current evidence consolidation ready: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- max interval target 통과.
+- preference fill 차단 유지.
+- pitch changed ratio review 필요 상태 유지.
+- musical quality claim 제외 유지.
+- 다음 boundary는 current evidence consolidation.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_next`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_next.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-objective-next`
+
+다음:
+
+- `Stage B MIDI-to-solo MVP current evidence consolidation`
 
 ## Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Pitch Contour Listening Review Input Guard Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_PITCH_CONTOUR_OBJECTIVE_NEXT_DECISION_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_PITCH_CONTOUR_OBJECTIVE_NEXT_DECISION_2026-06-09.md
@@ -1,0 +1,38 @@
+# Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Pitch Contour Objective-Only Next Decision
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- selected target: `current_evidence_consolidation`
+- review item count: `3`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `3`
+- max repaired interval: `11`
+- max interval threshold: `12`
+- pitch-contour target supported: `true`
+- max pitch changed ratio: `0.7174`
+- pitch changed ratio review required: `true`
+- audio review required: `true`
+- current evidence consolidation ready: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Decision
+
+- reason: `pitch-contour objective interval target passed; route to current evidence consolidation without quality claim`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo MVP current evidence consolidation`
+
+## Claim Boundary
+
+- `listening_review_completed`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -264,6 +264,8 @@ Modes:
                 Package pitch-contour repaired WAV/MIDI candidates for pending listening review.
   stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-listening-review-input-guard
                 Block pitch-contour preference fill while listening review input is pending.
+  stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-objective-next
+                Select the next boundary after pitch-contour objective evidence.
   stage-b-midi-to-solo-model-direct-generation-repair
                 Define the model-direct generation repair boundary from sequence budget evidence.
   stage-b-midi-to-solo-model-direct-sequence-budget-repair-smoke
@@ -6392,6 +6394,29 @@ run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pit
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_next() {
+  local input_guard_run_id="${INPUT_GUARD_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_next}"
+  local input_guard_report="outputs/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard/${input_guard_run_id}/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard.json"
+  if [[ ! -f "$input_guard_report" ]]; then
+    print_header "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour listening review input guard"
+    RUN_ID="$input_guard_run_id" run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard
+  fi
+  print_header "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour objective-only next decision"
+  "$PYTHON_BIN" scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_next.py \
+    --run_id "$run_id" \
+    --input_guard_report "$input_guard_report" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_INPUT_PATH_DEAD_AIR_TIMING_REPAIR_PITCH_CONTOUR_OBJECTIVE_NEXT_DECISION_2026-06-09.md \
+    --issue_number 706 \
+    --max_interval_threshold 12 \
+    --pitch_changed_ratio_review_threshold 0.5 \
+    --expected_boundary stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision \
+    --expected_next_boundary stage_b_midi_to_solo_mvp_current_evidence_consolidation \
+    --require_objective_decision \
+    --require_current_evidence_ready \
+    --require_no_quality_claim
+}
+
 run_stage_b_constrained_probe() {
   local run_id="${RUN_ID:-harness_stage_b_constrained_probe}"
   print_header "Stage B constrained probe"
@@ -8072,6 +8097,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-listening-review-input-guard)
     run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input_guard
+    ;;
+  stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-objective-next)
+    run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_next
     ;;
   stage-b-generic-tiny-checkpoint-generation-probe)
     run_stage_b_generic_tiny_checkpoint_generation_probe

--- a/scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_next.py
+++ b/scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_next.py
@@ -1,0 +1,429 @@
+"""Select the next boundary after pitch-contour listening input guard evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.guard_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+    OBJECTIVE_NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+class StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourObjectiveNextError(
+    ValueError
+):
+    pass
+
+
+BOUNDARY = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_pitch_contour_objective_only_next_decision"
+)
+CURRENT_EVIDENCE_NEXT_BOUNDARY = "stage_b_midi_to_solo_mvp_current_evidence_consolidation"
+PITCH_CONTOUR_RETRY_NEXT_BOUNDARY = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_pitch_contour_decision"
+)
+SCHEMA_VERSION = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_pitch_contour_objective_next_v1"
+)
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourObjectiveNextError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_input_guard_report(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    guard = _dict(report.get("guard_result"))
+    source = _dict(guard.get("source_summary"))
+    if str(report.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourObjectiveNextError(
+            "pitch-contour listening review input guard boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourObjectiveNextError(
+            "input guard must route to pitch-contour objective-only next decision"
+        )
+    if not bool(readiness.get("listening_review_input_guard_completed", False)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourObjectiveNextError(
+            "input guard completion required"
+        )
+    if bool(guard.get("validated_review_input_present", True)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourObjectiveNextError(
+            "objective-only decision requires pending review input"
+        )
+    if bool(guard.get("preference_fill_allowed", True)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourObjectiveNextError(
+            "preference fill must remain blocked"
+        )
+    if not bool(source.get("technical_wav_validation", False)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourObjectiveNextError(
+            "technical WAV validation required"
+        )
+    if _int(source.get("rendered_audio_file_count")) < 3:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourObjectiveNextError(
+            "rendered WAV count below 3"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourObjectiveNextError(
+            "critical user input should not be required"
+        )
+    _require_no_quality_claim(readiness, label="pitch-contour input guard readiness")
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "review_item_count": _int(guard.get("review_item_count")),
+        "required_input_field_count": _int(guard.get("required_input_field_count")),
+        "validated_review_input_present": bool(guard.get("validated_review_input_present", False)),
+        "preference_fill_allowed": bool(guard.get("preference_fill_allowed", False)),
+        "technical_wav_validation": bool(source.get("technical_wav_validation", False)),
+        "rendered_audio_file_count": _int(source.get("rendered_audio_file_count")),
+        "max_repaired_interval": _int(source.get("max_repaired_interval")),
+        "max_pitch_changed_ratio": _float(source.get("max_pitch_changed_ratio")),
+        "audio_review_required": bool(source.get("audio_review_required", False)),
+    }
+
+
+def build_objective_next_report(
+    *,
+    input_guard_report: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+    max_interval_threshold: int,
+    pitch_changed_ratio_review_threshold: float,
+) -> dict[str, Any]:
+    source = validate_input_guard_report(input_guard_report)
+    pitch_contour_target_supported = _int(source["max_repaired_interval"]) <= int(
+        max_interval_threshold
+    )
+    pitch_changed_ratio_review_required = _float(source["max_pitch_changed_ratio"]) >= float(
+        pitch_changed_ratio_review_threshold
+    )
+    next_boundary = (
+        CURRENT_EVIDENCE_NEXT_BOUNDARY
+        if pitch_contour_target_supported
+        else PITCH_CONTOUR_RETRY_NEXT_BOUNDARY
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundary": source["boundary"],
+        "objective_summary": {
+            "review_item_count": _int(source["review_item_count"]),
+            "validated_review_input_present": bool(source["validated_review_input_present"]),
+            "preference_fill_allowed": bool(source["preference_fill_allowed"]),
+            "technical_wav_validation": bool(source["technical_wav_validation"]),
+            "rendered_audio_file_count": _int(source["rendered_audio_file_count"]),
+            "max_repaired_interval": _int(source["max_repaired_interval"]),
+            "max_interval_threshold": int(max_interval_threshold),
+            "pitch_contour_target_supported": bool(pitch_contour_target_supported),
+            "max_pitch_changed_ratio": _float(source["max_pitch_changed_ratio"]),
+            "pitch_changed_ratio_review_threshold": float(pitch_changed_ratio_review_threshold),
+            "pitch_changed_ratio_review_required": bool(pitch_changed_ratio_review_required),
+            "audio_review_required": bool(source["audio_review_required"]),
+            "current_evidence_consolidation_ready": bool(pitch_contour_target_supported),
+        },
+        "selected_next_target": {
+            "target": (
+                "current_evidence_consolidation"
+                if pitch_contour_target_supported
+                else "wide_interval_pitch_contour_repair_retry"
+            ),
+            "next_boundary": next_boundary,
+            "reason": (
+                "pitch-contour objective interval target passed; route to current evidence consolidation without quality claim"
+                if pitch_contour_target_supported
+                else "pitch-contour objective interval target still fails; retry repair boundary"
+            ),
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "objective_next_decision_completed": True,
+            "technical_wav_validation": bool(source["technical_wav_validation"]),
+            "pitch_contour_target_supported": bool(pitch_contour_target_supported),
+            "pitch_changed_ratio_review_required": bool(pitch_changed_ratio_review_required),
+            "audio_review_required": bool(source["audio_review_required"]),
+            "current_evidence_consolidation_ready": bool(pitch_contour_target_supported),
+            "human_audio_preference_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": next_boundary,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "objective pitch-contour evidence selected the next boundary without quality claim",
+        },
+        "not_proven": [
+            "listening_review_completed",
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "audio_rendered_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo MVP current evidence consolidation"
+            if pitch_contour_target_supported
+            else "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour decision"
+        ),
+    }
+
+
+def validate_objective_next_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_objective_decision: bool,
+    require_current_evidence_ready: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("objective_summary"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourObjectiveNextError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourObjectiveNextError(
+            "unexpected next boundary"
+        )
+    if require_objective_decision and not bool(
+        readiness.get("objective_next_decision_completed", False)
+    ):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourObjectiveNextError(
+            "objective next decision completion required"
+        )
+    if require_current_evidence_ready and not bool(
+        readiness.get("current_evidence_consolidation_ready", False)
+    ):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourObjectiveNextError(
+            "current evidence consolidation readiness required"
+        )
+    if bool(summary.get("preference_fill_allowed", True)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourObjectiveNextError(
+            "preference fill must remain blocked"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourObjectiveNextError(
+            "critical user input should not be required"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="pitch-contour objective next readiness")
+    return {
+        "boundary": boundary,
+        "source_boundary": str(report.get("source_boundary") or ""),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "objective_next_decision_completed": bool(
+            readiness.get("objective_next_decision_completed", False)
+        ),
+        "review_item_count": _int(summary.get("review_item_count")),
+        "validated_review_input_present": bool(
+            summary.get("validated_review_input_present", True)
+        ),
+        "preference_fill_allowed": bool(summary.get("preference_fill_allowed", True)),
+        "technical_wav_validation": bool(summary.get("technical_wav_validation", False)),
+        "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
+        "max_repaired_interval": _int(summary.get("max_repaired_interval")),
+        "max_interval_threshold": _int(summary.get("max_interval_threshold")),
+        "pitch_contour_target_supported": bool(
+            summary.get("pitch_contour_target_supported", False)
+        ),
+        "max_pitch_changed_ratio": _float(summary.get("max_pitch_changed_ratio")),
+        "pitch_changed_ratio_review_required": bool(
+            summary.get("pitch_changed_ratio_review_required", False)
+        ),
+        "audio_review_required": bool(summary.get("audio_review_required", False)),
+        "current_evidence_consolidation_ready": bool(
+            summary.get("current_evidence_consolidation_ready", False)
+        ),
+        "human_audio_preference_claimed": bool(
+            readiness.get("human_audio_preference_claimed", True)
+        ),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    summary = report["objective_summary"]
+    target = report["selected_next_target"]
+    lines = [
+        "# Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Pitch Contour Objective-Only Next Decision",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- source boundary: `{report['source_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- selected target: `{target['target']}`",
+        f"- review item count: `{summary['review_item_count']}`",
+        f"- validated review input present: `{_bool_token(summary['validated_review_input_present'])}`",
+        f"- preference fill allowed: `{_bool_token(summary['preference_fill_allowed'])}`",
+        f"- technical WAV validation: `{_bool_token(summary['technical_wav_validation'])}`",
+        f"- rendered audio file count: `{summary['rendered_audio_file_count']}`",
+        f"- max repaired interval: `{summary['max_repaired_interval']}`",
+        f"- max interval threshold: `{summary['max_interval_threshold']}`",
+        f"- pitch-contour target supported: `{_bool_token(summary['pitch_contour_target_supported'])}`",
+        f"- max pitch changed ratio: `{summary['max_pitch_changed_ratio']:.4f}`",
+        f"- pitch changed ratio review required: `{_bool_token(summary['pitch_changed_ratio_review_required'])}`",
+        f"- audio review required: `{_bool_token(summary['audio_review_required'])}`",
+        f"- current evidence consolidation ready: `{_bool_token(readiness['current_evidence_consolidation_ready'])}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Decision",
+        "",
+        f"- reason: `{target['reason']}`",
+        f"- auto progress allowed: `{_bool_token(decision['auto_progress_allowed'])}`",
+        f"- critical user input required: `{_bool_token(decision['critical_user_input_required'])}`",
+        f"- next recommended issue: `{report['next_recommended_issue']}`",
+        "",
+        "## Claim Boundary",
+        "",
+    ]
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Decide pitch-contour objective-only next step"
+    )
+    parser.add_argument("--input_guard_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=(
+            "outputs/stage_b_midi_to_solo_model_conditioned_input_path_"
+            "dead_air_timing_repair_pitch_contour_objective_only_next_decision"
+        ),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=706)
+    parser.add_argument("--max_interval_threshold", type=int, default=12)
+    parser.add_argument("--pitch_changed_ratio_review_threshold", type=float, default=0.5)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_objective_decision", action="store_true")
+    parser.add_argument("--require_current_evidence_ready", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_objective_next_report(
+        input_guard_report=read_json(Path(args.input_guard_report)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+        max_interval_threshold=int(args.max_interval_threshold),
+        pitch_changed_ratio_review_threshold=float(args.pitch_changed_ratio_review_threshold),
+    )
+    summary = validate_objective_next_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_objective_decision=bool(args.require_objective_decision),
+        require_current_evidence_ready=bool(args.require_current_evidence_ready),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_next.py
+++ b/tests/test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_next.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_next import (
+    BOUNDARY,
+    CURRENT_EVIDENCE_NEXT_BOUNDARY,
+    PITCH_CONTOUR_RETRY_NEXT_BOUNDARY,
+    StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourObjectiveNextError,
+    build_objective_next_report,
+    validate_objective_next_report,
+)
+from scripts.guard_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_listening_review_input import (
+    BOUNDARY as SOURCE_BOUNDARY,
+    OBJECTIVE_NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+def input_guard(
+    *,
+    max_interval: int = 11,
+    preference_fill_allowed: bool = False,
+    quality_claim: bool = False,
+) -> dict:
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "guard_result": {
+            "validated_review_input_present": False,
+            "preference_fill_allowed": preference_fill_allowed,
+            "review_item_count": 3,
+            "required_input_field_count": 4,
+            "source_summary": {
+                "technical_wav_validation": True,
+                "rendered_audio_file_count": 3,
+                "max_repaired_interval": max_interval,
+                "max_pitch_changed_ratio": 0.7174,
+                "audio_review_required": True,
+            },
+        },
+        "readiness": {
+            "listening_review_input_guard_completed": True,
+            "human_audio_preference_claimed": quality_claim,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": SOURCE_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourObjectiveNextTest(
+    unittest.TestCase
+):
+    def test_routes_to_current_evidence_when_interval_target_passes(self) -> None:
+        report = build_objective_next_report(
+            input_guard_report=input_guard(),
+            output_dir="out",
+            issue_number=706,
+            max_interval_threshold=12,
+            pitch_changed_ratio_review_threshold=0.5,
+        )
+        summary = validate_objective_next_report(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=CURRENT_EVIDENCE_NEXT_BOUNDARY,
+            require_objective_decision=True,
+            require_current_evidence_ready=True,
+            require_no_quality_claim=True,
+        )
+
+        self.assertTrue(summary["objective_next_decision_completed"])
+        self.assertTrue(summary["technical_wav_validation"])
+        self.assertEqual(summary["rendered_audio_file_count"], 3)
+        self.assertEqual(summary["max_repaired_interval"], 11)
+        self.assertTrue(summary["pitch_contour_target_supported"])
+        self.assertTrue(summary["pitch_changed_ratio_review_required"])
+        self.assertTrue(summary["current_evidence_consolidation_ready"])
+        self.assertFalse(summary["preference_fill_allowed"])
+        self.assertFalse(summary["human_audio_preference_claimed"])
+
+    def test_routes_to_retry_when_interval_target_fails(self) -> None:
+        report = build_objective_next_report(
+            input_guard_report=input_guard(max_interval=13),
+            output_dir="out",
+            issue_number=706,
+            max_interval_threshold=12,
+            pitch_changed_ratio_review_threshold=0.5,
+        )
+        summary = validate_objective_next_report(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=PITCH_CONTOUR_RETRY_NEXT_BOUNDARY,
+            require_objective_decision=True,
+            require_current_evidence_ready=False,
+            require_no_quality_claim=True,
+        )
+
+        self.assertFalse(summary["pitch_contour_target_supported"])
+        self.assertFalse(summary["current_evidence_consolidation_ready"])
+
+    def test_rejects_preference_fill_allowed(self) -> None:
+        with self.assertRaises(
+            StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourObjectiveNextError
+        ):
+            build_objective_next_report(
+                input_guard_report=input_guard(preference_fill_allowed=True),
+                output_dir="out",
+                issue_number=706,
+                max_interval_threshold=12,
+                pitch_changed_ratio_review_threshold=0.5,
+            )
+
+    def test_rejects_upstream_quality_claim(self) -> None:
+        with self.assertRaises(
+            StageBMidiToSoloModelConditionedInputPathDeadAirTimingRepairPitchContourObjectiveNextError
+        ):
+            build_objective_next_report(
+                input_guard_report=input_guard(quality_claim=True),
+                output_dir="out",
+                issue_number=706,
+                max_interval_threshold=12,
+                pitch_changed_ratio_review_threshold=0.5,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- pitch-contour objective-only next decision 추가
- max interval target 통과 기준 current evidence consolidation 경계 선택
- pitch changed ratio review 필요 상태와 quality claim boundary 기록

## Context
- #704 input guard 완료
- validated review input: `false`
- preference fill allowed: `false`
- technical WAV validation: `true`
- rendered audio file count: `3`
- max repaired interval: `11`
- max interval threshold: `12`
- max pitch changed ratio: `0.7174`
- audio review required: `true`

## Scope
- input guard source boundary 검증
- preference fill blocked 상태 유지 검증
- pitch-contour target support 판단
- harness mode, unit test, README/status docs 갱신

## Result
- next boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
- pitch-contour target supported: `true`
- current evidence consolidation ready: `true`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_next`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_next.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-input-path-dead-air-timing-repair-pitch-contour-objective-next`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- 청음 입력 미검증
- pitch changed ratio `0.7174`에 대한 청음 품질 판단 제외
- current evidence consolidation은 technical/objective evidence 경계만 갱신 가능

## Follow-up
- Stage B MIDI-to-solo MVP current evidence consolidation

Closes #706