### PR TITLE
Stage B MIDI-to-solo targeted quality repair sweep

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -402,6 +402,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo post-MVP quality iteration plan: selected target `quality_rubric_baseline`, ordered work `4`, taxonomy seed `7`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_rubric_baseline`
 - MIDI-to-solo quality rubric baseline: rubric items `8`, metric groups `29`, candidate failure labeling ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_candidate_failure_labeling`
 - MIDI-to-solo candidate failure labeling: candidates `6`, failed `6`, failure label types `4`, not-evaluable types `2`, targeted repair ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- MIDI-to-solo targeted quality repair sweep: candidates `6`, failure labels `12 -> 8`, improved candidates `4`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
 - MIDI-to-solo pitch-contour changed-ratio repair probe: repaired/pass `3/3`, max pitch changed ratio `0.7174 -> 0.4348`, max interval `12`, dead-air max `0.0000`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
 - MIDI-to-solo pitch-contour changed-ratio repair audio package: rendered WAV `3`, duration `18.422s-18.978s`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
@@ -4387,6 +4388,7 @@ Issue #746은 Issue #744 post-MVP quality iteration plan 이후 candidate failur
 다음 작업:
 
 - `Stage B MIDI-to-solo candidate failure labeling`
+- `Stage B MIDI-to-solo targeted quality repair sweep`
 
 ## 9.65 Stage B MIDI-to-solo candidate failure labeling
 
@@ -4425,6 +4427,45 @@ Issue #748은 Issue #746 quality rubric baseline 이후 현재 MIDI 후보를 ru
 다음 작업:
 
 - `Stage B MIDI-to-solo targeted quality repair sweep`
+
+## 9.66 Stage B MIDI-to-solo targeted quality repair sweep
+
+Issue #750은 Issue #748 candidate failure labeling 결과를 입력으로 현재 후보 MIDI 6개에 timing/duration variation과 제한된 pitch contour variation을 적용한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
+- selected target: `targeted_quality_repair_audio_package`
+- candidate count: `6`
+- source total failure label count: `12`
+- repaired total failure label count: `8`
+- failure label delta: `4`
+- improved candidate count: `4`
+- technical regression count: `0`
+- repaired failure counts: `dead_air_or_density_gap=1`, `phrase_shape_missing_tension_release=2`, `songlike_melody_not_soloing=5`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- 현재 repair sweep은 objective failure label 총합 감소를 확인.
+- technical gate regression은 관측되지 않음.
+- songlike melody failure는 6개 중 5개에 잔존.
+- chord context 없는 항목은 이번 작업에서도 not_evaluable 범위 유지.
+- 다음 boundary는 repaired MIDI 후보의 audio package 생성.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-sweep`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo targeted quality repair audio package`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -1989,6 +1989,54 @@ Issue #748은 Issue #746 quality rubric baseline 이후 현재 MIDI 후보를 ru
 
 - `Stage B MIDI-to-solo targeted quality repair sweep`
 
+## Stage B MIDI-to-Solo Targeted Quality Repair Sweep Result
+
+Issue #750은 Issue #748 candidate failure labeling 결과를 입력으로 현재 후보 MIDI 6개에 targeted quality repair를 적용한 작업이다.
+
+변경:
+
+- targeted quality repair sweep script 추가
+- candidate failure labeling report와 quality rubric baseline 입력 검증 연결
+- 기존 MIDI 후보별 timing/duration variation 적용
+- 제한된 pitch contour variation 적용
+- repair 전후 failure label 재측정
+- 전용 harness mode와 unit test 추가
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_SWEEP_2026-06-09.md`
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
+- selected target: `targeted_quality_repair_audio_package`
+- candidate count: `6`
+- source total failure label count: `12`
+- repaired total failure label count: `8`
+- failure label delta: `4`
+- improved candidate count: `4`
+- technical regression count: `0`
+- repaired failure counts: `dead_air_or_density_gap=1`, `phrase_shape_missing_tension_release=2`, `songlike_melody_not_soloing=5`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- objective failure label 총합 감소 확인.
+- technical gate regression 미관측.
+- songlike melody failure 잔존.
+- 다음 boundary는 repaired MIDI 후보 audio package.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-sweep`
+
+다음:
+
+- `Stage B MIDI-to-solo targeted quality repair audio package`
+
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 
 Issue #666은 Issue #664 current evidence를 README 첫 상태 영역과 claim boundary에 반영하고, 다음 boundary를 MVP completion audit으로 넘긴 문서 작업이다.

--- a/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_SWEEP_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_SWEEP_2026-06-09.md
@@ -1,0 +1,30 @@
+# Stage B MIDI-to-Solo Targeted Quality Repair Sweep
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
+- selected target: `targeted_quality_repair_audio_package`
+- candidate count: `6`
+- source total failure label count: `12`
+- repaired total failure label count: `8`
+- failure label delta: `4`
+- improved candidate count: `4`
+- technical regression count: `0`
+- target supported: `true`
+
+## Repaired Failure Counts
+
+- `dead_air_or_density_gap`: `1`
+- `phrase_shape_missing_tension_release`: `2`
+- `songlike_melody_not_soloing`: `5`
+
+## Claim Boundary
+
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo targeted quality repair audio package`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -252,6 +252,8 @@ Modes:
                 Build the post-MVP MIDI evidence quality rubric baseline.
   stage-b-midi-to-solo-candidate-failure-labeling
                 Label current MIDI-to-solo candidates against the quality rubric.
+  stage-b-midi-to-solo-targeted-quality-repair-sweep
+                Run targeted MIDI-to-solo quality repair from candidate failure labels.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision
                 Decide the next pitch-contour changed-ratio repair boundary.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-probe
@@ -6133,6 +6135,34 @@ run_stage_b_midi_to_solo_candidate_failure_labeling() {
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_targeted_quality_repair_sweep() {
+  local labeling_run_id="${LABELING_RUN_ID:-harness_stage_b_midi_to_solo_candidate_failure_labeling}"
+  local rubric_run_id="${RUBRIC_RUN_ID:-harness_stage_b_midi_to_solo_quality_rubric_baseline}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_sweep}"
+  local labeling="outputs/stage_b_midi_to_solo_candidate_failure_labeling/${labeling_run_id}/stage_b_midi_to_solo_candidate_failure_labeling.json"
+  local rubric="outputs/stage_b_midi_to_solo_quality_rubric_baseline/${rubric_run_id}/stage_b_midi_to_solo_quality_rubric_baseline.json"
+  if [[ ! -f "$labeling" ]]; then
+    print_header "Stage B MIDI-to-solo candidate failure labeling"
+    RUN_ID="$labeling_run_id" run_stage_b_midi_to_solo_candidate_failure_labeling
+  fi
+  if [[ ! -f "$rubric" ]]; then
+    print_header "Stage B MIDI-to-solo quality rubric baseline"
+    RUN_ID="$rubric_run_id" run_stage_b_midi_to_solo_quality_rubric_baseline
+  fi
+  print_header "Stage B MIDI-to-solo targeted quality repair sweep"
+  "$PYTHON_BIN" scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py \
+    --run_id "$run_id" \
+    --candidate_failure_labeling "$labeling" \
+    --rubric_baseline "$rubric" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_SWEEP_2026-06-09.md \
+    --issue_number 750 \
+    --expected_boundary stage_b_midi_to_solo_targeted_quality_repair_sweep \
+    --min_candidate_count 6 \
+    --require_sweep_completed \
+    --require_failure_delta \
+    --require_no_quality_claim
+}
+
 run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision() {
   local quality_gap_run_id="${QUALITY_GAP_RUN_ID:-harness_stage_b_midi_to_solo_quality_gap_decision}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision}"
@@ -8398,6 +8428,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-candidate-failure-labeling)
     run_stage_b_midi_to_solo_candidate_failure_labeling
+    ;;
+  stage-b-midi-to-solo-targeted-quality-repair-sweep)
+    run_stage_b_midi_to_solo_targeted_quality_repair_sweep
     ;;
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision)
     run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision

--- a/scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
+++ b/scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
@@ -1,0 +1,524 @@
+"""Run a targeted post-MVP MIDI-to-solo quality repair sweep."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pretty_midi
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.label_stage_b_midi_to_solo_candidate_failures import (  # noqa: E402
+    BOUNDARY as LABELING_BOUNDARY,
+    REPAIR_NEXT_BOUNDARY as LABELING_NEXT_BOUNDARY,
+    REPAIR_TARGET as LABELING_TARGET,
+    StageBMidiToSoloCandidateFailureLabelingError,
+    analyze_candidate_midi,
+    label_candidate,
+    validate_candidate_failure_labeling_report,
+    validate_rubric_baseline,
+)
+
+
+class StageBMidiToSoloTargetedQualityRepairSweepError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_sweep"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_audio_package"
+FOLLOWUP_BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_followup_decision"
+SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_sweep_v1"
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_labeling_source(report: dict[str, Any]) -> dict[str, Any]:
+    if str(report.get("boundary") or "") != LABELING_BOUNDARY:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "candidate failure labeling boundary required"
+        )
+    try:
+        summary = validate_candidate_failure_labeling_report(
+            report,
+            expected_boundary=LABELING_BOUNDARY,
+            min_candidate_count=3,
+            require_labeling_completed=True,
+            require_no_quality_claim=True,
+        )
+    except StageBMidiToSoloCandidateFailureLabelingError as exc:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(str(exc)) from exc
+    readiness = _dict(report.get("readiness"))
+    selected = _dict(report.get("selected_next_target"))
+    _require_no_quality_claim(readiness, label="labeling readiness")
+    if str(selected.get("selected_target") or "") != LABELING_TARGET:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError("targeted repair target required")
+    if str(selected.get("selected_next_boundary") or "") != LABELING_NEXT_BOUNDARY:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError("targeted repair boundary required")
+    if _int(summary.get("failed_candidate_count")) <= 0:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError("failure labels required")
+    return summary
+
+
+def non_drum_notes(midi: pretty_midi.PrettyMIDI) -> list[pretty_midi.Note]:
+    notes: list[pretty_midi.Note] = []
+    for instrument in midi.instruments:
+        if not instrument.is_drum:
+            notes.extend(instrument.notes)
+    return sorted(notes, key=lambda note: (float(note.start), int(note.pitch), float(note.end)))
+
+
+def clamp_pitch(value: int, *, low: int = 45, high: int = 88) -> int:
+    return max(low, min(high, int(value)))
+
+
+def repaired_pitch(previous_pitch: int, original_pitch: int, *, index: int, variant: int) -> int:
+    if index == 0 or index % 6 != variant % 6:
+        return int(original_pitch)
+    direction = 1 if ((index // 6) + variant) % 2 == 0 else -1
+    target = previous_pitch + (7 * direction)
+    if target < 45 or target > 88:
+        target = previous_pitch - (7 * direction)
+    if abs(target - previous_pitch) > 12:
+        target = previous_pitch + (12 if target > previous_pitch else -12)
+    return clamp_pitch(target)
+
+
+def repair_midi_file(
+    *,
+    source_path: str,
+    output_path: Path,
+    variant: int,
+) -> dict[str, Any]:
+    midi = pretty_midi.PrettyMIDI(source_path)
+    repaired = copy.deepcopy(midi)
+    notes = non_drum_notes(repaired)
+    if not notes:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(f"empty MIDI: {source_path}")
+
+    original_starts = [float(note.start) for note in notes]
+    original_durations = [max(0.05, float(note.end) - float(note.start)) for note in notes]
+    base_iois = [
+        max(0.05, original_starts[index] - original_starts[index - 1])
+        for index in range(1, len(original_starts))
+    ]
+    rhythm_factors = [0.75, 1.25, 1.0, 1.5, 0.5, 1.125]
+    rotated = rhythm_factors[variant % len(rhythm_factors) :] + rhythm_factors[: variant % len(rhythm_factors)]
+    if base_iois:
+        scaled_iois = [ioi * rotated[index % len(rotated)] for index, ioi in enumerate(base_iois)]
+        original_span = max(0.05, original_starts[-1] - original_starts[0])
+        scale = original_span / max(0.05, sum(scaled_iois))
+        new_starts = [original_starts[0]]
+        for ioi in scaled_iois:
+            new_starts.append(new_starts[-1] + (ioi * scale))
+    else:
+        new_starts = original_starts
+
+    duration_factors = [0.65, 1.0, 0.85, 1.2, 0.75, 1.05]
+    previous_pitch = int(notes[0].pitch)
+    changed_pitch_count = 0
+    changed_time_count = 0
+    for index, note in enumerate(notes):
+        old_start = float(note.start)
+        old_pitch = int(note.pitch)
+        note.start = float(new_starts[index])
+        next_start = float(new_starts[index + 1]) if index + 1 < len(new_starts) else None
+        duration = original_durations[index] * duration_factors[(index + variant) % len(duration_factors)]
+        if next_start is not None:
+            duration = min(duration, max(0.05, next_start - note.start - 0.01))
+        note.end = note.start + max(0.05, duration)
+        note.pitch = repaired_pitch(previous_pitch, old_pitch, index=index, variant=variant)
+        if note.pitch != old_pitch:
+            changed_pitch_count += 1
+        if abs(note.start - old_start) > 0.001:
+            changed_time_count += 1
+        previous_pitch = int(note.pitch)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    repaired.write(str(output_path))
+    return {
+        "source_path": source_path,
+        "repaired_midi_path": str(output_path),
+        "changed_pitch_count": changed_pitch_count,
+        "changed_time_count": changed_time_count,
+        "note_count": len(notes),
+    }
+
+
+def relabel_repaired_candidates(
+    repaired_rows: list[dict[str, Any]],
+    *,
+    rubric_items: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    analyzed = [
+        analyze_candidate_midi(
+            {
+                "source": str(row.get("source") or ""),
+                "rank": _int(row.get("rank")),
+                "midi_path": str(row.get("repaired_midi_path") or ""),
+                "source_objective_supported": True,
+                "source_dead_air_ratio": 0.0,
+            }
+        )
+        for row in repaired_rows
+    ]
+    rhythm_counts = Counter(tuple(item.get("rhythm_signature", ((), ()))) for item in analyzed)
+    labeled: list[dict[str, Any]] = []
+    for row, item in zip(repaired_rows, analyzed, strict=False):
+        labeled_item = label_candidate(
+            item,
+            rubric_items=rubric_items,
+            shared_rhythm_signature_count=rhythm_counts[
+                tuple(item.get("rhythm_signature", ((), ())))
+            ],
+        )
+        labeled.append({**row, "repaired_labeling": labeled_item})
+    return labeled
+
+
+def build_targeted_quality_repair_sweep_report(
+    *,
+    candidate_failure_labeling: dict[str, Any],
+    rubric_baseline: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+) -> dict[str, Any]:
+    source_summary = validate_labeling_source(candidate_failure_labeling)
+    rubric_summary = validate_rubric_baseline(rubric_baseline)
+    rubric_items = [_dict(item) for item in _list(rubric_summary.get("rubric_items"))]
+    source_candidates = [_dict(item) for item in _list(candidate_failure_labeling.get("candidate_labels"))]
+    if len(source_candidates) < 3:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError("source candidate labels below 3")
+
+    midi_dir = output_dir / "midi"
+    repaired_rows: list[dict[str, Any]] = []
+    for index, candidate in enumerate(source_candidates, start=1):
+        source_path = str(candidate.get("midi_path") or "")
+        if not Path(source_path).exists():
+            raise StageBMidiToSoloTargetedQualityRepairSweepError(
+                f"source MIDI missing: {source_path}"
+            )
+        source_name = f"{str(candidate.get('source') or 'candidate')}_rank_{_int(candidate.get('rank')):02d}"
+        repaired_path = midi_dir / f"{index:02d}_{source_name}_targeted_quality_repair.mid"
+        repair_summary = repair_midi_file(
+            source_path=source_path,
+            output_path=repaired_path,
+            variant=index,
+        )
+        repaired_rows.append(
+            {
+                "source": str(candidate.get("source") or ""),
+                "rank": _int(candidate.get("rank")),
+                "source_midi_path": source_path,
+                "source_failure_labels": _list(candidate.get("failure_labels")),
+                "source_failure_label_count": len(_list(candidate.get("failure_labels"))),
+                **repair_summary,
+            }
+        )
+
+    relabeled = relabel_repaired_candidates(repaired_rows, rubric_items=rubric_items)
+    total_before = sum(_int(item.get("source_failure_label_count")) for item in relabeled)
+    total_after = sum(
+        len(_list(_dict(item.get("repaired_labeling")).get("failure_labels")))
+        for item in relabeled
+    )
+    improved_count = sum(
+        1
+        for item in relabeled
+        if len(_list(_dict(item.get("repaired_labeling")).get("failure_labels")))
+        < _int(item.get("source_failure_label_count"))
+    )
+    technical_regression_count = sum(
+        1
+        for item in relabeled
+        if "technical_gate_regression"
+        in _list(_dict(item.get("repaired_labeling")).get("failure_labels"))
+    )
+    failure_counts_after = Counter(
+        label
+        for item in relabeled
+        for label in _list(_dict(item.get("repaired_labeling")).get("failure_labels"))
+    )
+    target_supported = total_after < total_before and technical_regression_count == 0
+    next_boundary = NEXT_BOUNDARY if target_supported else FOLLOWUP_BOUNDARY
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundary": LABELING_BOUNDARY,
+        "candidate_repairs": relabeled,
+        "aggregate": {
+            "candidate_count": len(relabeled),
+            "source_total_failure_label_count": total_before,
+            "repaired_total_failure_label_count": total_after,
+            "failure_label_delta": total_before - total_after,
+            "improved_candidate_count": improved_count,
+            "technical_regression_count": technical_regression_count,
+            "repaired_failure_counts": dict(sorted(failure_counts_after.items())),
+            "target_supported": target_supported,
+        },
+        "selected_next_target": {
+            "selected_target": "targeted_quality_repair_audio_package"
+            if target_supported
+            else "targeted_quality_repair_followup_decision",
+            "selected_next_boundary": next_boundary,
+            "reason": "repair sweep reduced objective failure labels without technical regression"
+            if target_supported
+            else "repair sweep did not reduce objective failure labels enough",
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "targeted_quality_repair_sweep_completed": True,
+            "targeted_quality_repair_target_supported": target_supported,
+            "candidate_count": len(relabeled),
+            "failure_label_delta": total_before - total_after,
+            "technical_regression_count": technical_regression_count,
+            "audio_package_ready": target_supported,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": next_boundary,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "targeted repair sweep completed without musical quality claim",
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "audio_rendered_quality",
+            "broad_trained_model_quality",
+        ],
+        "next_recommended_issue": "Stage B MIDI-to-solo targeted quality repair audio package"
+        if target_supported
+        else "Stage B MIDI-to-solo targeted quality repair follow-up decision",
+        "source_summary": source_summary,
+    }
+
+
+def validate_targeted_quality_repair_sweep_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    min_candidate_count: int,
+    require_sweep_completed: bool,
+    require_failure_delta: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    aggregate = _dict(report.get("aggregate"))
+    repairs = _list(report.get("candidate_repairs"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if require_sweep_completed and not bool(
+        readiness.get("targeted_quality_repair_sweep_completed", False)
+    ):
+        raise StageBMidiToSoloTargetedQualityRepairSweepError("repair sweep completion required")
+    if len(repairs) < int(min_candidate_count):
+        raise StageBMidiToSoloTargetedQualityRepairSweepError("repair candidate count below minimum")
+    if _int(aggregate.get("candidate_count")) != len(repairs):
+        raise StageBMidiToSoloTargetedQualityRepairSweepError("candidate count mismatch")
+    if require_failure_delta and _int(aggregate.get("failure_label_delta")) <= 0:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError("positive failure label delta required")
+    if _int(aggregate.get("technical_regression_count")) != 0:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError("technical regression should be zero")
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "critical user input should not be required"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="targeted repair readiness")
+    return {
+        "boundary": boundary,
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "targeted_quality_repair_sweep_completed": bool(
+            readiness.get("targeted_quality_repair_sweep_completed", False)
+        ),
+        "targeted_quality_repair_target_supported": bool(
+            readiness.get("targeted_quality_repair_target_supported", False)
+        ),
+        "candidate_count": len(repairs),
+        "source_total_failure_label_count": _int(
+            aggregate.get("source_total_failure_label_count")
+        ),
+        "repaired_total_failure_label_count": _int(
+            aggregate.get("repaired_total_failure_label_count")
+        ),
+        "failure_label_delta": _int(aggregate.get("failure_label_delta")),
+        "improved_candidate_count": _int(aggregate.get("improved_candidate_count")),
+        "technical_regression_count": _int(aggregate.get("technical_regression_count")),
+        "audio_package_ready": bool(readiness.get("audio_package_ready", False)),
+        "human_audio_preference_claimed": bool(
+            readiness.get("human_audio_preference_claimed", True)
+        ),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    aggregate = report["aggregate"]
+    selected = report["selected_next_target"]
+    readiness = report["readiness"]
+    lines = [
+        "# Stage B MIDI-to-Solo Targeted Quality Repair Sweep",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- source boundary: `{report['source_boundary']}`",
+        f"- next boundary: `{selected['selected_next_boundary']}`",
+        f"- selected target: `{selected['selected_target']}`",
+        f"- candidate count: `{aggregate['candidate_count']}`",
+        f"- source total failure label count: `{aggregate['source_total_failure_label_count']}`",
+        f"- repaired total failure label count: `{aggregate['repaired_total_failure_label_count']}`",
+        f"- failure label delta: `{aggregate['failure_label_delta']}`",
+        f"- improved candidate count: `{aggregate['improved_candidate_count']}`",
+        f"- technical regression count: `{aggregate['technical_regression_count']}`",
+        f"- target supported: `{_bool_token(aggregate['target_supported'])}`",
+        "",
+        "## Repaired Failure Counts",
+        "",
+    ]
+    for label, count in aggregate["repaired_failure_counts"].items():
+        lines.append(f"- `{label}`: `{count}`")
+    if not aggregate["repaired_failure_counts"]:
+        lines.append("- none")
+    lines.extend(
+        [
+            "",
+            "## Claim Boundary",
+            "",
+            f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+            f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+            "",
+            "## Next",
+            "",
+            f"- `{report['next_recommended_issue']}`",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run MIDI-to-solo targeted quality repair sweep")
+    parser.add_argument("--candidate_failure_labeling", type=str, required=True)
+    parser.add_argument("--rubric_baseline", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_targeted_quality_repair_sweep",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=750)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--min_candidate_count", type=int, default=6)
+    parser.add_argument("--require_sweep_completed", action="store_true")
+    parser.add_argument("--require_failure_delta", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_targeted_quality_repair_sweep_report(
+        candidate_failure_labeling=read_json(Path(args.candidate_failure_labeling)),
+        rubric_baseline=read_json(Path(args.rubric_baseline)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+    )
+    summary = validate_targeted_quality_repair_sweep_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        min_candidate_count=int(args.min_candidate_count),
+        require_sweep_completed=bool(args.require_sweep_completed),
+        require_failure_delta=bool(args.require_failure_delta),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "stage_b_midi_to_solo_targeted_quality_repair_sweep.json", report)
+    write_json(
+        output_dir / "stage_b_midi_to_solo_targeted_quality_repair_sweep_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(output_dir / "stage_b_midi_to_solo_targeted_quality_repair_sweep.md", markdown)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import pretty_midi
+
+from scripts.build_stage_b_midi_to_solo_mvp_delivery_package import BOUNDARY as DELIVERY_BOUNDARY
+from scripts.build_stage_b_midi_to_solo_quality_rubric_baseline import (
+    build_quality_rubric_baseline_report,
+)
+from scripts.label_stage_b_midi_to_solo_candidate_failures import (
+    build_candidate_failure_labeling_report,
+)
+from scripts.plan_stage_b_midi_to_solo_post_mvp_quality_iteration import (
+    BOUNDARY as POST_MVP_BOUNDARY,
+    NEXT_BOUNDARY as POST_MVP_NEXT_BOUNDARY,
+    SELECTED_TARGET as POST_MVP_SELECTED_TARGET,
+)
+from scripts.run_stage_b_midi_to_solo_targeted_quality_repair_sweep import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloTargetedQualityRepairSweepError,
+    build_targeted_quality_repair_sweep_report,
+    validate_targeted_quality_repair_sweep_report,
+)
+
+
+def write_midi(path: Path, pitches: list[int]) -> None:
+    midi = pretty_midi.PrettyMIDI(initial_tempo=120)
+    midi.time_signature_changes.append(pretty_midi.TimeSignature(4, 4, 0.0))
+    instrument = pretty_midi.Instrument(program=0)
+    for index, pitch in enumerate(pitches):
+        start = index * 0.5
+        instrument.notes.append(
+            pretty_midi.Note(velocity=90, pitch=int(pitch), start=start, end=start + 0.25)
+        )
+    midi.instruments.append(instrument)
+    midi.write(str(path))
+
+
+def post_mvp_quality_plan() -> dict:
+    return {
+        "boundary": POST_MVP_BOUNDARY,
+        "selected_next_target": {
+            "selected_target": POST_MVP_SELECTED_TARGET,
+            "selected_next_boundary": POST_MVP_NEXT_BOUNDARY,
+        },
+        "ordered_work": [
+            {"target": "quality_rubric_baseline"},
+            {"target": "candidate_failure_labeling"},
+            {"target": "targeted_quality_repair_sweep"},
+            {"target": "audio_review_package"},
+        ],
+        "quality_failure_taxonomy_seed": [f"failure_{index}" for index in range(7)],
+        "post_mvp_status": {
+            "technical_mvp_complete": True,
+            "local_review_ready": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+        },
+        "readiness": {
+            "post_mvp_quality_iteration_plan_completed": True,
+            "quality_rubric_required": True,
+            "candidate_failure_labeling_required": True,
+            "targeted_quality_repair_sweep_required": True,
+            "audio_review_package_required": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": POST_MVP_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+def rubric_baseline(root: Path) -> dict:
+    return build_quality_rubric_baseline_report(
+        post_mvp_quality_plan=post_mvp_quality_plan(),
+        output_dir=root / "rubric",
+        issue_number=746,
+    )
+
+
+def delivery_package(paths: list[Path]) -> dict:
+    return {
+        "boundary": DELIVERY_BOUNDARY,
+        "delivery_package": {
+            "input_to_ranked_midi_ready": True,
+            "input_to_rendered_wav_evidence_ready": True,
+        },
+        "artifact_manifest": {
+            "cli_repaired_midi_candidates": [
+                {
+                    "rank": index + 1,
+                    "repaired_midi_path": str(path),
+                    "note_count": 24,
+                    "unique_pitch_count": 5,
+                    "dead_air_ratio": 0.0,
+                    "objective_supported": True,
+                }
+                for index, path in enumerate(paths[:3])
+            ],
+            "changed_ratio_repair_audio_candidates": [
+                {
+                    "rank": index + 1,
+                    "repaired_midi_path": str(path),
+                    "repaired_unique_pitch_count": 5,
+                    "pitch_changed_ratio": 0.3,
+                    "repaired_max_interval": 4,
+                }
+                for index, path in enumerate(paths[3:], start=1)
+            ],
+        },
+        "readiness": {
+            "mvp_delivery_package_completed": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "phrase_bank_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+    }
+
+
+def candidate_failure_labeling(root: Path, *, quality_claim: bool = False) -> dict:
+    paths = [root / f"candidate_{index}.mid" for index in range(6)]
+    for path in paths:
+        write_midi(path, [60, 62, 64, 65] * 6)
+    report = build_candidate_failure_labeling_report(
+        rubric_baseline=rubric_baseline(root),
+        mvp_delivery_package=delivery_package(paths),
+        output_dir=root / "labels",
+        issue_number=748,
+    )
+    if quality_claim:
+        report["readiness"]["midi_to_solo_musical_quality_claimed"] = True
+    return report
+
+
+class StageBMidiToSoloTargetedQualityRepairSweepTest(unittest.TestCase):
+    def test_repairs_current_failure_labels_without_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            report = build_targeted_quality_repair_sweep_report(
+                candidate_failure_labeling=candidate_failure_labeling(root),
+                rubric_baseline=rubric_baseline(root),
+                output_dir=root / "sweep",
+                issue_number=750,
+            )
+            summary = validate_targeted_quality_repair_sweep_report(
+                report,
+                expected_boundary=BOUNDARY,
+                min_candidate_count=6,
+                require_sweep_completed=True,
+                require_failure_delta=True,
+                require_no_quality_claim=True,
+            )
+
+            self.assertTrue(summary["targeted_quality_repair_sweep_completed"])
+            self.assertTrue(summary["targeted_quality_repair_target_supported"])
+            self.assertEqual(summary["candidate_count"], 6)
+            self.assertGreater(summary["failure_label_delta"], 0)
+            self.assertEqual(summary["technical_regression_count"], 0)
+            self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
+            self.assertTrue(summary["audio_package_ready"])
+            self.assertFalse(summary["human_audio_preference_claimed"])
+            self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+
+    def test_rejects_labeling_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaises(StageBMidiToSoloTargetedQualityRepairSweepError):
+                build_targeted_quality_repair_sweep_report(
+                    candidate_failure_labeling=candidate_failure_labeling(
+                        root,
+                        quality_claim=True,
+                    ),
+                    rubric_baseline=rubric_baseline(root),
+                    output_dir=root / "sweep",
+                    issue_number=750,
+                )
+
+    def test_constants_are_stable(self) -> None:
+        self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_targeted_quality_repair_sweep")
+        self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_targeted_quality_repair_audio_package")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary
- 현재 MIDI 후보 6개 대상 targeted quality repair sweep 추가
- timing/duration variation 및 제한된 pitch contour variation 적용
- repair 전후 quality rubric failure label 재측정

Context
- #748 candidate failure labeling 결과, 후보 6개 모두 repair 대상
- source total failure label count: 12
- 주요 failure labels: songlike melody, rhythmic monotony, phrase shape, dead-air/density gap
- chord context 부재 항목은 not_evaluable 범위 유지

Scope
- `scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py` 추가
- `tests/test_stage_b_midi_to_solo_targeted_quality_repair_sweep.py` 추가
- `scripts/agent_harness.sh` 전용 mode 추가
- 상태 문서 및 Issue #750 결과 문서 갱신

Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_sweep`
- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-sweep`
- `bash scripts/agent_harness.sh quick`

Result
- candidate count: 6
- failure labels: 12 -> 8
- improved candidates: 4
- technical regression count: 0
- human/audio preference claim: false
- MIDI-to-solo musical quality claim: false

Risk
- songlike melody failure 잔존: 5/6
- human/audio preference 미검증
- 다음 boundary: targeted quality repair audio package

Closes #750