### PR TITLE
Stage B MIDI-to-solo changed-ratio repair objective next decision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #724, Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair listening review input guard.
+- Latest functional issue completed: Issue #726, Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair objective-only next decision.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair objective-only next decision.
+- Recommended next issue: Stage B MIDI-to-solo MVP current evidence consolidation.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1084,6 +1084,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-pitch-conto
 ```
 
 This harness blocks changed-ratio repair preference fill while listening review input is pending.
+
+For Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair objective-only next decision changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-objective-next
+```
+
+This harness routes changed-ratio repair objective evidence to current evidence consolidation without claiming musical quality or human/audio preference.
 
 For Stage B MIDI-to-solo model-conditioned input path quality alignment changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_input_guard`
+- latest evidence boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_only_next_decision`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -122,8 +122,13 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - pitch-contour changed-ratio repair validated review input: `false`
 - pitch-contour changed-ratio repair listening review input guard completed: `true`
 - pitch-contour changed-ratio repair preference fill allowed: `false`
+- pitch-contour changed-ratio repair objective-only next decision completed: `true`
+- pitch-contour changed-ratio repair objective path supported: `true`
+- pitch-contour changed-ratio repair current evidence consolidation ready: `true`
+- pitch-contour changed-ratio repair max interval / target: `12 / 12`
+- pitch-contour changed-ratio repair max pitch changed ratio / target: `0.4348 / 0.5000`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_only_next_decision`
+- next boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -180,6 +185,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned pitch-contour changed-ratio repaired MIDI 후보의 WAV technical render 가능
 - model-conditioned pitch-contour changed-ratio repaired WAV/MIDI 후보의 listening review package 생성 가능
 - model-conditioned pitch-contour changed-ratio review input pending 상태에서 preference fill 차단 가능
+- model-conditioned pitch-contour changed-ratio objective evidence 기준 current evidence consolidation 경계 결정 가능
 
 현재 README가 주장하지 않는 것.
 
@@ -294,6 +300,22 @@ Pitch-contour changed-ratio repair listening review input guard.
 - technical WAV validation: `true`
 - max repaired pitch changed ratio / target: `0.4348 / 0.5000`
 - max repaired interval: `12`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+Pitch-contour changed-ratio repair objective-only next decision.
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- objective next completed: `true`
+- changed-ratio repair objective path supported: `true`
+- current evidence consolidation ready: `true`
+- technical WAV validation: `true`
+- rendered audio file count: `3`
+- max repaired pitch changed ratio / target: `0.4348 / 0.5000`
+- max repaired interval / target: `12 / 12`
+- preference fill allowed: `false`
 - human/audio preference claimed: `false`
 - MIDI-to-solo musical quality claimed: `false`
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -400,6 +400,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo pitch-contour changed-ratio repair audio package: rendered WAV `3`, duration `18.422s-18.978s`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
 - MIDI-to-solo pitch-contour changed-ratio repair listening review package: review items `3`, validated input `false`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_input_guard`
 - MIDI-to-solo pitch-contour changed-ratio repair listening review input guard: validated input `false`, preference fill `false`, review items `3`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_only_next_decision`
+- MIDI-to-solo pitch-contour changed-ratio repair objective-only next decision: objective path support `true`, max pitch changed ratio/target `0.4348/0.5000`, max interval/target `12/12`, current evidence ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - MIDI-to-solo MVP completion audit: technical model-core MVP `true`, input ranked MIDI/WAV `true/true`, selected-scale objective repair `true`, musical/product MVP `false/false`, next boundary `stage_b_midi_to_solo_quality_gap_decision`
 - MIDI-to-solo quality gap decision: selected target `model_conditioned_input_path_quality_alignment`, fallback path active `true`, human review required now `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment`
 - MIDI-to-solo model-conditioned input path quality alignment: aligned `false`, fallback replacement probe required `true`, selected probe target `replace_fallback_with_model_conditioned_input_path_probe`, quality claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_input_path_probe`
@@ -3966,6 +3967,44 @@ Issue #724는 Issue #722 listening review package 이후 validated listening inp
 다음 작업:
 
 - `Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair objective-only next decision`
+
+## 9.54 Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair objective-only next decision
+
+Issue #726은 Issue #724 input guard 이후 청음 입력이 없는 상태에서 objective evidence 기준 다음 경계를 선택한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- objective next completed: `true`
+- changed-ratio repair objective path supported: `true`
+- current evidence consolidation ready: `true`
+- technical WAV validation: `true`
+- rendered audio file count: `3`
+- max repaired pitch changed ratio / target: `0.4348 / 0.5000`
+- max repaired interval / target: `12 / 12`
+- preference fill allowed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- changed-ratio repair objective guardrail 통과.
+- 청음 입력 pending 상태와 preference fill 차단 유지.
+- human/audio preference와 final musical quality claim 제외 유지.
+- 다음 boundary는 MVP current evidence consolidation.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_next`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_next.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-objective-next`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo MVP current evidence consolidation`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #724, Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair listening review input guard
-- 다음 권장 이슈: `Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair objective-only next decision`
+- latest functional result: Issue #726, Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair objective-only next decision
+- 다음 권장 이슈: `Stage B MIDI-to-solo MVP current evidence consolidation`
 
 현재 범위가 아닌 것:
 
@@ -79,6 +79,7 @@
 - pitch-contour changed-ratio repaired 후보 3개 WAV technical render 완료
 - pitch-contour changed-ratio repaired WAV/MIDI 후보 3개 listening review package 준비 완료
 - pitch-contour changed-ratio repaired review input pending 상태에서 preference fill 차단 완료
+- pitch-contour changed-ratio repaired objective-only 기준 current evidence consolidation 준비 완료
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 
@@ -1422,6 +1423,52 @@ Issue #724는 Issue #722 listening review package 이후 validated listening inp
 다음:
 
 - `Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair objective-only next decision`
+
+## Stage B MIDI-to-Solo Model-Conditioned Pitch-Contour Changed-Ratio Repair Objective-Only Next Decision Result
+
+Issue #726은 Issue #724 input guard 이후 청음 입력이 없는 상태에서 objective evidence 기준 다음 경계를 선택한 작업이다.
+
+변경:
+
+- changed-ratio repair objective-only next decision script 추가
+- input guard boundary, pending review input, preference fill 차단 상태 검증
+- repaired pitch changed ratio, adjacent interval, WAV technical validation 기준 current evidence consolidation readiness 기록
+- generated decision document, README, handoff/status/core plan 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_PITCH_CONTOUR_CHANGED_RATIO_REPAIR_OBJECTIVE_NEXT_DECISION_2026-06-09.md`
+- boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- objective next completed: `true`
+- changed-ratio repair objective path supported: `true`
+- current evidence consolidation ready: `true`
+- technical WAV validation: `true`
+- rendered audio file count: `3`
+- max repaired pitch changed ratio / target: `0.4348 / 0.5000`
+- max repaired interval / target: `12 / 12`
+- preference fill allowed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- changed-ratio repair objective guardrail 통과.
+- 청음 입력 pending 상태와 preference fill 차단 유지.
+- human/audio preference와 final musical quality claim 제외 유지.
+- 다음 boundary는 MVP current evidence consolidation.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_next`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_next.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-objective-next`
+
+다음:
+
+- `Stage B MIDI-to-solo MVP current evidence consolidation`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_PITCH_CONTOUR_CHANGED_RATIO_REPAIR_OBJECTIVE_NEXT_DECISION_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_PITCH_CONTOUR_CHANGED_RATIO_REPAIR_OBJECTIVE_NEXT_DECISION_2026-06-09.md
@@ -1,0 +1,40 @@
+# Stage B MIDI-to-Solo Model-Conditioned Pitch-Contour Changed-Ratio Repair Objective-Only Next Decision
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- selected target: `current_evidence_consolidation`
+- review item count: `3`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `3`
+- max repaired interval: `12`
+- max interval threshold: `12`
+- interval target supported: `true`
+- max repaired pitch changed ratio: `0.4348`
+- target max pitch changed ratio: `0.5000`
+- changed-ratio target supported: `true`
+- changed-ratio repair objective path supported: `true`
+- current evidence consolidation ready: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Decision
+
+- reason: `changed-ratio repair objective targets passed; route to current evidence consolidation without quality claim`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo MVP current evidence consolidation`
+
+## Claim Boundary
+
+- `listening_review_completed`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -250,6 +250,8 @@ Modes:
                 Package changed-ratio repaired WAV/MIDI candidates for listening review.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-listening-review-input-guard
                 Block changed-ratio repair preference fill while listening review input is pending.
+  stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-objective-next
+                Decide the objective-only next boundary after changed-ratio repair input guard.
   stage-b-midi-to-solo-model-conditioned-input-path-quality-alignment
                 Decide model-conditioned input-path alignment requirements and next probe target.
   stage-b-midi-to-solo-model-conditioned-input-path-listening-review-input-guard
@@ -6082,6 +6084,29 @@ run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_li
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_next() {
+  local input_guard_run_id="${INPUT_GUARD_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_input_guard}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_next}"
+  local input_guard_report="outputs/stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_input_guard/${input_guard_run_id}/stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_input_guard.json"
+  if [[ ! -f "$input_guard_report" ]]; then
+    print_header "Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair listening review input guard"
+    RUN_ID="$input_guard_run_id" run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_input_guard
+  fi
+  print_header "Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair objective-only next decision"
+  "$PYTHON_BIN" scripts/decide_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_next.py \
+    --run_id "$run_id" \
+    --input_guard_report "$input_guard_report" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MODEL_CONDITIONED_PITCH_CONTOUR_CHANGED_RATIO_REPAIR_OBJECTIVE_NEXT_DECISION_2026-06-09.md \
+    --issue_number 726 \
+    --max_interval_threshold 12 \
+    --max_pitch_changed_ratio 0.5 \
+    --expected_boundary stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_only_next_decision \
+    --expected_next_boundary stage_b_midi_to_solo_mvp_current_evidence_consolidation \
+    --require_objective_support \
+    --require_current_evidence_ready \
+    --require_no_quality_claim
+}
+
 run_stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment() {
   local quality_gap_run_id="${QUALITY_GAP_RUN_ID:-harness_stage_b_midi_to_solo_quality_gap_decision}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment}"
@@ -8202,6 +8227,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-listening-review-input-guard)
     run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_input_guard
+    ;;
+  stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-objective-next)
+    run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_next
     ;;
   stage-b-midi-to-solo-model-conditioned-input-path-quality-alignment)
     run_stage_b_midi_to_solo_model_conditioned_input_path_quality_alignment

--- a/scripts/decide_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_next.py
+++ b/scripts/decide_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_next.py
@@ -1,0 +1,457 @@
+"""Select the next boundary after changed-ratio repair input guard evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.guard_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_input import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+    OBJECTIVE_NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+class StageBMidiToSoloPitchContourChangedRatioRepairObjectiveNextError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_only_next_decision"
+CURRENT_EVIDENCE_NEXT_BOUNDARY = "stage_b_midi_to_solo_mvp_current_evidence_consolidation"
+CHANGED_RATIO_REPAIR_RETRY_NEXT_BOUNDARY = (
+    "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe"
+)
+SCHEMA_VERSION = "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_next_v1"
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloPitchContourChangedRatioRepairObjectiveNextError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_input_guard_report(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    guard = _dict(report.get("guard_result"))
+    source = _dict(guard.get("source_summary"))
+    if str(report.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloPitchContourChangedRatioRepairObjectiveNextError(
+            "changed-ratio repair listening review input guard boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
+        raise StageBMidiToSoloPitchContourChangedRatioRepairObjectiveNextError(
+            "input guard must route to changed-ratio repair objective-only next decision"
+        )
+    if not bool(readiness.get("listening_review_input_guard_completed", False)):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairObjectiveNextError(
+            "input guard completion required"
+        )
+    if bool(guard.get("validated_review_input_present", True)):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairObjectiveNextError(
+            "objective-only decision requires pending review input"
+        )
+    if bool(guard.get("preference_fill_allowed", True)):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairObjectiveNextError(
+            "preference fill must remain blocked"
+        )
+    if not bool(source.get("technical_wav_validation", False)):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairObjectiveNextError(
+            "technical WAV validation required"
+        )
+    if _int(source.get("rendered_audio_file_count")) < 3:
+        raise StageBMidiToSoloPitchContourChangedRatioRepairObjectiveNextError(
+            "rendered WAV count below 3"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairObjectiveNextError(
+            "critical user input should not be required"
+        )
+    _require_no_quality_claim(readiness, label="changed-ratio repair input guard readiness")
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "review_item_count": _int(guard.get("review_item_count")),
+        "required_input_field_count": _int(guard.get("required_input_field_count")),
+        "validated_review_input_present": bool(
+            guard.get("validated_review_input_present", False)
+        ),
+        "preference_fill_allowed": bool(guard.get("preference_fill_allowed", False)),
+        "technical_wav_validation": bool(source.get("technical_wav_validation", False)),
+        "rendered_audio_file_count": _int(source.get("rendered_audio_file_count")),
+        "max_repaired_interval": _int(source.get("max_repaired_interval")),
+        "max_repaired_pitch_changed_ratio": _float(
+            source.get("max_repaired_pitch_changed_ratio")
+        ),
+        "target_max_pitch_changed_ratio": _float(source.get("target_max_pitch_changed_ratio")),
+        "audio_review_required": bool(source.get("audio_review_required", False)),
+    }
+
+
+def build_objective_next_report(
+    *,
+    input_guard_report: dict[str, Any],
+    output_dir: Path | str,
+    issue_number: int,
+    max_interval_threshold: int,
+    max_pitch_changed_ratio: float,
+) -> dict[str, Any]:
+    output_dir = Path(output_dir)
+    source = validate_input_guard_report(input_guard_report)
+    target_max_pitch_changed_ratio = (
+        _float(source["target_max_pitch_changed_ratio"]) or float(max_pitch_changed_ratio)
+    )
+    changed_ratio_target_supported = (
+        _float(source["max_repaired_pitch_changed_ratio"])
+        <= float(target_max_pitch_changed_ratio)
+    )
+    interval_target_supported = _int(source["max_repaired_interval"]) <= int(
+        max_interval_threshold
+    )
+    objective_path_supported = bool(
+        changed_ratio_target_supported and interval_target_supported
+    )
+    next_boundary = (
+        CURRENT_EVIDENCE_NEXT_BOUNDARY
+        if objective_path_supported
+        else CHANGED_RATIO_REPAIR_RETRY_NEXT_BOUNDARY
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundary": source["boundary"],
+        "objective_summary": {
+            "review_item_count": _int(source["review_item_count"]),
+            "required_input_field_count": _int(source["required_input_field_count"]),
+            "validated_review_input_present": bool(
+                source["validated_review_input_present"]
+            ),
+            "preference_fill_allowed": bool(source["preference_fill_allowed"]),
+            "technical_wav_validation": bool(source["technical_wav_validation"]),
+            "rendered_audio_file_count": _int(source["rendered_audio_file_count"]),
+            "max_repaired_interval": _int(source["max_repaired_interval"]),
+            "max_interval_threshold": int(max_interval_threshold),
+            "interval_target_supported": bool(interval_target_supported),
+            "max_repaired_pitch_changed_ratio": _float(
+                source["max_repaired_pitch_changed_ratio"]
+            ),
+            "target_max_pitch_changed_ratio": float(target_max_pitch_changed_ratio),
+            "changed_ratio_target_supported": bool(changed_ratio_target_supported),
+            "audio_review_required": bool(source["audio_review_required"]),
+            "changed_ratio_repair_objective_path_supported": bool(
+                objective_path_supported
+            ),
+            "current_evidence_consolidation_ready": bool(objective_path_supported),
+        },
+        "selected_next_target": {
+            "target": (
+                "current_evidence_consolidation"
+                if objective_path_supported
+                else "changed_ratio_repair_retry"
+            ),
+            "next_boundary": next_boundary,
+            "reason": (
+                "changed-ratio repair objective targets passed; route to current evidence consolidation without quality claim"
+                if objective_path_supported
+                else "changed-ratio repair objective targets still fail; retry repair probe"
+            ),
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "objective_next_completed": True,
+            "objective_next_decision_completed": True,
+            "technical_wav_validation": bool(source["technical_wav_validation"]),
+            "changed_ratio_target_supported": bool(changed_ratio_target_supported),
+            "interval_target_supported": bool(interval_target_supported),
+            "changed_ratio_repair_objective_path_supported": bool(
+                objective_path_supported
+            ),
+            "current_evidence_consolidation_ready": bool(objective_path_supported),
+            "human_audio_preference_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": next_boundary,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "objective changed-ratio repair evidence selected the next boundary without quality claim",
+        },
+        "not_proven": [
+            "listening_review_completed",
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "audio_rendered_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo MVP current evidence consolidation"
+            if objective_path_supported
+            else "Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair probe"
+        ),
+    }
+
+
+def validate_objective_next_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_objective_support: bool,
+    require_current_evidence_ready: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("objective_summary"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloPitchContourChangedRatioRepairObjectiveNextError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloPitchContourChangedRatioRepairObjectiveNextError(
+            "unexpected next boundary"
+        )
+    if not bool(readiness.get("objective_next_completed", False)):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairObjectiveNextError(
+            "objective next completion required"
+        )
+    if require_objective_support and not bool(
+        readiness.get("changed_ratio_repair_objective_path_supported", False)
+    ):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairObjectiveNextError(
+            "changed-ratio repair objective support required"
+        )
+    if require_current_evidence_ready and not bool(
+        readiness.get("current_evidence_consolidation_ready", False)
+    ):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairObjectiveNextError(
+            "current evidence consolidation readiness required"
+        )
+    if bool(summary.get("preference_fill_allowed", True)):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairObjectiveNextError(
+            "preference fill must remain blocked"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPitchContourChangedRatioRepairObjectiveNextError(
+            "critical user input should not be required"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(
+            readiness, label="changed-ratio repair objective next readiness"
+        )
+    return {
+        "boundary": boundary,
+        "source_boundary": str(report.get("source_boundary") or ""),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "objective_next_completed": bool(readiness.get("objective_next_completed", False)),
+        "objective_next_decision_completed": bool(
+            readiness.get("objective_next_decision_completed", False)
+        ),
+        "review_item_count": _int(summary.get("review_item_count")),
+        "required_input_field_count": _int(summary.get("required_input_field_count")),
+        "validated_review_input_present": bool(
+            summary.get("validated_review_input_present", True)
+        ),
+        "preference_fill_allowed": bool(summary.get("preference_fill_allowed", True)),
+        "technical_wav_validation": bool(summary.get("technical_wav_validation", False)),
+        "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
+        "max_repaired_interval": _int(summary.get("max_repaired_interval")),
+        "max_interval_threshold": _int(summary.get("max_interval_threshold")),
+        "interval_target_supported": bool(summary.get("interval_target_supported", False)),
+        "max_repaired_pitch_changed_ratio": _float(
+            summary.get("max_repaired_pitch_changed_ratio")
+        ),
+        "target_max_pitch_changed_ratio": _float(
+            summary.get("target_max_pitch_changed_ratio")
+        ),
+        "changed_ratio_target_supported": bool(
+            summary.get("changed_ratio_target_supported", False)
+        ),
+        "changed_ratio_repair_objective_path_supported": bool(
+            summary.get("changed_ratio_repair_objective_path_supported", False)
+        ),
+        "current_evidence_consolidation_ready": bool(
+            summary.get("current_evidence_consolidation_ready", False)
+        ),
+        "audio_review_required": bool(summary.get("audio_review_required", False)),
+        "human_audio_preference_claimed": bool(
+            readiness.get("human_audio_preference_claimed", True)
+        ),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    summary = report["objective_summary"]
+    target = report["selected_next_target"]
+    lines = [
+        "# Stage B MIDI-to-Solo Model-Conditioned Pitch-Contour Changed-Ratio Repair Objective-Only Next Decision",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- source boundary: `{report['source_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- selected target: `{target['target']}`",
+        f"- review item count: `{summary['review_item_count']}`",
+        f"- required input field count: `{summary['required_input_field_count']}`",
+        f"- validated review input present: `{_bool_token(summary['validated_review_input_present'])}`",
+        f"- preference fill allowed: `{_bool_token(summary['preference_fill_allowed'])}`",
+        f"- technical WAV validation: `{_bool_token(summary['technical_wav_validation'])}`",
+        f"- rendered audio file count: `{summary['rendered_audio_file_count']}`",
+        f"- max repaired interval: `{summary['max_repaired_interval']}`",
+        f"- max interval threshold: `{summary['max_interval_threshold']}`",
+        f"- interval target supported: `{_bool_token(summary['interval_target_supported'])}`",
+        f"- max repaired pitch changed ratio: `{summary['max_repaired_pitch_changed_ratio']:.4f}`",
+        f"- target max pitch changed ratio: `{summary['target_max_pitch_changed_ratio']:.4f}`",
+        f"- changed-ratio target supported: `{_bool_token(summary['changed_ratio_target_supported'])}`",
+        f"- changed-ratio repair objective path supported: `{_bool_token(readiness['changed_ratio_repair_objective_path_supported'])}`",
+        f"- current evidence consolidation ready: `{_bool_token(readiness['current_evidence_consolidation_ready'])}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Decision",
+        "",
+        f"- reason: `{target['reason']}`",
+        f"- auto progress allowed: `{_bool_token(decision['auto_progress_allowed'])}`",
+        f"- critical user input required: `{_bool_token(decision['critical_user_input_required'])}`",
+        f"- next recommended issue: `{report['next_recommended_issue']}`",
+        "",
+        "## Claim Boundary",
+        "",
+    ]
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Decide changed-ratio repair objective-only next step"
+    )
+    parser.add_argument("--input_guard_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_only_next_decision",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=726)
+    parser.add_argument("--max_interval_threshold", type=int, default=12)
+    parser.add_argument("--max_pitch_changed_ratio", type=float, default=0.5)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_objective_support", action="store_true")
+    parser.add_argument("--require_current_evidence_ready", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_objective_next_report(
+        input_guard_report=read_json(Path(args.input_guard_report)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+        max_interval_threshold=int(args.max_interval_threshold),
+        max_pitch_changed_ratio=float(args.max_pitch_changed_ratio),
+    )
+    summary = validate_objective_next_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_objective_support=bool(args.require_objective_support),
+        require_current_evidence_ready=bool(args.require_current_evidence_ready),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_only_next_decision.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_only_next_decision_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir
+        / "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_only_next_decision.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_next.py
+++ b/tests/test_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_next.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.decide_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_next import (
+    BOUNDARY,
+    CHANGED_RATIO_REPAIR_RETRY_NEXT_BOUNDARY,
+    CURRENT_EVIDENCE_NEXT_BOUNDARY,
+    StageBMidiToSoloPitchContourChangedRatioRepairObjectiveNextError,
+    build_objective_next_report,
+    validate_objective_next_report,
+)
+from scripts.guard_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_input import (
+    BOUNDARY as SOURCE_BOUNDARY,
+    OBJECTIVE_NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+SOURCE_SUMMARY = {
+    "technical_wav_validation": True,
+    "rendered_audio_file_count": 3,
+    "max_repaired_interval": 12,
+    "max_repaired_pitch_changed_ratio": 0.4348,
+    "target_max_pitch_changed_ratio": 0.5,
+    "audio_review_required": True,
+}
+
+
+def input_guard(
+    *,
+    preference_fill_allowed: bool = False,
+    quality_claim: bool = False,
+    source_summary: dict | None = None,
+) -> dict:
+    summary = source_summary if source_summary is not None else dict(SOURCE_SUMMARY)
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "guard_result": {
+            "validated_review_input_present": False,
+            "preference_fill_allowed": preference_fill_allowed,
+            "review_item_count": 3,
+            "required_input_field_count": 4,
+            "source_summary": dict(summary),
+        },
+        "readiness": {
+            "listening_review_input_guard_completed": True,
+            "human_audio_preference_claimed": quality_claim,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": SOURCE_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class StageBMidiToSoloPitchContourChangedRatioRepairObjectiveNextTest(
+    unittest.TestCase
+):
+    def test_routes_to_current_evidence_when_changed_ratio_targets_pass(self) -> None:
+        report = build_objective_next_report(
+            input_guard_report=input_guard(),
+            output_dir="out",
+            issue_number=726,
+            max_interval_threshold=12,
+            max_pitch_changed_ratio=0.5,
+        )
+        summary = validate_objective_next_report(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=CURRENT_EVIDENCE_NEXT_BOUNDARY,
+            require_objective_support=True,
+            require_current_evidence_ready=True,
+            require_no_quality_claim=True,
+        )
+
+        self.assertTrue(summary["objective_next_completed"])
+        self.assertTrue(summary["technical_wav_validation"])
+        self.assertEqual(summary["rendered_audio_file_count"], 3)
+        self.assertEqual(summary["max_repaired_interval"], 12)
+        self.assertTrue(summary["interval_target_supported"])
+        self.assertAlmostEqual(summary["max_repaired_pitch_changed_ratio"], 0.4348)
+        self.assertAlmostEqual(summary["target_max_pitch_changed_ratio"], 0.5)
+        self.assertTrue(summary["changed_ratio_target_supported"])
+        self.assertTrue(summary["changed_ratio_repair_objective_path_supported"])
+        self.assertTrue(summary["current_evidence_consolidation_ready"])
+        self.assertFalse(summary["preference_fill_allowed"])
+        self.assertFalse(summary["human_audio_preference_claimed"])
+
+    def test_routes_to_retry_when_changed_ratio_target_fails(self) -> None:
+        broken_summary = dict(SOURCE_SUMMARY)
+        broken_summary["max_repaired_pitch_changed_ratio"] = 0.6522
+        report = build_objective_next_report(
+            input_guard_report=input_guard(source_summary=broken_summary),
+            output_dir="out",
+            issue_number=726,
+            max_interval_threshold=12,
+            max_pitch_changed_ratio=0.5,
+        )
+        summary = validate_objective_next_report(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=CHANGED_RATIO_REPAIR_RETRY_NEXT_BOUNDARY,
+            require_objective_support=False,
+            require_current_evidence_ready=False,
+            require_no_quality_claim=True,
+        )
+
+        self.assertFalse(summary["changed_ratio_target_supported"])
+        self.assertFalse(summary["changed_ratio_repair_objective_path_supported"])
+        self.assertFalse(summary["current_evidence_consolidation_ready"])
+
+    def test_rejects_preference_fill_allowed(self) -> None:
+        with self.assertRaises(StageBMidiToSoloPitchContourChangedRatioRepairObjectiveNextError):
+            build_objective_next_report(
+                input_guard_report=input_guard(preference_fill_allowed=True),
+                output_dir="out",
+                issue_number=726,
+                max_interval_threshold=12,
+                max_pitch_changed_ratio=0.5,
+            )
+
+    def test_rejects_upstream_quality_claim(self) -> None:
+        with self.assertRaises(StageBMidiToSoloPitchContourChangedRatioRepairObjectiveNextError):
+            build_objective_next_report(
+                input_guard_report=input_guard(quality_claim=True),
+                output_dir="out",
+                issue_number=726,
+                max_interval_threshold=12,
+                max_pitch_changed_ratio=0.5,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary
- changed-ratio repair input guard 이후 objective-only next decision 추가
- current evidence consolidation readiness 기록
- human/audio preference 및 MIDI-to-solo musical quality claim 제외 유지

Context
- Issue #724 input guard 결과: validated review input false, preference fill false
- repaired pitch changed ratio / target: 0.4348 / 0.5000
- repaired max interval / target: 12 / 12
- technical WAV validation true, rendered WAV 3

Scope
- objective next decision script/test 추가
- 전용 harness mode 추가
- generated decision document 및 README/status/core plan/handoff 갱신

Result
- boundary: stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_only_next_decision
- next boundary: stage_b_midi_to_solo_mvp_current_evidence_consolidation
- changed-ratio repair objective path supported: true
- current evidence consolidation ready: true
- preference fill allowed: false

Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_next
- .venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_next.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-objective-next
- bash scripts/agent_harness.sh quick
- git diff --check

Risk
- 청음 선호 미확정
- 최종 jazz solo 품질 claim 제외

Follow-up
- Stage B MIDI-to-solo MVP current evidence consolidation

Closes #726