### PR TITLE
Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #780, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard.
+- Latest functional issue completed: Issue #782, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -180,6 +180,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phras
 ```
 
 This harness blocks preference fill while listening review input is pending and keeps quality claims false.
+
+For Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-objective-only-next-decision
+```
+
+This harness routes pending listening review input to the next objective-only follow-up boundary without claiming quality.
 
 For Stage A training-mode changes, run:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -5076,6 +5076,47 @@ Issue #780은 Issue #778 listening review package의 validated review input 부�
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision`
 
+## 9.82 Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision
+
+Issue #782는 Issue #780 input guard 이후 listening input 없이 objective evidence만으로 다음 boundary를 선택한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
+- selected target: `songlike_melody_contour_phrase_rhythm_repair_followup_decision`
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- failure label delta: `3`
+- phrase/rhythm failure delta: `3`
+- phrase/rhythm follow-up required: `true`
+- current quality claim ready: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- listening input 부재 상태에서 quality claim 불가.
+- preference fill blocked 상태 유지.
+- repair 결과가 quality claim으로 승격되지 않았으므로 follow-up decision 필요.
+- 다음 boundary는 phrase/rhythm repair follow-up decision.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-objective-only-next-decision`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #780, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision`
+- latest functional result: Issue #782, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision`
 
 현재 범위가 아닌 것:
 
@@ -163,6 +163,14 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 decision target: `songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
+- songlike melody contour phrase/rhythm repair objective-only next decision 완료
+- phrase/rhythm follow-up required: `true`
+- current quality claim ready: `false`
+- preference fill allowed: `false`
+- critical user input required: `false`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 follow-up target: `songlike_melody_contour_phrase_rhythm_repair_followup_decision`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-09.md
@@ -1,0 +1,37 @@
+# Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Repair Objective-Only Next Decision
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
+- selected target: `songlike_melody_contour_phrase_rhythm_repair_followup_decision`
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- failure label delta: `3`
+- phrase/rhythm failure count: `4 -> 1`
+- phrase/rhythm failure delta: `3`
+- phrase/rhythm follow-up required: `true`
+- current quality claim ready: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Decision
+
+- reason: `listening preference pending and quality claim unavailable; route to follow-up repair decision`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision`
+
+## Claim Boundary
+
+- `listening_review_completed`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -284,6 +284,8 @@ Modes:
                 Package phrase/rhythm repair WAV/MIDI candidates for listening review.
   stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-listening-review-input-guard
                 Block phrase/rhythm repair preference fill while listening review input is pending.
+  stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-objective-only-next-decision
+                Select objective-only next boundary after phrase/rhythm input guard.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision
                 Decide the next pitch-contour changed-ratio repair boundary.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-probe
@@ -6559,6 +6561,27 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision() {
+  local input_guard_run_id="${INPUT_GUARD_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision}"
+  local input_guard_report="outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard/${input_guard_run_id}/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard.json"
+  if [[ ! -f "$input_guard_report" ]]; then
+    print_header "Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard"
+    RUN_ID="$input_guard_run_id" run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard
+  fi
+  print_header "Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision"
+  "$PYTHON_BIN" scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next.py \
+    --run_id "$run_id" \
+    --input_guard_report "$input_guard_report" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-09.md \
+    --issue_number 782 \
+    --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision \
+    --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision \
+    --require_objective_decision \
+    --require_followup_required \
+    --require_no_quality_claim
+}
+
 run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision() {
   local quality_gap_run_id="${QUALITY_GAP_RUN_ID:-harness_stage_b_midi_to_solo_quality_gap_decision}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision}"
@@ -8872,6 +8895,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-listening-review-input-guard)
     run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard
+    ;;
+  stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-objective-only-next-decision)
+    run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision
     ;;
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision)
     run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision

--- a/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next.py
+++ b/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next.py
@@ -1,0 +1,404 @@
+"""Select the next boundary after songlike melody contour phrase/rhythm repair input guard evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+    OBJECTIVE_NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(ValueError):
+    pass
+
+
+BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision"
+FOLLOWUP_DECISION_NEXT_BOUNDARY = (
+    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision"
+)
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next_v1"
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_input_guard_report(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    guard = _dict(report.get("guard_result"))
+    source = _dict(guard.get("source_summary"))
+    if str(report.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
+            "songlike melody contour phrase/rhythm repair listening review input guard boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
+            "input guard must route to phrase/rhythm objective-only next decision"
+        )
+    if not bool(readiness.get("listening_review_input_guard_completed", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
+            "input guard completion required"
+        )
+    if bool(guard.get("validated_review_input_present", True)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
+            "objective-only decision requires pending review input"
+        )
+    if bool(guard.get("preference_fill_allowed", True)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
+            "preference fill must remain blocked"
+        )
+    if not bool(source.get("technical_wav_validation", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
+            "technical WAV validation required"
+        )
+    if _int(source.get("rendered_audio_file_count")) < 6:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
+            "rendered WAV count below 6"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
+            "critical user input should not be required"
+        )
+    _require_no_quality_claim(readiness, label="phrase/rhythm repair input guard readiness")
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "review_item_count": _int(guard.get("review_item_count")),
+        "required_input_field_count": _int(guard.get("required_input_field_count")),
+        "validated_review_input_present": bool(
+            guard.get("validated_review_input_present", False)
+        ),
+        "preference_fill_allowed": bool(guard.get("preference_fill_allowed", False)),
+        "technical_wav_validation": bool(source.get("technical_wav_validation", False)),
+        "rendered_audio_file_count": _int(source.get("rendered_audio_file_count")),
+        "sample_rate": _int(source.get("sample_rate")),
+        "duration_min_seconds": _float(source.get("duration_min_seconds")),
+        "duration_max_seconds": _float(source.get("duration_max_seconds")),
+        "failure_label_delta": _int(source.get("failure_label_delta")),
+        "source_phrase_rhythm_failure_count": _int(source.get("source_phrase_rhythm_failure_count")),
+        "repaired_phrase_rhythm_failure_count": _int(
+            source.get("repaired_phrase_rhythm_failure_count")
+        ),
+        "phrase_rhythm_failure_delta": _int(source.get("phrase_rhythm_failure_delta")),
+        "audio_review_required": bool(source.get("audio_review_required", False)),
+    }
+
+
+def build_objective_next_report(
+    *,
+    input_guard_report: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+) -> dict[str, Any]:
+    source = validate_input_guard_report(input_guard_report)
+    followup_required = True
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundary": source["boundary"],
+        "objective_summary": {
+            "review_item_count": _int(source["review_item_count"]),
+            "required_input_field_count": _int(source["required_input_field_count"]),
+            "validated_review_input_present": bool(
+                source["validated_review_input_present"]
+            ),
+            "preference_fill_allowed": bool(source["preference_fill_allowed"]),
+            "technical_wav_validation": bool(source["technical_wav_validation"]),
+            "rendered_audio_file_count": _int(source["rendered_audio_file_count"]),
+            "sample_rate": _int(source["sample_rate"]),
+            "duration_min_seconds": _float(source["duration_min_seconds"]),
+            "duration_max_seconds": _float(source["duration_max_seconds"]),
+            "failure_label_delta": _int(source["failure_label_delta"]),
+            "source_phrase_rhythm_failure_count": _int(
+                source["source_phrase_rhythm_failure_count"]
+            ),
+            "repaired_phrase_rhythm_failure_count": _int(
+                source["repaired_phrase_rhythm_failure_count"]
+            ),
+            "phrase_rhythm_failure_delta": _int(source["phrase_rhythm_failure_delta"]),
+            "audio_review_required": bool(source["audio_review_required"]),
+            "phrase_rhythm_followup_required": bool(followup_required),
+            "current_quality_claim_ready": False,
+        },
+        "selected_next_target": {
+            "target": "songlike_melody_contour_phrase_rhythm_repair_followup_decision",
+            "next_boundary": FOLLOWUP_DECISION_NEXT_BOUNDARY,
+            "reason": (
+                "listening preference pending and quality claim unavailable; route to follow-up repair decision"
+            ),
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "objective_next_decision_completed": True,
+            "technical_wav_validation": bool(source["technical_wav_validation"]),
+            "phrase_rhythm_followup_required": bool(followup_required),
+            "current_quality_claim_ready": False,
+            "human_audio_preference_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": FOLLOWUP_DECISION_NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "objective-only evidence selected follow-up repair decision without quality claim",
+        },
+        "not_proven": [
+            "listening_review_completed",
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "audio_rendered_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision"
+        ),
+    }
+
+
+def validate_objective_next_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_objective_decision: bool,
+    require_followup_required: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("objective_summary"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
+            "unexpected next boundary"
+        )
+    if require_objective_decision and not bool(
+        readiness.get("objective_next_decision_completed", False)
+    ):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
+            "objective next decision completion required"
+        )
+    if require_followup_required and not bool(
+        readiness.get("phrase_rhythm_followup_required", False)
+    ):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
+            "phrase/rhythm follow-up requirement expected"
+        )
+    if bool(summary.get("preference_fill_allowed", True)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
+            "preference fill must remain blocked"
+        )
+    if bool(summary.get("current_quality_claim_ready", True)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
+            "quality claim readiness must remain false"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
+            "critical user input should not be required"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="phrase/rhythm repair objective next readiness")
+    return {
+        "boundary": boundary,
+        "source_boundary": str(report.get("source_boundary") or ""),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "objective_next_decision_completed": bool(
+            readiness.get("objective_next_decision_completed", False)
+        ),
+        "review_item_count": _int(summary.get("review_item_count")),
+        "required_input_field_count": _int(summary.get("required_input_field_count")),
+        "validated_review_input_present": bool(
+            summary.get("validated_review_input_present", True)
+        ),
+        "preference_fill_allowed": bool(summary.get("preference_fill_allowed", True)),
+        "technical_wav_validation": bool(summary.get("technical_wav_validation", False)),
+        "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
+        "failure_label_delta": _int(summary.get("failure_label_delta")),
+        "phrase_rhythm_failure_delta": _int(summary.get("phrase_rhythm_failure_delta")),
+        "audio_review_required": bool(summary.get("audio_review_required", False)),
+        "phrase_rhythm_followup_required": bool(
+            summary.get("phrase_rhythm_followup_required", False)
+        ),
+        "current_quality_claim_ready": bool(summary.get("current_quality_claim_ready", True)),
+        "human_audio_preference_claimed": bool(
+            readiness.get("human_audio_preference_claimed", True)
+        ),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(decision.get("critical_user_input_required", True)),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    summary = report["objective_summary"]
+    target = report["selected_next_target"]
+    lines = [
+        "# Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Repair Objective-Only Next Decision",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- source boundary: `{report['source_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- selected target: `{target['target']}`",
+        f"- review item count: `{summary['review_item_count']}`",
+        f"- required input field count: `{summary['required_input_field_count']}`",
+        f"- validated review input present: `{_bool_token(summary['validated_review_input_present'])}`",
+        f"- preference fill allowed: `{_bool_token(summary['preference_fill_allowed'])}`",
+        f"- technical WAV validation: `{_bool_token(summary['technical_wav_validation'])}`",
+        f"- rendered audio file count: `{summary['rendered_audio_file_count']}`",
+        f"- failure label delta: `{summary['failure_label_delta']}`",
+        f"- phrase/rhythm failure count: `{summary['source_phrase_rhythm_failure_count']} -> {summary['repaired_phrase_rhythm_failure_count']}`",
+        f"- phrase/rhythm failure delta: `{summary['phrase_rhythm_failure_delta']}`",
+        f"- phrase/rhythm follow-up required: `{_bool_token(summary['phrase_rhythm_followup_required'])}`",
+        f"- current quality claim ready: `{_bool_token(summary['current_quality_claim_ready'])}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Decision",
+        "",
+        f"- reason: `{target['reason']}`",
+        f"- auto progress allowed: `{_bool_token(decision['auto_progress_allowed'])}`",
+        f"- critical user input required: `{_bool_token(decision['critical_user_input_required'])}`",
+        f"- next recommended issue: `{report['next_recommended_issue']}`",
+        "",
+        "## Claim Boundary",
+        "",
+    ]
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Decide songlike melody contour phrase/rhythm repair objective-only next step"
+    )
+    parser.add_argument("--input_guard_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=782)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_objective_decision", action="store_true")
+    parser.add_argument("--require_followup_required", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_objective_next_report(
+        input_guard_report=read_json(Path(args.input_guard_report)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+    )
+    summary = validate_objective_next_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_objective_decision=bool(args.require_objective_decision),
+        require_followup_required=bool(args.require_followup_required),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir / "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir / "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next import (
+    BOUNDARY,
+    FOLLOWUP_DECISION_NEXT_BOUNDARY,
+    StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError,
+    build_objective_next_report,
+    validate_objective_next_report,
+)
+from scripts.guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input import (
+    BOUNDARY as SOURCE_BOUNDARY,
+    OBJECTIVE_NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+def input_guard_report(*, quality_claim: bool = False) -> dict:
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "source_boundary": "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package",
+        "guard_result": {
+            "validated_review_input_present": False,
+            "preference_fill_allowed": False,
+            "review_item_count": 6,
+            "required_input_field_count": 4,
+            "source_summary": {
+                "technical_wav_validation": True,
+                "rendered_audio_file_count": 6,
+                "sample_rate": 44100,
+                "duration_min_seconds": 18.871,
+                "duration_max_seconds": 19.000,
+                "failure_label_delta": 3,
+                "source_phrase_rhythm_failure_count": 4,
+                "repaired_phrase_rhythm_failure_count": 1,
+                "phrase_rhythm_failure_delta": 3,
+                "audio_review_required": True,
+            },
+        },
+        "readiness": {
+            "boundary": SOURCE_BOUNDARY,
+            "listening_review_input_guard_completed": True,
+            "validated_review_input_present": False,
+            "preference_fill_allowed": False,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": quality_claim,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": SOURCE_BOUNDARY,
+            "next_boundary": SOURCE_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextTest(unittest.TestCase):
+    def test_routes_pending_review_to_followup_decision_without_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            report = build_objective_next_report(
+                input_guard_report=input_guard_report(),
+                output_dir=root / "objective_next",
+                issue_number=782,
+            )
+            summary = validate_objective_next_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=FOLLOWUP_DECISION_NEXT_BOUNDARY,
+                require_objective_decision=True,
+                require_followup_required=True,
+                require_no_quality_claim=True,
+            )
+
+            self.assertTrue(summary["objective_next_decision_completed"])
+            self.assertFalse(summary["validated_review_input_present"])
+            self.assertFalse(summary["preference_fill_allowed"])
+            self.assertTrue(summary["technical_wav_validation"])
+            self.assertEqual(summary["rendered_audio_file_count"], 6)
+            self.assertEqual(summary["failure_label_delta"], 3)
+            self.assertEqual(summary["phrase_rhythm_failure_delta"], 3)
+            self.assertTrue(summary["phrase_rhythm_followup_required"])
+            self.assertFalse(summary["current_quality_claim_ready"])
+            self.assertFalse(summary["human_audio_preference_claimed"])
+            self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+
+    def test_rejects_source_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaises(StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError):
+                build_objective_next_report(
+                    input_guard_report=input_guard_report(quality_claim=True),
+                    output_dir=root / "objective_next",
+                    issue_number=782,
+                )
+
+    def test_constants_are_stable(self) -> None:
+        self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision")
+        self.assertEqual(FOLLOWUP_DECISION_NEXT_BOUNDARY, "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary

- phrase/rhythm repair objective-only next decision 추가
- validated review input present: false
- preference fill allowed: false
- phrase/rhythm follow-up required: true
- current quality claim ready: false

Context

- Issue #780 input guard 결과
- review item count: 6
- preference fill allowed: false
- technical WAV validation: true
- next boundary: stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision

Scope

- Issue #780 input guard report 입력 검증
- pending review input 상태에서 quality claim ready false 기록
- phrase/rhythm repair follow-up decision으로 routing
- 하네스 모드 stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-objective-only-next-decision 추가
- handoff/status/core plan 갱신

Validation

- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next
- .venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-objective-only-next-decision
- bash scripts/agent_harness.sh quick

Risk

- objective-only decision은 human/audio preference 판단이 아님
- MIDI-to-solo musical quality claim 없음

Follow-up

- Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision

Closes #782