### PR TITLE
Stage B MIDI-to-solo MVP completion audit outside-soloing repair refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - MVP completion audit completed: `true`
 - MVP completion audit model-conditioned pitch-contour objective included: `true`
 - MVP completion audit changed-ratio repair objective included: `true`
+- MVP completion audit outside-soloing repair objective included: `true`
 - quality gap decision completed: `true`
 - quality gap decision listening review target selected: `true`
 - pitch-contour changed-ratio review decision completed: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -5806,6 +5806,54 @@ Issue #814는 README 현재 상태와 claim boundary에 Issue #812 current evide
 
 - `Stage B MIDI-to-solo MVP completion audit refresh`
 
+## 9.99 Stage B MIDI-to-solo MVP completion audit outside-soloing repair refresh
+
+Issue #816은 MVP completion audit에 Issue #812 outside-soloing repair current evidence path를 필수 완료 조건으로 반영한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- next boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- technical model-core MVP completed: `true`
+- input to ranked MIDI completed: `true`
+- input to rendered WAV completed: `true`
+- selected-scale objective repair completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour changed-ratio repair objective completed: `true`
+- outside-soloing repair objective completed: `true`
+- outside-soloing repair rendered audio file count: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing repair pitch-role risk count after: `0`
+- outside-soloing repair pitch-role risk delta: `2`
+- outside-soloing repair objective path supported: `true`
+- outside-soloing repair target supported: `true`
+- outside-soloing repair weak landing target supported: `true`
+- outside-soloing repair final landing target supported: `true`
+- outside-soloing repair non-chord run target supported: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- completion audit의 current evidence 필수 조건에 outside-soloing repair objective path 추가.
+- README required snippet에 outside-soloing repair current evidence 포함 상태 추가.
+- outside-soloing pitch-role risk count after `0` 기준 objective support 유지.
+- weak landing, final landing, non-chord run target support 모두 유지.
+- musical quality, human/audio preference, broad trained-model quality claim 제외 유지.
+- 다음 boundary는 quality gap decision refresh.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
+- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_mvp_completion.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo quality gap decision refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #814, Stage B MIDI-to-solo README evidence refresh outside-soloing repair path
-- 다음 권장 이슈: `Stage B MIDI-to-solo MVP completion audit refresh`
+- latest functional result: Issue #816, Stage B MIDI-to-solo MVP completion audit outside-soloing repair refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo quality gap decision refresh`
 
 현재 범위가 아닌 것:
 
@@ -364,6 +364,16 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 audit target: `stage_b_midi_to_solo_mvp_completion_audit`
+- MVP completion audit outside-soloing repair refresh 완료
+- technical model-core MVP completed: `true`
+- outside-soloing repair objective completed: `true`
+- outside-soloing repair rendered audio file count: `6`
+- outside-soloing repair pitch-role risk count after: `0`
+- outside-soloing repair pitch-role risk delta: `2`
+- outside-soloing repair objective path supported: `true`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 decision target: `stage_b_midi_to_solo_quality_gap_decision`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_OUTSIDE_SOLOING_REPAIR_REFRESH_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_OUTSIDE_SOLOING_REPAIR_REFRESH_2026-06-10.md
@@ -1,0 +1,78 @@
+# Stage B MIDI-to-Solo MVP Completion Audit
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- next boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- technical model-core MVP completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour changed-ratio repair objective completed: `true`
+- outside-soloing repair objective completed: `true`
+- musical quality MVP completed: `false`
+- human/audio preference completed: `false`
+- product MVP completed: `false`
+
+## Evidence
+
+- source boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- generation source: `context_conditioned_fallback`
+- exported / qualified candidates: `3` / `3`
+- rendered WAV files: `3`
+- technical WAV validation: `true`
+- WAV duration range: `18.617s-18.991s`
+- objective sample / strict / grammar: `9` / `9` / `9`
+- objective dead-air / collapse failure: `0` / `0`
+- objective avg / target postprocess removal: `0.21759259259259262` / `0.3`
+- phrase-bank CLI technical path ready: `true`
+- CLI candidate / rendered WAV: `3` / `3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- model-conditioned pitch-contour objective path ready: `true`
+- model-conditioned pitch-contour rendered WAV files: `3`
+- model-conditioned pitch-contour technical WAV validation: `true`
+- model-conditioned pitch-contour max interval / threshold: `11` / `12`
+- model-conditioned pitch-contour target supported: `true`
+- model-conditioned pitch-contour max pitch changed ratio: `0.7174`
+- model-conditioned pitch-contour changed-ratio review required: `true`
+- model-conditioned pitch-contour audio review required: `true`
+- model-conditioned pitch-contour preference fill allowed: `false`
+- model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
+- model-conditioned pitch-contour changed-ratio repair rendered WAV files: `3`
+- model-conditioned pitch-contour changed-ratio repair technical WAV validation: `true`
+- model-conditioned pitch-contour changed-ratio repair max interval / threshold: `12` / `12`
+- model-conditioned pitch-contour changed-ratio repair max ratio / target: `0.4348` / `0.5000`
+- model-conditioned pitch-contour changed-ratio repair target supported: `true`
+- model-conditioned pitch-contour changed-ratio repair audio review required: `true`
+- model-conditioned pitch-contour changed-ratio repair preference fill allowed: `false`
+- outside-soloing repair objective path ready: `true`
+- outside-soloing repair current evidence ready: `true`
+- outside-soloing repair rendered WAV files: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing pitch-role risk after / delta: `0` / `2`
+- outside-soloing repair objective path supported: `true`
+- outside-soloing repair target supported: `true`
+- outside-soloing repair weak landing target supported: `true`
+- outside-soloing repair final landing target supported: `true`
+- outside-soloing repair non-chord run target supported: `true`
+- outside-soloing repair preference fill allowed: `false`
+
+## Claim Boundary
+
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- broad trained model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+- production ready claimed: `false`
+
+## Not Proven
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`
+- `production_ready_improviser`
+
+## Next
+
+- `Stage B MIDI-to-solo quality gap decision`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6014,13 +6014,14 @@ run_stage_b_midi_to_solo_mvp_completion_audit() {
     --run_id "$run_id" \
     --current_evidence "$current_evidence" \
     --readme_path README.md \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_2026-06-09.md \
-    --issue_number 732 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_OUTSIDE_SOLOING_REPAIR_REFRESH_2026-06-10.md \
+    --issue_number 816 \
     --expected_boundary stage_b_midi_to_solo_mvp_completion_audit \
     --expected_next_boundary stage_b_midi_to_solo_quality_gap_decision \
     --require_technical_mvp_completion \
     --require_model_conditioned_pitch_contour_objective \
     --require_model_conditioned_pitch_contour_changed_ratio_repair_objective \
+    --require_outside_soloing_repair_objective \
     --require_no_quality_claim
 }
 

--- a/scripts/audit_stage_b_midi_to_solo_mvp_completion.py
+++ b/scripts/audit_stage_b_midi_to_solo_mvp_completion.py
@@ -67,6 +67,7 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
     model_conditioned_pitch_contour_changed_ratio_repair = _dict(
         report.get("model_conditioned_pitch_contour_changed_ratio_repair_objective_path")
     )
+    outside_soloing_repair = _dict(report.get("outside_soloing_repair_objective_path"))
     decision = _dict(report.get("decision"))
     required_true = [
         "mvp_current_evidence_consolidated",
@@ -79,6 +80,7 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
         "phrase_bank_cli_technical_path_ready",
         "model_conditioned_pitch_contour_objective_path_ready",
         "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready",
+        "outside_soloing_repair_objective_path_ready",
         "current_mvp_technical_execution_evidence_supported",
         "current_mvp_objective_repair_evidence_supported",
         "midi_to_solo_mvp_current_evidence_supported",
@@ -230,6 +232,55 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloMvpCompletionAuditError(
             "model-conditioned pitch-contour changed-ratio repair preference fill should remain blocked"
         )
+    if not bool(outside_soloing_repair):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "outside-soloing repair objective path required"
+        )
+    if not bool(outside_soloing_repair.get("current_evidence_consolidation_ready", False)):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "outside-soloing repair current evidence readiness required"
+        )
+    if not bool(outside_soloing_repair.get("outside_soloing_repair_objective_path_supported", False)):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "outside-soloing repair objective path support required"
+        )
+    if _int(outside_soloing_repair.get("rendered_audio_file_count")) < 6:
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "outside-soloing repair rendered WAV count below 6"
+        )
+    if not bool(outside_soloing_repair.get("technical_wav_validation", False)):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "outside-soloing repair technical WAV validation required"
+        )
+    if _int(outside_soloing_repair.get("outside_soloing_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "outside-soloing repair residual pitch-role risk should be zero"
+        )
+    if _int(outside_soloing_repair.get("weak_chord_tone_landing_risk_count_after")) != 0:
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "outside-soloing repair weak landing risk should be zero"
+        )
+    required_outside_targets = [
+        "outside_soloing_target_supported",
+        "weak_landing_target_supported",
+        "final_landing_target_supported",
+        "non_chord_run_target_supported",
+    ]
+    missing_outside_targets = [
+        name for name in required_outside_targets if not bool(outside_soloing_repair.get(name, False))
+    ]
+    if missing_outside_targets:
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            f"outside-soloing repair targets missing: {missing_outside_targets}"
+        )
+    if bool(outside_soloing_repair.get("validated_review_input_present", True)):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "outside-soloing repair review input should remain absent"
+        )
+    if bool(outside_soloing_repair.get("preference_fill_allowed", True)):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "outside-soloing repair preference fill should remain blocked"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloMvpCompletionAuditError("critical user input should not be required")
     return {
@@ -355,6 +406,45 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
                 True,
             )
         ),
+        "outside_soloing_repair_objective_path_ready": bool(
+            readiness.get("outside_soloing_repair_objective_path_ready", False)
+        ),
+        "outside_soloing_repair_current_evidence_ready": bool(
+            outside_soloing_repair.get("current_evidence_consolidation_ready", False)
+        ),
+        "outside_soloing_repair_rendered_audio_file_count": _int(
+            outside_soloing_repair.get("rendered_audio_file_count")
+        ),
+        "outside_soloing_repair_changed_note_total": _int(
+            outside_soloing_repair.get("changed_note_total")
+        ),
+        "outside_soloing_repair_pitch_role_risk_count_after": _int(
+            outside_soloing_repair.get("outside_soloing_pitch_role_risk_count_after")
+        ),
+        "outside_soloing_repair_pitch_role_risk_delta": _int(
+            outside_soloing_repair.get("outside_soloing_pitch_role_risk_delta")
+        ),
+        "outside_soloing_repair_objective_path_supported": bool(
+            outside_soloing_repair.get(
+                "outside_soloing_repair_objective_path_supported",
+                False,
+            )
+        ),
+        "outside_soloing_repair_target_supported": bool(
+            outside_soloing_repair.get("outside_soloing_target_supported", False)
+        ),
+        "outside_soloing_repair_weak_landing_target_supported": bool(
+            outside_soloing_repair.get("weak_landing_target_supported", False)
+        ),
+        "outside_soloing_repair_final_landing_target_supported": bool(
+            outside_soloing_repair.get("final_landing_target_supported", False)
+        ),
+        "outside_soloing_repair_non_chord_run_target_supported": bool(
+            outside_soloing_repair.get("non_chord_run_target_supported", False)
+        ),
+        "outside_soloing_repair_preference_fill_allowed": bool(
+            outside_soloing_repair.get("preference_fill_allowed", True)
+        ),
     }
 
 
@@ -376,6 +466,12 @@ def validate_readme_refresh(readme_text: str) -> dict[str, Any]:
         ),
         "model_conditioned_pitch_contour_changed_ratio_repair_in_current_evidence": (
             "current evidence changed-ratio repair objective path included: `true`"
+        ),
+        "outside_soloing_repair": (
+            "outside-soloing repair objective path included in current evidence: `true`"
+        ),
+        "outside_soloing_repair_in_current_evidence": (
+            "current evidence outside-soloing repair objective path included: `true`"
         ),
         "readme_refresh": "README evidence refreshed: `true`",
         "human_preference_false": "human/audio preference claim: `false`",
@@ -411,6 +507,7 @@ def build_mvp_completion_audit_report(
         and evidence[
             "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready"
         ]
+        and evidence["outside_soloing_repair_objective_path_ready"]
         and readme["readme_current_evidence_refreshed"]
     )
     return {
@@ -430,6 +527,7 @@ def build_mvp_completion_audit_report(
             "phrase_bank_cli_technical_path_completed": True,
             "model_conditioned_pitch_contour_objective_completed": True,
             "model_conditioned_pitch_contour_changed_ratio_repair_objective_completed": True,
+            "outside_soloing_repair_objective_completed": True,
             "readme_evidence_boundary_refreshed": True,
             "musical_quality_mvp_completed": False,
             "human_audio_preference_completed": False,
@@ -448,6 +546,9 @@ def build_mvp_completion_audit_report(
                 evidence[
                     "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready"
                 ]
+            ),
+            "outside_soloing_repair_objective_path_ready": bool(
+                evidence["outside_soloing_repair_objective_path_ready"]
             ),
             "quality_gap_decision_required": True,
             "human_audio_preference_claimed": False,
@@ -474,6 +575,7 @@ def build_mvp_completion_audit_report(
             "phrase_bank_cli_technical_path",
             "model_conditioned_pitch_contour_objective_path",
             "model_conditioned_pitch_contour_changed_ratio_repair_objective_path",
+            "outside_soloing_repair_objective_path",
             "readme_current_evidence_refresh",
         ],
         "not_proven": [
@@ -496,6 +598,7 @@ def validate_mvp_completion_audit_report(
     require_no_quality_claim: bool,
     require_model_conditioned_pitch_contour_objective: bool,
     require_model_conditioned_pitch_contour_changed_ratio_repair_objective: bool = False,
+    require_outside_soloing_repair_objective: bool = False,
 ) -> dict[str, Any]:
     boundary = str(report.get("boundary") or "")
     readiness = _dict(report.get("readiness"))
@@ -524,6 +627,12 @@ def validate_mvp_completion_audit_report(
     ):
         raise StageBMidiToSoloMvpCompletionAuditError(
             "model-conditioned pitch-contour changed-ratio repair objective completion required"
+        )
+    if require_outside_soloing_repair_objective and not bool(
+        audit.get("outside_soloing_repair_objective_completed", False)
+    ):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "outside-soloing repair objective completion required"
         )
     if not bool(readiness.get("quality_gap_decision_required", False)):
         raise StageBMidiToSoloMvpCompletionAuditError("quality gap decision should be required")
@@ -562,6 +671,9 @@ def validate_mvp_completion_audit_report(
                 "model_conditioned_pitch_contour_changed_ratio_repair_objective_completed",
                 False,
             )
+        ),
+        "outside_soloing_repair_objective_completed": bool(
+            audit.get("outside_soloing_repair_objective_completed", False)
         ),
         "musical_quality_mvp_completed": bool(audit.get("musical_quality_mvp_completed", True)),
         "human_audio_preference_completed": bool(audit.get("human_audio_preference_completed", True)),
@@ -642,6 +754,42 @@ def validate_mvp_completion_audit_report(
                 False,
             )
         ),
+        "outside_soloing_repair_objective_path_ready": bool(
+            evidence.get("outside_soloing_repair_objective_path_ready", False)
+        ),
+        "outside_soloing_repair_current_evidence_ready": bool(
+            evidence.get("outside_soloing_repair_current_evidence_ready", False)
+        ),
+        "outside_soloing_repair_rendered_audio_file_count": _int(
+            evidence.get("outside_soloing_repair_rendered_audio_file_count")
+        ),
+        "outside_soloing_repair_changed_note_total": _int(
+            evidence.get("outside_soloing_repair_changed_note_total")
+        ),
+        "outside_soloing_repair_pitch_role_risk_count_after": _int(
+            evidence.get("outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "outside_soloing_repair_pitch_role_risk_delta": _int(
+            evidence.get("outside_soloing_repair_pitch_role_risk_delta")
+        ),
+        "outside_soloing_repair_objective_path_supported": bool(
+            evidence.get("outside_soloing_repair_objective_path_supported", False)
+        ),
+        "outside_soloing_repair_target_supported": bool(
+            evidence.get("outside_soloing_repair_target_supported", False)
+        ),
+        "outside_soloing_repair_weak_landing_target_supported": bool(
+            evidence.get("outside_soloing_repair_weak_landing_target_supported", False)
+        ),
+        "outside_soloing_repair_final_landing_target_supported": bool(
+            evidence.get("outside_soloing_repair_final_landing_target_supported", False)
+        ),
+        "outside_soloing_repair_non_chord_run_target_supported": bool(
+            evidence.get("outside_soloing_repair_non_chord_run_target_supported", False)
+        ),
+        "outside_soloing_repair_preference_fill_allowed": bool(
+            evidence.get("outside_soloing_repair_preference_fill_allowed", True)
+        ),
         "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
         "midi_to_solo_musical_quality_claimed": bool(
             readiness.get("midi_to_solo_musical_quality_claimed", True)
@@ -667,6 +815,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- phrase-bank CLI technical path completed: `{_bool_token(audit['phrase_bank_cli_technical_path_completed'])}`",
         f"- model-conditioned pitch-contour objective completed: `{_bool_token(audit['model_conditioned_pitch_contour_objective_completed'])}`",
         f"- model-conditioned pitch-contour changed-ratio repair objective completed: `{_bool_token(audit['model_conditioned_pitch_contour_changed_ratio_repair_objective_completed'])}`",
+        f"- outside-soloing repair objective completed: `{_bool_token(audit['outside_soloing_repair_objective_completed'])}`",
         f"- musical quality MVP completed: `{_bool_token(audit['musical_quality_mvp_completed'])}`",
         f"- human/audio preference completed: `{_bool_token(audit['human_audio_preference_completed'])}`",
         f"- product MVP completed: `{_bool_token(audit['product_mvp_completed'])}`",
@@ -703,6 +852,17 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- model-conditioned pitch-contour changed-ratio repair target supported: `{_bool_token(evidence['model_conditioned_pitch_contour_changed_ratio_repair_target_supported'])}`",
         f"- model-conditioned pitch-contour changed-ratio repair audio review required: `{_bool_token(evidence['model_conditioned_pitch_contour_changed_ratio_repair_audio_review_required'])}`",
         f"- model-conditioned pitch-contour changed-ratio repair preference fill allowed: `{_bool_token(evidence['model_conditioned_pitch_contour_changed_ratio_repair_preference_fill_allowed'])}`",
+        f"- outside-soloing repair objective path ready: `{_bool_token(evidence['outside_soloing_repair_objective_path_ready'])}`",
+        f"- outside-soloing repair current evidence ready: `{_bool_token(evidence['outside_soloing_repair_current_evidence_ready'])}`",
+        f"- outside-soloing repair rendered WAV files: `{evidence['outside_soloing_repair_rendered_audio_file_count']}`",
+        f"- outside-soloing repair changed note total: `{evidence['outside_soloing_repair_changed_note_total']}`",
+        f"- outside-soloing pitch-role risk after / delta: `{evidence['outside_soloing_repair_pitch_role_risk_count_after']}` / `{evidence['outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- outside-soloing repair objective path supported: `{_bool_token(evidence['outside_soloing_repair_objective_path_supported'])}`",
+        f"- outside-soloing repair target supported: `{_bool_token(evidence['outside_soloing_repair_target_supported'])}`",
+        f"- outside-soloing repair weak landing target supported: `{_bool_token(evidence['outside_soloing_repair_weak_landing_target_supported'])}`",
+        f"- outside-soloing repair final landing target supported: `{_bool_token(evidence['outside_soloing_repair_final_landing_target_supported'])}`",
+        f"- outside-soloing repair non-chord run target supported: `{_bool_token(evidence['outside_soloing_repair_non_chord_run_target_supported'])}`",
+        f"- outside-soloing repair preference fill allowed: `{_bool_token(evidence['outside_soloing_repair_preference_fill_allowed'])}`",
         "",
         "## Claim Boundary",
         "",
@@ -742,6 +902,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--require_model_conditioned_pitch_contour_changed_ratio_repair_objective",
         action="store_true",
     )
+    parser.add_argument("--require_outside_soloing_repair_objective", action="store_true")
     return parser
 
 
@@ -769,6 +930,9 @@ def main() -> int:
         ),
         require_model_conditioned_pitch_contour_changed_ratio_repair_objective=bool(
             args.require_model_conditioned_pitch_contour_changed_ratio_repair_objective
+        ),
+        require_outside_soloing_repair_objective=bool(
+            args.require_outside_soloing_repair_objective
         ),
     )
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_stage_b_midi_to_solo_mvp_completion_audit.py
+++ b/tests/test_stage_b_midi_to_solo_mvp_completion_audit.py
@@ -21,7 +21,13 @@ def current_evidence(
     strict_count: int = 9,
     pitch_contour_supported: bool = True,
     changed_ratio_repair_supported: bool = True,
+    outside_soloing_repair_supported: bool = True,
 ) -> dict:
+    current_evidence_supported = bool(
+        pitch_contour_supported
+        and changed_ratio_repair_supported
+        and outside_soloing_repair_supported
+    )
     return {
         "boundary": CURRENT_EVIDENCE_BOUNDARY,
         "readiness": {
@@ -35,11 +41,10 @@ def current_evidence(
             "phrase_bank_cli_technical_path_ready": True,
             "model_conditioned_pitch_contour_objective_path_ready": pitch_contour_supported,
             "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready": changed_ratio_repair_supported,
+            "outside_soloing_repair_objective_path_ready": outside_soloing_repair_supported,
             "current_mvp_technical_execution_evidence_supported": True,
             "current_mvp_objective_repair_evidence_supported": True,
-            "midi_to_solo_mvp_current_evidence_supported": bool(
-                pitch_contour_supported and changed_ratio_repair_supported
-            ),
+            "midi_to_solo_mvp_current_evidence_supported": current_evidence_supported,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
             "broad_trained_model_quality_claimed": False,
@@ -113,6 +118,33 @@ def current_evidence(
             "changed_ratio_target_supported": changed_ratio_repair_supported,
             "audio_review_required": True,
         },
+        "outside_soloing_repair_objective_path": {
+            "boundary": (
+                "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_"
+                "chord_tone_landing_outside_soloing_repair_objective_only_next_decision"
+            ),
+            "objective_next_completed": True,
+            "objective_next_decision_completed": True,
+            "current_evidence_consolidation_ready": outside_soloing_repair_supported,
+            "outside_soloing_repair_objective_path_supported": outside_soloing_repair_supported,
+            "review_item_count": 6,
+            "validated_review_input_present": False,
+            "preference_fill_allowed": False,
+            "technical_wav_validation": True,
+            "rendered_audio_file_count": 6,
+            "changed_note_total": 2,
+            "outside_soloing_pitch_role_risk_count_after": (
+                0 if outside_soloing_repair_supported else 1
+            ),
+            "outside_soloing_pitch_role_risk_delta": 2,
+            "outside_soloing_target_supported": outside_soloing_repair_supported,
+            "weak_chord_tone_landing_risk_count_after": 0,
+            "weak_landing_target_supported": True,
+            "final_landing_chord_tone_count_after": 6,
+            "final_landing_target_supported": True,
+            "max_non_chord_tone_run_after": 3,
+            "non_chord_run_target_supported": True,
+        },
         "decision": {
             "critical_user_input_required": False,
         },
@@ -133,6 +165,8 @@ def readme_text(*, missing_boundary: bool = False) -> str:
             "- model-conditioned pitch-contour changed-ratio review required: `true`",
             "- model-conditioned pitch-contour changed-ratio repair objective path ready: `true`",
             "- current evidence changed-ratio repair objective path included: `true`",
+            "- outside-soloing repair objective path included in current evidence: `true`",
+            "- current evidence outside-soloing repair objective path included: `true`",
             "- README evidence refreshed: `true`",
             "- human/audio preference claim: `false`",
             "- MIDI-to-solo musical quality claim: `false`",
@@ -158,6 +192,7 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
             require_no_quality_claim=True,
             require_model_conditioned_pitch_contour_objective=True,
             require_model_conditioned_pitch_contour_changed_ratio_repair_objective=True,
+            require_outside_soloing_repair_objective=True,
         )
 
         self.assertTrue(summary["technical_model_core_mvp_completed"])
@@ -221,6 +256,19 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
                 "model_conditioned_pitch_contour_changed_ratio_repair_target_supported"
             ]
         )
+        self.assertTrue(summary["outside_soloing_repair_objective_completed"])
+        self.assertTrue(summary["outside_soloing_repair_objective_path_ready"])
+        self.assertTrue(summary["outside_soloing_repair_current_evidence_ready"])
+        self.assertEqual(summary["outside_soloing_repair_rendered_audio_file_count"], 6)
+        self.assertEqual(summary["outside_soloing_repair_changed_note_total"], 2)
+        self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_count_after"], 0)
+        self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_delta"], 2)
+        self.assertTrue(summary["outside_soloing_repair_objective_path_supported"])
+        self.assertTrue(summary["outside_soloing_repair_target_supported"])
+        self.assertTrue(summary["outside_soloing_repair_weak_landing_target_supported"])
+        self.assertTrue(summary["outside_soloing_repair_final_landing_target_supported"])
+        self.assertTrue(summary["outside_soloing_repair_non_chord_run_target_supported"])
+        self.assertFalse(summary["outside_soloing_repair_preference_fill_allowed"])
         self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
 
     def test_rejects_missing_readme_evidence_boundary(self) -> None:
@@ -266,6 +314,15 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
                 readme_text=readme_text(),
                 output_dir=Path("outputs/audit"),
                 issue_number=732,
+            )
+
+    def test_rejects_missing_outside_soloing_repair_support(self) -> None:
+        with self.assertRaises(StageBMidiToSoloMvpCompletionAuditError):
+            build_mvp_completion_audit_report(
+                current_evidence=current_evidence(outside_soloing_repair_supported=False),
+                readme_text=readme_text(),
+                output_dir=Path("outputs/audit"),
+                issue_number=816,
             )
 
     def test_boundary_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary

- MVP completion audit 필수 조건에 outside-soloing repair objective path 추가
- outside-soloing repair readiness, rendered WAV, changed note, pitch-role risk, target support summary 노출
- README required snippet, harness doc path, status/core plan 갱신

## Context

- Issue #812 current evidence consolidation 결과, outside-soloing repair objective path 포함
- Issue #814 README refresh 결과, outside-soloing repair evidence와 claim boundary 반영
- 기존 completion audit 필수 조건: selected-scale objective path, phrase-bank CLI technical path, pitch-contour objective path, changed-ratio repair objective path
- 누락 지점: outside-soloing repair objective path completion audit 조건 미반영

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_mvp_completion.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- musical quality, human/audio preference, broad trained-model quality claim 제외 유지
- objective evidence와 technical WAV validation 범위 안에서만 completion 판단

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated project planning and status documentation to include Stage B MIDI-to-solo MVP completion audit progress
  * Added comprehensive audit documentation with detailed evidence metrics and completion status tracking

* **Tests**
  * Added validation tests for completion audit requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->