### PR TITLE
Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #778, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package.
+- Latest functional issue completed: Issue #780, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -172,6 +172,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phras
 ```
 
 This harness packages phrase/rhythm repair WAV/MIDI candidates for listening review without claiming preference or musical quality.
+
+For Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-listening-review-input-guard
+```
+
+This harness blocks preference fill while listening review input is pending and keeps quality claims false.
 
 For Stage A training-mode changes, run:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -5037,6 +5037,45 @@ Issue #778은 Issue #776 phrase/rhythm repair WAV/MIDI 후보 6개를 listening 
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard`
 
+## 9.81 Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard
+
+Issue #780은 Issue #778 listening review package의 validated review input 부재 상태를 guard로 검증한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- failure label delta: `3`
+- phrase/rhythm failure delta: `3`
+- audio review required: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- review input pending 상태에서 preference fill 차단 확인.
+- listening review completion과 human/audio preference claim 제외.
+- critical user input required는 `false`로 유지.
+- 다음 boundary는 objective-only next decision.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
+- `.venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-listening-review-input-guard`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #778, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard`
+- latest functional result: Issue #780, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision`
 
 현재 범위가 아닌 것:
 
@@ -155,6 +155,14 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 guard target: `songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
+- songlike melody contour phrase/rhythm repair listening review input guard 완료
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- critical user input required: `false`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 decision target: `songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_LISTENING_REVIEW_INPUT_GUARD_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_LISTENING_REVIEW_INPUT_GUARD_2026-06-09.md
@@ -1,0 +1,52 @@
+# Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Repair Listening Review Input Guard
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- duration range: `18.871s-19.000s`
+- failure label delta: `3`
+- phrase/rhythm failure count: `4 -> 1`
+- phrase/rhythm failure delta: `3`
+- audio review required: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Decision
+
+- auto progress allowed: `true`
+- critical user input required: `false`
+- reason: `listening review input pending; preference fill blocked`
+- next recommended issue: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision`
+
+## Required Input Fields
+
+- `candidate_index`
+- `listening_status`
+- `preference`
+- `issue_notes`
+
+## Review WAV Paths
+
+- `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/audio/candidate_01_cli_repaired_midi_rank_01_phrase_rhythm_repair.wav`
+- `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/audio/candidate_02_cli_repaired_midi_rank_02_phrase_rhythm_repair.wav`
+- `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/audio/candidate_03_cli_repaired_midi_rank_03_phrase_rhythm_repair.wav`
+- `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/audio/candidate_04_changed_ratio_repair_rank_04_phrase_rhythm_repair.wav`
+- `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/audio/candidate_05_changed_ratio_repair_rank_05_phrase_rhythm_repair.wav`
+- `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/audio/candidate_06_changed_ratio_repair_rank_06_phrase_rhythm_repair.wav`
+
+## Claim Boundary
+
+- `listening_review_completed`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -282,6 +282,8 @@ Modes:
                 Render phrase/rhythm repair MIDI candidates to WAV files.
   stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-listening-review-package
                 Package phrase/rhythm repair WAV/MIDI candidates for listening review.
+  stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-listening-review-input-guard
+                Block phrase/rhythm repair preference fill while listening review input is pending.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision
                 Decide the next pitch-contour changed-ratio repair boundary.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-probe
@@ -6536,6 +6538,27 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard() {
+  local package_run_id="${PACKAGE_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package}"
+  local guard_run_id="${RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard}"
+  local source_package="outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package/${package_run_id}/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package.json"
+  if [[ ! -f "$source_package" ]]; then
+    print_header "Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package"
+    RUN_ID="$package_run_id" run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package
+  fi
+  print_header "Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard"
+  "$PYTHON_BIN" scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input.py \
+    --run_id "$guard_run_id" \
+    --source_package "$source_package" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_LISTENING_REVIEW_INPUT_GUARD_2026-06-09.md \
+    --issue_number 780 \
+    --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard \
+    --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision \
+    --require_guard_completed \
+    --require_pending_input \
+    --require_no_quality_claim
+}
+
 run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision() {
   local quality_gap_run_id="${QUALITY_GAP_RUN_ID:-harness_stage_b_midi_to_solo_quality_gap_decision}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision}"
@@ -8846,6 +8869,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-listening-review-package)
     run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package
+    ;;
+  stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-listening-review-input-guard)
+    run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard
     ;;
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision)
     run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision

--- a/scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input.py
+++ b/scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input.py
@@ -1,0 +1,410 @@
+"""Guard songlike melody contour phrase/rhythm repair listening review preference fill against missing input."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard"
+FILL_BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_fill"
+OBJECTIVE_NEXT_BOUNDARY = (
+    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision"
+)
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard_v1"
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_source_package(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    package = _dict(report.get("review_package"))
+    source = _dict(report.get("source_summary"))
+    review_items = [_dict(item) for item in _list(report.get("review_items"))]
+    boundary = str(report.get("boundary") or readiness.get("boundary") or "")
+    if boundary != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            "songlike melody contour phrase/rhythm repair listening review package boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            "songlike melody contour phrase/rhythm repair listening package must route to input guard"
+        )
+    if not bool(readiness.get("listening_review_package_ready", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            "listening review package readiness required"
+        )
+    if not bool(package.get("package_ready", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            "review package ready flag required"
+        )
+    review_item_count = _int(readiness.get("review_item_count") or package.get("review_item_count"))
+    if review_item_count <= 0 or len(review_items) < review_item_count:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            "review items required"
+        )
+    if not bool(source.get("technical_wav_validation", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            "technical WAV validation required"
+        )
+    if _int(source.get("rendered_audio_file_count")) < review_item_count:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            "rendered audio count below review item count"
+        )
+    if not bool(source.get("audio_review_required", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            "audio review requirement should remain recorded"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            "critical user input should not be required"
+        )
+    _require_no_quality_claim(readiness, label="phrase/rhythm repair listening package readiness")
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "review_item_count": review_item_count,
+        "validated_review_input": bool(readiness.get("validated_review_input", False)),
+        "human_review_required_now": bool(readiness.get("human_review_required_now", False)),
+        "required_input_fields": [
+            str(item) for item in _list(package.get("required_input_fields"))
+        ],
+        "wav_paths": [str(item.get("wav_path") or "") for item in review_items],
+        "source_summary": {
+            "technical_wav_validation": bool(source.get("technical_wav_validation", False)),
+            "rendered_audio_file_count": _int(source.get("rendered_audio_file_count")),
+            "sample_rate": _int(source.get("sample_rate")),
+            "duration_min_seconds": _float(source.get("duration_min_seconds")),
+            "duration_max_seconds": _float(source.get("duration_max_seconds")),
+            "failure_label_delta": _int(source.get("failure_label_delta")),
+            "source_phrase_rhythm_failure_count": _int(
+                source.get("source_phrase_rhythm_failure_count")
+            ),
+            "repaired_phrase_rhythm_failure_count": _int(
+                source.get("repaired_phrase_rhythm_failure_count")
+            ),
+            "phrase_rhythm_failure_delta": _int(source.get("phrase_rhythm_failure_delta")),
+            "remaining_failure_counts": _dict(source.get("remaining_failure_counts")),
+            "audio_review_required": bool(source.get("audio_review_required", False)),
+        },
+    }
+
+
+def build_listening_review_input_guard_report(
+    source_package: dict[str, Any],
+    *,
+    output_dir: Path,
+    issue_number: int,
+) -> dict[str, Any]:
+    source = validate_source_package(source_package)
+    validated_input = bool(source["validated_review_input"])
+    next_boundary = FILL_BOUNDARY if validated_input else OBJECTIVE_NEXT_BOUNDARY
+    reason = (
+        "validated listening review input present; preference fill allowed"
+        if validated_input
+        else "listening review input pending; preference fill blocked"
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundary": source["boundary"],
+        "source_package_summary": source,
+        "guard_result": {
+            "validated_review_input_present": bool(validated_input),
+            "preference_fill_allowed": bool(validated_input),
+            "review_item_count": int(source["review_item_count"]),
+            "required_input_field_count": len(source["required_input_fields"]),
+            "missing_validated_input_reason": ""
+            if validated_input
+            else "validated_review_input=false",
+            "source_summary": source["source_summary"],
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "listening_review_input_guard_completed": True,
+            "validated_review_input_present": bool(validated_input),
+            "preference_fill_allowed": bool(validated_input),
+            "listening_review_completed": False,
+            "human_review_required_now": bool(source["human_review_required_now"]),
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+            **source["source_summary"],
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": next_boundary,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": reason,
+        },
+        "not_proven": [
+            "listening_review_completed",
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "audio_rendered_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review fill"
+            if validated_input
+            else "Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision"
+        ),
+    }
+
+
+def validate_listening_review_input_guard_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_guard_completed: bool,
+    require_preference_blocked: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    guard = _dict(report.get("guard_result"))
+    source = _dict(guard.get("source_summary"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            "unexpected next boundary"
+        )
+    if require_guard_completed and not bool(
+        readiness.get("listening_review_input_guard_completed", False)
+    ):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            "guard completion required"
+        )
+    if require_preference_blocked and bool(guard.get("preference_fill_allowed", True)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            "preference fill should remain blocked"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            "critical user input should not be required"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="phrase/rhythm repair input guard readiness")
+    return {
+        "boundary": boundary,
+        "source_boundary": str(report.get("source_boundary") or ""),
+        "validated_review_input_present": bool(
+            guard.get("validated_review_input_present", True)
+        ),
+        "preference_fill_allowed": bool(guard.get("preference_fill_allowed", True)),
+        "review_item_count": _int(guard.get("review_item_count")),
+        "required_input_field_count": _int(guard.get("required_input_field_count")),
+        "technical_wav_validation": bool(source.get("technical_wav_validation", False)),
+        "rendered_audio_file_count": _int(source.get("rendered_audio_file_count")),
+        "sample_rate": _int(source.get("sample_rate")),
+        "duration_min_seconds": _float(source.get("duration_min_seconds")),
+        "duration_max_seconds": _float(source.get("duration_max_seconds")),
+        "failure_label_delta": _int(source.get("failure_label_delta")),
+        "phrase_rhythm_failure_delta": _int(source.get("phrase_rhythm_failure_delta")),
+        "audio_review_required": bool(source.get("audio_review_required", False)),
+        "human_audio_preference_claimed": bool(
+            readiness.get("human_audio_preference_claimed", True)
+        ),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    guard = report["guard_result"]
+    source = guard["source_summary"]
+    package = report["source_package_summary"]
+    lines = [
+        "# Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Repair Listening Review Input Guard",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- source boundary: `{report['source_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- review item count: `{guard['review_item_count']}`",
+        f"- required input field count: `{guard['required_input_field_count']}`",
+        f"- validated review input present: `{_bool_token(guard['validated_review_input_present'])}`",
+        f"- preference fill allowed: `{_bool_token(guard['preference_fill_allowed'])}`",
+        f"- technical WAV validation: `{_bool_token(source['technical_wav_validation'])}`",
+        f"- rendered audio file count: `{source['rendered_audio_file_count']}`",
+        f"- duration range: `{source['duration_min_seconds']:.3f}s-{source['duration_max_seconds']:.3f}s`",
+        f"- failure label delta: `{source['failure_label_delta']}`",
+        f"- phrase/rhythm failure count: `{source['source_phrase_rhythm_failure_count']} -> {source['repaired_phrase_rhythm_failure_count']}`",
+        f"- phrase/rhythm failure delta: `{source['phrase_rhythm_failure_delta']}`",
+        f"- audio review required: `{_bool_token(source['audio_review_required'])}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Decision",
+        "",
+        f"- auto progress allowed: `{_bool_token(decision['auto_progress_allowed'])}`",
+        f"- critical user input required: `{_bool_token(decision['critical_user_input_required'])}`",
+        f"- reason: `{decision['reason']}`",
+        f"- next recommended issue: `{report['next_recommended_issue']}`",
+        "",
+        "## Required Input Fields",
+        "",
+    ]
+    for field in package["required_input_fields"]:
+        lines.append(f"- `{field}`")
+    lines.extend(["", "## Review WAV Paths", ""])
+    for path in package["wav_paths"]:
+        lines.append(f"- `{path}`")
+    lines.extend(["", "## Claim Boundary", ""])
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Guard songlike melody contour phrase/rhythm repair listening review input"
+    )
+    parser.add_argument("--source_package", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=780)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_guard_completed", action="store_true")
+    parser.add_argument("--require_preference_blocked", action="store_true")
+    parser.add_argument("--require_pending_input", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_listening_review_input_guard_report(
+        read_json(Path(args.source_package)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+    )
+    summary = validate_listening_review_input_guard_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_guard_completed=bool(args.require_guard_completed),
+        require_preference_blocked=bool(
+            args.require_preference_blocked or args.require_pending_input
+        ),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir
+        / "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package import (
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+from scripts.guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input import (
+    BOUNDARY,
+    OBJECTIVE_NEXT_BOUNDARY,
+    StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError,
+    build_listening_review_input_guard_report,
+    validate_listening_review_input_guard_report,
+)
+
+
+def source_package(*, quality_claim: bool = False, validated_input: bool = False) -> dict:
+    review_items = [
+        {
+            "candidate_index": index,
+            "source": "unit_source",
+            "rank": index,
+            "midi_path": f"/tmp/candidate_{index}.mid",
+            "wav_path": f"/tmp/candidate_{index}.wav",
+            "duration_seconds": 0.1,
+            "sample_rate": 44100,
+            "size_bytes": 100,
+            "sha256": "abc",
+            "repaired_failure_labels": ["rhythmic_monotony"] if index == 4 else [],
+            "review_status": "pending",
+        }
+        for index in range(1, 7)
+    ]
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "source_summary": {
+            "rendered_audio_file_count": 6,
+            "technical_wav_validation": True,
+            "sample_rate": 44100,
+            "duration_min_seconds": 0.1,
+            "duration_max_seconds": 0.1,
+            "failure_label_delta": 3,
+            "source_phrase_rhythm_failure_count": 4,
+            "repaired_phrase_rhythm_failure_count": 1,
+            "phrase_rhythm_failure_delta": 3,
+            "remaining_failure_counts": {
+                "rhythmic_monotony": 1,
+            },
+            "audio_review_required": True,
+        },
+        "review_package": {
+            "package_ready": True,
+            "review_item_count": 6,
+            "validated_review_input": validated_input,
+            "required_input_fields": [
+                "candidate_index",
+                "listening_status",
+                "preference",
+                "issue_notes",
+            ],
+        },
+        "review_items": review_items,
+        "readiness": {
+            "boundary": SOURCE_BOUNDARY,
+            "listening_review_package_ready": True,
+            "review_item_count": 6,
+            "validated_review_input": validated_input,
+            "human_review_required_now": False,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": quality_claim,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": SOURCE_BOUNDARY,
+            "next_boundary": SOURCE_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardTest(unittest.TestCase):
+    def test_blocks_preference_fill_when_review_input_pending(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            report = build_listening_review_input_guard_report(
+                source_package(),
+                output_dir=root / "guard",
+                issue_number=780,
+            )
+            summary = validate_listening_review_input_guard_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=OBJECTIVE_NEXT_BOUNDARY,
+                require_guard_completed=True,
+                require_preference_blocked=True,
+                require_no_quality_claim=True,
+            )
+
+            self.assertTrue(summary["technical_wav_validation"])
+            self.assertFalse(summary["validated_review_input_present"])
+            self.assertFalse(summary["preference_fill_allowed"])
+            self.assertEqual(summary["review_item_count"], 6)
+            self.assertEqual(summary["required_input_field_count"], 4)
+            self.assertEqual(summary["failure_label_delta"], 3)
+            self.assertEqual(summary["phrase_rhythm_failure_delta"], 3)
+            self.assertFalse(summary["human_audio_preference_claimed"])
+            self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+
+    def test_rejects_source_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaises(StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError):
+                build_listening_review_input_guard_report(
+                    source_package(quality_claim=True),
+                    output_dir=root / "guard",
+                    issue_number=780,
+                )
+
+    def test_constants_are_stable(self) -> None:
+        self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard")
+        self.assertEqual(OBJECTIVE_NEXT_BOUNDARY, "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary

- phrase/rhythm repair listening review input guard 추가
- validated review input present: false
- preference fill allowed: false
- review item count: 6
- preference, musical quality claim 제외 유지

Context

- Issue #778 listening review package 결과
- review item count: 6
- validated review input: false
- technical WAV validation: true
- next boundary: stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard

Scope

- Issue #778 package report 입력 검증
- required input fields 검증
- pending review input 상태에서 preference fill 차단
- objective-only next decision으로 routing
- 하네스 모드 stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-listening-review-input-guard 추가
- handoff/status/core plan 갱신

Validation

- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard
- .venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-listening-review-input-guard
- bash scripts/agent_harness.sh quick

Risk

- guard는 listening review 결과 생성이 아님
- human/audio preference claim 없음
- MIDI-to-solo musical quality claim 없음

Follow-up

- Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision

Closes #780