### PR TITLE
Stage B MIDI-to-solo targeted quality repair follow-up decision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #732, Stage B MIDI-to-solo MVP completion audit.
+- Latest functional issue completed: Issue #760, Stage B MIDI-to-solo targeted quality repair follow-up decision.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo quality gap decision.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair sweep.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -4626,6 +4626,48 @@ Issue #758은 Issue #756 input guard 이후 listening input 없이 objective evi
 
 - `Stage B MIDI-to-solo targeted quality repair follow-up decision`
 
+## 9.71 Stage B MIDI-to-solo targeted quality repair follow-up decision
+
+Issue #760은 Issue #758 objective-only next decision과 Issue #750 repair sweep 결과를 함께 검증해 다음 repair target을 정한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
+- repair sweep boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- selected target: `songlike_melody_contour_repair_sweep`
+- candidate count: `6`
+- source total failure labels: `12`
+- repaired total failure labels: `8`
+- failure label delta: `4`
+- technical regression count: `0`
+- dominant remaining failure label: `songlike_melody_not_soloing`
+- dominant remaining failure count: `5`
+- remaining failure counts: `dead_air_or_density_gap=1`, `phrase_shape_missing_tension_release=2`, `songlike_melody_not_soloing=5`
+- not evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- listening input 부재 상태이므로 quality/preference claim 제외 유지.
+- technical regression 없이 failure label은 `12 -> 8`로 감소.
+- 잔여 failure 중 `songlike_melody_not_soloing`이 dominant target.
+- chord-context 기반 항목은 미평가 상태로 분리.
+- 다음 boundary는 songlike melody contour repair sweep.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-followup-decision`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour repair sweep`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #758, Stage B MIDI-to-solo targeted quality repair objective-only next decision
-- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair follow-up decision`
+- latest functional result: Issue #760, Stage B MIDI-to-solo targeted quality repair follow-up decision
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair sweep`
 
 현재 범위가 아닌 것:
 
@@ -91,6 +91,10 @@
 - post-MVP musical quality iteration plan 완료
 - quality rubric baseline 완료
 - candidate failure labeling 완료
+- targeted quality repair objective-only next decision 완료
+- targeted quality repair follow-up decision 완료
+- 남은 dominant failure label: `songlike_melody_not_soloing` = `5`
+- 다음 repair target: `songlike_melody_contour_repair_sweep`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_FOLLOWUP_DECISION_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_FOLLOWUP_DECISION_2026-06-09.md
@@ -1,0 +1,45 @@
+# Stage B MIDI-to-Solo Targeted Quality Repair Follow-Up Decision
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
+- repair sweep boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- selected target: `songlike_melody_contour_repair_sweep`
+- dominant remaining failure label: `songlike_melody_not_soloing`
+- dominant remaining failure count: `5`
+- candidate count: `6`
+- source total failure labels: `12`
+- repaired total failure labels: `8`
+- failure label delta: `4`
+- technical regression count: `0`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Remaining Failure Counts
+
+- `dead_air_or_density_gap`: `1`
+- `phrase_shape_missing_tension_release`: `2`
+- `songlike_melody_not_soloing`: `5`
+
+## Not Evaluable Counts
+
+- `outside_soloing_without_context`: `6`
+- `weak_chord_tone_landing`: `6`
+
+## Decision
+
+- reason: `remaining objective failure labels route to follow-up repair without quality claim`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo songlike melody contour repair sweep`
+
+## Claim Boundary
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `outside_soloing_without_context`
+- `weak_chord_tone_landing`
+- `broad_trained_model_quality`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -262,6 +262,8 @@ Modes:
                 Block targeted quality repair preference fill while listening review input is pending.
   stage-b-midi-to-solo-targeted-quality-repair-objective-only-next-decision
                 Select the objective-only next boundary after targeted quality repair input guard.
+  stage-b-midi-to-solo-targeted-quality-repair-followup-decision
+                Select the dominant remaining quality label and next repair target.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision
                 Decide the next pitch-contour changed-ratio repair boundary.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-probe
@@ -6256,6 +6258,35 @@ run_stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision() 
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_targeted_quality_repair_followup_decision() {
+  local objective_run_id="${OBJECTIVE_RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision}"
+  local sweep_run_id="${SWEEP_RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_sweep}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_followup_decision}"
+  local objective_report="outputs/stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision/${objective_run_id}/stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision.json"
+  local sweep_report="outputs/stage_b_midi_to_solo_targeted_quality_repair_sweep/${sweep_run_id}/stage_b_midi_to_solo_targeted_quality_repair_sweep.json"
+  if [[ ! -f "$objective_report" ]]; then
+    print_header "Stage B MIDI-to-solo targeted quality repair objective-only next decision"
+    RUN_ID="$objective_run_id" run_stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision
+  fi
+  if [[ ! -f "$sweep_report" ]]; then
+    print_header "Stage B MIDI-to-solo targeted quality repair sweep"
+    RUN_ID="$sweep_run_id" run_stage_b_midi_to_solo_targeted_quality_repair_sweep
+  fi
+  print_header "Stage B MIDI-to-solo targeted quality repair follow-up decision"
+  "$PYTHON_BIN" scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py \
+    --run_id "$run_id" \
+    --objective_next_report "$objective_report" \
+    --repair_sweep_report "$sweep_report" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_FOLLOWUP_DECISION_2026-06-09.md \
+    --issue_number 760 \
+    --expected_boundary stage_b_midi_to_solo_targeted_quality_repair_followup_decision \
+    --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_sweep \
+    --expected_target songlike_melody_contour_repair_sweep \
+    --require_followup_decision \
+    --require_dominant_songlike_target \
+    --require_no_quality_claim
+}
+
 run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision() {
   local quality_gap_run_id="${QUALITY_GAP_RUN_ID:-harness_stage_b_midi_to_solo_quality_gap_decision}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision}"
@@ -8536,6 +8567,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-targeted-quality-repair-objective-only-next-decision)
     run_stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision
+    ;;
+  stage-b-midi-to-solo-targeted-quality-repair-followup-decision)
+    run_stage_b_midi_to_solo_targeted_quality_repair_followup_decision
     ;;
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision)
     run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision

--- a/scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py
+++ b/scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py
@@ -1,0 +1,530 @@
+"""Decide the follow-up target after targeted quality repair evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.decide_stage_b_midi_to_solo_targeted_quality_repair_objective_next import (  # noqa: E402
+    BOUNDARY as OBJECTIVE_NEXT_BOUNDARY,
+    FOLLOWUP_DECISION_NEXT_BOUNDARY,
+)
+from scripts.run_stage_b_midi_to_solo_targeted_quality_repair_sweep import (  # noqa: E402
+    BOUNDARY as REPAIR_SWEEP_BOUNDARY,
+)
+
+
+class StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_followup_decision"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_sweep"
+SELECTED_TARGET = "songlike_melody_contour_repair_sweep"
+SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v1"
+DOMINANT_TARGET_LABEL = "songlike_melody_not_soloing"
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_objective_next_source(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("objective_summary"))
+    if str(report.get("boundary") or "") != OBJECTIVE_NEXT_BOUNDARY:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "targeted quality objective-only next decision boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != FOLLOWUP_DECISION_NEXT_BOUNDARY:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "objective-only next decision must route to follow-up decision"
+        )
+    if str(decision.get("next_boundary") or "") != BOUNDARY:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "follow-up decision boundary mismatch"
+        )
+    if not bool(readiness.get("objective_next_decision_completed", False)):
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "objective next decision completion required"
+        )
+    if not bool(readiness.get("targeted_quality_followup_required", False)):
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "targeted quality follow-up requirement required"
+        )
+    if bool(summary.get("validated_review_input_present", True)):
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "follow-up decision expects pending listening input"
+        )
+    if bool(summary.get("preference_fill_allowed", True)):
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "preference fill must remain blocked"
+        )
+    if bool(summary.get("current_quality_claim_ready", True)):
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "quality claim readiness must remain false"
+        )
+    if not bool(summary.get("technical_wav_validation", False)):
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "technical WAV validation required"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "critical user input should not be required"
+        )
+    _require_no_quality_claim(readiness, label="objective next readiness")
+    return {
+        "boundary": OBJECTIVE_NEXT_BOUNDARY,
+        "review_item_count": _int(summary.get("review_item_count")),
+        "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
+        "failure_label_delta": _int(summary.get("failure_label_delta")),
+        "technical_wav_validation": bool(summary.get("technical_wav_validation", False)),
+        "validated_review_input_present": bool(
+            summary.get("validated_review_input_present", False)
+        ),
+        "preference_fill_allowed": bool(summary.get("preference_fill_allowed", False)),
+        "current_quality_claim_ready": False,
+    }
+
+
+def _candidate_label_counts(rows: list[Any], key: str) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for row_value in rows:
+        row = _dict(row_value)
+        labels = _list(_dict(row.get("repaired_labeling")).get(key))
+        for label in labels:
+            counts[str(label)] += 1
+    return dict(sorted(counts.items()))
+
+
+def validate_repair_sweep_source(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    aggregate = _dict(report.get("aggregate"))
+    rows = _list(report.get("candidate_repairs"))
+    if str(report.get("boundary") or "") != REPAIR_SWEEP_BOUNDARY:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "targeted quality repair sweep boundary required"
+        )
+    if not bool(readiness.get("targeted_quality_repair_sweep_completed", False)):
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "repair sweep completion required"
+        )
+    if not bool(readiness.get("targeted_quality_repair_target_supported", False)):
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "targeted repair support required"
+        )
+    if _int(aggregate.get("candidate_count")) < 6:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "candidate count below 6"
+        )
+    if _int(aggregate.get("failure_label_delta")) <= 0:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "positive failure label delta required"
+        )
+    if _int(aggregate.get("technical_regression_count")) != 0:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "technical regression must remain zero"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "critical user input should not be required"
+        )
+    _require_no_quality_claim(readiness, label="repair sweep readiness")
+
+    remaining_counts = {
+        str(label): _int(count)
+        for label, count in _dict(aggregate.get("repaired_failure_counts")).items()
+        if _int(count) > 0
+    }
+    if not remaining_counts:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "remaining failure label counts required"
+        )
+    dominant_label, dominant_count = max(
+        remaining_counts.items(),
+        key=lambda item: (item[1], item[0]),
+    )
+    if not rows:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "candidate repair rows required"
+        )
+    return {
+        "boundary": REPAIR_SWEEP_BOUNDARY,
+        "candidate_count": _int(aggregate.get("candidate_count")),
+        "source_total_failure_label_count": _int(
+            aggregate.get("source_total_failure_label_count")
+        ),
+        "repaired_total_failure_label_count": _int(
+            aggregate.get("repaired_total_failure_label_count")
+        ),
+        "failure_label_delta": _int(aggregate.get("failure_label_delta")),
+        "improved_candidate_count": _int(aggregate.get("improved_candidate_count")),
+        "technical_regression_count": _int(aggregate.get("technical_regression_count")),
+        "remaining_failure_counts": remaining_counts,
+        "dominant_remaining_failure_label": dominant_label,
+        "dominant_remaining_failure_count": dominant_count,
+        "not_evaluable_counts": _candidate_label_counts(rows, "not_evaluable_labels"),
+    }
+
+
+def build_followup_decision_report(
+    *,
+    objective_next_report: dict[str, Any],
+    repair_sweep_report: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+) -> dict[str, Any]:
+    objective = validate_objective_next_source(objective_next_report)
+    sweep = validate_repair_sweep_source(repair_sweep_report)
+    dominant_label = str(sweep["dominant_remaining_failure_label"])
+    selected_target = SELECTED_TARGET if dominant_label == DOMINANT_TARGET_LABEL else "targeted_quality_repair_followup_sweep"
+    next_boundary = NEXT_BOUNDARY if dominant_label == DOMINANT_TARGET_LABEL else "stage_b_midi_to_solo_targeted_quality_repair_followup_sweep"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundary": objective["boundary"],
+        "repair_sweep_boundary": sweep["boundary"],
+        "objective_summary": objective,
+        "repair_sweep_summary": sweep,
+        "selected_next_target": {
+            "selected_target": selected_target,
+            "selected_next_boundary": next_boundary,
+            "dominant_remaining_failure_label": dominant_label,
+            "dominant_remaining_failure_count": _int(
+                sweep["dominant_remaining_failure_count"]
+            ),
+            "reason": "dominant remaining failure label selected for objective repair sweep",
+        },
+        "followup_targets": {
+            "primary_label": dominant_label,
+            "secondary_failure_counts": sweep["remaining_failure_counts"],
+            "not_evaluable_counts": sweep["not_evaluable_counts"],
+            "preserve_gates": [
+                "grammar_valid",
+                "strict_valid",
+                "technical_regression_count_zero",
+                "no_quality_claim",
+            ],
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "followup_decision_completed": True,
+            "dominant_songlike_target_selected": dominant_label == DOMINANT_TARGET_LABEL,
+            "songlike_melody_repair_required": _int(
+                sweep["remaining_failure_counts"].get(DOMINANT_TARGET_LABEL, 0)
+            )
+            > 0,
+            "candidate_count": _int(sweep["candidate_count"]),
+            "source_total_failure_label_count": _int(
+                sweep["source_total_failure_label_count"]
+            ),
+            "repaired_total_failure_label_count": _int(
+                sweep["repaired_total_failure_label_count"]
+            ),
+            "failure_label_delta": _int(sweep["failure_label_delta"]),
+            "technical_regression_count": _int(sweep["technical_regression_count"]),
+            "human_audio_preference_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": next_boundary,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "remaining objective failure labels route to follow-up repair without quality claim",
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "audio_rendered_quality",
+            "outside_soloing_without_context",
+            "weak_chord_tone_landing",
+            "broad_trained_model_quality",
+        ],
+        "next_recommended_issue": "Stage B MIDI-to-solo songlike melody contour repair sweep"
+        if next_boundary == NEXT_BOUNDARY
+        else "Stage B MIDI-to-solo targeted quality repair follow-up sweep",
+    }
+
+
+def validate_followup_decision_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    expected_target: str | None,
+    require_followup_decision: bool,
+    require_dominant_songlike_target: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    selected = _dict(report.get("selected_next_target"))
+    sweep = _dict(report.get("repair_sweep_summary"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "unexpected next boundary"
+        )
+    if expected_target and str(selected.get("selected_target") or "") != expected_target:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "unexpected selected target"
+        )
+    if require_followup_decision and not bool(
+        readiness.get("followup_decision_completed", False)
+    ):
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "follow-up decision completion required"
+        )
+    if require_dominant_songlike_target and not bool(
+        readiness.get("dominant_songlike_target_selected", False)
+    ):
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "dominant songlike target selection required"
+        )
+    if _int(readiness.get("technical_regression_count")) != 0:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "technical regression must remain zero"
+        )
+    if _int(readiness.get("failure_label_delta")) <= 0:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "positive failure label delta required"
+        )
+    if _int(selected.get("dominant_remaining_failure_count")) <= 0:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "dominant failure label count required"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "critical user input should not be required"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="follow-up readiness")
+    return {
+        "boundary": boundary,
+        "source_boundary": str(report.get("source_boundary") or ""),
+        "repair_sweep_boundary": str(report.get("repair_sweep_boundary") or ""),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "selected_target": str(selected.get("selected_target") or ""),
+        "followup_decision_completed": bool(
+            readiness.get("followup_decision_completed", False)
+        ),
+        "dominant_songlike_target_selected": bool(
+            readiness.get("dominant_songlike_target_selected", False)
+        ),
+        "dominant_remaining_failure_label": str(
+            selected.get("dominant_remaining_failure_label") or ""
+        ),
+        "dominant_remaining_failure_count": _int(
+            selected.get("dominant_remaining_failure_count")
+        ),
+        "candidate_count": _int(readiness.get("candidate_count")),
+        "source_total_failure_label_count": _int(
+            readiness.get("source_total_failure_label_count")
+        ),
+        "repaired_total_failure_label_count": _int(
+            readiness.get("repaired_total_failure_label_count")
+        ),
+        "failure_label_delta": _int(readiness.get("failure_label_delta")),
+        "technical_regression_count": _int(readiness.get("technical_regression_count")),
+        "remaining_failure_counts": _dict(sweep.get("remaining_failure_counts")),
+        "not_evaluable_counts": _dict(sweep.get("not_evaluable_counts")),
+        "human_audio_preference_claimed": bool(
+            readiness.get("human_audio_preference_claimed", True)
+        ),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(
+            decision.get("critical_user_input_required", True)
+        ),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    selected = report["selected_next_target"]
+    sweep = report["repair_sweep_summary"]
+    lines = [
+        "# Stage B MIDI-to-Solo Targeted Quality Repair Follow-Up Decision",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- source boundary: `{report['source_boundary']}`",
+        f"- repair sweep boundary: `{report['repair_sweep_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- selected target: `{selected['selected_target']}`",
+        f"- dominant remaining failure label: `{selected['dominant_remaining_failure_label']}`",
+        f"- dominant remaining failure count: `{selected['dominant_remaining_failure_count']}`",
+        f"- candidate count: `{readiness['candidate_count']}`",
+        f"- source total failure labels: `{readiness['source_total_failure_label_count']}`",
+        f"- repaired total failure labels: `{readiness['repaired_total_failure_label_count']}`",
+        f"- failure label delta: `{readiness['failure_label_delta']}`",
+        f"- technical regression count: `{readiness['technical_regression_count']}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Remaining Failure Counts",
+        "",
+    ]
+    for label, count in sweep["remaining_failure_counts"].items():
+        lines.append(f"- `{label}`: `{count}`")
+    lines.extend(
+        [
+            "",
+            "## Not Evaluable Counts",
+            "",
+        ]
+    )
+    for label, count in sweep["not_evaluable_counts"].items():
+        lines.append(f"- `{label}`: `{count}`")
+    lines.extend(
+        [
+            "",
+            "## Decision",
+            "",
+            f"- reason: `{decision['reason']}`",
+            f"- auto progress allowed: `{_bool_token(decision['auto_progress_allowed'])}`",
+            f"- critical user input required: `{_bool_token(decision['critical_user_input_required'])}`",
+            f"- next recommended issue: `{report['next_recommended_issue']}`",
+            "",
+            "## Claim Boundary",
+            "",
+        ]
+    )
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Decide targeted quality repair follow-up target"
+    )
+    parser.add_argument("--objective_next_report", type=str, required=True)
+    parser.add_argument("--repair_sweep_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_targeted_quality_repair_followup_decision",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=760)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--expected_target", type=str, default="")
+    parser.add_argument("--require_followup_decision", action="store_true")
+    parser.add_argument("--require_dominant_songlike_target", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_followup_decision_report(
+        objective_next_report=read_json(Path(args.objective_next_report)),
+        repair_sweep_report=read_json(Path(args.repair_sweep_report)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+    )
+    summary = validate_followup_decision_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        expected_target=str(args.expected_target or ""),
+        require_followup_decision=bool(args.require_followup_decision),
+        require_dominant_songlike_target=bool(args.require_dominant_songlike_target),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_targeted_quality_repair_followup_decision.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_targeted_quality_repair_followup_decision_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir / "stage_b_midi_to_solo_targeted_quality_repair_followup_decision.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.decide_stage_b_midi_to_solo_targeted_quality_repair_followup import (
+    BOUNDARY,
+    DOMINANT_TARGET_LABEL,
+    NEXT_BOUNDARY,
+    SELECTED_TARGET,
+    StageBMidiToSoloTargetedQualityRepairFollowupDecisionError,
+    build_followup_decision_report,
+    validate_followup_decision_report,
+)
+from scripts.decide_stage_b_midi_to_solo_targeted_quality_repair_objective_next import (
+    BOUNDARY as OBJECTIVE_NEXT_BOUNDARY,
+)
+from scripts.run_stage_b_midi_to_solo_targeted_quality_repair_sweep import (
+    BOUNDARY as SWEEP_BOUNDARY,
+)
+
+
+def objective_next_report(*, quality_claim: bool = False) -> dict:
+    return {
+        "boundary": OBJECTIVE_NEXT_BOUNDARY,
+        "objective_summary": {
+            "review_item_count": 6,
+            "validated_review_input_present": False,
+            "preference_fill_allowed": False,
+            "technical_wav_validation": True,
+            "rendered_audio_file_count": 6,
+            "failure_label_delta": 4,
+            "current_quality_claim_ready": False,
+        },
+        "readiness": {
+            "objective_next_decision_completed": True,
+            "targeted_quality_followup_required": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": quality_claim,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+def repair_sweep_report(*, technical_regression_count: int = 0) -> dict:
+    return {
+        "boundary": SWEEP_BOUNDARY,
+        "candidate_repairs": [
+            {
+                "repaired_labeling": {
+                    "failure_labels": ["songlike_melody_not_soloing"],
+                    "not_evaluable_labels": [
+                        "outside_soloing_without_context",
+                        "weak_chord_tone_landing",
+                    ],
+                }
+            }
+            for _ in range(6)
+        ],
+        "aggregate": {
+            "candidate_count": 6,
+            "source_total_failure_label_count": 12,
+            "repaired_total_failure_label_count": 8,
+            "failure_label_delta": 4,
+            "improved_candidate_count": 4,
+            "technical_regression_count": technical_regression_count,
+            "repaired_failure_counts": {
+                "dead_air_or_density_gap": 1,
+                "phrase_shape_missing_tension_release": 2,
+                DOMINANT_TARGET_LABEL: 5,
+            },
+        },
+        "readiness": {
+            "targeted_quality_repair_sweep_completed": True,
+            "targeted_quality_repair_target_supported": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCase):
+    def test_selects_dominant_songlike_repair_target(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            report = build_followup_decision_report(
+                objective_next_report=objective_next_report(),
+                repair_sweep_report=repair_sweep_report(),
+                output_dir=Path(tmp) / "followup",
+                issue_number=760,
+            )
+            summary = validate_followup_decision_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                expected_target=SELECTED_TARGET,
+                require_followup_decision=True,
+                require_dominant_songlike_target=True,
+                require_no_quality_claim=True,
+            )
+
+            self.assertTrue(summary["followup_decision_completed"])
+            self.assertTrue(summary["dominant_songlike_target_selected"])
+            self.assertEqual(
+                summary["dominant_remaining_failure_label"],
+                DOMINANT_TARGET_LABEL,
+            )
+            self.assertEqual(summary["dominant_remaining_failure_count"], 5)
+            self.assertEqual(summary["failure_label_delta"], 4)
+            self.assertEqual(summary["technical_regression_count"], 0)
+            self.assertEqual(summary["selected_target"], SELECTED_TARGET)
+            self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
+            self.assertFalse(summary["human_audio_preference_claimed"])
+            self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+
+    def test_rejects_objective_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(
+                StageBMidiToSoloTargetedQualityRepairFollowupDecisionError
+            ):
+                build_followup_decision_report(
+                    objective_next_report=objective_next_report(quality_claim=True),
+                    repair_sweep_report=repair_sweep_report(),
+                    output_dir=Path(tmp) / "followup",
+                    issue_number=760,
+                )
+
+    def test_rejects_technical_regression(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(
+                StageBMidiToSoloTargetedQualityRepairFollowupDecisionError
+            ):
+                build_followup_decision_report(
+                    objective_next_report=objective_next_report(),
+                    repair_sweep_report=repair_sweep_report(technical_regression_count=1),
+                    output_dir=Path(tmp) / "followup",
+                    issue_number=760,
+                )
+
+    def test_constants_are_stable(self) -> None:
+        self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_targeted_quality_repair_followup_decision")
+        self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_songlike_melody_contour_repair_sweep")
+        self.assertEqual(SELECTED_TARGET, "songlike_melody_contour_repair_sweep")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary
- targeted quality repair follow-up decision 추가
- dominant remaining failure label 기반 next repair target 선정
- songlike melody contour repair sweep 라우팅

Context
- #758 objective-only next decision 결과
- #750 repair sweep 결과
- candidate count: 6
- failure label count: 12 -> 8
- failure label delta: 4
- technical regression count: 0
- validated listening input: false

Remaining Labels
- songlike_melody_not_soloing: 5
- phrase_shape_missing_tension_release: 2
- dead_air_or_density_gap: 1
- outside_soloing_without_context: not evaluable 6
- weak_chord_tone_landing: not evaluable 6

Scope
- follow-up decision script/test 추가
- agent_harness 전용 mode 추가
- AGENTS handoff, Current Status, Core Plan 갱신
- #760 결과 문서 추가

Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision
- .venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-followup-decision
- bash scripts/agent_harness.sh quick

Result
- selected target: songlike_melody_contour_repair_sweep
- next boundary: stage_b_midi_to_solo_songlike_melody_contour_repair_sweep
- human/audio preference claim: false
- MIDI-to-solo musical quality claim: false

Risk
- listening input 없음
- chord-context 기반 항목 미평가
- quality claim 미수행

Closes #760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated project tracking documentation with latest completed milestone
  * Added comprehensive quality repair decision framework and workflow documentation

* **Chores**
  * Enhanced automation system with new quality repair follow-up decision workflow
  * Added test coverage for quality repair decision validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->