### PR TITLE
Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #788, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision.
+- Latest functional issue completed: Issue #790, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -212,6 +212,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phras
 ```
 
 This harness selects the next repair target from chord-context pitch-role objective evidence without claiming musical quality.
+
+For Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-repair-sweep
+```
+
+This harness repairs final landing and strong-beat chord-tone roles for phrase/rhythm candidates without claiming musical quality.
 
 For Stage A training-mode changes, run:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -5240,6 +5240,48 @@ Issue #788은 Issue #786 chord-context pitch-role bridge 결과를 기준으로 
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep`
 
+## 9.86 Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep
+
+Issue #790은 Issue #788 pitch-role objective decision에서 선택한 weak chord-tone landing risk를 대상으로 final landing/strong-beat chord-tone repair sweep을 실행한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- bridge boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package`
+- selected target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package`
+- repair policy: `strong_beat_and_final_note_nearest_chord_tone`
+- candidate count: `6`
+- repaired MIDI count: `6`
+- changed note total: `40`
+- weak chord-tone landing risk count: `6 -> 0`
+- outside-soloing pitch-role risk count: `5 -> 2`
+- final landing chord-tone count: `1 -> 6`
+- target supported: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- 분석 범위 내 final note 기준 repair 적용.
+- weak chord-tone landing risk는 `6 -> 0`으로 제거.
+- outside-soloing pitch-role risk는 `5 -> 2`로 감소했으나 잔여 risk 존재.
+- 현재 결과는 MIDI objective evidence와 repaired MIDI export 기준.
+- human/audio preference와 MIDI-to-solo musical quality claim은 제외.
+- 다음 boundary는 repaired MIDI audio package.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-repair-sweep`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #788, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep`
+- latest functional result: Issue #790, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package`
 
 현재 범위가 아닌 것:
 
@@ -205,6 +205,17 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 repair target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
+- songlike melody contour phrase/rhythm chord-tone landing repair sweep 완료
+- repair policy: `strong_beat_and_final_note_nearest_chord_tone`
+- repaired MIDI count: `6`
+- changed note total: `40`
+- weak chord-tone landing risk count: `6 -> 0`
+- outside-soloing pitch-role risk count: `5 -> 2`
+- final landing chord-tone count: `1 -> 6`
+- target supported: `true`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 audio package target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_SWEEP_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_SWEEP_2026-06-09.md
@@ -1,0 +1,45 @@
+# Stage B MIDI-to-Solo Chord-Tone Landing Repair Sweep
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- bridge boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package`
+- selected target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package`
+- repair policy: `strong_beat_and_final_note_nearest_chord_tone`
+- candidate count: `6`
+- repaired MIDI count: `6`
+- changed note total: `40`
+- weak chord-tone landing risk count: `6 -> 0`
+- outside-soloing pitch-role risk count: `5 -> 2`
+- final landing chord-tone count: `1 -> 6`
+- target supported: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Candidates
+
+| rank | changed | weak before | weak after | final before | final after | MIDI |
+|---:|---:|---|---|---|---|---|
+| 1 | 6 | `weak_chord_tone_landing_risk` | `none` | `approach` | `root` | `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep/midi/01_chord_tone_landing_repair.mid` |
+| 2 | 8 | `outside_soloing_pitch_role_risk,weak_chord_tone_landing_risk` | `none` | `approach` | `root` | `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep/midi/02_chord_tone_landing_repair.mid` |
+| 3 | 7 | `outside_soloing_pitch_role_risk,weak_chord_tone_landing_risk` | `outside_soloing_pitch_role_risk` | `approach` | `chord` | `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep/midi/03_chord_tone_landing_repair.mid` |
+| 4 | 6 | `outside_soloing_pitch_role_risk,weak_chord_tone_landing_risk` | `none` | `guide` | `guide` | `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep/midi/04_chord_tone_landing_repair.mid` |
+| 5 | 7 | `outside_soloing_pitch_role_risk,weak_chord_tone_landing_risk` | `outside_soloing_pitch_role_risk` | `approach` | `guide` | `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep/midi/05_chord_tone_landing_repair.mid` |
+| 6 | 6 | `outside_soloing_pitch_role_risk,weak_chord_tone_landing_risk` | `none` | `approach` | `guide` | `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep/midi/06_chord_tone_landing_repair.mid` |
+
+## Decision
+
+- reason: `chord-tone landing repair sweep completed without quality claim`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package`
+
+## Claim Boundary
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -292,6 +292,8 @@ Modes:
                 Build chord-context pitch-role metrics for phrase/rhythm repair candidates.
   stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-context-pitch-role-objective-decision
                 Select next repair target from chord-context pitch-role objective evidence.
+  stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-repair-sweep
+                Repair final landing and strong-beat chord-tone roles for phrase/rhythm candidates.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision
                 Decide the next pitch-contour changed-ratio repair boundary.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-probe
@@ -6668,6 +6670,34 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pit
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep() {
+  local decision_run_id="${DECISION_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision}"
+  local bridge_run_id="${BRIDGE_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep}"
+  local decision_report="outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision/${decision_run_id}/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision.json"
+  local bridge_report="outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge/${bridge_run_id}/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge.json"
+  if [[ ! -f "$decision_report" ]]; then
+    print_header "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision"
+    RUN_ID="$decision_run_id" run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision
+  fi
+  if [[ ! -f "$bridge_report" ]]; then
+    print_header "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge"
+    RUN_ID="$bridge_run_id" run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge
+  fi
+  print_header "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep"
+  "$PYTHON_BIN" scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep.py \
+    --run_id "$run_id" \
+    --objective_decision_report "$decision_report" \
+    --bridge_report "$bridge_report" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_SWEEP_2026-06-09.md \
+    --issue_number 790 \
+    --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep \
+    --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package \
+    --require_repair_completed \
+    --require_target_supported \
+    --require_no_quality_claim
+}
+
 run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision() {
   local quality_gap_run_id="${QUALITY_GAP_RUN_ID:-harness_stage_b_midi_to_solo_quality_gap_decision}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision}"
@@ -8993,6 +9023,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-context-pitch-role-objective-decision)
     run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision
+    ;;
+  stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-repair-sweep)
+    run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep
     ;;
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision)
     run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision

--- a/scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep.py
+++ b/scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep.py
@@ -1,0 +1,645 @@
+"""Repair weak chord-tone landing in phrase/rhythm candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pretty_midi
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge import (  # noqa: E402
+    BOUNDARY as BRIDGE_BOUNDARY,
+    bridge_candidate,
+    parse_chords,
+)
+from scripts.decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective import (  # noqa: E402
+    BOUNDARY as OBJECTIVE_DECISION_BOUNDARY,
+    NEXT_BOUNDARY as OBJECTIVE_DECISION_NEXT_BOUNDARY,
+    SELECTED_TARGET as OBJECTIVE_DECISION_SELECTED_TARGET,
+)
+from scripts.run_stage_b_generation_probe import chord_pitch_classes  # noqa: E402
+from scripts.run_stage_b_reference_stats import position_bucket  # noqa: E402
+from scripts.stage_b_tokens import PIANO_PITCH_MAX, PIANO_PITCH_MIN, quantize_note_position  # noqa: E402
+
+
+class StageBMidiToSoloChordToneLandingRepairSweepError(ValueError):
+    pass
+
+
+BOUNDARY = (
+    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep"
+)
+NEXT_BOUNDARY = (
+    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package"
+)
+SELECTED_TARGET = "songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep_v1"
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloChordToneLandingRepairSweepError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_objective_decision(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    selected = _dict(report.get("selected_next_target"))
+    if str(report.get("boundary") or "") != OBJECTIVE_DECISION_BOUNDARY:
+        raise StageBMidiToSoloChordToneLandingRepairSweepError(
+            "pitch-role objective decision boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != OBJECTIVE_DECISION_NEXT_BOUNDARY:
+        raise StageBMidiToSoloChordToneLandingRepairSweepError(
+            "objective decision must route to chord-tone landing repair sweep"
+        )
+    if str(selected.get("selected_target") or "") != OBJECTIVE_DECISION_SELECTED_TARGET:
+        raise StageBMidiToSoloChordToneLandingRepairSweepError(
+            "objective decision selected target mismatch"
+        )
+    if not bool(readiness.get("pitch_role_objective_decision_completed", False)):
+        raise StageBMidiToSoloChordToneLandingRepairSweepError(
+            "objective decision completion required"
+        )
+    if _int(readiness.get("weak_chord_tone_landing_risk_count")) <= 0:
+        raise StageBMidiToSoloChordToneLandingRepairSweepError(
+            "weak chord-tone landing risk required"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloChordToneLandingRepairSweepError(
+            "critical user input should not be required"
+        )
+    _require_no_quality_claim(readiness, label="objective decision readiness")
+    return {
+        "boundary": OBJECTIVE_DECISION_BOUNDARY,
+        "candidate_count": _int(readiness.get("candidate_count")),
+        "weak_chord_tone_landing_risk_count": _int(
+            readiness.get("weak_chord_tone_landing_risk_count")
+        ),
+        "outside_soloing_pitch_role_risk_count": _int(
+            readiness.get("outside_soloing_pitch_role_risk_count")
+        ),
+    }
+
+
+def validate_bridge_source(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    context = _dict(report.get("context"))
+    candidates = [_dict(candidate) for candidate in _list(report.get("contextualized_candidates"))]
+    if str(report.get("boundary") or "") != BRIDGE_BOUNDARY:
+        raise StageBMidiToSoloChordToneLandingRepairSweepError(
+            "chord-context pitch-role bridge boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != OBJECTIVE_DECISION_BOUNDARY:
+        raise StageBMidiToSoloChordToneLandingRepairSweepError(
+            "bridge must route to pitch-role objective decision"
+        )
+    if _int(readiness.get("candidate_count")) != len(candidates) or len(candidates) < 6:
+        raise StageBMidiToSoloChordToneLandingRepairSweepError(
+            "bridge candidate count mismatch"
+        )
+    if _int(readiness.get("not_evaluable_after_count")) != 0:
+        raise StageBMidiToSoloChordToneLandingRepairSweepError(
+            "not-evaluable labels must be cleared before repair"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloChordToneLandingRepairSweepError(
+            "critical user input should not be required"
+        )
+    _require_no_quality_claim(readiness, label="bridge readiness")
+    return {
+        "boundary": BRIDGE_BOUNDARY,
+        "candidates": candidates,
+        "chord_progression": [str(chord) for chord in _list(context.get("chord_progression"))],
+        "bpm": _float(context.get("bpm")) or 124.0,
+    }
+
+
+def nearest_chord_tone_pitch(pitch: int, chord: str) -> int:
+    pitch_classes = chord_pitch_classes(chord, pitch_mode="tones")
+    if not pitch_classes:
+        return int(pitch)
+    candidates = [
+        octave * 12 + pitch_class
+        for octave in range(0, 11)
+        for pitch_class in pitch_classes
+        if PIANO_PITCH_MIN <= octave * 12 + pitch_class <= PIANO_PITCH_MAX
+    ]
+    if not candidates:
+        return int(pitch)
+    return min(candidates, key=lambda value: (abs(value - int(pitch)), value))
+
+
+def all_notes(midi: pretty_midi.PrettyMIDI) -> list[pretty_midi.Note]:
+    notes: list[pretty_midi.Note] = []
+    for instrument in midi.instruments:
+        notes.extend(instrument.notes)
+    return sorted(notes, key=lambda note: (float(note.start), int(note.pitch), float(note.end)))
+
+
+def repair_midi(
+    *,
+    source_path: Path,
+    output_path: Path,
+    chords: list[str],
+    bpm: float,
+    bar_count: int,
+) -> dict[str, Any]:
+    midi = pretty_midi.PrettyMIDI(str(source_path))
+    notes = all_notes(midi)
+    changed = 0
+    quantized_notes = [
+        (note, *quantize_note_position(float(note.start), bpm))
+        for note in notes
+    ]
+    eligible_notes = [
+        note for note, bar, _position in quantized_notes if 0 <= int(bar) < int(bar_count)
+    ]
+    final_note = eligible_notes[-1] if eligible_notes else None
+    changed_positions: list[dict[str, Any]] = []
+    for note, bar, position in quantized_notes:
+        if bar < 0 or bar >= int(bar_count):
+            continue
+        chord = chords[bar % len(chords)] if chords else ""
+        should_repair = note is final_note or position_bucket(position) == "strong"
+        if not should_repair:
+            continue
+        original_pitch = int(note.pitch)
+        repaired_pitch = nearest_chord_tone_pitch(original_pitch, chord)
+        if repaired_pitch != original_pitch:
+            note.pitch = int(repaired_pitch)
+            changed += 1
+            changed_positions.append(
+                {
+                    "bar": int(bar),
+                    "position": int(position),
+                    "chord": chord,
+                    "from": original_pitch,
+                    "to": int(repaired_pitch),
+                    "final_note": bool(note is final_note),
+                }
+            )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    midi.write(str(output_path))
+    return {
+        "source_midi_path": str(source_path),
+        "repaired_midi_path": str(output_path),
+        "changed_note_count": int(changed),
+        "changed_positions": changed_positions,
+    }
+
+
+def repair_candidate(
+    *,
+    candidate: dict[str, Any],
+    output_dir: Path,
+    chords: list[str],
+    bpm: float,
+    manifest_path: Path,
+) -> dict[str, Any]:
+    rank = _int(candidate.get("rank"))
+    before_metrics = _dict(candidate.get("bridge_metrics"))
+    bar_count = _int(before_metrics.get("bar_count")) or 8
+    source_path = Path(str(candidate.get("midi_path") or ""))
+    if not source_path.is_absolute():
+        source_path = ROOT_DIR / source_path
+    if not source_path.exists():
+        raise StageBMidiToSoloChordToneLandingRepairSweepError(
+            f"candidate MIDI missing: {source_path}"
+        )
+    output_path = output_dir / "midi" / f"{rank:02d}_chord_tone_landing_repair.mid"
+    repair = repair_midi(
+        source_path=source_path,
+        output_path=output_path,
+        chords=chords,
+        bpm=bpm,
+        bar_count=bar_count,
+    )
+    row = {
+        "rank": rank,
+        "phrase_rhythm_repaired_midi_path": str(output_path),
+        "phrase_rhythm_repaired_labeling": {
+            "metrics": _dict(candidate.get("bridge_metrics")),
+            "failure_labels": [],
+            "not_evaluable_labels": [],
+        },
+    }
+    repaired = bridge_candidate(
+        row=row,
+        rank=rank,
+        chords=chords,
+        bpm=bpm,
+        manifest_path=manifest_path,
+    )
+    after_metrics = _dict(repaired.get("bridge_metrics"))
+    before_flags = [str(flag) for flag in _list(candidate.get("bridge_flags"))]
+    after_flags = [str(flag) for flag in _list(repaired.get("bridge_flags"))]
+    return {
+        "rank": rank,
+        "source_midi_path": str(source_path),
+        "repaired_midi_path": str(output_path),
+        "repair": repair,
+        "before": {
+            "chord_tone_ratio": _float(before_metrics.get("chord_tone_ratio")),
+            "strong_beat_chord_tone_ratio": _float(
+                before_metrics.get("strong_beat_chord_tone_ratio")
+            ),
+            "cadence_landing_chord_tone": bool(
+                before_metrics.get("cadence_landing_chord_tone", False)
+            ),
+            "cadence_landing_role": str(before_metrics.get("cadence_landing_role") or ""),
+            "max_non_chord_tone_run": _int(before_metrics.get("max_non_chord_tone_run")),
+            "bridge_flags": before_flags,
+        },
+        "after": {
+            "chord_tone_ratio": _float(after_metrics.get("chord_tone_ratio")),
+            "strong_beat_chord_tone_ratio": _float(
+                after_metrics.get("strong_beat_chord_tone_ratio")
+            ),
+            "cadence_landing_chord_tone": bool(
+                after_metrics.get("cadence_landing_chord_tone", False)
+            ),
+            "cadence_landing_role": str(after_metrics.get("cadence_landing_role") or ""),
+            "max_non_chord_tone_run": _int(after_metrics.get("max_non_chord_tone_run")),
+            "bridge_flags": after_flags,
+        },
+    }
+
+
+def count_flag(rows: list[dict[str, Any]], side: str, flag: str) -> int:
+    return sum(1 for row in rows if flag in _list(_dict(row.get(side)).get("bridge_flags")))
+
+
+def build_repair_sweep_report(
+    *,
+    objective_decision_report: dict[str, Any],
+    bridge_report: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+) -> dict[str, Any]:
+    objective = validate_objective_decision(objective_decision_report)
+    bridge = validate_bridge_source(bridge_report)
+    chords = bridge["chord_progression"] or parse_chords("")
+    bpm = _float(bridge["bpm"]) or 124.0
+    manifest_path = ROOT_DIR / "stage_b_midi_to_solo_chord_tone_landing_repair_manifest.json"
+    rows = [
+        repair_candidate(
+            candidate=candidate,
+            output_dir=output_dir,
+            chords=chords,
+            bpm=bpm,
+            manifest_path=manifest_path,
+        )
+        for candidate in bridge["candidates"]
+    ]
+    weak_before = count_flag(rows, "before", "weak_chord_tone_landing_risk")
+    weak_after = count_flag(rows, "after", "weak_chord_tone_landing_risk")
+    outside_before = count_flag(rows, "before", "outside_soloing_pitch_role_risk")
+    outside_after = count_flag(rows, "after", "outside_soloing_pitch_role_risk")
+    final_before = sum(1 for row in rows if bool(_dict(row.get("before")).get("cadence_landing_chord_tone", False)))
+    final_after = sum(1 for row in rows if bool(_dict(row.get("after")).get("cadence_landing_chord_tone", False)))
+    changed_note_total = sum(_int(_dict(row.get("repair")).get("changed_note_count")) for row in rows)
+    target_supported = weak_after < weak_before and final_after > final_before
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundary": objective["boundary"],
+        "bridge_boundary": bridge["boundary"],
+        "context": {
+            "chord_progression": chords,
+            "bpm": bpm,
+            "repair_policy": "strong_beat_and_final_note_nearest_chord_tone",
+        },
+        "candidate_repairs": rows,
+        "aggregate": {
+            "candidate_count": len(rows),
+            "repaired_midi_count": len(rows),
+            "changed_note_total": int(changed_note_total),
+            "weak_chord_tone_landing_risk_count_before": int(weak_before),
+            "weak_chord_tone_landing_risk_count_after": int(weak_after),
+            "weak_chord_tone_landing_risk_delta": int(weak_before - weak_after),
+            "outside_soloing_pitch_role_risk_count_before": int(outside_before),
+            "outside_soloing_pitch_role_risk_count_after": int(outside_after),
+            "final_landing_chord_tone_count_before": int(final_before),
+            "final_landing_chord_tone_count_after": int(final_after),
+            "target_supported": bool(target_supported),
+        },
+        "readiness": {
+            "boundary": BOUNDARY,
+            "chord_tone_landing_repair_sweep_completed": True,
+            "candidate_count": len(rows),
+            "repaired_midi_count": len(rows),
+            "target_supported": bool(target_supported),
+            "human_audio_preference_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY if target_supported else (
+                "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup_decision"
+            ),
+            "selected_target": SELECTED_TARGET if target_supported else (
+                "songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup_decision"
+            ),
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "chord-tone landing repair sweep completed without quality claim",
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "audio_rendered_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package"
+            if target_supported
+            else "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision"
+        ),
+    }
+
+
+def validate_repair_sweep_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    require_repair_completed: bool,
+    require_target_supported: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    aggregate = _dict(report.get("aggregate"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloChordToneLandingRepairSweepError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloChordToneLandingRepairSweepError(
+            "unexpected next boundary"
+        )
+    if require_repair_completed and not bool(
+        readiness.get("chord_tone_landing_repair_sweep_completed", False)
+    ):
+        raise StageBMidiToSoloChordToneLandingRepairSweepError(
+            "repair sweep completion required"
+        )
+    if require_target_supported and not bool(readiness.get("target_supported", False)):
+        raise StageBMidiToSoloChordToneLandingRepairSweepError(
+            "target support required"
+        )
+    if _int(readiness.get("repaired_midi_count")) != _int(readiness.get("candidate_count")):
+        raise StageBMidiToSoloChordToneLandingRepairSweepError(
+            "all candidates must have repaired MIDI"
+        )
+    if _int(aggregate.get("changed_note_total")) <= 0:
+        raise StageBMidiToSoloChordToneLandingRepairSweepError(
+            "changed note count required"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloChordToneLandingRepairSweepError(
+            "critical user input should not be required"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="repair readiness")
+    return {
+        "boundary": boundary,
+        "source_boundary": str(report.get("source_boundary") or ""),
+        "bridge_boundary": str(report.get("bridge_boundary") or ""),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "selected_target": str(decision.get("selected_target") or ""),
+        "chord_tone_landing_repair_sweep_completed": bool(
+            readiness.get("chord_tone_landing_repair_sweep_completed", False)
+        ),
+        "candidate_count": _int(readiness.get("candidate_count")),
+        "repaired_midi_count": _int(readiness.get("repaired_midi_count")),
+        "changed_note_total": _int(aggregate.get("changed_note_total")),
+        "weak_chord_tone_landing_risk_count_before": _int(
+            aggregate.get("weak_chord_tone_landing_risk_count_before")
+        ),
+        "weak_chord_tone_landing_risk_count_after": _int(
+            aggregate.get("weak_chord_tone_landing_risk_count_after")
+        ),
+        "weak_chord_tone_landing_risk_delta": _int(
+            aggregate.get("weak_chord_tone_landing_risk_delta")
+        ),
+        "outside_soloing_pitch_role_risk_count_before": _int(
+            aggregate.get("outside_soloing_pitch_role_risk_count_before")
+        ),
+        "outside_soloing_pitch_role_risk_count_after": _int(
+            aggregate.get("outside_soloing_pitch_role_risk_count_after")
+        ),
+        "final_landing_chord_tone_count_before": _int(
+            aggregate.get("final_landing_chord_tone_count_before")
+        ),
+        "final_landing_chord_tone_count_after": _int(
+            aggregate.get("final_landing_chord_tone_count_after")
+        ),
+        "target_supported": bool(readiness.get("target_supported", False)),
+        "human_audio_preference_claimed": bool(
+            readiness.get("human_audio_preference_claimed", True)
+        ),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(
+            decision.get("critical_user_input_required", True)
+        ),
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    aggregate = report["aggregate"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    context = report["context"]
+    lines = [
+        "# Stage B MIDI-to-Solo Chord-Tone Landing Repair Sweep",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- source boundary: `{report['source_boundary']}`",
+        f"- bridge boundary: `{report['bridge_boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- selected target: `{decision['selected_target']}`",
+        f"- repair policy: `{context['repair_policy']}`",
+        f"- candidate count: `{aggregate['candidate_count']}`",
+        f"- repaired MIDI count: `{aggregate['repaired_midi_count']}`",
+        f"- changed note total: `{aggregate['changed_note_total']}`",
+        f"- weak chord-tone landing risk count: `{aggregate['weak_chord_tone_landing_risk_count_before']} -> {aggregate['weak_chord_tone_landing_risk_count_after']}`",
+        f"- outside-soloing pitch-role risk count: `{aggregate['outside_soloing_pitch_role_risk_count_before']} -> {aggregate['outside_soloing_pitch_role_risk_count_after']}`",
+        f"- final landing chord-tone count: `{aggregate['final_landing_chord_tone_count_before']} -> {aggregate['final_landing_chord_tone_count_after']}`",
+        f"- target supported: `{_bool_token(aggregate['target_supported'])}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Candidates",
+        "",
+        "| rank | changed | weak before | weak after | final before | final after | MIDI |",
+        "|---:|---:|---|---|---|---|---|",
+    ]
+    for row in report["candidate_repairs"]:
+        before = row["before"]
+        after = row["after"]
+        repair = row["repair"]
+        lines.append(
+            "| {rank} | {changed} | `{before_flags}` | `{after_flags}` | `{before_final}` | `{after_final}` | `{midi}` |".format(
+                rank=row["rank"],
+                changed=repair["changed_note_count"],
+                before_flags=",".join(before["bridge_flags"]) or "none",
+                after_flags=",".join(after["bridge_flags"]) or "none",
+                before_final=before["cadence_landing_role"],
+                after_final=after["cadence_landing_role"],
+                midi=row["repaired_midi_path"],
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Decision",
+            "",
+            f"- reason: `{decision['reason']}`",
+            f"- auto progress allowed: `{_bool_token(decision['auto_progress_allowed'])}`",
+            f"- critical user input required: `{_bool_token(decision['critical_user_input_required'])}`",
+            f"- next recommended issue: `{report['next_recommended_issue']}`",
+            "",
+            "## Claim Boundary",
+            "",
+        ]
+    )
+    for item in report["not_proven"]:
+        lines.append(f"- `{item}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run chord-tone landing repair sweep for phrase/rhythm candidates"
+    )
+    parser.add_argument("--objective_decision_report", type=str, required=True)
+    parser.add_argument("--bridge_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=790)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_repair_completed", action="store_true")
+    parser.add_argument("--require_target_supported", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_repair_sweep_report(
+        objective_decision_report=read_json(Path(args.objective_decision_report)),
+        bridge_report=read_json(Path(args.bridge_report)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+    )
+    summary = validate_repair_sweep_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        require_repair_completed=bool(args.require_repair_completed),
+        require_target_supported=bool(args.require_target_supported),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep.json",
+        report,
+    )
+    write_json(
+        output_dir
+        / "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep_validation_summary.json",
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir
+        / "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep.md",
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import pretty_midi
+
+from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge import (
+    BOUNDARY as BRIDGE_BOUNDARY,
+)
+from scripts.decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective import (
+    BOUNDARY as OBJECTIVE_BOUNDARY,
+    NEXT_BOUNDARY as OBJECTIVE_NEXT_BOUNDARY,
+    SELECTED_TARGET as OBJECTIVE_SELECTED_TARGET,
+)
+from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    SELECTED_TARGET,
+    StageBMidiToSoloChordToneLandingRepairSweepError,
+    build_repair_sweep_report,
+    validate_repair_sweep_report,
+)
+
+
+CHORDS = ["Cm7", "Fm7", "Bb7", "Ebmaj7"]
+
+
+def write_weak_landing_midi(path: Path, *, bpm: float = 124.0) -> None:
+    seconds_per_beat = 60.0 / bpm
+    midi = pretty_midi.PrettyMIDI(initial_tempo=bpm)
+    instrument = pretty_midi.Instrument(program=0)
+    weak_pitches = [61, 66, 59, 64]
+    for bar in range(8):
+        base_start = bar * 4.0 * seconds_per_beat
+        for offset, pitch in enumerate(weak_pitches):
+            start = base_start + offset * 1.0 * seconds_per_beat
+            end = start + 0.35 * seconds_per_beat
+            instrument.notes.append(
+                pretty_midi.Note(velocity=90, pitch=pitch, start=start, end=end)
+            )
+    midi.instruments.append(instrument)
+    midi.write(str(path))
+
+
+def objective_decision_report(*, quality_claim: bool = False) -> dict:
+    return {
+        "boundary": OBJECTIVE_BOUNDARY,
+        "selected_next_target": {
+            "selected_target": OBJECTIVE_SELECTED_TARGET,
+        },
+        "readiness": {
+            "pitch_role_objective_decision_completed": True,
+            "candidate_count": 6,
+            "weak_chord_tone_landing_risk_count": 6,
+            "outside_soloing_pitch_role_risk_count": 5,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": quality_claim,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": OBJECTIVE_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+def bridge_report(midi_paths: list[Path], *, quality_claim: bool = False) -> dict:
+    return {
+        "boundary": BRIDGE_BOUNDARY,
+        "context": {
+            "chord_progression": CHORDS,
+            "bpm": 124.0,
+        },
+        "contextualized_candidates": [
+            {
+                "rank": index,
+                "midi_path": str(path),
+                "bridge_metrics": {
+                    "bar_count": 8,
+                    "chord_tone_ratio": 0.2,
+                    "strong_beat_chord_tone_ratio": 0.0,
+                    "cadence_landing_chord_tone": False,
+                    "cadence_landing_role": "approach",
+                    "max_non_chord_tone_run": 5,
+                },
+                "bridge_flags": ["weak_chord_tone_landing_risk"],
+            }
+            for index, path in enumerate(midi_paths, start=1)
+        ],
+        "readiness": {
+            "candidate_count": 6,
+            "not_evaluable_after_count": 0,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": quality_claim,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "next_boundary": OBJECTIVE_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class StageBMidiToSoloChordToneLandingRepairSweepTest(unittest.TestCase):
+    def test_repairs_final_landing_and_routes_audio_package(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            midi_paths = []
+            for index in range(6):
+                midi_path = root / f"candidate_{index}.mid"
+                write_weak_landing_midi(midi_path)
+                midi_paths.append(midi_path)
+
+            report = build_repair_sweep_report(
+                objective_decision_report=objective_decision_report(),
+                bridge_report=bridge_report(midi_paths),
+                output_dir=root / "repair",
+                issue_number=790,
+            )
+            summary = validate_repair_sweep_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                require_repair_completed=True,
+                require_target_supported=True,
+                require_no_quality_claim=True,
+            )
+
+            self.assertTrue(summary["chord_tone_landing_repair_sweep_completed"])
+            self.assertEqual(summary["candidate_count"], 6)
+            self.assertEqual(summary["repaired_midi_count"], 6)
+            self.assertGreater(summary["changed_note_total"], 0)
+            self.assertGreater(summary["weak_chord_tone_landing_risk_delta"], 0)
+            self.assertEqual(summary["final_landing_chord_tone_count_after"], 6)
+            self.assertEqual(summary["selected_target"], SELECTED_TARGET)
+            self.assertFalse(summary["human_audio_preference_claimed"])
+            self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+
+    def test_rejects_objective_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            midi_paths = []
+            for index in range(6):
+                midi_path = root / f"candidate_{index}.mid"
+                write_weak_landing_midi(midi_path)
+                midi_paths.append(midi_path)
+
+            with self.assertRaises(StageBMidiToSoloChordToneLandingRepairSweepError):
+                build_repair_sweep_report(
+                    objective_decision_report=objective_decision_report(quality_claim=True),
+                    bridge_report=bridge_report(midi_paths),
+                    output_dir=root / "repair",
+                    issue_number=790,
+                )
+
+    def test_rejects_bridge_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            midi_paths = []
+            for index in range(6):
+                midi_path = root / f"candidate_{index}.mid"
+                write_weak_landing_midi(midi_path)
+                midi_paths.append(midi_path)
+
+            with self.assertRaises(StageBMidiToSoloChordToneLandingRepairSweepError):
+                build_repair_sweep_report(
+                    objective_decision_report=objective_decision_report(),
+                    bridge_report=bridge_report(midi_paths, quality_claim=True),
+                    output_dir=root / "repair",
+                    issue_number=790,
+                )
+
+    def test_constants_are_stable(self) -> None:
+        self.assertEqual(
+            BOUNDARY,
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep",
+        )
+        self.assertEqual(
+            NEXT_BOUNDARY,
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package",
+        )
+        self.assertEqual(
+            SELECTED_TARGET,
+            "songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary

- chord-tone landing repair sweep 추가
- repaired MIDI count: 6
- changed note total: 40
- weak chord-tone landing risk count: 6 -> 0
- final landing chord-tone count: 1 -> 6
- quality/preference claim false 유지

Context

- Issue #788 objective decision 결과
- primary risk label: weak_chord_tone_landing_risk
- Issue #786 bridge 결과
- weak chord-tone landing risk count: 6
- outside-soloing pitch-role risk count: 5
- fallback chord context 기반 pitch-role metric

Scope

- objective decision report 입력 검증
- bridge report 입력 검증
- strong-beat / analyzed final note nearest chord tone repair
- repaired MIDI export
- pitch-role before/after 비교
- 하네스 모드 stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-repair-sweep 추가
- handoff/status/core plan 갱신

Validation

- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep
- .venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep.py
- bash -n scripts/agent_harness.sh
- git diff --check
- bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-repair-sweep
- bash scripts/agent_harness.sh quick

Risk

- objective MIDI/pitch-role repair 검증 단계
- human/audio preference 판단 아님
- MIDI-to-solo musical quality claim 없음
- outside-soloing pitch-role risk 잔여: 2

Follow-up

- Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package

Closes #790