### PR TITLE
Stage B MIDI-to-solo MVP completion audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #730, Stage B MIDI-to-solo README evidence refresh.
+- Latest functional issue completed: Issue #732, Stage B MIDI-to-solo MVP completion audit.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo MVP completion audit.
+- Recommended next issue: Stage B MIDI-to-solo quality gap decision.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1035,7 +1035,7 @@ For Stage B MIDI-to-solo MVP completion audit changes, run:
 bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit
 ```
 
-This harness audits technical model-core MVP completion, including the CLI technical path, and keeps musical quality, human preference, broad model quality, and product readiness claims excluded.
+This harness audits technical model-core MVP completion, including the CLI technical path, model-conditioned pitch-contour objective path, and changed-ratio repair objective path, while keeping musical quality, human preference, broad model quality, and product readiness claims excluded.
 
 For Stage B MIDI-to-solo quality gap decision changes, run:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- latest evidence boundary: `stage_b_midi_to_solo_mvp_completion_audit`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -106,6 +106,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - README evidence refreshed: `true`
 - MVP completion audit completed: `true`
 - MVP completion audit model-conditioned pitch-contour objective included: `true`
+- MVP completion audit changed-ratio repair objective included: `true`
 - quality gap decision completed: `true`
 - quality gap decision pitch-contour changed-ratio target selected: `true`
 - pitch-contour changed-ratio review decision completed: `true`
@@ -129,7 +130,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - pitch-contour changed-ratio repair max pitch changed ratio / target: `0.4348 / 0.5000`
 - current evidence changed-ratio repair objective path included: `true`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
+- next boundary: `stage_b_midi_to_solo_quality_gap_decision`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -222,8 +223,11 @@ Quality gap decision.
 - model-conditioned input path alignment required: `false`
 - phrase-bank CLI technical path completed: `true`
 - model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour changed-ratio repair objective completed: `true`
 - model-conditioned pitch-contour max interval / threshold: `11 / 12`
 - model-conditioned pitch-contour changed-ratio review required: `true`
+- model-conditioned pitch-contour changed-ratio repair max ratio / target: `0.4348 / 0.5000`
+- model-conditioned pitch-contour changed-ratio repair max interval / target: `12 / 12`
 - musical quality MVP completed: `false`
 - CLI candidate / rendered WAV: `3 / 3`
 - CLI preference fill allowed: `false`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -393,7 +393,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo controlled scale checkpoint training scale postprocess removal dead-air repair objective-only next decision: objective path support `true`, valid/strict/grammar `9/9/9`, dead-air/collapse `0/0`, avg/max postprocess removal `0.2176/0.2917`, preference/quality claim `false`, next boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - MIDI-to-solo MVP current evidence consolidation: evidence support `true`, technical path `true`, selected-scale objective path `true`, phrase-bank CLI path `true`, model-conditioned pitch-contour objective path `true`, changed-ratio repair objective path `true`, exported/rendered `3/3`, objective valid/strict/grammar `9/9/9`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_readme_evidence_refresh`
 - MIDI-to-solo README evidence refresh: latest boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`, input-to-WAV technical path `true`, selected-scale objective path `true`, phrase-bank CLI path `true`, model-conditioned pitch-contour objective path `true`, changed-ratio repair objective path `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_completion_audit`
-- MIDI-to-solo MVP completion audit refresh: technical model-core MVP `true`, model-conditioned pitch-contour objective `true`, max interval/threshold `11/12`, musical/product MVP `false/false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_gap_decision`
+- MIDI-to-solo MVP completion audit refresh: technical model-core MVP `true`, model-conditioned pitch-contour objective `true`, changed-ratio repair objective `true`, max interval/threshold `11/12`, changed-ratio repair ratio/target `0.4348/0.5000`, musical/product MVP `false/false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_gap_decision`
 - MIDI-to-solo quality gap decision refresh: selected target `model_conditioned_pitch_contour_changed_ratio_review`, fallback alignment required `false`, pitch-contour max interval/threshold `11/12`, changed-ratio review required `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
 - MIDI-to-solo pitch-contour changed-ratio repair probe: repaired/pass `3/3`, max pitch changed ratio `0.7174 -> 0.4348`, max interval `12`, dead-air max `0.0000`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
@@ -4084,6 +4084,45 @@ Issue #730은 Issue #728 current evidence를 README 첫 상태 영역과 evidenc
 다음 작업:
 
 - `Stage B MIDI-to-solo MVP completion audit`
+
+## 9.57 Stage B MIDI-to-solo MVP completion audit
+
+Issue #732는 Issue #730 README evidence refresh 이후 technical model-core MVP 완료 범위를 다시 audit한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- source boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- next boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- technical model-core MVP completed: `true`
+- input to ranked MIDI completed: `true`
+- input to rendered WAV completed: `true`
+- selected-scale objective repair completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour changed-ratio repair objective completed: `true`
+- changed-ratio repair max pitch changed ratio / target: `0.4348 / 0.5000`
+- changed-ratio repair max interval / target: `12 / 12`
+- musical quality MVP completed: `false`
+- human/audio preference completed: `false`
+- product MVP completed: `false`
+
+판단:
+
+- technical model-core MVP 완료 범위에 changed-ratio repair objective path 포함 완료.
+- 청음 preference와 musical quality claim 제외 유지.
+- 다음 boundary는 quality gap decision.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
+- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_mvp_completion.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo quality gap decision`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #730, Stage B MIDI-to-solo README evidence refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo MVP completion audit`
+- latest functional result: Issue #732, Stage B MIDI-to-solo MVP completion audit
+- 다음 권장 이슈: `Stage B MIDI-to-solo quality gap decision`
 
 현재 범위가 아닌 것:
 
@@ -82,6 +82,7 @@
 - pitch-contour changed-ratio repaired objective-only 기준 current evidence consolidation 준비 완료
 - pitch-contour changed-ratio repaired objective path를 current evidence에 통합 완료
 - README current evidence block에 changed-ratio repair objective path 반영 완료
+- MVP completion audit에 changed-ratio repair objective path 포함 완료
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 
@@ -1567,6 +1568,53 @@ Issue #730은 Issue #728 current evidence를 README 첫 상태 영역과 evidenc
 다음:
 
 - `Stage B MIDI-to-solo MVP completion audit`
+
+## Stage B MIDI-to-Solo MVP Completion Audit Result
+
+Issue #732는 Issue #730 README evidence refresh 이후 technical model-core MVP 완료 범위를 다시 audit한 작업이다.
+
+변경:
+
+- completion audit script에 changed-ratio repair objective path 검증 추가
+- README required snippet에 changed-ratio repair objective path 반영 여부 추가
+- completion audit validation summary에 changed-ratio repair ratio/interval 수치 노출
+- generated audit document, README, handoff/status/core plan 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_2026-06-09.md`
+- boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- source boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- next boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- technical model-core MVP completed: `true`
+- input to ranked MIDI completed: `true`
+- input to rendered WAV completed: `true`
+- selected-scale objective repair completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour changed-ratio repair objective completed: `true`
+- changed-ratio repair max pitch changed ratio / target: `0.4348 / 0.5000`
+- changed-ratio repair max interval / target: `12 / 12`
+- musical quality MVP completed: `false`
+- human/audio preference completed: `false`
+- product MVP completed: `false`
+
+판단:
+
+- technical model-core MVP 완료 범위에 changed-ratio repair objective path 포함 완료.
+- 청음 preference와 musical quality claim 제외 유지.
+- 다음 boundary는 quality gap decision.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
+- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_mvp_completion.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit`
+
+다음:
+
+- `Stage B MIDI-to-solo quality gap decision`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_2026-06-09.md
@@ -7,6 +7,7 @@
 - technical model-core MVP completed: `true`
 - phrase-bank CLI technical path completed: `true`
 - model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour changed-ratio repair objective completed: `true`
 - musical quality MVP completed: `false`
 - human/audio preference completed: `false`
 - product MVP completed: `false`
@@ -35,6 +36,14 @@
 - model-conditioned pitch-contour changed-ratio review required: `true`
 - model-conditioned pitch-contour audio review required: `true`
 - model-conditioned pitch-contour preference fill allowed: `false`
+- model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
+- model-conditioned pitch-contour changed-ratio repair rendered WAV files: `3`
+- model-conditioned pitch-contour changed-ratio repair technical WAV validation: `true`
+- model-conditioned pitch-contour changed-ratio repair max interval / threshold: `12` / `12`
+- model-conditioned pitch-contour changed-ratio repair max ratio / target: `0.4348` / `0.5000`
+- model-conditioned pitch-contour changed-ratio repair target supported: `true`
+- model-conditioned pitch-contour changed-ratio repair audio review required: `true`
+- model-conditioned pitch-contour changed-ratio repair preference fill allowed: `false`
 
 ## Claim Boundary
 

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -5945,11 +5945,12 @@ run_stage_b_midi_to_solo_mvp_completion_audit() {
     --current_evidence "$current_evidence" \
     --readme_path README.md \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_2026-06-09.md \
-    --issue_number 712 \
+    --issue_number 732 \
     --expected_boundary stage_b_midi_to_solo_mvp_completion_audit \
     --expected_next_boundary stage_b_midi_to_solo_quality_gap_decision \
     --require_technical_mvp_completion \
     --require_model_conditioned_pitch_contour_objective \
+    --require_model_conditioned_pitch_contour_changed_ratio_repair_objective \
     --require_no_quality_claim
 }
 

--- a/scripts/audit_stage_b_midi_to_solo_mvp_completion.py
+++ b/scripts/audit_stage_b_midi_to_solo_mvp_completion.py
@@ -64,6 +64,9 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
     model_conditioned_pitch_contour = _dict(
         report.get("model_conditioned_pitch_contour_objective_path")
     )
+    model_conditioned_pitch_contour_changed_ratio_repair = _dict(
+        report.get("model_conditioned_pitch_contour_changed_ratio_repair_objective_path")
+    )
     decision = _dict(report.get("decision"))
     required_true = [
         "mvp_current_evidence_consolidated",
@@ -75,6 +78,7 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
         "selected_scale_objective_path_complete",
         "phrase_bank_cli_technical_path_ready",
         "model_conditioned_pitch_contour_objective_path_ready",
+        "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready",
         "current_mvp_technical_execution_evidence_supported",
         "current_mvp_objective_repair_evidence_supported",
         "midi_to_solo_mvp_current_evidence_supported",
@@ -146,6 +150,86 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloMvpCompletionAuditError(
             "model-conditioned pitch-contour preference fill should remain blocked"
         )
+    if not bool(model_conditioned_pitch_contour_changed_ratio_repair):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "model-conditioned pitch-contour changed-ratio repair objective path required"
+        )
+    if not bool(
+        model_conditioned_pitch_contour_changed_ratio_repair.get(
+            "current_evidence_consolidation_ready",
+            False,
+        )
+    ):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "model-conditioned pitch-contour changed-ratio repair current evidence readiness required"
+        )
+    if not bool(
+        model_conditioned_pitch_contour_changed_ratio_repair.get(
+            "changed_ratio_repair_objective_path_supported",
+            False,
+        )
+    ):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "model-conditioned pitch-contour changed-ratio repair support required"
+        )
+    if _int(
+        model_conditioned_pitch_contour_changed_ratio_repair.get("max_repaired_interval")
+    ) > _int(
+        model_conditioned_pitch_contour_changed_ratio_repair.get(
+            "max_interval_threshold"
+        )
+    ):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "model-conditioned pitch-contour changed-ratio repair interval threshold exceeded"
+        )
+    target_ratio = _float(
+        model_conditioned_pitch_contour_changed_ratio_repair.get(
+            "target_max_pitch_changed_ratio"
+        )
+    )
+    if target_ratio and _float(
+        model_conditioned_pitch_contour_changed_ratio_repair.get(
+            "max_repaired_pitch_changed_ratio"
+        )
+    ) > target_ratio:
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "model-conditioned pitch-contour changed-ratio repair ratio threshold exceeded"
+        )
+    if _int(
+        model_conditioned_pitch_contour_changed_ratio_repair.get(
+            "rendered_audio_file_count"
+        )
+    ) < 3:
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "model-conditioned pitch-contour changed-ratio repair rendered WAV count below 3"
+        )
+    if not bool(
+        model_conditioned_pitch_contour_changed_ratio_repair.get(
+            "technical_wav_validation",
+            False,
+        )
+    ):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "model-conditioned pitch-contour changed-ratio repair technical WAV validation required"
+        )
+    if bool(
+        model_conditioned_pitch_contour_changed_ratio_repair.get(
+            "validated_review_input_present",
+            True,
+        )
+    ):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "model-conditioned pitch-contour changed-ratio repair review input should remain absent"
+        )
+    if bool(
+        model_conditioned_pitch_contour_changed_ratio_repair.get(
+            "preference_fill_allowed",
+            True,
+        )
+    ):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "model-conditioned pitch-contour changed-ratio repair preference fill should remain blocked"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloMvpCompletionAuditError("critical user input should not be required")
     return {
@@ -214,6 +298,63 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
         "model_conditioned_pitch_contour_preference_fill_allowed": bool(
             model_conditioned_pitch_contour.get("preference_fill_allowed", True)
         ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready": bool(
+            readiness.get(
+                "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready",
+                False,
+            )
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_current_evidence_ready": bool(
+            model_conditioned_pitch_contour_changed_ratio_repair.get(
+                "current_evidence_consolidation_ready",
+                False,
+            )
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_rendered_audio_file_count": _int(
+            model_conditioned_pitch_contour_changed_ratio_repair.get(
+                "rendered_audio_file_count"
+            )
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_technical_wav_validation": bool(
+            model_conditioned_pitch_contour_changed_ratio_repair.get(
+                "technical_wav_validation",
+                False,
+            )
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_max_interval": _int(
+            model_conditioned_pitch_contour_changed_ratio_repair.get(
+                "max_repaired_interval"
+            )
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_max_interval_threshold": _int(
+            model_conditioned_pitch_contour_changed_ratio_repair.get(
+                "max_interval_threshold"
+            )
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_max_pitch_changed_ratio": _float(
+            model_conditioned_pitch_contour_changed_ratio_repair.get(
+                "max_repaired_pitch_changed_ratio"
+            )
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_target_max_pitch_changed_ratio": target_ratio,
+        "model_conditioned_pitch_contour_changed_ratio_repair_target_supported": bool(
+            model_conditioned_pitch_contour_changed_ratio_repair.get(
+                "changed_ratio_target_supported",
+                False,
+            )
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_audio_review_required": bool(
+            model_conditioned_pitch_contour_changed_ratio_repair.get(
+                "audio_review_required",
+                False,
+            )
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_preference_fill_allowed": bool(
+            model_conditioned_pitch_contour_changed_ratio_repair.get(
+                "preference_fill_allowed",
+                True,
+            )
+        ),
     }
 
 
@@ -229,6 +370,12 @@ def validate_readme_refresh(readme_text: str) -> dict[str, Any]:
         ),
         "model_conditioned_pitch_contour_ratio": (
             "model-conditioned pitch-contour changed-ratio review required: `true`"
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair": (
+            "model-conditioned pitch-contour changed-ratio repair objective path ready: `true`"
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_in_current_evidence": (
+            "current evidence changed-ratio repair objective path included: `true`"
         ),
         "readme_refresh": "README evidence refreshed: `true`",
         "human_preference_false": "human/audio preference claim: `false`",
@@ -261,6 +408,9 @@ def build_mvp_completion_audit_report(
         and evidence["selected_scale_objective_path_complete"]
         and evidence["phrase_bank_cli_technical_path_ready"]
         and evidence["model_conditioned_pitch_contour_objective_path_ready"]
+        and evidence[
+            "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready"
+        ]
         and readme["readme_current_evidence_refreshed"]
     )
     return {
@@ -279,6 +429,7 @@ def build_mvp_completion_audit_report(
             "selected_scale_objective_repair_completed": True,
             "phrase_bank_cli_technical_path_completed": True,
             "model_conditioned_pitch_contour_objective_completed": True,
+            "model_conditioned_pitch_contour_changed_ratio_repair_objective_completed": True,
             "readme_evidence_boundary_refreshed": True,
             "musical_quality_mvp_completed": False,
             "human_audio_preference_completed": False,
@@ -292,6 +443,11 @@ def build_mvp_completion_audit_report(
             "technical_model_core_mvp_completed": technical_model_core_mvp_completed,
             "model_conditioned_pitch_contour_objective_path_ready": bool(
                 evidence["model_conditioned_pitch_contour_objective_path_ready"]
+            ),
+            "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready": bool(
+                evidence[
+                    "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready"
+                ]
             ),
             "quality_gap_decision_required": True,
             "human_audio_preference_claimed": False,
@@ -317,6 +473,7 @@ def build_mvp_completion_audit_report(
             "selected_scale_objective_repair_path",
             "phrase_bank_cli_technical_path",
             "model_conditioned_pitch_contour_objective_path",
+            "model_conditioned_pitch_contour_changed_ratio_repair_objective_path",
             "readme_current_evidence_refresh",
         ],
         "not_proven": [
@@ -338,6 +495,7 @@ def validate_mvp_completion_audit_report(
     require_technical_mvp_completion: bool,
     require_no_quality_claim: bool,
     require_model_conditioned_pitch_contour_objective: bool,
+    require_model_conditioned_pitch_contour_changed_ratio_repair_objective: bool = False,
 ) -> dict[str, Any]:
     boundary = str(report.get("boundary") or "")
     readiness = _dict(report.get("readiness"))
@@ -357,6 +515,15 @@ def validate_mvp_completion_audit_report(
     ):
         raise StageBMidiToSoloMvpCompletionAuditError(
             "model-conditioned pitch-contour objective completion required"
+        )
+    if require_model_conditioned_pitch_contour_changed_ratio_repair_objective and not bool(
+        audit.get(
+            "model_conditioned_pitch_contour_changed_ratio_repair_objective_completed",
+            False,
+        )
+    ):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "model-conditioned pitch-contour changed-ratio repair objective completion required"
         )
     if not bool(readiness.get("quality_gap_decision_required", False)):
         raise StageBMidiToSoloMvpCompletionAuditError("quality gap decision should be required")
@@ -389,6 +556,12 @@ def validate_mvp_completion_audit_report(
         ),
         "model_conditioned_pitch_contour_objective_completed": bool(
             audit.get("model_conditioned_pitch_contour_objective_completed", False)
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_objective_completed": bool(
+            audit.get(
+                "model_conditioned_pitch_contour_changed_ratio_repair_objective_completed",
+                False,
+            )
         ),
         "musical_quality_mvp_completed": bool(audit.get("musical_quality_mvp_completed", True)),
         "human_audio_preference_completed": bool(audit.get("human_audio_preference_completed", True)),
@@ -426,6 +599,49 @@ def validate_mvp_completion_audit_report(
         "model_conditioned_pitch_contour_audio_review_required": bool(
             evidence.get("model_conditioned_pitch_contour_audio_review_required", False)
         ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready": bool(
+            evidence.get(
+                "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready",
+                False,
+            )
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_rendered_audio_file_count": _int(
+            evidence.get(
+                "model_conditioned_pitch_contour_changed_ratio_repair_rendered_audio_file_count"
+            )
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_max_interval": _int(
+            evidence.get(
+                "model_conditioned_pitch_contour_changed_ratio_repair_max_interval"
+            )
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_max_interval_threshold": _int(
+            evidence.get(
+                "model_conditioned_pitch_contour_changed_ratio_repair_max_interval_threshold"
+            )
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_max_pitch_changed_ratio": _float(
+            evidence.get(
+                "model_conditioned_pitch_contour_changed_ratio_repair_max_pitch_changed_ratio"
+            )
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_target_max_pitch_changed_ratio": _float(
+            evidence.get(
+                "model_conditioned_pitch_contour_changed_ratio_repair_target_max_pitch_changed_ratio"
+            )
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_target_supported": bool(
+            evidence.get(
+                "model_conditioned_pitch_contour_changed_ratio_repair_target_supported",
+                False,
+            )
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_audio_review_required": bool(
+            evidence.get(
+                "model_conditioned_pitch_contour_changed_ratio_repair_audio_review_required",
+                False,
+            )
+        ),
         "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
         "midi_to_solo_musical_quality_claimed": bool(
             readiness.get("midi_to_solo_musical_quality_claimed", True)
@@ -450,6 +666,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- technical model-core MVP completed: `{_bool_token(audit['technical_model_core_mvp_completed'])}`",
         f"- phrase-bank CLI technical path completed: `{_bool_token(audit['phrase_bank_cli_technical_path_completed'])}`",
         f"- model-conditioned pitch-contour objective completed: `{_bool_token(audit['model_conditioned_pitch_contour_objective_completed'])}`",
+        f"- model-conditioned pitch-contour changed-ratio repair objective completed: `{_bool_token(audit['model_conditioned_pitch_contour_changed_ratio_repair_objective_completed'])}`",
         f"- musical quality MVP completed: `{_bool_token(audit['musical_quality_mvp_completed'])}`",
         f"- human/audio preference completed: `{_bool_token(audit['human_audio_preference_completed'])}`",
         f"- product MVP completed: `{_bool_token(audit['product_mvp_completed'])}`",
@@ -478,6 +695,14 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- model-conditioned pitch-contour changed-ratio review required: `{_bool_token(evidence['model_conditioned_pitch_contour_pitch_changed_ratio_review_required'])}`",
         f"- model-conditioned pitch-contour audio review required: `{_bool_token(evidence['model_conditioned_pitch_contour_audio_review_required'])}`",
         f"- model-conditioned pitch-contour preference fill allowed: `{_bool_token(evidence['model_conditioned_pitch_contour_preference_fill_allowed'])}`",
+        f"- model-conditioned pitch-contour changed-ratio repair objective path ready: `{_bool_token(evidence['model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready'])}`",
+        f"- model-conditioned pitch-contour changed-ratio repair rendered WAV files: `{evidence['model_conditioned_pitch_contour_changed_ratio_repair_rendered_audio_file_count']}`",
+        f"- model-conditioned pitch-contour changed-ratio repair technical WAV validation: `{_bool_token(evidence['model_conditioned_pitch_contour_changed_ratio_repair_technical_wav_validation'])}`",
+        f"- model-conditioned pitch-contour changed-ratio repair max interval / threshold: `{evidence['model_conditioned_pitch_contour_changed_ratio_repair_max_interval']}` / `{evidence['model_conditioned_pitch_contour_changed_ratio_repair_max_interval_threshold']}`",
+        f"- model-conditioned pitch-contour changed-ratio repair max ratio / target: `{evidence['model_conditioned_pitch_contour_changed_ratio_repair_max_pitch_changed_ratio']:.4f}` / `{evidence['model_conditioned_pitch_contour_changed_ratio_repair_target_max_pitch_changed_ratio']:.4f}`",
+        f"- model-conditioned pitch-contour changed-ratio repair target supported: `{_bool_token(evidence['model_conditioned_pitch_contour_changed_ratio_repair_target_supported'])}`",
+        f"- model-conditioned pitch-contour changed-ratio repair audio review required: `{_bool_token(evidence['model_conditioned_pitch_contour_changed_ratio_repair_audio_review_required'])}`",
+        f"- model-conditioned pitch-contour changed-ratio repair preference fill allowed: `{_bool_token(evidence['model_conditioned_pitch_contour_changed_ratio_repair_preference_fill_allowed'])}`",
         "",
         "## Claim Boundary",
         "",
@@ -513,6 +738,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--require_technical_mvp_completion", action="store_true")
     parser.add_argument("--require_no_quality_claim", action="store_true")
     parser.add_argument("--require_model_conditioned_pitch_contour_objective", action="store_true")
+    parser.add_argument(
+        "--require_model_conditioned_pitch_contour_changed_ratio_repair_objective",
+        action="store_true",
+    )
     return parser
 
 
@@ -537,6 +766,9 @@ def main() -> int:
         require_no_quality_claim=bool(args.require_no_quality_claim),
         require_model_conditioned_pitch_contour_objective=bool(
             args.require_model_conditioned_pitch_contour_objective
+        ),
+        require_model_conditioned_pitch_contour_changed_ratio_repair_objective=bool(
+            args.require_model_conditioned_pitch_contour_changed_ratio_repair_objective
         ),
     )
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_stage_b_midi_to_solo_mvp_completion_audit.py
+++ b/tests/test_stage_b_midi_to_solo_mvp_completion_audit.py
@@ -20,6 +20,7 @@ def current_evidence(
     quality_claim: bool = False,
     strict_count: int = 9,
     pitch_contour_supported: bool = True,
+    changed_ratio_repair_supported: bool = True,
 ) -> dict:
     return {
         "boundary": CURRENT_EVIDENCE_BOUNDARY,
@@ -33,9 +34,12 @@ def current_evidence(
             "selected_scale_objective_path_complete": True,
             "phrase_bank_cli_technical_path_ready": True,
             "model_conditioned_pitch_contour_objective_path_ready": pitch_contour_supported,
+            "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready": changed_ratio_repair_supported,
             "current_mvp_technical_execution_evidence_supported": True,
             "current_mvp_objective_repair_evidence_supported": True,
-            "midi_to_solo_mvp_current_evidence_supported": pitch_contour_supported,
+            "midi_to_solo_mvp_current_evidence_supported": bool(
+                pitch_contour_supported and changed_ratio_repair_supported
+            ),
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
             "broad_trained_model_quality_claimed": False,
@@ -89,6 +93,26 @@ def current_evidence(
             "pitch_changed_ratio_review_required": True,
             "audio_review_required": True,
         },
+        "model_conditioned_pitch_contour_changed_ratio_repair_objective_path": {
+            "objective_next_completed": True,
+            "current_evidence_consolidation_ready": changed_ratio_repair_supported,
+            "changed_ratio_repair_objective_path_supported": changed_ratio_repair_supported,
+            "review_item_count": 3,
+            "required_input_field_count": 4,
+            "validated_review_input_present": False,
+            "preference_fill_allowed": False,
+            "technical_wav_validation": True,
+            "rendered_audio_file_count": 3,
+            "max_repaired_interval": 12,
+            "max_interval_threshold": 12,
+            "interval_target_supported": True,
+            "max_repaired_pitch_changed_ratio": 0.4348
+            if changed_ratio_repair_supported
+            else 0.6522,
+            "target_max_pitch_changed_ratio": 0.5,
+            "changed_ratio_target_supported": changed_ratio_repair_supported,
+            "audio_review_required": True,
+        },
         "decision": {
             "critical_user_input_required": False,
         },
@@ -107,6 +131,8 @@ def readme_text(*, missing_boundary: bool = False) -> str:
             "- phrase-bank CLI technical path included in current evidence: `true`",
             "- model-conditioned pitch-contour objective path ready: `true`",
             "- model-conditioned pitch-contour changed-ratio review required: `true`",
+            "- model-conditioned pitch-contour changed-ratio repair objective path ready: `true`",
+            "- current evidence changed-ratio repair objective path included: `true`",
             "- README evidence refreshed: `true`",
             "- human/audio preference claim: `false`",
             "- MIDI-to-solo musical quality claim: `false`",
@@ -131,6 +157,7 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
             require_technical_mvp_completion=True,
             require_no_quality_claim=True,
             require_model_conditioned_pitch_contour_objective=True,
+            require_model_conditioned_pitch_contour_changed_ratio_repair_objective=True,
         )
 
         self.assertTrue(summary["technical_model_core_mvp_completed"])
@@ -161,6 +188,39 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
             summary["model_conditioned_pitch_contour_pitch_changed_ratio_review_required"]
         )
         self.assertTrue(summary["model_conditioned_pitch_contour_audio_review_required"])
+        self.assertTrue(
+            summary[
+                "model_conditioned_pitch_contour_changed_ratio_repair_objective_completed"
+            ]
+        )
+        self.assertTrue(
+            summary[
+                "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready"
+            ]
+        )
+        self.assertEqual(
+            summary[
+                "model_conditioned_pitch_contour_changed_ratio_repair_rendered_audio_file_count"
+            ],
+            3,
+        )
+        self.assertEqual(
+            summary[
+                "model_conditioned_pitch_contour_changed_ratio_repair_max_interval"
+            ],
+            12,
+        )
+        self.assertAlmostEqual(
+            summary[
+                "model_conditioned_pitch_contour_changed_ratio_repair_max_pitch_changed_ratio"
+            ],
+            0.4348,
+        )
+        self.assertTrue(
+            summary[
+                "model_conditioned_pitch_contour_changed_ratio_repair_target_supported"
+            ]
+        )
         self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
 
     def test_rejects_missing_readme_evidence_boundary(self) -> None:
@@ -197,6 +257,15 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
                 readme_text=readme_text(),
                 output_dir=Path("outputs/audit"),
                 issue_number=712,
+            )
+
+    def test_rejects_missing_changed_ratio_repair_support(self) -> None:
+        with self.assertRaises(StageBMidiToSoloMvpCompletionAuditError):
+            build_mvp_completion_audit_report(
+                current_evidence=current_evidence(changed_ratio_repair_supported=False),
+                readme_text=readme_text(),
+                output_dir=Path("outputs/audit"),
+                issue_number=732,
             )
 
     def test_boundary_constants_are_stable(self) -> None:


### PR DESCRIPTION
Summary
- MVP completion audit에 changed-ratio repair objective path 검증 추가
- current evidence와 README snippet에 changed-ratio repair path 포함 여부 확인
- musical/product MVP 및 human/audio preference claim 제외 유지

Context
- latest completed issue: #730
- source current evidence boundary: stage_b_midi_to_solo_mvp_current_evidence_consolidation
- technical model-core MVP completed: true
- changed-ratio repair objective path ready: true
- max repaired pitch changed ratio / target: 0.4348 / 0.5000
- max repaired interval / target: 12 / 12

Scope
- completion audit validation 확장
- unit test와 harness flag 갱신
- generated audit document 및 README/status/core plan/handoff 갱신

Result
- boundary: stage_b_midi_to_solo_mvp_completion_audit
- next boundary: stage_b_midi_to_solo_quality_gap_decision
- technical model-core MVP completed: true
- changed-ratio repair objective completed: true
- musical quality MVP completed: false
- product MVP completed: false

Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit
- .venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_mvp_completion.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit
- bash scripts/agent_harness.sh quick
- git diff --check

Risk
- 청음 선호 미확정
- 최종 jazz solo 품질 claim 제외

Follow-up
- Stage B MIDI-to-solo quality gap decision

Closes #732