### PR TITLE
Stage B MIDI-to-solo current evidence outside-soloing repair refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -5718,6 +5718,54 @@ Issue #810은 Issue #808 input guard 결과를 objective-only 기준으로 판�
 
 - `Stage B MIDI-to-solo MVP current evidence consolidation`
 
+## 9.97 Stage B MIDI-to-solo MVP current evidence consolidation outside-soloing repair refresh
+
+Issue #812는 current evidence consolidation에 Issue #810 outside-soloing repair objective path를 추가 반영한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- next boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
+- current MVP evidence supported: `true`
+- technical execution evidence supported: `true`
+- selected-scale objective path complete: `true`
+- phrase-bank CLI technical path ready: `true`
+- model-conditioned pitch-contour objective path ready: `true`
+- model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
+- outside-soloing repair objective path ready: `true`
+- outside-soloing repair rendered audio file count: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing repair pitch-role risk count after: `0`
+- outside-soloing repair pitch-role risk delta: `2`
+- outside-soloing repair target supported: `true`
+- outside-soloing repair weak landing target supported: `true`
+- outside-soloing repair final landing target supported: `true`
+- outside-soloing repair non-chord run target supported: `true`
+- outside-soloing repair objective path supported: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- 기존 current evidence consolidation 입력 유지.
+- Issue #810 outside-soloing repair objective-only next decision을 추가 evidence path로 연결.
+- outside-soloing pitch-role risk count after `0` 기준 support 유지.
+- weak landing, final landing, non-chord run target support 모두 유지.
+- current evidence support는 technical path, selected-scale objective path, phrase-bank CLI path, model-conditioned pitch-contour path, changed-ratio repair path, outside-soloing repair path를 모두 포함.
+- human/audio preference와 MIDI-to-solo musical quality claim은 제외.
+- 다음 boundary는 README evidence refresh.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- `.venv/bin/python -m py_compile scripts/consolidate_stage_b_midi_to_solo_mvp_current_evidence.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-current-evidence-consolidation`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo README evidence refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #810, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision
-- 다음 권장 이슈: `Stage B MIDI-to-solo MVP current evidence consolidation`
+- latest functional result: Issue #812, Stage B MIDI-to-solo MVP current evidence consolidation outside-soloing repair refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo README evidence refresh`
 
 현재 범위가 아닌 것:
 
@@ -339,6 +339,21 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 consolidation target: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- MVP current evidence consolidation outside-soloing repair refresh 완료
+- current MVP evidence supported: `true`
+- selected-scale objective path complete: `true`
+- phrase-bank CLI technical path ready: `true`
+- model-conditioned pitch-contour objective path ready: `true`
+- model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
+- outside-soloing repair objective path ready: `true`
+- outside-soloing repair rendered audio file count: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing repair pitch-role risk count after: `0`
+- outside-soloing repair pitch-role risk delta: `2`
+- outside-soloing repair objective path supported: `true`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 README target: `stage_b_midi_to_solo_readme_evidence_refresh`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MVP_CURRENT_EVIDENCE_CONSOLIDATION_OUTSIDE_SOLOING_REPAIR_REFRESH_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MVP_CURRENT_EVIDENCE_CONSOLIDATION_OUTSIDE_SOLOING_REPAIR_REFRESH_2026-06-10.md
@@ -1,0 +1,124 @@
+# Stage B MIDI-to-Solo MVP Current Evidence Consolidation
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- next boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
+- current MVP evidence supported: `true`
+- technical execution evidence supported: `true`
+- selected-scale objective path complete: `true`
+- phrase-bank CLI technical path ready: `true`
+- model-conditioned pitch-contour objective path ready: `true`
+- model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
+- outside-soloing repair objective path ready: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Input Contract
+
+- candidate count: `32`
+- exported MIDI candidates: `3`
+- target solo bars: `8`
+- min note count: `24`
+- min unique pitch count: `8`
+- max simultaneous notes: `1`
+- fallback path: `phrase_retrieval_data_motif_hybrid`
+
+## Context and Ranked MIDI
+
+- context bars / events: `8` / `128`
+- low-confidence chord bars: `4`
+- generation source: `context_conditioned_fallback`
+- exported / qualified candidates: `3` / `3`
+- best note / unique pitch / max simultaneous notes: `60` / `14` / `1`
+
+## Technical Audio Path
+
+- rendered WAV files: `3`
+- sample rate: `44100`
+- duration range: `18.617s-18.991s`
+- technical WAV validation: `true`
+
+## Selected-Scale Objective Path
+
+- final boundary: `stage_b_midi_to_solo_controlled_scale_checkpoint_training_scale_postprocess_removal_dead_air_repair_objective_path_complete`
+- sample / seed count: `9` / `3`
+- valid / strict / grammar: `9` / `9` / `9`
+- dead-air / collapse failure count: `0` / `0`
+- avg / max postprocess removal ratio: `0.21759259259259262` / `0.2916666666666667`
+- target avg postprocess removal ratio: `0.3`
+- validated review input present: `false`
+- preference fill allowed: `false`
+
+## Phrase-Bank CLI Technical Path
+
+- technical MIDI-to-solo CLI path ready: `true`
+- explicit input used: `true`
+- candidate / objective supported: `3` / `3`
+- repaired MIDI / rendered WAV: `3` / `3`
+- input context bars: `228`
+- dead-air range: `0.1895-0.2211`
+- preference fill allowed: `false`
+
+## Model-Conditioned Pitch-Contour Objective Path
+
+- current evidence consolidation ready: `true`
+- rendered WAV files: `3`
+- technical WAV validation: `true`
+- max interval / threshold: `11` / `12`
+- pitch-contour target supported: `true`
+- max pitch changed ratio: `0.7174`
+- pitch changed ratio review required: `true`
+- audio review required: `true`
+- preference fill allowed: `false`
+
+## Model-Conditioned Pitch-Contour Changed-Ratio Repair Objective Path
+
+- current evidence consolidation ready: `true`
+- objective path supported: `true`
+- rendered WAV files: `3`
+- technical WAV validation: `true`
+- max interval / threshold: `12` / `12`
+- max pitch changed ratio / target: `0.4348` / `0.5000`
+- changed-ratio target supported: `true`
+- audio review required: `true`
+- preference fill allowed: `false`
+
+## Outside-Soloing Repair Objective Path
+
+- current evidence consolidation ready: `true`
+- objective path supported: `true`
+- rendered WAV files: `6`
+- technical WAV validation: `true`
+- changed note total: `2`
+- outside-soloing pitch-role risk after / delta: `0` / `2`
+- outside-soloing target supported: `true`
+- weak landing target supported: `true`
+- final landing chord-tone count after: `6`
+- max non-chord-tone run after: `3`
+- non-chord run target supported: `true`
+- preference fill allowed: `false`
+
+## MIDI Paths
+
+- `outputs/stage_b_midi_to_solo_conditioned_generation_probe/harness_stage_b_midi_to_solo_conditioned_generation_probe/midi/rank_01_seed_489.mid`
+- `outputs/stage_b_midi_to_solo_conditioned_generation_probe/harness_stage_b_midi_to_solo_conditioned_generation_probe/midi/rank_02_seed_488.mid`
+- `outputs/stage_b_midi_to_solo_conditioned_generation_probe/harness_stage_b_midi_to_solo_conditioned_generation_probe/midi/rank_03_seed_487.mid`
+
+## WAV Paths
+
+- `outputs/stage_b_midi_to_solo_candidate_audio_render_package/harness_stage_b_midi_to_solo_candidate_audio_render_package/audio/rank_01_seed_489.wav`
+- `outputs/stage_b_midi_to_solo_candidate_audio_render_package/harness_stage_b_midi_to_solo_candidate_audio_render_package/audio/rank_02_seed_488.wav`
+- `outputs/stage_b_midi_to_solo_candidate_audio_render_package/harness_stage_b_midi_to_solo_candidate_audio_render_package/audio/rank_03_seed_487.wav`
+
+## Not Proven
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`
+- `production_ready_improviser`
+
+## Next
+
+- `Stage B MIDI-to-solo README evidence refresh`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -5922,6 +5922,7 @@ run_stage_b_midi_to_solo_mvp_current_evidence_consolidation() {
   local cli_objective_next_run_id="${CLI_OBJECTIVE_NEXT_RUN_ID:-harness_stage_b_midi_to_solo_phrase_bank_cli_objective_only_next_decision}"
   local model_conditioned_pitch_contour_objective_next_run_id="${MODEL_CONDITIONED_PITCH_CONTOUR_OBJECTIVE_NEXT_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_next}"
   local model_conditioned_pitch_contour_changed_ratio_repair_objective_next_run_id="${MODEL_CONDITIONED_PITCH_CONTOUR_CHANGED_RATIO_REPAIR_OBJECTIVE_NEXT_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_next}"
+  local outside_soloing_repair_objective_next_run_id="${OUTSIDE_SOLOING_REPAIR_OBJECTIVE_NEXT_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_only_next_decision}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_mvp_current_evidence_consolidation}"
   local contract_report="outputs/stage_b_midi_to_solo_mvp_contract/${contract_run_id}/stage_b_midi_to_solo_mvp_contract.json"
   local context_report="outputs/stage_b_midi_to_solo_context_extraction/${context_run_id}/stage_b_midi_to_solo_context_extraction.json"
@@ -5932,6 +5933,7 @@ run_stage_b_midi_to_solo_mvp_current_evidence_consolidation() {
   local cli_objective_next="outputs/stage_b_midi_to_solo_phrase_bank_cli_objective_only_next_decision/${cli_objective_next_run_id}/stage_b_midi_to_solo_phrase_bank_cli_objective_only_next_decision.json"
   local model_conditioned_pitch_contour_objective_next="outputs/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision/${model_conditioned_pitch_contour_objective_next_run_id}/stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_only_next_decision.json"
   local model_conditioned_pitch_contour_changed_ratio_repair_objective_next="outputs/stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_only_next_decision/${model_conditioned_pitch_contour_changed_ratio_repair_objective_next_run_id}/stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_only_next_decision.json"
+  local outside_soloing_repair_objective_next="outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_only_next_decision/${outside_soloing_repair_objective_next_run_id}/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_only_next_decision.json"
   if [[ ! -f "$contract_report" ]]; then
     print_header "Stage B MIDI-to-solo MVP input contract"
     RUN_ID="$contract_run_id" run_stage_b_midi_to_solo_mvp_contract
@@ -5968,6 +5970,10 @@ run_stage_b_midi_to_solo_mvp_current_evidence_consolidation() {
     print_header "Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio repair objective-only next decision"
     RUN_ID="$model_conditioned_pitch_contour_changed_ratio_repair_objective_next_run_id" run_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_next
   fi
+  if [[ ! -f "$outside_soloing_repair_objective_next" ]]; then
+    print_header "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision"
+    RUN_ID="$outside_soloing_repair_objective_next_run_id" run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_only_next_decision
+  fi
   print_header "Stage B MIDI-to-solo MVP current evidence consolidation"
   "$PYTHON_BIN" scripts/consolidate_stage_b_midi_to_solo_mvp_current_evidence.py \
     --run_id "$run_id" \
@@ -5980,8 +5986,9 @@ run_stage_b_midi_to_solo_mvp_current_evidence_consolidation() {
     --cli_objective_next "$cli_objective_next" \
     --model_conditioned_pitch_contour_objective_next "$model_conditioned_pitch_contour_objective_next" \
     --model_conditioned_pitch_contour_changed_ratio_repair_objective_next "$model_conditioned_pitch_contour_changed_ratio_repair_objective_next" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_CURRENT_EVIDENCE_CONSOLIDATION_2026-06-09.md \
-    --issue_number 728 \
+    --outside_soloing_repair_objective_next "$outside_soloing_repair_objective_next" \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_CURRENT_EVIDENCE_CONSOLIDATION_OUTSIDE_SOLOING_REPAIR_REFRESH_2026-06-10.md \
+    --issue_number 812 \
     --expected_boundary stage_b_midi_to_solo_mvp_current_evidence_consolidation \
     --expected_next_boundary stage_b_midi_to_solo_readme_evidence_refresh \
     --min_exported_candidates 3 \
@@ -5990,6 +5997,7 @@ run_stage_b_midi_to_solo_mvp_current_evidence_consolidation() {
     --require_current_evidence_support \
     --require_model_conditioned_pitch_contour_objective \
     --require_model_conditioned_pitch_contour_changed_ratio_repair_objective \
+    --require_outside_soloing_repair_objective \
     --require_no_quality_claim
 }
 

--- a/scripts/consolidate_stage_b_midi_to_solo_mvp_current_evidence.py
+++ b/scripts/consolidate_stage_b_midi_to_solo_mvp_current_evidence.py
@@ -45,6 +45,10 @@ MODEL_CONDITIONED_PITCH_CONTOUR_CHANGED_RATIO_REPAIR_OBJECTIVE_BOUNDARY = (
     "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_"
     "objective_only_next_decision"
 )
+OUTSIDE_SOLOING_REPAIR_OBJECTIVE_BOUNDARY = (
+    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_"
+    "outside_soloing_repair_objective_only_next_decision"
+)
 
 
 def _dict(value: Any) -> dict[str, Any]:
@@ -625,6 +629,140 @@ def validate_model_conditioned_pitch_contour_changed_ratio_repair_objective_next
     }
 
 
+def validate_outside_soloing_repair_objective_next(
+    report: dict[str, Any],
+) -> dict[str, Any]:
+    boundary = str(report.get("boundary") or "")
+    if boundary != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_BOUNDARY:
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "outside-soloing repair objective boundary required"
+        )
+    summary = _dict(report.get("objective_summary"))
+    readiness = _dict(report.get("readiness"))
+    decision = _dict(report.get("decision"))
+    if str(decision.get("next_boundary") or "") != BOUNDARY:
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "outside-soloing repair objective should route to current evidence"
+        )
+    if not bool(readiness.get("objective_next_decision_completed", False)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "outside-soloing repair objective completion required"
+        )
+    if not bool(summary.get("outside_soloing_repair_objective_path_supported", False)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "outside-soloing repair objective path support required"
+        )
+    if not bool(summary.get("current_evidence_consolidation_ready", False)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "outside-soloing repair current evidence readiness required"
+        )
+    if not bool(summary.get("technical_wav_validation", False)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "outside-soloing repair technical WAV validation required"
+        )
+    if _int(summary.get("rendered_audio_file_count")) < 6:
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "outside-soloing repair rendered WAV count below 6"
+        )
+    if _int(summary.get("outside_soloing_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "outside-soloing repair residual pitch-role risk should be zero"
+        )
+    if _int(summary.get("weak_chord_tone_landing_risk_count_after")) != 0:
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "outside-soloing repair weak landing risk should be zero"
+        )
+    if not bool(summary.get("outside_soloing_target_supported", False)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "outside-soloing target support required"
+        )
+    if not bool(summary.get("weak_landing_target_supported", False)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "weak landing target support required"
+        )
+    if not bool(summary.get("final_landing_target_supported", False)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "final landing target support required"
+        )
+    if not bool(summary.get("non_chord_run_target_supported", False)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "non-chord run target support required"
+        )
+    if bool(summary.get("validated_review_input_present", True)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "outside-soloing repair review input should remain absent"
+        )
+    if bool(summary.get("preference_fill_allowed", True)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "outside-soloing repair preference fill should remain blocked"
+        )
+    if bool(decision.get("critical_user_input_required", True)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "outside-soloing repair critical user input should not be required"
+        )
+    blocked_claims = [
+        "human_audio_preference_claimed",
+        "midi_to_solo_musical_quality_claimed",
+        "audio_rendered_quality_claimed",
+        "model_checkpoint_generation_quality_claimed",
+        "model_direct_generation_quality_claimed",
+        "broad_trained_model_quality_claimed",
+        "brad_style_adaptation_claimed",
+        "production_ready_claimed",
+    ]
+    claimed = [name for name in blocked_claims if bool(readiness.get(name, False))]
+    if claimed:
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            f"unexpected outside-soloing repair claim: {claimed}"
+        )
+    return {
+        "boundary": OUTSIDE_SOLOING_REPAIR_OBJECTIVE_BOUNDARY,
+        "objective_next_completed": bool(readiness.get("objective_next_completed", False)),
+        "objective_next_decision_completed": bool(
+            readiness.get("objective_next_decision_completed", False)
+        ),
+        "current_evidence_consolidation_ready": bool(
+            summary.get("current_evidence_consolidation_ready", False)
+        ),
+        "outside_soloing_repair_objective_path_supported": bool(
+            summary.get("outside_soloing_repair_objective_path_supported", False)
+        ),
+        "review_item_count": _int(summary.get("review_item_count")),
+        "validated_review_input_present": bool(
+            summary.get("validated_review_input_present", True)
+        ),
+        "preference_fill_allowed": bool(summary.get("preference_fill_allowed", True)),
+        "technical_wav_validation": bool(summary.get("technical_wav_validation", False)),
+        "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
+        "changed_note_total": _int(summary.get("changed_note_total")),
+        "outside_soloing_pitch_role_risk_count_after": _int(
+            summary.get("outside_soloing_pitch_role_risk_count_after")
+        ),
+        "outside_soloing_pitch_role_risk_delta": _int(
+            summary.get("outside_soloing_pitch_role_risk_delta")
+        ),
+        "outside_soloing_target_supported": bool(
+            summary.get("outside_soloing_target_supported", False)
+        ),
+        "weak_chord_tone_landing_risk_count_after": _int(
+            summary.get("weak_chord_tone_landing_risk_count_after")
+        ),
+        "weak_landing_target_supported": bool(
+            summary.get("weak_landing_target_supported", False)
+        ),
+        "final_landing_chord_tone_count_after": _int(
+            summary.get("final_landing_chord_tone_count_after")
+        ),
+        "final_landing_target_supported": bool(
+            summary.get("final_landing_target_supported", False)
+        ),
+        "max_non_chord_tone_run_after": _int(summary.get("max_non_chord_tone_run_after")),
+        "non_chord_run_target_supported": bool(
+            summary.get("non_chord_run_target_supported", False)
+        ),
+    }
+
+
 def build_current_evidence_consolidation_report(
     *,
     contract_report: dict[str, Any],
@@ -639,6 +777,7 @@ def build_current_evidence_consolidation_report(
         str, Any
     ]
     | None = None,
+    outside_soloing_repair_objective_next: dict[str, Any] | None = None,
     output_dir: Path,
     issue_number: int,
 ) -> dict[str, Any]:
@@ -663,6 +802,13 @@ def build_current_evidence_consolidation_report(
         if model_conditioned_pitch_contour_changed_ratio_repair_objective_next
         else {}
     )
+    outside_soloing_repair_objective = (
+        validate_outside_soloing_repair_objective_next(
+            outside_soloing_repair_objective_next
+        )
+        if outside_soloing_repair_objective_next
+        else {}
+    )
     technical_path_supported = (
         bool(resource["midi_to_solo_training_resource_ready"])
         and generation["exported_candidate_count"] >= 3
@@ -684,12 +830,19 @@ def build_current_evidence_consolidation_report(
             not bool(model_conditioned_pitch_contour_changed_ratio_repair_objective_next),
         )
     )
+    outside_soloing_repair_objective_path_ready = bool(
+        outside_soloing_repair_objective.get(
+            "current_evidence_consolidation_ready",
+            not bool(outside_soloing_repair_objective_next),
+        )
+    )
     current_evidence_supported = bool(
         technical_path_supported
         and selected_scale_objective_path_complete
         and phrase_bank_cli_technical_path_ready
         and model_conditioned_pitch_contour_objective_path_ready
         and model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready
+        and outside_soloing_repair_objective_path_ready
     )
     source_boundaries = {
         "contract": contract["boundary"],
@@ -709,6 +862,10 @@ def build_current_evidence_consolidation_report(
         source_boundaries[
             "model_conditioned_pitch_contour_changed_ratio_repair_objective_next"
         ] = model_conditioned_pitch_contour_changed_ratio_repair_objective["boundary"]
+    if outside_soloing_repair_objective:
+        source_boundaries["outside_soloing_repair_objective_next"] = (
+            outside_soloing_repair_objective["boundary"]
+        )
     return {
         "schema_version": SCHEMA_VERSION,
         "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
@@ -727,6 +884,7 @@ def build_current_evidence_consolidation_report(
         "model_conditioned_pitch_contour_changed_ratio_repair_objective_path": (
             model_conditioned_pitch_contour_changed_ratio_repair_objective
         ),
+        "outside_soloing_repair_objective_path": outside_soloing_repair_objective,
         "readiness": {
             "boundary": BOUNDARY,
             "mvp_current_evidence_consolidated": True,
@@ -742,6 +900,9 @@ def build_current_evidence_consolidation_report(
             ),
             "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready": bool(
                 model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready
+            ),
+            "outside_soloing_repair_objective_path_ready": bool(
+                outside_soloing_repair_objective_path_ready
             ),
             "current_mvp_technical_execution_evidence_supported": technical_path_supported,
             "current_mvp_objective_repair_evidence_supported": selected_scale_objective_path_complete,
@@ -783,6 +944,11 @@ def build_current_evidence_consolidation_report(
                 if model_conditioned_pitch_contour_changed_ratio_repair_objective
                 else []
             ),
+            *(
+                ["outside_soloing_repair_objective_path_ready"]
+                if outside_soloing_repair_objective
+                else []
+            ),
             "quality_claim_guard_preserved",
         ],
         "not_proven": [
@@ -808,6 +974,7 @@ def validate_current_evidence_consolidation_report(
     min_objective_sample_count: int,
     require_model_conditioned_pitch_contour_objective: bool = False,
     require_model_conditioned_pitch_contour_changed_ratio_repair_objective: bool = False,
+    require_outside_soloing_repair_objective: bool = False,
 ) -> dict[str, Any]:
     boundary = str(report.get("boundary") or "")
     readiness = _dict(report.get("readiness"))
@@ -822,9 +989,8 @@ def validate_current_evidence_consolidation_report(
     model_conditioned_pitch_contour_changed_ratio_repair = _dict(
         report.get("model_conditioned_pitch_contour_changed_ratio_repair_objective_path")
     )
-    model_conditioned_pitch_contour_changed_ratio_repair = _dict(
-        report.get("model_conditioned_pitch_contour_changed_ratio_repair_objective_path")
-    )
+    outside_soloing_repair = _dict(report.get("outside_soloing_repair_objective_path"))
+    outside_soloing_repair = _dict(report.get("outside_soloing_repair_objective_path"))
     if expected_boundary and boundary != expected_boundary:
         raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
             f"expected boundary {expected_boundary}, got {boundary}"
@@ -876,6 +1042,18 @@ def validate_current_evidence_consolidation_report(
     ):
         raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
             "model-conditioned pitch-contour changed-ratio repair preference fill should remain blocked"
+        )
+    if require_outside_soloing_repair_objective and not bool(
+        readiness.get("outside_soloing_repair_objective_path_ready", False)
+    ):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "outside-soloing repair objective path support required"
+        )
+    if outside_soloing_repair and bool(
+        outside_soloing_repair.get("preference_fill_allowed", True)
+    ):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "outside-soloing repair preference fill should remain blocked"
         )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError("critical user input should not be required")
@@ -963,6 +1141,39 @@ def validate_current_evidence_consolidation_report(
                 False,
             )
         ),
+        "outside_soloing_repair_objective_path_ready": bool(
+            readiness.get("outside_soloing_repair_objective_path_ready", False)
+        ),
+        "outside_soloing_repair_rendered_audio_file_count": _int(
+            outside_soloing_repair.get("rendered_audio_file_count")
+        ),
+        "outside_soloing_repair_changed_note_total": _int(
+            outside_soloing_repair.get("changed_note_total")
+        ),
+        "outside_soloing_repair_pitch_role_risk_count_after": _int(
+            outside_soloing_repair.get("outside_soloing_pitch_role_risk_count_after")
+        ),
+        "outside_soloing_repair_pitch_role_risk_delta": _int(
+            outside_soloing_repair.get("outside_soloing_pitch_role_risk_delta")
+        ),
+        "outside_soloing_repair_target_supported": bool(
+            outside_soloing_repair.get("outside_soloing_target_supported", False)
+        ),
+        "outside_soloing_repair_weak_landing_target_supported": bool(
+            outside_soloing_repair.get("weak_landing_target_supported", False)
+        ),
+        "outside_soloing_repair_final_landing_target_supported": bool(
+            outside_soloing_repair.get("final_landing_target_supported", False)
+        ),
+        "outside_soloing_repair_non_chord_run_target_supported": bool(
+            outside_soloing_repair.get("non_chord_run_target_supported", False)
+        ),
+        "outside_soloing_repair_objective_path_supported": bool(
+            outside_soloing_repair.get(
+                "outside_soloing_repair_objective_path_supported",
+                False,
+            )
+        ),
         "cli_candidate_count": _int(cli_objective.get("candidate_count")),
         "cli_rendered_audio_file_count": _int(cli_objective.get("rendered_audio_file_count")),
         "cli_input_context_bars": _int(cli_objective.get("input_context_bars")),
@@ -1011,6 +1222,7 @@ def markdown_report(report: dict[str, Any]) -> str:
     model_conditioned_pitch_contour_changed_ratio_repair = _dict(
         report.get("model_conditioned_pitch_contour_changed_ratio_repair_objective_path")
     )
+    outside_soloing_repair = _dict(report.get("outside_soloing_repair_objective_path"))
     lines = [
         "# Stage B MIDI-to-Solo MVP Current Evidence Consolidation",
         "",
@@ -1024,6 +1236,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- phrase-bank CLI technical path ready: `{_bool_token(readiness['phrase_bank_cli_technical_path_ready'])}`",
         f"- model-conditioned pitch-contour objective path ready: `{_bool_token(readiness['model_conditioned_pitch_contour_objective_path_ready'])}`",
         f"- model-conditioned pitch-contour changed-ratio repair objective path ready: `{_bool_token(readiness['model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready'])}`",
+        f"- outside-soloing repair objective path ready: `{_bool_token(readiness['outside_soloing_repair_objective_path_ready'])}`",
         f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
         f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
         "",
@@ -1108,6 +1321,26 @@ def markdown_report(report: dict[str, Any]) -> str:
                 "",
             ]
         )
+    if outside_soloing_repair:
+        lines.extend(
+            [
+                "## Outside-Soloing Repair Objective Path",
+                "",
+                f"- current evidence consolidation ready: `{_bool_token(outside_soloing_repair['current_evidence_consolidation_ready'])}`",
+                f"- objective path supported: `{_bool_token(outside_soloing_repair['outside_soloing_repair_objective_path_supported'])}`",
+                f"- rendered WAV files: `{outside_soloing_repair['rendered_audio_file_count']}`",
+                f"- technical WAV validation: `{_bool_token(outside_soloing_repair['technical_wav_validation'])}`",
+                f"- changed note total: `{outside_soloing_repair['changed_note_total']}`",
+                f"- outside-soloing pitch-role risk after / delta: `{outside_soloing_repair['outside_soloing_pitch_role_risk_count_after']}` / `{outside_soloing_repair['outside_soloing_pitch_role_risk_delta']}`",
+                f"- outside-soloing target supported: `{_bool_token(outside_soloing_repair['outside_soloing_target_supported'])}`",
+                f"- weak landing target supported: `{_bool_token(outside_soloing_repair['weak_landing_target_supported'])}`",
+                f"- final landing chord-tone count after: `{outside_soloing_repair['final_landing_chord_tone_count_after']}`",
+                f"- max non-chord-tone run after: `{outside_soloing_repair['max_non_chord_tone_run_after']}`",
+                f"- non-chord run target supported: `{_bool_token(outside_soloing_repair['non_chord_run_target_supported'])}`",
+                f"- preference fill allowed: `{_bool_token(outside_soloing_repair['preference_fill_allowed'])}`",
+                "",
+            ]
+        )
     lines.extend(["## MIDI Paths", ""])
     for item in generation["midi_paths"]:
         lines.append(f"- `{item}`")
@@ -1136,6 +1369,7 @@ def build_parser() -> argparse.ArgumentParser:
         type=str,
         default="",
     )
+    parser.add_argument("--outside_soloing_repair_objective_next", type=str, default="")
     parser.add_argument(
         "--output_root",
         type=str,
@@ -1152,6 +1386,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--require_model_conditioned_pitch_contour_changed_ratio_repair_objective",
         action="store_true",
     )
+    parser.add_argument("--require_outside_soloing_repair_objective", action="store_true")
     parser.add_argument("--require_no_quality_claim", action="store_true")
     parser.add_argument("--min_exported_candidates", type=int, default=3)
     parser.add_argument("--min_rendered_wav_files", type=int, default=3)
@@ -1185,6 +1420,11 @@ def main() -> int:
             if args.model_conditioned_pitch_contour_changed_ratio_repair_objective_next
             else None
         ),
+        outside_soloing_repair_objective_next=(
+            read_json(Path(args.outside_soloing_repair_objective_next))
+            if args.outside_soloing_repair_objective_next
+            else None
+        ),
         output_dir=output_dir,
         issue_number=int(args.issue_number),
     )
@@ -1202,6 +1442,9 @@ def main() -> int:
         ),
         require_model_conditioned_pitch_contour_changed_ratio_repair_objective=bool(
             args.require_model_conditioned_pitch_contour_changed_ratio_repair_objective
+        ),
+        require_outside_soloing_repair_objective=bool(
+            args.require_outside_soloing_repair_objective
         ),
     )
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_stage_b_midi_to_solo_mvp_current_evidence_consolidation.py
+++ b/tests/test_stage_b_midi_to_solo_mvp_current_evidence_consolidation.py
@@ -28,6 +28,7 @@ def reports(
     dead_air_failure_count: int = 0,
     pitch_contour_supported: bool = True,
     changed_ratio_repair_supported: bool = True,
+    outside_soloing_repair_supported: bool = True,
     collapse_count: int = 0,
     quality_claim: bool = False,
 ) -> dict[str, dict]:
@@ -297,6 +298,51 @@ def reports(
                 "critical_user_input_required": False,
             },
         },
+        "outside_soloing_repair_objective": {
+            "boundary": (
+                "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_"
+                "chord_tone_landing_outside_soloing_repair_objective_only_next_decision"
+            ),
+            "objective_summary": {
+                "review_item_count": 6,
+                "validated_review_input_present": False,
+                "preference_fill_allowed": False,
+                "technical_wav_validation": True,
+                "rendered_audio_file_count": 6,
+                "changed_note_total": 2,
+                "outside_soloing_pitch_role_risk_count_after": 0
+                if outside_soloing_repair_supported
+                else 1,
+                "outside_soloing_pitch_role_risk_delta": 2,
+                "outside_soloing_target_supported": outside_soloing_repair_supported,
+                "weak_chord_tone_landing_risk_count_after": 0,
+                "weak_landing_target_supported": True,
+                "final_landing_chord_tone_count_after": 6,
+                "final_landing_target_supported": True,
+                "max_non_chord_tone_run_after": 3,
+                "non_chord_run_target_supported": True,
+                "outside_soloing_repair_objective_path_supported": (
+                    outside_soloing_repair_supported
+                ),
+                "current_evidence_consolidation_ready": outside_soloing_repair_supported,
+            },
+            "readiness": {
+                "objective_next_completed": True,
+                "objective_next_decision_completed": True,
+                "human_audio_preference_claimed": False,
+                "midi_to_solo_musical_quality_claimed": quality_claim,
+                "audio_rendered_quality_claimed": False,
+                "model_checkpoint_generation_quality_claimed": False,
+                "model_direct_generation_quality_claimed": False,
+                "broad_trained_model_quality_claimed": False,
+                "brad_style_adaptation_claimed": False,
+                "production_ready_claimed": False,
+            },
+            "decision": {
+                "next_boundary": "stage_b_midi_to_solo_mvp_current_evidence_consolidation",
+                "critical_user_input_required": False,
+            },
+        },
     }
 
 
@@ -318,8 +364,11 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationTest(unittest.TestCase):
                 model_conditioned_pitch_contour_changed_ratio_repair_objective_next=data[
                     "model_conditioned_pitch_contour_changed_ratio_repair_objective"
                 ],
+                outside_soloing_repair_objective_next=data[
+                    "outside_soloing_repair_objective"
+                ],
                 output_dir=Path(tmp) / "out",
-                issue_number=728,
+                issue_number=812,
             )
             summary = validate_current_evidence_consolidation_report(
                 report,
@@ -332,6 +381,7 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationTest(unittest.TestCase):
                 min_objective_sample_count=9,
                 require_model_conditioned_pitch_contour_objective=True,
                 require_model_conditioned_pitch_contour_changed_ratio_repair_objective=True,
+                require_outside_soloing_repair_objective=True,
             )
 
             self.assertTrue(summary["midi_to_solo_mvp_current_evidence_supported"])
@@ -344,6 +394,7 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationTest(unittest.TestCase):
                     "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready"
                 ]
             )
+            self.assertTrue(summary["outside_soloing_repair_objective_path_ready"])
             self.assertEqual(summary["generation_source"], "context_conditioned_fallback")
             self.assertEqual(summary["exported_candidate_count"], 3)
             self.assertEqual(summary["rendered_audio_file_count"], 3)
@@ -386,6 +437,15 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationTest(unittest.TestCase):
                     "model_conditioned_pitch_contour_changed_ratio_repair_changed_ratio_target_supported"
                 ]
             )
+            self.assertEqual(summary["outside_soloing_repair_rendered_audio_file_count"], 6)
+            self.assertEqual(summary["outside_soloing_repair_changed_note_total"], 2)
+            self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_count_after"], 0)
+            self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_delta"], 2)
+            self.assertTrue(summary["outside_soloing_repair_target_supported"])
+            self.assertTrue(summary["outside_soloing_repair_weak_landing_target_supported"])
+            self.assertTrue(summary["outside_soloing_repair_final_landing_target_supported"])
+            self.assertTrue(summary["outside_soloing_repair_non_chord_run_target_supported"])
+            self.assertTrue(summary["outside_soloing_repair_objective_path_supported"])
             self.assertFalse(summary["human_audio_preference_claimed"])
             self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
             self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
@@ -493,6 +553,31 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationTest(unittest.TestCase):
                     ],
                     output_dir=Path(tmp) / "out",
                     issue_number=728,
+                )
+
+    def test_rejects_missing_outside_soloing_repair_support(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            data = reports(Path(tmp), outside_soloing_repair_supported=False)
+            with self.assertRaises(StageBMidiToSoloMvpCurrentEvidenceConsolidationError):
+                build_current_evidence_consolidation_report(
+                    contract_report=data["contract"],
+                    context_report=data["context"],
+                    resource_probe=data["resource"],
+                    generation_probe=data["generation"],
+                    audio_render=data["audio"],
+                    objective_next=data["objective"],
+                    cli_objective_next=data["cli_objective"],
+                    model_conditioned_pitch_contour_objective_next=data[
+                        "model_conditioned_pitch_contour_objective"
+                    ],
+                    model_conditioned_pitch_contour_changed_ratio_repair_objective_next=data[
+                        "model_conditioned_pitch_contour_changed_ratio_repair_objective"
+                    ],
+                    outside_soloing_repair_objective_next=data[
+                        "outside_soloing_repair_objective"
+                    ],
+                    output_dir=Path(tmp) / "out",
+                    issue_number=812,
                 )
 
     def test_boundary_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary

- current evidence consolidation에 outside-soloing repair objective path 추가
- outside-soloing repair readiness와 summary 필드 추가
- harness 입력 경로와 required flag 추가
- status/core plan 기록 갱신

## Context

- Issue #810 objective-only next decision 완료
- outside-soloing pitch-role risk count after: `0`
- outside-soloing pitch-role risk delta: `2`
- weak landing target supported: `true`
- final landing target supported: `true`
- non-chord run target supported: `true`
- current evidence consolidation ready: `true`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_current_evidence_consolidation`
- `.venv/bin/python -m py_compile scripts/consolidate_stage_b_midi_to_solo_mvp_current_evidence.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-current-evidence-consolidation`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- human/audio preference 미확정
- MIDI-to-solo musical quality 미확정
- README evidence refresh 미갱신

## Follow-up

- README evidence refresh

Closes #812


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated planning and status documentation to reflect progress on Stage B MIDI-to-solo development workflow.
  * Added new evidence consolidation documentation capturing current status and readiness metrics.

* **Tests**
  * Extended test coverage to validate new workflow requirements and constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->