### PR TITLE
Stage B MIDI-to-solo listening review quality gap

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -395,6 +395,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo README evidence refresh: latest boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`, input-to-WAV technical path `true`, selected-scale objective path `true`, phrase-bank CLI path `true`, model-conditioned pitch-contour objective path `true`, changed-ratio repair objective path `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_completion_audit`
 - MIDI-to-solo MVP completion audit refresh: technical model-core MVP `true`, model-conditioned pitch-contour objective `true`, changed-ratio repair objective `true`, max interval/threshold `11/12`, changed-ratio repair ratio/target `0.4348/0.5000`, musical/product MVP `false/false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_gap_decision`
 - MIDI-to-solo quality gap decision refresh: selected target `listening_review_quality_gap`, fallback alignment required `false`, changed-ratio repair objective `true`, changed-ratio repair ratio/target `0.4348/0.5000`, changed-ratio repair interval/target `12/12`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_listening_review_quality_gap`
+- MIDI-to-solo listening review quality gap: selected target `mvp_delivery_package`, technical delivery package ready `true`, listening gap open `true`, changed-ratio repair ratio/target `0.4348/0.5000`, interval/target `12/12`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_delivery_package`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
 - MIDI-to-solo pitch-contour changed-ratio repair probe: repaired/pass `3/3`, max pitch changed ratio `0.7174 -> 0.4348`, max interval `12`, dead-air max `0.0000`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
 - MIDI-to-solo pitch-contour changed-ratio repair audio package: rendered WAV `3`, duration `18.422s-18.978s`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
@@ -4161,6 +4162,43 @@ Issue #734는 Issue #732 MVP completion audit 이후 quality gap decision이 기
 다음 작업:
 
 - `Stage B MIDI-to-solo listening review quality gap`
+
+## 9.59 Stage B MIDI-to-solo listening review quality gap
+
+Issue #736은 Issue #734 quality gap decision 이후 남은 listening review quality gap을 분리한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- source boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- next boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- selected target: `mvp_delivery_package`
+- technical model-core MVP completed: `true`
+- changed-ratio repair objective completed: `true`
+- changed-ratio repair max pitch changed ratio / target: `0.4348 / 0.5000`
+- changed-ratio repair max interval / target: `12 / 12`
+- listening review quality gap open: `true`
+- technical MVP delivery package ready: `true`
+- human review required now: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- technical delivery package 준비는 청음 preference claim 없이 진행 가능.
+- 남은 gap은 listening review와 musical quality evidence로 유지.
+- 다음 boundary는 MVP delivery package.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_listening_review_quality_gap`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-listening-review-quality-gap`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo MVP delivery package`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #734, Stage B MIDI-to-solo quality gap decision refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo listening review quality gap`
+- latest functional result: Issue #736, Stage B MIDI-to-solo listening review quality gap
+- 다음 권장 이슈: `Stage B MIDI-to-solo MVP delivery package`
 
 현재 범위가 아닌 것:
 
@@ -84,6 +84,7 @@
 - README current evidence block에 changed-ratio repair objective path 반영 완료
 - MVP completion audit에 changed-ratio repair objective path 포함 완료
 - quality gap decision을 listening review quality gap target으로 갱신 완료
+- listening review quality gap을 MVP delivery package target으로 분리 완료
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 
@@ -1662,6 +1663,52 @@ Issue #734는 Issue #732 MVP completion audit 이후 quality gap decision을 갱
 다음:
 
 - `Stage B MIDI-to-solo listening review quality gap`
+
+## Stage B MIDI-to-Solo Listening Review Quality Gap Result
+
+Issue #736은 Issue #734 quality gap decision 이후 남은 listening review quality gap을 분리한 작업이다.
+
+변경:
+
+- listening review quality gap decision script 추가
+- quality gap decision report 검증 연결
+- changed-ratio repair objective evidence와 human/audio preference 미검증 범위 분리
+- next target을 `mvp_delivery_package`로 선택
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_2026-06-09.md`
+- boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- source boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- next boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- selected target: `mvp_delivery_package`
+- technical model-core MVP completed: `true`
+- changed-ratio repair objective completed: `true`
+- changed-ratio repair max pitch changed ratio / target: `0.4348 / 0.5000`
+- changed-ratio repair max interval / target: `12 / 12`
+- listening review quality gap open: `true`
+- technical MVP delivery package ready: `true`
+- human review required now: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- technical delivery package 준비는 청음 preference claim 없이 진행 가능.
+- 남은 gap은 listening review와 musical quality evidence로 유지.
+- 다음 boundary는 MVP delivery package.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_listening_review_quality_gap`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-listening-review-quality-gap`
+
+다음:
+
+- `Stage B MIDI-to-solo MVP delivery package`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_2026-06-09.md
@@ -1,0 +1,35 @@
+# Stage B MIDI-to-Solo Listening Review Quality Gap
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- source boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- next boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- selected target: `mvp_delivery_package`
+- listening review quality gap open: `true`
+- technical MVP delivery package ready: `true`
+- human review required now: `false`
+
+## Evidence
+
+- technical model-core MVP completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- changed-ratio repair objective completed: `true`
+- rendered WAV files: `3`
+- changed-ratio repair max interval / threshold: `12` / `12`
+- changed-ratio repair max ratio / target: `0.4348` / `0.5000`
+- musical quality MVP completed: `false`
+- human/audio preference completed: `false`
+- product MVP completed: `false`
+
+## Claim Boundary
+
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- broad trained model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo MVP delivery package`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -240,6 +240,8 @@ Modes:
                 Audit technical model-core MVP completion and separate remaining quality claims.
   stage-b-midi-to-solo-quality-gap-decision
                 Decide the next quality-gap repair target after technical MVP completion.
+  stage-b-midi-to-solo-listening-review-quality-gap
+                Separate remaining listening-review quality gap after objective repair evidence.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision
                 Decide the next pitch-contour changed-ratio repair boundary.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-probe
@@ -5974,6 +5976,27 @@ run_stage_b_midi_to_solo_quality_gap_decision() {
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_listening_review_quality_gap() {
+  local quality_gap_run_id="${QUALITY_GAP_RUN_ID:-harness_stage_b_midi_to_solo_quality_gap_decision}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_listening_review_quality_gap}"
+  local quality_gap="outputs/stage_b_midi_to_solo_quality_gap_decision/${quality_gap_run_id}/stage_b_midi_to_solo_quality_gap_decision.json"
+  if [[ ! -f "$quality_gap" ]]; then
+    print_header "Stage B MIDI-to-solo quality gap decision"
+    RUN_ID="$quality_gap_run_id" run_stage_b_midi_to_solo_quality_gap_decision
+  fi
+  print_header "Stage B MIDI-to-solo listening review quality gap"
+  "$PYTHON_BIN" scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py \
+    --run_id "$run_id" \
+    --quality_gap_decision "$quality_gap" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_2026-06-09.md \
+    --issue_number 736 \
+    --expected_boundary stage_b_midi_to_solo_listening_review_quality_gap \
+    --expected_next_boundary stage_b_midi_to_solo_mvp_delivery_package \
+    --expected_target mvp_delivery_package \
+    --require_delivery_package_ready \
+    --require_no_quality_claim
+}
+
 run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision() {
   local quality_gap_run_id="${QUALITY_GAP_RUN_ID:-harness_stage_b_midi_to_solo_quality_gap_decision}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision}"
@@ -8221,6 +8244,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-quality-gap-decision)
     run_stage_b_midi_to_solo_quality_gap_decision
+    ;;
+  stage-b-midi-to-solo-listening-review-quality-gap)
+    run_stage_b_midi_to_solo_listening_review_quality_gap
     ;;
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision)
     run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision

--- a/scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py
+++ b/scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py
@@ -1,0 +1,400 @@
+"""Separate the remaining listening-review quality gap after technical MVP evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.decide_stage_b_midi_to_solo_quality_gap import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+    LISTENING_REVIEW_NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+    LISTENING_REVIEW_TARGET,
+)
+
+
+class StageBMidiToSoloListeningReviewQualityGapError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_listening_review_quality_gap"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_mvp_delivery_package"
+SELECTED_TARGET = "mvp_delivery_package"
+SCHEMA_VERSION = "stage_b_midi_to_solo_listening_review_quality_gap_v1"
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_quality_gap_decision(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    quality_gap = _dict(report.get("quality_gap"))
+    selected = _dict(report.get("selected_target"))
+    summary = _dict(report.get("mvp_completion_summary"))
+
+    if str(report.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloListeningReviewQualityGapError("quality gap decision boundary required")
+    if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "quality gap decision should route to listening review quality gap"
+        )
+    if not bool(readiness.get("quality_gap_decision_completed", False)):
+        raise StageBMidiToSoloListeningReviewQualityGapError("quality gap decision completion required")
+    if str(readiness.get("selected_target") or "") != LISTENING_REVIEW_TARGET:
+        raise StageBMidiToSoloListeningReviewQualityGapError("listening review target required")
+    if str(selected.get("selected_target") or "") != LISTENING_REVIEW_TARGET:
+        raise StageBMidiToSoloListeningReviewQualityGapError("selected listening target required")
+    if not bool(quality_gap.get("technical_model_core_mvp_completed", False)):
+        raise StageBMidiToSoloListeningReviewQualityGapError("technical model-core MVP completion required")
+    if not bool(quality_gap.get("phrase_bank_cli_technical_path_completed", False)):
+        raise StageBMidiToSoloListeningReviewQualityGapError("phrase-bank CLI technical path required")
+    if not bool(quality_gap.get("model_conditioned_pitch_contour_objective_completed", False)):
+        raise StageBMidiToSoloListeningReviewQualityGapError("pitch-contour objective completion required")
+    if not bool(
+        quality_gap.get(
+            "model_conditioned_pitch_contour_changed_ratio_repair_objective_completed",
+            False,
+        )
+    ):
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "changed-ratio repair objective completion required"
+        )
+    if not bool(quality_gap.get("pitch_contour_changed_ratio_repair_objective_path_ready", False)):
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "changed-ratio repair objective path readiness required"
+        )
+    if not bool(quality_gap.get("pitch_contour_changed_ratio_repair_target_supported", False)):
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "changed-ratio repair target support required"
+        )
+    if bool(quality_gap.get("model_conditioned_input_path_alignment_required", True)):
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "model-conditioned input path alignment should not be selected"
+        )
+    if bool(quality_gap.get("musical_quality_mvp_completed", True)):
+        raise StageBMidiToSoloListeningReviewQualityGapError("musical quality should remain incomplete")
+    if bool(quality_gap.get("human_audio_preference_completed", True)):
+        raise StageBMidiToSoloListeningReviewQualityGapError("human/audio preference should remain incomplete")
+    if bool(quality_gap.get("product_mvp_completed", True)):
+        raise StageBMidiToSoloListeningReviewQualityGapError("product MVP should remain incomplete")
+    if _int(
+        summary.get("model_conditioned_pitch_contour_changed_ratio_repair_rendered_audio_file_count")
+    ) < 3:
+        raise StageBMidiToSoloListeningReviewQualityGapError("changed-ratio repair rendered WAV count below 3")
+    if _int(summary.get("model_conditioned_pitch_contour_changed_ratio_repair_max_interval")) > _int(
+        summary.get("model_conditioned_pitch_contour_changed_ratio_repair_max_interval_threshold")
+    ):
+        raise StageBMidiToSoloListeningReviewQualityGapError("changed-ratio repair interval threshold exceeded")
+    if _float(
+        summary.get("model_conditioned_pitch_contour_changed_ratio_repair_max_pitch_changed_ratio")
+    ) > _float(
+        summary.get("model_conditioned_pitch_contour_changed_ratio_repair_target_max_pitch_changed_ratio")
+    ):
+        raise StageBMidiToSoloListeningReviewQualityGapError("changed-ratio repair ratio threshold exceeded")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloListeningReviewQualityGapError("critical user input should not be required")
+    _require_no_quality_claim(readiness, label="quality gap decision readiness")
+
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "technical_model_core_mvp_completed": True,
+        "phrase_bank_cli_technical_path_completed": True,
+        "model_conditioned_pitch_contour_objective_completed": True,
+        "changed_ratio_repair_objective_completed": True,
+        "fallback_path_active": bool(quality_gap.get("fallback_path_active", False)),
+        "model_conditioned_input_path_alignment_required": bool(
+            quality_gap.get("model_conditioned_input_path_alignment_required", False)
+        ),
+        "rendered_audio_file_count": _int(
+            summary.get("model_conditioned_pitch_contour_changed_ratio_repair_rendered_audio_file_count")
+        ),
+        "max_repaired_interval": _int(
+            summary.get("model_conditioned_pitch_contour_changed_ratio_repair_max_interval")
+        ),
+        "max_interval_threshold": _int(
+            summary.get("model_conditioned_pitch_contour_changed_ratio_repair_max_interval_threshold")
+        ),
+        "max_repaired_pitch_changed_ratio": _float(
+            summary.get("model_conditioned_pitch_contour_changed_ratio_repair_max_pitch_changed_ratio")
+        ),
+        "target_max_pitch_changed_ratio": _float(
+            summary.get("model_conditioned_pitch_contour_changed_ratio_repair_target_max_pitch_changed_ratio")
+        ),
+        "human_review_required_now": bool(quality_gap.get("human_review_required_now", False)),
+        "musical_quality_mvp_completed": False,
+        "human_audio_preference_completed": False,
+        "product_mvp_completed": False,
+    }
+
+
+def build_listening_review_quality_gap_report(
+    *,
+    quality_gap_decision: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+) -> dict[str, Any]:
+    source = validate_quality_gap_decision(quality_gap_decision)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundary": source["boundary"],
+        "quality_gap_summary": {
+            **source,
+            "listening_review_quality_gap_open": True,
+            "technical_mvp_delivery_package_ready": True,
+            "human_audio_preference_gap_open": True,
+            "musical_quality_gap_open": True,
+        },
+        "selected_next_target": {
+            "selected_target": SELECTED_TARGET,
+            "selected_next_boundary": NEXT_BOUNDARY,
+            "reason": (
+                "technical MIDI-to-solo path and changed-ratio repair objective evidence are ready; "
+                "delivery package can be prepared while listening and musical quality claims remain excluded"
+            ),
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "listening_review_quality_gap_completed": True,
+            "technical_mvp_delivery_package_ready": True,
+            "listening_review_quality_gap_open": True,
+            "human_review_required_now": False,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "listening review gap is open, but technical delivery package preparation does not require a quality claim",
+        },
+        "not_proven": [
+            "listening_review_completed",
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "audio_rendered_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "production_ready_improviser",
+        ],
+        "next_recommended_issue": "Stage B MIDI-to-solo MVP delivery package",
+    }
+
+
+def validate_listening_review_quality_gap_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    expected_target: str | None,
+    require_delivery_package_ready: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    selected = _dict(report.get("selected_next_target"))
+    summary = _dict(report.get("quality_gap_summary"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloListeningReviewQualityGapError("unexpected next boundary")
+    if expected_target and str(selected.get("selected_target") or "") != expected_target:
+        raise StageBMidiToSoloListeningReviewQualityGapError("unexpected selected target")
+    if not bool(readiness.get("listening_review_quality_gap_completed", False)):
+        raise StageBMidiToSoloListeningReviewQualityGapError("quality gap boundary completion required")
+    if require_delivery_package_ready and not bool(
+        readiness.get("technical_mvp_delivery_package_ready", False)
+    ):
+        raise StageBMidiToSoloListeningReviewQualityGapError("delivery package readiness required")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloListeningReviewQualityGapError("critical user input should not be required")
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="listening review quality gap readiness")
+    return {
+        "boundary": boundary,
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "selected_target": str(selected.get("selected_target") or ""),
+        "technical_model_core_mvp_completed": bool(
+            summary.get("technical_model_core_mvp_completed", False)
+        ),
+        "changed_ratio_repair_objective_completed": bool(
+            summary.get("changed_ratio_repair_objective_completed", False)
+        ),
+        "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
+        "max_repaired_interval": _int(summary.get("max_repaired_interval")),
+        "max_interval_threshold": _int(summary.get("max_interval_threshold")),
+        "max_repaired_pitch_changed_ratio": _float(summary.get("max_repaired_pitch_changed_ratio")),
+        "target_max_pitch_changed_ratio": _float(summary.get("target_max_pitch_changed_ratio")),
+        "listening_review_quality_gap_open": bool(
+            summary.get("listening_review_quality_gap_open", False)
+        ),
+        "technical_mvp_delivery_package_ready": bool(
+            readiness.get("technical_mvp_delivery_package_ready", False)
+        ),
+        "human_review_required_now": bool(readiness.get("human_review_required_now", True)),
+        "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["quality_gap_summary"]
+    selected = report["selected_next_target"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    lines = [
+        "# Stage B MIDI-to-Solo Listening Review Quality Gap",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- source boundary: `{report['source_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- selected target: `{selected['selected_target']}`",
+        f"- listening review quality gap open: `{_bool_token(summary['listening_review_quality_gap_open'])}`",
+        f"- technical MVP delivery package ready: `{_bool_token(summary['technical_mvp_delivery_package_ready'])}`",
+        f"- human review required now: `{_bool_token(readiness['human_review_required_now'])}`",
+        "",
+        "## Evidence",
+        "",
+        f"- technical model-core MVP completed: `{_bool_token(summary['technical_model_core_mvp_completed'])}`",
+        f"- phrase-bank CLI technical path completed: `{_bool_token(summary['phrase_bank_cli_technical_path_completed'])}`",
+        f"- model-conditioned pitch-contour objective completed: `{_bool_token(summary['model_conditioned_pitch_contour_objective_completed'])}`",
+        f"- changed-ratio repair objective completed: `{_bool_token(summary['changed_ratio_repair_objective_completed'])}`",
+        f"- rendered WAV files: `{summary['rendered_audio_file_count']}`",
+        f"- changed-ratio repair max interval / threshold: `{summary['max_repaired_interval']}` / `{summary['max_interval_threshold']}`",
+        f"- changed-ratio repair max ratio / target: `{summary['max_repaired_pitch_changed_ratio']:.4f}` / `{summary['target_max_pitch_changed_ratio']:.4f}`",
+        f"- musical quality MVP completed: `{_bool_token(summary['musical_quality_mvp_completed'])}`",
+        f"- human/audio preference completed: `{_bool_token(summary['human_audio_preference_completed'])}`",
+        f"- product MVP completed: `{_bool_token(summary['product_mvp_completed'])}`",
+        "",
+        "## Claim Boundary",
+        "",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        f"- broad trained model quality claimed: `{_bool_token(readiness['broad_trained_model_quality_claimed'])}`",
+        f"- Brad style adaptation claimed: `{_bool_token(readiness['brad_style_adaptation_claimed'])}`",
+        "",
+        "## Next",
+        "",
+        f"- `{report['next_recommended_issue']}`",
+    ]
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Decide remaining MIDI-to-solo listening review quality gap")
+    parser.add_argument("--quality_gap_decision", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_listening_review_quality_gap",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=736)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--expected_target", type=str, default="")
+    parser.add_argument("--require_delivery_package_ready", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_listening_review_quality_gap_report(
+        quality_gap_decision=read_json(Path(args.quality_gap_decision)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+    )
+    summary = validate_listening_review_quality_gap_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        expected_target=str(args.expected_target or ""),
+        require_delivery_package_ready=bool(args.require_delivery_package_ready),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "stage_b_midi_to_solo_listening_review_quality_gap.json", report)
+    write_json(
+        output_dir / "stage_b_midi_to_solo_listening_review_quality_gap_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_midi_to_solo_listening_review_quality_gap.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_listening_review_quality_gap.py
+++ b/tests/test_stage_b_midi_to_solo_listening_review_quality_gap.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.decide_stage_b_midi_to_solo_listening_review_quality_gap import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    SELECTED_TARGET,
+    StageBMidiToSoloListeningReviewQualityGapError,
+    build_listening_review_quality_gap_report,
+    validate_listening_review_quality_gap_report,
+)
+from scripts.decide_stage_b_midi_to_solo_quality_gap import (
+    BOUNDARY as QUALITY_GAP_BOUNDARY,
+    LISTENING_REVIEW_NEXT_BOUNDARY,
+    LISTENING_REVIEW_TARGET,
+)
+
+
+def quality_gap_decision(
+    *,
+    selected_target: str = LISTENING_REVIEW_TARGET,
+    next_boundary: str = LISTENING_REVIEW_NEXT_BOUNDARY,
+    quality_claim: bool = False,
+    changed_ratio_supported: bool = True,
+) -> dict:
+    return {
+        "boundary": QUALITY_GAP_BOUNDARY,
+        "quality_gap": {
+            "technical_model_core_mvp_completed": True,
+            "phrase_bank_cli_technical_path_completed": True,
+            "model_conditioned_pitch_contour_objective_completed": True,
+            "model_conditioned_pitch_contour_changed_ratio_repair_objective_completed": (
+                changed_ratio_supported
+            ),
+            "musical_quality_mvp_completed": False,
+            "human_audio_preference_completed": False,
+            "product_mvp_completed": False,
+            "fallback_path_active": True,
+            "model_conditioned_input_path_alignment_required": False,
+            "model_conditioned_pitch_contour_objective_path_ready": True,
+            "pitch_contour_changed_ratio_review_required": True,
+            "pitch_contour_changed_ratio_repair_objective_path_ready": (
+                changed_ratio_supported
+            ),
+            "pitch_contour_changed_ratio_repair_target_supported": changed_ratio_supported,
+            "human_review_required_now": False,
+        },
+        "mvp_completion_summary": {
+            "model_conditioned_pitch_contour_changed_ratio_repair_rendered_audio_file_count": 3,
+            "model_conditioned_pitch_contour_changed_ratio_repair_max_interval": (
+                12 if changed_ratio_supported else 13
+            ),
+            "model_conditioned_pitch_contour_changed_ratio_repair_max_interval_threshold": 12,
+            "model_conditioned_pitch_contour_changed_ratio_repair_max_pitch_changed_ratio": (
+                0.4348 if changed_ratio_supported else 0.7174
+            ),
+            "model_conditioned_pitch_contour_changed_ratio_repair_target_max_pitch_changed_ratio": 0.5,
+        },
+        "selected_target": {
+            "selected_target": selected_target,
+            "selected_next_boundary": next_boundary,
+            "fallback_path_active": True,
+            "human_review_required_now": False,
+        },
+        "readiness": {
+            "quality_gap_decision_completed": True,
+            "selected_target": selected_target,
+            "next_boundary_selected": next_boundary,
+            "human_review_required_now": False,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": quality_claim,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": next_boundary,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class StageBMidiToSoloListeningReviewQualityGapTest(unittest.TestCase):
+    def test_routes_to_mvp_delivery_package_without_quality_claim(self) -> None:
+        report = build_listening_review_quality_gap_report(
+            quality_gap_decision=quality_gap_decision(),
+            output_dir=Path("outputs/listening_review_quality_gap"),
+            issue_number=736,
+        )
+        summary = validate_listening_review_quality_gap_report(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=NEXT_BOUNDARY,
+            expected_target=SELECTED_TARGET,
+            require_delivery_package_ready=True,
+            require_no_quality_claim=True,
+        )
+
+        self.assertEqual(summary["selected_target"], SELECTED_TARGET)
+        self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
+        self.assertTrue(summary["technical_model_core_mvp_completed"])
+        self.assertTrue(summary["changed_ratio_repair_objective_completed"])
+        self.assertEqual(summary["rendered_audio_file_count"], 3)
+        self.assertEqual(summary["max_repaired_interval"], 12)
+        self.assertEqual(summary["max_interval_threshold"], 12)
+        self.assertAlmostEqual(summary["max_repaired_pitch_changed_ratio"], 0.4348, places=4)
+        self.assertAlmostEqual(summary["target_max_pitch_changed_ratio"], 0.5, places=4)
+        self.assertTrue(summary["listening_review_quality_gap_open"])
+        self.assertTrue(summary["technical_mvp_delivery_package_ready"])
+        self.assertFalse(summary["human_review_required_now"])
+        self.assertFalse(summary["human_audio_preference_claimed"])
+        self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+        self.assertFalse(summary["critical_user_input_required"])
+        self.assertEqual(
+            summary["next_recommended_issue"],
+            "Stage B MIDI-to-solo MVP delivery package",
+        )
+
+    def test_rejects_wrong_selected_target(self) -> None:
+        with self.assertRaises(StageBMidiToSoloListeningReviewQualityGapError):
+            build_listening_review_quality_gap_report(
+                quality_gap_decision=quality_gap_decision(selected_target="other_target"),
+                output_dir=Path("outputs/listening_review_quality_gap"),
+                issue_number=736,
+            )
+
+    def test_rejects_wrong_next_boundary(self) -> None:
+        with self.assertRaises(StageBMidiToSoloListeningReviewQualityGapError):
+            build_listening_review_quality_gap_report(
+                quality_gap_decision=quality_gap_decision(next_boundary="other_boundary"),
+                output_dir=Path("outputs/listening_review_quality_gap"),
+                issue_number=736,
+            )
+
+    def test_rejects_missing_changed_ratio_repair_support(self) -> None:
+        with self.assertRaises(StageBMidiToSoloListeningReviewQualityGapError):
+            build_listening_review_quality_gap_report(
+                quality_gap_decision=quality_gap_decision(changed_ratio_supported=False),
+                output_dir=Path("outputs/listening_review_quality_gap"),
+                issue_number=736,
+            )
+
+    def test_rejects_quality_claim(self) -> None:
+        with self.assertRaises(StageBMidiToSoloListeningReviewQualityGapError):
+            build_listening_review_quality_gap_report(
+                quality_gap_decision=quality_gap_decision(quality_claim=True),
+                output_dir=Path("outputs/listening_review_quality_gap"),
+                issue_number=736,
+            )
+
+    def test_boundary_constants_are_stable(self) -> None:
+        self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_listening_review_quality_gap")
+        self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_mvp_delivery_package")
+        self.assertEqual(SELECTED_TARGET, "mvp_delivery_package")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- listening review quality gap boundary added after Issue #734 quality gap decision
- objective repair evidence separated from human/audio preference and musical quality claims
- next boundary selected: `stage_b_midi_to_solo_mvp_delivery_package`

## Context

- source issue: #736
- source boundary: `stage_b_midi_to_solo_quality_gap_decision`
- selected target from source: `listening_review_quality_gap`
- technical model-core MVP completed: `true`
- changed-ratio repair objective completed: `true`
- changed-ratio repair max ratio / target: `0.4348` / `0.5000`
- changed-ratio repair max interval / target: `12` / `12`
- human/audio preference claimed: `false`
- MIDI-to-solo musical quality claimed: `false`

## Scope

- `scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py`
- `tests/test_stage_b_midi_to_solo_listening_review_quality_gap.py`
- `scripts/agent_harness.sh`
- `docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_2026-06-09.md`
- `docs/CURRENT_STATUS_AND_PLAN.md`
- `docs/CORE_PLAN.md`

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_listening_review_quality_gap`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-listening-review-quality-gap`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`
- broad trained model / Brad style adaptation claim: `false`

Closes #736
