### PR TITLE
Stage B MIDI-to-solo quality gap decision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #712, Stage B MIDI-to-solo MVP completion audit.
+- Latest functional issue completed: Issue #714, Stage B MIDI-to-solo quality gap decision.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo quality gap decision.
+- Recommended next issue: Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio review decision.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- latest evidence boundary: `stage_b_midi_to_solo_quality_gap_decision`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
-- selected quality gap target: `model_conditioned_input_path_quality_alignment`
+- selected quality gap target: `model_conditioned_pitch_contour_changed_ratio_review`
 - model-conditioned input path aligned: `false`
 - model-conditioned candidate source available: `true`
 - model-conditioned audio technical path available: `true`
@@ -107,8 +107,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - MVP completion audit completed: `true`
 - MVP completion audit model-conditioned pitch-contour objective included: `true`
 - quality gap decision completed: `true`
+- quality gap decision pitch-contour changed-ratio target selected: `true`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -189,11 +190,14 @@ MVP completion audit.
 Quality gap decision.
 
 - boundary: `stage_b_midi_to_solo_quality_gap_decision`
-- next boundary: `stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment`
-- selected target: `model_conditioned_input_path_quality_alignment`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision`
+- selected target: `model_conditioned_pitch_contour_changed_ratio_review`
 - fallback path active: `true`
-- model-conditioned input path alignment required: `true`
+- model-conditioned input path alignment required: `false`
 - phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour max interval / threshold: `11 / 12`
+- model-conditioned pitch-contour changed-ratio review required: `true`
 - musical quality MVP completed: `false`
 - CLI candidate / rendered WAV: `3 / 3`
 - CLI preference fill allowed: `false`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -394,6 +394,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo MVP current evidence consolidation: evidence support `true`, technical path `true`, selected-scale objective path `true`, phrase-bank CLI path `true`, model-conditioned pitch-contour objective path `true`, exported/rendered `3/3`, objective valid/strict/grammar `9/9/9`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_readme_evidence_refresh`
 - MIDI-to-solo README evidence refresh: latest boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`, input-to-WAV technical path `true`, selected-scale objective path `true`, phrase-bank CLI path `true`, model-conditioned pitch-contour objective path `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_completion_audit`
 - MIDI-to-solo MVP completion audit refresh: technical model-core MVP `true`, model-conditioned pitch-contour objective `true`, max interval/threshold `11/12`, musical/product MVP `false/false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_gap_decision`
+- MIDI-to-solo quality gap decision refresh: selected target `model_conditioned_pitch_contour_changed_ratio_review`, fallback alignment required `false`, pitch-contour max interval/threshold `11/12`, changed-ratio review required `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision`
 - MIDI-to-solo MVP completion audit: technical model-core MVP `true`, input ranked MIDI/WAV `true/true`, selected-scale objective repair `true`, musical/product MVP `false/false`, next boundary `stage_b_midi_to_solo_quality_gap_decision`
 - MIDI-to-solo quality gap decision: selected target `model_conditioned_input_path_quality_alignment`, fallback path active `true`, human review required now `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment`
 - MIDI-to-solo model-conditioned input path quality alignment: aligned `false`, fallback replacement probe required `true`, selected probe target `replace_fallback_with_model_conditioned_input_path_probe`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_probe`
@@ -3738,6 +3739,44 @@ Issue #712는 Issue #708 current evidence와 Issue #710 README refresh를 기준
 다음 작업:
 
 - `Stage B MIDI-to-solo quality gap decision`
+
+## 9.48 Stage B MIDI-to-solo quality gap decision refresh
+
+Issue #714는 Issue #712 MVP completion audit 이후 남은 quality gap target을 다시 선택한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision`
+- selected target: `model_conditioned_pitch_contour_changed_ratio_review`
+- fallback path active: `true`
+- model-conditioned input path alignment required: `false`
+- technical model-core MVP completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour max interval / threshold: `11 / 12`
+- pitch-contour changed-ratio review required: `true`
+- musical quality MVP completed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- model-conditioned pitch-contour objective path는 interval target 통과.
+- 남은 gap은 fallback replacement alignment가 아니라 pitch changed ratio review boundary.
+- human/audio preference와 musical quality claim 제외 유지.
+- 다음 boundary는 changed-ratio review decision.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_gap_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_quality_gap.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-gap-decision`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio review decision`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -73,6 +73,7 @@
 - model-conditioned input path pitch-contour objective path를 current evidence에 통합 완료
 - README current evidence boundary refresh 완료
 - MVP completion audit에 model-conditioned pitch-contour objective path 포함 완료
+- quality gap decision을 pitch-contour changed-ratio review target으로 갱신 완료
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 
@@ -1145,6 +1146,52 @@ Issue #668은 Issue #664 current evidence와 Issue #666 README refresh를 기준
 다음:
 
 - `Stage B MIDI-to-solo quality gap decision`
+
+## Stage B MIDI-to-Solo Quality Gap Decision Result
+
+Issue #714는 Issue #712 MVP completion audit 이후 남은 quality gap target을 다시 선택한 작업이다.
+
+변경:
+
+- quality gap decision script에 model-conditioned pitch-contour objective completion 검증 추가
+- pitch-contour interval threshold 통과와 changed-ratio review 필요 상태를 target selection에 반영
+- 기존 fallback alignment 반복 진입을 방지하고 changed-ratio review decision boundary 선택
+- generated quality gap decision document를 2026-06-09 기준으로 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_2026-06-09.md`
+- boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision`
+- selected target: `model_conditioned_pitch_contour_changed_ratio_review`
+- fallback path active: `true`
+- model-conditioned input path alignment required: `false`
+- technical model-core MVP completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour max interval / threshold: `11 / 12`
+- pitch-contour changed-ratio review required: `true`
+- musical quality MVP completed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- model-conditioned pitch-contour objective path는 interval target 통과.
+- 남은 gap은 fallback replacement alignment가 아니라 pitch changed ratio review boundary.
+- human/audio preference와 musical quality claim 제외 유지.
+- 다음 작업은 changed-ratio review decision.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_gap_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_quality_gap.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-gap-decision`
+
+다음:
+
+- `Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio review decision`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_2026-06-09.md
@@ -1,0 +1,40 @@
+# Stage B MIDI-to-Solo Quality Gap Decision
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision`
+- selected target: `model_conditioned_pitch_contour_changed_ratio_review`
+- fallback path active: `true`
+- pitch-contour changed-ratio review required: `true`
+- human review required now: `false`
+
+## Evidence
+
+- technical model-core MVP completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- musical quality MVP completed: `false`
+- generation source: `context_conditioned_fallback`
+- exported candidates: `3`
+- rendered WAV files: `3`
+- objective strict/sample: `9` / `9`
+- objective dead-air failure: `0`
+- CLI candidate / rendered WAV: `3` / `3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- model-conditioned pitch-contour max interval / threshold: `11` / `12`
+- model-conditioned pitch-contour target supported: `true`
+- model-conditioned pitch-contour changed-ratio review required: `true`
+- model-conditioned pitch-contour audio review required: `true`
+
+## Claim Boundary
+
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- broad trained model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio review decision`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -5945,10 +5945,11 @@ run_stage_b_midi_to_solo_quality_gap_decision() {
   "$PYTHON_BIN" scripts/decide_stage_b_midi_to_solo_quality_gap.py \
     --run_id "$run_id" \
     --mvp_completion_audit "$completion_audit" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_2026-06-05.md \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_2026-06-09.md \
+    --issue_number 714 \
     --expected_boundary stage_b_midi_to_solo_quality_gap_decision \
-    --expected_next_boundary stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment \
-    --expected_target model_conditioned_input_path_quality_alignment \
+    --expected_next_boundary stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision \
+    --expected_target model_conditioned_pitch_contour_changed_ratio_review \
     --require_no_quality_claim
 }
 

--- a/scripts/decide_stage_b_midi_to_solo_quality_gap.py
+++ b/scripts/decide_stage_b_midi_to_solo_quality_gap.py
@@ -25,6 +25,10 @@ class StageBMidiToSoloQualityGapDecisionError(ValueError):
 BOUNDARY = "stage_b_midi_to_solo_quality_gap_decision"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment"
 SELECTED_TARGET = "model_conditioned_input_path_quality_alignment"
+PITCH_CONTOUR_CHANGED_RATIO_TARGET = "model_conditioned_pitch_contour_changed_ratio_review"
+PITCH_CONTOUR_CHANGED_RATIO_NEXT_BOUNDARY = (
+    "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision"
+)
 SCHEMA_VERSION = "stage_b_midi_to_solo_quality_gap_decision_v1"
 
 
@@ -71,6 +75,10 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloQualityGapDecisionError("product MVP should remain incomplete")
     if not bool(audit.get("phrase_bank_cli_technical_path_completed", False)):
         raise StageBMidiToSoloQualityGapDecisionError("phrase-bank CLI technical path completion required")
+    if not bool(audit.get("model_conditioned_pitch_contour_objective_completed", False)):
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "model-conditioned pitch-contour objective completion required"
+        )
     if _int(evidence.get("exported_candidate_count")) < 3:
         raise StageBMidiToSoloQualityGapDecisionError("exported candidate count below 3")
     if _int(evidence.get("rendered_audio_file_count")) < 3:
@@ -83,6 +91,20 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloQualityGapDecisionError("CLI rendered WAV count below 3")
     if bool(evidence.get("cli_preference_fill_allowed", True)):
         raise StageBMidiToSoloQualityGapDecisionError("CLI preference fill should remain blocked")
+    if not bool(evidence.get("model_conditioned_pitch_contour_objective_path_ready", False)):
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "model-conditioned pitch-contour objective path readiness required"
+        )
+    if _int(evidence.get("model_conditioned_pitch_contour_max_interval")) > _int(
+        evidence.get("model_conditioned_pitch_contour_max_interval_threshold")
+    ):
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "model-conditioned pitch-contour interval threshold exceeded"
+        )
+    if not bool(evidence.get("model_conditioned_pitch_contour_target_supported", False)):
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "model-conditioned pitch-contour target support required"
+        )
     if _int(evidence.get("objective_strict_valid_sample_count")) != _int(evidence.get("objective_sample_count")):
         raise StageBMidiToSoloQualityGapDecisionError("objective strict valid count must match sample count")
     blocked_claims = [
@@ -98,6 +120,7 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
     return {
         "technical_model_core_mvp_completed": True,
         "phrase_bank_cli_technical_path_completed": True,
+        "model_conditioned_pitch_contour_objective_completed": True,
         "musical_quality_mvp_completed": False,
         "human_audio_preference_completed": False,
         "product_mvp_completed": False,
@@ -120,23 +143,60 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
         "cli_rendered_audio_file_count": _int(evidence.get("cli_rendered_audio_file_count")),
         "cli_input_context_bars": _int(evidence.get("cli_input_context_bars")),
         "cli_preference_fill_allowed": bool(evidence.get("cli_preference_fill_allowed", True)),
+        "model_conditioned_pitch_contour_objective_path_ready": bool(
+            evidence.get("model_conditioned_pitch_contour_objective_path_ready", False)
+        ),
+        "model_conditioned_pitch_contour_max_interval": _int(
+            evidence.get("model_conditioned_pitch_contour_max_interval")
+        ),
+        "model_conditioned_pitch_contour_max_interval_threshold": _int(
+            evidence.get("model_conditioned_pitch_contour_max_interval_threshold")
+        ),
+        "model_conditioned_pitch_contour_target_supported": bool(
+            evidence.get("model_conditioned_pitch_contour_target_supported", False)
+        ),
+        "model_conditioned_pitch_contour_pitch_changed_ratio_review_required": bool(
+            evidence.get("model_conditioned_pitch_contour_pitch_changed_ratio_review_required", False)
+        ),
+        "model_conditioned_pitch_contour_audio_review_required": bool(
+            evidence.get("model_conditioned_pitch_contour_audio_review_required", False)
+        ),
     }
 
 
 def select_quality_gap_target(audit_summary: dict[str, Any]) -> dict[str, Any]:
     generation_source = str(audit_summary.get("generation_source") or "")
     fallback_path_active = generation_source == "context_conditioned_fallback"
-    target = SELECTED_TARGET if fallback_path_active else "listening_review_quality_gap"
-    next_boundary = NEXT_BOUNDARY if fallback_path_active else "stage_b_midi_to_solo_listening_review_quality_gap"
-    reason = (
-        "input-to-WAV path still uses context_conditioned_fallback while selected-scale and CLI paths are technical evidence, not model-conditioned quality"
-        if fallback_path_active
-        else "model-conditioned path is available; listening review gap remains"
+    pitch_contour_path_ready = bool(
+        audit_summary.get("model_conditioned_pitch_contour_objective_path_ready", False)
     )
+    pitch_contour_changed_ratio_review_required = bool(
+        audit_summary.get("model_conditioned_pitch_contour_pitch_changed_ratio_review_required", False)
+    )
+    if pitch_contour_path_ready and pitch_contour_changed_ratio_review_required:
+        target = PITCH_CONTOUR_CHANGED_RATIO_TARGET
+        next_boundary = PITCH_CONTOUR_CHANGED_RATIO_NEXT_BOUNDARY
+        reason = (
+            "model-conditioned pitch-contour path is objective-complete, but pitch changed ratio still requires "
+            "review before any musical quality claim"
+        )
+    elif fallback_path_active:
+        target = SELECTED_TARGET
+        next_boundary = NEXT_BOUNDARY
+        reason = (
+            "input-to-WAV path still uses context_conditioned_fallback while selected-scale and CLI paths are "
+            "technical evidence, not model-conditioned quality"
+        )
+    else:
+        target = "listening_review_quality_gap"
+        next_boundary = "stage_b_midi_to_solo_listening_review_quality_gap"
+        reason = "model-conditioned path is available; listening review gap remains"
     return {
         "selected_target": target,
         "selected_next_boundary": next_boundary,
         "fallback_path_active": fallback_path_active,
+        "model_conditioned_pitch_contour_objective_path_ready": pitch_contour_path_ready,
+        "pitch_contour_changed_ratio_review_required": pitch_contour_changed_ratio_review_required,
         "quality_gap_reason": reason,
         "human_review_required_now": False,
     }
@@ -161,11 +221,23 @@ def build_quality_gap_decision_report(
         "quality_gap": {
             "technical_model_core_mvp_completed": True,
             "phrase_bank_cli_technical_path_completed": True,
+            "model_conditioned_pitch_contour_objective_completed": bool(
+                audit_summary["model_conditioned_pitch_contour_objective_completed"]
+            ),
             "musical_quality_mvp_completed": False,
             "human_audio_preference_completed": False,
             "product_mvp_completed": False,
             "fallback_path_active": bool(target["fallback_path_active"]),
-            "model_conditioned_input_path_alignment_required": bool(target["fallback_path_active"]),
+            "model_conditioned_input_path_alignment_required": bool(
+                target["fallback_path_active"]
+                and str(target["selected_target"]) == SELECTED_TARGET
+            ),
+            "model_conditioned_pitch_contour_objective_path_ready": bool(
+                target["model_conditioned_pitch_contour_objective_path_ready"]
+            ),
+            "pitch_contour_changed_ratio_review_required": bool(
+                target["pitch_contour_changed_ratio_review_required"]
+            ),
             "human_review_required_now": False,
         },
         "selected_target": target,
@@ -195,7 +267,11 @@ def build_quality_gap_decision_report(
             "brad_style_adaptation",
             "production_ready_improviser",
         ],
-        "next_recommended_issue": "Stage B MIDI-to-solo model-conditioned input path quality alignment",
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio review decision"
+            if str(target["selected_target"]) == PITCH_CONTOUR_CHANGED_RATIO_TARGET
+            else "Stage B MIDI-to-solo model-conditioned input path quality alignment"
+        ),
     }
 
 
@@ -221,6 +297,10 @@ def validate_quality_gap_decision_report(
         raise StageBMidiToSoloQualityGapDecisionError("quality gap decision completion required")
     if not bool(quality_gap.get("technical_model_core_mvp_completed", False)):
         raise StageBMidiToSoloQualityGapDecisionError("technical model-core MVP completion required")
+    if not bool(quality_gap.get("model_conditioned_pitch_contour_objective_completed", False)):
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "model-conditioned pitch-contour objective completion required"
+        )
     if bool(quality_gap.get("musical_quality_mvp_completed", True)):
         raise StageBMidiToSoloQualityGapDecisionError("musical quality should remain incomplete")
     if bool(decision.get("critical_user_input_required", True)):
@@ -251,6 +331,15 @@ def validate_quality_gap_decision_report(
         "phrase_bank_cli_technical_path_completed": bool(
             quality_gap.get("phrase_bank_cli_technical_path_completed", False)
         ),
+        "model_conditioned_pitch_contour_objective_completed": bool(
+            quality_gap.get("model_conditioned_pitch_contour_objective_completed", False)
+        ),
+        "model_conditioned_pitch_contour_objective_path_ready": bool(
+            quality_gap.get("model_conditioned_pitch_contour_objective_path_ready", False)
+        ),
+        "pitch_contour_changed_ratio_review_required": bool(
+            quality_gap.get("pitch_contour_changed_ratio_review_required", False)
+        ),
         "musical_quality_mvp_completed": bool(quality_gap.get("musical_quality_mvp_completed", True)),
         "cli_candidate_count": _int(_dict(report.get("mvp_completion_summary")).get("cli_candidate_count")),
         "cli_rendered_audio_file_count": _int(
@@ -259,6 +348,21 @@ def validate_quality_gap_decision_report(
         "cli_input_context_bars": _int(_dict(report.get("mvp_completion_summary")).get("cli_input_context_bars")),
         "cli_preference_fill_allowed": bool(
             _dict(report.get("mvp_completion_summary")).get("cli_preference_fill_allowed", True)
+        ),
+        "model_conditioned_pitch_contour_max_interval": _int(
+            _dict(report.get("mvp_completion_summary")).get(
+                "model_conditioned_pitch_contour_max_interval"
+            )
+        ),
+        "model_conditioned_pitch_contour_max_interval_threshold": _int(
+            _dict(report.get("mvp_completion_summary")).get(
+                "model_conditioned_pitch_contour_max_interval_threshold"
+            )
+        ),
+        "model_conditioned_pitch_contour_target_supported": bool(
+            _dict(report.get("mvp_completion_summary")).get(
+                "model_conditioned_pitch_contour_target_supported", False
+            )
         ),
         "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
         "midi_to_solo_musical_quality_claimed": bool(
@@ -284,12 +388,14 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- next boundary: `{decision['next_boundary']}`",
         f"- selected target: `{selected['selected_target']}`",
         f"- fallback path active: `{_bool_token(quality_gap['fallback_path_active'])}`",
+        f"- pitch-contour changed-ratio review required: `{_bool_token(quality_gap['pitch_contour_changed_ratio_review_required'])}`",
         f"- human review required now: `{_bool_token(quality_gap['human_review_required_now'])}`",
         "",
         "## Evidence",
         "",
         f"- technical model-core MVP completed: `{_bool_token(summary['technical_model_core_mvp_completed'])}`",
         f"- phrase-bank CLI technical path completed: `{_bool_token(summary['phrase_bank_cli_technical_path_completed'])}`",
+        f"- model-conditioned pitch-contour objective completed: `{_bool_token(summary['model_conditioned_pitch_contour_objective_completed'])}`",
         f"- musical quality MVP completed: `{_bool_token(summary['musical_quality_mvp_completed'])}`",
         f"- generation source: `{summary['generation_source']}`",
         f"- exported candidates: `{summary['exported_candidate_count']}`",
@@ -299,6 +405,10 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- CLI candidate / rendered WAV: `{summary['cli_candidate_count']}` / `{summary['cli_rendered_audio_file_count']}`",
         f"- CLI input context bars: `{summary['cli_input_context_bars']}`",
         f"- CLI preference fill allowed: `{_bool_token(summary['cli_preference_fill_allowed'])}`",
+        f"- model-conditioned pitch-contour max interval / threshold: `{summary['model_conditioned_pitch_contour_max_interval']}` / `{summary['model_conditioned_pitch_contour_max_interval_threshold']}`",
+        f"- model-conditioned pitch-contour target supported: `{_bool_token(summary['model_conditioned_pitch_contour_target_supported'])}`",
+        f"- model-conditioned pitch-contour changed-ratio review required: `{_bool_token(summary['model_conditioned_pitch_contour_pitch_changed_ratio_review_required'])}`",
+        f"- model-conditioned pitch-contour audio review required: `{_bool_token(summary['model_conditioned_pitch_contour_audio_review_required'])}`",
         "",
         "## Claim Boundary",
         "",

--- a/tests/test_stage_b_midi_to_solo_quality_gap_decision.py
+++ b/tests/test_stage_b_midi_to_solo_quality_gap_decision.py
@@ -9,6 +9,8 @@ from scripts.audit_stage_b_midi_to_solo_mvp_completion import (
 from scripts.decide_stage_b_midi_to_solo_quality_gap import (
     BOUNDARY,
     NEXT_BOUNDARY,
+    PITCH_CONTOUR_CHANGED_RATIO_NEXT_BOUNDARY,
+    PITCH_CONTOUR_CHANGED_RATIO_TARGET,
     SELECTED_TARGET,
     StageBMidiToSoloQualityGapDecisionError,
     build_quality_gap_decision_report,
@@ -22,6 +24,8 @@ def mvp_completion_audit(
     musical_complete: bool = False,
     quality_claim: bool = False,
     strict_count: int = 9,
+    pitch_contour_changed_ratio_review_required: bool = True,
+    pitch_contour_supported: bool = True,
 ) -> dict:
     return {
         "boundary": MVP_COMPLETION_BOUNDARY,
@@ -41,6 +45,7 @@ def mvp_completion_audit(
             "input_to_rendered_wav_completed": True,
             "selected_scale_objective_repair_completed": True,
             "phrase_bank_cli_technical_path_completed": True,
+            "model_conditioned_pitch_contour_objective_completed": pitch_contour_supported,
             "readme_evidence_boundary_refreshed": True,
             "musical_quality_mvp_completed": musical_complete,
             "human_audio_preference_completed": False,
@@ -62,6 +67,14 @@ def mvp_completion_audit(
             "cli_rendered_audio_file_count": 3,
             "cli_input_context_bars": 228,
             "cli_preference_fill_allowed": False,
+            "model_conditioned_pitch_contour_objective_path_ready": pitch_contour_supported,
+            "model_conditioned_pitch_contour_max_interval": 11 if pitch_contour_supported else 13,
+            "model_conditioned_pitch_contour_max_interval_threshold": 12,
+            "model_conditioned_pitch_contour_target_supported": pitch_contour_supported,
+            "model_conditioned_pitch_contour_pitch_changed_ratio_review_required": (
+                pitch_contour_changed_ratio_review_required
+            ),
+            "model_conditioned_pitch_contour_audio_review_required": True,
         },
         "decision": {
             "next_boundary": "stage_b_midi_to_solo_quality_gap_decision",
@@ -71,11 +84,48 @@ def mvp_completion_audit(
 
 
 class StageBMidiToSoloQualityGapDecisionTest(unittest.TestCase):
-    def test_selects_model_conditioned_input_path_alignment_for_fallback_path(self) -> None:
+    def test_selects_pitch_contour_changed_ratio_review_after_objective_path(self) -> None:
         report = build_quality_gap_decision_report(
             mvp_completion_audit=mvp_completion_audit(),
             output_dir=Path("outputs/quality_gap"),
-            issue_number=618,
+            issue_number=714,
+        )
+        summary = validate_quality_gap_decision_report(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=PITCH_CONTOUR_CHANGED_RATIO_NEXT_BOUNDARY,
+            expected_target=PITCH_CONTOUR_CHANGED_RATIO_TARGET,
+            require_no_quality_claim=True,
+        )
+
+        self.assertEqual(summary["selected_target"], PITCH_CONTOUR_CHANGED_RATIO_TARGET)
+        self.assertEqual(summary["next_boundary"], PITCH_CONTOUR_CHANGED_RATIO_NEXT_BOUNDARY)
+        self.assertTrue(summary["fallback_path_active"])
+        self.assertFalse(summary["model_conditioned_input_path_alignment_required"])
+        self.assertTrue(summary["model_conditioned_pitch_contour_objective_completed"])
+        self.assertTrue(summary["model_conditioned_pitch_contour_objective_path_ready"])
+        self.assertTrue(summary["pitch_contour_changed_ratio_review_required"])
+        self.assertEqual(summary["model_conditioned_pitch_contour_max_interval"], 11)
+        self.assertEqual(summary["model_conditioned_pitch_contour_max_interval_threshold"], 12)
+        self.assertTrue(summary["model_conditioned_pitch_contour_target_supported"])
+        self.assertFalse(summary["human_review_required_now"])
+        self.assertTrue(summary["technical_model_core_mvp_completed"])
+        self.assertTrue(summary["phrase_bank_cli_technical_path_completed"])
+        self.assertEqual(summary["cli_candidate_count"], 3)
+        self.assertEqual(summary["cli_rendered_audio_file_count"], 3)
+        self.assertEqual(summary["cli_input_context_bars"], 228)
+        self.assertFalse(summary["cli_preference_fill_allowed"])
+        self.assertFalse(summary["musical_quality_mvp_completed"])
+        self.assertFalse(summary["human_audio_preference_claimed"])
+        self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+
+    def test_selects_model_conditioned_input_path_alignment_when_pitch_ratio_review_not_required(self) -> None:
+        report = build_quality_gap_decision_report(
+            mvp_completion_audit=mvp_completion_audit(
+                pitch_contour_changed_ratio_review_required=False
+            ),
+            output_dir=Path("outputs/quality_gap"),
+            issue_number=714,
         )
         summary = validate_quality_gap_decision_report(
             report,
@@ -89,16 +139,7 @@ class StageBMidiToSoloQualityGapDecisionTest(unittest.TestCase):
         self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
         self.assertTrue(summary["fallback_path_active"])
         self.assertTrue(summary["model_conditioned_input_path_alignment_required"])
-        self.assertFalse(summary["human_review_required_now"])
-        self.assertTrue(summary["technical_model_core_mvp_completed"])
-        self.assertTrue(summary["phrase_bank_cli_technical_path_completed"])
-        self.assertEqual(summary["cli_candidate_count"], 3)
-        self.assertEqual(summary["cli_rendered_audio_file_count"], 3)
-        self.assertEqual(summary["cli_input_context_bars"], 228)
-        self.assertFalse(summary["cli_preference_fill_allowed"])
-        self.assertFalse(summary["musical_quality_mvp_completed"])
-        self.assertFalse(summary["human_audio_preference_claimed"])
-        self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+        self.assertFalse(summary["pitch_contour_changed_ratio_review_required"])
 
     def test_rejects_completed_musical_quality(self) -> None:
         with self.assertRaises(StageBMidiToSoloQualityGapDecisionError):
@@ -124,6 +165,14 @@ class StageBMidiToSoloQualityGapDecisionTest(unittest.TestCase):
                 issue_number=618,
             )
 
+    def test_rejects_missing_pitch_contour_support(self) -> None:
+        with self.assertRaises(StageBMidiToSoloQualityGapDecisionError):
+            build_quality_gap_decision_report(
+                mvp_completion_audit=mvp_completion_audit(pitch_contour_supported=False),
+                output_dir=Path("outputs/quality_gap"),
+                issue_number=714,
+            )
+
     def test_boundary_constants_are_stable(self) -> None:
         self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_quality_gap_decision")
         self.assertEqual(
@@ -131,6 +180,14 @@ class StageBMidiToSoloQualityGapDecisionTest(unittest.TestCase):
             "stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment",
         )
         self.assertEqual(SELECTED_TARGET, "model_conditioned_input_path_quality_alignment")
+        self.assertEqual(
+            PITCH_CONTOUR_CHANGED_RATIO_NEXT_BOUNDARY,
+            "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision",
+        )
+        self.assertEqual(
+            PITCH_CONTOUR_CHANGED_RATIO_TARGET,
+            "model_conditioned_pitch_contour_changed_ratio_review",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- quality gap decision target 갱신
- model-conditioned pitch-contour objective path 완료 근거 반영
- fallback alignment 반복 진입 방지

## Context
- #712 technical model-core MVP completed: true
- model-conditioned pitch-contour objective completed: true
- model-conditioned pitch-contour max interval / threshold: 11 / 12
- pitch-contour changed-ratio review required: true
- musical quality MVP completed: false
- human/audio preference claim: false

## Scope
- MVP completion audit validation에 pitch-contour objective completion 필드 추가
- selected target을 model_conditioned_pitch_contour_changed_ratio_review로 갱신
- next boundary를 stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision으로 갱신
- generated decision document, README, current status, core plan, handoff scope 갱신

## Result
- selected target: model_conditioned_pitch_contour_changed_ratio_review
- fallback path active: true
- model-conditioned input path alignment required: false
- technical model-core MVP completed: true
- phrase-bank CLI technical path completed: true
- model-conditioned pitch-contour objective completed: true
- model-conditioned pitch-contour max interval / threshold: 11 / 12
- pitch-contour changed-ratio review required: true
- musical quality MVP completed: false
- next boundary: stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_gap_decision
- .venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_quality_gap.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-gap-decision
- bash scripts/agent_harness.sh quick
- git diff --check
- git diff -U0 | rg -n "Codex|codex|코덱스" exits 1 with no matches

## Risk
- musical quality claim excluded
- human/audio preference claim excluded
- next boundary is decision target only, not quality completion

## Follow-up
- Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio review decision

Closes #714

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project status and planning documentation for the MIDI-to-solo feature.
  * Added new decision boundary documentation to track quality assurance progress.

* **Chores**
  * Updated project handoff tracking and internal process workflows.
  * Expanded test coverage for decision validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->