### PR TITLE
Stage B MIDI-to-solo README outside-soloing evidence refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- latest evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -129,6 +129,13 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - pitch-contour changed-ratio repair max interval / target: `12 / 12`
 - pitch-contour changed-ratio repair max pitch changed ratio / target: `0.4348 / 0.5000`
 - current evidence changed-ratio repair objective path included: `true`
+- outside-soloing repair objective path included in current evidence: `true`
+- outside-soloing repair WAV files: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing pitch-role risk count after: `0`
+- outside-soloing pitch-role risk delta: `2`
+- outside-soloing repair objective path supported: `true`
+- current evidence outside-soloing repair objective path included: `true`
 - listening review quality gap completed: `true`
 - listening review quality gap open: `true`
 - MVP delivery package completed: `true`
@@ -199,6 +206,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - model-conditioned pitch-contour changed-ratio review input pending 상태에서 preference fill 차단 가능
 - model-conditioned pitch-contour changed-ratio objective evidence 기준 current evidence consolidation 경계 결정 가능
 - model-conditioned pitch-contour changed-ratio objective path를 current evidence로 통합 가능
+- outside-soloing repair objective path를 current evidence로 통합 가능
 - listening review quality gap을 delivery package 경계로 분리 가능
 - runnable CLI command와 local MIDI/WAV evidence path를 delivery manifest로 기록 가능
 - raw MIDI/WAV artifact upload 없이 local output path 기준 MVP delivery package 기록 가능
@@ -226,6 +234,23 @@ MVP completion audit.
 - human/audio preference completed: `false`
 - product MVP completed: `false`
 - next boundary: `stage_b_midi_to_solo_quality_gap_decision`
+
+MVP current evidence refresh.
+
+- boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- next boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
+- current MVP evidence supported: `true`
+- selected-scale objective path complete: `true`
+- phrase-bank CLI technical path ready: `true`
+- model-conditioned pitch-contour objective path ready: `true`
+- model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
+- outside-soloing repair objective path ready: `true`
+- outside-soloing repair rendered audio file count: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing repair pitch-role risk count after: `0`
+- outside-soloing repair pitch-role risk delta: `2`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
 
 Quality gap decision.
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -5766,6 +5766,46 @@ Issue #812는 current evidence consolidation에 Issue #810 outside-soloing repai
 
 - `Stage B MIDI-to-solo README evidence refresh`
 
+## 9.98 Stage B MIDI-to-solo README evidence refresh outside-soloing repair path
+
+Issue #814는 README 현재 상태와 claim boundary에 Issue #812 current evidence를 반영한 문서 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
+- source boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- next boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- latest evidence boundary reflected: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- current MVP evidence supported: `true`
+- selected-scale objective path complete: `true`
+- phrase-bank CLI technical path ready: `true`
+- model-conditioned pitch-contour objective path ready: `true`
+- model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
+- outside-soloing repair objective path ready: `true`
+- outside-soloing repair rendered audio file count: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing repair pitch-role risk count after: `0`
+- outside-soloing repair pitch-role risk delta: `2`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- README 첫 상태 영역에 Issue #812 current evidence 반영.
+- outside-soloing repair objective path 포함 상태 추가.
+- current evidence section에 outside-soloing repair 수치 추가.
+- 청음 preference와 musical quality claim 제외 유지.
+- 다음 boundary는 MVP completion audit refresh.
+
+검증:
+
+- `git diff --check`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo MVP completion audit refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #812, Stage B MIDI-to-solo MVP current evidence consolidation outside-soloing repair refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo README evidence refresh`
+- latest functional result: Issue #814, Stage B MIDI-to-solo README evidence refresh outside-soloing repair path
+- 다음 권장 이슈: `Stage B MIDI-to-solo MVP completion audit refresh`
 
 현재 범위가 아닌 것:
 
@@ -354,6 +354,16 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 README target: `stage_b_midi_to_solo_readme_evidence_refresh`
+- README evidence refresh outside-soloing repair path 완료
+- latest evidence boundary reflected: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- current MVP evidence supported: `true`
+- outside-soloing repair objective path ready: `true`
+- outside-soloing repair rendered audio file count: `6`
+- outside-soloing repair pitch-role risk count after: `0`
+- outside-soloing repair pitch-role risk delta: `2`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 audit target: `stage_b_midi_to_solo_mvp_completion_audit`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_README_EVIDENCE_REFRESH_OUTSIDE_SOLOING_REPAIR_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_README_EVIDENCE_REFRESH_OUTSIDE_SOLOING_REPAIR_2026-06-10.md
@@ -1,0 +1,34 @@
+# Stage B MIDI-to-Solo README Evidence Refresh Outside-Soloing Repair
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
+- source boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- next boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- latest evidence boundary reflected: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- current MVP evidence supported: `true`
+- selected-scale objective path complete: `true`
+- phrase-bank CLI technical path ready: `true`
+- model-conditioned pitch-contour objective path ready: `true`
+- model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
+- outside-soloing repair objective path ready: `true`
+- outside-soloing repair rendered audio file count: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing repair pitch-role risk count after: `0`
+- outside-soloing repair pitch-role risk delta: `2`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Claim Boundary
+
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- broad trained-model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+
+## Decision
+
+- README current status에 Issue #812 current evidence 반영.
+- outside-soloing repair objective path 포함 상태 반영.
+- 청음 preference와 musical quality claim 제외 유지.
+- next recommended issue: `Stage B MIDI-to-solo MVP completion audit refresh`


### PR DESCRIPTION
## Summary

- README current evidence boundary 갱신
- outside-soloing repair objective path 수치 반영
- README evidence refresh 문서 추가
- status/core plan 기록 갱신

## Context

- Issue #812 current evidence consolidation refresh 완료
- current MVP evidence supported: `true`
- outside-soloing repair objective path ready: `true`
- outside-soloing repair rendered audio file count: `6`
- outside-soloing repair changed note total: `2`
- outside-soloing pitch-role risk count after: `0`
- outside-soloing pitch-role risk delta: `2`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Validation

- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- human/audio preference 미확정
- MIDI-to-solo musical quality 미확정

## Follow-up

- MVP completion audit refresh

Closes #814
