### PR TITLE
Stage B MIDI-to-solo outside-soloing repair audio package

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -5536,6 +5536,50 @@ Issue #802는 Issue #800 follow-up decision 결과에 따라 chord-tone landing 
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package`
 
+## 9.93 Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package
+
+Issue #804는 Issue #802 outside-soloing repair sweep 결과의 repaired MIDI 6개를 WAV로 렌더하고 technical metadata를 검증한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package`
+- rendered audio file count: `6`
+- technical WAV validation: `true`
+- sample rate: `44100`
+- duration range: `18.871s-19.000s`
+- changed note total: `2`
+- outside-soloing pitch-role risk count: `2 -> 0`
+- outside-soloing pitch-role risk delta: `2`
+- weak chord-tone landing risk count after: `0`
+- final landing chord-tone count after: `6`
+- max non-chord-tone run: `4 -> 3`
+- audio review required: `true`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- Issue #802 repaired MIDI 후보 6개 모두 WAV 파일 생성.
+- WAV 존재, sample rate, frame count, size 기준 technical validation 통과.
+- objective repair 수치와 rendered audio package 연결 완료.
+- 현재 결과는 렌더 성공 및 technical metadata 검증 기준.
+- audio rendered quality, human/audio preference, MIDI-to-solo musical quality claim은 제외.
+- 다음 boundary는 rendered WAV/MIDI 후보의 listening review package.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio`
+- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-outside-soloing-repair-audio-package`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #802, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package`
+- latest functional result: Issue #804, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package`
 
 현재 범위가 아닌 것:
 
@@ -290,6 +290,18 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 audio package target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package`
+- songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair WAV 6개 렌더 완료
+- WAV sample rate: `44100`
+- WAV duration range: `18.871s-19.000s`
+- technical WAV validation: `true`
+- changed note total: `2`
+- outside-soloing pitch-role risk count: `2 -> 0`
+- weak chord-tone landing risk count after: `0`
+- final landing chord-tone count after: `6`
+- audio rendered quality claim: `false`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 review target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_AUDIO_PACKAGE_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_AUDIO_PACKAGE_2026-06-10.md
@@ -1,0 +1,41 @@
+# Stage B MIDI-to-Solo Chord-Tone Landing Outside-Soloing Repair Audio Package
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package`
+- render attempted: `true`
+- rendered audio file count: `6`
+- technical WAV validation: `true`
+- duration range: `18.871s-19.000s`
+- changed note total: `2`
+- outside-soloing pitch-role risk count: `2 -> 0`
+- outside-soloing pitch-role risk delta: `2`
+- weak chord-tone landing risk count after: `0`
+- final landing chord-tone count after: `6`
+- max non-chord-tone run: `4 -> 3`
+- audio review required: `true`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Rendered Files
+
+- candidate `1` rank `1`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package/audio/candidate_01_rank_01_outside_soloing_repair.wav`, duration `18.990`, sample rate `44100`, changed `0`, max run `3 -> 3`, flags `none`, sha256 `a4cbafc90c93`
+- candidate `2` rank `2`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package/audio/candidate_02_rank_02_outside_soloing_repair.wav`, duration `18.974`, sample rate `44100`, changed `0`, max run `2 -> 2`, flags `none`, sha256 `f2bd55925a42`
+- candidate `3` rank `3`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package/audio/candidate_03_rank_03_outside_soloing_repair.wav`, duration `19.000`, sample rate `44100`, changed `1`, max run `4 -> 3`, flags `none`, sha256 `c770fd415c85`
+- candidate `4` rank `4`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package/audio/candidate_04_rank_04_outside_soloing_repair.wav`, duration `18.871`, sample rate `44100`, changed `0`, max run `3 -> 3`, flags `none`, sha256 `5369edccdf9c`
+- candidate `5` rank `5`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package/audio/candidate_05_rank_05_outside_soloing_repair.wav`, duration `18.985`, sample rate `44100`, changed `1`, max run `4 -> 3`, flags `none`, sha256 `7f81e759d641`
+- candidate `6` rank `6`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package/audio/candidate_06_rank_06_outside_soloing_repair.wav`, duration `18.992`, sample rate `44100`, changed `0`, max run `2 -> 2`, flags `none`, sha256 `47080c51e631`
+
+## Claim Boundary
+
+- `audio_rendered_quality`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`
+
+## Next
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6848,6 +6848,28 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landin
     --require_no_quality_claim
 }
 
+run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package() {
+  local sweep_run_id="${SWEEP_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package}"
+  local sweep_report="outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep/${sweep_run_id}/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep.json"
+  if [[ ! -f "$sweep_report" ]]; then
+    print_header "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep"
+    RUN_ID="$sweep_run_id" run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep
+  fi
+  print_header "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package"
+  "$PYTHON_BIN" scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio.py \
+    --run_id "$run_id" \
+    --outside_soloing_repair_sweep_report "$sweep_report" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_AUDIO_PACKAGE_2026-06-10.md \
+    --issue_number 804 \
+    --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package \
+    --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package \
+    --expected_file_count 6 \
+    --sample_rate 44100 \
+    --require_audio_package_completed \
+    --require_no_quality_claim
+}
+
 run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision() {
   local quality_gap_run_id="${QUALITY_GAP_RUN_ID:-harness_stage_b_midi_to_solo_quality_gap_decision}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision}"
@@ -9194,6 +9216,9 @@ case "$MODE" in
     ;;
   stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-outside-soloing-repair-sweep)
     run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep
+    ;;
+  stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-outside-soloing-repair-audio-package)
+    run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package
     ;;
   stage-b-midi-to-solo-model-conditioned-pitch-contour-changed-ratio-review-decision)
     run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_review_decision

--- a/scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio.py
+++ b/scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio.py
@@ -1,0 +1,611 @@
+"""Render outside-soloing repair MIDI candidates to WAV files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.render_stage_b_midi_to_solo_candidate_audio import (  # noqa: E402
+    resolve_soundfont,
+    sha256_file,
+    wav_meta,
+)
+from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep import (  # noqa: E402
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+    StageBMidiToSoloChordToneLandingOutsideSoloingRepairSweepError,
+    validate_outside_soloing_repair_sweep_report,
+)
+
+
+class StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(ValueError):
+    pass
+
+
+BOUNDARY = (
+    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package"
+)
+NEXT_BOUNDARY = (
+    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package"
+)
+SCHEMA_VERSION = (
+    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package_v1"
+)
+CommandRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+QUALITY_CLAIM_KEYS = [
+    "human_audio_preference_claimed",
+    "midi_to_solo_musical_quality_claimed",
+    "musical_quality_claimed",
+    "audio_rendered_quality_claimed",
+    "model_checkpoint_generation_quality_claimed",
+    "model_direct_generation_quality_claimed",
+    "broad_trained_model_quality_claimed",
+    "brad_style_adaptation_claimed",
+    "production_ready_claimed",
+]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _path_exists(path_text: str) -> bool:
+    return bool(path_text and Path(path_text).exists())
+
+
+def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
+    claimed = [name for name in QUALITY_CLAIM_KEYS if bool(container.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+            f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def validate_source_report(
+    report: dict[str, Any],
+    *,
+    expected_count: int,
+) -> list[dict[str, Any]]:
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    if str(report.get("boundary") or readiness.get("boundary") or "") != SOURCE_BOUNDARY:
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+            "outside-soloing repair sweep boundary required"
+        )
+    if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+            "outside-soloing repair sweep must route to audio package"
+        )
+    try:
+        validate_outside_soloing_repair_sweep_report(
+            report,
+            expected_boundary=SOURCE_BOUNDARY,
+            expected_next_boundary=SOURCE_NEXT_BOUNDARY,
+            require_repair_completed=True,
+            require_target_supported=True,
+            require_no_quality_claim=True,
+        )
+    except StageBMidiToSoloChordToneLandingOutsideSoloingRepairSweepError as exc:
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(str(exc)) from exc
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+            "critical user input should not be required"
+        )
+    _require_no_quality_claim(readiness, label="outside-soloing repair readiness")
+
+    rows = [_dict(item) for item in _list(report.get("candidate_repairs"))]
+    if len(rows) < int(expected_count):
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+            "candidate repair count below expected count"
+        )
+    compacted: list[dict[str, Any]] = []
+    for index, row in enumerate(rows[: int(expected_count)], start=1):
+        repaired_midi_path = str(row.get("repaired_midi_path") or "")
+        if not _path_exists(repaired_midi_path):
+            raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+                f"repaired MIDI missing: {repaired_midi_path}"
+            )
+        before = _dict(row.get("before"))
+        after = _dict(row.get("after"))
+        repair = _dict(row.get("repair"))
+        compacted.append(
+            {
+                "candidate_index": int(index),
+                "rank": _int(row.get("rank")) or index,
+                "source_midi_path": str(row.get("source_midi_path") or ""),
+                "repaired_midi_path": repaired_midi_path,
+                "changed_note_count": _int(repair.get("changed_note_count")),
+                "before_bridge_flags": [str(flag) for flag in _list(before.get("bridge_flags"))],
+                "after_bridge_flags": [str(flag) for flag in _list(after.get("bridge_flags"))],
+                "before_max_non_chord_tone_run": _int(
+                    before.get("max_non_chord_tone_run")
+                ),
+                "after_max_non_chord_tone_run": _int(
+                    after.get("max_non_chord_tone_run")
+                ),
+                "before_chord_tone_ratio": _float(before.get("chord_tone_ratio")),
+                "after_chord_tone_ratio": _float(after.get("chord_tone_ratio")),
+                "before_cadence_landing_chord_tone": bool(
+                    before.get("cadence_landing_chord_tone", False)
+                ),
+                "after_cadence_landing_chord_tone": bool(
+                    after.get("cadence_landing_chord_tone", False)
+                ),
+            }
+        )
+    return compacted
+
+
+def build_render_plan(
+    candidates: list[dict[str, Any]],
+    *,
+    output_dir: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+) -> list[dict[str, Any]]:
+    renderer = Path(renderer_path)
+    soundfont = Path(soundfont_path).expanduser()
+    if not renderer.exists():
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+            f"renderer not found: {renderer}"
+        )
+    if not soundfont.exists():
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+            f"soundfont not found: {soundfont}"
+        )
+    plan: list[dict[str, Any]] = []
+    for item in candidates:
+        wav_path = output_dir / "audio" / (
+            f"candidate_{int(item['candidate_index']):02d}_rank_{int(item['rank']):02d}_"
+            "outside_soloing_repair.wav"
+        )
+        plan.append(
+            {
+                **item,
+                "wav_path": str(wav_path),
+                "command": [
+                    str(renderer),
+                    "-ni",
+                    "-F",
+                    str(wav_path),
+                    "-r",
+                    str(sample_rate),
+                    str(soundfont),
+                    str(item["repaired_midi_path"]),
+                ],
+            }
+        )
+    return plan
+
+
+def default_runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(list(command), check=False, text=True, capture_output=True)
+
+
+def execute_render_plan(
+    plan: list[dict[str, Any]],
+    *,
+    runner: CommandRunner = default_runner,
+) -> list[dict[str, Any]]:
+    rendered: list[dict[str, Any]] = []
+    for item in plan:
+        wav_path = Path(str(item["wav_path"]))
+        wav_path.parent.mkdir(parents=True, exist_ok=True)
+        completed = runner(item["command"])
+        if completed.returncode != 0:
+            raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+                f"render failed for candidate {item['candidate_index']}: "
+                f"{completed.stderr or completed.stdout}"
+            )
+        rendered.append(
+            {
+                "candidate_index": item["candidate_index"],
+                "rank": item["rank"],
+                "source_midi_path": item["source_midi_path"],
+                "repaired_midi_path": item["repaired_midi_path"],
+                "changed_note_count": item["changed_note_count"],
+                "before_bridge_flags": item["before_bridge_flags"],
+                "after_bridge_flags": item["after_bridge_flags"],
+                "before_max_non_chord_tone_run": item["before_max_non_chord_tone_run"],
+                "after_max_non_chord_tone_run": item["after_max_non_chord_tone_run"],
+                "before_chord_tone_ratio": item["before_chord_tone_ratio"],
+                "after_chord_tone_ratio": item["after_chord_tone_ratio"],
+                "before_cadence_landing_chord_tone": item[
+                    "before_cadence_landing_chord_tone"
+                ],
+                "after_cadence_landing_chord_tone": item[
+                    "after_cadence_landing_chord_tone"
+                ],
+                "wav_file": wav_meta(wav_path),
+                "command": list(item["command"]),
+                "stdout_tail": (completed.stdout or "")[-1000:],
+                "stderr_tail": (completed.stderr or "")[-1000:],
+            }
+        )
+    return rendered
+
+
+def build_audio_render_report(
+    source_report: dict[str, Any],
+    *,
+    output_dir: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+    expected_file_count: int,
+    issue_number: int = 804,
+    runner: CommandRunner = default_runner,
+) -> dict[str, Any]:
+    candidates = validate_source_report(source_report, expected_count=expected_file_count)
+    resolved_renderer = renderer_path or shutil.which("fluidsynth") or ""
+    resolved_soundfont = resolve_soundfont(soundfont_path)
+    plan = build_render_plan(
+        candidates,
+        output_dir=output_dir,
+        renderer_path=resolved_renderer,
+        soundfont_path=resolved_soundfont,
+        sample_rate=int(sample_rate),
+    )
+    rendered = execute_render_plan(plan, runner=runner)
+    aggregate = _dict(source_report.get("aggregate"))
+    durations = [
+        _float(_dict(item.get("wav_file")).get("duration_seconds")) for item in rendered
+    ]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "issue_number": int(issue_number),
+        "source_boundary": SOURCE_BOUNDARY,
+        "source_summary": aggregate,
+        "renderer": {
+            "name": "fluidsynth",
+            "path": resolved_renderer,
+        },
+        "soundfont": {
+            "path": str(Path(resolved_soundfont).expanduser()),
+            "sha256": sha256_file(Path(resolved_soundfont).expanduser()),
+        },
+        "rendered_audio_files": rendered,
+        "summary": {
+            "rendered_audio_file_count": int(len(rendered)),
+            "technical_wav_validation": True,
+            "sample_rate": int(sample_rate),
+            "duration_min_seconds": min(durations, default=0.0),
+            "duration_max_seconds": max(durations, default=0.0),
+            "changed_note_total": _int(aggregate.get("changed_note_total")),
+            "outside_soloing_pitch_role_risk_count_before": _int(
+                aggregate.get("outside_soloing_pitch_role_risk_count_before")
+            ),
+            "outside_soloing_pitch_role_risk_count_after": _int(
+                aggregate.get("outside_soloing_pitch_role_risk_count_after")
+            ),
+            "outside_soloing_pitch_role_risk_delta": _int(
+                aggregate.get("outside_soloing_pitch_role_risk_delta")
+            ),
+            "weak_chord_tone_landing_risk_count_after": _int(
+                aggregate.get("weak_chord_tone_landing_risk_count_after")
+            ),
+            "final_landing_chord_tone_count_after": _int(
+                aggregate.get("final_landing_chord_tone_count_after")
+            ),
+            "max_non_chord_tone_run_before": _int(
+                aggregate.get("max_non_chord_tone_run_before")
+            ),
+            "max_non_chord_tone_run_after": _int(
+                aggregate.get("max_non_chord_tone_run_after")
+            ),
+            "target_supported": bool(aggregate.get("target_supported", False)),
+            "audio_review_required": True,
+        },
+        "audio_render_boundary": {
+            "boundary": BOUNDARY,
+            "render_attempted": True,
+            "rendered_audio_file_count": int(len(rendered)),
+            "technical_wav_validation": True,
+            "outside_soloing_repair_audio_package_completed": True,
+            "human_audio_preference_claimed": False,
+            "audio_rendered_quality_claimed": False,
+            "midi_to_solo_musical_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY,
+            "auto_progress_allowed": True,
+            "critical_user_input_required": False,
+            "reason": "outside-soloing repair MIDI rendered to WAV; prepare listening review package next",
+        },
+        "not_proven": [
+            "audio_rendered_quality",
+            "human_audio_preference",
+            "midi_to_solo_musical_quality",
+            "broad_trained_model_quality",
+            "brad_style_adaptation",
+        ],
+        "next_recommended_issue": (
+            "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package"
+        ),
+    }
+
+
+def validate_audio_render_report(
+    report: dict[str, Any],
+    *,
+    expected_boundary: str | None,
+    expected_next_boundary: str | None,
+    expected_file_count: int,
+    expected_sample_rate: int,
+    require_audio_package_completed: bool,
+    require_no_quality_claim: bool,
+) -> dict[str, Any]:
+    boundary = _dict(report.get("audio_render_boundary"))
+    decision = _dict(report.get("decision"))
+    summary = _dict(report.get("summary"))
+    if expected_boundary and str(boundary.get("boundary") or "") != expected_boundary:
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+            "unexpected boundary"
+        )
+    if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+            "unexpected next boundary"
+        )
+    files = [_dict(item) for item in _list(report.get("rendered_audio_files"))]
+    if len(files) != int(expected_file_count):
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+            f"expected {expected_file_count} rendered files"
+        )
+    for item in files:
+        wav_file = _dict(item.get("wav_file"))
+        if not bool(wav_file.get("exists", False)) or not _path_exists(
+            str(wav_file.get("path") or "")
+        ):
+            raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+                "missing rendered WAV"
+            )
+        if _int(wav_file.get("sample_rate")) != int(expected_sample_rate):
+            raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+                "unexpected sample rate"
+            )
+        if _int(wav_file.get("frame_count")) <= 0:
+            raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+                "empty WAV"
+            )
+        if _int(wav_file.get("size_bytes")) <= 44:
+            raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+                "invalid WAV size"
+            )
+    if require_audio_package_completed and not bool(
+        boundary.get("outside_soloing_repair_audio_package_completed", False)
+    ):
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+            "audio package completion required"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+            "critical user input should not be required"
+        )
+    if require_no_quality_claim:
+        _require_no_quality_claim(boundary, label="audio render boundary")
+    return {
+        "boundary": str(boundary.get("boundary") or ""),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "render_attempted": bool(boundary.get("render_attempted", False)),
+        "rendered_audio_file_count": _int(boundary.get("rendered_audio_file_count")),
+        "technical_wav_validation": bool(boundary.get("technical_wav_validation", False)),
+        "outside_soloing_repair_audio_package_completed": bool(
+            boundary.get("outside_soloing_repair_audio_package_completed", False)
+        ),
+        "sample_rate": _int(summary.get("sample_rate")),
+        "duration_min_seconds": _float(summary.get("duration_min_seconds")),
+        "duration_max_seconds": _float(summary.get("duration_max_seconds")),
+        "changed_note_total": _int(summary.get("changed_note_total")),
+        "outside_soloing_pitch_role_risk_count_before": _int(
+            summary.get("outside_soloing_pitch_role_risk_count_before")
+        ),
+        "outside_soloing_pitch_role_risk_count_after": _int(
+            summary.get("outside_soloing_pitch_role_risk_count_after")
+        ),
+        "outside_soloing_pitch_role_risk_delta": _int(
+            summary.get("outside_soloing_pitch_role_risk_delta")
+        ),
+        "weak_chord_tone_landing_risk_count_after": _int(
+            summary.get("weak_chord_tone_landing_risk_count_after")
+        ),
+        "final_landing_chord_tone_count_after": _int(
+            summary.get("final_landing_chord_tone_count_after")
+        ),
+        "max_non_chord_tone_run_before": _int(
+            summary.get("max_non_chord_tone_run_before")
+        ),
+        "max_non_chord_tone_run_after": _int(
+            summary.get("max_non_chord_tone_run_after")
+        ),
+        "target_supported": bool(summary.get("target_supported", False)),
+        "audio_review_required": bool(summary.get("audio_review_required", False)),
+        "audio_rendered_quality_claimed": bool(
+            boundary.get("audio_rendered_quality_claimed", True)
+        ),
+        "human_audio_preference_claimed": bool(
+            boundary.get("human_audio_preference_claimed", True)
+        ),
+        "midi_to_solo_musical_quality_claimed": bool(
+            boundary.get("midi_to_solo_musical_quality_claimed", True)
+        ),
+        "critical_user_input_required": bool(
+            decision.get("critical_user_input_required", True)
+        ),
+        "wav_paths": [str(_dict(item.get("wav_file")).get("path") or "") for item in files],
+        "next_recommended_issue": str(report.get("next_recommended_issue") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    boundary = report["audio_render_boundary"]
+    decision = report["decision"]
+    summary = report["summary"]
+    lines = [
+        "# Stage B MIDI-to-Solo Chord-Tone Landing Outside-Soloing Repair Audio Package",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{boundary['boundary']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- render attempted: `{_bool_token(boundary['render_attempted'])}`",
+        f"- rendered audio file count: `{boundary['rendered_audio_file_count']}`",
+        f"- technical WAV validation: `{_bool_token(boundary['technical_wav_validation'])}`",
+        f"- duration range: `{summary['duration_min_seconds']:.3f}s-{summary['duration_max_seconds']:.3f}s`",
+        f"- changed note total: `{summary['changed_note_total']}`",
+        f"- outside-soloing pitch-role risk count: `{summary['outside_soloing_pitch_role_risk_count_before']} -> {summary['outside_soloing_pitch_role_risk_count_after']}`",
+        f"- outside-soloing pitch-role risk delta: `{summary['outside_soloing_pitch_role_risk_delta']}`",
+        f"- weak chord-tone landing risk count after: `{summary['weak_chord_tone_landing_risk_count_after']}`",
+        f"- final landing chord-tone count after: `{summary['final_landing_chord_tone_count_after']}`",
+        f"- max non-chord-tone run: `{summary['max_non_chord_tone_run_before']} -> {summary['max_non_chord_tone_run_after']}`",
+        f"- audio review required: `{_bool_token(summary['audio_review_required'])}`",
+        f"- audio rendered quality claimed: `{_bool_token(boundary['audio_rendered_quality_claimed'])}`",
+        f"- human/audio preference claimed: `{_bool_token(boundary['human_audio_preference_claimed'])}`",
+        f"- MIDI-to-solo musical quality claimed: `{_bool_token(boundary['midi_to_solo_musical_quality_claimed'])}`",
+        "",
+        "## Rendered Files",
+        "",
+    ]
+    for item in report.get("rendered_audio_files", []):
+        wav_file = item["wav_file"]
+        lines.append(
+            f"- candidate `{item['candidate_index']}` rank `{item['rank']}`: "
+            f"`{wav_file['path']}`, duration `{float(wav_file['duration_seconds']):.3f}`, "
+            f"sample rate `{wav_file['sample_rate']}`, changed `{item['changed_note_count']}`, "
+            f"max run `{item['before_max_non_chord_tone_run']} -> {item['after_max_non_chord_tone_run']}`, "
+            f"flags `{','.join(item['after_bridge_flags']) or 'none'}`, "
+            f"sha256 `{str(wav_file['sha256'])[:12]}`"
+        )
+    lines.extend(["", "## Claim Boundary", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    lines.extend(["", "## Next", "", f"- `{report['next_recommended_issue']}`"])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Render outside-soloing repair MIDI candidates to WAV files"
+    )
+    parser.add_argument("--outside_soloing_repair_sweep_report", type=str, required=True)
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default=(
+            "outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_"
+            "chord_tone_landing_outside_soloing_repair_audio_package"
+        ),
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--issue_number", type=int, default=804)
+    parser.add_argument("--renderer", type=str, default=shutil.which("fluidsynth") or "")
+    parser.add_argument("--soundfont", type=str, default="")
+    parser.add_argument("--sample_rate", type=int, default=44100)
+    parser.add_argument("--expected_boundary", type=str, default="")
+    parser.add_argument("--expected_next_boundary", type=str, default="")
+    parser.add_argument("--expected_file_count", type=int, default=6)
+    parser.add_argument("--require_audio_package_completed", action="store_true")
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_audio_render_report(
+        read_json(Path(args.outside_soloing_repair_sweep_report)),
+        output_dir=output_dir,
+        renderer_path=str(args.renderer or ""),
+        soundfont_path=str(args.soundfont or ""),
+        sample_rate=int(args.sample_rate),
+        expected_file_count=int(args.expected_file_count),
+        issue_number=int(args.issue_number),
+    )
+    summary = validate_audio_render_report(
+        report,
+        expected_boundary=str(args.expected_boundary or ""),
+        expected_next_boundary=str(args.expected_next_boundary or ""),
+        expected_file_count=int(args.expected_file_count),
+        expected_sample_rate=int(args.sample_rate),
+        require_audio_package_completed=bool(args.require_audio_package_completed),
+        require_no_quality_claim=bool(args.require_no_quality_claim),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        output_dir
+        / (
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_"
+            "chord_tone_landing_outside_soloing_repair_audio_package.json"
+        ),
+        report,
+    )
+    write_json(
+        output_dir
+        / (
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_"
+            "chord_tone_landing_outside_soloing_repair_audio_package_validation_summary.json"
+        ),
+        summary,
+    )
+    markdown = markdown_report(report)
+    write_text(
+        output_dir
+        / (
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_"
+            "chord_tone_landing_outside_soloing_repair_audio_package.md"
+        ),
+        markdown,
+    )
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown)
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+import wave
+from pathlib import Path
+from typing import Sequence
+
+import pretty_midi
+
+from scripts.render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio import (
+    BOUNDARY,
+    NEXT_BOUNDARY,
+    StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError,
+    build_audio_render_report,
+    validate_audio_render_report,
+)
+from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep import (
+    BOUNDARY as SOURCE_BOUNDARY,
+    NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+    SELECTED_TARGET as SOURCE_SELECTED_TARGET,
+)
+
+
+def write_midi(path: Path) -> None:
+    midi = pretty_midi.PrettyMIDI(initial_tempo=124)
+    midi.time_signature_changes.append(pretty_midi.TimeSignature(4, 4, 0.0))
+    instrument = pretty_midi.Instrument(program=0)
+    for index, pitch in enumerate([60, 63, 67, 70] * 8):
+        start = index * 0.35
+        instrument.notes.append(
+            pretty_midi.Note(velocity=90, pitch=int(pitch), start=start, end=start + 0.18)
+        )
+    midi.instruments.append(instrument)
+    midi.write(str(path))
+
+
+def write_wav(path: Path, *, sample_rate: int = 44100) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(sample_rate)
+        handle.writeframes(b"\x00\x00" * (sample_rate // 10))
+
+
+def fake_runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    wav_path = Path(str(command[list(command).index("-F") + 1]))
+    sample_rate = int(command[list(command).index("-r") + 1])
+    write_wav(wav_path, sample_rate=sample_rate)
+    return subprocess.CompletedProcess(list(command), 0, stdout="rendered", stderr="")
+
+
+def source_report(root: Path, *, quality_claim: bool = False) -> dict:
+    repairs = []
+    for index in range(1, 7):
+        source_path = root / f"source_{index}.mid"
+        repaired_path = root / f"outside_soloing_repair_{index}.mid"
+        write_midi(source_path)
+        write_midi(repaired_path)
+        before_flags = ["outside_soloing_pitch_role_risk"] if index in {3, 5} else []
+        repairs.append(
+            {
+                "rank": index,
+                "source_midi_path": str(source_path),
+                "repaired_midi_path": str(repaired_path),
+                "repair": {
+                    "changed_note_count": 1 if index in {3, 5} else 0,
+                },
+                "before": {
+                    "chord_tone_ratio": 0.42,
+                    "cadence_landing_chord_tone": True,
+                    "max_non_chord_tone_run": 4 if index in {3, 5} else 3,
+                    "bridge_flags": before_flags,
+                },
+                "after": {
+                    "chord_tone_ratio": 0.5,
+                    "cadence_landing_chord_tone": True,
+                    "max_non_chord_tone_run": 3,
+                    "bridge_flags": [],
+                },
+            }
+        )
+    return {
+        "boundary": SOURCE_BOUNDARY,
+        "candidate_repairs": repairs,
+        "aggregate": {
+            "candidate_count": 6,
+            "repaired_midi_count": 6,
+            "changed_note_total": 2,
+            "outside_soloing_pitch_role_risk_count_before": 2,
+            "outside_soloing_pitch_role_risk_count_after": 0,
+            "outside_soloing_pitch_role_risk_delta": 2,
+            "weak_chord_tone_landing_risk_count_before": 0,
+            "weak_chord_tone_landing_risk_count_after": 0,
+            "final_landing_chord_tone_count_before": 6,
+            "final_landing_chord_tone_count_after": 6,
+            "max_non_chord_tone_run_before": 4,
+            "max_non_chord_tone_run_after": 3,
+            "target_supported": True,
+        },
+        "readiness": {
+            "outside_soloing_repair_sweep_completed": True,
+            "candidate_count": 6,
+            "repaired_midi_count": 6,
+            "target_supported": True,
+            "outside_soloing_pitch_role_risk_delta": 2,
+            "weak_chord_tone_landing_risk_count_after": 0,
+            "human_audio_preference_claimed": False,
+            "midi_to_solo_musical_quality_claimed": quality_claim,
+            "audio_rendered_quality_claimed": False,
+            "model_checkpoint_generation_quality_claimed": False,
+            "model_direct_generation_quality_claimed": False,
+            "broad_trained_model_quality_claimed": False,
+            "brad_style_adaptation_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": SOURCE_BOUNDARY,
+            "next_boundary": SOURCE_NEXT_BOUNDARY,
+            "selected_target": SOURCE_SELECTED_TARGET,
+            "critical_user_input_required": False,
+        },
+    }
+
+
+class StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioTest(unittest.TestCase):
+    def test_renders_outside_soloing_repair_wavs_without_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = root / "fluidsynth"
+            soundfont = root / "soundfont.sf2"
+            renderer.write_text("#!/bin/sh\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            report = build_audio_render_report(
+                source_report(root),
+                output_dir=root / "audio_package",
+                renderer_path=str(renderer),
+                soundfont_path=str(soundfont),
+                sample_rate=44100,
+                expected_file_count=6,
+                runner=fake_runner,
+            )
+            summary = validate_audio_render_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                expected_file_count=6,
+                expected_sample_rate=44100,
+                require_audio_package_completed=True,
+                require_no_quality_claim=True,
+            )
+
+            self.assertTrue(summary["outside_soloing_repair_audio_package_completed"])
+            self.assertEqual(summary["rendered_audio_file_count"], 6)
+            self.assertTrue(summary["technical_wav_validation"])
+            self.assertEqual(summary["outside_soloing_pitch_role_risk_delta"], 2)
+            self.assertEqual(summary["outside_soloing_pitch_role_risk_count_after"], 0)
+            self.assertEqual(summary["weak_chord_tone_landing_risk_count_after"], 0)
+            self.assertEqual(summary["max_non_chord_tone_run_after"], 3)
+            self.assertTrue(summary["audio_review_required"])
+            self.assertFalse(summary["human_audio_preference_claimed"])
+            self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+
+    def test_rejects_source_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = root / "fluidsynth"
+            soundfont = root / "soundfont.sf2"
+            renderer.write_text("#!/bin/sh\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            with self.assertRaises(
+                StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError
+            ):
+                build_audio_render_report(
+                    source_report(root, quality_claim=True),
+                    output_dir=root / "audio_package",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(soundfont),
+                    sample_rate=44100,
+                    expected_file_count=6,
+                    runner=fake_runner,
+                )
+
+    def test_constants_are_stable(self) -> None:
+        self.assertEqual(
+            BOUNDARY,
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package",
+        )
+        self.assertEqual(
+            NEXT_BOUNDARY,
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary
- outside-soloing repair MIDI 후보 WAV 렌더 package 추가
- WAV technical metadata 검증
- quality/preference claim false 유지

Context
- Issue #802 outside-soloing repair sweep 결과
- changed note total: `2`
- outside-soloing pitch-role risk count: `2 -> 0`
- weak chord-tone landing risk count after: `0`
- max non-chord-tone run: `4 -> 3`

Scope
- outside-soloing repair audio package script 추가
- fake renderer unit test 추가
- harness mode 추가
- current status/core plan 갱신
- generated audio package markdown 기록

Result
- rendered audio file count: `6`
- sample rate: `44100`
- duration range: `18.871s-19.000s`
- technical WAV validation: `true`

Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio`
- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio.py`
- `bash -n scripts/agent_harness.sh`
- `git diff --check`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-outside-soloing-repair-audio-package`
- `bash scripts/agent_harness.sh quick`

Risk
- audio rendered quality claim 없음
- listening preference 없음
- musical quality claim 없음

Follow-up
- Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package

Closes #804