### PR TITLE
Stage B MIDI-to-solo MVP completion audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #710, Stage B MIDI-to-solo README evidence refresh.
+- Latest functional issue completed: Issue #712, Stage B MIDI-to-solo MVP completion audit.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo MVP completion audit.
+- Recommended next issue: Stage B MIDI-to-solo quality gap decision.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- latest evidence boundary: `stage_b_midi_to_solo_mvp_completion_audit`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -105,9 +105,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - phrase-bank CLI technical path included in current evidence: `true`
 - README evidence refreshed: `true`
 - MVP completion audit completed: `true`
+- MVP completion audit model-conditioned pitch-contour objective included: `true`
 - quality gap decision completed: `true`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- next boundary: `stage_b_midi_to_solo_quality_gap_decision`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -707,6 +708,23 @@ README evidence refresh.
 - model-conditioned pitch-contour changed-ratio review required: `true`
 - quality/preference claim excluded: `true`
 - next boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+
+MVP completion audit.
+
+- latest evidence boundary reflected: `stage_b_midi_to_solo_mvp_completion_audit`
+- source current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- technical model-core MVP completed: `true`
+- input to ranked MIDI completed: `true`
+- input to rendered WAV completed: `true`
+- selected-scale objective repair completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour max interval / threshold: `11 / 12`
+- model-conditioned pitch-contour changed-ratio review required: `true`
+- musical quality MVP completed: `false`
+- human/audio preference completed: `false`
+- product MVP completed: `false`
+- next boundary: `stage_b_midi_to_solo_quality_gap_decision`
 
 MIDI-to-solo input contract.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -393,6 +393,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo controlled scale checkpoint training scale postprocess removal dead-air repair objective-only next decision: objective path support `true`, valid/strict/grammar `9/9/9`, dead-air/collapse `0/0`, avg/max postprocess removal `0.2176/0.2917`, preference/quality claim `false`, next boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - MIDI-to-solo MVP current evidence consolidation: evidence support `true`, technical path `true`, selected-scale objective path `true`, phrase-bank CLI path `true`, model-conditioned pitch-contour objective path `true`, exported/rendered `3/3`, objective valid/strict/grammar `9/9/9`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_readme_evidence_refresh`
 - MIDI-to-solo README evidence refresh: latest boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`, input-to-WAV technical path `true`, selected-scale objective path `true`, phrase-bank CLI path `true`, model-conditioned pitch-contour objective path `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_completion_audit`
+- MIDI-to-solo MVP completion audit refresh: technical model-core MVP `true`, model-conditioned pitch-contour objective `true`, max interval/threshold `11/12`, musical/product MVP `false/false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_gap_decision`
 - MIDI-to-solo MVP completion audit: technical model-core MVP `true`, input ranked MIDI/WAV `true/true`, selected-scale objective repair `true`, musical/product MVP `false/false`, next boundary `stage_b_midi_to_solo_quality_gap_decision`
 - MIDI-to-solo quality gap decision: selected target `model_conditioned_input_path_quality_alignment`, fallback path active `true`, human review required now `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment`
 - MIDI-to-solo model-conditioned input path quality alignment: aligned `false`, fallback replacement probe required `true`, selected probe target `replace_fallback_with_model_conditioned_input_path_probe`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_probe`
@@ -3698,6 +3699,45 @@ Issue #710은 Issue #708 current evidence를 README 첫 상태 영역과 evidenc
 다음 작업:
 
 - `Stage B MIDI-to-solo MVP completion audit`
+
+## 9.47 Stage B MIDI-to-solo MVP completion audit refresh
+
+Issue #712는 Issue #708 current evidence와 Issue #710 README refresh를 기준으로 technical model-core MVP 완료 범위를 audit한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- source boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- next boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- technical model-core MVP completed: `true`
+- input to ranked MIDI completed: `true`
+- input to rendered WAV completed: `true`
+- selected-scale objective repair completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour max interval / threshold: `11 / 12`
+- model-conditioned pitch-contour changed-ratio review required: `true`
+- musical quality MVP completed: `false`
+- human/audio preference completed: `false`
+- product MVP completed: `false`
+
+판단:
+
+- current evidence 기준 technical model-core MVP 완료 범위 확인.
+- model-conditioned pitch-contour objective path는 completion audit 필수 근거에 포함.
+- 음악 품질, 사용자 선호, 제품 MVP 완료 claim 제외 유지.
+- 다음 boundary는 quality gap decision.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
+- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_mvp_completion.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo quality gap decision`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -72,6 +72,7 @@
 - model-conditioned input path pitch-contour objective-only 기준 current evidence consolidation 준비 완료
 - model-conditioned input path pitch-contour objective path를 current evidence에 통합 완료
 - README current evidence boundary refresh 완료
+- MVP completion audit에 model-conditioned pitch-contour objective path 포함 완료
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 
@@ -114,6 +115,53 @@ Issue #710은 Issue #708 current evidence를 README 첫 상태 영역과 evidenc
 다음:
 
 - `Stage B MIDI-to-solo MVP completion audit`
+
+## Stage B MIDI-to-Solo MVP Completion Audit Result
+
+Issue #712는 Issue #708 current evidence와 Issue #710 README refresh를 기준으로 technical model-core MVP 완료 범위를 audit한 작업이다.
+
+변경:
+
+- completion audit script에 model-conditioned pitch-contour objective path 검증 추가
+- README required snippet에 pitch-contour objective readiness와 changed-ratio review 필요 상태 추가
+- completion audit validation summary에 pitch-contour interval, threshold, review boundary 노출
+- generated audit document를 2026-06-09 current evidence 기준으로 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_2026-06-09.md`
+- boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- source boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- next boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- technical model-core MVP completed: `true`
+- input to ranked MIDI completed: `true`
+- input to rendered WAV completed: `true`
+- selected-scale objective repair completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour max interval / threshold: `11 / 12`
+- model-conditioned pitch-contour changed-ratio review required: `true`
+- musical quality MVP completed: `false`
+- human/audio preference completed: `false`
+- product MVP completed: `false`
+
+판단:
+
+- current evidence 기준 technical model-core MVP 완료 범위 확인.
+- model-conditioned pitch-contour objective path는 MVP completion audit에 포함.
+- 음악 품질, 사용자 선호, 제품 MVP 완료 claim 제외 유지.
+- 다음 작업은 quality gap decision.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
+- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_mvp_completion.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit`
+
+다음:
+
+- `Stage B MIDI-to-solo quality gap decision`
 
 ## Stage B MIDI-to-Solo MVP Current Evidence Consolidation Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_2026-06-09.md
@@ -1,0 +1,57 @@
+# Stage B MIDI-to-Solo MVP Completion Audit
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- next boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- technical model-core MVP completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- musical quality MVP completed: `false`
+- human/audio preference completed: `false`
+- product MVP completed: `false`
+
+## Evidence
+
+- source boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- generation source: `context_conditioned_fallback`
+- exported / qualified candidates: `3` / `3`
+- rendered WAV files: `3`
+- technical WAV validation: `true`
+- WAV duration range: `18.617s-18.991s`
+- objective sample / strict / grammar: `9` / `9` / `9`
+- objective dead-air / collapse failure: `0` / `0`
+- objective avg / target postprocess removal: `0.21759259259259262` / `0.3`
+- phrase-bank CLI technical path ready: `true`
+- CLI candidate / rendered WAV: `3` / `3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- model-conditioned pitch-contour objective path ready: `true`
+- model-conditioned pitch-contour rendered WAV files: `3`
+- model-conditioned pitch-contour technical WAV validation: `true`
+- model-conditioned pitch-contour max interval / threshold: `11` / `12`
+- model-conditioned pitch-contour target supported: `true`
+- model-conditioned pitch-contour max pitch changed ratio: `0.7174`
+- model-conditioned pitch-contour changed-ratio review required: `true`
+- model-conditioned pitch-contour audio review required: `true`
+- model-conditioned pitch-contour preference fill allowed: `false`
+
+## Claim Boundary
+
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- broad trained model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+- production ready claimed: `false`
+
+## Not Proven
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`
+- `production_ready_improviser`
+
+## Next
+
+- `Stage B MIDI-to-solo quality gap decision`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -5924,10 +5924,12 @@ run_stage_b_midi_to_solo_mvp_completion_audit() {
     --run_id "$run_id" \
     --current_evidence "$current_evidence" \
     --readme_path README.md \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_2026-06-05.md \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_2026-06-09.md \
+    --issue_number 712 \
     --expected_boundary stage_b_midi_to_solo_mvp_completion_audit \
     --expected_next_boundary stage_b_midi_to_solo_quality_gap_decision \
     --require_technical_mvp_completion \
+    --require_model_conditioned_pitch_contour_objective \
     --require_no_quality_claim
 }
 

--- a/scripts/audit_stage_b_midi_to_solo_mvp_completion.py
+++ b/scripts/audit_stage_b_midi_to_solo_mvp_completion.py
@@ -61,6 +61,9 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
     audio = _dict(report.get("technical_audio_render"))
     objective = _dict(report.get("selected_scale_objective_path"))
     cli_objective = _dict(report.get("phrase_bank_cli_technical_path"))
+    model_conditioned_pitch_contour = _dict(
+        report.get("model_conditioned_pitch_contour_objective_path")
+    )
     decision = _dict(report.get("decision"))
     required_true = [
         "mvp_current_evidence_consolidated",
@@ -71,6 +74,7 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
         "technical_wav_path_ready",
         "selected_scale_objective_path_complete",
         "phrase_bank_cli_technical_path_ready",
+        "model_conditioned_pitch_contour_objective_path_ready",
         "current_mvp_technical_execution_evidence_supported",
         "current_mvp_objective_repair_evidence_supported",
         "midi_to_solo_mvp_current_evidence_supported",
@@ -108,6 +112,40 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloMvpCompletionAuditError("CLI rendered WAV count below 3")
     if bool(cli_objective.get("preference_fill_allowed", True)):
         raise StageBMidiToSoloMvpCompletionAuditError("CLI preference fill should remain blocked")
+    if not bool(model_conditioned_pitch_contour):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "model-conditioned pitch-contour objective path required"
+        )
+    if not bool(model_conditioned_pitch_contour.get("current_evidence_consolidation_ready", False)):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "model-conditioned pitch-contour current evidence readiness required"
+        )
+    if not bool(model_conditioned_pitch_contour.get("pitch_contour_target_supported", False)):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "model-conditioned pitch-contour target support required"
+        )
+    if _int(model_conditioned_pitch_contour.get("max_repaired_interval")) > _int(
+        model_conditioned_pitch_contour.get("max_interval_threshold")
+    ):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "model-conditioned pitch-contour interval threshold exceeded"
+        )
+    if _int(model_conditioned_pitch_contour.get("rendered_audio_file_count")) < 3:
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "model-conditioned pitch-contour rendered WAV count below 3"
+        )
+    if not bool(model_conditioned_pitch_contour.get("technical_wav_validation", False)):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "model-conditioned pitch-contour technical WAV validation required"
+        )
+    if bool(model_conditioned_pitch_contour.get("validated_review_input_present", True)):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "model-conditioned pitch-contour review input should remain absent"
+        )
+    if bool(model_conditioned_pitch_contour.get("preference_fill_allowed", True)):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "model-conditioned pitch-contour preference fill should remain blocked"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloMvpCompletionAuditError("critical user input should not be required")
     return {
@@ -140,6 +178,42 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
         "cli_rendered_audio_file_count": _int(cli_objective.get("rendered_audio_file_count")),
         "cli_input_context_bars": _int(cli_objective.get("input_context_bars")),
         "cli_preference_fill_allowed": bool(cli_objective.get("preference_fill_allowed", True)),
+        "model_conditioned_pitch_contour_objective_path_ready": bool(
+            readiness.get("model_conditioned_pitch_contour_objective_path_ready", False)
+        ),
+        "model_conditioned_pitch_contour_current_evidence_ready": bool(
+            model_conditioned_pitch_contour.get("current_evidence_consolidation_ready", False)
+        ),
+        "model_conditioned_pitch_contour_rendered_audio_file_count": _int(
+            model_conditioned_pitch_contour.get("rendered_audio_file_count")
+        ),
+        "model_conditioned_pitch_contour_technical_wav_validation": bool(
+            model_conditioned_pitch_contour.get("technical_wav_validation", False)
+        ),
+        "model_conditioned_pitch_contour_max_interval": _int(
+            model_conditioned_pitch_contour.get("max_repaired_interval")
+        ),
+        "model_conditioned_pitch_contour_max_interval_threshold": _int(
+            model_conditioned_pitch_contour.get("max_interval_threshold")
+        ),
+        "model_conditioned_pitch_contour_target_supported": bool(
+            model_conditioned_pitch_contour.get("pitch_contour_target_supported", False)
+        ),
+        "model_conditioned_pitch_contour_max_pitch_changed_ratio": _float(
+            model_conditioned_pitch_contour.get("max_pitch_changed_ratio")
+        ),
+        "model_conditioned_pitch_contour_pitch_changed_ratio_review_required": bool(
+            model_conditioned_pitch_contour.get("pitch_changed_ratio_review_required", False)
+        ),
+        "model_conditioned_pitch_contour_audio_review_required": bool(
+            model_conditioned_pitch_contour.get("audio_review_required", False)
+        ),
+        "model_conditioned_pitch_contour_validated_review_input_present": bool(
+            model_conditioned_pitch_contour.get("validated_review_input_present", True)
+        ),
+        "model_conditioned_pitch_contour_preference_fill_allowed": bool(
+            model_conditioned_pitch_contour.get("preference_fill_allowed", True)
+        ),
     }
 
 
@@ -150,6 +224,12 @@ def validate_readme_refresh(readme_text: str) -> dict[str, Any]:
         "technical_path": "input MIDI -> context -> ranked MIDI -> WAV technical path: `true`",
         "objective_path": "selected-scale objective repair path complete: `true`",
         "cli_path": "phrase-bank CLI technical path included in current evidence: `true`",
+        "model_conditioned_pitch_contour": (
+            "model-conditioned pitch-contour objective path ready: `true`"
+        ),
+        "model_conditioned_pitch_contour_ratio": (
+            "model-conditioned pitch-contour changed-ratio review required: `true`"
+        ),
         "readme_refresh": "README evidence refreshed: `true`",
         "human_preference_false": "human/audio preference claim: `false`",
         "musical_quality_false": "MIDI-to-solo musical quality claim: `false`",
@@ -180,6 +260,7 @@ def build_mvp_completion_audit_report(
         and evidence["technical_execution_evidence_supported"]
         and evidence["selected_scale_objective_path_complete"]
         and evidence["phrase_bank_cli_technical_path_ready"]
+        and evidence["model_conditioned_pitch_contour_objective_path_ready"]
         and readme["readme_current_evidence_refreshed"]
     )
     return {
@@ -197,6 +278,7 @@ def build_mvp_completion_audit_report(
             "input_to_rendered_wav_completed": True,
             "selected_scale_objective_repair_completed": True,
             "phrase_bank_cli_technical_path_completed": True,
+            "model_conditioned_pitch_contour_objective_completed": True,
             "readme_evidence_boundary_refreshed": True,
             "musical_quality_mvp_completed": False,
             "human_audio_preference_completed": False,
@@ -208,6 +290,9 @@ def build_mvp_completion_audit_report(
             "boundary": BOUNDARY,
             "mvp_completion_audit_completed": True,
             "technical_model_core_mvp_completed": technical_model_core_mvp_completed,
+            "model_conditioned_pitch_contour_objective_path_ready": bool(
+                evidence["model_conditioned_pitch_contour_objective_path_ready"]
+            ),
             "quality_gap_decision_required": True,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
@@ -231,6 +316,7 @@ def build_mvp_completion_audit_report(
             "technical_wav_render_path",
             "selected_scale_objective_repair_path",
             "phrase_bank_cli_technical_path",
+            "model_conditioned_pitch_contour_objective_path",
             "readme_current_evidence_refresh",
         ],
         "not_proven": [
@@ -251,6 +337,7 @@ def validate_mvp_completion_audit_report(
     expected_next_boundary: str | None,
     require_technical_mvp_completion: bool,
     require_no_quality_claim: bool,
+    require_model_conditioned_pitch_contour_objective: bool,
 ) -> dict[str, Any]:
     boundary = str(report.get("boundary") or "")
     readiness = _dict(report.get("readiness"))
@@ -265,6 +352,12 @@ def validate_mvp_completion_audit_report(
         raise StageBMidiToSoloMvpCompletionAuditError("unexpected next boundary")
     if require_technical_mvp_completion and not bool(audit.get("technical_model_core_mvp_completed", False)):
         raise StageBMidiToSoloMvpCompletionAuditError("technical model-core MVP completion required")
+    if require_model_conditioned_pitch_contour_objective and not bool(
+        audit.get("model_conditioned_pitch_contour_objective_completed", False)
+    ):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "model-conditioned pitch-contour objective completion required"
+        )
     if not bool(readiness.get("quality_gap_decision_required", False)):
         raise StageBMidiToSoloMvpCompletionAuditError("quality gap decision should be required")
     if bool(decision.get("critical_user_input_required", True)):
@@ -294,6 +387,9 @@ def validate_mvp_completion_audit_report(
         "phrase_bank_cli_technical_path_completed": bool(
             audit.get("phrase_bank_cli_technical_path_completed", False)
         ),
+        "model_conditioned_pitch_contour_objective_completed": bool(
+            audit.get("model_conditioned_pitch_contour_objective_completed", False)
+        ),
         "musical_quality_mvp_completed": bool(audit.get("musical_quality_mvp_completed", True)),
         "human_audio_preference_completed": bool(audit.get("human_audio_preference_completed", True)),
         "product_mvp_completed": bool(audit.get("product_mvp_completed", True)),
@@ -312,6 +408,24 @@ def validate_mvp_completion_audit_report(
         "cli_rendered_audio_file_count": _int(evidence.get("cli_rendered_audio_file_count")),
         "cli_input_context_bars": _int(evidence.get("cli_input_context_bars")),
         "cli_preference_fill_allowed": bool(evidence.get("cli_preference_fill_allowed", True)),
+        "model_conditioned_pitch_contour_objective_path_ready": bool(
+            evidence.get("model_conditioned_pitch_contour_objective_path_ready", False)
+        ),
+        "model_conditioned_pitch_contour_max_interval": _int(
+            evidence.get("model_conditioned_pitch_contour_max_interval")
+        ),
+        "model_conditioned_pitch_contour_max_interval_threshold": _int(
+            evidence.get("model_conditioned_pitch_contour_max_interval_threshold")
+        ),
+        "model_conditioned_pitch_contour_target_supported": bool(
+            evidence.get("model_conditioned_pitch_contour_target_supported", False)
+        ),
+        "model_conditioned_pitch_contour_pitch_changed_ratio_review_required": bool(
+            evidence.get("model_conditioned_pitch_contour_pitch_changed_ratio_review_required", False)
+        ),
+        "model_conditioned_pitch_contour_audio_review_required": bool(
+            evidence.get("model_conditioned_pitch_contour_audio_review_required", False)
+        ),
         "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
         "midi_to_solo_musical_quality_claimed": bool(
             readiness.get("midi_to_solo_musical_quality_claimed", True)
@@ -335,6 +449,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- next boundary: `{decision['next_boundary']}`",
         f"- technical model-core MVP completed: `{_bool_token(audit['technical_model_core_mvp_completed'])}`",
         f"- phrase-bank CLI technical path completed: `{_bool_token(audit['phrase_bank_cli_technical_path_completed'])}`",
+        f"- model-conditioned pitch-contour objective completed: `{_bool_token(audit['model_conditioned_pitch_contour_objective_completed'])}`",
         f"- musical quality MVP completed: `{_bool_token(audit['musical_quality_mvp_completed'])}`",
         f"- human/audio preference completed: `{_bool_token(audit['human_audio_preference_completed'])}`",
         f"- product MVP completed: `{_bool_token(audit['product_mvp_completed'])}`",
@@ -354,6 +469,15 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- CLI candidate / rendered WAV: `{evidence['cli_candidate_count']}` / `{evidence['cli_rendered_audio_file_count']}`",
         f"- CLI input context bars: `{evidence['cli_input_context_bars']}`",
         f"- CLI preference fill allowed: `{_bool_token(evidence['cli_preference_fill_allowed'])}`",
+        f"- model-conditioned pitch-contour objective path ready: `{_bool_token(evidence['model_conditioned_pitch_contour_objective_path_ready'])}`",
+        f"- model-conditioned pitch-contour rendered WAV files: `{evidence['model_conditioned_pitch_contour_rendered_audio_file_count']}`",
+        f"- model-conditioned pitch-contour technical WAV validation: `{_bool_token(evidence['model_conditioned_pitch_contour_technical_wav_validation'])}`",
+        f"- model-conditioned pitch-contour max interval / threshold: `{evidence['model_conditioned_pitch_contour_max_interval']}` / `{evidence['model_conditioned_pitch_contour_max_interval_threshold']}`",
+        f"- model-conditioned pitch-contour target supported: `{_bool_token(evidence['model_conditioned_pitch_contour_target_supported'])}`",
+        f"- model-conditioned pitch-contour max pitch changed ratio: `{evidence['model_conditioned_pitch_contour_max_pitch_changed_ratio']:.4f}`",
+        f"- model-conditioned pitch-contour changed-ratio review required: `{_bool_token(evidence['model_conditioned_pitch_contour_pitch_changed_ratio_review_required'])}`",
+        f"- model-conditioned pitch-contour audio review required: `{_bool_token(evidence['model_conditioned_pitch_contour_audio_review_required'])}`",
+        f"- model-conditioned pitch-contour preference fill allowed: `{_bool_token(evidence['model_conditioned_pitch_contour_preference_fill_allowed'])}`",
         "",
         "## Claim Boundary",
         "",
@@ -388,6 +512,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--require_technical_mvp_completion", action="store_true")
     parser.add_argument("--require_no_quality_claim", action="store_true")
+    parser.add_argument("--require_model_conditioned_pitch_contour_objective", action="store_true")
     return parser
 
 
@@ -410,6 +535,9 @@ def main() -> int:
         expected_next_boundary=str(args.expected_next_boundary or ""),
         require_technical_mvp_completion=bool(args.require_technical_mvp_completion),
         require_no_quality_claim=bool(args.require_no_quality_claim),
+        require_model_conditioned_pitch_contour_objective=bool(
+            args.require_model_conditioned_pitch_contour_objective
+        ),
     )
     output_dir.mkdir(parents=True, exist_ok=True)
     write_json(output_dir / "stage_b_midi_to_solo_mvp_completion_audit.json", report)

--- a/tests/test_stage_b_midi_to_solo_mvp_completion_audit.py
+++ b/tests/test_stage_b_midi_to_solo_mvp_completion_audit.py
@@ -15,7 +15,12 @@ from scripts.consolidate_stage_b_midi_to_solo_mvp_current_evidence import (
 )
 
 
-def current_evidence(*, quality_claim: bool = False, strict_count: int = 9) -> dict:
+def current_evidence(
+    *,
+    quality_claim: bool = False,
+    strict_count: int = 9,
+    pitch_contour_supported: bool = True,
+) -> dict:
     return {
         "boundary": CURRENT_EVIDENCE_BOUNDARY,
         "readiness": {
@@ -27,9 +32,10 @@ def current_evidence(*, quality_claim: bool = False, strict_count: int = 9) -> d
             "technical_wav_path_ready": True,
             "selected_scale_objective_path_complete": True,
             "phrase_bank_cli_technical_path_ready": True,
+            "model_conditioned_pitch_contour_objective_path_ready": pitch_contour_supported,
             "current_mvp_technical_execution_evidence_supported": True,
             "current_mvp_objective_repair_evidence_supported": True,
-            "midi_to_solo_mvp_current_evidence_supported": True,
+            "midi_to_solo_mvp_current_evidence_supported": pitch_contour_supported,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
             "broad_trained_model_quality_claimed": False,
@@ -64,6 +70,25 @@ def current_evidence(*, quality_claim: bool = False, strict_count: int = 9) -> d
             "input_context_bars": 228,
             "preference_fill_allowed": False,
         },
+        "model_conditioned_pitch_contour_objective_path": {
+            "boundary": (
+                "stage_b_midi_to_solo_model_conditioned_input_path_"
+                "dead_air_timing_repair_pitch_contour_objective_only_next_decision"
+            ),
+            "objective_next_decision_completed": True,
+            "current_evidence_consolidation_ready": pitch_contour_supported,
+            "review_item_count": 3,
+            "validated_review_input_present": False,
+            "preference_fill_allowed": False,
+            "technical_wav_validation": True,
+            "rendered_audio_file_count": 3,
+            "max_repaired_interval": 11 if pitch_contour_supported else 13,
+            "max_interval_threshold": 12,
+            "pitch_contour_target_supported": pitch_contour_supported,
+            "max_pitch_changed_ratio": 0.7174,
+            "pitch_changed_ratio_review_required": True,
+            "audio_review_required": True,
+        },
         "decision": {
             "critical_user_input_required": False,
         },
@@ -80,6 +105,8 @@ def readme_text(*, missing_boundary: bool = False) -> str:
             "- input MIDI -> context -> ranked MIDI -> WAV technical path: `true`",
             "- selected-scale objective repair path complete: `true`",
             "- phrase-bank CLI technical path included in current evidence: `true`",
+            "- model-conditioned pitch-contour objective path ready: `true`",
+            "- model-conditioned pitch-contour changed-ratio review required: `true`",
             "- README evidence refreshed: `true`",
             "- human/audio preference claim: `false`",
             "- MIDI-to-solo musical quality claim: `false`",
@@ -103,6 +130,7 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
             expected_next_boundary=NEXT_BOUNDARY,
             require_technical_mvp_completion=True,
             require_no_quality_claim=True,
+            require_model_conditioned_pitch_contour_objective=True,
         )
 
         self.assertTrue(summary["technical_model_core_mvp_completed"])
@@ -124,6 +152,15 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
         self.assertEqual(summary["cli_rendered_audio_file_count"], 3)
         self.assertEqual(summary["cli_input_context_bars"], 228)
         self.assertFalse(summary["cli_preference_fill_allowed"])
+        self.assertTrue(summary["model_conditioned_pitch_contour_objective_completed"])
+        self.assertTrue(summary["model_conditioned_pitch_contour_objective_path_ready"])
+        self.assertEqual(summary["model_conditioned_pitch_contour_max_interval"], 11)
+        self.assertEqual(summary["model_conditioned_pitch_contour_max_interval_threshold"], 12)
+        self.assertTrue(summary["model_conditioned_pitch_contour_target_supported"])
+        self.assertTrue(
+            summary["model_conditioned_pitch_contour_pitch_changed_ratio_review_required"]
+        )
+        self.assertTrue(summary["model_conditioned_pitch_contour_audio_review_required"])
         self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
 
     def test_rejects_missing_readme_evidence_boundary(self) -> None:
@@ -151,6 +188,15 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
                 readme_text=readme_text(),
                 output_dir=Path("outputs/audit"),
                 issue_number=616,
+            )
+
+    def test_rejects_missing_pitch_contour_support(self) -> None:
+        with self.assertRaises(StageBMidiToSoloMvpCompletionAuditError):
+            build_mvp_completion_audit_report(
+                current_evidence=current_evidence(pitch_contour_supported=False),
+                readme_text=readme_text(),
+                output_dir=Path("outputs/audit"),
+                issue_number=712,
             )
 
     def test_boundary_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary
- completion audit 기준에 model-conditioned pitch-contour objective path 포함
- technical model-core MVP 완료 범위 재검증
- musical quality, human/audio preference, product MVP claim 제외 유지

## Context
- #708 current evidence: selected-scale objective path, phrase-bank CLI technical path, model-conditioned pitch-contour objective path 통합
- #710 README refresh: current evidence boundary와 pitch-contour objective readiness 반영
- 기존 completion audit: model-conditioned pitch-contour objective path 필수 근거 미포함

## Scope
- completion audit 검증 조건 확장
- README required snippet 검증 확장
- validation summary와 generated audit document에 pitch-contour interval/review boundary 노출
- README, current status, core plan, handoff scope 갱신

## Result
- technical model-core MVP completed: true
- input to ranked MIDI / rendered WAV completed: true / true
- selected-scale objective repair completed: true
- phrase-bank CLI technical path completed: true
- model-conditioned pitch-contour objective completed: true
- model-conditioned pitch-contour max interval / threshold: 11 / 12
- model-conditioned pitch-contour changed-ratio review required: true
- musical quality MVP completed: false
- human/audio preference completed: false
- product MVP completed: false
- next boundary: stage_b_midi_to_solo_quality_gap_decision

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit
- .venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_mvp_completion.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit
- bash scripts/agent_harness.sh quick
- git diff --check
- git diff -U0 | rg -n "Codex|codex|코덱스" exits 1 with no matches

## Risk
- technical MVP completion claim only
- musical quality and human/audio preference claim excluded
- generated output quality still routed to quality gap decision

## Follow-up
- Stage B MIDI-to-solo quality gap decision

Closes #712