### PR TITLE
Stage B MIDI-to-solo quality gap decision refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -394,7 +394,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo MVP current evidence consolidation: evidence support `true`, technical path `true`, selected-scale objective path `true`, phrase-bank CLI path `true`, model-conditioned pitch-contour objective path `true`, changed-ratio repair objective path `true`, exported/rendered `3/3`, objective valid/strict/grammar `9/9/9`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_readme_evidence_refresh`
 - MIDI-to-solo README evidence refresh: latest boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`, input-to-WAV technical path `true`, selected-scale objective path `true`, phrase-bank CLI path `true`, model-conditioned pitch-contour objective path `true`, changed-ratio repair objective path `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_completion_audit`
 - MIDI-to-solo MVP completion audit refresh: technical model-core MVP `true`, model-conditioned pitch-contour objective `true`, changed-ratio repair objective `true`, max interval/threshold `11/12`, changed-ratio repair ratio/target `0.4348/0.5000`, musical/product MVP `false/false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_gap_decision`
-- MIDI-to-solo quality gap decision refresh: selected target `model_conditioned_pitch_contour_changed_ratio_review`, fallback alignment required `false`, pitch-contour max interval/threshold `11/12`, changed-ratio review required `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision`
+- MIDI-to-solo quality gap decision refresh: selected target `listening_review_quality_gap`, fallback alignment required `false`, changed-ratio repair objective `true`, changed-ratio repair ratio/target `0.4348/0.5000`, changed-ratio repair interval/target `12/12`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_listening_review_quality_gap`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
 - MIDI-to-solo pitch-contour changed-ratio repair probe: repaired/pass `3/3`, max pitch changed ratio `0.7174 -> 0.4348`, max interval `12`, dead-air max `0.0000`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
 - MIDI-to-solo pitch-contour changed-ratio repair audio package: rendered WAV `3`, duration `18.422s-18.978s`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
@@ -4123,6 +4123,44 @@ Issue #732는 Issue #730 README evidence refresh 이후 technical model-core MVP
 다음 작업:
 
 - `Stage B MIDI-to-solo quality gap decision`
+
+## 9.58 Stage B MIDI-to-solo quality gap decision refresh
+
+Issue #734는 Issue #732 MVP completion audit 이후 quality gap decision이 기존 changed-ratio review 경계로 재진입하지 않도록 갱신한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- source boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- next boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- selected target: `listening_review_quality_gap`
+- fallback path active: `true`
+- model-conditioned input path alignment required: `false`
+- model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour changed-ratio repair objective completed: `true`
+- changed-ratio repair max pitch changed ratio / target: `0.4348 / 0.5000`
+- changed-ratio repair max interval / target: `12 / 12`
+- human review required now: `false`
+- musical quality MVP completed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- changed-ratio repair objective path가 현재 ratio/interval target 충족.
+- 다음 gap은 추가 changed-ratio repair가 아니라 listening review와 musical quality evidence.
+- 청음 preference와 musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_gap_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_quality_gap.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-gap-decision`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo listening review quality gap`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #732, Stage B MIDI-to-solo MVP completion audit
-- 다음 권장 이슈: `Stage B MIDI-to-solo quality gap decision`
+- latest functional result: Issue #734, Stage B MIDI-to-solo quality gap decision refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo listening review quality gap`
 
 현재 범위가 아닌 것:
 
@@ -83,6 +83,7 @@
 - pitch-contour changed-ratio repaired objective path를 current evidence에 통합 완료
 - README current evidence block에 changed-ratio repair objective path 반영 완료
 - MVP completion audit에 changed-ratio repair objective path 포함 완료
+- quality gap decision을 listening review quality gap target으로 갱신 완료
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 
@@ -1615,6 +1616,52 @@ Issue #732는 Issue #730 README evidence refresh 이후 technical model-core MVP
 다음:
 
 - `Stage B MIDI-to-solo quality gap decision`
+
+## Stage B MIDI-to-Solo Quality Gap Decision Refresh Result
+
+Issue #734는 Issue #732 MVP completion audit 이후 quality gap decision을 갱신한 작업이다.
+
+변경:
+
+- quality gap decision 입력 검증에 changed-ratio repair objective evidence 추가
+- changed-ratio repair objective 완료 시 기존 changed-ratio review 경계 재진입 방지
+- next target을 `listening_review_quality_gap`으로 선택
+- generated decision document, handoff/status/core plan 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_2026-06-09.md`
+- boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- source boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- next boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- selected target: `listening_review_quality_gap`
+- fallback path active: `true`
+- model-conditioned input path alignment required: `false`
+- model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour changed-ratio repair objective completed: `true`
+- changed-ratio repair max pitch changed ratio / target: `0.4348 / 0.5000`
+- changed-ratio repair max interval / target: `12 / 12`
+- human review required now: `false`
+- musical quality MVP completed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- changed-ratio repair objective path가 현재 ratio/interval target 충족.
+- 다음 gap은 추가 changed-ratio repair가 아니라 listening review와 musical quality evidence.
+- 청음 preference와 musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_gap_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_quality_gap.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-gap-decision`
+
+다음:
+
+- `Stage B MIDI-to-solo listening review quality gap`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_2026-06-09.md
@@ -3,8 +3,8 @@
 ## Summary
 
 - boundary: `stage_b_midi_to_solo_quality_gap_decision`
-- next boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision`
-- selected target: `model_conditioned_pitch_contour_changed_ratio_review`
+- next boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- selected target: `listening_review_quality_gap`
 - fallback path active: `true`
 - pitch-contour changed-ratio review required: `true`
 - human review required now: `false`
@@ -14,6 +14,7 @@
 - technical model-core MVP completed: `true`
 - phrase-bank CLI technical path completed: `true`
 - model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour changed-ratio repair objective completed: `true`
 - musical quality MVP completed: `false`
 - generation source: `context_conditioned_fallback`
 - exported candidates: `3`
@@ -27,6 +28,14 @@
 - model-conditioned pitch-contour target supported: `true`
 - model-conditioned pitch-contour changed-ratio review required: `true`
 - model-conditioned pitch-contour audio review required: `true`
+- model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
+- model-conditioned pitch-contour changed-ratio repair rendered WAV files: `3`
+- model-conditioned pitch-contour changed-ratio repair technical WAV validation: `true`
+- model-conditioned pitch-contour changed-ratio repair max interval / threshold: `12` / `12`
+- model-conditioned pitch-contour changed-ratio repair max ratio / target: `0.4348` / `0.5000`
+- model-conditioned pitch-contour changed-ratio repair target supported: `true`
+- model-conditioned pitch-contour changed-ratio repair audio review required: `true`
+- model-conditioned pitch-contour changed-ratio repair preference fill allowed: `false`
 
 ## Claim Boundary
 
@@ -37,4 +46,4 @@
 
 ## Next
 
-- `Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio review decision`
+- `Stage B MIDI-to-solo listening review quality gap`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -5967,10 +5967,10 @@ run_stage_b_midi_to_solo_quality_gap_decision() {
     --run_id "$run_id" \
     --mvp_completion_audit "$completion_audit" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_2026-06-09.md \
-    --issue_number 714 \
+    --issue_number 734 \
     --expected_boundary stage_b_midi_to_solo_quality_gap_decision \
-    --expected_next_boundary stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision \
-    --expected_target model_conditioned_pitch_contour_changed_ratio_review \
+    --expected_next_boundary stage_b_midi_to_solo_listening_review_quality_gap \
+    --expected_target listening_review_quality_gap \
     --require_no_quality_claim
 }
 

--- a/scripts/decide_stage_b_midi_to_solo_quality_gap.py
+++ b/scripts/decide_stage_b_midi_to_solo_quality_gap.py
@@ -29,6 +29,8 @@ PITCH_CONTOUR_CHANGED_RATIO_TARGET = "model_conditioned_pitch_contour_changed_ra
 PITCH_CONTOUR_CHANGED_RATIO_NEXT_BOUNDARY = (
     "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision"
 )
+LISTENING_REVIEW_TARGET = "listening_review_quality_gap"
+LISTENING_REVIEW_NEXT_BOUNDARY = "stage_b_midi_to_solo_listening_review_quality_gap"
 SCHEMA_VERSION = "stage_b_midi_to_solo_quality_gap_decision_v1"
 
 
@@ -105,6 +107,52 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloQualityGapDecisionError(
             "model-conditioned pitch-contour target support required"
         )
+    if bool(audit.get("model_conditioned_pitch_contour_changed_ratio_repair_objective_completed", False)):
+        if not bool(
+            evidence.get(
+                "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready",
+                False,
+            )
+        ):
+            raise StageBMidiToSoloQualityGapDecisionError(
+                "model-conditioned pitch-contour changed-ratio repair path readiness required"
+            )
+        if _int(
+            evidence.get("model_conditioned_pitch_contour_changed_ratio_repair_rendered_audio_file_count")
+        ) < 3:
+            raise StageBMidiToSoloQualityGapDecisionError(
+                "model-conditioned pitch-contour changed-ratio repair rendered WAV count below 3"
+            )
+        if not bool(
+            evidence.get("model_conditioned_pitch_contour_changed_ratio_repair_technical_wav_validation")
+        ):
+            raise StageBMidiToSoloQualityGapDecisionError(
+                "model-conditioned pitch-contour changed-ratio repair technical WAV validation required"
+            )
+        if _int(evidence.get("model_conditioned_pitch_contour_changed_ratio_repair_max_interval")) > _int(
+            evidence.get("model_conditioned_pitch_contour_changed_ratio_repair_max_interval_threshold")
+        ):
+            raise StageBMidiToSoloQualityGapDecisionError(
+                "model-conditioned pitch-contour changed-ratio repair interval threshold exceeded"
+            )
+        if _float(evidence.get("model_conditioned_pitch_contour_changed_ratio_repair_max_pitch_changed_ratio")) > _float(
+            evidence.get("model_conditioned_pitch_contour_changed_ratio_repair_target_max_pitch_changed_ratio")
+        ):
+            raise StageBMidiToSoloQualityGapDecisionError(
+                "model-conditioned pitch-contour changed-ratio repair ratio threshold exceeded"
+            )
+        if not bool(
+            evidence.get("model_conditioned_pitch_contour_changed_ratio_repair_target_supported")
+        ):
+            raise StageBMidiToSoloQualityGapDecisionError(
+                "model-conditioned pitch-contour changed-ratio repair target support required"
+            )
+        if bool(
+            evidence.get("model_conditioned_pitch_contour_changed_ratio_repair_preference_fill_allowed", True)
+        ):
+            raise StageBMidiToSoloQualityGapDecisionError(
+                "model-conditioned pitch-contour changed-ratio repair preference fill should remain blocked"
+            )
     if _int(evidence.get("objective_strict_valid_sample_count")) != _int(evidence.get("objective_sample_count")):
         raise StageBMidiToSoloQualityGapDecisionError("objective strict valid count must match sample count")
     blocked_claims = [
@@ -121,6 +169,9 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
         "technical_model_core_mvp_completed": True,
         "phrase_bank_cli_technical_path_completed": True,
         "model_conditioned_pitch_contour_objective_completed": True,
+        "model_conditioned_pitch_contour_changed_ratio_repair_objective_completed": bool(
+            audit.get("model_conditioned_pitch_contour_changed_ratio_repair_objective_completed", False)
+        ),
         "musical_quality_mvp_completed": False,
         "human_audio_preference_completed": False,
         "product_mvp_completed": False,
@@ -161,6 +212,39 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
         "model_conditioned_pitch_contour_audio_review_required": bool(
             evidence.get("model_conditioned_pitch_contour_audio_review_required", False)
         ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready": bool(
+            evidence.get(
+                "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready",
+                False,
+            )
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_rendered_audio_file_count": _int(
+            evidence.get("model_conditioned_pitch_contour_changed_ratio_repair_rendered_audio_file_count")
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_technical_wav_validation": bool(
+            evidence.get("model_conditioned_pitch_contour_changed_ratio_repair_technical_wav_validation", False)
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_max_interval": _int(
+            evidence.get("model_conditioned_pitch_contour_changed_ratio_repair_max_interval")
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_max_interval_threshold": _int(
+            evidence.get("model_conditioned_pitch_contour_changed_ratio_repair_max_interval_threshold")
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_max_pitch_changed_ratio": _float(
+            evidence.get("model_conditioned_pitch_contour_changed_ratio_repair_max_pitch_changed_ratio")
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_target_max_pitch_changed_ratio": _float(
+            evidence.get("model_conditioned_pitch_contour_changed_ratio_repair_target_max_pitch_changed_ratio")
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_target_supported": bool(
+            evidence.get("model_conditioned_pitch_contour_changed_ratio_repair_target_supported", False)
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_audio_review_required": bool(
+            evidence.get("model_conditioned_pitch_contour_changed_ratio_repair_audio_review_required", False)
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_preference_fill_allowed": bool(
+            evidence.get("model_conditioned_pitch_contour_changed_ratio_repair_preference_fill_allowed", True)
+        ),
     }
 
 
@@ -173,12 +257,32 @@ def select_quality_gap_target(audit_summary: dict[str, Any]) -> dict[str, Any]:
     pitch_contour_changed_ratio_review_required = bool(
         audit_summary.get("model_conditioned_pitch_contour_pitch_changed_ratio_review_required", False)
     )
-    if pitch_contour_path_ready and pitch_contour_changed_ratio_review_required:
+    changed_ratio_repair_ready = bool(
+        audit_summary.get(
+            "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready",
+            False,
+        )
+    )
+    changed_ratio_repair_supported = bool(
+        audit_summary.get("model_conditioned_pitch_contour_changed_ratio_repair_target_supported", False)
+    )
+    if (
+        pitch_contour_path_ready
+        and pitch_contour_changed_ratio_review_required
+        and not changed_ratio_repair_supported
+    ):
         target = PITCH_CONTOUR_CHANGED_RATIO_TARGET
         next_boundary = PITCH_CONTOUR_CHANGED_RATIO_NEXT_BOUNDARY
         reason = (
             "model-conditioned pitch-contour path is objective-complete, but pitch changed ratio still requires "
             "review before any musical quality claim"
+        )
+    elif changed_ratio_repair_ready and changed_ratio_repair_supported:
+        target = LISTENING_REVIEW_TARGET
+        next_boundary = LISTENING_REVIEW_NEXT_BOUNDARY
+        reason = (
+            "changed-ratio repair objective path meets current ratio and interval targets; remaining gap is "
+            "listening review and musical quality evidence, not another changed-ratio repair loop"
         )
     elif fallback_path_active:
         target = SELECTED_TARGET
@@ -188,8 +292,8 @@ def select_quality_gap_target(audit_summary: dict[str, Any]) -> dict[str, Any]:
             "technical evidence, not model-conditioned quality"
         )
     else:
-        target = "listening_review_quality_gap"
-        next_boundary = "stage_b_midi_to_solo_listening_review_quality_gap"
+        target = LISTENING_REVIEW_TARGET
+        next_boundary = LISTENING_REVIEW_NEXT_BOUNDARY
         reason = "model-conditioned path is available; listening review gap remains"
     return {
         "selected_target": target,
@@ -197,6 +301,8 @@ def select_quality_gap_target(audit_summary: dict[str, Any]) -> dict[str, Any]:
         "fallback_path_active": fallback_path_active,
         "model_conditioned_pitch_contour_objective_path_ready": pitch_contour_path_ready,
         "pitch_contour_changed_ratio_review_required": pitch_contour_changed_ratio_review_required,
+        "pitch_contour_changed_ratio_repair_objective_path_ready": changed_ratio_repair_ready,
+        "pitch_contour_changed_ratio_repair_target_supported": changed_ratio_repair_supported,
         "quality_gap_reason": reason,
         "human_review_required_now": False,
     }
@@ -224,6 +330,9 @@ def build_quality_gap_decision_report(
             "model_conditioned_pitch_contour_objective_completed": bool(
                 audit_summary["model_conditioned_pitch_contour_objective_completed"]
             ),
+            "model_conditioned_pitch_contour_changed_ratio_repair_objective_completed": bool(
+                audit_summary["model_conditioned_pitch_contour_changed_ratio_repair_objective_completed"]
+            ),
             "musical_quality_mvp_completed": False,
             "human_audio_preference_completed": False,
             "product_mvp_completed": False,
@@ -237,6 +346,12 @@ def build_quality_gap_decision_report(
             ),
             "pitch_contour_changed_ratio_review_required": bool(
                 target["pitch_contour_changed_ratio_review_required"]
+            ),
+            "pitch_contour_changed_ratio_repair_objective_path_ready": bool(
+                target["pitch_contour_changed_ratio_repair_objective_path_ready"]
+            ),
+            "pitch_contour_changed_ratio_repair_target_supported": bool(
+                target["pitch_contour_changed_ratio_repair_target_supported"]
             ),
             "human_review_required_now": False,
         },
@@ -270,7 +385,11 @@ def build_quality_gap_decision_report(
         "next_recommended_issue": (
             "Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio review decision"
             if str(target["selected_target"]) == PITCH_CONTOUR_CHANGED_RATIO_TARGET
-            else "Stage B MIDI-to-solo model-conditioned input path quality alignment"
+            else (
+                "Stage B MIDI-to-solo listening review quality gap"
+                if str(target["selected_target"]) == LISTENING_REVIEW_TARGET
+                else "Stage B MIDI-to-solo model-conditioned input path quality alignment"
+            )
         ),
     }
 
@@ -334,11 +453,23 @@ def validate_quality_gap_decision_report(
         "model_conditioned_pitch_contour_objective_completed": bool(
             quality_gap.get("model_conditioned_pitch_contour_objective_completed", False)
         ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_objective_completed": bool(
+            quality_gap.get(
+                "model_conditioned_pitch_contour_changed_ratio_repair_objective_completed",
+                False,
+            )
+        ),
         "model_conditioned_pitch_contour_objective_path_ready": bool(
             quality_gap.get("model_conditioned_pitch_contour_objective_path_ready", False)
         ),
         "pitch_contour_changed_ratio_review_required": bool(
             quality_gap.get("pitch_contour_changed_ratio_review_required", False)
+        ),
+        "pitch_contour_changed_ratio_repair_objective_path_ready": bool(
+            quality_gap.get("pitch_contour_changed_ratio_repair_objective_path_ready", False)
+        ),
+        "pitch_contour_changed_ratio_repair_target_supported": bool(
+            quality_gap.get("pitch_contour_changed_ratio_repair_target_supported", False)
         ),
         "musical_quality_mvp_completed": bool(quality_gap.get("musical_quality_mvp_completed", True)),
         "cli_candidate_count": _int(_dict(report.get("mvp_completion_summary")).get("cli_candidate_count")),
@@ -362,6 +493,31 @@ def validate_quality_gap_decision_report(
         "model_conditioned_pitch_contour_target_supported": bool(
             _dict(report.get("mvp_completion_summary")).get(
                 "model_conditioned_pitch_contour_target_supported", False
+            )
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_rendered_audio_file_count": _int(
+            _dict(report.get("mvp_completion_summary")).get(
+                "model_conditioned_pitch_contour_changed_ratio_repair_rendered_audio_file_count"
+            )
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_max_interval": _int(
+            _dict(report.get("mvp_completion_summary")).get(
+                "model_conditioned_pitch_contour_changed_ratio_repair_max_interval"
+            )
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_max_interval_threshold": _int(
+            _dict(report.get("mvp_completion_summary")).get(
+                "model_conditioned_pitch_contour_changed_ratio_repair_max_interval_threshold"
+            )
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_max_pitch_changed_ratio": _float(
+            _dict(report.get("mvp_completion_summary")).get(
+                "model_conditioned_pitch_contour_changed_ratio_repair_max_pitch_changed_ratio"
+            )
+        ),
+        "model_conditioned_pitch_contour_changed_ratio_repair_target_max_pitch_changed_ratio": _float(
+            _dict(report.get("mvp_completion_summary")).get(
+                "model_conditioned_pitch_contour_changed_ratio_repair_target_max_pitch_changed_ratio"
             )
         ),
         "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
@@ -396,6 +552,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- technical model-core MVP completed: `{_bool_token(summary['technical_model_core_mvp_completed'])}`",
         f"- phrase-bank CLI technical path completed: `{_bool_token(summary['phrase_bank_cli_technical_path_completed'])}`",
         f"- model-conditioned pitch-contour objective completed: `{_bool_token(summary['model_conditioned_pitch_contour_objective_completed'])}`",
+        f"- model-conditioned pitch-contour changed-ratio repair objective completed: `{_bool_token(summary['model_conditioned_pitch_contour_changed_ratio_repair_objective_completed'])}`",
         f"- musical quality MVP completed: `{_bool_token(summary['musical_quality_mvp_completed'])}`",
         f"- generation source: `{summary['generation_source']}`",
         f"- exported candidates: `{summary['exported_candidate_count']}`",
@@ -409,6 +566,14 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- model-conditioned pitch-contour target supported: `{_bool_token(summary['model_conditioned_pitch_contour_target_supported'])}`",
         f"- model-conditioned pitch-contour changed-ratio review required: `{_bool_token(summary['model_conditioned_pitch_contour_pitch_changed_ratio_review_required'])}`",
         f"- model-conditioned pitch-contour audio review required: `{_bool_token(summary['model_conditioned_pitch_contour_audio_review_required'])}`",
+        f"- model-conditioned pitch-contour changed-ratio repair objective path ready: `{_bool_token(summary['model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready'])}`",
+        f"- model-conditioned pitch-contour changed-ratio repair rendered WAV files: `{summary['model_conditioned_pitch_contour_changed_ratio_repair_rendered_audio_file_count']}`",
+        f"- model-conditioned pitch-contour changed-ratio repair technical WAV validation: `{_bool_token(summary['model_conditioned_pitch_contour_changed_ratio_repair_technical_wav_validation'])}`",
+        f"- model-conditioned pitch-contour changed-ratio repair max interval / threshold: `{summary['model_conditioned_pitch_contour_changed_ratio_repair_max_interval']}` / `{summary['model_conditioned_pitch_contour_changed_ratio_repair_max_interval_threshold']}`",
+        f"- model-conditioned pitch-contour changed-ratio repair max ratio / target: `{summary['model_conditioned_pitch_contour_changed_ratio_repair_max_pitch_changed_ratio']:.4f}` / `{summary['model_conditioned_pitch_contour_changed_ratio_repair_target_max_pitch_changed_ratio']:.4f}`",
+        f"- model-conditioned pitch-contour changed-ratio repair target supported: `{_bool_token(summary['model_conditioned_pitch_contour_changed_ratio_repair_target_supported'])}`",
+        f"- model-conditioned pitch-contour changed-ratio repair audio review required: `{_bool_token(summary['model_conditioned_pitch_contour_changed_ratio_repair_audio_review_required'])}`",
+        f"- model-conditioned pitch-contour changed-ratio repair preference fill allowed: `{_bool_token(summary['model_conditioned_pitch_contour_changed_ratio_repair_preference_fill_allowed'])}`",
         "",
         "## Claim Boundary",
         "",

--- a/tests/test_stage_b_midi_to_solo_quality_gap_decision.py
+++ b/tests/test_stage_b_midi_to_solo_quality_gap_decision.py
@@ -8,6 +8,8 @@ from scripts.audit_stage_b_midi_to_solo_mvp_completion import (
 )
 from scripts.decide_stage_b_midi_to_solo_quality_gap import (
     BOUNDARY,
+    LISTENING_REVIEW_NEXT_BOUNDARY,
+    LISTENING_REVIEW_TARGET,
     NEXT_BOUNDARY,
     PITCH_CONTOUR_CHANGED_RATIO_NEXT_BOUNDARY,
     PITCH_CONTOUR_CHANGED_RATIO_TARGET,
@@ -26,6 +28,7 @@ def mvp_completion_audit(
     strict_count: int = 9,
     pitch_contour_changed_ratio_review_required: bool = True,
     pitch_contour_supported: bool = True,
+    changed_ratio_repair_supported: bool = True,
 ) -> dict:
     return {
         "boundary": MVP_COMPLETION_BOUNDARY,
@@ -46,6 +49,9 @@ def mvp_completion_audit(
             "selected_scale_objective_repair_completed": True,
             "phrase_bank_cli_technical_path_completed": True,
             "model_conditioned_pitch_contour_objective_completed": pitch_contour_supported,
+            "model_conditioned_pitch_contour_changed_ratio_repair_objective_completed": (
+                changed_ratio_repair_supported
+            ),
             "readme_evidence_boundary_refreshed": True,
             "musical_quality_mvp_completed": musical_complete,
             "human_audio_preference_completed": False,
@@ -75,6 +81,28 @@ def mvp_completion_audit(
                 pitch_contour_changed_ratio_review_required
             ),
             "model_conditioned_pitch_contour_audio_review_required": True,
+            "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready": (
+                changed_ratio_repair_supported
+            ),
+            "model_conditioned_pitch_contour_changed_ratio_repair_rendered_audio_file_count": (
+                3 if changed_ratio_repair_supported else 0
+            ),
+            "model_conditioned_pitch_contour_changed_ratio_repair_technical_wav_validation": (
+                changed_ratio_repair_supported
+            ),
+            "model_conditioned_pitch_contour_changed_ratio_repair_max_interval": (
+                12 if changed_ratio_repair_supported else 13
+            ),
+            "model_conditioned_pitch_contour_changed_ratio_repair_max_interval_threshold": 12,
+            "model_conditioned_pitch_contour_changed_ratio_repair_max_pitch_changed_ratio": (
+                0.4348 if changed_ratio_repair_supported else 0.7174
+            ),
+            "model_conditioned_pitch_contour_changed_ratio_repair_target_max_pitch_changed_ratio": 0.5,
+            "model_conditioned_pitch_contour_changed_ratio_repair_target_supported": (
+                changed_ratio_repair_supported
+            ),
+            "model_conditioned_pitch_contour_changed_ratio_repair_audio_review_required": True,
+            "model_conditioned_pitch_contour_changed_ratio_repair_preference_fill_allowed": False,
         },
         "decision": {
             "next_boundary": "stage_b_midi_to_solo_quality_gap_decision",
@@ -84,9 +112,73 @@ def mvp_completion_audit(
 
 
 class StageBMidiToSoloQualityGapDecisionTest(unittest.TestCase):
-    def test_selects_pitch_contour_changed_ratio_review_after_objective_path(self) -> None:
+    def test_selects_listening_review_after_changed_ratio_repair_objective_path(self) -> None:
         report = build_quality_gap_decision_report(
             mvp_completion_audit=mvp_completion_audit(),
+            output_dir=Path("outputs/quality_gap"),
+            issue_number=734,
+        )
+        summary = validate_quality_gap_decision_report(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=LISTENING_REVIEW_NEXT_BOUNDARY,
+            expected_target=LISTENING_REVIEW_TARGET,
+            require_no_quality_claim=True,
+        )
+
+        self.assertEqual(summary["selected_target"], LISTENING_REVIEW_TARGET)
+        self.assertEqual(summary["next_boundary"], LISTENING_REVIEW_NEXT_BOUNDARY)
+        self.assertTrue(summary["fallback_path_active"])
+        self.assertFalse(summary["model_conditioned_input_path_alignment_required"])
+        self.assertTrue(summary["model_conditioned_pitch_contour_objective_completed"])
+        self.assertTrue(
+            summary["model_conditioned_pitch_contour_changed_ratio_repair_objective_completed"]
+        )
+        self.assertTrue(summary["model_conditioned_pitch_contour_objective_path_ready"])
+        self.assertTrue(summary["pitch_contour_changed_ratio_review_required"])
+        self.assertTrue(summary["pitch_contour_changed_ratio_repair_objective_path_ready"])
+        self.assertTrue(summary["pitch_contour_changed_ratio_repair_target_supported"])
+        self.assertEqual(summary["model_conditioned_pitch_contour_max_interval"], 11)
+        self.assertEqual(summary["model_conditioned_pitch_contour_max_interval_threshold"], 12)
+        self.assertEqual(
+            summary["model_conditioned_pitch_contour_changed_ratio_repair_max_interval"],
+            12,
+        )
+        self.assertEqual(
+            summary["model_conditioned_pitch_contour_changed_ratio_repair_max_interval_threshold"],
+            12,
+        )
+        self.assertAlmostEqual(
+            summary["model_conditioned_pitch_contour_changed_ratio_repair_max_pitch_changed_ratio"],
+            0.4348,
+            places=4,
+        )
+        self.assertAlmostEqual(
+            summary[
+                "model_conditioned_pitch_contour_changed_ratio_repair_target_max_pitch_changed_ratio"
+            ],
+            0.5,
+            places=4,
+        )
+        self.assertTrue(summary["model_conditioned_pitch_contour_target_supported"])
+        self.assertFalse(summary["human_review_required_now"])
+        self.assertTrue(summary["technical_model_core_mvp_completed"])
+        self.assertTrue(summary["phrase_bank_cli_technical_path_completed"])
+        self.assertEqual(summary["cli_candidate_count"], 3)
+        self.assertEqual(summary["cli_rendered_audio_file_count"], 3)
+        self.assertEqual(summary["cli_input_context_bars"], 228)
+        self.assertFalse(summary["cli_preference_fill_allowed"])
+        self.assertFalse(summary["musical_quality_mvp_completed"])
+        self.assertFalse(summary["human_audio_preference_claimed"])
+        self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+        self.assertEqual(
+            summary["next_recommended_issue"],
+            "Stage B MIDI-to-solo listening review quality gap",
+        )
+
+    def test_selects_pitch_contour_changed_ratio_review_without_repair_path(self) -> None:
+        report = build_quality_gap_decision_report(
+            mvp_completion_audit=mvp_completion_audit(changed_ratio_repair_supported=False),
             output_dir=Path("outputs/quality_gap"),
             issue_number=714,
         )
@@ -105,6 +197,8 @@ class StageBMidiToSoloQualityGapDecisionTest(unittest.TestCase):
         self.assertTrue(summary["model_conditioned_pitch_contour_objective_completed"])
         self.assertTrue(summary["model_conditioned_pitch_contour_objective_path_ready"])
         self.assertTrue(summary["pitch_contour_changed_ratio_review_required"])
+        self.assertFalse(summary["pitch_contour_changed_ratio_repair_objective_path_ready"])
+        self.assertFalse(summary["pitch_contour_changed_ratio_repair_target_supported"])
         self.assertEqual(summary["model_conditioned_pitch_contour_max_interval"], 11)
         self.assertEqual(summary["model_conditioned_pitch_contour_max_interval_threshold"], 12)
         self.assertTrue(summary["model_conditioned_pitch_contour_target_supported"])
@@ -122,7 +216,8 @@ class StageBMidiToSoloQualityGapDecisionTest(unittest.TestCase):
     def test_selects_model_conditioned_input_path_alignment_when_pitch_ratio_review_not_required(self) -> None:
         report = build_quality_gap_decision_report(
             mvp_completion_audit=mvp_completion_audit(
-                pitch_contour_changed_ratio_review_required=False
+                pitch_contour_changed_ratio_review_required=False,
+                changed_ratio_repair_supported=False,
             ),
             output_dir=Path("outputs/quality_gap"),
             issue_number=714,
@@ -173,6 +268,22 @@ class StageBMidiToSoloQualityGapDecisionTest(unittest.TestCase):
                 issue_number=714,
             )
 
+    def test_rejects_missing_changed_ratio_repair_support_after_completion(self) -> None:
+        source = mvp_completion_audit()
+        source["completion_audit"][
+            "model_conditioned_pitch_contour_changed_ratio_repair_objective_completed"
+        ] = True
+        source["current_evidence"][
+            "model_conditioned_pitch_contour_changed_ratio_repair_target_supported"
+        ] = False
+
+        with self.assertRaises(StageBMidiToSoloQualityGapDecisionError):
+            build_quality_gap_decision_report(
+                mvp_completion_audit=source,
+                output_dir=Path("outputs/quality_gap"),
+                issue_number=734,
+            )
+
     def test_boundary_constants_are_stable(self) -> None:
         self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_quality_gap_decision")
         self.assertEqual(
@@ -187,6 +298,11 @@ class StageBMidiToSoloQualityGapDecisionTest(unittest.TestCase):
         self.assertEqual(
             PITCH_CONTOUR_CHANGED_RATIO_TARGET,
             "model_conditioned_pitch_contour_changed_ratio_review",
+        )
+        self.assertEqual(LISTENING_REVIEW_TARGET, "listening_review_quality_gap")
+        self.assertEqual(
+            LISTENING_REVIEW_NEXT_BOUNDARY,
+            "stage_b_midi_to_solo_listening_review_quality_gap",
         )
 
 


### PR DESCRIPTION
## Summary

- quality gap decision refresh after Issue #732 MVP completion audit
- changed-ratio repair objective evidence added to decision input validation
- next boundary changed to `stage_b_midi_to_solo_listening_review_quality_gap`
- `model_conditioned_pitch_contour_changed_ratio_review` re-entry prevented after repair objective completion

## Context

- source issue: #734
- latest completed issue: #732
- technical model-core MVP completed: `true`
- model-conditioned pitch-contour objective completed: `true`
- model-conditioned pitch-contour changed-ratio repair objective completed: `true`
- changed-ratio repair max ratio / target: `0.4348` / `0.5000`
- changed-ratio repair max interval / target: `12` / `12`
- musical quality MVP completed: `false`
- human/audio preference completed: `false`

## Scope

- `scripts/decide_stage_b_midi_to_solo_quality_gap.py`
- `tests/test_stage_b_midi_to_solo_quality_gap_decision.py`
- `scripts/agent_harness.sh`
- `docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_2026-06-09.md`
- `docs/CURRENT_STATUS_AND_PLAN.md`
- `docs/CORE_PLAN.md`

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_gap_decision`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_quality_gap.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-gap-decision`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`
- broad trained model / Brad style adaptation claim: `false`

Closes #734
