### PR TITLE
Stage B MIDI-to-solo README evidence refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #728, Stage B MIDI-to-solo MVP current evidence consolidation.
+- Latest functional issue completed: Issue #730, Stage B MIDI-to-solo README evidence refresh.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo README evidence refresh.
+- Recommended next issue: Stage B MIDI-to-solo MVP completion audit.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -831,6 +831,8 @@ README evidence refresh.
 - phrase-bank CLI technical path ready: `true`
 - model-conditioned pitch-contour objective path ready: `true`
 - model-conditioned pitch-contour changed-ratio review required: `true`
+- model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
+- model-conditioned pitch-contour changed-ratio repair max ratio / target: `0.4348 / 0.5000`
 - quality/preference claim excluded: `true`
 - next boundary: `stage_b_midi_to_solo_mvp_completion_audit`
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -392,7 +392,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo controlled scale checkpoint training scale postprocess removal dead-air repair listening review: review template `true`, pending status/candidate/field `4/3/9`, preference fill `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_training_scale_postprocess_removal_dead_air_repair_objective_only_next_decision`
 - MIDI-to-solo controlled scale checkpoint training scale postprocess removal dead-air repair objective-only next decision: objective path support `true`, valid/strict/grammar `9/9/9`, dead-air/collapse `0/0`, avg/max postprocess removal `0.2176/0.2917`, preference/quality claim `false`, next boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - MIDI-to-solo MVP current evidence consolidation: evidence support `true`, technical path `true`, selected-scale objective path `true`, phrase-bank CLI path `true`, model-conditioned pitch-contour objective path `true`, changed-ratio repair objective path `true`, exported/rendered `3/3`, objective valid/strict/grammar `9/9/9`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_readme_evidence_refresh`
-- MIDI-to-solo README evidence refresh: latest boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`, input-to-WAV technical path `true`, selected-scale objective path `true`, phrase-bank CLI path `true`, model-conditioned pitch-contour objective path `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_completion_audit`
+- MIDI-to-solo README evidence refresh: latest boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`, input-to-WAV technical path `true`, selected-scale objective path `true`, phrase-bank CLI path `true`, model-conditioned pitch-contour objective path `true`, changed-ratio repair objective path `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_completion_audit`
 - MIDI-to-solo MVP completion audit refresh: technical model-core MVP `true`, model-conditioned pitch-contour objective `true`, max interval/threshold `11/12`, musical/product MVP `false/false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_gap_decision`
 - MIDI-to-solo quality gap decision refresh: selected target `model_conditioned_pitch_contour_changed_ratio_review`, fallback alignment required `false`, pitch-contour max interval/threshold `11/12`, changed-ratio review required `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
@@ -4047,6 +4047,43 @@ Issue #728은 Issue #726 changed-ratio repair objective-only next decision을 cu
 다음 작업:
 
 - `Stage B MIDI-to-solo README evidence refresh`
+
+## 9.56 Stage B MIDI-to-solo README evidence refresh
+
+Issue #730은 Issue #728 current evidence를 README 첫 상태 영역과 evidence section에 반영한 문서 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
+- source boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- next boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- latest evidence boundary reflected: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- current MVP evidence supported: `true`
+- technical execution evidence supported: `true`
+- selected-scale objective path complete: `true`
+- phrase-bank CLI technical path ready: `true`
+- model-conditioned pitch-contour objective path ready: `true`
+- model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
+- changed-ratio repair max pitch changed ratio / target: `0.4348 / 0.5000`
+- changed-ratio repair max interval / target: `12 / 12`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- README 첫 상태 영역에서 Issue #728 current evidence 확인 가능.
+- changed-ratio repair objective path 포함 상태 반영 완료.
+- 청음 preference와 musical quality claim 제외 유지.
+- 다음 boundary는 MVP completion audit.
+
+검증:
+
+- `git diff --check`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo MVP completion audit`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #728, Stage B MIDI-to-solo MVP current evidence consolidation
-- 다음 권장 이슈: `Stage B MIDI-to-solo README evidence refresh`
+- latest functional result: Issue #730, Stage B MIDI-to-solo README evidence refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo MVP completion audit`
 
 현재 범위가 아닌 것:
 
@@ -81,6 +81,7 @@
 - pitch-contour changed-ratio repaired review input pending 상태에서 preference fill 차단 완료
 - pitch-contour changed-ratio repaired objective-only 기준 current evidence consolidation 준비 완료
 - pitch-contour changed-ratio repaired objective path를 current evidence에 통합 완료
+- README current evidence block에 changed-ratio repair objective path 반영 완료
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 
@@ -1521,6 +1522,51 @@ Issue #728은 Issue #726 changed-ratio repair objective-only next decision을 cu
 다음:
 
 - `Stage B MIDI-to-solo README evidence refresh`
+
+## Stage B MIDI-to-Solo README Evidence Refresh Result
+
+Issue #730은 Issue #728 current evidence를 README 첫 상태 영역과 evidence section에 반영한 문서 작업이다.
+
+변경:
+
+- README latest/current evidence boundary 확인
+- changed-ratio repair objective path ready 상태 반영
+- changed-ratio repair ratio/interval guardrail 수치 반영
+- generated README evidence document, handoff/status/core plan 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_README_EVIDENCE_REFRESH_2026-06-09.md`
+- boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
+- source boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- next boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- latest evidence boundary reflected: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- current MVP evidence supported: `true`
+- technical execution evidence supported: `true`
+- selected-scale objective path complete: `true`
+- phrase-bank CLI technical path ready: `true`
+- model-conditioned pitch-contour objective path ready: `true`
+- model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
+- changed-ratio repair max pitch changed ratio / target: `0.4348 / 0.5000`
+- changed-ratio repair max interval / target: `12 / 12`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- README 첫 상태 영역에서 Issue #728 current evidence 확인 가능.
+- changed-ratio repair objective path 포함 상태 반영 완료.
+- 청음 preference와 musical quality claim 제외 유지.
+- 다음 boundary는 MVP completion audit.
+
+검증:
+
+- `git diff --check`
+- `bash scripts/agent_harness.sh quick`
+
+다음:
+
+- `Stage B MIDI-to-solo MVP completion audit`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_README_EVIDENCE_REFRESH_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_README_EVIDENCE_REFRESH_2026-06-09.md
@@ -12,6 +12,9 @@
 - phrase-bank CLI technical path ready: `true`
 - model-conditioned pitch-contour objective path ready: `true`
 - model-conditioned pitch-contour changed-ratio review required: `true`
+- model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
+- model-conditioned pitch-contour changed-ratio repair max ratio / target: `0.4348 / 0.5000`
+- model-conditioned pitch-contour changed-ratio repair max interval / target: `12 / 12`
 - quality/preference claim excluded: `true`
 
 ## Claim Boundary
@@ -23,6 +26,6 @@
 
 ## Decision
 
-- current README status reflects Issue #708 current evidence.
+- current README status reflects Issue #728 current evidence.
 - no new musical quality claim added.
 - next recommended issue: `Stage B MIDI-to-solo MVP completion audit`


### PR DESCRIPTION
Summary
- #728 current evidence consolidation 결과를 README evidence에 반영
- changed-ratio repair objective path ready 상태와 guardrail 수치 추가
- human/audio preference 및 MIDI-to-solo musical quality claim 제외 유지

Context
- latest completed issue: #728
- source boundary: stage_b_midi_to_solo_mvp_current_evidence_consolidation
- current MVP evidence supported: true
- changed-ratio repair objective path ready: true
- max repaired pitch changed ratio / target: 0.4348 / 0.5000
- max repaired interval / target: 12 / 12

Scope
- README current/evidence block 갱신
- generated README evidence refresh document 갱신
- status/core plan/handoff 갱신

Result
- boundary: stage_b_midi_to_solo_readme_evidence_refresh
- next boundary: stage_b_midi_to_solo_mvp_completion_audit
- latest evidence boundary reflected: stage_b_midi_to_solo_mvp_current_evidence_consolidation
- changed-ratio repair objective path reflected: true
- quality/preference claim excluded: true

Validation
- git diff --check
- bash scripts/agent_harness.sh quick

Risk
- 청음 선호 미확정
- 최종 jazz solo 품질 claim 제외

Follow-up
- Stage B MIDI-to-solo MVP completion audit

Closes #730