### PR TITLE
Stage B MIDI-to-solo pitch-contour changed-ratio repair probe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #716, Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio review decision.
+- Latest functional issue completed: Issue #718, Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair probe.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair probe.
+- Recommended next issue: Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair audio package.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1052,6 +1052,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-pitch-conto
 ```
 
 This harness routes pitch-contour changed-ratio review evidence to the next repair probe without claiming musical quality or human/audio preference.
+
+For Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair probe changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-probe
+```
+
+This harness repairs pitch-contour candidates with a lower pitch-change ratio objective and routes passed repaired MIDI candidates to audio render packaging without claiming musical quality.
 
 For Stage B MIDI-to-solo model-conditioned input path quality alignment changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision`
+- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -110,8 +110,12 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - quality gap decision pitch-contour changed-ratio target selected: `true`
 - pitch-contour changed-ratio review decision completed: `true`
 - pitch-contour changed-ratio repair probe required: `true`
+- pitch-contour changed-ratio repair probe completed: `true`
+- pitch-contour changed-ratio repair passed: `true`
+- pitch-contour changed-ratio max: `0.7174 -> 0.4348`
+- pitch-contour changed-ratio repaired / passed candidates: `3 / 3`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -164,6 +168,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned pitch-contour review input pending 상태에서 preference fill 차단 가능
 - model-conditioned pitch-contour objective evidence 기준 current evidence consolidation 경계 결정 가능
 - model-conditioned dead-air/timing repaired MIDI/WAV objective next decision 가능
+- model-conditioned pitch-contour changed-ratio repair probe 가능
 
 현재 README가 주장하지 않는 것.
 
@@ -218,6 +223,21 @@ Pitch-contour changed-ratio review decision.
 - changed-ratio review threshold: `0.5`
 - changed-ratio review required: `true`
 - audio review required: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+Pitch-contour changed-ratio repair probe.
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
+- repair strategy: `minimum_change_pitch_class_dynamic_programming`
+- repaired / passed candidates: `3 / 3`
+- source max pitch changed ratio: `0.7174`
+- repaired max pitch changed ratio: `0.4348`
+- pitch changed ratio reduction: `0.2826`
+- repaired max interval / target: `12 / 12`
+- repaired dead-air max: `0.0000`
+- min repaired unique pitch count: `24`
 - human/audio preference claimed: `false`
 - MIDI-to-solo musical quality claimed: `false`
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -396,6 +396,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo MVP completion audit refresh: technical model-core MVP `true`, model-conditioned pitch-contour objective `true`, max interval/threshold `11/12`, musical/product MVP `false/false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_gap_decision`
 - MIDI-to-solo quality gap decision refresh: selected target `model_conditioned_pitch_contour_changed_ratio_review`, fallback alignment required `false`, pitch-contour max interval/threshold `11/12`, changed-ratio review required `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
+- MIDI-to-solo pitch-contour changed-ratio repair probe: repaired/pass `3/3`, max pitch changed ratio `0.7174 -> 0.4348`, max interval `12`, dead-air max `0.0000`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
 - MIDI-to-solo MVP completion audit: technical model-core MVP `true`, input ranked MIDI/WAV `true/true`, selected-scale objective repair `true`, musical/product MVP `false/false`, next boundary `stage_b_midi_to_solo_quality_gap_decision`
 - MIDI-to-solo quality gap decision: selected target `model_conditioned_input_path_quality_alignment`, fallback path active `true`, human review required now `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment`
 - MIDI-to-solo model-conditioned input path quality alignment: aligned `false`, fallback replacement probe required `true`, selected probe target `replace_fallback_with_model_conditioned_input_path_probe`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_probe`
@@ -3815,6 +3816,43 @@ Issue #716은 Issue #714 quality gap decision 이후 changed-ratio review bounda
 다음 작업:
 
 - `Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair probe`
+
+## 9.50 Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair probe
+
+Issue #718은 Issue #716 changed-ratio review decision 이후 pitch-contour 후보의 pitch 변경 비율을 낮추는 repair probe를 추가한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
+- repair strategy: `minimum_change_pitch_class_dynamic_programming`
+- repaired / passed candidates: `3 / 3`
+- source max pitch changed ratio: `0.7174`
+- repaired max pitch changed ratio: `0.4348`
+- pitch changed ratio reduction: `0.2826`
+- repaired max interval / target: `12 / 12`
+- repaired dead-air max: `0.0000`
+- min repaired unique pitch count: `24`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- interval target 유지 범위에서 pitch changed ratio threshold `0.5` 통과.
+- 기존 pitch-contour 후보의 과도한 octave remap 비율 축소.
+- objective MIDI evidence만 기록.
+- human/audio preference, final musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-probe`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair audio package`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #710, Stage B MIDI-to-solo README evidence refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo MVP completion audit`
+- latest functional result: Issue #718, Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair probe
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair audio package`
 
 현재 범위가 아닌 것:
 
@@ -75,6 +75,7 @@
 - MVP completion audit에 model-conditioned pitch-contour objective path 포함 완료
 - quality gap decision을 pitch-contour changed-ratio review target으로 갱신 완료
 - pitch-contour changed-ratio review decision 기준 repair probe 필요 판정 완료
+- pitch-contour changed-ratio repair probe 기준 repaired 후보 3개 objective target 통과
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 
@@ -1239,6 +1240,50 @@ Issue #716은 Issue #714 quality gap decision 이후 changed-ratio review bounda
 다음:
 
 - `Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair probe`
+
+## Stage B MIDI-to-Solo Model-Conditioned Pitch-Contour Changed-Ratio Repair Probe Result
+
+Issue #718은 Issue #716 changed-ratio review decision 이후 pitch-contour 후보의 pitch 변경 비율을 낮추는 repair probe를 추가한 작업이다.
+
+변경:
+
+- minimum-change pitch-class dynamic programming repair script 추가
+- 기존 pitch-contour repaired MIDI 후보 3개 입력 검증
+- pitch changed ratio, interval, dead-air, unique pitch, monophonic gate 검증
+- generated repair probe document, README, handoff/status/core plan 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_PITCH_CONTOUR_CHANGED_RATIO_REPAIR_PROBE_2026-06-09.md`
+- boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
+- repaired / passed candidates: `3 / 3`
+- source max pitch changed ratio: `0.7174`
+- repaired max pitch changed ratio: `0.4348`
+- pitch changed ratio reduction: `0.2826`
+- repaired max interval / target: `12 / 12`
+- repaired dead-air max: `0.0000`
+- min repaired unique pitch count: `24`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- interval target 유지 범위에서 pitch changed ratio threshold `0.5` 통과.
+- dead-air target 유지.
+- 품질/선호 claim 제외 유지.
+- 다음 boundary는 repaired MIDI WAV technical render package.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-probe`
+
+다음:
+
+- `Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair audio package`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_PITCH_CONTOUR_CHANGED_RATIO_REPAIR_PROBE_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_PITCH_CONTOUR_CHANGED_RATIO_REPAIR_PROBE_2026-06-09.md
@@ -1,0 +1,30 @@
+# Stage B MIDI-to-Solo Model-Conditioned Pitch-Contour Changed-Ratio Repair Probe
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
+- changed-ratio repair passed: `true`
+- repaired candidates: `3`
+- repaired pass count: `3`
+
+## Evidence
+
+- source max pitch changed ratio: `0.7174`
+- repaired max pitch changed ratio: `0.4348`
+- max pitch changed ratio: `0.5000`
+- pitch changed ratio reduction: `0.2826`
+- repaired max interval / target: `12` / `12`
+- repaired dead-air max: `0.0000`
+- min repaired unique pitch count: `24`
+
+## Claim Boundary
+
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- broad trained model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair audio package`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -242,6 +242,8 @@ Modes:
                 Decide the next quality-gap repair target after technical MVP completion.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision
                 Decide the next pitch-contour changed-ratio repair boundary.
+  stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-probe
+                Repair pitch-contour candidates with a lower pitch-change ratio objective.
   stage-b-midi-to-solo-model-conditioned-input-path-quality-alignment
                 Decide model-conditioned input-path alignment requirements and next probe target.
   stage-b-midi-to-solo-model-conditioned-input-path-listening-review-input-guard
@@ -5977,6 +5979,40 @@ run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_de
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe() {
+  local changed_ratio_decision_run_id="${CHANGED_RATIO_DECISION_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision}"
+  local pitch_contour_probe_run_id="${PITCH_CONTOUR_PROBE_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe}"
+  local changed_ratio_decision="outputs/stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision/${changed_ratio_decision_run_id}/stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision.json"
+  local pitch_contour_probe="outputs/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe/${pitch_contour_probe_run_id}/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe.json"
+  if [[ ! -f "$changed_ratio_decision" ]]; then
+    print_header "Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio review decision"
+    RUN_ID="$changed_ratio_decision_run_id" run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision
+  fi
+  if [[ ! -f "$pitch_contour_probe" ]]; then
+    print_header "Stage B MIDI-to-solo model-conditioned input path dead-air timing repair pitch contour probe"
+    RUN_ID="$pitch_contour_probe_run_id" run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe
+  fi
+  print_header "Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair probe"
+  "$PYTHON_BIN" scripts/run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe.py \
+    --run_id "$run_id" \
+    --changed_ratio_decision "$changed_ratio_decision" \
+    --pitch_contour_probe "$pitch_contour_probe" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_PITCH_CONTOUR_CHANGED_RATIO_REPAIR_PROBE_2026-06-09.md \
+    --issue_number 718 \
+    --min_repaired_candidates 3 \
+    --dead_air_threshold_seconds 0.5 \
+    --preferred_pitch_min 48 \
+    --preferred_pitch_max 88 \
+    --max_adjacent_interval 12 \
+    --max_pitch_changed_ratio 0.5 \
+    --min_unique_pitch_count 20 \
+    --expected_boundary stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe \
+    --expected_next_boundary stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package \
+    --require_repair_passed \
+    --require_no_quality_claim
+}
+
 run_stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment() {
   local quality_gap_run_id="${QUALITY_GAP_RUN_ID:-harness_stage_b_midi_to_solo_quality_gap_decision}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment}"
@@ -8085,6 +8121,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision)
     run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision
+    ;;
+  stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-probe)
+    run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe
     ;;
   stage-b-midi-to-solo-model-conditioned-input-path-quality-alignment)
     run_stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment

--- a/scripts/run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe.py
+++ b/scripts/run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe.py
@@ -1,0 +1,693 @@
+"""Run a minimum-change pitch-contour repair probe for model-conditioned MIDI-to-solo output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pretty_midi
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.decide_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review import (  # noqa: E402
+    BOUNDARY as DECISION_BOUNDARY,
+    NEXT_BOUNDARY as DECISION_NEXT_BOUNDARY,
+    SELECTED_TARGET as DECISION_TARGET,
+)
+from scripts.run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe import (  # noqa: E402
+    BOUNDARY as PITCH_CONTOUR_PROBE_BOUNDARY,
+    load_midi_notes,
+    max_simultaneous_notes,
+    objective_metrics_for_path,
+)
+
+
+class StageBMidiToSoloPitchContourChangedRatioRepairProbeError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package"
+FAIL_NEXT_BOUNDARY = "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_decision"
+SCHEMA_VERSION = "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe_v1"
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloPitchContourChangedRatioRepairProbeError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def pitch_class_options(
+    pitch: int,
+    *,
+    preferred_pitch_min: int,
+    preferred_pitch_max: int,
+) -> list[int]:
+    candidates: list[int] = []
+    for octave_shift in range(-8, 9):
+        candidate = int(pitch) + (12 * octave_shift)
+        if int(preferred_pitch_min) <= candidate <= int(preferred_pitch_max):
+            candidates.append(candidate)
+    return sorted(set(candidates))
+
+
+def minimum_change_contour_pitches(
+    source_pitches: list[int],
+    *,
+    preferred_pitch_min: int,
+    preferred_pitch_max: int,
+    max_adjacent_interval: int,
+) -> list[int]:
+    if not source_pitches:
+        return []
+    states: dict[int, tuple[int, int, list[int]]] = {}
+    for candidate in pitch_class_options(
+        source_pitches[0],
+        preferred_pitch_min=int(preferred_pitch_min),
+        preferred_pitch_max=int(preferred_pitch_max),
+    ):
+        states[candidate] = (
+            0 if candidate == int(source_pitches[0]) else 1,
+            abs(candidate - int(source_pitches[0])),
+            [candidate],
+        )
+    for source_pitch in source_pitches[1:]:
+        next_states: dict[int, tuple[int, int, list[int]]] = {}
+        for previous_pitch, (changed_count, total_shift, path) in states.items():
+            for candidate in pitch_class_options(
+                source_pitch,
+                preferred_pitch_min=int(preferred_pitch_min),
+                preferred_pitch_max=int(preferred_pitch_max),
+            ):
+                if abs(candidate - int(previous_pitch)) > int(max_adjacent_interval):
+                    continue
+                value = (
+                    changed_count + (0 if candidate == int(source_pitch) else 1),
+                    total_shift + abs(candidate - int(source_pitch)),
+                    [*path, candidate],
+                )
+                current = next_states.get(candidate)
+                if current is None or value[:2] < current[:2]:
+                    next_states[candidate] = value
+        states = next_states
+        if not states:
+            raise StageBMidiToSoloPitchContourChangedRatioRepairProbeError(
+                "no minimum-change contour path satisfies interval guard"
+            )
+    return min(states.values(), key=lambda item: (item[0], item[1]))[2]
+
+
+def write_minimum_change_repaired_midi(
+    source_midi_path: str | Path,
+    repaired_midi_path: str | Path,
+    *,
+    preferred_pitch_min: int,
+    preferred_pitch_max: int,
+    max_adjacent_interval: int,
+) -> dict[str, Any]:
+    source_midi_path = Path(source_midi_path)
+    repaired_midi_path = Path(repaired_midi_path)
+    source = pretty_midi.PrettyMIDI(str(source_midi_path))
+    source_notes = load_midi_notes(source_midi_path)
+    if not source_notes:
+        raise StageBMidiToSoloPitchContourChangedRatioRepairProbeError(
+            f"source MIDI has no notes: {source_midi_path}"
+        )
+    repaired_pitches = minimum_change_contour_pitches(
+        [int(note.pitch) for note in source_notes],
+        preferred_pitch_min=int(preferred_pitch_min),
+        preferred_pitch_max=int(preferred_pitch_max),
+        max_adjacent_interval=int(max_adjacent_interval),
+    )
+    repaired = pretty_midi.PrettyMIDI(initial_tempo=float(source.estimate_tempo() or 120.0))
+    program = 0
+    for instrument in source.instruments:
+        if not instrument.is_drum:
+            program = int(instrument.program)
+            break
+    repaired_instrument = pretty_midi.Instrument(
+        program=program,
+        is_drum=False,
+        name="pitch_change_ratio_repaired_solo",
+    )
+    changed_count = 0
+    max_pitch_shift_abs = 0
+    for note, pitch in zip(source_notes, repaired_pitches, strict=True):
+        if int(pitch) != int(note.pitch):
+            changed_count += 1
+            max_pitch_shift_abs = max(max_pitch_shift_abs, abs(int(pitch) - int(note.pitch)))
+        repaired_instrument.notes.append(
+            pretty_midi.Note(
+                velocity=max(1, min(127, int(note.velocity or 80))),
+                pitch=int(pitch),
+                start=float(note.start),
+                end=float(note.end),
+            )
+        )
+    repaired.instruments.append(repaired_instrument)
+    repaired_midi_path.parent.mkdir(parents=True, exist_ok=True)
+    repaired.write(str(repaired_midi_path))
+    return {
+        "source_note_count": int(len(source_notes)),
+        "repaired_note_count": int(len(repaired_pitches)),
+        "changed_note_count": int(changed_count),
+        "pitch_changed_ratio": float(changed_count / max(1, len(source_notes))),
+        "max_pitch_shift_abs": int(max_pitch_shift_abs),
+    }
+
+
+def validate_changed_ratio_decision(report: dict[str, Any]) -> dict[str, Any]:
+    if str(report.get("boundary") or "") != DECISION_BOUNDARY:
+        raise StageBMidiToSoloPitchContourChangedRatioRepairProbeError(
+            "changed-ratio review decision boundary required"
+        )
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    review = _dict(report.get("changed_ratio_review"))
+    if str(decision.get("next_boundary") or "") != DECISION_NEXT_BOUNDARY:
+        raise StageBMidiToSoloPitchContourChangedRatioRepairProbeError(
+            "changed-ratio decision should route to repair probe"
+        )
+    if str(readiness.get("selected_target") or "") != DECISION_TARGET:
+        raise StageBMidiToSoloPitchContourChangedRatioRepairProbeError(
+            "changed-ratio selected target mismatch"
+        )
+    if not bool(readiness.get("changed_ratio_review_decision_completed", False)):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairProbeError(
+            "changed-ratio decision completion required"
+        )
+    if not bool(readiness.get("repair_probe_required", False)):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairProbeError(
+            "repair probe requirement required"
+        )
+    if bool(review.get("model_conditioned_input_path_alignment_required", True)):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairProbeError(
+            "input-path alignment should not be required"
+        )
+    if _int(review.get("max_interval")) > _int(review.get("max_interval_threshold")):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairProbeError(
+            "source interval target should already be supported"
+        )
+    if not bool(review.get("changed_ratio_review_required", False)):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairProbeError(
+            "changed-ratio review requirement expected"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairProbeError(
+            "critical user input should not be required"
+        )
+    _require_no_quality_claim(readiness, label="changed-ratio decision readiness")
+    return {
+        "boundary": DECISION_BOUNDARY,
+        "max_interval_threshold": _int(review.get("max_interval_threshold")),
+        "changed_ratio_review_threshold": _float(
+            review.get("changed_ratio_review_threshold")
+        ),
+        "audio_review_required": bool(review.get("audio_review_required", False)),
+    }
+
+
+def validate_pitch_contour_probe_source(
+    report: dict[str, Any],
+    *,
+    min_candidate_count: int,
+) -> dict[str, Any]:
+    if str(report.get("boundary") or "") != PITCH_CONTOUR_PROBE_BOUNDARY:
+        raise StageBMidiToSoloPitchContourChangedRatioRepairProbeError(
+            "pitch-contour probe boundary required"
+        )
+    readiness = _dict(report.get("readiness"))
+    summary = _dict(report.get("summary"))
+    repairs = [_dict(item) for item in _list(report.get("candidate_repairs")) if isinstance(item, dict)]
+    if not bool(readiness.get("pitch_contour_repair_passed", False)):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairProbeError(
+            "pitch-contour repair pass required"
+        )
+    if _float(summary.get("max_pitch_changed_ratio")) <= 0:
+        raise StageBMidiToSoloPitchContourChangedRatioRepairProbeError(
+            "source pitch changed ratio required"
+        )
+    if len(repairs) < int(min_candidate_count):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairProbeError(
+            "pitch-contour repair candidate count below threshold"
+        )
+    for row in repairs[: int(min_candidate_count)]:
+        if not Path(str(row.get("source_midi_path") or "")).exists():
+            raise StageBMidiToSoloPitchContourChangedRatioRepairProbeError(
+                f"source MIDI missing: {row.get('source_midi_path')}"
+            )
+    if bool(_dict(report.get("decision")).get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairProbeError(
+            "critical user input should not be required"
+        )
+    _require_no_quality_claim(readiness, label="pitch-contour probe readiness")
+    return {
+        "boundary": PITCH_CONTOUR_PROBE_BOUNDARY,
+        "candidate_repairs": repairs[: int(min_candidate_count)],
+        "source_max_pitch_changed_ratio": _float(summary.get("max_pitch_changed_ratio")),
+        "source_repaired_max_interval": _int(summary.get("repaired_max_interval")),
+        "source_repaired_dead_air_max": _float(summary.get("repaired_dead_air_max")),
+    }
+
+
+def build_changed_ratio_repair_probe_report(
+    *,
+    changed_ratio_decision: dict[str, Any],
+    pitch_contour_probe: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+    min_repaired_candidates: int,
+    dead_air_threshold_seconds: float,
+    preferred_pitch_min: int,
+    preferred_pitch_max: int,
+    max_adjacent_interval: int,
+    max_pitch_changed_ratio: float,
+    min_unique_pitch_count: int,
+) -> dict[str, Any]:
+    decision_source = validate_changed_ratio_decision(changed_ratio_decision)
+    probe_source = validate_pitch_contour_probe_source(
+        pitch_contour_probe,
+        min_candidate_count=int(min_repaired_candidates),
+    )
+    repaired_dir = output_dir / "midi"
+    candidate_repairs: list[dict[str, Any]] = []
+    for row in probe_source["candidate_repairs"]:
+        rank = _int(row.get("rank"))
+        sample_index = _int(row.get("sample_index"))
+        source_path = Path(str(row.get("source_midi_path") or ""))
+        repaired_path = repaired_dir / (
+            f"rank_{rank:02d}_sample_{sample_index:02d}_changed_ratio_repair.mid"
+        )
+        before = objective_metrics_for_path(
+            source_path,
+            dead_air_threshold_seconds=float(dead_air_threshold_seconds),
+        )
+        pitch_stats = write_minimum_change_repaired_midi(
+            source_path,
+            repaired_path,
+            preferred_pitch_min=int(preferred_pitch_min),
+            preferred_pitch_max=int(preferred_pitch_max),
+            max_adjacent_interval=int(max_adjacent_interval),
+        )
+        after = objective_metrics_for_path(
+            repaired_path,
+            dead_air_threshold_seconds=float(dead_air_threshold_seconds),
+        )
+        repaired_notes = load_midi_notes(repaired_path)
+        candidate_passed = bool(
+            _float(pitch_stats.get("pitch_changed_ratio")) <= float(max_pitch_changed_ratio)
+            and _int(after.get("max_interval")) <= int(max_adjacent_interval)
+            and _float(after.get("dead_air_ratio")) <= 0.35
+            and _int(after.get("note_count")) >= _int(before.get("note_count"))
+            and _int(after.get("unique_pitch_count")) >= int(min_unique_pitch_count)
+            and max_simultaneous_notes(repaired_notes) <= 1
+        )
+        candidate_repairs.append(
+            {
+                "rank": rank,
+                "sample_index": sample_index,
+                "sample_seed": _int(row.get("sample_seed")),
+                "source_midi_path": str(source_path),
+                "repaired_midi_path": str(repaired_path),
+                "source_metrics": {
+                    "note_count": _int(before.get("note_count")),
+                    "unique_pitch_count": _int(before.get("unique_pitch_count")),
+                    "dead_air_ratio": _float(before.get("dead_air_ratio")),
+                    "max_interval": _int(before.get("max_interval")),
+                },
+                "repaired_metrics": {
+                    "note_count": _int(after.get("note_count")),
+                    "unique_pitch_count": _int(after.get("unique_pitch_count")),
+                    "dead_air_ratio": _float(after.get("dead_air_ratio")),
+                    "max_interval": _int(after.get("max_interval")),
+                    "max_simultaneous_notes": max_simultaneous_notes(repaired_notes),
+                },
+                "pitch_repair_stats": pitch_stats,
+                "candidate_repair_passed": bool(candidate_passed),
+            }
+        )
+    repaired_pass_count = sum(
+        1 for row in candidate_repairs if bool(row.get("candidate_repair_passed", False))
+    )
+    max_ratio = max(
+        (_float(row.get("pitch_repair_stats", {}).get("pitch_changed_ratio")) for row in candidate_repairs),
+        default=0.0,
+    )
+    repaired_max_interval = max(
+        (_int(row.get("repaired_metrics", {}).get("max_interval")) for row in candidate_repairs),
+        default=0,
+    )
+    repaired_dead_air_max = max(
+        (_float(row.get("repaired_metrics", {}).get("dead_air_ratio")) for row in candidate_repairs),
+        default=0.0,
+    )
+    min_unique = min(
+        (_int(row.get("repaired_metrics", {}).get("unique_pitch_count")) for row in candidate_repairs),
+        default=0,
+    )
+    repair_passed = bool(
+        repaired_pass_count >= int(min_repaired_candidates)
+        and max_ratio <= float(max_pitch_changed_ratio)
+        and repaired_max_interval <= int(max_adjacent_interval)
+        and repaired_dead_air_max <= 0.35
+    )
+    next_boundary = NEXT_BOUNDARY if repair_passed else FAIL_NEXT_BOUNDARY
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundaries": {
+            "changed_ratio_decision": decision_source["boundary"],
+            "pitch_contour_probe": probe_source["boundary"],
+        },
+        "repair_config": {
+            "strategy": "minimum_change_pitch_class_dynamic_programming",
+            "dead_air_threshold_seconds": float(dead_air_threshold_seconds),
+            "preferred_pitch_min": int(preferred_pitch_min),
+            "preferred_pitch_max": int(preferred_pitch_max),
+            "max_adjacent_interval": int(max_adjacent_interval),
+            "max_pitch_changed_ratio": float(max_pitch_changed_ratio),
+            "min_repaired_candidates": int(min_repaired_candidates),
+            "min_unique_pitch_count": int(min_unique_pitch_count),
+        },
+        "source_summary": {
+            "source_max_pitch_changed_ratio": _float(
+                probe_source["source_max_pitch_changed_ratio"]
+            ),
+            "decision_changed_ratio_review_threshold": _float(
+                decision_source["changed_ratio_review_threshold"]
+            ),
+            "source_repaired_max_interval": _int(probe_source["source_repaired_max_interval"]),
+            "source_repaired_dead_air_max": _float(
+                probe_source["source_repaired_dead_air_max"]
+            ),
+        },
+        "candidate_repairs": candidate_repairs,
+        "summary": {
+            "source_candidate_count": int(len(candidate_repairs)),
+            "repaired_candidate_count": int(len(candidate_repairs)),
+            "repaired_pass_count": int(repaired_pass_count),
+            "source_max_pitch_changed_ratio": _float(
+                probe_source["source_max_pitch_changed_ratio"]
+            ),
+            "repaired_max_pitch_changed_ratio": float(max_ratio),
+            "max_pitch_changed_ratio": float(max_pitch_changed_ratio),
+            "pitch_changed_ratio_reduction": float(
+                _float(probe_source["source_max_pitch_changed_ratio"]) - max_ratio
+            ),
+            "repaired_max_interval": int(repaired_max_interval),
+            "target_max_interval": int(max_adjacent_interval),
+            "repaired_dead_air_max": float(repaired_dead_air_max),
+            "min_repaired_unique_pitch_count": int(min_unique),
+            "changed_ratio_repair_passed": bool(repair_passed),
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "changed_ratio_repair_probe_completed": True,
+            "repaired_ranked_midi_written": bool(len(candidate_repairs) >= int(min_repaired_candidates)),
+            "changed_ratio_repair_passed": bool(repair_passed),
+            "changed_ratio_repair_audio_render_required": bool(repair_passed),
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": next_boundary,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": (
+                "changed-ratio objective repair passed; render repaired MIDI to WAV next"
+                if repair_passed
+                else "changed-ratio objective repair needs follow-up"
+            ),
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "audio_rendered_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair audio package"
+            if repair_passed
+            else "Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair decision"
+        ),
+    }
+
+
+def validate_changed_ratio_repair_probe_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    min_repaired_candidates: int,
+    require_repair_passed: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("summary"))
+    repairs = [_dict(item) for item in _list(report.get("candidate_repairs"))]
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloPitchContourChangedRatioRepairProbeError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloPitchContourChangedRatioRepairProbeError(
+            "unexpected next boundary"
+        )
+    if len(repairs) < int(min_repaired_candidates):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairProbeError(
+            "repaired candidate count below threshold"
+        )
+    if require_repair_passed and not bool(readiness.get("changed_ratio_repair_passed", False)):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairProbeError(
+            "changed-ratio repair pass required"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairProbeError(
+            "critical user input should not be required"
+        )
+    for row in repairs[: int(min_repaired_candidates)]:
+        if not Path(str(row.get("repaired_midi_path") or "")).exists():
+            raise StageBMidiToSoloPitchContourChangedRatioRepairProbeError(
+                f"repaired MIDI missing: {row.get('repaired_midi_path')}"
+            )
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="changed-ratio repair readiness")
+    return {
+        "boundary": boundary,
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "changed_ratio_repair_probe_completed": bool(
+            readiness.get("changed_ratio_repair_probe_completed", False)
+        ),
+        "changed_ratio_repair_passed": bool(
+            readiness.get("changed_ratio_repair_passed", False)
+        ),
+        "changed_ratio_repair_audio_render_required": bool(
+            readiness.get("changed_ratio_repair_audio_render_required", False)
+        ),
+        "source_candidate_count": _int(summary.get("source_candidate_count")),
+        "repaired_candidate_count": _int(summary.get("repaired_candidate_count")),
+        "repaired_pass_count": _int(summary.get("repaired_pass_count")),
+        "source_max_pitch_changed_ratio": _float(
+            summary.get("source_max_pitch_changed_ratio")
+        ),
+        "repaired_max_pitch_changed_ratio": _float(
+            summary.get("repaired_max_pitch_changed_ratio")
+        ),
+        "max_pitch_changed_ratio": _float(summary.get("max_pitch_changed_ratio")),
+        "pitch_changed_ratio_reduction": _float(
+            summary.get("pitch_changed_ratio_reduction")
+        ),
+        "repaired_max_interval": _int(summary.get("repaired_max_interval")),
+        "target_max_interval": _int(summary.get("target_max_interval")),
+        "repaired_dead_air_max": _float(summary.get("repaired_dead_air_max")),
+        "min_repaired_unique_pitch_count": _int(summary.get("min_repaired_unique_pitch_count")),
+        "human_audio_preference_claimed": bool(
+            readiness.get("human_audio_preference_claimed", True)
+        ),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    lines = [
+        "# Stage B MIDI-to-Solo Model-Conditioned Pitch-Contour Changed-Ratio Repair Probe",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- changed-ratio repair passed: `{_bool_token(readiness['changed_ratio_repair_passed'])}`",
+        f"- repaired candidates: `{summary['repaired_candidate_count']}`",
+        f"- repaired pass count: `{summary['repaired_pass_count']}`",
+        "",
+        "## Evidence",
+        "",
+        f"- source max pitch changed ratio: `{summary['source_max_pitch_changed_ratio']:.4f}`",
+        f"- repaired max pitch changed ratio: `{summary['repaired_max_pitch_changed_ratio']:.4f}`",
+        f"- max pitch changed ratio: `{summary['max_pitch_changed_ratio']:.4f}`",
+        f"- pitch changed ratio reduction: `{summary['pitch_changed_ratio_reduction']:.4f}`",
+        f"- repaired max interval / target: `{summary['repaired_max_interval']}` / `{summary['target_max_interval']}`",
+        f"- repaired dead-air max: `{summary['repaired_dead_air_max']:.4f}`",
+        f"- min repaired unique pitch count: `{summary['min_repaired_unique_pitch_count']}`",
+        "",
+        "## Claim Boundary",
+        "",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        f"- broad trained model quality claimed: `{_bool_token(readiness['broad_trained_model_quality_claimed'])}`",
+        f"- Brad style adaptation claimed: `{_bool_token(readiness['brad_style_adaptation_claimed'])}`",
+        "",
+        "## Next",
+        "",
+        f"- `{report['next_recommended_issue']}`",
+    ]
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run pitch-contour changed-ratio repair probe")
+    parser.add_argument("--changed_ratio_decision", type=str, required=True)
+    parser.add_argument("--pitch_contour_probe", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=718)
+    parser.add_argument("--min_repaired_candidates", type=int, default=3)
+    parser.add_argument("--dead_air_threshold_seconds", type=float, default=0.5)
+    parser.add_argument("--preferred_pitch_min", type=int, default=48)
+    parser.add_argument("--preferred_pitch_max", type=int, default=88)
+    parser.add_argument("--max_adjacent_interval", type=int, default=12)
+    parser.add_argument("--max_pitch_changed_ratio", type=float, default=0.5)
+    parser.add_argument("--min_unique_pitch_count", type=int, default=20)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_repair_passed", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_changed_ratio_repair_probe_report(
+        changed_ratio_decision=read_json(Path(args.changed_ratio_decision)),
+        pitch_contour_probe=read_json(Path(args.pitch_contour_probe)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+        min_repaired_candidates=int(args.min_repaired_candidates),
+        dead_air_threshold_seconds=float(args.dead_air_threshold_seconds),
+        preferred_pitch_min=int(args.preferred_pitch_min),
+        preferred_pitch_max=int(args.preferred_pitch_max),
+        max_adjacent_interval=int(args.max_adjacent_interval),
+        max_pitch_changed_ratio=float(args.max_pitch_changed_ratio),
+        min_unique_pitch_count=int(args.min_unique_pitch_count),
+    )
+    summary = validate_changed_ratio_repair_probe_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        min_repaired_candidates=int(args.min_repaired_candidates),
+        require_repair_passed=bool(args.require_repair_passed),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / (
+            "stage_b_midi_to_solo_model_conditioned_pitch_contour_"
+            "changed_ratio_repair_probe_validation_summary.json"
+        ),
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe.py
+++ b/tests/test_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import pretty_midi
+
+from scripts.decide_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review import (
+    BOUNDARY as DECISION_BOUNDARY,
+    NEXT_BOUNDARY as DECISION_NEXT_BOUNDARY,
+    SELECTED_TARGET as DECISION_TARGET,
+)
+from scripts.run_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_probe import (
+    BOUNDARY as PITCH_CONTOUR_PROBE_BOUNDARY,
+)
+from scripts.run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloPitchContourChangedRatioRepairProbeError,
+    build_changed_ratio_repair_probe_report,
+    minimum_change_contour_pitches,
+    validate_changed_ratio_repair_probe_report,
+)
+
+
+def write_midi(path: Path, pitches: list[int]) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    midi = pretty_midi.PrettyMIDI(initial_tempo=120)
+    piano = pretty_midi.Instrument(program=0, is_drum=False, name="solo")
+    for index, pitch in enumerate(pitches):
+        start = index * 0.25
+        piano.notes.append(
+            pretty_midi.Note(
+                velocity=84,
+                pitch=int(pitch),
+                start=float(start),
+                end=float(start + 0.18),
+            )
+        )
+    midi.instruments.append(piano)
+    midi.write(str(path))
+    return str(path)
+
+
+def changed_ratio_decision_source(*, quality_claim: bool = False) -> dict:
+    return {
+        "boundary": DECISION_BOUNDARY,
+        "source_boundary": "stage_b_midi_to_solo_quality_gap_decision",
+        "changed_ratio_review": {
+            "technical_model_core_mvp_completed": True,
+            "model_conditioned_pitch_contour_objective_completed": True,
+            "fallback_path_active": True,
+            "model_conditioned_input_path_alignment_required": False,
+            "max_interval": 11,
+            "max_interval_threshold": 12,
+            "pitch_contour_target_supported": True,
+            "changed_ratio_review_threshold": 0.5,
+            "changed_ratio_review_required": True,
+            "repair_probe_required": True,
+            "audio_review_required": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+        },
+        "selected_target": {
+            "selected_target": DECISION_TARGET,
+            "selected_next_boundary": DECISION_NEXT_BOUNDARY,
+        },
+        "readiness": {
+            "changed_ratio_review_decision_completed": True,
+            "selected_target": DECISION_TARGET,
+            "next_boundary_selected": DECISION_NEXT_BOUNDARY,
+            "repair_probe_required": True,
+            "human_audio_preference_claimed": quality_claim,
+            "midi_to_solo_musical_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": DECISION_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+def pitch_contour_probe_source(root: Path) -> dict:
+    midi_paths = [
+        write_midi(root / "rank_01_source.mid", [48, 84, 50, 86, 52, 88]),
+        write_midi(root / "rank_02_source.mid", [55, 88, 57, 84, 59, 86]),
+        write_midi(root / "rank_03_source.mid", [60, 88, 62, 84, 64, 86]),
+    ]
+    return {
+        "boundary": PITCH_CONTOUR_PROBE_BOUNDARY,
+        "summary": {
+            "pitch_contour_repair_passed": True,
+            "repaired_candidate_count": 3,
+            "repaired_pass_count": 3,
+            "max_pitch_changed_ratio": 0.7174,
+            "repaired_max_interval": 11,
+            "repaired_dead_air_max": 0.0,
+        },
+        "candidate_repairs": [
+            {
+                "rank": index,
+                "sample_index": index,
+                "sample_seed": 490 + index,
+                "source_midi_path": path,
+                "repaired_midi_path": path,
+                "candidate_repair_passed": True,
+            }
+            for index, path in enumerate(midi_paths, start=1)
+        ],
+        "readiness": {
+            "pitch_contour_repair_passed": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class StageBMidiToSoloPitchContourChangedRatioRepairProbeTest(unittest.TestCase):
+    def test_minimum_change_contour_keeps_more_original_pitches(self) -> None:
+        repaired = minimum_change_contour_pitches(
+            [48, 84, 50, 86, 52, 88],
+            preferred_pitch_min=48,
+            preferred_pitch_max=88,
+            max_adjacent_interval=12,
+        )
+        changed = sum(1 for before, after in zip([48, 84, 50, 86, 52, 88], repaired) if before != after)
+
+        self.assertLessEqual(max(abs(repaired[index] - repaired[index - 1]) for index in range(1, len(repaired))), 12)
+        self.assertLessEqual(changed / len(repaired), 0.5)
+
+    def test_repairs_changed_ratio_and_routes_audio_package(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            report = build_changed_ratio_repair_probe_report(
+                changed_ratio_decision=changed_ratio_decision_source(),
+                pitch_contour_probe=pitch_contour_probe_source(root / "source"),
+                output_dir=root / "out",
+                issue_number=718,
+                min_repaired_candidates=3,
+                dead_air_threshold_seconds=0.5,
+                preferred_pitch_min=48,
+                preferred_pitch_max=88,
+                max_adjacent_interval=12,
+                max_pitch_changed_ratio=0.5,
+                min_unique_pitch_count=3,
+            )
+            summary = validate_changed_ratio_repair_probe_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                min_repaired_candidates=3,
+                require_repair_passed=True,
+                require_no_quality_claim=True,
+            )
+
+        self.assertTrue(summary["changed_ratio_repair_probe_completed"])
+        self.assertTrue(summary["changed_ratio_repair_passed"])
+        self.assertEqual(summary["repaired_pass_count"], 3)
+        self.assertGreater(summary["source_max_pitch_changed_ratio"], 0.5)
+        self.assertLessEqual(summary["repaired_max_pitch_changed_ratio"], 0.5)
+        self.assertGreater(summary["pitch_changed_ratio_reduction"], 0.0)
+        self.assertLessEqual(summary["repaired_max_interval"], 12)
+        self.assertFalse(summary["human_audio_preference_claimed"])
+        self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+
+    def test_rejects_quality_claim_in_decision_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with self.assertRaises(StageBMidiToSoloPitchContourChangedRatioRepairProbeError):
+                build_changed_ratio_repair_probe_report(
+                    changed_ratio_decision=changed_ratio_decision_source(quality_claim=True),
+                    pitch_contour_probe=pitch_contour_probe_source(root / "source"),
+                    output_dir=root / "out",
+                    issue_number=718,
+                    min_repaired_candidates=3,
+                    dead_air_threshold_seconds=0.5,
+                    preferred_pitch_min=48,
+                    preferred_pitch_max=88,
+                    max_adjacent_interval=12,
+                    max_pitch_changed_ratio=0.5,
+                    min_unique_pitch_count=3,
+                )
+
+    def test_boundary_constants_are_stable(self) -> None:
+        self.assertEqual(
+            BOUNDARY,
+            "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe",
+        )
+        self.assertEqual(
+            NEXT_BOUNDARY,
+            "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- minimum-change pitch-class dynamic programming repair probe 추가
- pitch-contour repaired 후보 3개 대상 changed-ratio objective gate 검증
- README, status, core plan, handoff 문서 갱신

## Context
- #716 changed-ratio review decision 결과, interval target은 통과
- source max pitch changed ratio: `0.7174`
- changed-ratio review threshold: `0.5`
- 다음 검토 대상: lower pitch-change ratio repair probe

## Scope
- new script: `scripts/run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe.py`
- new test: `tests/test_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe.py`
- harness mode: `stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-probe`
- generated evidence doc: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_PITCH_CONTOUR_CHANGED_RATIO_REPAIR_PROBE_2026-06-09.md`

## Result
- repaired / passed candidates: `3 / 3`
- max pitch changed ratio: `0.7174 -> 0.4348`
- pitch changed ratio reduction: `0.2826`
- repaired max interval / target: `12 / 12`
- repaired dead-air max: `0.0000`
- min repaired unique pitch count: `24`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-probe`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- public artifact naming scan: no output

## Risk
- objective MIDI gate 통과만 확인
- WAV render와 listening preference 미검증
- final musical quality claim 제외

## Follow-up
- Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair audio package

Closes #718