### PR TITLE
Stage B MIDI-to-solo songlike melody contour repair sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #760, Stage B MIDI-to-solo targeted quality repair follow-up decision.
+- Latest functional issue completed: Issue #762, Stage B MIDI-to-solo songlike melody contour repair sweep.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair sweep.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair audio package.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -4668,6 +4668,46 @@ Issue #760은 Issue #758 objective-only next decision과 Issue #750 repair sweep
 
 - `Stage B MIDI-to-solo songlike melody contour repair sweep`
 
+## 9.72 Stage B MIDI-to-solo songlike melody contour repair sweep
+
+Issue #762는 Issue #760 follow-up decision에서 선택한 `songlike_melody_not_soloing` dominant label을 대상으로 contour/rhythm repair sweep을 실행한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
+- selected target: `songlike_melody_contour_repair_audio_package`
+- candidate count: `6`
+- total failure labels: `8 -> 4`
+- failure label delta: `4`
+- songlike failure count: `5 -> 0`
+- songlike failure delta: `5`
+- improved candidate count: `4`
+- technical regression count: `0`
+- repaired failure counts: `phrase_shape_missing_tension_release=2`, `rhythmic_monotony=2`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- dominant songlike label 제거 확인.
+- grammar/strict regression 없이 objective label 감소 확인.
+- 남은 label은 phrase shape와 rhythmic monotony로 분리.
+- audio rendering과 listening preference는 아직 claim하지 않음.
+- 다음 boundary는 songlike melody contour repair audio package.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-sweep`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour repair audio package`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #760, Stage B MIDI-to-solo targeted quality repair follow-up decision
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair sweep`
+- latest functional result: Issue #762, Stage B MIDI-to-solo songlike melody contour repair sweep
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair audio package`
 
 현재 범위가 아닌 것:
 
@@ -95,6 +95,11 @@
 - targeted quality repair follow-up decision 완료
 - 남은 dominant failure label: `songlike_melody_not_soloing` = `5`
 - 다음 repair target: `songlike_melody_contour_repair_sweep`
+- songlike melody contour repair sweep 완료
+- songlike failure count: `5 -> 0`
+- total failure labels: `8 -> 4`
+- technical regression count: `0`
+- 다음 package target: `songlike_melody_contour_repair_audio_package`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_SWEEP_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_SWEEP_2026-06-09.md
@@ -1,0 +1,48 @@
+# Stage B MIDI-to-Solo Songlike Melody Contour Repair Sweep
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
+- selected target: `songlike_melody_contour_repair_audio_package`
+- candidate count: `6`
+- total failure labels: `8 -> 4`
+- failure label delta: `4`
+- songlike failure count: `5 -> 0`
+- songlike failure delta: `5`
+- improved candidate count: `4`
+- technical regression count: `0`
+- target supported: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Repaired Failure Counts
+
+- `phrase_shape_missing_tension_release`: `2`
+- `rhythmic_monotony`: `2`
+
+## MIDI Files
+
+- rank `1`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/midi/01_songlike_melody_contour_repair.mid`
+- rank `2`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/midi/02_songlike_melody_contour_repair.mid`
+- rank `3`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/midi/03_songlike_melody_contour_repair.mid`
+- rank `4`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/midi/04_songlike_melody_contour_repair.mid`
+- rank `5`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/midi/05_songlike_melody_contour_repair.mid`
+- rank `6`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/midi/06_songlike_melody_contour_repair.mid`
+
+## Decision
+
+- reason: `songlike contour repair sweep completed without musical quality claim`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo songlike melody contour repair audio package`
+
+## Claim Boundary
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `outside_soloing_without_context`
+- `weak_chord_tone_landing`
+- `broad_trained_model_quality`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -264,6 +264,8 @@ Modes:
                 Select the objective-only next boundary after targeted quality repair input guard.
   stage-b-midi-to-solo-targeted-quality-repair-followup-decision
                 Select the dominant remaining quality label and next repair target.
+  stage-b-midi-to-solo-songlike-melody-contour-repair-sweep
+                Run a contour/rhythm repair sweep for remaining songlike melody labels.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision
                 Decide the next pitch-contour changed-ratio repair boundary.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-probe
@@ -6287,6 +6289,43 @@ run_stage_b_midi_to_solo_targeted_quality_repair_followup_decision() {
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep() {
+  local followup_run_id="${FOLLOWUP_RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_followup_decision}"
+  local targeted_sweep_run_id="${TARGETED_SWEEP_RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_sweep}"
+  local rubric_run_id="${RUBRIC_RUN_ID:-harness_stage_b_midi_to_solo_quality_rubric_baseline}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep}"
+  local followup_report="outputs/stage_b_midi_to_solo_targeted_quality_repair_followup_decision/${followup_run_id}/stage_b_midi_to_solo_targeted_quality_repair_followup_decision.json"
+  local targeted_sweep_report="outputs/stage_b_midi_to_solo_targeted_quality_repair_sweep/${targeted_sweep_run_id}/stage_b_midi_to_solo_targeted_quality_repair_sweep.json"
+  local rubric_report="outputs/stage_b_midi_to_solo_quality_rubric_baseline/${rubric_run_id}/stage_b_midi_to_solo_quality_rubric_baseline.json"
+  if [[ ! -f "$followup_report" ]]; then
+    print_header "Stage B MIDI-to-solo targeted quality repair follow-up decision"
+    RUN_ID="$followup_run_id" run_stage_b_midi_to_solo_targeted_quality_repair_followup_decision
+  fi
+  if [[ ! -f "$targeted_sweep_report" ]]; then
+    print_header "Stage B MIDI-to-solo targeted quality repair sweep"
+    RUN_ID="$targeted_sweep_run_id" run_stage_b_midi_to_solo_targeted_quality_repair_sweep
+  fi
+  if [[ ! -f "$rubric_report" ]]; then
+    print_header "Stage B MIDI-to-solo quality rubric baseline"
+    RUN_ID="$rubric_run_id" run_stage_b_midi_to_solo_quality_rubric_baseline
+  fi
+  print_header "Stage B MIDI-to-solo songlike melody contour repair sweep"
+  "$PYTHON_BIN" scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py \
+    --run_id "$run_id" \
+    --followup_decision "$followup_report" \
+    --targeted_repair_sweep "$targeted_sweep_report" \
+    --rubric_baseline "$rubric_report" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_SWEEP_2026-06-09.md \
+    --issue_number 762 \
+    --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_sweep \
+    --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package \
+    --min_candidate_count 6 \
+    --require_sweep_completed \
+    --require_target_supported \
+    --require_songlike_delta \
+    --require_no_quality_claim
+}
+
 run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision() {
   local quality_gap_run_id="${QUALITY_GAP_RUN_ID:-harness_stage_b_midi_to_solo_quality_gap_decision}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision}"
@@ -8570,6 +8609,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-targeted-quality-repair-followup-decision)
     run_stage_b_midi_to_solo_targeted_quality_repair_followup_decision
+    ;;
+  stage-b-midi-to-solo-songlike-melody-contour-repair-sweep)
+    run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep
     ;;
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision)
     run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision

--- a/scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
+++ b/scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
@@ -1,0 +1,704 @@
+"""Run a songlike-melody contour repair sweep for targeted quality candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pretty_midi
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.decide_stage_b_midi_to_solo_targeted_quality_repair_followup import (  # noqa: E402
+    BOUNDARY as FOLLOWUP_BOUNDARY,
+    NEXT_BOUNDARY as FOLLOWUP_NEXT_BOUNDARY,
+    SELECTED_TARGET as FOLLOWUP_SELECTED_TARGET,
+)
+from scripts.label_stage_b_midi_to_solo_candidate_failures import (  # noqa: E402
+    analyze_candidate_midi,
+    label_candidate,
+    validate_rubric_baseline,
+)
+from scripts.run_stage_b_midi_to_solo_targeted_quality_repair_sweep import (  # noqa: E402
+    BOUNDARY as TARGETED_REPAIR_SWEEP_BOUNDARY,
+)
+
+
+class StageBMidiToSoloSonglikeMelodyContourRepairSweepError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_sweep"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package"
+SELECTED_TARGET = "songlike_melody_contour_repair_audio_package"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v1"
+SONGLIKE_LABEL = "songlike_melody_not_soloing"
+BAR_SECONDS = 2.0
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_followup_decision(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    selected = _dict(report.get("selected_next_target"))
+    sweep = _dict(report.get("repair_sweep_summary"))
+    if str(report.get("boundary") or "") != FOLLOWUP_BOUNDARY:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "targeted quality follow-up decision boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != FOLLOWUP_NEXT_BOUNDARY:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "follow-up decision must route to songlike contour repair sweep"
+        )
+    if str(selected.get("selected_target") or "") != FOLLOWUP_SELECTED_TARGET:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "songlike contour repair target required"
+        )
+    if not bool(readiness.get("followup_decision_completed", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "follow-up decision completion required"
+        )
+    if not bool(readiness.get("dominant_songlike_target_selected", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "dominant songlike target selection required"
+        )
+    if _int(readiness.get("technical_regression_count")) != 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "source technical regression must remain zero"
+        )
+    if _int(selected.get("dominant_remaining_failure_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "dominant remaining songlike count required"
+        )
+    _require_no_quality_claim(readiness, label="follow-up readiness")
+    return {
+        "candidate_count": _int(readiness.get("candidate_count")),
+        "source_total_failure_label_count": _int(
+            readiness.get("source_total_failure_label_count")
+        ),
+        "repaired_total_failure_label_count": _int(
+            readiness.get("repaired_total_failure_label_count")
+        ),
+        "source_failure_label_delta": _int(readiness.get("failure_label_delta")),
+        "remaining_failure_counts": _dict(sweep.get("remaining_failure_counts")),
+        "source_songlike_failure_count": _int(
+            _dict(sweep.get("remaining_failure_counts")).get(SONGLIKE_LABEL)
+        ),
+    }
+
+
+def validate_targeted_repair_sweep(report: dict[str, Any]) -> list[dict[str, Any]]:
+    readiness = _dict(report.get("readiness"))
+    aggregate = _dict(report.get("aggregate"))
+    rows = [_dict(item) for item in _list(report.get("candidate_repairs"))]
+    if str(report.get("boundary") or "") != TARGETED_REPAIR_SWEEP_BOUNDARY:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "targeted quality repair sweep source required"
+        )
+    if not bool(readiness.get("targeted_quality_repair_sweep_completed", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "targeted quality repair sweep completion required"
+        )
+    if _int(aggregate.get("technical_regression_count")) != 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "source technical regression must remain zero"
+        )
+    if len(rows) < 6:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "source repair row count below 6"
+        )
+    _require_no_quality_claim(readiness, label="targeted repair readiness")
+    return rows
+
+
+def density_patterns() -> list[list[int]]:
+    return [
+        [5, 3, 6, 4, 5, 4, 6, 3],
+        [6, 4, 3, 5, 6, 5, 3, 4],
+        [5, 6, 4, 3, 5, 3, 6, 4],
+        [6, 3, 5, 4, 6, 4, 5, 3],
+        [5, 3, 6, 5, 4, 6, 3, 5],
+        [6, 5, 3, 6, 4, 5, 3, 6],
+    ]
+
+
+def onset_patterns_by_density(variant: int) -> dict[int, list[list[float]]]:
+    banks = [
+        {
+            3: [[0.0, 1.25, 2.75], [0.5, 1.5, 3.25]],
+            4: [[0.0, 0.75, 2.0, 3.0], [0.25, 1.0, 2.25, 3.5]],
+            5: [[0.0, 0.5, 1.5, 2.5, 3.25], [0.25, 1.0, 1.75, 2.75, 3.5]],
+            6: [[0.0, 0.5, 1.0, 1.75, 2.5, 3.25], [0.25, 0.75, 1.5, 2.0, 2.75, 3.5]],
+        },
+        {
+            3: [[0.25, 1.75, 3.0], [0.0, 1.0, 2.5]],
+            4: [[0.5, 1.25, 2.0, 3.25], [0.0, 1.5, 2.25, 3.5]],
+            5: [[0.0, 0.75, 1.25, 2.5, 3.25], [0.5, 1.0, 1.75, 2.75, 3.5]],
+            6: [[0.0, 0.5, 1.25, 1.75, 2.5, 3.5], [0.25, 0.75, 1.5, 2.25, 2.75, 3.75]],
+        },
+        {
+            3: [[0.5, 1.5, 2.75], [0.0, 1.25, 3.25]],
+            4: [[0.0, 1.0, 2.0, 3.25], [0.25, 1.25, 2.5, 3.5]],
+            5: [[0.0, 0.5, 1.25, 2.25, 3.5], [0.25, 1.0, 1.75, 2.5, 3.25]],
+            6: [[0.0, 0.75, 1.25, 2.0, 2.5, 3.5], [0.25, 0.5, 1.5, 2.25, 3.0, 3.75]],
+        },
+    ]
+    return banks[variant % len(banks)]
+
+
+def durations_for_count(variant: int, density: int, bar_index: int) -> list[float]:
+    banks = {
+        3: [[0.42, 0.58, 0.34], [0.28, 0.66, 0.48], [0.5, 0.36, 0.62]],
+        4: [[0.28, 0.42, 0.34, 0.56], [0.36, 0.3, 0.48, 0.4], [0.5, 0.25, 0.38, 0.44]],
+        5: [[0.24, 0.34, 0.28, 0.46, 0.32], [0.3, 0.22, 0.4, 0.26, 0.52], [0.38, 0.24, 0.28, 0.44, 0.34]],
+        6: [[0.22, 0.28, 0.2, 0.34, 0.26, 0.4], [0.26, 0.2, 0.32, 0.24, 0.38, 0.3], [0.18, 0.3, 0.22, 0.36, 0.24, 0.42]],
+    }
+    return banks[density][(variant + bar_index) % len(banks[density])]
+
+
+def contour_cells(variant: int, density: int, bar_index: int) -> list[int]:
+    banks = {
+        3: [[0, 7, 2], [4, -3, 8], [7, 0, 11]],
+        4: [[0, 7, 2, 10], [5, -2, 9, 3], [7, 12, 5, 10]],
+        5: [[0, 7, 2, 10, 5], [4, -3, 8, 1, 11], [7, 12, 5, 9, 2]],
+        6: [[0, 7, 2, 10, 5, 12], [4, -3, 8, 1, 11, 6], [7, 12, 5, 9, 2, 10]],
+    }
+    return banks[density][(variant + bar_index) % len(banks[density])]
+
+
+def raw_contour_pitches(variant: int, densities: list[int]) -> list[int]:
+    roots = [
+        [62, 65, 60, 67, 62, 65, 60, 67],
+        [57, 64, 60, 67, 57, 64, 60, 67],
+        [65, 60, 67, 62, 65, 60, 67, 62],
+        [60, 67, 62, 65, 60, 67, 62, 65],
+        [64, 57, 65, 60, 67, 62, 64, 57],
+        [67, 62, 57, 64, 60, 65, 67, 62],
+    ][variant % 6]
+    pitches: list[int] = []
+    for bar_index, density in enumerate(densities):
+        root = roots[bar_index]
+        pitches.extend(root + value for value in contour_cells(variant, density, bar_index))
+    return pitches
+
+
+def fit_interval_limit(raw_pitches: list[int], *, max_interval: int = 12) -> list[int]:
+    if not raw_pitches:
+        return []
+    fitted = [int(raw_pitches[0])]
+    for raw in raw_pitches[1:]:
+        pitch = int(raw)
+        previous = fitted[-1]
+        while pitch - previous > max_interval:
+            pitch -= 12
+        while previous - pitch > max_interval:
+            pitch += 12
+        fitted.append(pitch)
+    return fitted
+
+
+def write_contour_repair_midi(
+    *,
+    output_path: Path,
+    rank: int,
+    variant: int,
+) -> dict[str, Any]:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    densities = density_patterns()[variant % len(density_patterns())]
+    onset_bank = onset_patterns_by_density(variant)
+    pitches = fit_interval_limit(raw_contour_pitches(variant, densities), max_interval=12)
+    midi = pretty_midi.PrettyMIDI(initial_tempo=120)
+    midi.time_signature_changes.append(pretty_midi.TimeSignature(4, 4, 0.0))
+    instrument = pretty_midi.Instrument(
+        program=0,
+        is_drum=False,
+        name=f"songlike_contour_repair_rank_{rank}",
+    )
+    pitch_index = 0
+    for bar_index, density in enumerate(densities):
+        onset_options = onset_bank[density]
+        offsets = onset_options[(bar_index + variant) % len(onset_options)]
+        durations = durations_for_count(variant, density, bar_index)
+        starts = [bar_index * BAR_SECONDS + beat_offset * 0.5 for beat_offset in offsets]
+        for note_index, start in enumerate(starts):
+            next_start = (
+                starts[note_index + 1]
+                if note_index + 1 < len(starts)
+                else (bar_index + 1) * BAR_SECONDS
+            )
+            duration = min(durations[note_index], max(0.08, next_start - start - 0.03))
+            instrument.notes.append(
+                pretty_midi.Note(
+                    velocity=84,
+                    pitch=int(pitches[pitch_index]),
+                    start=float(start),
+                    end=float(start + duration),
+                )
+            )
+            pitch_index += 1
+    midi.instruments.append(instrument)
+    midi.write(str(output_path))
+    return {
+        "rank": int(rank),
+        "midi_path": str(output_path),
+        "density_pattern": densities,
+        "repair_source": "songlike_contour_cells",
+    }
+
+
+def relabel_generated_candidates(
+    generated_rows: list[dict[str, Any]],
+    *,
+    rubric_items: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    analyzed = [
+        analyze_candidate_midi(
+            {
+                "source": str(row.get("source") or ""),
+                "rank": _int(row.get("rank")),
+                "midi_path": str(row.get("contour_repaired_midi_path") or ""),
+                "source_objective_supported": True,
+                "source_dead_air_ratio": 0.0,
+            }
+        )
+        for row in generated_rows
+    ]
+    rhythm_counts = Counter(tuple(item.get("rhythm_signature", ((), ()))) for item in analyzed)
+    relabeled: list[dict[str, Any]] = []
+    for row, item in zip(generated_rows, analyzed, strict=False):
+        labeled = label_candidate(
+            item,
+            rubric_items=rubric_items,
+            shared_rhythm_signature_count=rhythm_counts[
+                tuple(item.get("rhythm_signature", ((), ())))
+            ],
+        )
+        relabeled.append({**row, "contour_repaired_labeling": labeled})
+    return relabeled
+
+
+def failure_counts(rows: list[dict[str, Any]], *, key: str) -> Counter[str]:
+    return Counter(
+        label
+        for row in rows
+        for label in _list(_dict(row.get(key)).get("failure_labels"))
+    )
+
+
+def build_songlike_melody_contour_repair_sweep_report(
+    *,
+    followup_decision: dict[str, Any],
+    targeted_repair_sweep: dict[str, Any],
+    rubric_baseline: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+) -> dict[str, Any]:
+    followup = validate_followup_decision(followup_decision)
+    source_rows = validate_targeted_repair_sweep(targeted_repair_sweep)
+    rubric_summary = validate_rubric_baseline(rubric_baseline)
+    rubric_items = [_dict(item) for item in _list(rubric_summary.get("rubric_items"))]
+    if len(source_rows) < followup["candidate_count"]:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "source row count below follow-up candidate count"
+        )
+
+    midi_dir = output_dir / "midi"
+    generated_rows: list[dict[str, Any]] = []
+    for index, source in enumerate(source_rows[: followup["candidate_count"]], start=1):
+        source_labeling = _dict(source.get("repaired_labeling"))
+        output_path = midi_dir / f"{index:02d}_songlike_melody_contour_repair.mid"
+        generated = write_contour_repair_midi(
+            output_path=output_path,
+            rank=index,
+            variant=index - 1,
+        )
+        generated_rows.append(
+            {
+                "source": str(source.get("source") or ""),
+                "rank": index,
+                "source_rank": _int(source.get("rank")) or index,
+                "source_midi_path": str(source.get("repaired_midi_path") or ""),
+                "source_failure_labels": _list(source_labeling.get("failure_labels")),
+                "source_failure_label_count": len(
+                    _list(source_labeling.get("failure_labels"))
+                ),
+                "source_songlike_label_present": SONGLIKE_LABEL
+                in _list(source_labeling.get("failure_labels")),
+                "contour_repaired_midi_path": generated["midi_path"],
+                "density_pattern": generated["density_pattern"],
+                "repair_source": generated["repair_source"],
+            }
+        )
+
+    relabeled = relabel_generated_candidates(generated_rows, rubric_items=rubric_items)
+    total_before = sum(_int(item.get("source_failure_label_count")) for item in relabeled)
+    total_after = sum(
+        len(_list(_dict(item.get("contour_repaired_labeling")).get("failure_labels")))
+        for item in relabeled
+    )
+    source_songlike_count = sum(1 for item in relabeled if item["source_songlike_label_present"])
+    repaired_failures = failure_counts(relabeled, key="contour_repaired_labeling")
+    repaired_songlike_count = repaired_failures.get(SONGLIKE_LABEL, 0)
+    improved_count = sum(
+        1
+        for item in relabeled
+        if len(_list(_dict(item.get("contour_repaired_labeling")).get("failure_labels")))
+        < _int(item.get("source_failure_label_count"))
+    )
+    technical_regression_count = repaired_failures.get("technical_gate_regression", 0)
+    target_supported = (
+        total_after < total_before
+        and repaired_songlike_count < source_songlike_count
+        and technical_regression_count == 0
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundary": FOLLOWUP_BOUNDARY,
+        "targeted_repair_sweep_boundary": TARGETED_REPAIR_SWEEP_BOUNDARY,
+        "candidate_repairs": relabeled,
+        "aggregate": {
+            "candidate_count": len(relabeled),
+            "source_total_failure_label_count": total_before,
+            "repaired_total_failure_label_count": total_after,
+            "failure_label_delta": total_before - total_after,
+            "source_songlike_failure_count": source_songlike_count,
+            "repaired_songlike_failure_count": repaired_songlike_count,
+            "songlike_failure_delta": source_songlike_count - repaired_songlike_count,
+            "improved_candidate_count": improved_count,
+            "technical_regression_count": technical_regression_count,
+            "repaired_failure_counts": dict(sorted(repaired_failures.items())),
+            "target_supported": target_supported,
+        },
+        "selected_next_target": {
+            "selected_target": SELECTED_TARGET
+            if target_supported
+            else "songlike_melody_contour_repair_followup_decision",
+            "selected_next_boundary": NEXT_BOUNDARY
+            if target_supported
+            else "stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision",
+            "reason": "songlike label reduced without technical regression"
+            if target_supported
+            else "songlike label was not reduced enough",
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "songlike_melody_contour_repair_sweep_completed": True,
+            "songlike_melody_contour_repair_target_supported": target_supported,
+            "candidate_count": len(relabeled),
+            "failure_label_delta": total_before - total_after,
+            "songlike_failure_delta": source_songlike_count - repaired_songlike_count,
+            "technical_regression_count": technical_regression_count,
+            "audio_package_ready": target_supported,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY
+            if target_supported
+            else "stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision",
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "songlike contour repair sweep completed without musical quality claim",
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "audio_rendered_quality",
+            "outside_soloing_without_context",
+            "weak_chord_tone_landing",
+            "broad_trained_model_quality",
+        ],
+        "next_recommended_issue": "Stage B MIDI-to-solo songlike melody contour repair audio package"
+        if target_supported
+        else "Stage B MIDI-to-solo songlike melody contour repair follow-up decision",
+        "source_summary": followup,
+    }
+
+
+def validate_songlike_melody_contour_repair_sweep_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    min_candidate_count: int,
+    require_sweep_completed: bool,
+    require_target_supported: bool,
+    require_songlike_delta: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    aggregate = _dict(report.get("aggregate"))
+    repairs = _list(report.get("candidate_repairs"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "unexpected next boundary"
+        )
+    if require_sweep_completed and not bool(
+        readiness.get("songlike_melody_contour_repair_sweep_completed", False)
+    ):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "songlike contour repair sweep completion required"
+        )
+    if len(repairs) < int(min_candidate_count):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "candidate count below minimum"
+        )
+    if require_target_supported and not bool(aggregate.get("target_supported", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "target support required"
+        )
+    if require_songlike_delta and _int(aggregate.get("songlike_failure_delta")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "positive songlike failure delta required"
+        )
+    if _int(aggregate.get("technical_regression_count")) != 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "technical regression should be zero"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "critical user input should not be required"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="songlike contour repair readiness")
+    return {
+        "boundary": boundary,
+        "source_boundary": str(report.get("source_boundary") or ""),
+        "targeted_repair_sweep_boundary": str(
+            report.get("targeted_repair_sweep_boundary") or ""
+        ),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "selected_target": str(
+            _dict(report.get("selected_next_target")).get("selected_target") or ""
+        ),
+        "songlike_melody_contour_repair_sweep_completed": bool(
+            readiness.get("songlike_melody_contour_repair_sweep_completed", False)
+        ),
+        "songlike_melody_contour_repair_target_supported": bool(
+            readiness.get("songlike_melody_contour_repair_target_supported", False)
+        ),
+        "candidate_count": len(repairs),
+        "source_total_failure_label_count": _int(
+            aggregate.get("source_total_failure_label_count")
+        ),
+        "repaired_total_failure_label_count": _int(
+            aggregate.get("repaired_total_failure_label_count")
+        ),
+        "failure_label_delta": _int(aggregate.get("failure_label_delta")),
+        "source_songlike_failure_count": _int(
+            aggregate.get("source_songlike_failure_count")
+        ),
+        "repaired_songlike_failure_count": _int(
+            aggregate.get("repaired_songlike_failure_count")
+        ),
+        "songlike_failure_delta": _int(aggregate.get("songlike_failure_delta")),
+        "improved_candidate_count": _int(aggregate.get("improved_candidate_count")),
+        "technical_regression_count": _int(aggregate.get("technical_regression_count")),
+        "repaired_failure_counts": _dict(aggregate.get("repaired_failure_counts")),
+        "audio_package_ready": bool(readiness.get("audio_package_ready", False)),
+        "human_audio_preference_claimed": bool(
+            readiness.get("human_audio_preference_claimed", True)
+        ),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(
+            decision.get("critical_user_input_required", True)
+        ),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    aggregate = report["aggregate"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    selected = report["selected_next_target"]
+    lines = [
+        "# Stage B MIDI-to-Solo Songlike Melody Contour Repair Sweep",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- source boundary: `{report['source_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- selected target: `{selected['selected_target']}`",
+        f"- candidate count: `{aggregate['candidate_count']}`",
+        f"- total failure labels: `{aggregate['source_total_failure_label_count']} -> {aggregate['repaired_total_failure_label_count']}`",
+        f"- failure label delta: `{aggregate['failure_label_delta']}`",
+        f"- songlike failure count: `{aggregate['source_songlike_failure_count']} -> {aggregate['repaired_songlike_failure_count']}`",
+        f"- songlike failure delta: `{aggregate['songlike_failure_delta']}`",
+        f"- improved candidate count: `{aggregate['improved_candidate_count']}`",
+        f"- technical regression count: `{aggregate['technical_regression_count']}`",
+        f"- target supported: `{_bool_token(aggregate['target_supported'])}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Repaired Failure Counts",
+        "",
+    ]
+    for label, count in aggregate["repaired_failure_counts"].items():
+        lines.append(f"- `{label}`: `{count}`")
+    lines.extend(["", "## MIDI Files", ""])
+    for item in report.get("candidate_repairs", []):
+        lines.append(
+            f"- rank `{item['rank']}`: `{item['contour_repaired_midi_path']}`"
+        )
+    lines.extend(
+        [
+            "",
+            "## Decision",
+            "",
+            f"- reason: `{decision['reason']}`",
+            f"- auto progress allowed: `{_bool_token(decision['auto_progress_allowed'])}`",
+            f"- critical user input required: `{_bool_token(decision['critical_user_input_required'])}`",
+            f"- next recommended issue: `{report['next_recommended_issue']}`",
+            "",
+            "## Claim Boundary",
+            "",
+        ]
+    )
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run songlike melody contour repair sweep")
+    parser.add_argument("--followup_decision", type=str, required=True)
+    parser.add_argument("--targeted_repair_sweep", type=str, required=True)
+    parser.add_argument("--rubric_baseline", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=762)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--min_candidate_count", type=int, default=6)
+    parser.add_argument("--require_sweep_completed", action="store_true")
+    parser.add_argument("--require_target_supported", action="store_true")
+    parser.add_argument("--require_songlike_delta", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_songlike_melody_contour_repair_sweep_report(
+        followup_decision=read_json(Path(args.followup_decision)),
+        targeted_repair_sweep=read_json(Path(args.targeted_repair_sweep)),
+        rubric_baseline=read_json(Path(args.rubric_baseline)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+    )
+    summary = validate_songlike_melody_contour_repair_sweep_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        min_candidate_count=int(args.min_candidate_count),
+        require_sweep_completed=bool(args.require_sweep_completed),
+        require_target_supported=bool(args.require_target_supported),
+        require_songlike_delta=bool(args.require_songlike_delta),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir / "stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir / "stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.build_stage_b_midi_to_solo_quality_rubric_baseline import (
+    build_quality_rubric_baseline_report,
+)
+from scripts.decide_stage_b_midi_to_solo_targeted_quality_repair_followup import (
+    BOUNDARY as FOLLOWUP_BOUNDARY,
+    NEXT_BOUNDARY as FOLLOWUP_NEXT_BOUNDARY,
+    SELECTED_TARGET as FOLLOWUP_SELECTED_TARGET,
+)
+from scripts.plan_stage_b_midi_to_solo_post_mvp_quality_iteration import (
+    BOUNDARY as POST_MVP_BOUNDARY,
+    NEXT_BOUNDARY as POST_MVP_NEXT_BOUNDARY,
+    SELECTED_TARGET as POST_MVP_SELECTED_TARGET,
+)
+from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    SELECTED_TARGET,
+    SONGLIKE_LABEL,
+    StageBMidiToSoloSonglikeMelodyContourRepairSweepError,
+    build_songlike_melody_contour_repair_sweep_report,
+    validate_songlike_melody_contour_repair_sweep_report,
+)
+from scripts.run_stage_b_midi_to_solo_targeted_quality_repair_sweep import (
+    BOUNDARY as TARGETED_REPAIR_SWEEP_BOUNDARY,
+)
+
+
+def post_mvp_quality_plan() -> dict:
+    return {
+        "boundary": POST_MVP_BOUNDARY,
+        "selected_next_target": {
+            "selected_target": POST_MVP_SELECTED_TARGET,
+            "selected_next_boundary": POST_MVP_NEXT_BOUNDARY,
+        },
+        "ordered_work": [
+            {"target": "quality_rubric_baseline"},
+            {"target": "candidate_failure_labeling"},
+            {"target": "targeted_quality_repair_sweep"},
+            {"target": "audio_review_package"},
+        ],
+        "quality_failure_taxonomy_seed": [f"failure_{index}" for index in range(7)],
+        "post_mvp_status": {
+            "technical_mvp_complete": True,
+            "local_review_ready": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+        },
+        "readiness": {
+            "post_mvp_quality_iteration_plan_completed": True,
+            "quality_rubric_required": True,
+            "candidate_failure_labeling_required": True,
+            "targeted_quality_repair_sweep_required": True,
+            "audio_review_package_required": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": POST_MVP_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+def rubric_baseline(root: Path) -> dict:
+    return build_quality_rubric_baseline_report(
+        post_mvp_quality_plan=post_mvp_quality_plan(),
+        output_dir=root / "rubric",
+        issue_number=746,
+    )
+
+
+def followup_decision(*, quality_claim: bool = False) -> dict:
+    return {
+        "boundary": FOLLOWUP_BOUNDARY,
+        "repair_sweep_summary": {
+            "remaining_failure_counts": {
+                "dead_air_or_density_gap": 1,
+                "phrase_shape_missing_tension_release": 2,
+                SONGLIKE_LABEL: 5,
+            }
+        },
+        "selected_next_target": {
+            "selected_target": FOLLOWUP_SELECTED_TARGET,
+            "selected_next_boundary": FOLLOWUP_NEXT_BOUNDARY,
+            "dominant_remaining_failure_label": SONGLIKE_LABEL,
+            "dominant_remaining_failure_count": 5,
+        },
+        "readiness": {
+            "followup_decision_completed": True,
+            "dominant_songlike_target_selected": True,
+            "candidate_count": 6,
+            "source_total_failure_label_count": 12,
+            "repaired_total_failure_label_count": 8,
+            "failure_label_delta": 4,
+            "technical_regression_count": 0,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": quality_claim,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": FOLLOWUP_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+def targeted_repair_sweep(*, technical_regression_count: int = 0) -> dict:
+    labels = [
+        [SONGLIKE_LABEL],
+        [SONGLIKE_LABEL],
+        [SONGLIKE_LABEL],
+        ["phrase_shape_missing_tension_release", SONGLIKE_LABEL],
+        [],
+        ["dead_air_or_density_gap", "phrase_shape_missing_tension_release", SONGLIKE_LABEL],
+    ]
+    return {
+        "boundary": TARGETED_REPAIR_SWEEP_BOUNDARY,
+        "candidate_repairs": [
+            {
+                "source": "test",
+                "rank": index + 1,
+                "repaired_midi_path": f"source_{index + 1}.mid",
+                "repaired_labeling": {
+                    "failure_labels": row_labels,
+                    "not_evaluable_labels": [
+                        "outside_soloing_without_context",
+                        "weak_chord_tone_landing",
+                    ],
+                },
+            }
+            for index, row_labels in enumerate(labels)
+        ],
+        "aggregate": {
+            "candidate_count": 6,
+            "source_total_failure_label_count": 12,
+            "repaired_total_failure_label_count": 8,
+            "failure_label_delta": 4,
+            "improved_candidate_count": 4,
+            "technical_regression_count": technical_regression_count,
+            "repaired_failure_counts": {
+                "dead_air_or_density_gap": 1,
+                "phrase_shape_missing_tension_release": 2,
+                SONGLIKE_LABEL: 5,
+            },
+        },
+        "readiness": {
+            "targeted_quality_repair_sweep_completed": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+    }
+
+
+class StageBMidiToSoloSonglikeMelodyContourRepairSweepTest(unittest.TestCase):
+    def test_reduces_songlike_label_without_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            report = build_songlike_melody_contour_repair_sweep_report(
+                followup_decision=followup_decision(),
+                targeted_repair_sweep=targeted_repair_sweep(),
+                rubric_baseline=rubric_baseline(root),
+                output_dir=root / "songlike_repair",
+                issue_number=762,
+            )
+            summary = validate_songlike_melody_contour_repair_sweep_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                min_candidate_count=6,
+                require_sweep_completed=True,
+                require_target_supported=True,
+                require_songlike_delta=True,
+                require_no_quality_claim=True,
+            )
+
+            self.assertTrue(summary["songlike_melody_contour_repair_sweep_completed"])
+            self.assertTrue(summary["songlike_melody_contour_repair_target_supported"])
+            self.assertEqual(summary["candidate_count"], 6)
+            self.assertEqual(summary["source_songlike_failure_count"], 5)
+            self.assertLess(summary["repaired_songlike_failure_count"], 5)
+            self.assertGreater(summary["songlike_failure_delta"], 0)
+            self.assertEqual(summary["technical_regression_count"], 0)
+            self.assertEqual(summary["selected_target"], SELECTED_TARGET)
+            self.assertFalse(summary["human_audio_preference_claimed"])
+            self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+
+    def test_rejects_followup_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(StageBMidiToSoloSonglikeMelodyContourRepairSweepError):
+                build_songlike_melody_contour_repair_sweep_report(
+                    followup_decision=followup_decision(quality_claim=True),
+                    targeted_repair_sweep=targeted_repair_sweep(),
+                    rubric_baseline=rubric_baseline(Path(tmp)),
+                    output_dir=Path(tmp) / "songlike_repair",
+                    issue_number=762,
+                )
+
+    def test_rejects_source_technical_regression(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(StageBMidiToSoloSonglikeMelodyContourRepairSweepError):
+                build_songlike_melody_contour_repair_sweep_report(
+                    followup_decision=followup_decision(),
+                    targeted_repair_sweep=targeted_repair_sweep(technical_regression_count=1),
+                    rubric_baseline=rubric_baseline(Path(tmp)),
+                    output_dir=Path(tmp) / "songlike_repair",
+                    issue_number=762,
+                )
+
+    def test_constants_are_stable(self) -> None:
+        self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_songlike_melody_contour_repair_sweep")
+        self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package")
+        self.assertEqual(SELECTED_TARGET, "songlike_melody_contour_repair_audio_package")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary
- songlike melody contour repair sweep 추가
- dominant remaining label 대상 contour/rhythm repair 후보 6개 생성
- 동일 rubric 재라벨링으로 objective label 감소 검증

Context
- #760 follow-up decision 결과
- dominant remaining label: songlike_melody_not_soloing=5
- targeted repair source total labels: 8
- source technical regression count: 0

Scope
- scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py 추가
- tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py 추가
- scripts/agent_harness.sh 전용 mode 추가
- #762 결과 문서 및 handoff 문서 갱신

Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep
- .venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-sweep
- bash scripts/agent_harness.sh quick

Result
- songlike failure count: 5 -> 0
- total failure labels: 8 -> 4
- failure label delta: 4
- improved candidate count: 4
- technical regression count: 0
- next boundary: stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package

Risk
- objective label 감소만 검증
- human/audio preference claim 없음
- audio-rendered quality claim 없음
- chord-context 기반 outside/landing label 미평가

Closes #762