### PR TITLE
Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #774, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep.
+- Latest functional issue completed: Issue #776, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -156,6 +156,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phras
 ```
 
 This harness checks whether phrase/rhythm failure labels are reduced without claiming listening or musical quality.
+
+For Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-audio-package
+```
+
+This harness renders phrase/rhythm repair MIDI candidates to WAV files and validates technical metadata without claiming listening or musical quality.
 
 For Stage A training-mode changes, run:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -4959,6 +4959,46 @@ Issue #774는 Issue #772 follow-up decision과 Issue #762 songlike contour repai
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package`
 
+## 9.79 Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package
+
+Issue #776은 Issue #774 phrase/rhythm repair sweep MIDI 후보 6개를 WAV로 렌더링하고 기술 메타데이터를 검증한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package`
+- rendered audio file count: `6`
+- technical WAV validation: `true`
+- sample rate: `44100`
+- duration range: `18.871s-19.000s`
+- total failure labels: `4 -> 1`
+- phrase/rhythm failure count: `4 -> 1`
+- phrase/rhythm failure delta: `3`
+- improved candidate count: `2`
+- technical regression count: `0`
+- audio review required: `true`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- #774 MIDI 후보 6개 모두 WAV 파일 생성 완료.
+- sample rate, frame count, file size 기준 technical WAV validation 통과.
+- WAV 생성은 음악 품질 claim이 아니므로 audio rendered quality와 human/audio preference claim 제외.
+- 다음 boundary는 phrase/rhythm repair listening review package.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio`
+- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-audio-package`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #774, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package`
+- latest functional result: Issue #776, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package`
 
 현재 범위가 아닌 것:
 
@@ -139,6 +139,14 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 package target: `songlike_melody_contour_phrase_rhythm_repair_audio_package`
+- songlike melody contour phrase/rhythm repair WAV 6개 렌더 완료
+- WAV sample rate: `44100`
+- WAV duration range: `18.871s-19.000s`
+- technical WAV validation: `true`
+- audio rendered quality claim: `false`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 review target: `songlike_melody_contour_phrase_rhythm_repair_listening_review_package`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_AUDIO_PACKAGE_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_AUDIO_PACKAGE_2026-06-09.md
@@ -1,0 +1,41 @@
+# Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Repair Audio Package
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package`
+- render attempted: `true`
+- rendered audio file count: `6`
+- technical WAV validation: `true`
+- duration range: `18.871s-19.000s`
+- failure labels: `4 -> 1`
+- phrase/rhythm failure count: `4 -> 1`
+- phrase/rhythm failure delta: `3`
+- improved candidate count: `2`
+- technical regression count: `0`
+- audio review required: `true`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Rendered Files
+
+- candidate `1` rank `1`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/audio/candidate_01_cli_repaired_midi_rank_01_phrase_rhythm_repair.wav`, duration `18.990`, sample rate `44100`, failure labels `none`, sha256 `35b8cfeb6b0c`
+- candidate `2` rank `2`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/audio/candidate_02_cli_repaired_midi_rank_02_phrase_rhythm_repair.wav`, duration `18.974`, sample rate `44100`, failure labels `none`, sha256 `86e5add1a6f7`
+- candidate `3` rank `3`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/audio/candidate_03_cli_repaired_midi_rank_03_phrase_rhythm_repair.wav`, duration `19.000`, sample rate `44100`, failure labels `none`, sha256 `94ad4ea2ec08`
+- candidate `4` rank `4`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/audio/candidate_04_changed_ratio_repair_rank_04_phrase_rhythm_repair.wav`, duration `18.871`, sample rate `44100`, failure labels `rhythmic_monotony`, sha256 `8574cb7adf4a`
+- candidate `5` rank `5`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/audio/candidate_05_changed_ratio_repair_rank_05_phrase_rhythm_repair.wav`, duration `18.985`, sample rate `44100`, failure labels `none`, sha256 `1253cd5bd379`
+- candidate `6` rank `6`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/audio/candidate_06_changed_ratio_repair_rank_06_phrase_rhythm_repair.wav`, duration `18.992`, sample rate `44100`, failure labels `none`, sha256 `43bc476f8d16`
+
+## Claim Boundary
+
+- `audio_rendered_quality`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `model_checkpoint_generation_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`
+
+## Next
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -278,6 +278,8 @@ Modes:
                 Select phrase/rhythm repair target after songlike contour objective evidence.
   stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-sweep
                 Run phrase/rhythm repair sweep for songlike contour candidates.
+  stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-audio-package
+                Render phrase/rhythm repair MIDI candidates to WAV files.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision
                 Decide the next pitch-contour changed-ratio repair boundary.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-probe
@@ -6489,6 +6491,28 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep() {
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package() {
+  local sweep_run_id="${SWEEP_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package}"
+  local sweep_report="outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/${sweep_run_id}/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.json"
+  if [[ ! -f "$sweep_report" ]]; then
+    print_header "Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep"
+    RUN_ID="$sweep_run_id" run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep
+  fi
+  print_header "Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package"
+  "$PYTHON_BIN" scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio.py \
+    --run_id "$run_id" \
+    --phrase_rhythm_repair_sweep_report "$sweep_report" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_AUDIO_PACKAGE_2026-06-09.md \
+    --issue_number 776 \
+    --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package \
+    --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package \
+    --expected_file_count 6 \
+    --sample_rate 44100 \
+    --require_audio_package_completed \
+    --require_no_quality_claim
+}
+
 run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision() {
   local quality_gap_run_id="${QUALITY_GAP_RUN_ID:-harness_stage_b_midi_to_solo_quality_gap_decision}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision}"
@@ -8793,6 +8817,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-sweep)
     run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep
+    ;;
+  stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-audio-package)
+    run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package
     ;;
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision)
     run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision

--- a/scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio.py
+++ b/scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio.py
@@ -1,0 +1,603 @@
+"""Render songlike melody contour phrase/rhythm repair MIDI candidates to WAV files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.render_stage_b_midi_to_solo_candidate_audio import (  # noqa: E402
+    resolve_soundfont,
+    sha256_file,
+    wav_meta,
+)
+from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+    StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError,
+    validate_songlike_melody_contour_phrase_rhythm_repair_sweep_report,
+)
+
+
+class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package"
+NEXT_BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package_v1"
+CommandRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _path_exists(path_text: str) -> bool:
+    return bool(path_text and Path(path_text).exists())
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_source_report(
+    report: dict[str, Any],
+    *,
+    expected_count: int,
+) -> list[dict[str, Any]]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    aggregate = _dict(report.get("aggregate"))
+    if str(report.get("boundary") or readiness.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
+            "phrase/rhythm repair sweep boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
+            "phrase/rhythm repair sweep must route to audio package"
+        )
+    try:
+        validate_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
+            report,
+            expected_boundary=SOURCE_BOUNDARY,
+            expected_next_boundary=SOURCE_NEXT_BOUNDARY,
+            min_candidate_count=int(expected_count),
+            require_sweep_completed=True,
+            require_target_supported=True,
+            require_phrase_rhythm_delta=True,
+            require_no_quality_claim=True,
+        )
+    except StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError as exc:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(str(exc)) from exc
+    if not bool(readiness.get("songlike_melody_contour_phrase_rhythm_repair_target_supported", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
+            "phrase/rhythm repair support required"
+        )
+    if not bool(readiness.get("audio_package_ready", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
+            "audio package readiness required"
+        )
+    if _int(aggregate.get("technical_regression_count")) != 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
+            "technical regression count should be zero"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
+            "critical user input should not be required"
+        )
+    _require_no_quality_claim(readiness, label="phrase/rhythm repair readiness")
+
+    rows = [_dict(item) for item in _list(report.get("candidate_repairs"))]
+    if len(rows) < int(expected_count):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
+            "candidate repair count below expected count"
+        )
+    compacted: list[dict[str, Any]] = []
+    for index, row in enumerate(rows[: int(expected_count)], start=1):
+        repaired_midi_path = str(row.get("phrase_rhythm_repaired_midi_path") or "")
+        if not _path_exists(repaired_midi_path):
+            raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
+                f"phrase/rhythm repair MIDI missing: {repaired_midi_path}"
+            )
+        repaired_labeling = _dict(row.get("phrase_rhythm_repaired_labeling"))
+        repaired_metrics = _dict(repaired_labeling.get("metrics"))
+        if "technical_gate_regression" in _list(repaired_labeling.get("failure_labels")):
+            raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
+                "technical gate regression label should not be rendered"
+            )
+        compacted.append(
+            {
+                "candidate_index": int(index),
+                "source": str(row.get("source") or ""),
+                "rank": _int(row.get("rank")) or index,
+                "source_rank": _int(row.get("source_rank")),
+                "source_midi_path": str(row.get("source_midi_path") or ""),
+                "repaired_midi_path": repaired_midi_path,
+                "source_failure_labels": _list(row.get("source_failure_labels")),
+                "repaired_failure_labels": _list(
+                    repaired_labeling.get("failure_labels")
+                ),
+                "density_pattern": _list(row.get("density_pattern")),
+                "note_count": _int(repaired_metrics.get("note_count")),
+                "repaired_unique_pitch_count": _int(
+                    repaired_metrics.get("unique_pitch_count")
+                ),
+                "repaired_dead_air_ratio": _float(repaired_metrics.get("dead_air_ratio")),
+                "repaired_max_interval": _int(repaired_metrics.get("max_abs_interval")),
+                "repaired_max_simultaneous_notes": _int(
+                    repaired_metrics.get("max_simultaneous_notes")
+                ),
+            }
+        )
+    return compacted
+
+
+def _safe_name(value: str) -> str:
+    safe = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in value)
+    return safe.strip("_") or "candidate"
+
+
+def build_render_plan(
+    candidates: list[dict[str, Any]],
+    *,
+    output_dir: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+) -> list[dict[str, Any]]:
+    renderer = Path(renderer_path)
+    soundfont = Path(soundfont_path).expanduser()
+    if not renderer.exists():
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
+            f"renderer not found: {renderer}"
+        )
+    if not soundfont.exists():
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
+            f"soundfont not found: {soundfont}"
+        )
+    plan: list[dict[str, Any]] = []
+    for item in candidates:
+        name = _safe_name(str(item["source"]))
+        wav_path = output_dir / "audio" / (
+            f"candidate_{int(item['candidate_index']):02d}_{name}_rank_{int(item['rank']):02d}_"
+            "phrase_rhythm_repair.wav"
+        )
+        plan.append(
+            {
+                **item,
+                "wav_path": str(wav_path),
+                "command": [
+                    str(renderer),
+                    "-ni",
+                    "-F",
+                    str(wav_path),
+                    "-r",
+                    str(sample_rate),
+                    str(soundfont),
+                    str(item["repaired_midi_path"]),
+                ],
+            }
+        )
+    return plan
+
+
+def default_runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(list(command), check=False, text=True, capture_output=True)
+
+
+def execute_render_plan(
+    plan: list[dict[str, Any]],
+    *,
+    runner: CommandRunner = default_runner,
+) -> list[dict[str, Any]]:
+    rendered: list[dict[str, Any]] = []
+    for item in plan:
+        wav_path = Path(str(item["wav_path"]))
+        wav_path.parent.mkdir(parents=True, exist_ok=True)
+        completed = runner(item["command"])
+        if completed.returncode != 0:
+            raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
+                f"render failed for candidate {item['candidate_index']}: "
+                f"{completed.stderr or completed.stdout}"
+            )
+        rendered.append(
+            {
+                "candidate_index": item["candidate_index"],
+                "source": item["source"],
+                "rank": item["rank"],
+                "source_rank": item["source_rank"],
+                "source_midi_path": item["source_midi_path"],
+                "repaired_midi_path": item["repaired_midi_path"],
+                "source_failure_labels": item["source_failure_labels"],
+                "repaired_failure_labels": item["repaired_failure_labels"],
+                "density_pattern": item["density_pattern"],
+                "note_count": item["note_count"],
+                "repaired_unique_pitch_count": item["repaired_unique_pitch_count"],
+                "repaired_dead_air_ratio": item["repaired_dead_air_ratio"],
+                "repaired_max_interval": item["repaired_max_interval"],
+                "repaired_max_simultaneous_notes": item["repaired_max_simultaneous_notes"],
+                "wav_file": wav_meta(wav_path),
+                "command": list(item["command"]),
+                "stdout_tail": (completed.stdout or "")[-1000:],
+                "stderr_tail": (completed.stderr or "")[-1000:],
+            }
+        )
+    return rendered
+
+
+def build_audio_render_report(
+    source_report: dict[str, Any],
+    *,
+    output_dir: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+    expected_file_count: int,
+    issue_number: int = 776,
+    runner: CommandRunner = default_runner,
+) -> dict[str, Any]:
+    candidates = validate_source_report(source_report, expected_count=expected_file_count)
+    resolved_renderer = renderer_path or shutil.which("fluidsynth") or ""
+    resolved_soundfont = resolve_soundfont(soundfont_path)
+    plan = build_render_plan(
+        candidates,
+        output_dir=output_dir,
+        renderer_path=resolved_renderer,
+        soundfont_path=resolved_soundfont,
+        sample_rate=int(sample_rate),
+    )
+    rendered = execute_render_plan(plan, runner=runner)
+    aggregate = _dict(source_report.get("aggregate"))
+    failure_counts = Counter(
+        label for item in rendered for label in _list(item.get("repaired_failure_labels"))
+    )
+    durations = [
+        _float(_dict(item.get("wav_file")).get("duration_seconds")) for item in rendered
+    ]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "source_boundary": SOURCE_BOUNDARY,
+        "source_summary": aggregate,
+        "renderer": {
+            "name": "fluidsynth",
+            "path": resolved_renderer,
+        },
+        "soundfont": {
+            "path": str(Path(resolved_soundfont).expanduser()),
+            "sha256": sha256_file(Path(resolved_soundfont).expanduser()),
+        },
+        "rendered_audio_files": rendered,
+        "summary": {
+            "rendered_audio_file_count": int(len(rendered)),
+            "technical_wav_validation": True,
+            "sample_rate": int(sample_rate),
+            "duration_min_seconds": min(durations, default=0.0),
+            "duration_max_seconds": max(durations, default=0.0),
+            "source_total_failure_label_count": _int(
+                aggregate.get("source_total_failure_label_count")
+            ),
+            "repaired_total_failure_label_count": _int(
+                aggregate.get("repaired_total_failure_label_count")
+            ),
+            "failure_label_delta": _int(aggregate.get("failure_label_delta")),
+            "source_phrase_rhythm_failure_count": _int(
+                aggregate.get("source_phrase_rhythm_failure_count")
+            ),
+            "repaired_phrase_rhythm_failure_count": _int(
+                aggregate.get("repaired_phrase_rhythm_failure_count")
+            ),
+            "phrase_rhythm_failure_delta": _int(aggregate.get("phrase_rhythm_failure_delta")),
+            "improved_candidate_count": _int(aggregate.get("improved_candidate_count")),
+            "technical_regression_count": _int(aggregate.get("technical_regression_count")),
+            "remaining_failure_counts": dict(sorted(failure_counts.items())),
+            "audio_review_required": True,
+        },
+        "audio_render_boundary": {
+            "boundary": BOUNDARY,
+            "render_attempted": True,
+            "rendered_audio_file_count": int(len(rendered)),
+            "technical_wav_validation": True,
+            "songlike_melody_contour_phrase_rhythm_repair_audio_package_completed": True,
+            "human_audio_preference_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "phrase/rhythm repair MIDI rendered to WAV; prepare listening review package next",
+        },
+        "not_proven": [
+            "audio_rendered_quality",
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "model_checkpoint_generation_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package"
+        ),
+    }
+
+
+def validate_audio_render_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    expected_file_count: int,
+    expected_sample_rate: int,
+    require_audio_package_completed: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = _dict(report.get("audio_render_boundary"))
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("summary"))
+    if expected_boundary and str(boundary.get("boundary") or "") != expected_boundary:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
+            "unexpected boundary"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
+            "unexpected next boundary"
+        )
+    files = [_dict(item) for item in _list(report.get("rendered_audio_files"))]
+    if len(files) != int(expected_file_count):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
+            f"expected {expected_file_count} rendered files"
+        )
+    for item in files:
+        wav_file = _dict(item.get("wav_file"))
+        if not bool(wav_file.get("exists", False)) or not _path_exists(
+            str(wav_file.get("path") or "")
+        ):
+            raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
+                "missing rendered WAV"
+            )
+        if _int(wav_file.get("sample_rate")) != int(expected_sample_rate):
+            raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
+                "unexpected sample rate"
+            )
+        if _int(wav_file.get("frame_count")) <= 0:
+            raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError("empty WAV")
+        if _int(wav_file.get("size_bytes")) <= 44:
+            raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
+                "invalid WAV size"
+            )
+    if require_audio_package_completed and not bool(
+        boundary.get("songlike_melody_contour_phrase_rhythm_repair_audio_package_completed", False)
+    ):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
+            "audio package completion required"
+        )
+    if _int(summary.get("technical_regression_count")) != 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
+            "technical regression count should be zero"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
+            "critical user input should not be required"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(boundary, label="audio render boundary")
+    return {
+        "boundary": str(boundary.get("boundary") or ""),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "render_attempted": bool(boundary.get("render_attempted", False)),
+        "rendered_audio_file_count": _int(boundary.get("rendered_audio_file_count")),
+        "technical_wav_validation": bool(boundary.get("technical_wav_validation", False)),
+        "songlike_melody_contour_phrase_rhythm_repair_audio_package_completed": bool(
+            boundary.get("songlike_melody_contour_phrase_rhythm_repair_audio_package_completed", False)
+        ),
+        "sample_rate": _int(summary.get("sample_rate")),
+        "duration_min_seconds": _float(summary.get("duration_min_seconds")),
+        "duration_max_seconds": _float(summary.get("duration_max_seconds")),
+        "source_total_failure_label_count": _int(
+            summary.get("source_total_failure_label_count")
+        ),
+        "repaired_total_failure_label_count": _int(
+            summary.get("repaired_total_failure_label_count")
+        ),
+        "failure_label_delta": _int(summary.get("failure_label_delta")),
+        "source_phrase_rhythm_failure_count": _int(
+            summary.get("source_phrase_rhythm_failure_count")
+        ),
+        "repaired_phrase_rhythm_failure_count": _int(
+            summary.get("repaired_phrase_rhythm_failure_count")
+        ),
+        "phrase_rhythm_failure_delta": _int(summary.get("phrase_rhythm_failure_delta")),
+        "improved_candidate_count": _int(summary.get("improved_candidate_count")),
+        "technical_regression_count": _int(summary.get("technical_regression_count")),
+        "audio_review_required": bool(summary.get("audio_review_required", False)),
+        "audio_rendered_quality_claimed": bool(
+            boundary.get("audio_rendered_quality_claimed", True)
+        ),
+        "human_audio_preference_claimed": bool(
+            boundary.get("human_audio_preference_claimed", True)
+        ),
+        "midi_to_solo_musical_quality_claimed": bool(
+            boundary.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(
+            decision.get("critical_user_input_required", True)
+        ),
+        "wav_paths": [str(_dict(item.get("wav_file")).get("path") or "") for item in files],
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    boundary = report["audio_render_boundary"]
+    decision = report["decision"]
+    summary = report["summary"]
+    lines = [
+        "# Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Repair Audio Package",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{boundary['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- render attempted: `{_bool_token(boundary['render_attempted'])}`",
+        f"- rendered audio file count: `{boundary['rendered_audio_file_count']}`",
+        f"- technical WAV validation: `{_bool_token(boundary['technical_wav_validation'])}`",
+        f"- duration range: `{summary['duration_min_seconds']:.3f}s-{summary['duration_max_seconds']:.3f}s`",
+        f"- failure labels: `{summary['source_total_failure_label_count']} -> {summary['repaired_total_failure_label_count']}`",
+        f"- phrase/rhythm failure count: `{summary['source_phrase_rhythm_failure_count']} -> {summary['repaired_phrase_rhythm_failure_count']}`",
+        f"- phrase/rhythm failure delta: `{summary['phrase_rhythm_failure_delta']}`",
+        f"- improved candidate count: `{summary['improved_candidate_count']}`",
+        f"- technical regression count: `{summary['technical_regression_count']}`",
+        f"- audio review required: `{_bool_token(summary['audio_review_required'])}`",
+        f"- audio rendered quality claimed: `{_bool_token(boundary['audio_rendered_quality_claimed'])}`",
+        f"- human/audio preference claimed: `{_bool_token(boundary['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(boundary['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Rendered Files",
+        "",
+    ]
+    for item in report.get("rendered_audio_files", []):
+        wav_file = item["wav_file"]
+        lines.append(
+            f"- candidate `{item['candidate_index']}` rank `{item['rank']}`: "
+            f"`{wav_file['path']}`, duration `{float(wav_file['duration_seconds']):.3f}`, "
+            f"sample rate `{wav_file['sample_rate']}`, failure labels "
+            f"`{','.join(item['repaired_failure_labels']) or 'none'}`, "
+            f"sha256 `{str(wav_file['sha256'])[:12]}`"
+        )
+    lines.extend(["", "## Claim Boundary", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    lines.extend(["", "## Next", "", f"- `{report['next_recommended_issue']}`"])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Render songlike melody contour phrase/rhythm repair MIDI candidates to WAV files"
+    )
+    parser.add_argument("--phrase_rhythm_repair_sweep_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=776)
+    parser.add_argument("--renderer", type=str, default=shutil.which("fluidsynth") or "")
+    parser.add_argument("--soundfont", type=str, default="")
+    parser.add_argument("--sample_rate", type=int, default=44100)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--expected_file_count", type=int, default=6)
+    parser.add_argument("--require_audio_package_completed", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_audio_render_report(
+        read_json(Path(args.phrase_rhythm_repair_sweep_report)),
+        output_dir=output_dir,
+        renderer_path=str(args.renderer or ""),
+        soundfont_path=str(args.soundfont or ""),
+        sample_rate=int(args.sample_rate),
+        expected_file_count=int(args.expected_file_count),
+        issue_number=int(args.issue_number),
+    )
+    summary = validate_audio_render_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        expected_file_count=int(args.expected_file_count),
+        expected_sample_rate=int(args.sample_rate),
+        require_audio_package_completed=bool(args.require_audio_package_completed),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir / "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+import wave
+from pathlib import Path
+from typing import Sequence
+
+import pretty_midi
+
+from scripts.render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError,
+    build_audio_render_report,
+    validate_audio_render_report,
+)
+from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep import (
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+def write_midi(path: Path, pitches: list[int]) -> None:
+    midi = pretty_midi.PrettyMIDI(initial_tempo=120)
+    midi.time_signature_changes.append(pretty_midi.TimeSignature(4, 4, 0.0))
+    instrument = pretty_midi.Instrument(program=0)
+    for index, pitch in enumerate(pitches):
+        start = index * 0.5
+        instrument.notes.append(
+            pretty_midi.Note(velocity=90, pitch=int(pitch), start=start, end=start + 0.25)
+        )
+    midi.instruments.append(instrument)
+    midi.write(str(path))
+
+
+def write_wav(path: Path, *, sample_rate: int = 44100) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(sample_rate)
+        handle.writeframes(b"\x00\x00" * (sample_rate // 10))
+
+
+def fake_runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    wav_path = Path(str(command[list(command).index("-F") + 1]))
+    sample_rate = int(command[list(command).index("-r") + 1])
+    write_wav(wav_path, sample_rate=sample_rate)
+    return subprocess.CompletedProcess(list(command), 0, stdout="rendered", stderr="")
+
+
+def source_report(root: Path, *, quality_claim: bool = False) -> dict:
+    repairs = []
+    for index in range(1, 7):
+        midi_path = root / f"phrase_rhythm_repair_{index}.mid"
+        write_midi(midi_path, [60, 67, 62, 72, 65, 77] * 4)
+        labels = ["rhythmic_monotony"] if index == 3 else []
+        source_labels = []
+        if index in {1, 2}:
+            source_labels = ["phrase_shape_missing_tension_release"]
+        if index in {3, 4}:
+            source_labels = ["rhythmic_monotony"]
+        repairs.append(
+            {
+                "source": "unit_source",
+                "rank": index,
+                "source_rank": index,
+                "source_midi_path": f"source_{index}.mid",
+                "phrase_rhythm_repaired_midi_path": str(midi_path),
+                "source_failure_labels": source_labels,
+                "density_pattern": [5, 3, 6, 4, 5, 4, 6, 3],
+                "phrase_rhythm_repaired_labeling": {
+                    "failure_labels": labels,
+                    "metrics": {
+                        "note_count": 24,
+                        "unique_pitch_count": 6,
+                        "dead_air_ratio": 0.0,
+                        "max_abs_interval": 12,
+                        "max_simultaneous_notes": 1,
+                    },
+                },
+            }
+        )
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "candidate_repairs": repairs,
+        "aggregate": {
+            "candidate_count": 6,
+            "source_total_failure_label_count": 4,
+            "repaired_total_failure_label_count": 1,
+            "failure_label_delta": 3,
+            "source_phrase_rhythm_failure_count": 4,
+            "repaired_phrase_rhythm_failure_count": 1,
+            "phrase_rhythm_failure_delta": 3,
+            "improved_candidate_count": 2,
+            "technical_regression_count": 0,
+            "repaired_failure_counts": {
+                "rhythmic_monotony": 1,
+            },
+            "target_supported": True,
+        },
+        "selected_next_target": {
+            "selected_target": "songlike_melody_contour_phrase_rhythm_repair_audio_package",
+            "selected_next_boundary": SOURCE_NEXT_BOUNDARY,
+        },
+        "readiness": {
+            "boundary": SOURCE_BOUNDARY,
+            "songlike_melody_contour_phrase_rhythm_repair_sweep_completed": True,
+            "songlike_melody_contour_phrase_rhythm_repair_target_supported": True,
+            "candidate_count": 6,
+            "failure_label_delta": 3,
+            "phrase_rhythm_failure_delta": 3,
+            "technical_regression_count": 0,
+            "audio_package_ready": True,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": quality_claim,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": SOURCE_BOUNDARY,
+            "next_boundary": SOURCE_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioTest(unittest.TestCase):
+    def test_renders_phrase_rhythm_repair_wavs_without_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = root / "fluidsynth"
+            soundfont = root / "soundfont.sf2"
+            renderer.write_text("#!/bin/sh\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            report = build_audio_render_report(
+                source_report(root),
+                output_dir=root / "audio_package",
+                renderer_path=str(renderer),
+                soundfont_path=str(soundfont),
+                sample_rate=44100,
+                expected_file_count=6,
+                runner=fake_runner,
+            )
+            summary = validate_audio_render_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                expected_file_count=6,
+                expected_sample_rate=44100,
+                require_audio_package_completed=True,
+                require_no_quality_claim=True,
+            )
+
+            self.assertTrue(
+                summary["songlike_melody_contour_phrase_rhythm_repair_audio_package_completed"]
+            )
+            self.assertEqual(summary["rendered_audio_file_count"], 6)
+            self.assertTrue(summary["technical_wav_validation"])
+            self.assertEqual(summary["phrase_rhythm_failure_delta"], 3)
+            self.assertEqual(summary["technical_regression_count"], 0)
+            self.assertTrue(summary["audio_review_required"])
+            self.assertFalse(summary["human_audio_preference_claimed"])
+            self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+
+    def test_rejects_source_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = root / "fluidsynth"
+            soundfont = root / "soundfont.sf2"
+            renderer.write_text("#!/bin/sh\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            with self.assertRaises(StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError):
+                build_audio_render_report(
+                    source_report(root, quality_claim=True),
+                    output_dir=root / "audio_package",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(soundfont),
+                    sample_rate=44100,
+                    expected_file_count=6,
+                    runner=fake_runner,
+                )
+
+    def test_constants_are_stable(self) -> None:
+        self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package")
+        self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary

- phrase/rhythm repair MIDI 후보 6개 WAV 렌더 package 추가
- technical WAV validation: true
- rendered audio file count: 6
- sample rate: 44100
- duration range: 18.871s-19.000s
- MIDI-to-solo musical quality claim 제외 유지

Context

- Issue #774 phrase/rhythm repair sweep 결과
- total failure labels: 4 -> 1
- phrase/rhythm failure count: 4 -> 1
- technical regression count: 0
- next boundary: stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package

Scope

- Issue #774 sweep report 입력 검증
- phrase/rhythm repaired MIDI 후보 WAV 렌더
- sample rate, frame count, file size, duration 기술 메타데이터 검증
- audio package report, validation summary, markdown 문서 생성
- 하네스 모드 stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-audio-package 추가
- handoff/status/core plan 갱신

Validation

- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio
- .venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-audio-package
- bash scripts/agent_harness.sh quick

Risk

- WAV 생성은 음악 품질 검증이 아님
- human/audio preference claim 없음
- MIDI-to-solo musical quality claim 없음

Follow-up

- Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package

Closes #776