### PR TITLE
Stage B MIDI-to-solo MVP delivery package

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -396,6 +396,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo MVP completion audit refresh: technical model-core MVP `true`, model-conditioned pitch-contour objective `true`, changed-ratio repair objective `true`, max interval/threshold `11/12`, changed-ratio repair ratio/target `0.4348/0.5000`, musical/product MVP `false/false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_gap_decision`
 - MIDI-to-solo quality gap decision refresh: selected target `listening_review_quality_gap`, fallback alignment required `false`, changed-ratio repair objective `true`, changed-ratio repair ratio/target `0.4348/0.5000`, changed-ratio repair interval/target `12/12`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_listening_review_quality_gap`
 - MIDI-to-solo listening review quality gap: selected target `mvp_delivery_package`, technical delivery package ready `true`, listening gap open `true`, changed-ratio repair ratio/target `0.4348/0.5000`, interval/target `12/12`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_delivery_package`
+- MIDI-to-solo MVP delivery package: runnable CLI `true`, input ranked MIDI `true`, rendered WAV evidence `true`, CLI/changed-ratio audio candidate count `3/3`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_readme_final_evidence_refresh`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
 - MIDI-to-solo pitch-contour changed-ratio repair probe: repaired/pass `3/3`, max pitch changed ratio `0.7174 -> 0.4348`, max interval `12`, dead-air max `0.0000`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
 - MIDI-to-solo pitch-contour changed-ratio repair audio package: rendered WAV `3`, duration `18.422s-18.978s`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
@@ -4199,6 +4200,42 @@ Issue #736은 Issue #734 quality gap decision 이후 남은 listening review qua
 다음 작업:
 
 - `Stage B MIDI-to-solo MVP delivery package`
+
+## 9.60 Stage B MIDI-to-solo MVP delivery package
+
+Issue #738은 Issue #736 listening review quality gap 이후 technical MVP 전달 manifest를 정리한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- next boundary: `stage_b_midi_to_solo_readme_final_evidence_refresh`
+- MVP delivery package completed: `true`
+- runnable CLI ready: `true`
+- input to ranked MIDI ready: `true`
+- input to rendered WAV evidence ready: `true`
+- changed-ratio repair audio evidence ready: `true`
+- CLI candidate count: `3`
+- changed-ratio repair WAV count: `3`
+- raw artifact upload required: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- 현재 technical MVP는 실행 명령과 evidence manifest 기준 전달 가능.
+- raw MIDI/WAV 업로드 없이 local output path 기준으로 추적.
+- listening review와 musical quality claim은 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_delivery_package`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_mvp_delivery_package.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-delivery-package`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo README final evidence refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #736, Stage B MIDI-to-solo listening review quality gap
-- 다음 권장 이슈: `Stage B MIDI-to-solo MVP delivery package`
+- latest functional result: Issue #738, Stage B MIDI-to-solo MVP delivery package
+- 다음 권장 이슈: `Stage B MIDI-to-solo README final evidence refresh`
 
 현재 범위가 아닌 것:
 
@@ -85,6 +85,7 @@
 - MVP completion audit에 changed-ratio repair objective path 포함 완료
 - quality gap decision을 listening review quality gap target으로 갱신 완료
 - listening review quality gap을 MVP delivery package target으로 분리 완료
+- MVP delivery package manifest 생성 완료
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 
@@ -1709,6 +1710,51 @@ Issue #736은 Issue #734 quality gap decision 이후 남은 listening review qua
 다음:
 
 - `Stage B MIDI-to-solo MVP delivery package`
+
+## Stage B MIDI-to-Solo MVP Delivery Package Result
+
+Issue #738은 Issue #736 listening review quality gap 이후 technical MVP 전달 manifest를 정리한 작업이다.
+
+변경:
+
+- MVP delivery package manifest script 추가
+- listening review quality gap, phrase-bank CLI package, changed-ratio repair audio package 검증 연결
+- runnable CLI command와 local MIDI/WAV evidence path 기록
+- raw artifact upload 없이 local artifact path만 manifest에 기록
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MVP_DELIVERY_PACKAGE_2026-06-09.md`
+- boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- next boundary: `stage_b_midi_to_solo_readme_final_evidence_refresh`
+- MVP delivery package completed: `true`
+- runnable CLI ready: `true`
+- input to ranked MIDI ready: `true`
+- input to rendered WAV evidence ready: `true`
+- changed-ratio repair audio evidence ready: `true`
+- CLI candidate count: `3`
+- changed-ratio repair WAV count: `3`
+- raw artifact upload required: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- 현재 technical MVP는 실행 명령과 evidence manifest 기준 전달 가능.
+- raw MIDI/WAV 업로드 없이 local output path 기준으로 추적.
+- listening review와 musical quality claim은 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_delivery_package`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_mvp_delivery_package.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-delivery-package`
+
+다음:
+
+- `Stage B MIDI-to-solo README final evidence refresh`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MVP_DELIVERY_PACKAGE_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MVP_DELIVERY_PACKAGE_2026-06-09.md
@@ -1,0 +1,38 @@
+# Stage B MIDI-to-Solo MVP Delivery Package
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- next boundary: `stage_b_midi_to_solo_readme_final_evidence_refresh`
+- technical MVP delivery package completed: `true`
+- runnable CLI ready: `true`
+- input to ranked MIDI ready: `true`
+- input to rendered WAV evidence ready: `true`
+- changed-ratio repair audio evidence ready: `true`
+- listening review quality gap open: `true`
+
+## Run Command
+
+- `.venv/bin/python scripts/run_stage_b_midi_to_solo_phrase_bank_cli_mvp_package.py --input_midi outputs/stage_b_midi_to_solo_phrase_bank_cli_mvp_package/harness_stage_b_midi_to_solo_phrase_bank_cli_mvp_package/input/fixture.mid --run_id harness_stage_b_midi_to_solo_phrase_bank_cli_mvp_package`
+
+## Evidence
+
+- CLI candidate count: `3`
+- CLI objective-supported candidate count: `3`
+- CLI dead-air ratio range: `0.1895` - `0.2211`
+- changed-ratio repair WAV count: `3`
+- changed-ratio repair max ratio / target: `0.4348` / `0.5000`
+- changed-ratio repair max interval / target: `12` / `12`
+- changed-ratio repair WAV duration range: `18.422s` - `18.978s`
+
+## Claim Boundary
+
+- raw artifact upload required: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- broad trained model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo README final evidence refresh`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -242,6 +242,8 @@ Modes:
                 Decide the next quality-gap repair target after technical MVP completion.
   stage-b-midi-to-solo-listening-review-quality-gap
                 Separate remaining listening-review quality gap after objective repair evidence.
+  stage-b-midi-to-solo-mvp-delivery-package
+                Build the current technical MVP delivery manifest and claim boundary.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision
                 Decide the next pitch-contour changed-ratio repair boundary.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-probe
@@ -5997,6 +5999,40 @@ run_stage_b_midi_to_solo_listening_review_quality_gap() {
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_mvp_delivery_package() {
+  local listening_gap_run_id="${LISTENING_GAP_RUN_ID:-harness_stage_b_midi_to_solo_listening_review_quality_gap}"
+  local cli_package_run_id="${CLI_PACKAGE_RUN_ID:-harness_stage_b_midi_to_solo_phrase_bank_cli_mvp_package}"
+  local changed_ratio_audio_run_id="${CHANGED_RATIO_AUDIO_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_mvp_delivery_package}"
+  local listening_gap="outputs/stage_b_midi_to_solo_listening_review_quality_gap/${listening_gap_run_id}/stage_b_midi_to_solo_listening_review_quality_gap.json"
+  local cli_package="outputs/stage_b_midi_to_solo_phrase_bank_cli_mvp_package/${cli_package_run_id}/stage_b_midi_to_solo_phrase_bank_cli_mvp_package.json"
+  local changed_ratio_audio="outputs/stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package/${changed_ratio_audio_run_id}/stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package.json"
+  if [[ ! -f "$listening_gap" ]]; then
+    print_header "Stage B MIDI-to-solo listening review quality gap"
+    RUN_ID="$listening_gap_run_id" run_stage_b_midi_to_solo_listening_review_quality_gap
+  fi
+  if [[ ! -f "$cli_package" ]]; then
+    print_header "Stage B MIDI-to-solo phrase-bank CLI MVP package"
+    RUN_ID="$cli_package_run_id" run_stage_b_midi_to_solo_phrase_bank_cli_mvp_package
+  fi
+  if [[ ! -f "$changed_ratio_audio" ]]; then
+    print_header "Stage B MIDI-to-solo changed-ratio repair audio package"
+    RUN_ID="$changed_ratio_audio_run_id" run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package
+  fi
+  print_header "Stage B MIDI-to-solo MVP delivery package"
+  "$PYTHON_BIN" scripts/build_stage_b_midi_to_solo_mvp_delivery_package.py \
+    --run_id "$run_id" \
+    --listening_review_quality_gap "$listening_gap" \
+    --cli_mvp_package "$cli_package" \
+    --changed_ratio_audio_package "$changed_ratio_audio" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_DELIVERY_PACKAGE_2026-06-09.md \
+    --issue_number 738 \
+    --expected_boundary stage_b_midi_to_solo_mvp_delivery_package \
+    --expected_next_boundary stage_b_midi_to_solo_readme_final_evidence_refresh \
+    --require_delivery_completed \
+    --require_no_quality_claim
+}
+
 run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision() {
   local quality_gap_run_id="${QUALITY_GAP_RUN_ID:-harness_stage_b_midi_to_solo_quality_gap_decision}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision}"
@@ -8247,6 +8283,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-listening-review-quality-gap)
     run_stage_b_midi_to_solo_listening_review_quality_gap
+    ;;
+  stage-b-midi-to-solo-mvp-delivery-package)
+    run_stage_b_midi_to_solo_mvp_delivery_package
     ;;
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision)
     run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision

--- a/scripts/build_stage_b_midi_to_solo_mvp_delivery_package.py
+++ b/scripts/build_stage_b_midi_to_solo_mvp_delivery_package.py
@@ -1,0 +1,502 @@
+"""Build a delivery manifest for the current MIDI-to-solo technical MVP."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.decide_stage_b_midi_to_solo_listening_review_quality_gap import (  # noqa: E402
+    BOUNDARY as LISTENING_GAP_BOUNDARY,
+    NEXT_BOUNDARY as LISTENING_GAP_NEXT_BOUNDARY,
+)
+from scripts.run_stage_b_midi_to_solo_phrase_bank_cli_mvp_package import (  # noqa: E402
+    BOUNDARY as CLI_PACKAGE_BOUNDARY,
+)
+
+
+class StageBMidiToSoloMvpDeliveryPackageError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_mvp_delivery_package"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_readme_final_evidence_refresh"
+SCHEMA_VERSION = "stage_b_midi_to_solo_mvp_delivery_package_v1"
+CHANGED_RATIO_AUDIO_BOUNDARY = (
+    "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package"
+)
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "phrase_bank_musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def _require_existing_file(path: str, *, label: str) -> str:
+    if not path:
+        raise StageBMidiToSoloMvpDeliveryPackageError(f"{label} path required")
+    if not Path(path).exists():
+        raise StageBMidiToSoloMvpDeliveryPackageError(f"{label} missing: {path}")
+    return path
+
+
+def validate_listening_gap(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("quality_gap_summary"))
+    if str(report.get("boundary") or "") != LISTENING_GAP_BOUNDARY:
+        raise StageBMidiToSoloMvpDeliveryPackageError("listening review quality gap boundary required")
+    if str(decision.get("next_boundary") or "") != LISTENING_GAP_NEXT_BOUNDARY:
+        raise StageBMidiToSoloMvpDeliveryPackageError("listening gap must route to MVP delivery package")
+    if not bool(readiness.get("listening_review_quality_gap_completed", False)):
+        raise StageBMidiToSoloMvpDeliveryPackageError("listening review quality gap completion required")
+    if not bool(readiness.get("technical_mvp_delivery_package_ready", False)):
+        raise StageBMidiToSoloMvpDeliveryPackageError("technical MVP delivery package readiness required")
+    if not bool(summary.get("technical_model_core_mvp_completed", False)):
+        raise StageBMidiToSoloMvpDeliveryPackageError("technical model-core MVP completion required")
+    if not bool(summary.get("changed_ratio_repair_objective_completed", False)):
+        raise StageBMidiToSoloMvpDeliveryPackageError("changed-ratio repair objective completion required")
+    if _int(summary.get("rendered_audio_file_count")) < 3:
+        raise StageBMidiToSoloMvpDeliveryPackageError("changed-ratio repair rendered WAV count below 3")
+    if _int(summary.get("max_repaired_interval")) > _int(summary.get("max_interval_threshold")):
+        raise StageBMidiToSoloMvpDeliveryPackageError("changed-ratio repair interval threshold exceeded")
+    if _float(summary.get("max_repaired_pitch_changed_ratio")) > _float(
+        summary.get("target_max_pitch_changed_ratio")
+    ):
+        raise StageBMidiToSoloMvpDeliveryPackageError("changed-ratio repair ratio threshold exceeded")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloMvpDeliveryPackageError("critical user input should not be required")
+    _require_no_quality_claim(readiness, label="listening gap readiness")
+    return {
+        "technical_model_core_mvp_completed": True,
+        "changed_ratio_repair_objective_completed": True,
+        "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
+        "max_repaired_interval": _int(summary.get("max_repaired_interval")),
+        "max_interval_threshold": _int(summary.get("max_interval_threshold")),
+        "max_repaired_pitch_changed_ratio": _float(summary.get("max_repaired_pitch_changed_ratio")),
+        "target_max_pitch_changed_ratio": _float(summary.get("target_max_pitch_changed_ratio")),
+        "listening_review_quality_gap_open": bool(
+            summary.get("listening_review_quality_gap_open", False)
+        ),
+    }
+
+
+def validate_cli_package(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    cli = _dict(report.get("cli"))
+    objective = _dict(report.get("objective_summary"))
+    package_input = _dict(report.get("input"))
+    candidates = [_dict(item) for item in _list(report.get("candidate_manifest"))]
+    if str(report.get("boundary") or "") != CLI_PACKAGE_BOUNDARY:
+        raise StageBMidiToSoloMvpDeliveryPackageError("phrase-bank CLI MVP package boundary required")
+    if not bool(readiness.get("cli_mvp_package_completed", False)):
+        raise StageBMidiToSoloMvpDeliveryPackageError("CLI MVP package completion required")
+    if not bool(objective.get("cli_mvp_package_ready", False)):
+        raise StageBMidiToSoloMvpDeliveryPackageError("CLI MVP package ready flag required")
+    if _int(objective.get("candidate_count")) < 3:
+        raise StageBMidiToSoloMvpDeliveryPackageError("CLI candidate count below 3")
+    if _int(objective.get("objective_supported_candidate_count")) != _int(
+        objective.get("candidate_count")
+    ):
+        raise StageBMidiToSoloMvpDeliveryPackageError("CLI objective support count mismatch")
+    if not str(cli.get("command") or ""):
+        raise StageBMidiToSoloMvpDeliveryPackageError("CLI command required")
+    input_midi = _require_existing_file(str(package_input.get("midi_path") or ""), label="CLI input MIDI")
+    rows: list[dict[str, Any]] = []
+    for item in candidates:
+        repaired_midi = _require_existing_file(
+            str(item.get("repaired_midi_path") or ""),
+            label="CLI repaired MIDI",
+        )
+        rows.append(
+            {
+                "rank": _int(item.get("rank")),
+                "repaired_midi_path": repaired_midi,
+                "note_count": _int(item.get("note_count")),
+                "unique_pitch_count": _int(item.get("unique_pitch_count")),
+                "dead_air_ratio": _float(item.get("dead_air_ratio")),
+                "objective_supported": bool(item.get("objective_supported", False)),
+            }
+        )
+    if len(rows) < 3:
+        raise StageBMidiToSoloMvpDeliveryPackageError("CLI repaired MIDI candidates below 3")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloMvpDeliveryPackageError("CLI package critical user input should be false")
+    _require_no_quality_claim(readiness, label="CLI package readiness")
+    return {
+        "input_midi": input_midi,
+        "cli_script": str(cli.get("script") or ""),
+        "cli_command": str(cli.get("command") or ""),
+        "candidate_count": _int(objective.get("candidate_count")),
+        "objective_supported_candidate_count": _int(
+            objective.get("objective_supported_candidate_count")
+        ),
+        "min_dead_air_ratio": _float(objective.get("min_dead_air_ratio")),
+        "max_dead_air_ratio": _float(objective.get("max_dead_air_ratio")),
+        "candidate_manifest": rows,
+    }
+
+
+def validate_changed_ratio_audio_package(report: dict[str, Any]) -> dict[str, Any]:
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("summary"))
+    source_summary = _dict(report.get("source_summary"))
+    audio_files = [_dict(item) for item in _list(report.get("rendered_audio_files"))]
+    if str(decision.get("current_boundary") or "") != CHANGED_RATIO_AUDIO_BOUNDARY:
+        raise StageBMidiToSoloMvpDeliveryPackageError("changed-ratio audio boundary required")
+    if _int(summary.get("rendered_audio_file_count")) < 3:
+        raise StageBMidiToSoloMvpDeliveryPackageError("changed-ratio audio rendered count below 3")
+    if not bool(summary.get("technical_wav_validation", False)):
+        raise StageBMidiToSoloMvpDeliveryPackageError("changed-ratio audio technical validation required")
+    if not bool(source_summary.get("changed_ratio_repair_passed", False)):
+        raise StageBMidiToSoloMvpDeliveryPackageError("changed-ratio repair pass required")
+    if _float(source_summary.get("repaired_max_pitch_changed_ratio")) > _float(
+        source_summary.get("max_pitch_changed_ratio")
+    ):
+        raise StageBMidiToSoloMvpDeliveryPackageError("changed-ratio repair ratio threshold exceeded")
+    rows: list[dict[str, Any]] = []
+    for item in audio_files:
+        wav_file = _dict(item.get("wav_file"))
+        wav_path = _require_existing_file(str(wav_file.get("path") or ""), label="changed-ratio WAV")
+        repaired_midi = _require_existing_file(
+            str(item.get("repaired_midi_path") or ""),
+            label="changed-ratio repaired MIDI",
+        )
+        rows.append(
+            {
+                "rank": _int(item.get("rank")),
+                "repaired_midi_path": repaired_midi,
+                "wav_path": wav_path,
+                "duration_seconds": _float(wav_file.get("duration_seconds")),
+                "sample_rate": _int(wav_file.get("sample_rate")),
+                "pitch_changed_ratio": _float(item.get("pitch_changed_ratio")),
+                "repaired_max_interval": _int(item.get("repaired_max_interval")),
+                "repaired_unique_pitch_count": _int(item.get("repaired_unique_pitch_count")),
+            }
+        )
+    if len(rows) < 3:
+        raise StageBMidiToSoloMvpDeliveryPackageError("changed-ratio WAV rows below 3")
+    durations = [_float(item.get("duration_seconds")) for item in rows]
+    return {
+        "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
+        "technical_wav_validation": bool(summary.get("technical_wav_validation", False)),
+        "duration_min_seconds": min(durations) if durations else 0.0,
+        "duration_max_seconds": max(durations) if durations else 0.0,
+        "repaired_max_pitch_changed_ratio": _float(
+            source_summary.get("repaired_max_pitch_changed_ratio")
+        ),
+        "target_max_pitch_changed_ratio": _float(source_summary.get("max_pitch_changed_ratio")),
+        "repaired_max_interval": _int(source_summary.get("repaired_max_interval")),
+        "target_max_interval": _int(source_summary.get("target_max_interval")),
+        "audio_manifest": rows,
+    }
+
+
+def build_delivery_package_report(
+    *,
+    listening_review_quality_gap: dict[str, Any],
+    cli_mvp_package: dict[str, Any],
+    changed_ratio_audio_package: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+) -> dict[str, Any]:
+    listening = validate_listening_gap(listening_review_quality_gap)
+    cli = validate_cli_package(cli_mvp_package)
+    audio = validate_changed_ratio_audio_package(changed_ratio_audio_package)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundaries": {
+            "listening_review_quality_gap": LISTENING_GAP_BOUNDARY,
+            "phrase_bank_cli_mvp_package": CLI_PACKAGE_BOUNDARY,
+            "changed_ratio_repair_audio_package": CHANGED_RATIO_AUDIO_BOUNDARY,
+        },
+        "delivery_package": {
+            "technical_mvp_delivery_package_completed": True,
+            "runnable_cli_ready": True,
+            "input_to_ranked_midi_ready": True,
+            "input_to_rendered_wav_evidence_ready": True,
+            "changed_ratio_repair_audio_evidence_ready": True,
+            "listening_review_quality_gap_open": bool(
+                listening["listening_review_quality_gap_open"]
+            ),
+            "cli_command": cli["cli_command"],
+            "cli_input_midi": cli["input_midi"],
+            "cli_candidate_count": cli["candidate_count"],
+            "cli_objective_supported_candidate_count": cli[
+                "objective_supported_candidate_count"
+            ],
+            "cli_dead_air_ratio_range": [
+                cli["min_dead_air_ratio"],
+                cli["max_dead_air_ratio"],
+            ],
+            "changed_ratio_repair_wav_count": audio["rendered_audio_file_count"],
+            "changed_ratio_repair_ratio_target": [
+                audio["repaired_max_pitch_changed_ratio"],
+                audio["target_max_pitch_changed_ratio"],
+            ],
+            "changed_ratio_repair_interval_target": [
+                audio["repaired_max_interval"],
+                audio["target_max_interval"],
+            ],
+            "changed_ratio_repair_wav_duration_range": [
+                audio["duration_min_seconds"],
+                audio["duration_max_seconds"],
+            ],
+        },
+        "artifact_manifest": {
+            "cli_repaired_midi_candidates": cli["candidate_manifest"],
+            "changed_ratio_repair_audio_candidates": audio["audio_manifest"],
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "mvp_delivery_package_completed": True,
+            "technical_mvp_delivery_package_completed": True,
+            "runnable_cli_ready": True,
+            "local_artifact_paths_recorded": True,
+            "raw_artifact_upload_required": False,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "phrase_bank_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "technical MVP delivery package is recorded; refresh README final evidence without quality claims",
+        },
+        "not_proven": [
+            "listening_review_completed",
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "audio_rendered_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+            "production_ready_improviser",
+        ],
+        "next_recommended_issue": "Stage B MIDI-to-solo README final evidence refresh",
+    }
+
+
+def validate_delivery_package_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_delivery_completed: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    package = _dict(report.get("delivery_package"))
+    artifact_manifest = _dict(report.get("artifact_manifest"))
+    cli_candidates = _list(artifact_manifest.get("cli_repaired_midi_candidates"))
+    audio_candidates = _list(artifact_manifest.get("changed_ratio_repair_audio_candidates"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloMvpDeliveryPackageError("unexpected next boundary")
+    if require_delivery_completed and not bool(
+        readiness.get("mvp_delivery_package_completed", False)
+    ):
+        raise StageBMidiToSoloMvpDeliveryPackageError("MVP delivery package completion required")
+    if not bool(package.get("runnable_cli_ready", False)):
+        raise StageBMidiToSoloMvpDeliveryPackageError("runnable CLI readiness required")
+    if _int(package.get("cli_candidate_count")) < 3 or len(cli_candidates) < 3:
+        raise StageBMidiToSoloMvpDeliveryPackageError("CLI candidate manifest below 3")
+    if _int(package.get("changed_ratio_repair_wav_count")) < 3 or len(audio_candidates) < 3:
+        raise StageBMidiToSoloMvpDeliveryPackageError("changed-ratio audio manifest below 3")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloMvpDeliveryPackageError("critical user input should not be required")
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="MVP delivery package readiness")
+    return {
+        "boundary": boundary,
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "mvp_delivery_package_completed": bool(
+            readiness.get("mvp_delivery_package_completed", False)
+        ),
+        "runnable_cli_ready": bool(package.get("runnable_cli_ready", False)),
+        "input_to_ranked_midi_ready": bool(package.get("input_to_ranked_midi_ready", False)),
+        "input_to_rendered_wav_evidence_ready": bool(
+            package.get("input_to_rendered_wav_evidence_ready", False)
+        ),
+        "changed_ratio_repair_audio_evidence_ready": bool(
+            package.get("changed_ratio_repair_audio_evidence_ready", False)
+        ),
+        "cli_candidate_count": _int(package.get("cli_candidate_count")),
+        "changed_ratio_repair_wav_count": _int(package.get("changed_ratio_repair_wav_count")),
+        "listening_review_quality_gap_open": bool(
+            package.get("listening_review_quality_gap_open", False)
+        ),
+        "raw_artifact_upload_required": bool(readiness.get("raw_artifact_upload_required", True)),
+        "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    package = report["delivery_package"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    lines = [
+        "# Stage B MIDI-to-Solo MVP Delivery Package",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- technical MVP delivery package completed: `{_bool_token(package['technical_mvp_delivery_package_completed'])}`",
+        f"- runnable CLI ready: `{_bool_token(package['runnable_cli_ready'])}`",
+        f"- input to ranked MIDI ready: `{_bool_token(package['input_to_ranked_midi_ready'])}`",
+        f"- input to rendered WAV evidence ready: `{_bool_token(package['input_to_rendered_wav_evidence_ready'])}`",
+        f"- changed-ratio repair audio evidence ready: `{_bool_token(package['changed_ratio_repair_audio_evidence_ready'])}`",
+        f"- listening review quality gap open: `{_bool_token(package['listening_review_quality_gap_open'])}`",
+        "",
+        "## Run Command",
+        "",
+        f"- `{package['cli_command']}`",
+        "",
+        "## Evidence",
+        "",
+        f"- CLI candidate count: `{package['cli_candidate_count']}`",
+        f"- CLI objective-supported candidate count: `{package['cli_objective_supported_candidate_count']}`",
+        f"- CLI dead-air ratio range: `{package['cli_dead_air_ratio_range'][0]:.4f}` - `{package['cli_dead_air_ratio_range'][1]:.4f}`",
+        f"- changed-ratio repair WAV count: `{package['changed_ratio_repair_wav_count']}`",
+        f"- changed-ratio repair max ratio / target: `{package['changed_ratio_repair_ratio_target'][0]:.4f}` / `{package['changed_ratio_repair_ratio_target'][1]:.4f}`",
+        f"- changed-ratio repair max interval / target: `{package['changed_ratio_repair_interval_target'][0]}` / `{package['changed_ratio_repair_interval_target'][1]}`",
+        f"- changed-ratio repair WAV duration range: `{package['changed_ratio_repair_wav_duration_range'][0]:.3f}s` - `{package['changed_ratio_repair_wav_duration_range'][1]:.3f}s`",
+        "",
+        "## Claim Boundary",
+        "",
+        f"- raw artifact upload required: `{_bool_token(readiness['raw_artifact_upload_required'])}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        f"- broad trained model quality claimed: `{_bool_token(readiness['broad_trained_model_quality_claimed'])}`",
+        f"- Brad style adaptation claimed: `{_bool_token(readiness['brad_style_adaptation_claimed'])}`",
+        "",
+        "## Next",
+        "",
+        f"- `{report['next_recommended_issue']}`",
+    ]
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build MIDI-to-solo MVP delivery package manifest")
+    parser.add_argument("--listening_review_quality_gap", type=str, required=True)
+    parser.add_argument("--cli_mvp_package", type=str, required=True)
+    parser.add_argument("--changed_ratio_audio_package", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_mvp_delivery_package",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=738)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_delivery_completed", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_delivery_package_report(
+        listening_review_quality_gap=read_json(Path(args.listening_review_quality_gap)),
+        cli_mvp_package=read_json(Path(args.cli_mvp_package)),
+        changed_ratio_audio_package=read_json(Path(args.changed_ratio_audio_package)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+    )
+    summary = validate_delivery_package_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_delivery_completed=bool(args.require_delivery_completed),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "stage_b_midi_to_solo_mvp_delivery_package.json", report)
+    write_json(output_dir / "stage_b_midi_to_solo_mvp_delivery_package_validation_summary.json", summary)
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_midi_to_solo_mvp_delivery_package.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_mvp_delivery_package.py
+++ b/tests/test_stage_b_midi_to_solo_mvp_delivery_package.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.build_stage_b_midi_to_solo_mvp_delivery_package import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloMvpDeliveryPackageError,
+    build_delivery_package_report,
+    validate_delivery_package_report,
+)
+from scripts.decide_stage_b_midi_to_solo_listening_review_quality_gap import (
+    BOUNDARY as LISTENING_GAP_BOUNDARY,
+    NEXT_BOUNDARY as LISTENING_GAP_NEXT_BOUNDARY,
+)
+from scripts.run_stage_b_midi_to_solo_phrase_bank_cli_mvp_package import (
+    BOUNDARY as CLI_PACKAGE_BOUNDARY,
+)
+
+
+def touch(path: Path) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"fixture")
+    return str(path)
+
+
+def listening_gap_report(*, quality_claim: bool = False) -> dict:
+    return {
+        "boundary": LISTENING_GAP_BOUNDARY,
+        "quality_gap_summary": {
+            "technical_model_core_mvp_completed": True,
+            "changed_ratio_repair_objective_completed": True,
+            "rendered_audio_file_count": 3,
+            "max_repaired_interval": 12,
+            "max_interval_threshold": 12,
+            "max_repaired_pitch_changed_ratio": 0.4348,
+            "target_max_pitch_changed_ratio": 0.5,
+            "listening_review_quality_gap_open": True,
+        },
+        "readiness": {
+            "listening_review_quality_gap_completed": True,
+            "technical_mvp_delivery_package_ready": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": quality_claim,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": LISTENING_GAP_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+def cli_package_report(tmp_path: Path, *, quality_claim: bool = False) -> dict:
+    input_midi = touch(tmp_path / "input" / "fixture.mid")
+    candidates = []
+    for rank in range(1, 4):
+        candidates.append(
+            {
+                "rank": rank,
+                "repaired_midi_path": touch(tmp_path / "cli" / f"rank_{rank:02d}.mid"),
+                "note_count": 96,
+                "unique_pitch_count": 20 + rank,
+                "dead_air_ratio": 0.18 + (rank * 0.01),
+                "objective_supported": True,
+            }
+        )
+    return {
+        "boundary": CLI_PACKAGE_BOUNDARY,
+        "input": {"midi_path": input_midi},
+        "cli": {
+            "script": "scripts/run_stage_b_midi_to_solo_phrase_bank_cli_mvp_package.py",
+            "command": ".venv/bin/python scripts/run_stage_b_midi_to_solo_phrase_bank_cli_mvp_package.py --input_midi input.mid",
+        },
+        "objective_summary": {
+            "candidate_count": 3,
+            "objective_supported_candidate_count": 3,
+            "cli_mvp_package_ready": True,
+            "min_dead_air_ratio": 0.19,
+            "max_dead_air_ratio": 0.22,
+        },
+        "candidate_manifest": candidates,
+        "readiness": {
+            "cli_mvp_package_completed": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": quality_claim,
+            "phrase_bank_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {"critical_user_input_required": False},
+    }
+
+
+def changed_ratio_audio_report(tmp_path: Path, *, rendered_count: int = 3) -> dict:
+    rendered = []
+    for rank in range(1, rendered_count + 1):
+        rendered.append(
+            {
+                "rank": rank,
+                "repaired_midi_path": touch(tmp_path / "changed_ratio" / f"rank_{rank:02d}.mid"),
+                "repaired_max_interval": 12,
+                "repaired_unique_pitch_count": 23 + rank,
+                "pitch_changed_ratio": 0.43 - (rank * 0.02),
+                "wav_file": {
+                    "path": touch(tmp_path / "changed_ratio" / f"rank_{rank:02d}.wav"),
+                    "duration_seconds": 18.4 + rank,
+                    "sample_rate": 44100,
+                },
+            }
+        )
+    return {
+        "summary": {
+            "rendered_audio_file_count": rendered_count,
+            "technical_wav_validation": True,
+            "duration_min_seconds": 18.4,
+            "duration_max_seconds": 19.0,
+        },
+        "source_summary": {
+            "changed_ratio_repair_passed": True,
+            "repaired_max_pitch_changed_ratio": 0.4348,
+            "max_pitch_changed_ratio": 0.5,
+            "repaired_max_interval": 12,
+            "target_max_interval": 12,
+        },
+        "rendered_audio_files": rendered,
+        "decision": {
+            "current_boundary": "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package",
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class StageBMidiToSoloMvpDeliveryPackageTest(unittest.TestCase):
+    def test_builds_delivery_package_manifest_without_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            report = build_delivery_package_report(
+                listening_review_quality_gap=listening_gap_report(),
+                cli_mvp_package=cli_package_report(tmp_path),
+                changed_ratio_audio_package=changed_ratio_audio_report(tmp_path),
+                output_dir=tmp_path / "delivery",
+                issue_number=738,
+            )
+            summary = validate_delivery_package_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                require_delivery_completed=True,
+                require_no_quality_claim=True,
+            )
+
+        self.assertTrue(summary["mvp_delivery_package_completed"])
+        self.assertTrue(summary["runnable_cli_ready"])
+        self.assertTrue(summary["input_to_ranked_midi_ready"])
+        self.assertTrue(summary["input_to_rendered_wav_evidence_ready"])
+        self.assertTrue(summary["changed_ratio_repair_audio_evidence_ready"])
+        self.assertEqual(summary["cli_candidate_count"], 3)
+        self.assertEqual(summary["changed_ratio_repair_wav_count"], 3)
+        self.assertTrue(summary["listening_review_quality_gap_open"])
+        self.assertFalse(summary["raw_artifact_upload_required"])
+        self.assertFalse(summary["human_audio_preference_claimed"])
+        self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+        self.assertEqual(
+            summary["next_recommended_issue"],
+            "Stage B MIDI-to-solo README final evidence refresh",
+        )
+
+    def test_rejects_listening_gap_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            with self.assertRaises(StageBMidiToSoloMvpDeliveryPackageError):
+                build_delivery_package_report(
+                    listening_review_quality_gap=listening_gap_report(quality_claim=True),
+                    cli_mvp_package=cli_package_report(tmp_path),
+                    changed_ratio_audio_package=changed_ratio_audio_report(tmp_path),
+                    output_dir=tmp_path / "delivery",
+                    issue_number=738,
+                )
+
+    def test_rejects_cli_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            with self.assertRaises(StageBMidiToSoloMvpDeliveryPackageError):
+                build_delivery_package_report(
+                    listening_review_quality_gap=listening_gap_report(),
+                    cli_mvp_package=cli_package_report(tmp_path, quality_claim=True),
+                    changed_ratio_audio_package=changed_ratio_audio_report(tmp_path),
+                    output_dir=tmp_path / "delivery",
+                    issue_number=738,
+                )
+
+    def test_rejects_missing_changed_ratio_audio_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            with self.assertRaises(StageBMidiToSoloMvpDeliveryPackageError):
+                build_delivery_package_report(
+                    listening_review_quality_gap=listening_gap_report(),
+                    cli_mvp_package=cli_package_report(tmp_path),
+                    changed_ratio_audio_package=changed_ratio_audio_report(tmp_path, rendered_count=2),
+                    output_dir=tmp_path / "delivery",
+                    issue_number=738,
+                )
+
+    def test_boundary_constants_are_stable(self) -> None:
+        self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_mvp_delivery_package")
+        self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_readme_final_evidence_refresh")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- MVP delivery package manifest added after Issue #736 listening review quality gap
- runnable CLI command and local MIDI/WAV evidence paths recorded
- next boundary selected: `stage_b_midi_to_solo_readme_final_evidence_refresh`

## Context

- source issue: #738
- source boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
- selected target from source: `mvp_delivery_package`
- runnable CLI ready: `true`
- input to ranked MIDI ready: `true`
- input to rendered WAV evidence ready: `true`
- changed-ratio repair audio evidence ready: `true`
- CLI / changed-ratio audio candidate count: `3` / `3`
- raw artifact upload required: `false`
- human/audio preference claimed: `false`
- MIDI-to-solo musical quality claimed: `false`

## Scope

- `scripts/build_stage_b_midi_to_solo_mvp_delivery_package.py`
- `tests/test_stage_b_midi_to_solo_mvp_delivery_package.py`
- `scripts/agent_harness.sh`
- `docs/STAGE_B_MIDI_TO_SOLO_MVP_DELIVERY_PACKAGE_2026-06-09.md`
- `docs/CURRENT_STATUS_AND_PLAN.md`
- `docs/CORE_PLAN.md`

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_delivery_package`
- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_mvp_delivery_package.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-delivery-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- raw MIDI/WAV artifact upload: `false`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`
- broad trained model / Brad style adaptation claim: `false`

Closes #738
