### PR TITLE
Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #792, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package.
+- Latest functional issue completed: Issue #794, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -228,6 +228,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phras
 ```
 
 This harness renders chord-tone landing repair MIDI candidates to WAV files and validates technical metadata without claiming listening or musical quality.
+
+For Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-repair-listening-review-package
+```
+
+This harness packages chord-tone landing repair WAV/MIDI candidates for listening review while keeping preference and quality claims false.
 
 For Stage A training-mode changes, run:
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -5324,6 +5324,47 @@ Issue #792는 Issue #790 chord-tone landing repair sweep 결과의 repaired MIDI
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package`
 
+## 9.88 Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package
+
+Issue #794는 Issue #792 audio package 결과의 WAV/MIDI 후보 6개를 listening review package로 묶은 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard`
+- package ready: `true`
+- review item count: `6`
+- validated review input: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- duration range: `18.871s-19.000s`
+- changed note total: `40`
+- weak chord-tone landing risk delta: `6`
+- outside-soloing pitch-role risk count after: `2`
+- final landing chord-tone count after: `6`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- Issue #792 WAV/MIDI 후보 6개를 review item으로 패키징.
+- required input fields: `candidate_index`, `listening_status`, `preference`, `issue_notes`.
+- validated review input은 없음.
+- preference fill과 musical quality claim은 제외.
+- 다음 boundary는 pending review input을 차단하는 input guard.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-repair-listening-review-package`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #792, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package`
+- latest functional result: Issue #794, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard`
 
 현재 범위가 아닌 것:
 
@@ -228,6 +228,18 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 review target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package`
+- songlike melody contour phrase/rhythm chord-tone landing repair listening review package 완료
+- review item count: `6`
+- validated review input: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- changed note total: `40`
+- weak chord-tone landing risk delta: `6`
+- outside-soloing pitch-role risk count after: `2`
+- final landing chord-tone count after: `6`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 guard target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_LISTENING_REVIEW_PACKAGE_2026-06-09.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_LISTENING_REVIEW_PACKAGE_2026-06-09.md
@@ -1,0 +1,43 @@
+# Stage B MIDI-to-Solo Chord-Tone Landing Repair Listening Review Package
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard`
+- package ready: `true`
+- review item count: `6`
+- validated review input: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- duration range: `18.871s-19.000s`
+- changed note total: `40`
+- weak chord-tone landing risk delta: `6`
+- outside-soloing pitch-role risk count after: `2`
+- final landing chord-tone count after: `6`
+- human/audio preference claimed: `false`
+
+## Review Items
+
+- candidate `1` rank `1`: WAV `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package/audio/candidate_01_rank_01_chord_tone_landing_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep/midi/01_chord_tone_landing_repair.mid`, duration `18.990`, changed `6`, flags `none`, cadence `root`
+- candidate `2` rank `2`: WAV `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package/audio/candidate_02_rank_02_chord_tone_landing_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep/midi/02_chord_tone_landing_repair.mid`, duration `18.974`, changed `8`, flags `none`, cadence `root`
+- candidate `3` rank `3`: WAV `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package/audio/candidate_03_rank_03_chord_tone_landing_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep/midi/03_chord_tone_landing_repair.mid`, duration `19.000`, changed `7`, flags `outside_soloing_pitch_role_risk`, cadence `chord`
+- candidate `4` rank `4`: WAV `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package/audio/candidate_04_rank_04_chord_tone_landing_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep/midi/04_chord_tone_landing_repair.mid`, duration `18.871`, changed `6`, flags `none`, cadence `guide`
+- candidate `5` rank `5`: WAV `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package/audio/candidate_05_rank_05_chord_tone_landing_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep/midi/05_chord_tone_landing_repair.mid`, duration `18.985`, changed `7`, flags `outside_soloing_pitch_role_risk`, cadence `guide`
+- candidate `6` rank `6`: WAV `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package/audio/candidate_06_rank_06_chord_tone_landing_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep/midi/06_chord_tone_landing_repair.mid`, duration `18.992`, changed `6`, flags `none`, cadence `guide`
+
+## Required Input Fields
+
+- `candidate_index`
+- `listening_status`
+- `preference`
+- `issue_notes`
+
+## Claim Boundary
+
+- MIDI-to-solo musical quality claimed: `false`
+- audio rendered quality claimed: `false`
+- broad trained-model quality claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -296,6 +296,8 @@ Modes:
                 Repair final landing and strong-beat chord-tone roles for phrase/rhythm candidates.
   stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-repair-audio-package
                 Render chord-tone landing repair MIDI candidates to WAV files.
+  stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-repair-listening-review-package
+                Package chord-tone landing repair WAV/MIDI candidates for listening review.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision
                 Decide the next pitch-contour changed-ratio repair boundary.
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-repair-probe
@@ -6722,6 +6724,27 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landin
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package() {
+  local audio_package_run_id="${AUDIO_PACKAGE_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package}"
+  local review_run_id="${RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package}"
+  local audio_package_report="outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package/${audio_package_run_id}/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package.json"
+  if [[ ! -f "$audio_package_report" ]]; then
+    print_header "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package"
+    RUN_ID="$audio_package_run_id" run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package
+  fi
+  print_header "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package"
+  "$PYTHON_BIN" scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package.py \
+    --run_id "$review_run_id" \
+    --audio_package_report "$audio_package_report" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_LISTENING_REVIEW_PACKAGE_2026-06-09.md \
+    --issue_number 794 \
+    --expected_review_item_count 6 \
+    --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package \
+    --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard \
+    --require_package_ready \
+    --require_no_quality_claim
+}
+
 run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision() {
   local quality_gap_run_id="${QUALITY_GAP_RUN_ID:-harness_stage_b_midi_to_solo_quality_gap_decision}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision}"
@@ -9053,6 +9076,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-repair-audio-package)
     run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package
+    ;;
+  stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-repair-listening-review-package)
+    run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package
     ;;
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision)
     run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision

--- a/scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package.py
+++ b/scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package.py
@@ -1,0 +1,483 @@
+"""Build a listening review package for chord-tone landing repaired MIDI-to-solo output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+class StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError(ValueError):
+    pass
+
+
+BOUNDARY = (
+    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package"
+)
+NEXT_BOUNDARY = (
+    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard"
+)
+SCHEMA_VERSION = (
+    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package_v1"
+)
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _path_exists(path_text: str) -> bool:
+    return bool(path_text and Path(path_text).exists())
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_audio_package_report(
+    report: dict[str, Any],
+    *,
+    expected_count: int,
+) -> list[dict[str, Any]]:
+    boundary = _dict(report.get("audio_render_boundary"))
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("summary"))
+    if str(boundary.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError(
+            "chord-tone landing repair audio package boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
+        raise StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError(
+            "audio package must route to listening review package"
+        )
+    required_true = [
+        "render_attempted",
+        "technical_wav_validation",
+        "songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package_completed",
+    ]
+    missing = [name for name in required_true if not bool(boundary.get(name, False))]
+    if missing:
+        raise StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError(
+            f"missing audio package readiness: {missing}"
+        )
+    if not bool(summary.get("audio_review_required", False)):
+        raise StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError(
+            "audio review requirement should be recorded"
+        )
+    if _int(boundary.get("rendered_audio_file_count")) < int(expected_count):
+        raise StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError(
+            "rendered audio count below expected"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError(
+            "critical user input should not be required"
+        )
+    _require_no_quality_claim(boundary, label="audio package boundary")
+
+    rendered = [_dict(item) for item in _list(report.get("rendered_audio_files"))]
+    if len(rendered) < int(expected_count):
+        raise StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError(
+            "rendered audio file rows below expected"
+        )
+    review_items: list[dict[str, Any]] = []
+    for item in rendered[: int(expected_count)]:
+        wav = _dict(item.get("wav_file"))
+        wav_path = str(wav.get("path") or "")
+        midi_path = str(item.get("repaired_midi_path") or "")
+        if not _path_exists(wav_path) or not _path_exists(midi_path):
+            raise StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError(
+                "review item MIDI/WAV artifact required"
+            )
+        review_items.append(
+            {
+                "candidate_index": _int(item.get("candidate_index")),
+                "rank": _int(item.get("rank")),
+                "midi_path": midi_path,
+                "wav_path": wav_path,
+                "duration_seconds": _float(wav.get("duration_seconds")),
+                "sample_rate": _int(wav.get("sample_rate")),
+                "size_bytes": _int(wav.get("size_bytes")),
+                "sha256": str(wav.get("sha256") or ""),
+                "changed_note_count": _int(item.get("changed_note_count")),
+                "after_bridge_flags": [
+                    str(flag) for flag in _list(item.get("after_bridge_flags"))
+                ],
+                "after_chord_tone_ratio": _float(item.get("after_chord_tone_ratio")),
+                "after_strong_beat_chord_tone_ratio": _float(
+                    item.get("after_strong_beat_chord_tone_ratio")
+                ),
+                "after_cadence_landing_chord_tone": bool(
+                    item.get("after_cadence_landing_chord_tone", False)
+                ),
+                "after_cadence_landing_role": str(
+                    item.get("after_cadence_landing_role") or ""
+                ),
+                "after_max_non_chord_tone_run": _int(
+                    item.get("after_max_non_chord_tone_run")
+                ),
+                "review_status": "pending",
+            }
+        )
+    return review_items
+
+
+def build_listening_review_package_report(
+    *,
+    audio_package_report: dict[str, Any],
+    output_dir: Path,
+    issue_number: int,
+    expected_count: int,
+) -> dict[str, Any]:
+    review_items = validate_audio_package_report(
+        audio_package_report,
+        expected_count=int(expected_count),
+    )
+    summary = _dict(audio_package_report.get("summary"))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace(
+            "+00:00", "Z"
+        ),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "boundary": BOUNDARY,
+        "source_boundary": SOURCE_BOUNDARY,
+        "source_summary": {
+            "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
+            "technical_wav_validation": bool(summary.get("technical_wav_validation", False)),
+            "sample_rate": _int(summary.get("sample_rate")),
+            "duration_min_seconds": _float(summary.get("duration_min_seconds")),
+            "duration_max_seconds": _float(summary.get("duration_max_seconds")),
+            "changed_note_total": _int(summary.get("changed_note_total")),
+            "weak_chord_tone_landing_risk_count_before": _int(
+                summary.get("weak_chord_tone_landing_risk_count_before")
+            ),
+            "weak_chord_tone_landing_risk_count_after": _int(
+                summary.get("weak_chord_tone_landing_risk_count_after")
+            ),
+            "weak_chord_tone_landing_risk_delta": _int(
+                summary.get("weak_chord_tone_landing_risk_delta")
+            ),
+            "outside_soloing_pitch_role_risk_count_before": _int(
+                summary.get("outside_soloing_pitch_role_risk_count_before")
+            ),
+            "outside_soloing_pitch_role_risk_count_after": _int(
+                summary.get("outside_soloing_pitch_role_risk_count_after")
+            ),
+            "final_landing_chord_tone_count_before": _int(
+                summary.get("final_landing_chord_tone_count_before")
+            ),
+            "final_landing_chord_tone_count_after": _int(
+                summary.get("final_landing_chord_tone_count_after")
+            ),
+            "target_supported": bool(summary.get("target_supported", False)),
+            "audio_review_required": bool(summary.get("audio_review_required", False)),
+        },
+        "review_package": {
+            "package_ready": True,
+            "review_item_count": int(len(review_items)),
+            "review_basis": "human_audio_listening_pending",
+            "validated_review_input": False,
+            "required_input_fields": [
+                "candidate_index",
+                "listening_status",
+                "preference",
+                "issue_notes",
+            ],
+        },
+        "review_items": review_items,
+        "readiness": {
+            "boundary": BOUNDARY,
+            "listening_review_package_ready": True,
+            "review_item_count": int(len(review_items)),
+            "validated_review_input": False,
+            "human_review_required_now": False,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "chord-tone landing repair WAV review items are packaged; preference remains pending until validated listening input",
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "audio_rendered_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard"
+        ),
+    }
+
+
+def validate_listening_review_package_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    expected_review_item_count: int,
+    require_package_ready: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    source = _dict(report.get("source_summary"))
+    if expected_boundary and boundary != expected_boundary:
+        raise StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError(
+            f"expected boundary {expected_boundary}, got {boundary}"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError(
+            "unexpected next boundary"
+        )
+    if require_package_ready and not bool(readiness.get("listening_review_package_ready", False)):
+        raise StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError(
+            "listening review package should be ready"
+        )
+    if _int(readiness.get("review_item_count")) != int(expected_review_item_count):
+        raise StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError(
+            "review item count mismatch"
+        )
+    if bool(readiness.get("validated_review_input", True)):
+        raise StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError(
+            "review input should remain pending"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError(
+            "critical user input should not be required"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness, label="listening package readiness")
+    return {
+        "boundary": boundary,
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "listening_review_package_ready": bool(
+            readiness.get("listening_review_package_ready", False)
+        ),
+        "review_item_count": _int(readiness.get("review_item_count")),
+        "validated_review_input": bool(readiness.get("validated_review_input", True)),
+        "technical_wav_validation": bool(source.get("technical_wav_validation", False)),
+        "rendered_audio_file_count": _int(source.get("rendered_audio_file_count")),
+        "sample_rate": _int(source.get("sample_rate")),
+        "duration_min_seconds": _float(source.get("duration_min_seconds")),
+        "duration_max_seconds": _float(source.get("duration_max_seconds")),
+        "changed_note_total": _int(source.get("changed_note_total")),
+        "weak_chord_tone_landing_risk_delta": _int(
+            source.get("weak_chord_tone_landing_risk_delta")
+        ),
+        "outside_soloing_pitch_role_risk_count_after": _int(
+            source.get("outside_soloing_pitch_role_risk_count_after")
+        ),
+        "final_landing_chord_tone_count_after": _int(
+            source.get("final_landing_chord_tone_count_after")
+        ),
+        "audio_review_required": bool(source.get("audio_review_required", False)),
+        "human_review_required_now": bool(readiness.get("human_review_required_now", True)),
+        "human_audio_preference_claimed": bool(
+            readiness.get("human_audio_preference_claimed", True)
+        ),
+        "midi_to_solo_musical_quality_claimed": bool(
+            readiness.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(
+            decision.get("critical_user_input_required", True)
+        ),
+        "wav_paths": [
+            str(_dict(item).get("wav_path") or "") for item in _list(report.get("review_items"))
+        ],
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    package = report["review_package"]
+    source = report["source_summary"]
+    lines = [
+        "# Stage B MIDI-to-Solo Chord-Tone Landing Repair Listening Review Package",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- package ready: `{_bool_token(package['package_ready'])}`",
+        f"- review item count: `{package['review_item_count']}`",
+        f"- validated review input: `{_bool_token(package['validated_review_input'])}`",
+        f"- technical WAV validation: `{_bool_token(source['technical_wav_validation'])}`",
+        f"- rendered audio file count: `{source['rendered_audio_file_count']}`",
+        f"- duration range: `{source['duration_min_seconds']:.3f}s-{source['duration_max_seconds']:.3f}s`",
+        f"- changed note total: `{source['changed_note_total']}`",
+        f"- weak chord-tone landing risk delta: `{source['weak_chord_tone_landing_risk_delta']}`",
+        f"- outside-soloing pitch-role risk count after: `{source['outside_soloing_pitch_role_risk_count_after']}`",
+        f"- final landing chord-tone count after: `{source['final_landing_chord_tone_count_after']}`",
+        f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
+        "",
+        "## Review Items",
+        "",
+    ]
+    for item in report["review_items"]:
+        flags = ",".join(item["after_bridge_flags"]) or "none"
+        lines.append(
+            f"- candidate `{item['candidate_index']}` rank `{item['rank']}`: "
+            f"WAV `{item['wav_path']}`, MIDI `{item['midi_path']}`, "
+            f"duration `{item['duration_seconds']:.3f}`, changed `{item['changed_note_count']}`, "
+            f"flags `{flags}`, cadence `{item['after_cadence_landing_role']}`"
+        )
+    lines.extend(["", "## Required Input Fields", ""])
+    for field in package["required_input_fields"]:
+        lines.append(f"- `{field}`")
+    lines.extend(
+        [
+            "",
+            "## Claim Boundary",
+            "",
+            f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
+            f"- audio rendered quality claimed: `{_bool_token(readiness['audio_rendered_quality_claimed'])}`",
+            f"- broad trained-model quality claimed: `{_bool_token(readiness['broad_trained_model_quality_claimed'])}`",
+            "",
+            "## Next",
+            "",
+            f"- `{report['next_recommended_issue']}`",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build chord-tone landing repair listening review package"
+    )
+    parser.add_argument("--audio_package_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=(
+            "outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_"
+            "chord_tone_landing_repair_listening_review_package"
+        ),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=794)
+    parser.add_argument("--expected_review_item_count", type=int, default=6)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--require_package_ready", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_listening_review_package_report(
+        audio_package_report=read_json(Path(args.audio_package_report)),
+        output_dir=output_dir,
+        issue_number=int(args.issue_number),
+        expected_count=int(args.expected_review_item_count),
+    )
+    summary = validate_listening_review_package_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        expected_review_item_count=int(args.expected_review_item_count),
+        require_package_ready=bool(args.require_package_ready),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir
+        / (
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_"
+            "chord_tone_landing_repair_listening_review_package.json"
+        ),
+        report,
+    )
+    write_json(
+        output_dir
+        / (
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_"
+            "chord_tone_landing_repair_listening_review_package_validation_summary.json"
+        ),
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir
+        / (
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_"
+            "chord_tone_landing_repair_listening_review_package.md"
+        ),
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import hashlib
+import tempfile
+import unittest
+import wave
+from pathlib import Path
+
+import pretty_midi
+
+from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError,
+    build_listening_review_package_report,
+    validate_listening_review_package_report,
+)
+from scripts.render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio import (
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+)
+
+
+def write_midi(path: Path) -> None:
+    midi = pretty_midi.PrettyMIDI(initial_tempo=124)
+    midi.time_signature_changes.append(pretty_midi.TimeSignature(4, 4, 0.0))
+    instrument = pretty_midi.Instrument(program=0)
+    for index, pitch in enumerate([60, 63, 67, 70] * 6):
+        start = index * 0.5
+        instrument.notes.append(
+            pretty_midi.Note(velocity=90, pitch=int(pitch), start=start, end=start + 0.25)
+        )
+    midi.instruments.append(instrument)
+    midi.write(str(path))
+
+
+def write_wav(path: Path, *, sample_rate: int = 44100) -> dict:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(sample_rate)
+        handle.writeframes(b"\x00\x00" * (sample_rate // 10))
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    return {
+        "path": str(path),
+        "exists": True,
+        "size_bytes": path.stat().st_size,
+        "sha256": digest,
+        "channels": 1,
+        "sample_width_bytes": 2,
+        "sample_rate": sample_rate,
+        "frame_count": sample_rate // 10,
+        "duration_seconds": 0.1,
+    }
+
+
+def audio_package_report(root: Path, *, quality_claim: bool = False) -> dict:
+    rendered = []
+    for index in range(1, 7):
+        midi_path = root / f"candidate_{index}.mid"
+        wav_path = root / f"candidate_{index}.wav"
+        write_midi(midi_path)
+        wav_file = write_wav(wav_path)
+        rendered.append(
+            {
+                "candidate_index": index,
+                "rank": index,
+                "source_midi_path": str(midi_path),
+                "repaired_midi_path": str(midi_path),
+                "changed_note_count": 6 + index,
+                "after_bridge_flags": ["outside_soloing_pitch_role_risk"]
+                if index in {3, 5}
+                else [],
+                "after_chord_tone_ratio": 0.7,
+                "after_strong_beat_chord_tone_ratio": 1.0,
+                "after_cadence_landing_chord_tone": True,
+                "after_cadence_landing_role": "guide",
+                "after_max_non_chord_tone_run": 2,
+                "wav_file": wav_file,
+            }
+        )
+    return {
+        "audio_render_boundary": {
+            "boundary": SOURCE_BOUNDARY,
+            "render_attempted": True,
+            "rendered_audio_file_count": 6,
+            "technical_wav_validation": True,
+            "songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package_completed": True,
+            "human_audio_preference_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": quality_claim,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": SOURCE_BOUNDARY,
+            "next_boundary": SOURCE_NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+        },
+        "summary": {
+            "rendered_audio_file_count": 6,
+            "technical_wav_validation": True,
+            "sample_rate": 44100,
+            "duration_min_seconds": 0.1,
+            "duration_max_seconds": 0.1,
+            "changed_note_total": 40,
+            "weak_chord_tone_landing_risk_count_before": 6,
+            "weak_chord_tone_landing_risk_count_after": 0,
+            "weak_chord_tone_landing_risk_delta": 6,
+            "outside_soloing_pitch_role_risk_count_before": 5,
+            "outside_soloing_pitch_role_risk_count_after": 2,
+            "final_landing_chord_tone_count_before": 1,
+            "final_landing_chord_tone_count_after": 6,
+            "target_supported": True,
+            "audio_review_required": True,
+        },
+        "rendered_audio_files": rendered,
+    }
+
+
+class StageBMidiToSoloChordToneLandingRepairListeningReviewPackageTest(unittest.TestCase):
+    def test_builds_pending_listening_review_package_without_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            report = build_listening_review_package_report(
+                audio_package_report=audio_package_report(root),
+                output_dir=root / "review_package",
+                issue_number=794,
+                expected_count=6,
+            )
+            summary = validate_listening_review_package_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                expected_review_item_count=6,
+                require_package_ready=True,
+                require_no_quality_claim=True,
+            )
+
+            self.assertTrue(summary["listening_review_package_ready"])
+            self.assertEqual(summary["review_item_count"], 6)
+            self.assertFalse(summary["validated_review_input"])
+            self.assertTrue(summary["technical_wav_validation"])
+            self.assertEqual(summary["weak_chord_tone_landing_risk_delta"], 6)
+            self.assertEqual(summary["outside_soloing_pitch_role_risk_count_after"], 2)
+            self.assertEqual(summary["final_landing_chord_tone_count_after"], 6)
+            self.assertFalse(summary["human_audio_preference_claimed"])
+            self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+
+    def test_rejects_audio_package_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaises(
+                StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError
+            ):
+                build_listening_review_package_report(
+                    audio_package_report=audio_package_report(root, quality_claim=True),
+                    output_dir=root / "review_package",
+                    issue_number=794,
+                    expected_count=6,
+                )
+
+    def test_constants_are_stable(self) -> None:
+        self.assertEqual(
+            BOUNDARY,
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package",
+        )
+        self.assertEqual(
+            NEXT_BOUNDARY,
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary

- chord-tone landing repair listening review package 추가
- review item count: 6
- validated review input: false
- technical WAV validation: true
- quality/preference claim false 유지

Context

- Issue #792 audio package 결과
- rendered audio file count: 6
- duration range: 18.871s-19.000s
- changed note total: 40
- weak chord-tone landing risk delta: 6
- outside-soloing pitch-role risk count after: 2
- final landing chord-tone count after: 6

Scope

- audio package report 입력 검증
- WAV/MIDI review item 6개 패키징
- required input fields 기록
- validated review input pending 유지
- 하네스 모드 stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-repair-listening-review-package 추가
- handoff/status/core plan 갱신

Validation

- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package
- .venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package.py
- bash -n scripts/agent_harness.sh
- git diff --check
- bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-repair-listening-review-package
- bash scripts/agent_harness.sh quick

Risk

- review package 생성 단계
- validated listening input 없음
- preference fill 및 musical quality claim 없음

Follow-up

- Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard

Closes #794