### PR TITLE
Stage B MIDI-to-solo candidate failure labeling

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -401,6 +401,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo final status audit: technical MVP complete `true`, local review ready `true`, README final evidence reflected `true`, CLI/WAV count `3/3`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
 - MIDI-to-solo post-MVP quality iteration plan: selected target `quality_rubric_baseline`, ordered work `4`, taxonomy seed `7`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_rubric_baseline`
 - MIDI-to-solo quality rubric baseline: rubric items `8`, metric groups `29`, candidate failure labeling ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_candidate_failure_labeling`
+- MIDI-to-solo candidate failure labeling: candidates `6`, failed `6`, failure label types `4`, not-evaluable types `2`, targeted repair ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_sweep`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
 - MIDI-to-solo pitch-contour changed-ratio repair probe: repaired/pass `3/3`, max pitch changed ratio `0.7174 -> 0.4348`, max interval `12`, dead-air max `0.0000`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
 - MIDI-to-solo pitch-contour changed-ratio repair audio package: rendered WAV `3`, duration `18.422s-18.978s`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
@@ -4386,6 +4387,44 @@ Issue #746은 Issue #744 post-MVP quality iteration plan 이후 candidate failur
 다음 작업:
 
 - `Stage B MIDI-to-solo candidate failure labeling`
+
+## 9.65 Stage B MIDI-to-solo candidate failure labeling
+
+Issue #748은 Issue #746 quality rubric baseline 이후 현재 MIDI 후보를 rubric 기준으로 labeling한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
+- source boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- selected target: `targeted_quality_repair_sweep`
+- candidate count: `6`
+- failed candidate count: `6`
+- failure label type count: `4`
+- not evaluable label type count: `2`
+- failure counts: `dead_air_or_density_gap=1`, `phrase_shape_missing_tension_release=2`, `rhythmic_monotony=3`, `songlike_melody_not_soloing=6`
+- not evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
+- targeted quality repair sweep ready: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- 현재 후보 6개 모두 musical-quality rubric 기준 repair 대상.
+- 공통 실패 신호는 songlike melody. CLI 후보 3개는 rhythm monotony 동반.
+- chord context 없는 항목은 실패로 단정하지 않고 not_evaluable로 유지.
+- 다음 boundary는 targeted quality repair sweep.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_candidate_failure_labeling`
+- `.venv/bin/python -m py_compile scripts/label_stage_b_midi_to_solo_candidate_failures.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-candidate-failure-labeling`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo targeted quality repair sweep`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #746, Stage B MIDI-to-solo quality rubric baseline
-- 다음 권장 이슈: `Stage B MIDI-to-solo candidate failure labeling`
+- latest functional result: Issue #748, Stage B MIDI-to-solo candidate failure labeling
+- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair sweep`
 
 현재 범위가 아닌 것:
 
@@ -90,6 +90,7 @@
 - final status audit 완료
 - post-MVP musical quality iteration plan 완료
 - quality rubric baseline 완료
+- candidate failure labeling 완료
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 
@@ -1940,6 +1941,53 @@ Issue #746은 Issue #744 post-MVP quality iteration plan 이후 candidate failur
 다음:
 
 - `Stage B MIDI-to-solo candidate failure labeling`
+
+## Stage B MIDI-to-Solo Candidate Failure Labeling Result
+
+Issue #748은 Issue #746 quality rubric baseline 이후 현재 MIDI 후보를 rubric 기준으로 labeling한 작업이다.
+
+변경:
+
+- candidate failure labeling script 추가
+- quality rubric baseline report와 MVP delivery package 입력 검증 연결
+- current candidate 6개 MIDI note metric 산출
+- chord context 부재 항목을 not_evaluable로 분리
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_CANDIDATE_FAILURE_LABELING_2026-06-09.md`
+- boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
+- source boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- selected target: `targeted_quality_repair_sweep`
+- candidate count: `6`
+- failed candidate count: `6`
+- failure label type count: `4`
+- not evaluable label type count: `2`
+- failure counts: `dead_air_or_density_gap=1`, `phrase_shape_missing_tension_release=2`, `rhythmic_monotony=3`, `songlike_melody_not_soloing=6`
+- not evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
+- targeted quality repair sweep ready: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- 현재 후보 6개 모두 musical-quality rubric 기준 repair 대상.
+- 공통 실패 신호는 songlike melody. CLI 후보 3개는 rhythm monotony 동반.
+- chord context 없는 항목은 실패로 단정하지 않고 not_evaluable로 유지.
+- 다음 boundary는 targeted quality repair sweep.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_candidate_failure_labeling`
+- `.venv/bin/python -m py_compile scripts/label_stage_b_midi_to_solo_candidate_failures.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-candidate-failure-labeling`
+
+다음:
+
+- `Stage B MIDI-to-solo targeted quality repair sweep`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_CANDIDATE_FAILURE_LABELING_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_CANDIDATE_FAILURE_LABELING_2026-06-09.md
@@ -1,0 +1,32 @@
+# Stage B MIDI-to-Solo Candidate Failure Labeling
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
+- source boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- selected target: `targeted_quality_repair_sweep`
+- candidate count: `6`
+- failed candidate count: `6`
+- targeted quality repair sweep ready: `true`
+
+## Failure Counts
+
+- `dead_air_or_density_gap`: `1`
+- `phrase_shape_missing_tension_release`: `2`
+- `rhythmic_monotony`: `3`
+- `songlike_melody_not_soloing`: `6`
+
+## Not Evaluable
+
+- `outside_soloing_without_context`: `6`
+- `weak_chord_tone_landing`: `6`
+
+## Claim Boundary
+
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo targeted quality repair sweep`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -250,6 +250,8 @@ Modes:
                 Plan the first post-MVP musical quality iteration boundary.
   stage-b-midi-to-solo-quality-rubric-baseline
                 Build the post-MVP MIDI evidence quality rubric baseline.
+  stage-b-midi-to-solo-candidate-failure-labeling
+                Label current MIDI-to-solo candidates against the quality rubric.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision
                 Decide the next pitch-contour changed-ratio repair boundary.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-probe
@@ -6104,6 +6106,33 @@ run_stage_b_midi_to_solo_quality_rubric_baseline() {
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_candidate_failure_labeling() {
+  local rubric_run_id="${RUBRIC_RUN_ID:-harness_stage_b_midi_to_solo_quality_rubric_baseline}"
+  local delivery_run_id="${DELIVERY_PACKAGE_RUN_ID:-harness_stage_b_midi_to_solo_mvp_delivery_package}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_candidate_failure_labeling}"
+  local rubric="outputs/stage_b_midi_to_solo_quality_rubric_baseline/${rubric_run_id}/stage_b_midi_to_solo_quality_rubric_baseline.json"
+  local delivery="outputs/stage_b_midi_to_solo_mvp_delivery_package/${delivery_run_id}/stage_b_midi_to_solo_mvp_delivery_package.json"
+  if [[ ! -f "$rubric" ]]; then
+    print_header "Stage B MIDI-to-solo quality rubric baseline"
+    RUN_ID="$rubric_run_id" run_stage_b_midi_to_solo_quality_rubric_baseline
+  fi
+  if [[ ! -f "$delivery" ]]; then
+    print_header "Stage B MIDI-to-solo MVP delivery package"
+    RUN_ID="$delivery_run_id" run_stage_b_midi_to_solo_mvp_delivery_package
+  fi
+  print_header "Stage B MIDI-to-solo candidate failure labeling"
+  "$PYTHON_BIN" scripts/label_stage_b_midi_to_solo_candidate_failures.py \
+    --run_id "$run_id" \
+    --rubric_baseline "$rubric" \
+    --mvp_delivery_package "$delivery" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_CANDIDATE_FAILURE_LABELING_2026-06-09.md \
+    --issue_number 748 \
+    --expected_boundary stage_b_midi_to_solo_candidate_failure_labeling \
+    --min_candidate_count 6 \
+    --require_labeling_completed \
+    --require_no_quality_claim
+}
+
 run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision() {
   local quality_gap_run_id="${QUALITY_GAP_RUN_ID:-harness_stage_b_midi_to_solo_quality_gap_decision}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision}"
@@ -8366,6 +8395,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-quality-rubric-baseline)
     run_stage_b_midi_to_solo_quality_rubric_baseline
+    ;;
+  stage-b-midi-to-solo-candidate-failure-labeling)
+    run_stage_b_midi_to_solo_candidate_failure_labeling
     ;;
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision)
     run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision

--- a/scripts/label_stage_b_midi_to_solo_candidate_failures.py
+++ b/scripts/label_stage_b_midi_to_solo_candidate_failures.py
@@ -1,0 +1,701 @@
+"""Label current MIDI-to-solo candidates with the quality rubric baseline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from statistics import median
+from typing import Any
+
+import pretty_midi
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.build_stage_b_midi_to_solo_mvp_delivery_package import (  # noqa: E402
+    BOUNDARY as DELIVERY_BOUNDARY,
+)
+from scripts.build_stage_b_midi_to_solo_quality_rubric_baseline import (  # noqa: E402
+    BOUNDARY as RUBRIC_BOUNDARY,
+    NEXT_BOUNDARY as RUBRIC_NEXT_BOUNDARY,
+    SELECTED_TARGET as RUBRIC_SELECTED_TARGET,
+    StageBMidiToSoloQualityRubricBaselineError,
+    validate_quality_rubric_baseline_report,
+)
+
+
+class StageBMidiToSoloCandidateFailureLabelingError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_candidate_failure_labeling"
+REPAIR_NEXT_BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_sweep"
+AUDIO_REVIEW_NEXT_BOUNDARY = "stage_b_midi_to_solo_audio_review_package"
+REPAIR_TARGET = "targeted_quality_repair_sweep"
+AUDIO_REVIEW_TARGET = "audio_review_package"
+SCHEMA_VERSION = "stage_b_midi_to_solo_candidate_failure_labeling_v1"
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloCandidateFailureLabelingError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_rubric_baseline(report: dict[str, Any]) -> dict[str, Any]:
+    if str(report.get("boundary") or "") != RUBRIC_BOUNDARY:
+        raise StageBMidiToSoloCandidateFailureLabelingError("rubric baseline boundary required")
+    try:
+        summary = validate_quality_rubric_baseline_report(
+            report,
+            expected_boundary=RUBRIC_BOUNDARY,
+            expected_next_boundary=RUBRIC_NEXT_BOUNDARY,
+            expected_target=RUBRIC_SELECTED_TARGET,
+            min_rubric_item_count=8,
+            require_candidate_labeling_ready=True,
+            require_no_quality_claim=True,
+        )
+    except StageBMidiToSoloQualityRubricBaselineError as exc:
+        raise StageBMidiToSoloCandidateFailureLabelingError(str(exc)) from exc
+    rubric_items = [_dict(item) for item in _list(report.get("rubric_items"))]
+    if len(rubric_items) < 8:
+        raise StageBMidiToSoloCandidateFailureLabelingError("rubric items below 8")
+    return {**summary, "rubric_items": rubric_items}
+
+
+def _require_existing_file(path: str, *, label: str) -> str:
+    if not path:
+        raise StageBMidiToSoloCandidateFailureLabelingError(f"{label} path required")
+    if not Path(path).exists():
+        raise StageBMidiToSoloCandidateFailureLabelingError(f"{label} missing: {path}")
+    return path
+
+
+def validate_delivery_package(report: dict[str, Any]) -> list[dict[str, Any]]:
+    readiness = _dict(report.get("readiness"))
+    package = _dict(report.get("delivery_package"))
+    manifest = _dict(report.get("artifact_manifest"))
+    if str(report.get("boundary") or "") != DELIVERY_BOUNDARY:
+        raise StageBMidiToSoloCandidateFailureLabelingError("MVP delivery package boundary required")
+    if not bool(readiness.get("mvp_delivery_package_completed", False)):
+        raise StageBMidiToSoloCandidateFailureLabelingError("MVP delivery package completion required")
+    if not bool(package.get("input_to_ranked_midi_ready", False)):
+        raise StageBMidiToSoloCandidateFailureLabelingError("input to ranked MIDI readiness required")
+    if not bool(package.get("input_to_rendered_wav_evidence_ready", False)):
+        raise StageBMidiToSoloCandidateFailureLabelingError("input to rendered WAV evidence required")
+    _require_no_quality_claim(readiness, label="delivery readiness")
+
+    candidates: list[dict[str, Any]] = []
+    for item in [_dict(row) for row in _list(manifest.get("cli_repaired_midi_candidates"))]:
+        candidates.append(
+            {
+                "source": "cli_repaired_midi",
+                "rank": _int(item.get("rank")),
+                "midi_path": _require_existing_file(
+                    str(item.get("repaired_midi_path") or ""),
+                    label="CLI repaired MIDI",
+                ),
+                "source_note_count": _int(item.get("note_count")),
+                "source_unique_pitch_count": _int(item.get("unique_pitch_count")),
+                "source_dead_air_ratio": _float(item.get("dead_air_ratio")),
+                "source_objective_supported": bool(item.get("objective_supported", False)),
+            }
+        )
+    for item in [_dict(row) for row in _list(manifest.get("changed_ratio_repair_audio_candidates"))]:
+        candidates.append(
+            {
+                "source": "changed_ratio_repair",
+                "rank": _int(item.get("rank")),
+                "midi_path": _require_existing_file(
+                    str(item.get("repaired_midi_path") or ""),
+                    label="changed-ratio repaired MIDI",
+                ),
+                "source_note_count": 0,
+                "source_unique_pitch_count": _int(item.get("repaired_unique_pitch_count")),
+                "source_dead_air_ratio": 0.0,
+                "source_objective_supported": True,
+                "wav_path": str(item.get("wav_path") or ""),
+                "pitch_changed_ratio": _float(item.get("pitch_changed_ratio")),
+                "repaired_max_interval": _int(item.get("repaired_max_interval")),
+            }
+        )
+    if len(candidates) < 3:
+        raise StageBMidiToSoloCandidateFailureLabelingError("at least 3 MIDI candidates required")
+    return candidates
+
+
+def most_common_ratio(values: list[float | int], *, precision: int = 3) -> float:
+    if not values:
+        return 0.0
+    rounded = [round(float(value), precision) for value in values]
+    return max(Counter(rounded).values()) / len(rounded)
+
+
+def repeated_cycle(values: list[tuple[float, ...]], *, cycle_length: int) -> bool:
+    if len(values) < cycle_length * 2:
+        return False
+    return values[:cycle_length] == values[cycle_length : cycle_length * 2]
+
+
+def load_midi_notes(path: str | Path) -> tuple[pretty_midi.PrettyMIDI, list[pretty_midi.Note]]:
+    midi = pretty_midi.PrettyMIDI(str(path))
+    notes: list[pretty_midi.Note] = []
+    for instrument in midi.instruments:
+        if not instrument.is_drum:
+            notes.extend(instrument.notes)
+    return midi, sorted(notes, key=lambda note: (float(note.start), int(note.pitch), float(note.end)))
+
+
+def beat_length_seconds(midi: pretty_midi.PrettyMIDI) -> float:
+    beats = [float(value) for value in midi.get_beats()]
+    diffs = [beats[index] - beats[index - 1] for index in range(1, len(beats))]
+    positive = [value for value in diffs if value > 0.0]
+    if positive:
+        return float(median(positive))
+    tempo_times, tempi = midi.get_tempo_changes()
+    if len(tempi) > 0 and float(tempi[0]) > 0.0:
+        return 60.0 / float(tempi[0])
+    return 0.5
+
+
+def bar_grid(midi: pretty_midi.PrettyMIDI, notes: list[pretty_midi.Note]) -> tuple[list[float], float]:
+    end_time = max(float(midi.get_end_time()), max((float(note.end) for note in notes), default=0.0))
+    downbeats = [float(value) for value in midi.get_downbeats()]
+    if len(downbeats) >= 2:
+        while downbeats[-1] < end_time:
+            downbeats.append(downbeats[-1] + max(0.0001, downbeats[-1] - downbeats[-2]))
+        return downbeats, max(0.0001, downbeats[1] - downbeats[0])
+    bar_length = max(0.0001, beat_length_seconds(midi) * 4.0)
+    grid = [0.0]
+    while grid[-1] < end_time:
+        grid.append(grid[-1] + bar_length)
+    if len(grid) < 2:
+        grid.append(bar_length)
+    return grid, bar_length
+
+
+def bar_metrics(
+    midi: pretty_midi.PrettyMIDI,
+    notes: list[pretty_midi.Note],
+) -> dict[str, Any]:
+    grid, _bar_length = bar_grid(midi, notes)
+    note_counts: list[int] = []
+    onset_patterns: list[tuple[float, ...]] = []
+    for index in range(len(grid) - 1):
+        start = grid[index]
+        end = grid[index + 1]
+        length = max(0.0001, end - start)
+        bar_notes = [note for note in notes if start <= float(note.start) < end]
+        note_counts.append(len(bar_notes))
+        onset_patterns.append(
+            tuple(round((float(note.start) - start) / length * 4.0, 3) for note in bar_notes)
+        )
+    active_bar_count = sum(1 for count in note_counts if count > 0)
+    return {
+        "bar_count": len(note_counts),
+        "active_bar_count": active_bar_count,
+        "empty_bar_count": sum(1 for count in note_counts if count == 0),
+        "note_counts_per_bar": note_counts,
+        "note_count_per_bar_most_common_ratio": most_common_ratio(note_counts, precision=0),
+        "most_common_note_count_per_bar": Counter(note_counts).most_common(1)[0][0]
+        if note_counts
+        else 0,
+        "unique_onset_pattern_count": len(set(onset_patterns)),
+        "four_bar_rhythm_cycle_repeated": repeated_cycle(onset_patterns, cycle_length=4),
+        "four_notes_per_bar_template": bool(note_counts)
+        and Counter(note_counts).most_common(1)[0][0] == 4,
+    }
+
+
+def rhythm_signature(notes: list[pretty_midi.Note]) -> tuple[tuple[float, ...], tuple[float, ...]]:
+    starts = [round(float(note.start), 3) for note in notes]
+    durations = [round(max(0.0, float(note.end) - float(note.start)), 3) for note in notes]
+    iois = [round(starts[index] - starts[index - 1], 3) for index in range(1, len(starts))]
+    return tuple(iois), tuple(durations)
+
+
+def max_simultaneous_notes(notes: list[pretty_midi.Note]) -> int:
+    events: list[tuple[float, int]] = []
+    for note in notes:
+        events.append((float(note.start), 1))
+        events.append((float(note.end), -1))
+    active = 0
+    max_active = 0
+    for _time, delta in sorted(events, key=lambda item: (item[0], item[1])):
+        active += delta
+        max_active = max(max_active, active)
+    return max_active
+
+
+def contour_turn_count(pitches: list[int]) -> int:
+    signs: list[int] = []
+    for index in range(1, len(pitches)):
+        delta = pitches[index] - pitches[index - 1]
+        if delta > 0:
+            signs.append(1)
+        elif delta < 0:
+            signs.append(-1)
+    return sum(1 for index in range(1, len(signs)) if signs[index] != signs[index - 1])
+
+
+def analyze_candidate_midi(candidate: dict[str, Any]) -> dict[str, Any]:
+    midi, notes = load_midi_notes(candidate["midi_path"])
+    if not notes:
+        return {
+            "source": candidate["source"],
+            "rank": candidate["rank"],
+            "midi_path": candidate["midi_path"],
+            "note_count": 0,
+            "rhythm_signature": ((), ()),
+            "metrics": {
+                "note_count": 0,
+                "active_bar_count": 0,
+                "empty_bar_count": 0,
+                "max_simultaneous_notes": 0,
+                "grammar_valid": False,
+                "strict_valid": False,
+            },
+        }
+    pitches = [int(note.pitch) for note in notes]
+    starts = [float(note.start) for note in notes]
+    durations = [max(0.0, float(note.end) - float(note.start)) for note in notes]
+    iois = [max(0.0, starts[index] - starts[index - 1]) for index in range(1, len(starts))]
+    intervals = [abs(pitches[index] - pitches[index - 1]) for index in range(1, len(pitches))]
+    beat_length = beat_length_seconds(midi)
+    long_gap_threshold = beat_length * 2.0
+    dead_air_events = sum(1 for gap in iois if gap >= long_gap_threshold)
+    max_gap_beats = max((gap / max(0.0001, beat_length) for gap in iois), default=0.0)
+    bar = bar_metrics(midi, notes)
+    small_interval_ratio = sum(1 for value in intervals if value <= 4) / max(1, len(intervals))
+    large_interval_ratio = sum(1 for value in intervals if value >= 12) / max(1, len(intervals))
+    max_simultaneous = max_simultaneous_notes(notes)
+    peak_index = max(range(len(pitches)), key=lambda index: pitches[index]) if pitches else 0
+    peak_position_ratio = peak_index / max(1, len(pitches) - 1)
+    metrics = {
+        **bar,
+        "note_count": len(notes),
+        "unique_pitch_count": len(set(pitches)),
+        "unique_pitch_class_count": len({pitch % 12 for pitch in pitches}),
+        "pitch_span": max(pitches) - min(pitches),
+        "max_abs_interval": max(intervals) if intervals else 0,
+        "large_interval_ratio_gte12": large_interval_ratio,
+        "small_interval_ratio_le4": small_interval_ratio,
+        "duration_most_common_ratio": most_common_ratio(durations),
+        "ioi_most_common_ratio": most_common_ratio(iois),
+        "dead_air_ratio": dead_air_events / max(1, len(iois)),
+        "source_dead_air_ratio": _float(candidate.get("source_dead_air_ratio")),
+        "max_gap_beats": max_gap_beats,
+        "contour_turn_count": contour_turn_count(pitches),
+        "phrase_peak_position_ratio": peak_position_ratio,
+        "max_simultaneous_notes": max_simultaneous,
+        "grammar_valid": bool(candidate.get("source_objective_supported", False)),
+        "strict_valid": max_simultaneous <= 1,
+        "chord_context_available": False,
+        "cadence_resolution_present": None,
+        "strong_beat_chord_tone_ratio": None,
+        "cadence_landing_chord_tone": None,
+    }
+    return {
+        "source": candidate["source"],
+        "rank": candidate["rank"],
+        "midi_path": candidate["midi_path"],
+        "wav_path": str(candidate.get("wav_path") or ""),
+        "rhythm_signature": rhythm_signature(notes),
+        "metrics": metrics,
+    }
+
+
+def threshold_for(rubric_items: list[dict[str, Any]], rubric_id: str) -> dict[str, Any]:
+    for item in rubric_items:
+        if str(item.get("id") or "") == rubric_id:
+            return _dict(item.get("threshold"))
+    return {}
+
+
+def label_candidate(
+    candidate: dict[str, Any],
+    *,
+    rubric_items: list[dict[str, Any]],
+    shared_rhythm_signature_count: int,
+) -> dict[str, Any]:
+    metrics = _dict(candidate.get("metrics"))
+    failure_labels: list[str] = []
+    not_evaluable_labels: list[str] = []
+    evidence: dict[str, Any] = {}
+
+    sparse = threshold_for(rubric_items, "sparse_or_empty_output")
+    if _int(metrics.get("note_count")) < _int(sparse.get("min_note_count")) or _int(
+        metrics.get("active_bar_count")
+    ) < _int(sparse.get("min_active_bar_count")):
+        failure_labels.append("sparse_or_empty_output")
+
+    dead_air = threshold_for(rubric_items, "dead_air_or_density_gap")
+    if _float(metrics.get("dead_air_ratio")) > _float(dead_air.get("max_dead_air_ratio")) or _int(
+        metrics.get("empty_bar_count")
+    ) > _int(dead_air.get("max_empty_bar_count")):
+        failure_labels.append("dead_air_or_density_gap")
+
+    rhythm = threshold_for(rubric_items, "rhythmic_monotony")
+    if (
+        _float(metrics.get("duration_most_common_ratio"))
+        >= _float(rhythm.get("max_duration_most_common_ratio"))
+        or _float(metrics.get("ioi_most_common_ratio"))
+        >= _float(rhythm.get("max_ioi_most_common_ratio"))
+        or _float(metrics.get("note_count_per_bar_most_common_ratio"))
+        >= _float(rhythm.get("max_note_count_per_bar_most_common_ratio"))
+    ):
+        failure_labels.append("rhythmic_monotony")
+
+    songlike = threshold_for(rubric_items, "songlike_melody_not_soloing")
+    if (
+        bool(metrics.get("four_notes_per_bar_template", False))
+        or bool(metrics.get("four_bar_rhythm_cycle_repeated", False))
+        or int(shared_rhythm_signature_count) > _int(songlike.get("max_shared_rhythm_signature_count"))
+        or _float(metrics.get("small_interval_ratio_le4"))
+        > _float(songlike.get("max_small_interval_ratio_le4"))
+    ):
+        failure_labels.append("songlike_melody_not_soloing")
+
+    if not bool(metrics.get("chord_context_available", False)):
+        not_evaluable_labels.extend(
+            ["outside_soloing_without_context", "weak_chord_tone_landing"]
+        )
+
+    phrase = threshold_for(rubric_items, "phrase_shape_missing_tension_release")
+    peak_range = _list(phrase.get("phrase_peak_position_ratio_range"))
+    peak_min = _float(peak_range[0]) if len(peak_range) >= 2 else 0.25
+    peak_max = _float(peak_range[1]) if len(peak_range) >= 2 else 0.85
+    if (
+        _int(metrics.get("contour_turn_count")) < _int(phrase.get("min_contour_turn_count"))
+        or _float(metrics.get("large_interval_ratio_gte12"))
+        > _float(phrase.get("max_large_interval_ratio_gte12"))
+        or not (peak_min <= _float(metrics.get("phrase_peak_position_ratio")) <= peak_max)
+    ):
+        failure_labels.append("phrase_shape_missing_tension_release")
+
+    technical = threshold_for(rubric_items, "technical_gate_regression")
+    if (
+        not bool(metrics.get("grammar_valid", False))
+        or not bool(metrics.get("strict_valid", False))
+        or _int(metrics.get("max_simultaneous_notes"))
+        > _int(technical.get("max_simultaneous_notes"))
+    ):
+        failure_labels.append("technical_gate_regression")
+
+    evidence["shared_rhythm_signature_count"] = int(shared_rhythm_signature_count)
+    evidence["failure_label_count"] = len(failure_labels)
+    evidence["not_evaluable_label_count"] = len(not_evaluable_labels)
+    return {
+        **candidate,
+        "failure_labels": sorted(set(failure_labels)),
+        "not_evaluable_labels": sorted(set(not_evaluable_labels)),
+        "label_evidence": evidence,
+    }
+
+
+def build_candidate_failure_labeling_report(
+    *,
+    rubric_baseline: dict[str, Any],
+    mvp_delivery_package: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+) -> dict[str, Any]:
+    rubric_summary = validate_rubric_baseline(rubric_baseline)
+    rubric_items = [_dict(item) for item in _list(rubric_summary.get("rubric_items"))]
+    candidates = validate_delivery_package(mvp_delivery_package)
+    analyzed = [analyze_candidate_midi(candidate) for candidate in candidates]
+    rhythm_counts = Counter(tuple(item.get("rhythm_signature", ((), ()))) for item in analyzed)
+    labeled = [
+        label_candidate(
+            item,
+            rubric_items=rubric_items,
+            shared_rhythm_signature_count=rhythm_counts[
+                tuple(item.get("rhythm_signature", ((), ())))
+            ],
+        )
+        for item in analyzed
+    ]
+    failure_counts = Counter(label for item in labeled for label in _list(item.get("failure_labels")))
+    not_evaluable_counts = Counter(
+        label for item in labeled for label in _list(item.get("not_evaluable_labels"))
+    )
+    failed_candidate_count = sum(1 for item in labeled if _list(item.get("failure_labels")))
+    selected_target = REPAIR_TARGET if failed_candidate_count > 0 else AUDIO_REVIEW_TARGET
+    next_boundary = REPAIR_NEXT_BOUNDARY if failed_candidate_count > 0 else AUDIO_REVIEW_NEXT_BOUNDARY
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundary": RUBRIC_BOUNDARY,
+        "delivery_source_boundary": DELIVERY_BOUNDARY,
+        "candidate_labels": labeled,
+        "aggregate": {
+            "candidate_count": len(labeled),
+            "failed_candidate_count": failed_candidate_count,
+            "failure_counts": dict(sorted(failure_counts.items())),
+            "not_evaluable_counts": dict(sorted(not_evaluable_counts.items())),
+            "max_failure_label_count": max(
+                (len(_list(item.get("failure_labels"))) for item in labeled),
+                default=0,
+            ),
+            "candidate_sources": dict(
+                sorted(Counter(str(item.get("source") or "") for item in labeled).items())
+            ),
+        },
+        "selected_next_target": {
+            "selected_target": selected_target,
+            "selected_next_boundary": next_boundary,
+            "reason": "failure labels exist" if failed_candidate_count > 0 else "no objective failure labels found",
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "candidate_failure_labeling_completed": True,
+            "candidate_count": len(labeled),
+            "failed_candidate_count": failed_candidate_count,
+            "targeted_quality_repair_sweep_ready": failed_candidate_count > 0,
+            "audio_review_package_ready": failed_candidate_count == 0,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": next_boundary,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "candidate MIDI evidence labeled against quality rubric without quality claim",
+        },
+        "not_proven": [
+            "targeted_quality_repair_completed",
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "broad_trained_model_quality",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo targeted quality repair sweep"
+            if failed_candidate_count > 0
+            else "Stage B MIDI-to-solo audio review package"
+        ),
+    }
+
+
+def validate_candidate_failure_labeling_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    min_candidate_count: int,
+    require_labeling_completed: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    selected = _dict(report.get("selected_next_target"))
+    aggregate = _dict(report.get("aggregate"))
+    labels = _list(report.get("candidate_labels"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloCandidateFailureLabelingError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if require_labeling_completed and not bool(
+        readiness.get("candidate_failure_labeling_completed", False)
+    ):
+        raise StageBMidiToSoloCandidateFailureLabelingError("labeling completion required")
+    if len(labels) < int(min_candidate_count):
+        raise StageBMidiToSoloCandidateFailureLabelingError("candidate label count below minimum")
+    if _int(aggregate.get("candidate_count")) != len(labels):
+        raise StageBMidiToSoloCandidateFailureLabelingError("candidate count mismatch")
+    if str(selected.get("selected_target") or "") not in {REPAIR_TARGET, AUDIO_REVIEW_TARGET}:
+        raise StageBMidiToSoloCandidateFailureLabelingError("unexpected selected target")
+    if str(decision.get("next_boundary") or "") not in {
+        REPAIR_NEXT_BOUNDARY,
+        AUDIO_REVIEW_NEXT_BOUNDARY,
+    }:
+        raise StageBMidiToSoloCandidateFailureLabelingError("unexpected next boundary")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloCandidateFailureLabelingError(
+            "critical user input should not be required"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="candidate labeling readiness")
+    return {
+        "boundary": boundary,
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "selected_target": str(selected.get("selected_target") or ""),
+        "candidate_failure_labeling_completed": bool(
+            readiness.get("candidate_failure_labeling_completed", False)
+        ),
+        "candidate_count": len(labels),
+        "failed_candidate_count": _int(aggregate.get("failed_candidate_count")),
+        "failure_label_type_count": len(_dict(aggregate.get("failure_counts"))),
+        "not_evaluable_label_type_count": len(_dict(aggregate.get("not_evaluable_counts"))),
+        "targeted_quality_repair_sweep_ready": bool(
+            readiness.get("targeted_quality_repair_sweep_ready", False)
+        ),
+        "audio_review_package_ready": bool(readiness.get("audio_review_package_ready", False)),
+        "human_audio_preference_claimed": bool(
+            readiness.get("human_audio_preference_claimed", True)
+        ),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    aggregate = report["aggregate"]
+    selected = report["selected_next_target"]
+    readiness = report["readiness"]
+    lines = [
+        "# Stage B MIDI-to-Solo Candidate Failure Labeling",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- source boundary: `{report['source_boundary']}`",
+        f"- next boundary: `{selected['selected_next_boundary']}`",
+        f"- selected target: `{selected['selected_target']}`",
+        f"- candidate count: `{aggregate['candidate_count']}`",
+        f"- failed candidate count: `{aggregate['failed_candidate_count']}`",
+        f"- targeted quality repair sweep ready: `{_bool_token(readiness['targeted_quality_repair_sweep_ready'])}`",
+        "",
+        "## Failure Counts",
+        "",
+    ]
+    for label, count in aggregate["failure_counts"].items():
+        lines.append(f"- `{label}`: `{count}`")
+    if not aggregate["failure_counts"]:
+        lines.append("- none")
+    lines.extend(
+        [
+            "",
+            "## Not Evaluable",
+            "",
+        ]
+    )
+    for label, count in aggregate["not_evaluable_counts"].items():
+        lines.append(f"- `{label}`: `{count}`")
+    if not aggregate["not_evaluable_counts"]:
+        lines.append("- none")
+    lines.extend(
+        [
+            "",
+            "## Claim Boundary",
+            "",
+            f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+            f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+            "",
+            "## Next",
+            "",
+            f"- `{report['next_recommended_issue']}`",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Label MIDI-to-solo candidate failures")
+    parser.add_argument("--rubric_baseline", type=str, required=True)
+    parser.add_argument("--mvp_delivery_package", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_candidate_failure_labeling",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=748)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--min_candidate_count", type=int, default=6)
+    parser.add_argument("--require_labeling_completed", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_candidate_failure_labeling_report(
+        rubric_baseline=read_json(Path(args.rubric_baseline)),
+        mvp_delivery_package=read_json(Path(args.mvp_delivery_package)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+    )
+    summary = validate_candidate_failure_labeling_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        min_candidate_count=int(args.min_candidate_count),
+        require_labeling_completed=bool(args.require_labeling_completed),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "stage_b_midi_to_solo_candidate_failure_labeling.json", report)
+    write_json(
+        output_dir / "stage_b_midi_to_solo_candidate_failure_labeling_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_midi_to_solo_candidate_failure_labeling.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_candidate_failure_labeling.py
+++ b/tests/test_stage_b_midi_to_solo_candidate_failure_labeling.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import pretty_midi
+
+from scripts.build_stage_b_midi_to_solo_mvp_delivery_package import BOUNDARY as DELIVERY_BOUNDARY
+from scripts.build_stage_b_midi_to_solo_quality_rubric_baseline import (
+    BOUNDARY as RUBRIC_BOUNDARY,
+    NEXT_BOUNDARY as RUBRIC_NEXT_BOUNDARY,
+    SELECTED_TARGET as RUBRIC_SELECTED_TARGET,
+    build_quality_rubric_baseline_report,
+)
+from scripts.label_stage_b_midi_to_solo_candidate_failures import (
+    BOUNDARY,
+    REPAIR_NEXT_BOUNDARY,
+    REPAIR_TARGET,
+    StageBMidiToSoloCandidateFailureLabelingError,
+    build_candidate_failure_labeling_report,
+    validate_candidate_failure_labeling_report,
+)
+from scripts.plan_stage_b_midi_to_solo_post_mvp_quality_iteration import (
+    BOUNDARY as POST_MVP_BOUNDARY,
+    NEXT_BOUNDARY as POST_MVP_NEXT_BOUNDARY,
+    SELECTED_TARGET as POST_MVP_SELECTED_TARGET,
+)
+
+
+def write_midi(path: Path, pitches: list[int]) -> None:
+    midi = pretty_midi.PrettyMIDI(initial_tempo=120)
+    midi.time_signature_changes.append(pretty_midi.TimeSignature(4, 4, 0.0))
+    instrument = pretty_midi.Instrument(program=0)
+    for index, pitch in enumerate(pitches):
+        start = index * 0.5
+        instrument.notes.append(
+            pretty_midi.Note(velocity=90, pitch=int(pitch), start=start, end=start + 0.25)
+        )
+    midi.instruments.append(instrument)
+    midi.write(str(path))
+
+
+def post_mvp_quality_plan() -> dict:
+    return {
+        "boundary": POST_MVP_BOUNDARY,
+        "selected_next_target": {
+            "selected_target": POST_MVP_SELECTED_TARGET,
+            "selected_next_boundary": POST_MVP_NEXT_BOUNDARY,
+        },
+        "ordered_work": [
+            {"target": "quality_rubric_baseline"},
+            {"target": "candidate_failure_labeling"},
+            {"target": "targeted_quality_repair_sweep"},
+            {"target": "audio_review_package"},
+        ],
+        "quality_failure_taxonomy_seed": [f"failure_{index}" for index in range(7)],
+        "post_mvp_status": {
+            "technical_mvp_complete": True,
+            "local_review_ready": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+        },
+        "readiness": {
+            "post_mvp_quality_iteration_plan_completed": True,
+            "quality_rubric_required": True,
+            "candidate_failure_labeling_required": True,
+            "targeted_quality_repair_sweep_required": True,
+            "audio_review_package_required": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": POST_MVP_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+def rubric_baseline(root: Path, *, quality_claim: bool = False) -> dict:
+    report = build_quality_rubric_baseline_report(
+        post_mvp_quality_plan=post_mvp_quality_plan(),
+        output_dir=root / "rubric",
+        issue_number=746,
+    )
+    if quality_claim:
+        report["readiness"]["midi_to_solo_musical_quality_claimed"] = True
+    return report
+
+
+def delivery_package(paths: list[Path], *, quality_claim: bool = False) -> dict:
+    return {
+        "boundary": DELIVERY_BOUNDARY,
+        "delivery_package": {
+            "input_to_ranked_midi_ready": True,
+            "input_to_rendered_wav_evidence_ready": True,
+        },
+        "artifact_manifest": {
+            "cli_repaired_midi_candidates": [
+                {
+                    "rank": 1,
+                    "repaired_midi_path": str(paths[0]),
+                    "note_count": 16,
+                    "unique_pitch_count": 5,
+                    "dead_air_ratio": 0.0,
+                    "objective_supported": True,
+                },
+                {
+                    "rank": 2,
+                    "repaired_midi_path": str(paths[1]),
+                    "note_count": 16,
+                    "unique_pitch_count": 5,
+                    "dead_air_ratio": 0.0,
+                    "objective_supported": True,
+                },
+            ],
+            "changed_ratio_repair_audio_candidates": [
+                {
+                    "rank": 1,
+                    "repaired_midi_path": str(paths[2]),
+                    "repaired_unique_pitch_count": 5,
+                    "pitch_changed_ratio": 0.3,
+                    "repaired_max_interval": 4,
+                }
+            ],
+        },
+        "readiness": {
+            "mvp_delivery_package_completed": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": quality_claim,
+            "phrase_bank_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+    }
+
+
+class StageBMidiToSoloCandidateFailureLabelingTest(unittest.TestCase):
+    def test_labels_candidate_failures_without_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = [root / f"candidate_{index}.mid" for index in range(3)]
+            for path in paths:
+                write_midi(path, [60, 62, 64, 65] * 4)
+            report = build_candidate_failure_labeling_report(
+                rubric_baseline=rubric_baseline(root),
+                mvp_delivery_package=delivery_package(paths),
+                output_dir=root / "labels",
+                issue_number=748,
+            )
+            summary = validate_candidate_failure_labeling_report(
+                report,
+                expected_boundary=BOUNDARY,
+                min_candidate_count=3,
+                require_labeling_completed=True,
+                require_no_quality_claim=True,
+            )
+
+            self.assertTrue(summary["candidate_failure_labeling_completed"])
+            self.assertEqual(summary["candidate_count"], 3)
+            self.assertGreater(summary["failed_candidate_count"], 0)
+            self.assertGreater(summary["failure_label_type_count"], 0)
+            self.assertGreaterEqual(summary["not_evaluable_label_type_count"], 2)
+            self.assertEqual(summary["selected_target"], REPAIR_TARGET)
+            self.assertEqual(summary["next_boundary"], REPAIR_NEXT_BOUNDARY)
+            self.assertTrue(summary["targeted_quality_repair_sweep_ready"])
+            self.assertFalse(summary["human_audio_preference_claimed"])
+            self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+
+    def test_rejects_delivery_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = [root / f"candidate_{index}.mid" for index in range(3)]
+            for path in paths:
+                write_midi(path, [60, 62, 64, 65] * 4)
+            with self.assertRaises(StageBMidiToSoloCandidateFailureLabelingError):
+                build_candidate_failure_labeling_report(
+                    rubric_baseline=rubric_baseline(root),
+                    mvp_delivery_package=delivery_package(paths, quality_claim=True),
+                    output_dir=root / "labels",
+                    issue_number=748,
+                )
+
+    def test_rejects_rubric_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = [root / f"candidate_{index}.mid" for index in range(3)]
+            for path in paths:
+                write_midi(path, [60, 62, 64, 65] * 4)
+            with self.assertRaises(StageBMidiToSoloCandidateFailureLabelingError):
+                build_candidate_failure_labeling_report(
+                    rubric_baseline=rubric_baseline(root, quality_claim=True),
+                    mvp_delivery_package=delivery_package(paths),
+                    output_dir=root / "labels",
+                    issue_number=748,
+                )
+
+    def test_rejects_missing_candidate_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = [root / f"candidate_{index}.mid" for index in range(3)]
+            for path in paths[:2]:
+                write_midi(path, [60, 62, 64, 65] * 4)
+            with self.assertRaises(StageBMidiToSoloCandidateFailureLabelingError):
+                build_candidate_failure_labeling_report(
+                    rubric_baseline=rubric_baseline(root),
+                    mvp_delivery_package=delivery_package(paths),
+                    output_dir=root / "labels",
+                    issue_number=748,
+                )
+
+    def test_rejects_wrong_rubric_boundary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = rubric_baseline(root)
+            source["boundary"] = "wrong_boundary"
+            with self.assertRaises(StageBMidiToSoloCandidateFailureLabelingError):
+                build_candidate_failure_labeling_report(
+                    rubric_baseline=source,
+                    mvp_delivery_package=delivery_package([root / "a.mid"] * 3),
+                    output_dir=root / "labels",
+                    issue_number=748,
+                )
+
+    def test_constants_are_stable(self) -> None:
+        self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_candidate_failure_labeling")
+        self.assertEqual(RUBRIC_BOUNDARY, "stage_b_midi_to_solo_quality_rubric_baseline")
+        self.assertEqual(RUBRIC_NEXT_BOUNDARY, "stage_b_midi_to_solo_candidate_failure_labeling")
+        self.assertEqual(RUBRIC_SELECTED_TARGET, "candidate_failure_labeling")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary
- current MIDI 후보 6개 failure label 산출
- failed candidate count: 6/6
- selected target: targeted_quality_repair_sweep

Context
- Issue #746 quality rubric baseline 완료
- rubric item count: 8
- MVP delivery package candidate source: CLI repaired 3, changed-ratio repair 3
- musical quality claim: false

Scope
- candidate failure labeling script 추가
- rubric baseline과 MVP delivery package 입력 검증
- MIDI note metric 기반 failure/not_evaluable label 산출
- 전용 harness mode, unit test, 상태 문서 추가

Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_candidate_failure_labeling`
- `.venv/bin/python -m py_compile scripts/label_stage_b_midi_to_solo_candidate_failures.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-candidate-failure-labeling`
- `bash scripts/agent_harness.sh quick`

Risk
- human/audio preference claim: false
- MIDI-to-solo musical quality claim: false
- chord context 없는 항목은 not_evaluable로 분리

Closes #748