### PR TITLE
Stage B MIDI-to-solo MVP current evidence consolidation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #706, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour objective-only next decision.
+- Latest functional issue completed: Issue #708, Stage B MIDI-to-solo MVP current evidence consolidation.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo MVP current evidence consolidation.
+- Recommended next issue: Stage B MIDI-to-solo README evidence refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1018,7 +1018,7 @@ For Stage B MIDI-to-solo MVP current evidence consolidation changes, run:
 bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-current-evidence-consolidation
 ```
 
-This harness consolidates the input contract, context extraction, ranked MIDI candidates, technical WAV render path, selected-scale objective repair boundary, and CLI technical path without claiming musical quality.
+This harness consolidates the input contract, context extraction, ranked MIDI candidates, technical WAV render path, selected-scale objective repair boundary, CLI technical path, and model-conditioned pitch-contour objective path without claiming musical quality.
 
 For Stage B MIDI-to-solo README evidence refresh changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision`
+- latest evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -67,6 +67,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned pitch-contour target supported: `true`
 - model-conditioned pitch-contour current evidence consolidation ready: `true`
 - model-conditioned pitch-contour changed-ratio review required: `true`
+- model-conditioned pitch-contour objective path included in current evidence: `true`
 - phrase-bank retrieval baseline completed: `true`
 - phrase-bank source records / motifs: `56 / 803`
 - phrase-bank exported / qualified MIDI candidates: `3 / 3`
@@ -106,7 +107,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - MVP completion audit completed: `true`
 - quality gap decision completed: `true`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- next boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -141,6 +142,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - 명시적 `--input_midi` 경로 기준 phrase-bank CLI review input pending 상태에서 preference fill 차단 가능
 - 명시적 `--input_midi` 경로 기준 phrase-bank CLI technical path objective decision 가능
 - selected-scale objective path와 phrase-bank CLI technical path를 current evidence로 통합 가능
+- model-conditioned pitch-contour objective path를 current evidence로 통합 가능
 - README 첫 상태 영역에 current evidence와 claim boundary 반영 완료
 - technical model-core MVP 완료 범위 audit 가능
 - model-conditioned input path alignment decision 가능
@@ -682,12 +684,15 @@ MVP current evidence consolidation.
 - technical execution evidence supported: `true`
 - selected-scale objective path complete: `true`
 - phrase-bank CLI technical path ready: `true`
+- model-conditioned pitch-contour objective path ready: `true`
 - generation exported / qualified candidates: `3 / 3`
 - technical audio rendered WAV files: `3`
 - selected-scale objective valid / strict / grammar: `9 / 9 / 9`
 - CLI candidate / rendered WAV files: `3 / 3`
 - CLI input context bars: `228`
 - CLI preference fill allowed: `false`
+- model-conditioned pitch-contour max interval / threshold: `11 / 12`
+- model-conditioned pitch-contour changed-ratio review required: `true`
 - human/audio preference claimed: `false`
 - MIDI-to-solo musical quality claimed: `false`
 - next boundary: `stage_b_midi_to_solo_readme_evidence_refresh`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -391,7 +391,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo controlled scale checkpoint training scale postprocess removal dead-air repair audio review package: candidate/rendered `3/3`, sample rate `44100`, duration `6.866s-6.869s`, technical validation `true`, preference claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_training_scale_postprocess_removal_dead_air_repair_listening_review`
 - MIDI-to-solo controlled scale checkpoint training scale postprocess removal dead-air repair listening review: review template `true`, pending status/candidate/field `4/3/9`, preference fill `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_training_scale_postprocess_removal_dead_air_repair_objective_only_next_decision`
 - MIDI-to-solo controlled scale checkpoint training scale postprocess removal dead-air repair objective-only next decision: objective path support `true`, valid/strict/grammar `9/9/9`, dead-air/collapse `0/0`, avg/max postprocess removal `0.2176/0.2917`, preference/quality claim `false`, next boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
-- MIDI-to-solo MVP current evidence consolidation: evidence support `true`, technical path `true`, selected-scale objective path `true`, exported/rendered `3/3`, objective valid/strict/grammar `9/9/9`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_readme_evidence_refresh`
+- MIDI-to-solo MVP current evidence consolidation: evidence support `true`, technical path `true`, selected-scale objective path `true`, phrase-bank CLI path `true`, model-conditioned pitch-contour objective path `true`, exported/rendered `3/3`, objective valid/strict/grammar `9/9/9`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_readme_evidence_refresh`
 - MIDI-to-solo README evidence refresh: latest boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`, input-to-WAV technical path `true`, selected-scale objective path `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_completion_audit`
 - MIDI-to-solo MVP completion audit: technical model-core MVP `true`, input ranked MIDI/WAV `true/true`, selected-scale objective repair `true`, musical/product MVP `false/false`, next boundary `stage_b_midi_to_solo_quality_gap_decision`
 - MIDI-to-solo quality gap decision: selected target `model_conditioned_input_path_quality_alignment`, fallback path active `true`, human review required now `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment`
@@ -476,7 +476,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - Stage B MIDI-to-solo controlled scale checkpoint training scale postprocess removal dead-air repair audio review package: candidate/rendered `3/3`, sample rate `44100`, duration `6.866s-6.869s`, technical validation `true`, preference claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_training_scale_postprocess_removal_dead_air_repair_listening_review`
 - Stage B MIDI-to-solo controlled scale checkpoint training scale postprocess removal dead-air repair listening review: candidate/rendered `3/3`, validated review input `false`, pending fields `4/3/9`, preference fill `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_training_scale_postprocess_removal_dead_air_repair_objective_only_next_decision`
 - Stage B MIDI-to-solo controlled scale checkpoint training scale postprocess removal dead-air repair objective-only next decision: objective path support `true`, final boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_training_scale_postprocess_removal_dead_air_repair_objective_path_complete`, next boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`, quality claim `false`
-- Stage B MIDI-to-solo MVP current evidence consolidation: current evidence support `true`, technical execution support `true`, selected-scale objective path complete `true`, generation source `context_conditioned_fallback`, rendered WAV `3`, quality claim `false`, next boundary `stage_b_midi_to_solo_readme_evidence_refresh`
+- Stage B MIDI-to-solo MVP current evidence consolidation: current evidence support `true`, technical execution support `true`, selected-scale objective path complete `true`, phrase-bank CLI technical path `true`, model-conditioned pitch-contour objective path `true`, generation source `context_conditioned_fallback`, rendered WAV `3`, quality claim `false`, next boundary `stage_b_midi_to_solo_readme_evidence_refresh`
 - Stage B MIDI-to-solo README evidence refresh: README current status refreshed to #612 evidence, stale boundary removed, implemented scope / problem-action-result / artifacts / validation commands reduced, quality claim `false`, next boundary `stage_b_midi_to_solo_mvp_completion_audit`
 - Stage B MIDI-to-solo MVP completion audit: technical model-core MVP completed `true`, musical quality MVP completed `false`, product MVP completed `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_quality_gap_decision`
 - Stage B MIDI-to-solo quality gap decision: current input-to-WAV generation source `context_conditioned_fallback`, selected target `model_conditioned_input_path_quality_alignment`, human review required now `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment`
@@ -3623,6 +3623,47 @@ Issue #706은 Issue #704 input guard 결과를 source로 사용해 청음 입력
 다음 작업:
 
 - `Stage B MIDI-to-solo MVP current evidence consolidation`
+
+## 9.45 Stage B MIDI-to-solo MVP current evidence consolidation
+
+Issue #708은 Issue #706 pitch-contour objective-only next decision 결과를 기존 current evidence consolidation source에 추가한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- next boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
+- current MVP evidence supported: `true`
+- technical execution evidence supported: `true`
+- selected-scale objective path complete: `true`
+- phrase-bank CLI technical path ready: `true`
+- model-conditioned pitch-contour objective path ready: `true`
+- model-conditioned pitch-contour max interval: `11`
+- model-conditioned pitch-contour target supported: `true`
+- model-conditioned pitch-contour changed-ratio review required: `true`
+- model-conditioned pitch-contour audio review required: `true`
+- CLI candidate / rendered WAV: `3 / 3`
+- CLI input context bars: `228`
+- objective valid / strict / grammar: `9 / 9 / 9`
+- objective dead-air / collapse failure count: `0 / 0`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- technical/objective current evidence support 유지.
+- model-conditioned pitch-contour objective path current evidence에 포함.
+- pitch changed ratio review 필요 상태 유지.
+- musical quality claim 제외 유지.
+- 다음 boundary는 README evidence refresh.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-current-evidence-consolidation`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo README evidence refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #706, Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour objective-only next decision
-- 다음 권장 이슈: `Stage B MIDI-to-solo MVP current evidence consolidation`
+- latest functional result: Issue #708, Stage B MIDI-to-solo MVP current evidence consolidation
+- 다음 권장 이슈: `Stage B MIDI-to-solo README evidence refresh`
 
 현재 범위가 아닌 것:
 
@@ -70,6 +70,59 @@
 - model-conditioned input path pitch-contour repaired WAV/MIDI 후보 3개 listening review package 준비 완료
 - model-conditioned input path pitch-contour review input pending 상태에서 preference fill 차단 완료
 - model-conditioned input path pitch-contour objective-only 기준 current evidence consolidation 준비 완료
+- model-conditioned input path pitch-contour objective path를 current evidence에 통합 완료
+
+## Stage B MIDI-to-Solo MVP Current Evidence Consolidation Result
+
+Issue #708은 Issue #706 pitch-contour objective-only next decision 결과를 기존 current evidence consolidation source에 추가한 작업이다.
+
+변경:
+
+- current evidence consolidation script에 model-conditioned pitch-contour objective source 추가
+- selected-scale objective path, phrase-bank CLI technical path, model-conditioned pitch-contour objective path 통합
+- current evidence support와 quality claim boundary 분리 유지
+- 전용 harness와 unit test 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MVP_CURRENT_EVIDENCE_CONSOLIDATION_2026-06-09.md`
+- boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- next boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
+- current MVP evidence supported: `true`
+- technical execution evidence supported: `true`
+- selected-scale objective path complete: `true`
+- phrase-bank CLI technical path ready: `true`
+- model-conditioned pitch-contour objective path ready: `true`
+- model-conditioned pitch-contour max interval: `11`
+- model-conditioned pitch-contour target supported: `true`
+- model-conditioned pitch-contour changed-ratio review required: `true`
+- model-conditioned pitch-contour audio review required: `true`
+- CLI candidate / rendered WAV: `3 / 3`
+- CLI input context bars: `228`
+- objective valid / strict / grammar: `9 / 9 / 9`
+- objective dead-air / collapse failure count: `0 / 0`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- critical user input required: `false`
+
+판단:
+
+- technical/objective current evidence support 유지.
+- model-conditioned pitch-contour objective path current evidence에 포함.
+- pitch changed ratio review 필요 상태 유지.
+- musical quality claim 제외 유지.
+- 다음 boundary는 README evidence refresh.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- `.venv/bin/python -m py_compile scripts/consolidate_stage_b_midi_to_solo_mvp_current_evidence.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-current-evidence-consolidation`
+
+다음:
+
+- `Stage B MIDI-to-solo README evidence refresh`
 
 ## Stage B MIDI-to-Solo Model-Conditioned Input Path Dead-Air Timing Repair Pitch Contour Objective-Only Next Decision Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MVP_CURRENT_EVIDENCE_CONSOLIDATION_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MVP_CURRENT_EVIDENCE_CONSOLIDATION_2026-06-09.md
@@ -1,0 +1,95 @@
+# Stage B MIDI-to-Solo MVP Current Evidence Consolidation
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- next boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
+- current MVP evidence supported: `true`
+- technical execution evidence supported: `true`
+- selected-scale objective path complete: `true`
+- phrase-bank CLI technical path ready: `true`
+- model-conditioned pitch-contour objective path ready: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Input Contract
+
+- candidate count: `32`
+- exported MIDI candidates: `3`
+- target solo bars: `8`
+- min note count: `24`
+- min unique pitch count: `8`
+- max simultaneous notes: `1`
+- fallback path: `phrase_retrieval_data_motif_hybrid`
+
+## Context and Ranked MIDI
+
+- context bars / events: `8` / `128`
+- low-confidence chord bars: `4`
+- generation source: `context_conditioned_fallback`
+- exported / qualified candidates: `3` / `3`
+- best note / unique pitch / max simultaneous notes: `60` / `14` / `1`
+
+## Technical Audio Path
+
+- rendered WAV files: `3`
+- sample rate: `44100`
+- duration range: `18.617s-18.991s`
+- technical WAV validation: `true`
+
+## Selected-Scale Objective Path
+
+- final boundary: `stage_b_midi_to_solo_controlled_scale_checkpoint_training_scale_postprocess_removal_dead_air_repair_objective_path_complete`
+- sample / seed count: `9` / `3`
+- valid / strict / grammar: `9` / `9` / `9`
+- dead-air / collapse failure count: `0` / `0`
+- avg / max postprocess removal ratio: `0.21759259259259262` / `0.2916666666666667`
+- target avg postprocess removal ratio: `0.3`
+- validated review input present: `false`
+- preference fill allowed: `false`
+
+## Phrase-Bank CLI Technical Path
+
+- technical MIDI-to-solo CLI path ready: `true`
+- explicit input used: `true`
+- candidate / objective supported: `3` / `3`
+- repaired MIDI / rendered WAV: `3` / `3`
+- input context bars: `228`
+- dead-air range: `0.1895-0.2211`
+- preference fill allowed: `false`
+
+## Model-Conditioned Pitch-Contour Objective Path
+
+- current evidence consolidation ready: `true`
+- rendered WAV files: `3`
+- technical WAV validation: `true`
+- max interval / threshold: `11` / `12`
+- pitch-contour target supported: `true`
+- max pitch changed ratio: `0.7174`
+- pitch changed ratio review required: `true`
+- audio review required: `true`
+- preference fill allowed: `false`
+
+## MIDI Paths
+
+- `outputs/stage_b_midi_to_solo_conditioned_generation_probe/harness_stage_b_midi_to_solo_conditioned_generation_probe/midi/rank_01_seed_489.mid`
+- `outputs/stage_b_midi_to_solo_conditioned_generation_probe/harness_stage_b_midi_to_solo_conditioned_generation_probe/midi/rank_02_seed_488.mid`
+- `outputs/stage_b_midi_to_solo_conditioned_generation_probe/harness_stage_b_midi_to_solo_conditioned_generation_probe/midi/rank_03_seed_487.mid`
+
+## WAV Paths
+
+- `outputs/stage_b_midi_to_solo_candidate_audio_render_package/harness_stage_b_midi_to_solo_candidate_audio_render_package/audio/rank_01_seed_489.wav`
+- `outputs/stage_b_midi_to_solo_candidate_audio_render_package/harness_stage_b_midi_to_solo_candidate_audio_render_package/audio/rank_02_seed_488.wav`
+- `outputs/stage_b_midi_to_solo_candidate_audio_render_package/harness_stage_b_midi_to_solo_candidate_audio_render_package/audio/rank_03_seed_487.wav`
+
+## Not Proven
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`
+- `production_ready_improviser`
+
+## Next
+
+- `Stage B MIDI-to-solo README evidence refresh`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -5846,6 +5846,7 @@ run_stage_b_midi_to_solo_mvp_current_evidence_consolidation() {
   local candidate_audio_run_id="${CANDIDATE_AUDIO_RUN_ID:-harness_stage_b_midi_to_solo_candidate_audio_render_package}"
   local objective_next_run_id="${OBJECTIVE_NEXT_RUN_ID:-harness_stage_b_midi_to_solo_controlled_scale_checkpoint_training_scale_postprocess_removal_dead_air_repair_objective_next}"
   local cli_objective_next_run_id="${CLI_OBJECTIVE_NEXT_RUN_ID:-harness_stage_b_midi_to_solo_phrase_bank_cli_objective_only_next_decision}"
+  local model_conditioned_pitch_contour_objective_next_run_id="${MODEL_CONDITIONED_PITCH_CONTOUR_OBJECTIVE_NEXT_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_next}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_mvp_current_evidence_consolidation}"
   local contract_report="outputs/stage_b_midi_to_solo_mvp_contract/${contract_run_id}/stage_b_midi_to_solo_mvp_contract.json"
   local context_report="outputs/stage_b_midi_to_solo_context_extraction/${context_run_id}/stage_b_midi_to_solo_context_extraction.json"
@@ -5854,6 +5855,7 @@ run_stage_b_midi_to_solo_mvp_current_evidence_consolidation() {
   local candidate_audio="outputs/stage_b_midi_to_solo_candidate_audio_render_package/${candidate_audio_run_id}/stage_b_midi_to_solo_candidate_audio_render_package.json"
   local objective_next="outputs/stage_b_midi_to_solo_controlled_scale_checkpoint_training_scale_postprocess_removal_dead_air_repair_objective_next/${objective_next_run_id}/stage_b_midi_to_solo_controlled_scale_checkpoint_training_scale_postprocess_removal_dead_air_repair_objective_next.json"
   local cli_objective_next="outputs/stage_b_midi_to_solo_phrase_bank_cli_objective_only_next_decision/${cli_objective_next_run_id}/stage_b_midi_to_solo_phrase_bank_cli_objective_only_next_decision.json"
+  local model_conditioned_pitch_contour_objective_next="outputs/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision/${model_conditioned_pitch_contour_objective_next_run_id}/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision.json"
   if [[ ! -f "$contract_report" ]]; then
     print_header "Stage B MIDI-to-solo MVP input contract"
     RUN_ID="$contract_run_id" run_stage_b_midi_to_solo_mvp_contract
@@ -5882,6 +5884,10 @@ run_stage_b_midi_to_solo_mvp_current_evidence_consolidation() {
     print_header "Stage B MIDI-to-solo phrase-bank CLI objective-only next decision"
     RUN_ID="$cli_objective_next_run_id" run_stage_b_midi_to_solo_phrase_bank_cli_objective_only_next_decision
   fi
+  if [[ ! -f "$model_conditioned_pitch_contour_objective_next" ]]; then
+    print_header "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour objective-only next decision"
+    RUN_ID="$model_conditioned_pitch_contour_objective_next_run_id" run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_next
+  fi
   print_header "Stage B MIDI-to-solo MVP current evidence consolidation"
   "$PYTHON_BIN" scripts/consolidate_stage_b_midi_to_solo_mvp_current_evidence.py \
     --run_id "$run_id" \
@@ -5892,13 +5898,16 @@ run_stage_b_midi_to_solo_mvp_current_evidence_consolidation() {
     --audio_render "$candidate_audio" \
     --objective_next "$objective_next" \
     --cli_objective_next "$cli_objective_next" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_CURRENT_EVIDENCE_CONSOLIDATION_2026-06-05.md \
+    --model_conditioned_pitch_contour_objective_next "$model_conditioned_pitch_contour_objective_next" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_CURRENT_EVIDENCE_CONSOLIDATION_2026-06-09.md \
+    --issue_number 708 \
     --expected_boundary stage_b_midi_to_solo_mvp_current_evidence_consolidation \
     --expected_next_boundary stage_b_midi_to_solo_readme_evidence_refresh \
     --min_exported_candidates 3 \
     --min_rendered_wav_files 3 \
     --min_objective_sample_count 9 \
     --require_current_evidence_support \
+    --require_model_conditioned_pitch_contour_objective \
     --require_no_quality_claim
 }
 

--- a/scripts/consolidate_stage_b_midi_to_solo_mvp_current_evidence.py
+++ b/scripts/consolidate_stage_b_midi_to_solo_mvp_current_evidence.py
@@ -37,6 +37,10 @@ OBJECTIVE_FINAL_BOUNDARY = (
     "postprocess_removal_dead_air_repair_objective_path_complete"
 )
 CLI_OBJECTIVE_BOUNDARY = "stage_b_midi_to_solo_phrase_bank_cli_objective_only_next_decision"
+MODEL_CONDITIONED_PITCH_CONTOUR_OBJECTIVE_BOUNDARY = (
+    "stage_b_midi_to_solo_model_conditioned_input_path_"
+    "dead_air_timing_repair_pitch_contour_objective_only_next_decision"
+)
 
 
 def _dict(value: Any) -> dict[str, Any]:
@@ -428,6 +432,93 @@ def validate_cli_objective_next(report: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def validate_model_conditioned_pitch_contour_objective_next(
+    report: dict[str, Any],
+) -> dict[str, Any]:
+    if str(report.get("boundary") or "") != MODEL_CONDITIONED_PITCH_CONTOUR_OBJECTIVE_BOUNDARY:
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "model-conditioned pitch-contour objective boundary required"
+        )
+    summary = _dict(report.get("objective_summary"))
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    if str(decision.get("next_boundary") or "") != BOUNDARY:
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "model-conditioned pitch-contour objective should route to current evidence"
+        )
+    if not bool(readiness.get("objective_next_decision_completed", False)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "model-conditioned pitch-contour objective completion required"
+        )
+    if not bool(summary.get("pitch_contour_target_supported", False)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "model-conditioned pitch-contour target support required"
+        )
+    if not bool(summary.get("current_evidence_consolidation_ready", False)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "model-conditioned pitch-contour current evidence readiness required"
+        )
+    if not bool(summary.get("technical_wav_validation", False)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "model-conditioned pitch-contour technical WAV validation required"
+        )
+    if _int(summary.get("rendered_audio_file_count")) < 3:
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "model-conditioned pitch-contour rendered WAV count below 3"
+        )
+    if bool(summary.get("validated_review_input_present", True)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "model-conditioned pitch-contour review input should remain absent"
+        )
+    if bool(summary.get("preference_fill_allowed", True)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "model-conditioned pitch-contour preference fill should remain blocked"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "model-conditioned pitch-contour critical user input should not be required"
+        )
+    blocked_claims = [
+        "human_audio_preference_claimed",
+        "midi_to_solo_musical_quality_claimed",
+        "audio_rendered_quality_claimed",
+        "model_checkpoint_generation_quality_claimed",
+        "model_direct_generation_quality_claimed",
+        "broad_trained_model_quality_claimed",
+        "brad_style_adaptation_claimed",
+        "production_ready_claimed",
+    ]
+    claimed = [name for name in blocked_claims if bool(readiness.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            f"unexpected model-conditioned pitch-contour claim: {claimed}"
+        )
+    return {
+        "boundary": MODEL_CONDITIONED_PITCH_CONTOUR_OBJECTIVE_BOUNDARY,
+        "objective_next_decision_completed": bool(
+            readiness.get("objective_next_decision_completed", False)
+        ),
+        "current_evidence_consolidation_ready": bool(
+            summary.get("current_evidence_consolidation_ready", False)
+        ),
+        "review_item_count": _int(summary.get("review_item_count")),
+        "validated_review_input_present": bool(
+            summary.get("validated_review_input_present", True)
+        ),
+        "preference_fill_allowed": bool(summary.get("preference_fill_allowed", True)),
+        "technical_wav_validation": bool(summary.get("technical_wav_validation", False)),
+        "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
+        "max_repaired_interval": _int(summary.get("max_repaired_interval")),
+        "max_interval_threshold": _int(summary.get("max_interval_threshold")),
+        "pitch_contour_target_supported": bool(summary.get("pitch_contour_target_supported", False)),
+        "max_pitch_changed_ratio": _float(summary.get("max_pitch_changed_ratio")),
+        "pitch_changed_ratio_review_required": bool(
+            summary.get("pitch_changed_ratio_review_required", False)
+        ),
+        "audio_review_required": bool(summary.get("audio_review_required", False)),
+    }
+
+
 def build_current_evidence_consolidation_report(
     *,
     contract_report: dict[str, Any],
@@ -437,6 +528,7 @@ def build_current_evidence_consolidation_report(
     audio_render: dict[str, Any],
     objective_next: dict[str, Any],
     cli_objective_next: dict[str, Any],
+    model_conditioned_pitch_contour_objective_next: dict[str, Any] | None = None,
     output_dir: Path,
     issue_number: int,
 ) -> dict[str, Any]:
@@ -447,6 +539,13 @@ def build_current_evidence_consolidation_report(
     audio = validate_audio(audio_render)
     objective = validate_objective_next(objective_next)
     cli_objective = validate_cli_objective_next(cli_objective_next)
+    model_conditioned_pitch_contour_objective = (
+        validate_model_conditioned_pitch_contour_objective_next(
+            model_conditioned_pitch_contour_objective_next
+        )
+        if model_conditioned_pitch_contour_objective_next
+        else {}
+    )
     technical_path_supported = (
         bool(resource["midi_to_solo_training_resource_ready"])
         and generation["exported_candidate_count"] >= 3
@@ -456,27 +555,39 @@ def build_current_evidence_consolidation_report(
     )
     selected_scale_objective_path_complete = bool(objective["objective_path_supported"])
     phrase_bank_cli_technical_path_ready = bool(cli_objective["technical_midi_to_solo_cli_path_ready"])
+    model_conditioned_pitch_contour_objective_path_ready = bool(
+        model_conditioned_pitch_contour_objective.get(
+            "current_evidence_consolidation_ready",
+            not bool(model_conditioned_pitch_contour_objective_next),
+        )
+    )
     current_evidence_supported = bool(
         technical_path_supported
         and selected_scale_objective_path_complete
         and phrase_bank_cli_technical_path_ready
+        and model_conditioned_pitch_contour_objective_path_ready
     )
+    source_boundaries = {
+        "contract": contract["boundary"],
+        "context": context["boundary"],
+        "resource": resource["boundary"],
+        "generation": generation["boundary"],
+        "audio": audio["boundary"],
+        "objective_next": objective["boundary"],
+        "objective_final": objective["final_boundary"],
+        "phrase_bank_cli_objective_next": cli_objective["boundary"],
+    }
+    if model_conditioned_pitch_contour_objective:
+        source_boundaries["model_conditioned_pitch_contour_objective_next"] = (
+            model_conditioned_pitch_contour_objective["boundary"]
+        )
     return {
         "schema_version": SCHEMA_VERSION,
         "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
         "output_dir": str(output_dir),
         "issue_number": int(issue_number),
         "boundary": BOUNDARY,
-        "source_boundaries": {
-            "contract": contract["boundary"],
-            "context": context["boundary"],
-            "resource": resource["boundary"],
-            "generation": generation["boundary"],
-            "audio": audio["boundary"],
-            "objective_next": objective["boundary"],
-            "objective_final": objective["final_boundary"],
-            "phrase_bank_cli_objective_next": cli_objective["boundary"],
-        },
+        "source_boundaries": source_boundaries,
         "mvp_contract": contract,
         "context_extraction": context,
         "training_resource": resource,
@@ -484,6 +595,7 @@ def build_current_evidence_consolidation_report(
         "technical_audio_render": audio,
         "selected_scale_objective_path": objective,
         "phrase_bank_cli_technical_path": cli_objective,
+        "model_conditioned_pitch_contour_objective_path": model_conditioned_pitch_contour_objective,
         "readiness": {
             "boundary": BOUNDARY,
             "mvp_current_evidence_consolidated": True,
@@ -494,6 +606,9 @@ def build_current_evidence_consolidation_report(
             "technical_wav_path_ready": True,
             "selected_scale_objective_path_complete": selected_scale_objective_path_complete,
             "phrase_bank_cli_technical_path_ready": phrase_bank_cli_technical_path_ready,
+            "model_conditioned_pitch_contour_objective_path_ready": bool(
+                model_conditioned_pitch_contour_objective_path_ready
+            ),
             "current_mvp_technical_execution_evidence_supported": technical_path_supported,
             "current_mvp_objective_repair_evidence_supported": selected_scale_objective_path_complete,
             "midi_to_solo_mvp_current_evidence_supported": current_evidence_supported,
@@ -522,6 +637,11 @@ def build_current_evidence_consolidation_report(
             "technical_wav_render_path_validated",
             "selected_scale_objective_dead_air_repair_path_complete",
             "explicit_input_cli_ranked_midi_wav_path_validated",
+            *(
+                ["model_conditioned_pitch_contour_objective_path_ready"]
+                if model_conditioned_pitch_contour_objective
+                else []
+            ),
             "quality_claim_guard_preserved",
         ],
         "not_proven": [
@@ -545,6 +665,7 @@ def validate_current_evidence_consolidation_report(
     min_exported_candidates: int,
     min_rendered_wav_files: int,
     min_objective_sample_count: int,
+    require_model_conditioned_pitch_contour_objective: bool = False,
 ) -> dict[str, Any]:
     boundary = str(report.get("boundary") or "")
     readiness = _dict(report.get("readiness"))
@@ -553,6 +674,9 @@ def validate_current_evidence_consolidation_report(
     audio = _dict(report.get("technical_audio_render"))
     objective = _dict(report.get("selected_scale_objective_path"))
     cli_objective = _dict(report.get("phrase_bank_cli_technical_path"))
+    model_conditioned_pitch_contour = _dict(
+        report.get("model_conditioned_pitch_contour_objective_path")
+    )
     if expected_boundary and boundary != expected_boundary:
         raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
             f"expected boundary {expected_boundary}, got {boundary}"
@@ -575,6 +699,18 @@ def validate_current_evidence_consolidation_report(
         raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError("CLI technical path support required")
     if bool(cli_objective.get("preference_fill_allowed", True)):
         raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError("CLI preference fill should remain blocked")
+    if require_model_conditioned_pitch_contour_objective and not bool(
+        readiness.get("model_conditioned_pitch_contour_objective_path_ready", False)
+    ):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "model-conditioned pitch-contour objective path support required"
+        )
+    if model_conditioned_pitch_contour and bool(
+        model_conditioned_pitch_contour.get("preference_fill_allowed", True)
+    ):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "model-conditioned pitch-contour preference fill should remain blocked"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError("critical user input should not be required")
     for item in _list(generation.get("midi_paths")) + _list(audio.get("wav_paths")):
@@ -607,6 +743,21 @@ def validate_current_evidence_consolidation_report(
         ),
         "phrase_bank_cli_technical_path_ready": bool(
             readiness.get("phrase_bank_cli_technical_path_ready", False)
+        ),
+        "model_conditioned_pitch_contour_objective_path_ready": bool(
+            readiness.get("model_conditioned_pitch_contour_objective_path_ready", False)
+        ),
+        "model_conditioned_pitch_contour_max_interval": _int(
+            model_conditioned_pitch_contour.get("max_repaired_interval")
+        ),
+        "model_conditioned_pitch_contour_target_supported": bool(
+            model_conditioned_pitch_contour.get("pitch_contour_target_supported", False)
+        ),
+        "model_conditioned_pitch_contour_pitch_changed_ratio_review_required": bool(
+            model_conditioned_pitch_contour.get("pitch_changed_ratio_review_required", False)
+        ),
+        "model_conditioned_pitch_contour_audio_review_required": bool(
+            model_conditioned_pitch_contour.get("audio_review_required", False)
         ),
         "cli_candidate_count": _int(cli_objective.get("candidate_count")),
         "cli_rendered_audio_file_count": _int(cli_objective.get("rendered_audio_file_count")),
@@ -650,6 +801,9 @@ def markdown_report(report: dict[str, Any]) -> str:
     audio = report["technical_audio_render"]
     objective = report["selected_scale_objective_path"]
     cli_objective = report["phrase_bank_cli_technical_path"]
+    model_conditioned_pitch_contour = _dict(
+        report.get("model_conditioned_pitch_contour_objective_path")
+    )
     lines = [
         "# Stage B MIDI-to-Solo MVP Current Evidence Consolidation",
         "",
@@ -661,6 +815,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- technical execution evidence supported: `{_bool_token(readiness['current_mvp_technical_execution_evidence_supported'])}`",
         f"- selected-scale objective path complete: `{_bool_token(readiness['selected_scale_objective_path_complete'])}`",
         f"- phrase-bank CLI technical path ready: `{_bool_token(readiness['phrase_bank_cli_technical_path_ready'])}`",
+        f"- model-conditioned pitch-contour objective path ready: `{_bool_token(readiness['model_conditioned_pitch_contour_objective_path_ready'])}`",
         f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
         f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
         "",
@@ -710,9 +865,25 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- dead-air range: `{cli_objective['min_dead_air_ratio']:.4f}-{cli_objective['max_dead_air_ratio']:.4f}`",
         f"- preference fill allowed: `{_bool_token(cli_objective['preference_fill_allowed'])}`",
         "",
-        "## MIDI Paths",
-        "",
     ]
+    if model_conditioned_pitch_contour:
+        lines.extend(
+            [
+                "## Model-Conditioned Pitch-Contour Objective Path",
+                "",
+                f"- current evidence consolidation ready: `{_bool_token(model_conditioned_pitch_contour['current_evidence_consolidation_ready'])}`",
+                f"- rendered WAV files: `{model_conditioned_pitch_contour['rendered_audio_file_count']}`",
+                f"- technical WAV validation: `{_bool_token(model_conditioned_pitch_contour['technical_wav_validation'])}`",
+                f"- max interval / threshold: `{model_conditioned_pitch_contour['max_repaired_interval']}` / `{model_conditioned_pitch_contour['max_interval_threshold']}`",
+                f"- pitch-contour target supported: `{_bool_token(model_conditioned_pitch_contour['pitch_contour_target_supported'])}`",
+                f"- max pitch changed ratio: `{model_conditioned_pitch_contour['max_pitch_changed_ratio']:.4f}`",
+                f"- pitch changed ratio review required: `{_bool_token(model_conditioned_pitch_contour['pitch_changed_ratio_review_required'])}`",
+                f"- audio review required: `{_bool_token(model_conditioned_pitch_contour['audio_review_required'])}`",
+                f"- preference fill allowed: `{_bool_token(model_conditioned_pitch_contour['preference_fill_allowed'])}`",
+                "",
+            ]
+        )
+    lines.extend(["## MIDI Paths", ""])
     for item in generation["midi_paths"]:
         lines.append(f"- `{item}`")
     lines.extend(["", "## WAV Paths", ""])
@@ -734,6 +905,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--audio_render", type=str, required=True)
     parser.add_argument("--objective_next", type=str, required=True)
     parser.add_argument("--cli_objective_next", type=str, required=True)
+    parser.add_argument("--model_conditioned_pitch_contour_objective_next", type=str, default="")
     parser.add_argument(
         "--output_root",
         type=str,
@@ -745,6 +917,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--require_current_evidence_support", action="store_true")
+    parser.add_argument("--require_model_conditioned_pitch_contour_objective", action="store_true")
     parser.add_argument("--require_no_quality_claim", action="store_true")
     parser.add_argument("--min_exported_candidates", type=int, default=3)
     parser.add_argument("--min_rendered_wav_files", type=int, default=3)
@@ -764,6 +937,11 @@ def main() -> int:
         audio_render=read_json(Path(args.audio_render)),
         objective_next=read_json(Path(args.objective_next)),
         cli_objective_next=read_json(Path(args.cli_objective_next)),
+        model_conditioned_pitch_contour_objective_next=(
+            read_json(Path(args.model_conditioned_pitch_contour_objective_next))
+            if args.model_conditioned_pitch_contour_objective_next
+            else None
+        ),
         output_dir=output_dir,
         issue_number=int(args.issue_number),
     )
@@ -776,6 +954,9 @@ def main() -> int:
         min_exported_candidates=int(args.min_exported_candidates),
         min_rendered_wav_files=int(args.min_rendered_wav_files),
         min_objective_sample_count=int(args.min_objective_sample_count),
+        require_model_conditioned_pitch_contour_objective=bool(
+            args.require_model_conditioned_pitch_contour_objective
+        ),
     )
     output_dir.mkdir(parents=True, exist_ok=True)
     write_json(output_dir / "stage_b_midi_to_solo_mvp_current_evidence_consolidation.json", report)

--- a/tests/test_stage_b_midi_to_solo_mvp_current_evidence_consolidation.py
+++ b/tests/test_stage_b_midi_to_solo_mvp_current_evidence_consolidation.py
@@ -26,6 +26,7 @@ def reports(
     *,
     strict_count: int = 9,
     dead_air_failure_count: int = 0,
+    pitch_contour_supported: bool = True,
     collapse_count: int = 0,
     quality_claim: bool = False,
 ) -> dict[str, dict]:
@@ -219,6 +220,41 @@ def reports(
                 "critical_user_input_required": False,
             },
         },
+        "model_conditioned_pitch_contour_objective": {
+            "boundary": (
+                "stage_b_midi_to_solo_model_conditioned_input_path_"
+                "dead_air_timing_repair_pitch_contour_objective_only_next_decision"
+            ),
+            "objective_summary": {
+                "review_item_count": 3,
+                "validated_review_input_present": False,
+                "preference_fill_allowed": False,
+                "technical_wav_validation": True,
+                "rendered_audio_file_count": 3,
+                "max_repaired_interval": 11 if pitch_contour_supported else 13,
+                "max_interval_threshold": 12,
+                "pitch_contour_target_supported": pitch_contour_supported,
+                "max_pitch_changed_ratio": 0.7174,
+                "pitch_changed_ratio_review_required": True,
+                "audio_review_required": True,
+                "current_evidence_consolidation_ready": pitch_contour_supported,
+            },
+            "readiness": {
+                "objective_next_decision_completed": True,
+                "human_audio_preference_claimed": False,
+                "midi_to_solo_musical_quality_claimed": quality_claim,
+                "audio_rendered_quality_claimed": False,
+                "model_checkpoint_generation_quality_claimed": False,
+                "model_direct_generation_quality_claimed": False,
+                "broad_trained_model_quality_claimed": False,
+                "brad_style_adaptation_claimed": False,
+                "production_ready_claimed": False,
+            },
+            "decision": {
+                "next_boundary": "stage_b_midi_to_solo_mvp_current_evidence_consolidation",
+                "critical_user_input_required": False,
+            },
+        },
     }
 
 
@@ -234,6 +270,9 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationTest(unittest.TestCase):
                 audio_render=data["audio"],
                 objective_next=data["objective"],
                 cli_objective_next=data["cli_objective"],
+                model_conditioned_pitch_contour_objective_next=data[
+                    "model_conditioned_pitch_contour_objective"
+                ],
                 output_dir=Path(tmp) / "out",
                 issue_number=612,
             )
@@ -246,12 +285,14 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationTest(unittest.TestCase):
                 min_exported_candidates=3,
                 min_rendered_wav_files=3,
                 min_objective_sample_count=9,
+                require_model_conditioned_pitch_contour_objective=True,
             )
 
             self.assertTrue(summary["midi_to_solo_mvp_current_evidence_supported"])
             self.assertTrue(summary["technical_execution_evidence_supported"])
             self.assertTrue(summary["selected_scale_objective_path_complete"])
             self.assertTrue(summary["phrase_bank_cli_technical_path_ready"])
+            self.assertTrue(summary["model_conditioned_pitch_contour_objective_path_ready"])
             self.assertEqual(summary["generation_source"], "context_conditioned_fallback")
             self.assertEqual(summary["exported_candidate_count"], 3)
             self.assertEqual(summary["rendered_audio_file_count"], 3)
@@ -264,6 +305,13 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationTest(unittest.TestCase):
             self.assertEqual(summary["objective_grammar_gate_sample_count"], 9)
             self.assertEqual(summary["objective_dead_air_failure_count"], 0)
             self.assertEqual(summary["objective_collapse_warning_sample_count"], 0)
+            self.assertEqual(summary["model_conditioned_pitch_contour_max_interval"], 11)
+            self.assertTrue(summary["model_conditioned_pitch_contour_target_supported"])
+            self.assertTrue(
+                summary[
+                    "model_conditioned_pitch_contour_pitch_changed_ratio_review_required"
+                ]
+            )
             self.assertFalse(summary["human_audio_preference_claimed"])
             self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
             self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
@@ -328,6 +376,25 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationTest(unittest.TestCase):
                     audio_render=data["audio"],
                     objective_next=data["objective"],
                     cli_objective_next=data["cli_objective"],
+                    output_dir=Path(tmp) / "out",
+                    issue_number=612,
+                )
+
+    def test_rejects_missing_model_conditioned_pitch_contour_support(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            data = reports(Path(tmp), pitch_contour_supported=False)
+            with self.assertRaises(StageBMidiToSoloMvpCurrentEvidenceConsolidationError):
+                build_current_evidence_consolidation_report(
+                    contract_report=data["contract"],
+                    context_report=data["context"],
+                    resource_probe=data["resource"],
+                    generation_probe=data["generation"],
+                    audio_render=data["audio"],
+                    objective_next=data["objective"],
+                    cli_objective_next=data["cli_objective"],
+                    model_conditioned_pitch_contour_objective_next=data[
+                        "model_conditioned_pitch_contour_objective"
+                    ],
                     output_dir=Path(tmp) / "out",
                     issue_number=612,
                 )


### PR DESCRIPTION
## Summary
- current evidence consolidation에 model-conditioned pitch-contour objective source 추가
- selected-scale objective path, phrase-bank CLI technical path, model-conditioned pitch-contour objective path 통합
- README/status docs 최신 evidence boundary 갱신

## Context
- #706 pitch-contour objective-only next decision 완료
- next boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
- pitch-contour target supported: `true`
- max repaired interval / threshold: `11 / 12`
- max pitch changed ratio: `0.7174`
- pitch changed ratio review required: `true`
- preference fill allowed: `false`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Scope
- current evidence consolidation validator 확장
- model-conditioned pitch-contour objective report 필수 harness source 연결
- unit test fixture와 rejection case 추가
- README, Current Status, Core Plan, handoff 갱신

## Result
- current MVP evidence supported: `true`
- technical execution evidence supported: `true`
- selected-scale objective path complete: `true`
- phrase-bank CLI technical path ready: `true`
- model-conditioned pitch-contour objective path ready: `true`
- next boundary: `stage_b_midi_to_solo_readme_evidence_refresh`

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_current_evidence_consolidation`
- `.venv/bin/python -m py_compile scripts/consolidate_stage_b_midi_to_solo_mvp_current_evidence.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-current-evidence-consolidation`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- current evidence는 technical/objective support 경계
- human/audio preference와 MIDI-to-solo musical quality claim 제외
- pitch changed ratio `0.7174` review 필요 상태 유지

## Follow-up
- Stage B MIDI-to-solo README evidence refresh

Closes #708