### PR TITLE
Stage B MIDI-to-solo post-MVP quality iteration plan

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -399,6 +399,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo MVP delivery package: runnable CLI `true`, input ranked MIDI `true`, rendered WAV evidence `true`, CLI/changed-ratio audio candidate count `3/3`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_readme_final_evidence_refresh`
 - MIDI-to-solo README final evidence refresh: latest evidence boundary `stage_b_midi_to_solo_mvp_delivery_package`, runnable CLI `true`, input ranked MIDI/WAV evidence `true/true`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_final_status_audit`
 - MIDI-to-solo final status audit: technical MVP complete `true`, local review ready `true`, README final evidence reflected `true`, CLI/WAV count `3/3`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- MIDI-to-solo post-MVP quality iteration plan: selected target `quality_rubric_baseline`, ordered work `4`, taxonomy seed `7`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_rubric_baseline`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
 - MIDI-to-solo pitch-contour changed-ratio repair probe: repaired/pass `3/3`, max pitch changed ratio `0.7174 -> 0.4348`, max interval `12`, dead-air max `0.0000`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
 - MIDI-to-solo pitch-contour changed-ratio repair audio package: rendered WAV `3`, duration `18.422s-18.978s`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
@@ -4312,6 +4313,45 @@ Issue #742는 Issue #740 README final evidence refresh와 Issue #738 MVP deliver
 다음 작업:
 
 - `Stage B MIDI-to-solo post-MVP musical quality iteration plan`
+
+## 9.63 Stage B MIDI-to-solo post-MVP quality iteration plan
+
+Issue #744는 Issue #742 final status audit 이후 technical MVP 완료 상태에서 첫 post-MVP musical quality iteration boundary를 정의한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- source boundary: `stage_b_midi_to_solo_final_status_audit`
+- next boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
+- selected target: `quality_rubric_baseline`
+- technical MVP complete: `true`
+- local review ready: `true`
+- quality rubric required: `true`
+- candidate failure labeling required: `true`
+- targeted quality repair sweep required: `true`
+- audio review package required: `true`
+- ordered work count: `4`
+- quality failure taxonomy seed count: `7`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- technical MVP 완료 이후 무작위 repair 재진입 대신 quality rubric baseline 선행.
+- 현재 MIDI/WAV evidence와 objective metric 기준 candidate failure label 정의 필요.
+- musical quality, human/audio preference claim 제외 유지.
+- 다음 boundary는 quality rubric baseline.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- `.venv/bin/python -m py_compile scripts/plan_stage_b_midi_to_solo_post_mvp_quality_iteration.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-post-mvp-quality-iteration-plan`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo quality rubric baseline`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #742, Stage B MIDI-to-solo final status audit
-- 다음 권장 이슈: `Stage B MIDI-to-solo post-MVP musical quality iteration plan`
+- latest functional result: Issue #744, Stage B MIDI-to-solo post-MVP musical quality iteration plan
+- 다음 권장 이슈: `Stage B MIDI-to-solo quality rubric baseline`
 
 현재 범위가 아닌 것:
 
@@ -88,6 +88,7 @@
 - MVP delivery package manifest 생성 완료
 - README final evidence refresh 완료
 - final status audit 완료
+- post-MVP musical quality iteration plan 완료
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 
@@ -1848,6 +1849,54 @@ Issue #742는 Issue #740 README final evidence refresh와 Issue #738 MVP deliver
 다음:
 
 - `Stage B MIDI-to-solo post-MVP musical quality iteration plan`
+
+## Stage B MIDI-to-Solo Post-MVP Quality Iteration Plan Result
+
+Issue #744는 Issue #742 final status audit 이후 technical MVP 완료 상태에서 첫 post-MVP musical quality iteration boundary를 정의한 작업이다.
+
+변경:
+
+- post-MVP quality iteration plan script 추가
+- final status audit report 검증 연결
+- 다음 품질 작업 target을 `quality_rubric_baseline`으로 고정
+- quality failure taxonomy seed와 ordered work 기록
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_POST_MVP_QUALITY_ITERATION_PLAN_2026-06-09.md`
+- boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- source boundary: `stage_b_midi_to_solo_final_status_audit`
+- next boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
+- selected target: `quality_rubric_baseline`
+- technical MVP complete: `true`
+- local review ready: `true`
+- quality rubric required: `true`
+- candidate failure labeling required: `true`
+- targeted quality repair sweep required: `true`
+- audio review package required: `true`
+- ordered work count: `4`
+- quality failure taxonomy seed count: `7`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- technical MVP 완료 이후 무작위 repair 재진입 대신 quality rubric baseline 선행.
+- 현재 MIDI/WAV evidence와 objective metric 기준 candidate failure label 정의 필요.
+- musical quality, human/audio preference claim 제외 유지.
+- 다음 boundary는 quality rubric baseline.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- `.venv/bin/python -m py_compile scripts/plan_stage_b_midi_to_solo_post_mvp_quality_iteration.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-post-mvp-quality-iteration-plan`
+
+다음:
+
+- `Stage B MIDI-to-solo quality rubric baseline`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_POST_MVP_QUALITY_ITERATION_PLAN_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_POST_MVP_QUALITY_ITERATION_PLAN_2026-06-09.md
@@ -1,0 +1,27 @@
+# Stage B MIDI-to-Solo Post-MVP Quality Iteration Plan
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- source boundary: `stage_b_midi_to_solo_final_status_audit`
+- next boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
+- selected target: `quality_rubric_baseline`
+- technical MVP complete: `true`
+- local review ready: `true`
+
+## Required Work
+
+- `quality_rubric_baseline`: define MIDI-evidence quality rubric before another repair sweep
+- `candidate_failure_labeling`: label current candidates against sparse-output, songlike-melody, outside-soloing, monotony, and phrase-shape failures
+- `targeted_quality_repair_sweep`: run repair/generation sweep against the highest-count failure labels
+- `audio_review_package`: render selected repaired candidates for listening comparison
+
+## Claim Boundary
+
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- broad trained model quality claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo quality rubric baseline`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -246,6 +246,8 @@ Modes:
                 Build the current technical MVP delivery manifest and claim boundary.
   stage-b-midi-to-solo-final-status-audit
                 Audit final technical MVP status against README and delivery package evidence.
+  stage-b-midi-to-solo-post-mvp-quality-iteration-plan
+                Plan the first post-MVP musical quality iteration boundary.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision
                 Decide the next pitch-contour changed-ratio repair boundary.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-probe
@@ -6057,6 +6059,27 @@ run_stage_b_midi_to_solo_final_status_audit() {
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_post_mvp_quality_iteration_plan() {
+  local final_status_run_id="${FINAL_STATUS_RUN_ID:-harness_stage_b_midi_to_solo_final_status_audit}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_post_mvp_quality_iteration_plan}"
+  local final_status="outputs/stage_b_midi_to_solo_final_status_audit/${final_status_run_id}/stage_b_midi_to_solo_final_status_audit.json"
+  if [[ ! -f "$final_status" ]]; then
+    print_header "Stage B MIDI-to-solo final status audit"
+    RUN_ID="$final_status_run_id" run_stage_b_midi_to_solo_final_status_audit
+  fi
+  print_header "Stage B MIDI-to-solo post-MVP quality iteration plan"
+  "$PYTHON_BIN" scripts/plan_stage_b_midi_to_solo_post_mvp_quality_iteration.py \
+    --run_id "$run_id" \
+    --final_status_audit "$final_status" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_POST_MVP_QUALITY_ITERATION_PLAN_2026-06-09.md \
+    --issue_number 744 \
+    --expected_boundary stage_b_midi_to_solo_post_mvp_quality_iteration_plan \
+    --expected_next_boundary stage_b_midi_to_solo_quality_rubric_baseline \
+    --expected_target quality_rubric_baseline \
+    --require_quality_rubric \
+    --require_no_quality_claim
+}
+
 run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision() {
   local quality_gap_run_id="${QUALITY_GAP_RUN_ID:-harness_stage_b_midi_to_solo_quality_gap_decision}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision}"
@@ -8313,6 +8336,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-final-status-audit)
     run_stage_b_midi_to_solo_final_status_audit
+    ;;
+  stage-b-midi-to-solo-post-mvp-quality-iteration-plan)
+    run_stage_b_midi_to_solo_post_mvp_quality_iteration_plan
     ;;
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision)
     run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision

--- a/scripts/plan_stage_b_midi_to_solo_post_mvp_quality_iteration.py
+++ b/scripts/plan_stage_b_midi_to_solo_post_mvp_quality_iteration.py
@@ -1,0 +1,406 @@
+"""Plan the first post-MVP MIDI-to-solo musical quality iteration."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
+    BOUNDARY as FINAL_STATUS_BOUNDARY,
+    NEXT_BOUNDARY as FINAL_STATUS_NEXT_BOUNDARY,
+    StageBMidiToSoloFinalStatusAuditError,
+    validate_final_status_audit_report,
+)
+
+
+class StageBMidiToSoloPostMvpQualityIterationPlanError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_post_mvp_quality_iteration_plan"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_quality_rubric_baseline"
+SELECTED_TARGET = "quality_rubric_baseline"
+SCHEMA_VERSION = "stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v1"
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "phrase_bank_musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_final_status_source(report: dict[str, Any]) -> dict[str, Any]:
+    if str(report.get("boundary") or "") != FINAL_STATUS_BOUNDARY:
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            "final status audit boundary required"
+        )
+    try:
+        summary = validate_final_status_audit_report(
+            report,
+            expected_boundary=FINAL_STATUS_BOUNDARY,
+            expected_next_boundary=FINAL_STATUS_NEXT_BOUNDARY,
+            require_technical_mvp_complete=True,
+            require_readme_reflected=True,
+            require_no_quality_claim=True,
+        )
+    except StageBMidiToSoloFinalStatusAuditError as exc:
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(str(exc)) from exc
+
+    final_status = _dict(report.get("final_status"))
+    readiness = _dict(report.get("readiness"))
+    _require_no_quality_claim(final_status, label="final status")
+    _require_no_quality_claim(readiness, label="readiness")
+
+    if not bool(summary.get("technical_mvp_complete", False)):
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            "technical MVP completion required"
+        )
+    if not bool(summary.get("technical_mvp_ready_for_local_review", False)):
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            "local review readiness required"
+        )
+    if not bool(summary.get("readme_final_evidence_reflected", False)):
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            "README final evidence reflection required"
+        )
+    if _int(summary.get("cli_candidate_count")) < 3:
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError("CLI candidate count below 3")
+    if _int(summary.get("changed_ratio_repair_wav_count")) < 3:
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            "changed-ratio repair WAV count below 3"
+        )
+    if not bool(summary.get("listening_review_quality_gap_open", False)):
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            "listening review quality gap should remain open"
+        )
+    if bool(summary.get("raw_artifact_upload_required", True)):
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            "raw artifact upload should not be required"
+        )
+    if bool(summary.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            "critical user input should not be required"
+        )
+    return summary
+
+
+def build_post_mvp_quality_iteration_plan_report(
+    *,
+    final_status_audit: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+) -> dict[str, Any]:
+    source = validate_final_status_source(final_status_audit)
+    ordered_work = [
+        {
+            "target": "quality_rubric_baseline",
+            "objective": "define MIDI-evidence quality rubric before another repair sweep",
+            "reason": "technical MVP is complete; musical-quality failure boundary is still unscored",
+            "required_input": "current ranked MIDI/WAV evidence and existing objective metrics",
+            "claim_boundary": "no musical quality or preference claim",
+        },
+        {
+            "target": "candidate_failure_labeling",
+            "objective": "label current candidates against sparse-output, songlike-melody, outside-soloing, monotony, and phrase-shape failures",
+            "reason": "previous listening feedback rejected musical quality while technical gates passed",
+            "required_input": "MIDI notes, timing grid, pitch role, cadence, and rendered WAV metadata",
+            "claim_boundary": "objective labels only",
+        },
+        {
+            "target": "targeted_quality_repair_sweep",
+            "objective": "run repair/generation sweep against the highest-count failure labels",
+            "reason": "avoid unbounded parameter changes after technical MVP completion",
+            "required_input": "rubric baseline report and labeled candidate failures",
+            "claim_boundary": "repair evidence, not final quality",
+        },
+        {
+            "target": "audio_review_package",
+            "objective": "render selected repaired candidates for listening comparison",
+            "reason": "quality preference remains unclaimed until reviewed audio input exists",
+            "required_input": "ranked repaired MIDI candidates",
+            "claim_boundary": "technical WAV validation only",
+        },
+    ]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundary": FINAL_STATUS_BOUNDARY,
+        "source_summary": source,
+        "post_mvp_status": {
+            "technical_mvp_complete": bool(source["technical_mvp_complete"]),
+            "local_review_ready": bool(source["technical_mvp_ready_for_local_review"]),
+            "readme_final_evidence_reflected": bool(source["readme_final_evidence_reflected"]),
+            "cli_candidate_count": _int(source["cli_candidate_count"]),
+            "changed_ratio_repair_wav_count": _int(source["changed_ratio_repair_wav_count"]),
+            "listening_review_quality_gap_open": bool(
+                source["listening_review_quality_gap_open"]
+            ),
+            "raw_artifact_upload_required": False,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+        },
+        "selected_next_target": {
+            "selected_target": SELECTED_TARGET,
+            "selected_next_boundary": NEXT_BOUNDARY,
+            "reason": "technical MVP is complete; the next blocker is an explicit musical-quality rubric and failure taxonomy",
+        },
+        "ordered_work": ordered_work,
+        "quality_failure_taxonomy_seed": [
+            "sparse_or_empty_output",
+            "songlike_melody_not_soloing",
+            "outside_soloing_without_context",
+            "rhythmic_monotony",
+            "phrase_shape_missing_tension_release",
+            "weak_chord_tone_landing",
+            "dead_air_or_density_gap",
+        ],
+        "readiness": {
+            "boundary": BOUNDARY,
+            "post_mvp_quality_iteration_plan_completed": True,
+            "selected_target": SELECTED_TARGET,
+            "technical_mvp_complete": True,
+            "quality_rubric_required": True,
+            "candidate_failure_labeling_required": True,
+            "targeted_quality_repair_sweep_required": True,
+            "audio_review_package_required": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "quality iteration can continue from MIDI evidence without claiming listening preference",
+        },
+        "not_proven": [
+            "quality_rubric_baseline_completed",
+            "candidate_failure_labels_completed",
+            "targeted_quality_repair_completed",
+            "listening_review_completed",
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "broad_trained_model_quality",
+        ],
+        "next_recommended_issue": "Stage B MIDI-to-solo quality rubric baseline",
+    }
+
+
+def validate_post_mvp_quality_iteration_plan_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    expected_target: str | None,
+    require_quality_rubric: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    decision = _dict(report.get("decision"))
+    readiness = _dict(report.get("readiness"))
+    selected = _dict(report.get("selected_next_target"))
+    post_mvp_status = _dict(report.get("post_mvp_status"))
+    ordered_work = report.get("ordered_work")
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError("unexpected next boundary")
+    if expected_target and str(selected.get("selected_target") or "") != expected_target:
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError("unexpected selected target")
+    if not bool(readiness.get("post_mvp_quality_iteration_plan_completed", False)):
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            "post-MVP quality iteration plan completion required"
+        )
+    if not bool(post_mvp_status.get("technical_mvp_complete", False)):
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError("technical MVP completion required")
+    if require_quality_rubric and not bool(readiness.get("quality_rubric_required", False)):
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError("quality rubric requirement expected")
+    if not isinstance(ordered_work, list) or len(ordered_work) < 4:
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError("ordered work must include at least 4 steps")
+    if str(ordered_work[0].get("target") if isinstance(ordered_work[0], dict) else "") != SELECTED_TARGET:
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError("quality rubric must be first ordered target")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            "critical user input should not be required"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="post-MVP quality iteration readiness")
+        _require_no_quality_claim(post_mvp_status, label="post-MVP status")
+    return {
+        "boundary": boundary,
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "selected_target": str(selected.get("selected_target") or ""),
+        "post_mvp_quality_iteration_plan_completed": bool(
+            readiness.get("post_mvp_quality_iteration_plan_completed", False)
+        ),
+        "technical_mvp_complete": bool(post_mvp_status.get("technical_mvp_complete", False)),
+        "local_review_ready": bool(post_mvp_status.get("local_review_ready", False)),
+        "quality_rubric_required": bool(readiness.get("quality_rubric_required", False)),
+        "candidate_failure_labeling_required": bool(
+            readiness.get("candidate_failure_labeling_required", False)
+        ),
+        "targeted_quality_repair_sweep_required": bool(
+            readiness.get("targeted_quality_repair_sweep_required", False)
+        ),
+        "audio_review_package_required": bool(
+            readiness.get("audio_review_package_required", False)
+        ),
+        "ordered_work_count": len(ordered_work),
+        "quality_failure_taxonomy_seed_count": len(
+            report.get("quality_failure_taxonomy_seed")
+            if isinstance(report.get("quality_failure_taxonomy_seed"), list)
+            else []
+        ),
+        "human_audio_preference_claimed": bool(
+            readiness.get("human_audio_preference_claimed", True)
+        ),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    status = report["post_mvp_status"]
+    selected = report["selected_next_target"]
+    readiness = report["readiness"]
+    lines = [
+        "# Stage B MIDI-to-Solo Post-MVP Quality Iteration Plan",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- source boundary: `{report['source_boundary']}`",
+        f"- next boundary: `{selected['selected_next_boundary']}`",
+        f"- selected target: `{selected['selected_target']}`",
+        f"- technical MVP complete: `{_bool_token(status['technical_mvp_complete'])}`",
+        f"- local review ready: `{_bool_token(status['local_review_ready'])}`",
+        "",
+        "## Required Work",
+        "",
+    ]
+    for item in report["ordered_work"]:
+        lines.append(f"- `{item['target']}`: {item['objective']}")
+    lines.extend(
+        [
+            "",
+            "## Claim Boundary",
+            "",
+            f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+            f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+            f"- broad trained model quality claimed: `{_bool_token(readiness['broad_trained_model_quality_claimed'])}`",
+            "",
+            "## Next",
+            "",
+            f"- `{report['next_recommended_issue']}`",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Plan post-MVP MIDI-to-solo quality iteration")
+    parser.add_argument("--final_status_audit", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_post_mvp_quality_iteration_plan",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=744)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--expected_target", type=str, default="")
+    parser.add_argument("--require_quality_rubric", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_post_mvp_quality_iteration_plan_report(
+        final_status_audit=read_json(Path(args.final_status_audit)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+    )
+    summary = validate_post_mvp_quality_iteration_plan_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        expected_target=str(args.expected_target or ""),
+        require_quality_rubric=bool(args.require_quality_rubric),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir / "stage_b_midi_to_solo_post_mvp_quality_iteration_plan.json",
+        report,
+    )
+    write_json(
+        output_dir / "stage_b_midi_to_solo_post_mvp_quality_iteration_plan_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_midi_to_solo_post_mvp_quality_iteration_plan.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan.py
+++ b/tests/test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.audit_stage_b_midi_to_solo_final_status import (
+    BOUNDARY as FINAL_STATUS_BOUNDARY,
+    NEXT_BOUNDARY as FINAL_STATUS_NEXT_BOUNDARY,
+)
+from scripts.plan_stage_b_midi_to_solo_post_mvp_quality_iteration import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    SELECTED_TARGET,
+    StageBMidiToSoloPostMvpQualityIterationPlanError,
+    build_post_mvp_quality_iteration_plan_report,
+    validate_post_mvp_quality_iteration_plan_report,
+)
+
+
+def final_status_audit(
+    *,
+    quality_claim: bool = False,
+    listening_gap_open: bool = True,
+    cli_count: int = 3,
+    wav_count: int = 3,
+) -> dict:
+    return {
+        "boundary": FINAL_STATUS_BOUNDARY,
+        "source_boundary": "stage_b_midi_to_solo_mvp_delivery_package",
+        "final_status": {
+            "technical_mvp_complete": True,
+            "technical_mvp_ready_for_local_review": True,
+            "readme_final_evidence_reflected": True,
+            "input_to_ranked_midi_ready": True,
+            "input_to_rendered_wav_evidence_ready": True,
+            "changed_ratio_repair_audio_evidence_ready": True,
+            "cli_candidate_count": cli_count,
+            "changed_ratio_repair_wav_count": wav_count,
+            "listening_review_quality_gap_open": listening_gap_open,
+            "raw_artifact_upload_required": False,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": quality_claim,
+        },
+        "readiness": {
+            "final_status_audit_completed": True,
+            "technical_mvp_complete": True,
+            "technical_mvp_ready_for_local_review": True,
+            "readme_final_evidence_reflected": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": quality_claim,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": FINAL_STATUS_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+        "next_recommended_issue": "Stage B MIDI-to-solo post-MVP musical quality iteration plan",
+    }
+
+
+class StageBMidiToSoloPostMvpQualityIterationPlanTest(unittest.TestCase):
+    def test_selects_quality_rubric_baseline_without_quality_claim(self) -> None:
+        report = build_post_mvp_quality_iteration_plan_report(
+            final_status_audit=final_status_audit(),
+            output_dir=Path("outputs/post_mvp_quality"),
+            issue_number=744,
+        )
+        summary = validate_post_mvp_quality_iteration_plan_report(
+            report,
+            expected_boundary=BOUNDARY,
+            expected_next_boundary=NEXT_BOUNDARY,
+            expected_target=SELECTED_TARGET,
+            require_quality_rubric=True,
+            require_no_quality_claim=True,
+        )
+
+        self.assertTrue(summary["post_mvp_quality_iteration_plan_completed"])
+        self.assertTrue(summary["technical_mvp_complete"])
+        self.assertTrue(summary["local_review_ready"])
+        self.assertEqual(summary["selected_target"], SELECTED_TARGET)
+        self.assertTrue(summary["quality_rubric_required"])
+        self.assertTrue(summary["candidate_failure_labeling_required"])
+        self.assertTrue(summary["targeted_quality_repair_sweep_required"])
+        self.assertTrue(summary["audio_review_package_required"])
+        self.assertGreaterEqual(summary["ordered_work_count"], 4)
+        self.assertGreaterEqual(summary["quality_failure_taxonomy_seed_count"], 7)
+        self.assertFalse(summary["human_audio_preference_claimed"])
+        self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+        self.assertEqual(
+            summary["next_recommended_issue"],
+            "Stage B MIDI-to-solo quality rubric baseline",
+        )
+
+    def test_rejects_wrong_source_boundary(self) -> None:
+        source = final_status_audit()
+        source["boundary"] = "wrong_boundary"
+        with self.assertRaises(StageBMidiToSoloPostMvpQualityIterationPlanError):
+            build_post_mvp_quality_iteration_plan_report(
+                final_status_audit=source,
+                output_dir=Path("outputs/post_mvp_quality"),
+                issue_number=744,
+            )
+
+    def test_rejects_quality_claim(self) -> None:
+        with self.assertRaises(StageBMidiToSoloPostMvpQualityIterationPlanError):
+            build_post_mvp_quality_iteration_plan_report(
+                final_status_audit=final_status_audit(quality_claim=True),
+                output_dir=Path("outputs/post_mvp_quality"),
+                issue_number=744,
+            )
+
+    def test_rejects_closed_listening_gap(self) -> None:
+        with self.assertRaises(StageBMidiToSoloPostMvpQualityIterationPlanError):
+            build_post_mvp_quality_iteration_plan_report(
+                final_status_audit=final_status_audit(listening_gap_open=False),
+                output_dir=Path("outputs/post_mvp_quality"),
+                issue_number=744,
+            )
+
+    def test_rejects_low_candidate_or_wav_count(self) -> None:
+        with self.assertRaises(StageBMidiToSoloPostMvpQualityIterationPlanError):
+            build_post_mvp_quality_iteration_plan_report(
+                final_status_audit=final_status_audit(cli_count=2),
+                output_dir=Path("outputs/post_mvp_quality"),
+                issue_number=744,
+            )
+        with self.assertRaises(StageBMidiToSoloPostMvpQualityIterationPlanError):
+            build_post_mvp_quality_iteration_plan_report(
+                final_status_audit=final_status_audit(wav_count=2),
+                output_dir=Path("outputs/post_mvp_quality"),
+                issue_number=744,
+            )
+
+    def test_boundary_constants_are_stable(self) -> None:
+        self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_post_mvp_quality_iteration_plan")
+        self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_quality_rubric_baseline")
+        self.assertEqual(SELECTED_TARGET, "quality_rubric_baseline")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary
- post-MVP musical quality iteration plan 추가
- final status audit report 기준 다음 target 선정
- selected target: `quality_rubric_baseline`

Context
- Issue #742 final status audit 완료
- technical MVP complete: true
- local review ready: true
- listening review quality gap open: true
- musical quality claim: false

Scope
- post-MVP quality iteration plan script 추가
- final status audit report 입력 검증
- ordered work와 quality failure taxonomy seed 기록
- 전용 harness mode, unit test, 상태 문서 추가

Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
- `.venv/bin/python -m py_compile scripts/plan_stage_b_midi_to_solo_post_mvp_quality_iteration.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-post-mvp-quality-iteration-plan`
- `bash scripts/agent_harness.sh quick`

Risk
- human/audio preference claim: false
- MIDI-to-solo musical quality claim: false
- raw artifact upload: false

Closes #744

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project planning documentation with additional post-MVP quality iteration planning requirements and tracking
  * Added new Stage B MIDI-to-Solo post-MVP quality iteration plan document

* **Tests**
  * Added comprehensive test suite for post-MVP quality iteration planning

* **Chores**
  * Added new scripts for generating and validating quality iteration plans

<!-- end of auto-generated comment: release notes by coderabbit.ai -->