### PR TITLE
Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #786, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge.
+- Latest functional issue completed: Issue #788, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -204,6 +204,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phras
 ```
 
 This harness attaches fallback chord context to phrase/rhythm repair candidates and records pitch-role metrics without claiming musical quality.
+
+For Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-context-pitch-role-objective-decision
+```
+
+This harness selects the next repair target from chord-context pitch-role objective evidence without claiming musical quality.
 
 For Stage A training-mode changes, run:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -5201,6 +5201,45 @@ Issue #786은 Issue #784 follow-up decision에서 선택한 chord-context pitch-
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision`
 
+## 9.85 Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision
+
+Issue #788은 Issue #786 chord-context pitch-role bridge 결과를 기준으로 다음 repair target을 선택한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
+- selected target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
+- primary risk label: `weak_chord_tone_landing_risk`
+- candidate count: `6`
+- not evaluable count: `12 -> 0`
+- weak chord-tone landing risk count: `6`
+- outside-soloing pitch-role risk count: `5`
+- min chord-tone ratio: `0.216`
+- max outside ratio: `0.027`
+- max non-chord run: `5`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- bridge 이후 outside/chord-tone landing 평가 불가 상태는 해소.
+- 전체 후보 `6/6`에서 weak chord-tone landing risk 관측.
+- outside-soloing pitch-role risk도 `5/6`이지만 primary risk count는 weak chord-tone landing.
+- 다음 boundary는 chord-tone landing repair sweep.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-context-pitch-role-objective-decision`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #786, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision`
+- latest functional result: Issue #788, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep`
 
 현재 범위가 아닌 것:
 
@@ -194,6 +194,17 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 objective decision target: `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- songlike melody contour phrase/rhythm chord-context pitch-role objective decision 완료
+- primary risk label: `weak_chord_tone_landing_risk`
+- weak chord-tone landing risk count: `6`
+- outside-soloing pitch-role risk count: `5`
+- not evaluable count: `12 -> 0`
+- min chord-tone ratio: `0.216`
+- max outside ratio: `0.027`
+- max non-chord run: `5`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 repair target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_CONTEXT_PITCH_ROLE_OBJECTIVE_DECISION_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_CONTEXT_PITCH_ROLE_OBJECTIVE_DECISION_2026-06-09.md
@@ -1,0 +1,33 @@
+# Stage B MIDI-to-Solo Pitch-Role Objective Decision
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
+- selected target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
+- primary risk label: `weak_chord_tone_landing_risk`
+- candidate count: `6`
+- not evaluable count: `12 -> 0`
+- weak chord-tone landing risk count: `6`
+- outside-soloing pitch-role risk count: `5`
+- min chord-tone ratio: `0.216`
+- max outside ratio: `0.027`
+- max non-chord run: `5`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Decision
+
+- reason: `largest pitch-role risk count selected as next repair target`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep`
+
+## Claim Boundary
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -290,6 +290,8 @@ Modes:
                 Select chord-context pitch-role bridge after phrase/rhythm objective evidence.
   stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-context-pitch-role-bridge
                 Build chord-context pitch-role metrics for phrase/rhythm repair candidates.
+  stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-context-pitch-role-objective-decision
+                Select next repair target from chord-context pitch-role objective evidence.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision
                 Decide the next pitch-contour changed-ratio repair boundary.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-probe
@@ -6645,6 +6647,27 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pit
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision() {
+  local bridge_run_id="${BRIDGE_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision}"
+  local bridge_report="outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge/${bridge_run_id}/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge.json"
+  if [[ ! -f "$bridge_report" ]]; then
+    print_header "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge"
+    RUN_ID="$bridge_run_id" run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge
+  fi
+  print_header "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision"
+  "$PYTHON_BIN" scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective.py \
+    --run_id "$run_id" \
+    --bridge_report "$bridge_report" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_CONTEXT_PITCH_ROLE_OBJECTIVE_DECISION_2026-06-09.md \
+    --issue_number 788 \
+    --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision \
+    --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep \
+    --expected_target songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep \
+    --require_objective_decision \
+    --require_no_quality_claim
+}
+
 run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision() {
   local quality_gap_run_id="${QUALITY_GAP_RUN_ID:-harness_stage_b_midi_to_solo_quality_gap_decision}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision}"
@@ -8967,6 +8990,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-context-pitch-role-bridge)
     run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge
+    ;;
+  stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-context-pitch-role-objective-decision)
+    run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision
     ;;
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision)
     run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision

--- a/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective.py
+++ b/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective.py
@@ -1,0 +1,392 @@
+"""Select the next repair target from chord-context pitch-role bridge evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge import (  # noqa: E402
+    BOUNDARY as BRIDGE_BOUNDARY,
+    NEXT_BOUNDARY as BRIDGE_NEXT_BOUNDARY,
+)
+
+
+class StageBMidiToSoloPitchRoleObjectiveDecisionError(ValueError):
+    pass
+
+
+BOUNDARY = (
+    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision"
+)
+NEXT_BOUNDARY = (
+    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep"
+)
+SELECTED_TARGET = "songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision_v1"
+PRIMARY_RISK_LABEL = "weak_chord_tone_landing_risk"
+SECONDARY_RISK_LABEL = "outside_soloing_pitch_role_risk"
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_bridge_source(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("summary"))
+    flags = _dict(summary.get("bridge_flag_counts"))
+    if str(report.get("boundary") or "") != BRIDGE_BOUNDARY:
+        raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+            "chord-context pitch-role bridge boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != BRIDGE_NEXT_BOUNDARY:
+        raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+            "bridge must route to pitch-role objective decision"
+        )
+    if not bool(readiness.get("chord_context_pitch_role_bridge_completed", False)):
+        raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+            "bridge completion required"
+        )
+    candidate_count = _int(readiness.get("candidate_count"))
+    if candidate_count < 6:
+        raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+            "candidate count below 6"
+        )
+    if _int(readiness.get("chord_context_available_count")) != candidate_count:
+        raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+            "all candidates must have chord context"
+        )
+    if _int(readiness.get("pitch_role_metrics_defined_count")) != candidate_count:
+        raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+            "all candidates must have pitch-role metrics"
+        )
+    if _int(readiness.get("not_evaluable_after_count")) != 0:
+        raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+            "not-evaluable labels must be cleared before objective decision"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+            "critical user input should not be required"
+        )
+    _require_no_quality_claim(readiness, label="bridge readiness")
+    return {
+        "boundary": BRIDGE_BOUNDARY,
+        "candidate_count": candidate_count,
+        "not_evaluable_before_count": _int(readiness.get("not_evaluable_before_count")),
+        "not_evaluable_after_count": _int(readiness.get("not_evaluable_after_count")),
+        "weak_chord_tone_landing_risk_count": _int(flags.get(PRIMARY_RISK_LABEL)),
+        "outside_soloing_pitch_role_risk_count": _int(flags.get(SECONDARY_RISK_LABEL)),
+        "min_chord_tone_ratio": _float(summary.get("min_chord_tone_ratio")),
+        "max_outside_ratio": _float(summary.get("max_outside_ratio")),
+        "max_non_chord_tone_run": _int(summary.get("max_non_chord_tone_run")),
+    }
+
+
+def build_objective_decision_report(
+    *,
+    bridge_report: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+) -> dict[str, Any]:
+    bridge = validate_bridge_source(bridge_report)
+    weak_count = _int(bridge["weak_chord_tone_landing_risk_count"])
+    outside_count = _int(bridge["outside_soloing_pitch_role_risk_count"])
+    if weak_count <= 0 and outside_count <= 0:
+        selected_target = "songlike_melody_contour_phrase_rhythm_pitch_role_audio_review_package"
+        next_boundary = (
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_pitch_role_audio_review_package"
+        )
+        primary_label = "no_pitch_role_repair_required"
+    elif weak_count >= outside_count:
+        selected_target = SELECTED_TARGET
+        next_boundary = NEXT_BOUNDARY
+        primary_label = PRIMARY_RISK_LABEL
+    else:
+        selected_target = "songlike_melody_contour_phrase_rhythm_outside_soloing_pitch_role_repair_sweep"
+        next_boundary = (
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_outside_soloing_pitch_role_repair_sweep"
+        )
+        primary_label = SECONDARY_RISK_LABEL
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundary": bridge["boundary"],
+        "objective_summary": bridge,
+        "selected_next_target": {
+            "selected_target": selected_target,
+            "selected_next_boundary": next_boundary,
+            "primary_risk_label": primary_label,
+            "weak_chord_tone_landing_risk_count": weak_count,
+            "outside_soloing_pitch_role_risk_count": outside_count,
+            "reason": "largest pitch-role risk count selected as next repair target",
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "pitch_role_objective_decision_completed": True,
+            "candidate_count": _int(bridge["candidate_count"]),
+            "primary_risk_label": primary_label,
+            "weak_chord_tone_landing_risk_count": weak_count,
+            "outside_soloing_pitch_role_risk_count": outside_count,
+            "not_evaluable_after_count": _int(bridge["not_evaluable_after_count"]),
+            "human_audio_preference_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": next_boundary,
+            "selected_target": selected_target,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "pitch-role objective evidence selected next repair target without quality claim",
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "audio_rendered_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep"
+            if next_boundary == NEXT_BOUNDARY
+            else "Stage B MIDI-to-solo songlike melody contour phrase/rhythm outside-soloing pitch-role repair sweep"
+        ),
+    }
+
+
+def validate_objective_decision_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    expected_target: str | None,
+    require_objective_decision: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    selected = _dict(report.get("selected_next_target"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+            "unexpected next boundary"
+        )
+    if expected_target and str(selected.get("selected_target") or "") != expected_target:
+        raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+            "unexpected selected target"
+        )
+    if require_objective_decision and not bool(
+        readiness.get("pitch_role_objective_decision_completed", False)
+    ):
+        raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+            "objective decision completion required"
+        )
+    if _int(readiness.get("candidate_count")) <= 0:
+        raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+            "candidate count required"
+        )
+    if _int(readiness.get("not_evaluable_after_count")) != 0:
+        raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+            "not-evaluable labels must remain cleared"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+            "critical user input should not be required"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="objective decision readiness")
+    return {
+        "boundary": boundary,
+        "source_boundary": str(report.get("source_boundary") or ""),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "selected_target": str(decision.get("selected_target") or ""),
+        "pitch_role_objective_decision_completed": bool(
+            readiness.get("pitch_role_objective_decision_completed", False)
+        ),
+        "candidate_count": _int(readiness.get("candidate_count")),
+        "primary_risk_label": str(readiness.get("primary_risk_label") or ""),
+        "weak_chord_tone_landing_risk_count": _int(
+            readiness.get("weak_chord_tone_landing_risk_count")
+        ),
+        "outside_soloing_pitch_role_risk_count": _int(
+            readiness.get("outside_soloing_pitch_role_risk_count")
+        ),
+        "not_evaluable_after_count": _int(readiness.get("not_evaluable_after_count")),
+        "human_audio_preference_claimed": bool(
+            readiness.get("human_audio_preference_claimed", True)
+        ),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(
+            decision.get("critical_user_input_required", True)
+        ),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    summary = report["objective_summary"]
+    selected = report["selected_next_target"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    lines = [
+        "# Stage B MIDI-to-Solo Pitch-Role Objective Decision",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- source boundary: `{report['source_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- selected target: `{decision['selected_target']}`",
+        f"- primary risk label: `{selected['primary_risk_label']}`",
+        f"- candidate count: `{summary['candidate_count']}`",
+        f"- not evaluable count: `{summary['not_evaluable_before_count']} -> {summary['not_evaluable_after_count']}`",
+        f"- weak chord-tone landing risk count: `{summary['weak_chord_tone_landing_risk_count']}`",
+        f"- outside-soloing pitch-role risk count: `{summary['outside_soloing_pitch_role_risk_count']}`",
+        f"- min chord-tone ratio: `{summary['min_chord_tone_ratio']:.3f}`",
+        f"- max outside ratio: `{summary['max_outside_ratio']:.3f}`",
+        f"- max non-chord run: `{summary['max_non_chord_tone_run']}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Decision",
+        "",
+        f"- reason: `{selected['reason']}`",
+        f"- auto progress allowed: `{_bool_token(decision['auto_progress_allowed'])}`",
+        f"- critical user input required: `{_bool_token(decision['critical_user_input_required'])}`",
+        f"- next recommended issue: `{report['next_recommended_issue']}`",
+        "",
+        "## Claim Boundary",
+        "",
+    ]
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Decide next target from chord-context pitch-role bridge evidence"
+    )
+    parser.add_argument("--bridge_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=788)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--expected_target", type=str, default="")
+    parser.add_argument("--require_objective_decision", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_objective_decision_report(
+        bridge_report=read_json(Path(args.bridge_report)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+    )
+    summary = validate_objective_decision_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        expected_target=str(args.expected_target or ""),
+        require_objective_decision=bool(args.require_objective_decision),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir
+        / "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge import (
+    BOUNDARY as BRIDGE_BOUNDARY,
+    NEXT_BOUNDARY as BRIDGE_NEXT_BOUNDARY,
+)
+from scripts.decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    PRIMARY_RISK_LABEL,
+    SELECTED_TARGET,
+    StageBMidiToSoloPitchRoleObjectiveDecisionError,
+    build_objective_decision_report,
+    validate_objective_decision_report,
+)
+
+
+def bridge_report(*, quality_claim: bool = False, weak_count: int = 6, outside_count: int = 5) -> dict:
+    return {
+        "boundary": BRIDGE_BOUNDARY,
+        "summary": {
+            "candidate_count": 6,
+            "chord_context_available_count": 6,
+            "pitch_role_metrics_defined_count": 6,
+            "not_evaluable_before_count": 12,
+            "not_evaluable_after_count": 0,
+            "bridge_flag_counts": {
+                "weak_chord_tone_landing_risk": weak_count,
+                "outside_soloing_pitch_role_risk": outside_count,
+            },
+            "min_chord_tone_ratio": 0.216,
+            "max_outside_ratio": 0.027,
+            "max_non_chord_tone_run": 5,
+        },
+        "readiness": {
+            "chord_context_pitch_role_bridge_completed": True,
+            "candidate_count": 6,
+            "chord_context_available_count": 6,
+            "pitch_role_metrics_defined_count": 6,
+            "not_evaluable_before_count": 12,
+            "not_evaluable_after_count": 0,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": quality_claim,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": BRIDGE_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class StageBMidiToSoloPitchRoleObjectiveDecisionTest(unittest.TestCase):
+    def test_selects_chord_tone_landing_repair_target(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            report = build_objective_decision_report(
+                bridge_report=bridge_report(),
+                output_dir=Path(tmp) / "decision",
+                issue_number=788,
+            )
+            summary = validate_objective_decision_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                expected_target=SELECTED_TARGET,
+                require_objective_decision=True,
+                require_no_quality_claim=True,
+            )
+
+            self.assertTrue(summary["pitch_role_objective_decision_completed"])
+            self.assertEqual(summary["primary_risk_label"], PRIMARY_RISK_LABEL)
+            self.assertEqual(summary["weak_chord_tone_landing_risk_count"], 6)
+            self.assertEqual(summary["outside_soloing_pitch_role_risk_count"], 5)
+            self.assertEqual(summary["not_evaluable_after_count"], 0)
+            self.assertEqual(summary["selected_target"], SELECTED_TARGET)
+            self.assertFalse(summary["human_audio_preference_claimed"])
+            self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+
+    def test_rejects_bridge_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(StageBMidiToSoloPitchRoleObjectiveDecisionError):
+                build_objective_decision_report(
+                    bridge_report=bridge_report(quality_claim=True),
+                    output_dir=Path(tmp) / "decision",
+                    issue_number=788,
+                )
+
+    def test_routes_outside_soloing_when_it_dominates(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            report = build_objective_decision_report(
+                bridge_report=bridge_report(weak_count=2, outside_count=5),
+                output_dir=Path(tmp) / "decision",
+                issue_number=788,
+            )
+            summary = validate_objective_decision_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=(
+                    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_outside_soloing_pitch_role_repair_sweep"
+                ),
+                expected_target=(
+                    "songlike_melody_contour_phrase_rhythm_outside_soloing_pitch_role_repair_sweep"
+                ),
+                require_objective_decision=True,
+                require_no_quality_claim=True,
+            )
+
+            self.assertEqual(summary["primary_risk_label"], "outside_soloing_pitch_role_risk")
+
+    def test_constants_are_stable(self) -> None:
+        self.assertEqual(
+            BOUNDARY,
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision",
+        )
+        self.assertEqual(
+            NEXT_BOUNDARY,
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep",
+        )
+        self.assertEqual(
+            SELECTED_TARGET,
+            "songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary

- chord-context pitch-role objective decision 추가
- primary risk label: weak_chord_tone_landing_risk
- weak chord-tone landing risk count: 6
- outside-soloing pitch-role risk count: 5
- next target: songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep

Context

- Issue #786 bridge 결과
- chord context available count: 6/6
- pitch-role metrics defined count: 6/6
- not evaluable count: 12 -> 0
- min chord-tone ratio: 0.216
- max outside ratio: 0.027
- max non-chord run: 5

Scope

- bridge report 입력 검증
- pitch-role risk count 기준 primary target 선택
- chord-tone landing repair sweep boundary 선택
- quality/preference claim false 유지
- 하네스 모드 stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-context-pitch-role-objective-decision 추가
- handoff/status/core plan 갱신

Validation

- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision
- .venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-context-pitch-role-objective-decision
- bash scripts/agent_harness.sh quick

Risk

- objective decision은 repair 실행이 아님
- fallback chord context 기반 지표
- human/audio preference 판단 아님
- MIDI-to-solo musical quality claim 없음

Follow-up

- Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep

Closes #788