### PR TITLE
Stage B MIDI-to-solo changed-ratio repair listening review package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #720, Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair audio package.
+- Latest functional issue completed: Issue #722, Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair listening review package.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair listening review package.
+- Recommended next issue: Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair listening review input guard.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1068,6 +1068,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-pitch-conto
 ```
 
 This harness renders changed-ratio repaired model-conditioned MIDI candidates to WAV and verifies technical audio metadata without claiming musical quality or human/audio preference.
+
+For Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair listening review package changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-listening-review-package
+```
+
+This harness packages changed-ratio repaired WAV/MIDI candidates for pending listening review without claiming musical quality or human/audio preference.
 
 For Stage B MIDI-to-solo model-conditioned input path quality alignment changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
+- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -117,8 +117,11 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - pitch-contour changed-ratio repair WAV files: `3`
 - pitch-contour changed-ratio repair WAV technical validation: `true`
 - pitch-contour changed-ratio repair WAV duration range: `18.422s - 18.978s`
+- pitch-contour changed-ratio repair listening review package ready: `true`
+- pitch-contour changed-ratio repair listening review items: `3`
+- pitch-contour changed-ratio repair validated review input: `false`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_input_guard`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -173,6 +176,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned dead-air/timing repaired MIDI/WAV objective next decision 가능
 - model-conditioned pitch-contour changed-ratio repair probe 가능
 - model-conditioned pitch-contour changed-ratio repaired MIDI 후보의 WAV technical render 가능
+- model-conditioned pitch-contour changed-ratio repaired WAV/MIDI 후보의 listening review package 생성 가능
 
 현재 README가 주장하지 않는 것.
 
@@ -258,6 +262,20 @@ Pitch-contour changed-ratio repair audio package.
 - min repaired unique pitch count: `24`
 - audio review required: `true`
 - audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+Pitch-contour changed-ratio repair listening review package.
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_input_guard`
+- package ready: `true`
+- review item count: `3`
+- validated review input: `false`
+- technical WAV validation: `true`
+- max repaired pitch changed ratio / target: `0.4348 / 0.5000`
+- max repaired interval: `12`
+- required input fields: `candidate_rank`, `listening_status`, `preference`, `issue_notes`
 - human/audio preference claimed: `false`
 - MIDI-to-solo musical quality claimed: `false`
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -398,6 +398,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
 - MIDI-to-solo pitch-contour changed-ratio repair probe: repaired/pass `3/3`, max pitch changed ratio `0.7174 -> 0.4348`, max interval `12`, dead-air max `0.0000`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
 - MIDI-to-solo pitch-contour changed-ratio repair audio package: rendered WAV `3`, duration `18.422s-18.978s`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
+- MIDI-to-solo pitch-contour changed-ratio repair listening review package: review items `3`, validated input `false`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_input_guard`
 - MIDI-to-solo MVP completion audit: technical model-core MVP `true`, input ranked MIDI/WAV `true/true`, selected-scale objective repair `true`, musical/product MVP `false/false`, next boundary `stage_b_midi_to_solo_quality_gap_decision`
 - MIDI-to-solo quality gap decision: selected target `model_conditioned_input_path_quality_alignment`, fallback path active `true`, human review required now `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment`
 - MIDI-to-solo model-conditioned input path quality alignment: aligned `false`, fallback replacement probe required `true`, selected probe target `replace_fallback_with_model_conditioned_input_path_probe`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_probe`
@@ -3892,6 +3893,42 @@ Issue #720은 Issue #718 changed-ratio repair probe 이후 repaired MIDI 후보 
 다음 작업:
 
 - `Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair listening review package`
+
+## 9.52 Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair listening review package
+
+Issue #722는 Issue #720 audio package 이후 repaired WAV/MIDI 후보 3개를 listening review package로 묶은 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_input_guard`
+- package ready: `true`
+- review item count: `3`
+- validated review input: `false`
+- technical WAV validation: `true`
+- max repaired pitch changed ratio / target: `0.4348 / 0.5000`
+- max repaired interval: `12`
+- required input fields: `candidate_rank`, `listening_status`, `preference`, `issue_notes`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- #720 WAV/MIDI 산출물 3개 review item package 완료.
+- validated listening input은 아직 없음.
+- preference fill과 final musical quality claim 제외 유지.
+- 다음 boundary는 listening review input guard.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-listening-review-package`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair listening review input guard`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #720, Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair audio package
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair listening review package`
+- latest functional result: Issue #722, Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair listening review package
+- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair listening review input guard`
 
 현재 범위가 아닌 것:
 
@@ -77,6 +77,7 @@
 - pitch-contour changed-ratio review decision 기준 repair probe 필요 판정 완료
 - pitch-contour changed-ratio repair probe 기준 repaired 후보 3개 objective target 통과
 - pitch-contour changed-ratio repaired 후보 3개 WAV technical render 완료
+- pitch-contour changed-ratio repaired WAV/MIDI 후보 3개 listening review package 준비 완료
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 
@@ -1331,6 +1332,51 @@ Issue #720은 Issue #718 changed-ratio repair probe 이후 repaired MIDI 후보 
 다음:
 
 - `Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair listening review package`
+
+## Stage B MIDI-to-Solo Model-Conditioned Pitch-Contour Changed-Ratio Repair Listening Review Package Result
+
+Issue #722는 Issue #720 audio package 이후 repaired WAV/MIDI 후보 3개를 listening review package로 묶은 작업이다.
+
+변경:
+
+- changed-ratio repaired WAV/MIDI review package script 추가
+- candidate별 WAV path, MIDI path, duration, interval, pitch changed ratio 기록
+- required listening input fields 정의
+- preference fill은 pending 상태 유지
+- generated review package document, README, handoff/status/core plan 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_PITCH_CONTOUR_CHANGED_RATIO_REPAIR_LISTENING_REVIEW_PACKAGE_2026-06-09.md`
+- boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_input_guard`
+- package ready: `true`
+- review item count: `3`
+- validated review input: `false`
+- technical WAV validation: `true`
+- max repaired pitch changed ratio / target: `0.4348 / 0.5000`
+- max repaired interval: `12`
+- required input fields: `candidate_rank`, `listening_status`, `preference`, `issue_notes`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- #720 WAV/MIDI 산출물 3개 review item으로 패키징 완료.
+- validated listening input은 아직 없음.
+- preference fill과 final musical quality claim 제외 유지.
+- 다음 boundary는 listening review input guard.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-listening-review-package`
+
+다음:
+
+- `Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair listening review input guard`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_PITCH_CONTOUR_CHANGED_RATIO_REPAIR_LISTENING_REVIEW_PACKAGE_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_PITCH_CONTOUR_CHANGED_RATIO_REPAIR_LISTENING_REVIEW_PACKAGE_2026-06-09.md
@@ -1,0 +1,37 @@
+# Stage B MIDI-to-Solo Model-Conditioned Pitch-Contour Changed-Ratio Repair Listening Review Package
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_input_guard`
+- package ready: `true`
+- review item count: `3`
+- validated review input: `false`
+- technical WAV validation: `true`
+- max repaired interval: `12`
+- max repaired pitch changed ratio: `0.4348`
+- target max pitch changed ratio: `0.5000`
+- human/audio preference claimed: `false`
+
+## Review Items
+
+- rank `1` sample `1` seed `497`: WAV `outputs/stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package/harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package/audio/rank_01_sample_01_changed_ratio_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe/harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe/midi/rank_01_sample_01_changed_ratio_repair.mid`, duration `18.422`, max interval `12`, pitch changed ratio `0.4348`
+- rank `2` sample `2` seed `498`: WAV `outputs/stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package/harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package/audio/rank_02_sample_02_changed_ratio_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe/harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe/midi/rank_02_sample_02_changed_ratio_repair.mid`, duration `18.978`, max interval `12`, pitch changed ratio `0.3478`
+- rank `3` sample `3` seed `499`: WAV `outputs/stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package/harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package/audio/rank_03_sample_03_changed_ratio_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe/harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe/midi/rank_03_sample_03_changed_ratio_repair.mid`, duration `18.765`, max interval `12`, pitch changed ratio `0.2826`
+
+## Required Input Fields
+
+- `candidate_rank`
+- `listening_status`
+- `preference`
+- `issue_notes`
+
+## Claim Boundary
+
+- MIDI-to-solo musical quality claimed: `false`
+- audio rendered quality claimed: `false`
+- broad trained-model quality claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair listening review input guard`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -246,6 +246,8 @@ Modes:
                 Repair pitch-contour candidates with a lower pitch-change ratio objective.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-audio-package
                 Render changed-ratio repaired model-conditioned MIDI candidates to WAV.
+  stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-listening-review-package
+                Package changed-ratio repaired WAV/MIDI candidates for listening review.
   stage-b-midi-to-solo-model-conditioned-input-path-quality-alignment
                 Decide model-conditioned input-path alignment requirements and next probe target.
   stage-b-midi-to-solo-model-conditioned-input-path-listening-review-input-guard
@@ -6036,6 +6038,27 @@ run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_au
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package() {
+  local audio_package_run_id="${AUDIO_PACKAGE_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package}"
+  local package_run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package}"
+  local audio_package_report="outputs/stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package/${audio_package_run_id}/stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package.json"
+  if [[ ! -f "$audio_package_report" ]]; then
+    print_header "Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair audio package"
+    RUN_ID="$audio_package_run_id" run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package
+  fi
+  print_header "Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair listening review package"
+  "$PYTHON_BIN" scripts/build_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package.py \
+    --run_id "$package_run_id" \
+    --audio_package_report "$audio_package_report" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_PITCH_CONTOUR_CHANGED_RATIO_REPAIR_LISTENING_REVIEW_PACKAGE_2026-06-09.md \
+    --issue_number 722 \
+    --expected_review_item_count 3 \
+    --expected_boundary stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package \
+    --expected_next_boundary stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_input_guard \
+    --require_package_ready \
+    --require_no_quality_claim
+}
+
 run_stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment() {
   local quality_gap_run_id="${QUALITY_GAP_RUN_ID:-harness_stage_b_midi_to_solo_quality_gap_decision}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment}"
@@ -8150,6 +8173,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-audio-package)
     run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package
+    ;;
+  stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-listening-review-package)
+    run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package
     ;;
   stage-b-midi-to-solo-model-conditioned-input-path-quality-alignment)
     run_stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment

--- a/scripts/build_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package.py
+++ b/scripts/build_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package.py
@@ -1,0 +1,420 @@
+"""Build a listening review package for changed-ratio repaired MIDI-to-solo output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.render_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+class StageBMidiToSoloPitchContourChangedRatioRepairListeningReviewPackageError(
+    ValueError
+):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_input_guard"
+SCHEMA_VERSION = "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package_v1"
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _path_exists(path_text: str) -> bool:
+    return bool(path_text and Path(path_text).exists())
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloPitchContourChangedRatioRepairListeningReviewPackageError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_audio_package_report(
+    report: dict[str, Any],
+    *,
+    expected_count: int,
+) -> list[dict[str, Any]]:
+    boundary = _dict(report.get("audio_render_boundary"))
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("summary"))
+    if str(boundary.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloPitchContourChangedRatioRepairListeningReviewPackageError(
+            "changed-ratio repair audio package boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
+        raise StageBMidiToSoloPitchContourChangedRatioRepairListeningReviewPackageError(
+            "audio package must route to listening review package"
+        )
+    required_true = [
+        "render_attempted",
+        "technical_wav_validation",
+        "changed_ratio_repair_audio_package_completed",
+    ]
+    missing = [name for name in required_true if not bool(boundary.get(name, False))]
+    if missing:
+        raise StageBMidiToSoloPitchContourChangedRatioRepairListeningReviewPackageError(
+            f"missing audio package readiness: {missing}"
+        )
+    if not bool(summary.get("audio_review_required", False)):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairListeningReviewPackageError(
+            "audio review requirement should be recorded"
+        )
+    if _int(boundary.get("rendered_audio_file_count")) < int(expected_count):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairListeningReviewPackageError(
+            "rendered audio count below expected"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairListeningReviewPackageError(
+            "critical user input should not be required"
+        )
+    _require_no_quality_claim(boundary, label="audio package boundary")
+    rendered = [_dict(item) for item in _list(report.get("rendered_audio_files"))]
+    if len(rendered) < int(expected_count):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairListeningReviewPackageError(
+            "rendered audio file rows below expected"
+        )
+    review_items: list[dict[str, Any]] = []
+    for item in rendered[: int(expected_count)]:
+        wav = _dict(item.get("wav_file"))
+        wav_path = str(wav.get("path") or "")
+        midi_path = str(item.get("repaired_midi_path") or "")
+        if not _path_exists(wav_path) or not _path_exists(midi_path):
+            raise StageBMidiToSoloPitchContourChangedRatioRepairListeningReviewPackageError(
+                "review item MIDI/WAV artifact required"
+            )
+        review_items.append(
+            {
+                "rank": _int(item.get("rank")),
+                "sample_index": _int(item.get("sample_index")),
+                "sample_seed": _int(item.get("sample_seed")),
+                "midi_path": midi_path,
+                "wav_path": wav_path,
+                "duration_seconds": _float(wav.get("duration_seconds")),
+                "sample_rate": _int(wav.get("sample_rate")),
+                "size_bytes": _int(wav.get("size_bytes")),
+                "sha256": str(wav.get("sha256") or ""),
+                "repaired_dead_air_ratio": _float(item.get("repaired_dead_air_ratio")),
+                "repaired_max_interval": _int(item.get("repaired_max_interval")),
+                "repaired_unique_pitch_count": _int(item.get("repaired_unique_pitch_count")),
+                "pitch_changed_ratio": _float(item.get("pitch_changed_ratio")),
+                "review_status": "pending",
+            }
+        )
+    return review_items
+
+
+def build_listening_review_package_report(
+    *,
+    audio_package_report: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+    expected_count: int,
+) -> dict[str, Any]:
+    review_items = validate_audio_package_report(
+        audio_package_report,
+        expected_count=int(expected_count),
+    )
+    summary = _dict(audio_package_report.get("summary"))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace(
+            "+00:00", "Z"
+        ),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundary": SOURCE_BOUNDARY,
+        "source_summary": {
+            "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
+            "technical_wav_validation": bool(summary.get("technical_wav_validation", False)),
+            "repaired_dead_air_max": _float(summary.get("repaired_dead_air_max")),
+            "max_repaired_interval": _int(summary.get("max_repaired_interval")),
+            "min_repaired_unique_pitch_count": _int(
+                summary.get("min_repaired_unique_pitch_count")
+            ),
+            "max_repaired_pitch_changed_ratio": _float(
+                summary.get("max_repaired_pitch_changed_ratio")
+            ),
+            "target_max_pitch_changed_ratio": _float(
+                summary.get("target_max_pitch_changed_ratio")
+            ),
+            "audio_review_required": bool(summary.get("audio_review_required", False)),
+        },
+        "review_package": {
+            "package_ready": True,
+            "review_item_count": int(len(review_items)),
+            "review_basis": "human_audio_listening_pending",
+            "validated_review_input": False,
+            "required_input_fields": [
+                "candidate_rank",
+                "listening_status",
+                "preference",
+                "issue_notes",
+            ],
+        },
+        "review_items": review_items,
+        "readiness": {
+            "boundary": BOUNDARY,
+            "listening_review_package_ready": True,
+            "review_item_count": int(len(review_items)),
+            "validated_review_input": False,
+            "human_review_required_now": False,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "changed-ratio repaired WAV review items are packaged; preference remains pending until validated listening input",
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "audio_rendered_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair listening review input guard"
+        ),
+    }
+
+
+def validate_listening_review_package_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    expected_review_item_count: int,
+    require_package_ready: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    source = _dict(report.get("source_summary"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloPitchContourChangedRatioRepairListeningReviewPackageError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloPitchContourChangedRatioRepairListeningReviewPackageError(
+            "unexpected next boundary"
+        )
+    if require_package_ready and not bool(readiness.get("listening_review_package_ready", False)):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairListeningReviewPackageError(
+            "listening review package should be ready"
+        )
+    if _int(readiness.get("review_item_count")) != int(expected_review_item_count):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairListeningReviewPackageError(
+            "review item count mismatch"
+        )
+    if bool(readiness.get("validated_review_input", True)):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairListeningReviewPackageError(
+            "review input should remain pending"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairListeningReviewPackageError(
+            "critical user input should not be required"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="listening package readiness")
+    return {
+        "boundary": boundary,
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "listening_review_package_ready": bool(readiness.get("listening_review_package_ready", False)),
+        "review_item_count": _int(readiness.get("review_item_count")),
+        "validated_review_input": bool(readiness.get("validated_review_input", True)),
+        "technical_wav_validation": bool(source.get("technical_wav_validation", False)),
+        "rendered_audio_file_count": _int(source.get("rendered_audio_file_count")),
+        "max_repaired_interval": _int(source.get("max_repaired_interval")),
+        "max_repaired_pitch_changed_ratio": _float(
+            source.get("max_repaired_pitch_changed_ratio")
+        ),
+        "target_max_pitch_changed_ratio": _float(
+            source.get("target_max_pitch_changed_ratio")
+        ),
+        "audio_review_required": bool(source.get("audio_review_required", False)),
+        "human_review_required_now": bool(readiness.get("human_review_required_now", True)),
+        "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "wav_paths": [str(_dict(item).get("wav_path") or "") for item in _list(report.get("review_items"))],
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    package = report["review_package"]
+    source = report["source_summary"]
+    lines = [
+        "# Stage B MIDI-to-Solo Model-Conditioned Pitch-Contour Changed-Ratio Repair Listening Review Package",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- package ready: `{_bool_token(package['package_ready'])}`",
+        f"- review item count: `{package['review_item_count']}`",
+        f"- validated review input: `{_bool_token(package['validated_review_input'])}`",
+        f"- technical WAV validation: `{_bool_token(source['technical_wav_validation'])}`",
+        f"- max repaired interval: `{source['max_repaired_interval']}`",
+        f"- max repaired pitch changed ratio: `{source['max_repaired_pitch_changed_ratio']:.4f}`",
+        f"- target max pitch changed ratio: `{source['target_max_pitch_changed_ratio']:.4f}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        "",
+        "## Review Items",
+        "",
+    ]
+    for item in report["review_items"]:
+        lines.append(
+            f"- rank `{item['rank']}` sample `{item['sample_index']}` seed `{item['sample_seed']}`: "
+            f"WAV `{item['wav_path']}`, MIDI `{item['midi_path']}`, duration `{item['duration_seconds']:.3f}`, "
+            f"max interval `{item['repaired_max_interval']}`, pitch changed ratio `{item['pitch_changed_ratio']:.4f}`"
+        )
+    lines.extend(["", "## Required Input Fields", ""])
+    for field in package["required_input_fields"]:
+        lines.append(f"- `{field}`")
+    lines.extend(
+        [
+            "",
+            "## Claim Boundary",
+            "",
+            f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+            f"- audio rendered quality claimed: `{_bool_token(readiness['audio_rendered_quality_claimed'])}`",
+            f"- broad trained-model quality claimed: `{_bool_token(readiness['broad_trained_model_quality_claimed'])}`",
+            "",
+            "## Next",
+            "",
+            f"- `{report['next_recommended_issue']}`",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build changed-ratio repair listening review package"
+    )
+    parser.add_argument("--audio_package_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=722)
+    parser.add_argument("--expected_review_item_count", type=int, default=3)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_package_ready", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_listening_review_package_report(
+        audio_package_report=read_json(Path(args.audio_package_report)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+        expected_count=int(args.expected_review_item_count),
+    )
+    summary = validate_listening_review_package_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        expected_review_item_count=int(args.expected_review_item_count),
+        require_package_ready=bool(args.require_package_ready),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package.py
+++ b/tests/test_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.build_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloPitchContourChangedRatioRepairListeningReviewPackageError,
+    build_listening_review_package_report,
+    validate_listening_review_package_report,
+)
+from scripts.render_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio import (
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+def touch_file(root: Path, name: str) -> str:
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"artifact")
+    return str(path)
+
+
+def audio_package_report(root: Path, *, quality_claim: bool = False) -> dict:
+    files = []
+    for index in range(1, 4):
+        files.append(
+            {
+                "rank": index,
+                "sample_index": index,
+                "sample_seed": 698 + index,
+                "repaired_midi_path": touch_file(root, f"midi/rank_{index}.mid"),
+                "repaired_dead_air_ratio": 0.0,
+                "repaired_max_interval": 8 + index,
+                "repaired_unique_pitch_count": 20 + index,
+                "pitch_changed_ratio": 0.4,
+                "wav_file": {
+                    "path": touch_file(root, f"audio/rank_{index}.wav"),
+                    "exists": True,
+                    "duration_seconds": 18.0 + index,
+                    "sample_rate": 44100,
+                    "size_bytes": 1000,
+                    "sha256": f"sha-{index}",
+                },
+            }
+        )
+    return {
+        "summary": {
+            "rendered_audio_file_count": 3,
+            "technical_wav_validation": True,
+            "repaired_dead_air_max": 0.0,
+            "max_repaired_interval": 11,
+            "min_repaired_unique_pitch_count": 21,
+            "max_repaired_pitch_changed_ratio": 0.4,
+            "target_max_pitch_changed_ratio": 0.5,
+            "audio_review_required": True,
+        },
+        "audio_render_boundary": {
+            "boundary": SOURCE_BOUNDARY,
+            "render_attempted": True,
+            "rendered_audio_file_count": 3,
+            "technical_wav_validation": True,
+            "changed_ratio_repair_audio_package_completed": True,
+            "human_audio_preference_claimed": quality_claim,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "rendered_audio_files": files,
+        "decision": {
+            "next_boundary": SOURCE_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class StageBMidiToSoloPitchContourChangedRatioRepairListeningReviewPackageTest(
+    unittest.TestCase
+):
+    def test_builds_pending_listening_review_package(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            report = build_listening_review_package_report(
+                audio_package_report=audio_package_report(root),
+                output_dir=root / "out",
+                issue_number=722,
+                expected_count=3,
+            )
+            summary = validate_listening_review_package_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                expected_review_item_count=3,
+                require_package_ready=True,
+                require_no_quality_claim=True,
+            )
+
+        self.assertTrue(summary["listening_review_package_ready"])
+        self.assertEqual(summary["review_item_count"], 3)
+        self.assertFalse(summary["validated_review_input"])
+        self.assertTrue(summary["technical_wav_validation"])
+        self.assertEqual(summary["rendered_audio_file_count"], 3)
+        self.assertEqual(summary["max_repaired_interval"], 11)
+        self.assertLessEqual(summary["max_repaired_pitch_changed_ratio"], 0.5)
+        self.assertTrue(summary["audio_review_required"])
+        self.assertFalse(summary["human_audio_preference_claimed"])
+        self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+        self.assertEqual(len(summary["wav_paths"]), 3)
+
+    def test_rejects_audio_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaises(
+                StageBMidiToSoloPitchContourChangedRatioRepairListeningReviewPackageError
+            ):
+                build_listening_review_package_report(
+                    audio_package_report=audio_package_report(root, quality_claim=True),
+                    output_dir=root / "out",
+                    issue_number=722,
+                    expected_count=3,
+                )
+
+    def test_rejects_missing_review_item_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            audio = audio_package_report(root)
+            audio["rendered_audio_files"][0]["wav_file"]["path"] = "missing.wav"
+            with self.assertRaises(
+                StageBMidiToSoloPitchContourChangedRatioRepairListeningReviewPackageError
+            ):
+                build_listening_review_package_report(
+                    audio_package_report=audio,
+                    output_dir=root / "out",
+                    issue_number=722,
+                    expected_count=3,
+                )
+
+    def test_boundary_constants_are_stable(self) -> None:
+        self.assertEqual(
+            BOUNDARY,
+            "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package",
+        )
+        self.assertEqual(
+            NEXT_BOUNDARY,
+            "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_input_guard",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- changed-ratio repaired WAV/MIDI listening review package 추가
- review item 3개와 required input fields 기록
- README, status, core plan, handoff 문서 갱신

## Context
- #720 changed-ratio repair audio package 완료
- rendered audio file count: `3`
- technical WAV validation: `true`
- max repaired pitch changed ratio / target: `0.4348 / 0.5000`
- validated listening input: `false`

## Scope
- new script: `scripts/build_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package.py`
- new test: `tests/test_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package.py`
- harness mode: `stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-listening-review-package`
- generated evidence doc: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_PITCH_CONTOUR_CHANGED_RATIO_REPAIR_LISTENING_REVIEW_PACKAGE_2026-06-09.md`

## Result
- package ready: `true`
- review item count: `3`
- validated review input: `false`
- technical WAV validation: `true`
- max repaired pitch changed ratio / target: `0.4348 / 0.5000`
- max repaired interval: `12`
- required input fields: `candidate_rank`, `listening_status`, `preference`, `issue_notes`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-listening-review-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- public artifact naming scan: no output

## Risk
- package 생성만 포함
- validated listening input 미포함
- preference fill과 final musical quality claim 제외

## Follow-up
- Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair listening review input guard

Closes #722