### PR TITLE
Stage B MIDI-to-solo README final evidence refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
-- selected quality gap target: `model_conditioned_pitch_contour_changed_ratio_review`
+- selected quality gap target: `mvp_delivery_package`
 - model-conditioned input path aligned: `false`
 - model-conditioned candidate source available: `true`
 - model-conditioned audio technical path available: `true`
@@ -108,7 +108,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - MVP completion audit model-conditioned pitch-contour objective included: `true`
 - MVP completion audit changed-ratio repair objective included: `true`
 - quality gap decision completed: `true`
-- quality gap decision pitch-contour changed-ratio target selected: `true`
+- quality gap decision listening review target selected: `true`
 - pitch-contour changed-ratio review decision completed: `true`
 - pitch-contour changed-ratio repair probe required: `true`
 - pitch-contour changed-ratio repair probe completed: `true`
@@ -129,8 +129,18 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - pitch-contour changed-ratio repair max interval / target: `12 / 12`
 - pitch-contour changed-ratio repair max pitch changed ratio / target: `0.4348 / 0.5000`
 - current evidence changed-ratio repair objective path included: `true`
+- listening review quality gap completed: `true`
+- listening review quality gap open: `true`
+- MVP delivery package completed: `true`
+- runnable CLI ready: `true`
+- input to ranked MIDI ready: `true`
+- input to rendered WAV evidence ready: `true`
+- changed-ratio repair audio evidence ready: `true`
+- MVP delivery CLI candidates: `3`
+- MVP delivery changed-ratio repair WAV files: `3`
+- MVP delivery raw artifact upload required: `false`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- next boundary: `stage_b_midi_to_solo_readme_final_evidence_refresh`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`
@@ -189,6 +199,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned pitch-contour changed-ratio review input pending 상태에서 preference fill 차단 가능
 - model-conditioned pitch-contour changed-ratio objective evidence 기준 current evidence consolidation 경계 결정 가능
 - model-conditioned pitch-contour changed-ratio objective path를 current evidence로 통합 가능
+- listening review quality gap을 delivery package 경계로 분리 가능
+- runnable CLI command와 local MIDI/WAV evidence path를 delivery manifest로 기록 가능
+- raw MIDI/WAV artifact upload 없이 local output path 기준 MVP delivery package 기록 가능
 
 현재 README가 주장하지 않는 것.
 
@@ -217,8 +230,8 @@ MVP completion audit.
 Quality gap decision.
 
 - boundary: `stage_b_midi_to_solo_quality_gap_decision`
-- next boundary: `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision`
-- selected target: `model_conditioned_pitch_contour_changed_ratio_review`
+- next boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- selected target: `listening_review_quality_gap`
 - fallback path active: `true`
 - model-conditioned input path alignment required: `false`
 - phrase-bank CLI technical path completed: `true`
@@ -232,6 +245,38 @@ Quality gap decision.
 - CLI candidate / rendered WAV: `3 / 3`
 - CLI preference fill allowed: `false`
 - human review required now: `false`
+
+Listening review quality gap.
+
+- boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- next boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- selected target: `mvp_delivery_package`
+- technical model-core MVP completed: `true`
+- changed-ratio repair objective completed: `true`
+- changed-ratio repair max ratio / target: `0.4348 / 0.5000`
+- changed-ratio repair max interval / target: `12 / 12`
+- listening review quality gap open: `true`
+- technical MVP delivery package ready: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+MVP delivery package.
+
+- boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- next boundary: `stage_b_midi_to_solo_readme_final_evidence_refresh`
+- runnable CLI ready: `true`
+- input to ranked MIDI ready: `true`
+- input to rendered WAV evidence ready: `true`
+- changed-ratio repair audio evidence ready: `true`
+- CLI candidate count: `3`
+- changed-ratio repair WAV count: `3`
+- CLI dead-air ratio range: `0.1895 - 0.2211`
+- changed-ratio repair max ratio / target: `0.4348 / 0.5000`
+- changed-ratio repair max interval / target: `12 / 12`
+- changed-ratio repair WAV duration range: `18.422s - 18.978s`
+- raw artifact upload required: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
 
 Pitch-contour changed-ratio review decision.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -397,6 +397,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo quality gap decision refresh: selected target `listening_review_quality_gap`, fallback alignment required `false`, changed-ratio repair objective `true`, changed-ratio repair ratio/target `0.4348/0.5000`, changed-ratio repair interval/target `12/12`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_listening_review_quality_gap`
 - MIDI-to-solo listening review quality gap: selected target `mvp_delivery_package`, technical delivery package ready `true`, listening gap open `true`, changed-ratio repair ratio/target `0.4348/0.5000`, interval/target `12/12`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_delivery_package`
 - MIDI-to-solo MVP delivery package: runnable CLI `true`, input ranked MIDI `true`, rendered WAV evidence `true`, CLI/changed-ratio audio candidate count `3/3`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_readme_final_evidence_refresh`
+- MIDI-to-solo README final evidence refresh: latest evidence boundary `stage_b_midi_to_solo_mvp_delivery_package`, runnable CLI `true`, input ranked MIDI/WAV evidence `true/true`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_final_status_audit`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
 - MIDI-to-solo pitch-contour changed-ratio repair probe: repaired/pass `3/3`, max pitch changed ratio `0.7174 -> 0.4348`, max interval `12`, dead-air max `0.0000`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
 - MIDI-to-solo pitch-contour changed-ratio repair audio package: rendered WAV `3`, duration `18.422s-18.978s`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
@@ -4236,6 +4237,40 @@ Issue #738은 Issue #736 listening review quality gap 이후 technical MVP 전�
 다음 작업:
 
 - `Stage B MIDI-to-solo README final evidence refresh`
+
+## 9.61 Stage B MIDI-to-solo README final evidence refresh
+
+Issue #740은 Issue #738 MVP delivery package 결과를 README 첫 상태와 current evidence section에 반영한 문서 작업이다.
+
+결과:
+
+- source boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- latest evidence boundary reflected: `stage_b_midi_to_solo_mvp_delivery_package`
+- next boundary: `stage_b_midi_to_solo_final_status_audit`
+- runnable CLI ready: `true`
+- input to ranked MIDI ready: `true`
+- input to rendered WAV evidence ready: `true`
+- changed-ratio repair audio evidence ready: `true`
+- CLI candidate count: `3`
+- changed-ratio repair WAV count: `3`
+- raw artifact upload required: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- README 첫 상태에서 technical MVP delivery package 완료 범위 확인 가능.
+- listening review quality gap과 musical quality claim 제외 유지.
+- 다음 boundary는 final status audit.
+
+검증:
+
+- `git diff --check`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo final status audit`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #738, Stage B MIDI-to-solo MVP delivery package
-- 다음 권장 이슈: `Stage B MIDI-to-solo README final evidence refresh`
+- latest functional result: Issue #740, Stage B MIDI-to-solo README final evidence refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo final status audit`
 
 현재 범위가 아닌 것:
 
@@ -86,6 +86,7 @@
 - quality gap decision을 listening review quality gap target으로 갱신 완료
 - listening review quality gap을 MVP delivery package target으로 분리 완료
 - MVP delivery package manifest 생성 완료
+- README final evidence refresh 완료
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 
@@ -1755,6 +1756,48 @@ Issue #738은 Issue #736 listening review quality gap 이후 technical MVP 전�
 다음:
 
 - `Stage B MIDI-to-solo README final evidence refresh`
+
+## Stage B MIDI-to-Solo README Final Evidence Refresh Result
+
+Issue #740은 Issue #738 MVP delivery package 결과를 README 첫 상태와 current evidence section에 반영한 문서 작업이다.
+
+변경:
+
+- README latest evidence boundary를 `stage_b_midi_to_solo_mvp_delivery_package`로 갱신
+- README 현재 상태에 runnable CLI, ranked MIDI, rendered WAV evidence, changed-ratio repair audio evidence 반영
+- README evidence section에 listening review quality gap과 MVP delivery package 결과 추가
+- claim boundary 유지
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_README_FINAL_EVIDENCE_REFRESH_2026-06-09.md`
+- source boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- latest evidence boundary reflected: `stage_b_midi_to_solo_mvp_delivery_package`
+- next boundary: `stage_b_midi_to_solo_final_status_audit`
+- runnable CLI ready: `true`
+- input to ranked MIDI ready: `true`
+- input to rendered WAV evidence ready: `true`
+- changed-ratio repair audio evidence ready: `true`
+- CLI candidate count: `3`
+- changed-ratio repair WAV count: `3`
+- raw artifact upload required: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- README 첫 상태에서 technical MVP delivery package 완료 범위 확인 가능.
+- listening review quality gap과 musical quality claim 제외 유지.
+- 다음 boundary는 final status audit.
+
+검증:
+
+- `git diff --check`
+- `bash scripts/agent_harness.sh quick`
+
+다음:
+
+- `Stage B MIDI-to-solo final status audit`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_README_FINAL_EVIDENCE_REFRESH_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_README_FINAL_EVIDENCE_REFRESH_2026-06-09.md
@@ -1,0 +1,32 @@
+# Stage B MIDI-to-Solo README Final Evidence Refresh
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_readme_final_evidence_refresh`
+- source boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- latest evidence boundary reflected: `stage_b_midi_to_solo_mvp_delivery_package`
+- next boundary: `stage_b_midi_to_solo_final_status_audit`
+
+## Evidence
+
+- runnable CLI ready: `true`
+- input to ranked MIDI ready: `true`
+- input to rendered WAV evidence ready: `true`
+- changed-ratio repair audio evidence ready: `true`
+- CLI candidate count: `3`
+- changed-ratio repair WAV count: `3`
+- changed-ratio repair max ratio / target: `0.4348` / `0.5000`
+- changed-ratio repair max interval / target: `12` / `12`
+- changed-ratio repair WAV duration range: `18.422s - 18.978s`
+- raw artifact upload required: `false`
+
+## Claim Boundary
+
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- broad trained model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo final status audit`


### PR DESCRIPTION
## Summary

- README final evidence refreshed after Issue #738 MVP delivery package
- README current status now reflects `stage_b_midi_to_solo_mvp_delivery_package`
- listening review quality gap and MVP delivery package evidence added
- claim boundary preserved

## Context

- source issue: #740
- latest completed issue: #738
- runnable CLI ready: `true`
- input to ranked MIDI ready: `true`
- input to rendered WAV evidence ready: `true`
- changed-ratio repair audio evidence ready: `true`
- CLI / changed-ratio audio candidate count: `3` / `3`
- raw artifact upload required: `false`
- human/audio preference claimed: `false`
- MIDI-to-solo musical quality claimed: `false`

## Scope

- `README.md`
- `docs/STAGE_B_MIDI_TO_SOLO_README_FINAL_EVIDENCE_REFRESH_2026-06-09.md`
- `docs/CURRENT_STATUS_AND_PLAN.md`
- `docs/CORE_PLAN.md`

## Validation

- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`
- raw MIDI/WAV artifact upload: `false`

Closes #740
