### PR TITLE
Stage B MIDI-to-solo quality gap decision outside-soloing repair refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - MVP completion audit outside-soloing repair objective included: `true`
 - quality gap decision completed: `true`
 - quality gap decision listening review target selected: `true`
+- quality gap decision outside-soloing repair objective included: `true`
 - pitch-contour changed-ratio review decision completed: `true`
 - pitch-contour changed-ratio repair probe required: `true`
 - pitch-contour changed-ratio repair probe completed: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -5854,6 +5854,51 @@ Issue #816은 MVP completion audit에 Issue #812 outside-soloing repair current 
 
 - `Stage B MIDI-to-solo quality gap decision refresh`
 
+## 9.100 Stage B MIDI-to-solo quality gap decision outside-soloing repair refresh
+
+Issue #818은 quality gap decision에 Issue #816 MVP completion audit의 outside-soloing repair evidence를 반영한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- next boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- selected target: `listening_review_quality_gap`
+- technical model-core MVP completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour changed-ratio repair objective completed: `true`
+- outside-soloing repair objective completed: `true`
+- pitch-contour changed-ratio repair objective path ready: `true`
+- pitch-contour changed-ratio repair target supported: `true`
+- outside-soloing repair objective path ready: `true`
+- outside-soloing repair target supported: `true`
+- outside-soloing repair rendered audio file count: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing repair pitch-role risk count after: `0`
+- outside-soloing repair pitch-role risk delta: `2`
+- musical quality MVP completed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- quality gap decision 입력 검증에 outside-soloing repair objective completion 추가.
+- changed-ratio repair와 outside-soloing repair target support를 모두 만족할 때 listening review quality gap으로 이동.
+- remaining gap은 추가 objective repair가 아니라 listening review와 musical quality evidence.
+- musical quality, human/audio preference, broad trained-model quality claim 제외 유지.
+- 다음 boundary는 listening review quality gap refresh.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_gap_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_quality_gap.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-gap-decision`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo listening review quality gap refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #816, Stage B MIDI-to-solo MVP completion audit outside-soloing repair refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo quality gap decision refresh`
+- latest functional result: Issue #818, Stage B MIDI-to-solo quality gap decision outside-soloing repair refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo listening review quality gap refresh`
 
 현재 범위가 아닌 것:
 
@@ -374,6 +374,15 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 decision target: `stage_b_midi_to_solo_quality_gap_decision`
+- quality gap decision outside-soloing repair refresh 완료
+- selected target: `listening_review_quality_gap`
+- next boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- outside-soloing repair objective completed: `true`
+- outside-soloing repair target supported: `true`
+- outside-soloing repair pitch-role risk count after: `0`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 review target: `stage_b_midi_to_solo_listening_review_quality_gap`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_OUTSIDE_SOLOING_REPAIR_REFRESH_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_OUTSIDE_SOLOING_REPAIR_REFRESH_2026-06-10.md
@@ -1,0 +1,59 @@
+# Stage B MIDI-to-Solo Quality Gap Decision
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- next boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- selected target: `listening_review_quality_gap`
+- fallback path active: `true`
+- pitch-contour changed-ratio review required: `true`
+- human review required now: `false`
+
+## Evidence
+
+- technical model-core MVP completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour changed-ratio repair objective completed: `true`
+- outside-soloing repair objective completed: `true`
+- musical quality MVP completed: `false`
+- generation source: `context_conditioned_fallback`
+- exported candidates: `3`
+- rendered WAV files: `3`
+- objective strict/sample: `9` / `9`
+- objective dead-air failure: `0`
+- CLI candidate / rendered WAV: `3` / `3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- model-conditioned pitch-contour max interval / threshold: `11` / `12`
+- model-conditioned pitch-contour target supported: `true`
+- model-conditioned pitch-contour changed-ratio review required: `true`
+- model-conditioned pitch-contour audio review required: `true`
+- model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
+- model-conditioned pitch-contour changed-ratio repair rendered WAV files: `3`
+- model-conditioned pitch-contour changed-ratio repair technical WAV validation: `true`
+- model-conditioned pitch-contour changed-ratio repair max interval / threshold: `12` / `12`
+- model-conditioned pitch-contour changed-ratio repair max ratio / target: `0.4348` / `0.5000`
+- model-conditioned pitch-contour changed-ratio repair target supported: `true`
+- model-conditioned pitch-contour changed-ratio repair audio review required: `true`
+- model-conditioned pitch-contour changed-ratio repair preference fill allowed: `false`
+- outside-soloing repair objective path ready: `true`
+- outside-soloing repair rendered WAV files: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing pitch-role risk after / delta: `0` / `2`
+- outside-soloing repair objective path supported: `true`
+- outside-soloing repair target supported: `true`
+- outside-soloing repair weak landing target supported: `true`
+- outside-soloing repair final landing target supported: `true`
+- outside-soloing repair non-chord run target supported: `true`
+
+## Claim Boundary
+
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- broad trained model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo listening review quality gap`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6037,8 +6037,8 @@ run_stage_b_midi_to_solo_quality_gap_decision() {
   "$PYTHON_BIN" scripts/decide_stage_b_midi_to_solo_quality_gap.py \
     --run_id "$run_id" \
     --mvp_completion_audit "$completion_audit" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_2026-06-09.md \
-    --issue_number 734 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_OUTSIDE_SOLOING_REPAIR_REFRESH_2026-06-10.md \
+    --issue_number 818 \
     --expected_boundary stage_b_midi_to_solo_quality_gap_decision \
     --expected_next_boundary stage_b_midi_to_solo_listening_review_quality_gap \
     --expected_target listening_review_quality_gap \

--- a/scripts/decide_stage_b_midi_to_solo_quality_gap.py
+++ b/scripts/decide_stage_b_midi_to_solo_quality_gap.py
@@ -81,6 +81,10 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloQualityGapDecisionError(
             "model-conditioned pitch-contour objective completion required"
         )
+    if not bool(audit.get("outside_soloing_repair_objective_completed", False)):
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing repair objective completion required"
+        )
     if _int(evidence.get("exported_candidate_count")) < 3:
         raise StageBMidiToSoloQualityGapDecisionError("exported candidate count below 3")
     if _int(evidence.get("rendered_audio_file_count")) < 3:
@@ -153,6 +157,40 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
             raise StageBMidiToSoloQualityGapDecisionError(
                 "model-conditioned pitch-contour changed-ratio repair preference fill should remain blocked"
             )
+    if not bool(evidence.get("outside_soloing_repair_objective_path_ready", False)):
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing repair objective path readiness required"
+        )
+    if not bool(evidence.get("outside_soloing_repair_current_evidence_ready", False)):
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing repair current evidence readiness required"
+        )
+    if _int(evidence.get("outside_soloing_repair_rendered_audio_file_count")) < 6:
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing repair rendered WAV count below 6"
+        )
+    if _int(evidence.get("outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing repair residual pitch-role risk should be zero"
+        )
+    outside_targets = [
+        "outside_soloing_repair_objective_path_supported",
+        "outside_soloing_repair_target_supported",
+        "outside_soloing_repair_weak_landing_target_supported",
+        "outside_soloing_repair_final_landing_target_supported",
+        "outside_soloing_repair_non_chord_run_target_supported",
+    ]
+    missing_outside_targets = [
+        name for name in outside_targets if not bool(evidence.get(name, False))
+    ]
+    if missing_outside_targets:
+        raise StageBMidiToSoloQualityGapDecisionError(
+            f"outside-soloing repair targets missing: {missing_outside_targets}"
+        )
+    if bool(evidence.get("outside_soloing_repair_preference_fill_allowed", True)):
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing repair preference fill should remain blocked"
+        )
     if _int(evidence.get("objective_strict_valid_sample_count")) != _int(evidence.get("objective_sample_count")):
         raise StageBMidiToSoloQualityGapDecisionError("objective strict valid count must match sample count")
     blocked_claims = [
@@ -171,6 +209,9 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
         "model_conditioned_pitch_contour_objective_completed": True,
         "model_conditioned_pitch_contour_changed_ratio_repair_objective_completed": bool(
             audit.get("model_conditioned_pitch_contour_changed_ratio_repair_objective_completed", False)
+        ),
+        "outside_soloing_repair_objective_completed": bool(
+            audit.get("outside_soloing_repair_objective_completed", False)
         ),
         "musical_quality_mvp_completed": False,
         "human_audio_preference_completed": False,
@@ -245,6 +286,42 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
         "model_conditioned_pitch_contour_changed_ratio_repair_preference_fill_allowed": bool(
             evidence.get("model_conditioned_pitch_contour_changed_ratio_repair_preference_fill_allowed", True)
         ),
+        "outside_soloing_repair_objective_path_ready": bool(
+            evidence.get("outside_soloing_repair_objective_path_ready", False)
+        ),
+        "outside_soloing_repair_current_evidence_ready": bool(
+            evidence.get("outside_soloing_repair_current_evidence_ready", False)
+        ),
+        "outside_soloing_repair_rendered_audio_file_count": _int(
+            evidence.get("outside_soloing_repair_rendered_audio_file_count")
+        ),
+        "outside_soloing_repair_changed_note_total": _int(
+            evidence.get("outside_soloing_repair_changed_note_total")
+        ),
+        "outside_soloing_repair_pitch_role_risk_count_after": _int(
+            evidence.get("outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "outside_soloing_repair_pitch_role_risk_delta": _int(
+            evidence.get("outside_soloing_repair_pitch_role_risk_delta")
+        ),
+        "outside_soloing_repair_objective_path_supported": bool(
+            evidence.get("outside_soloing_repair_objective_path_supported", False)
+        ),
+        "outside_soloing_repair_target_supported": bool(
+            evidence.get("outside_soloing_repair_target_supported", False)
+        ),
+        "outside_soloing_repair_weak_landing_target_supported": bool(
+            evidence.get("outside_soloing_repair_weak_landing_target_supported", False)
+        ),
+        "outside_soloing_repair_final_landing_target_supported": bool(
+            evidence.get("outside_soloing_repair_final_landing_target_supported", False)
+        ),
+        "outside_soloing_repair_non_chord_run_target_supported": bool(
+            evidence.get("outside_soloing_repair_non_chord_run_target_supported", False)
+        ),
+        "outside_soloing_repair_preference_fill_allowed": bool(
+            evidence.get("outside_soloing_repair_preference_fill_allowed", True)
+        ),
     }
 
 
@@ -266,6 +343,12 @@ def select_quality_gap_target(audit_summary: dict[str, Any]) -> dict[str, Any]:
     changed_ratio_repair_supported = bool(
         audit_summary.get("model_conditioned_pitch_contour_changed_ratio_repair_target_supported", False)
     )
+    outside_soloing_repair_ready = bool(
+        audit_summary.get("outside_soloing_repair_objective_path_ready", False)
+    )
+    outside_soloing_repair_supported = bool(
+        audit_summary.get("outside_soloing_repair_target_supported", False)
+    )
     if (
         pitch_contour_path_ready
         and pitch_contour_changed_ratio_review_required
@@ -277,12 +360,17 @@ def select_quality_gap_target(audit_summary: dict[str, Any]) -> dict[str, Any]:
             "model-conditioned pitch-contour path is objective-complete, but pitch changed ratio still requires "
             "review before any musical quality claim"
         )
-    elif changed_ratio_repair_ready and changed_ratio_repair_supported:
+    elif (
+        changed_ratio_repair_ready
+        and changed_ratio_repair_supported
+        and outside_soloing_repair_ready
+        and outside_soloing_repair_supported
+    ):
         target = LISTENING_REVIEW_TARGET
         next_boundary = LISTENING_REVIEW_NEXT_BOUNDARY
         reason = (
-            "changed-ratio repair objective path meets current ratio and interval targets; remaining gap is "
-            "listening review and musical quality evidence, not another changed-ratio repair loop"
+            "changed-ratio and outside-soloing repair objective paths meet current targets; remaining gap is "
+            "listening review and musical quality evidence, not another objective repair loop"
         )
     elif fallback_path_active:
         target = SELECTED_TARGET
@@ -303,6 +391,8 @@ def select_quality_gap_target(audit_summary: dict[str, Any]) -> dict[str, Any]:
         "pitch_contour_changed_ratio_review_required": pitch_contour_changed_ratio_review_required,
         "pitch_contour_changed_ratio_repair_objective_path_ready": changed_ratio_repair_ready,
         "pitch_contour_changed_ratio_repair_target_supported": changed_ratio_repair_supported,
+        "outside_soloing_repair_objective_path_ready": outside_soloing_repair_ready,
+        "outside_soloing_repair_target_supported": outside_soloing_repair_supported,
         "quality_gap_reason": reason,
         "human_review_required_now": False,
     }
@@ -333,6 +423,9 @@ def build_quality_gap_decision_report(
             "model_conditioned_pitch_contour_changed_ratio_repair_objective_completed": bool(
                 audit_summary["model_conditioned_pitch_contour_changed_ratio_repair_objective_completed"]
             ),
+            "outside_soloing_repair_objective_completed": bool(
+                audit_summary["outside_soloing_repair_objective_completed"]
+            ),
             "musical_quality_mvp_completed": False,
             "human_audio_preference_completed": False,
             "product_mvp_completed": False,
@@ -352,6 +445,12 @@ def build_quality_gap_decision_report(
             ),
             "pitch_contour_changed_ratio_repair_target_supported": bool(
                 target["pitch_contour_changed_ratio_repair_target_supported"]
+            ),
+            "outside_soloing_repair_objective_path_ready": bool(
+                target["outside_soloing_repair_objective_path_ready"]
+            ),
+            "outside_soloing_repair_target_supported": bool(
+                target["outside_soloing_repair_target_supported"]
             ),
             "human_review_required_now": False,
         },
@@ -420,6 +519,10 @@ def validate_quality_gap_decision_report(
         raise StageBMidiToSoloQualityGapDecisionError(
             "model-conditioned pitch-contour objective completion required"
         )
+    if not bool(quality_gap.get("outside_soloing_repair_objective_completed", False)):
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing repair objective completion required"
+        )
     if bool(quality_gap.get("musical_quality_mvp_completed", True)):
         raise StageBMidiToSoloQualityGapDecisionError("musical quality should remain incomplete")
     if bool(decision.get("critical_user_input_required", True)):
@@ -459,6 +562,9 @@ def validate_quality_gap_decision_report(
                 False,
             )
         ),
+        "outside_soloing_repair_objective_completed": bool(
+            quality_gap.get("outside_soloing_repair_objective_completed", False)
+        ),
         "model_conditioned_pitch_contour_objective_path_ready": bool(
             quality_gap.get("model_conditioned_pitch_contour_objective_path_ready", False)
         ),
@@ -470,6 +576,12 @@ def validate_quality_gap_decision_report(
         ),
         "pitch_contour_changed_ratio_repair_target_supported": bool(
             quality_gap.get("pitch_contour_changed_ratio_repair_target_supported", False)
+        ),
+        "outside_soloing_repair_objective_path_ready": bool(
+            quality_gap.get("outside_soloing_repair_objective_path_ready", False)
+        ),
+        "outside_soloing_repair_target_supported": bool(
+            quality_gap.get("outside_soloing_repair_target_supported", False)
         ),
         "musical_quality_mvp_completed": bool(quality_gap.get("musical_quality_mvp_completed", True)),
         "cli_candidate_count": _int(_dict(report.get("mvp_completion_summary")).get("cli_candidate_count")),
@@ -520,6 +632,50 @@ def validate_quality_gap_decision_report(
                 "model_conditioned_pitch_contour_changed_ratio_repair_target_max_pitch_changed_ratio"
             )
         ),
+        "outside_soloing_repair_rendered_audio_file_count": _int(
+            _dict(report.get("mvp_completion_summary")).get(
+                "outside_soloing_repair_rendered_audio_file_count"
+            )
+        ),
+        "outside_soloing_repair_changed_note_total": _int(
+            _dict(report.get("mvp_completion_summary")).get(
+                "outside_soloing_repair_changed_note_total"
+            )
+        ),
+        "outside_soloing_repair_pitch_role_risk_count_after": _int(
+            _dict(report.get("mvp_completion_summary")).get(
+                "outside_soloing_repair_pitch_role_risk_count_after"
+            )
+        ),
+        "outside_soloing_repair_pitch_role_risk_delta": _int(
+            _dict(report.get("mvp_completion_summary")).get(
+                "outside_soloing_repair_pitch_role_risk_delta"
+            )
+        ),
+        "outside_soloing_repair_objective_path_supported": bool(
+            _dict(report.get("mvp_completion_summary")).get(
+                "outside_soloing_repair_objective_path_supported",
+                False,
+            )
+        ),
+        "outside_soloing_repair_weak_landing_target_supported": bool(
+            _dict(report.get("mvp_completion_summary")).get(
+                "outside_soloing_repair_weak_landing_target_supported",
+                False,
+            )
+        ),
+        "outside_soloing_repair_final_landing_target_supported": bool(
+            _dict(report.get("mvp_completion_summary")).get(
+                "outside_soloing_repair_final_landing_target_supported",
+                False,
+            )
+        ),
+        "outside_soloing_repair_non_chord_run_target_supported": bool(
+            _dict(report.get("mvp_completion_summary")).get(
+                "outside_soloing_repair_non_chord_run_target_supported",
+                False,
+            )
+        ),
         "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
         "midi_to_solo_musical_quality_claimed": bool(
             readiness.get("midi_to_solo_musical_quality_claimed", True)
@@ -553,6 +709,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- phrase-bank CLI technical path completed: `{_bool_token(summary['phrase_bank_cli_technical_path_completed'])}`",
         f"- model-conditioned pitch-contour objective completed: `{_bool_token(summary['model_conditioned_pitch_contour_objective_completed'])}`",
         f"- model-conditioned pitch-contour changed-ratio repair objective completed: `{_bool_token(summary['model_conditioned_pitch_contour_changed_ratio_repair_objective_completed'])}`",
+        f"- outside-soloing repair objective completed: `{_bool_token(summary['outside_soloing_repair_objective_completed'])}`",
         f"- musical quality MVP completed: `{_bool_token(summary['musical_quality_mvp_completed'])}`",
         f"- generation source: `{summary['generation_source']}`",
         f"- exported candidates: `{summary['exported_candidate_count']}`",
@@ -574,6 +731,15 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- model-conditioned pitch-contour changed-ratio repair target supported: `{_bool_token(summary['model_conditioned_pitch_contour_changed_ratio_repair_target_supported'])}`",
         f"- model-conditioned pitch-contour changed-ratio repair audio review required: `{_bool_token(summary['model_conditioned_pitch_contour_changed_ratio_repair_audio_review_required'])}`",
         f"- model-conditioned pitch-contour changed-ratio repair preference fill allowed: `{_bool_token(summary['model_conditioned_pitch_contour_changed_ratio_repair_preference_fill_allowed'])}`",
+        f"- outside-soloing repair objective path ready: `{_bool_token(summary['outside_soloing_repair_objective_path_ready'])}`",
+        f"- outside-soloing repair rendered WAV files: `{summary['outside_soloing_repair_rendered_audio_file_count']}`",
+        f"- outside-soloing repair changed note total: `{summary['outside_soloing_repair_changed_note_total']}`",
+        f"- outside-soloing pitch-role risk after / delta: `{summary['outside_soloing_repair_pitch_role_risk_count_after']}` / `{summary['outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- outside-soloing repair objective path supported: `{_bool_token(summary['outside_soloing_repair_objective_path_supported'])}`",
+        f"- outside-soloing repair target supported: `{_bool_token(summary['outside_soloing_repair_target_supported'])}`",
+        f"- outside-soloing repair weak landing target supported: `{_bool_token(summary['outside_soloing_repair_weak_landing_target_supported'])}`",
+        f"- outside-soloing repair final landing target supported: `{_bool_token(summary['outside_soloing_repair_final_landing_target_supported'])}`",
+        f"- outside-soloing repair non-chord run target supported: `{_bool_token(summary['outside_soloing_repair_non_chord_run_target_supported'])}`",
         "",
         "## Claim Boundary",
         "",

--- a/tests/test_stage_b_midi_to_solo_quality_gap_decision.py
+++ b/tests/test_stage_b_midi_to_solo_quality_gap_decision.py
@@ -29,6 +29,7 @@ def mvp_completion_audit(
     pitch_contour_changed_ratio_review_required: bool = True,
     pitch_contour_supported: bool = True,
     changed_ratio_repair_supported: bool = True,
+    outside_soloing_repair_supported: bool = True,
 ) -> dict:
     return {
         "boundary": MVP_COMPLETION_BOUNDARY,
@@ -52,6 +53,7 @@ def mvp_completion_audit(
             "model_conditioned_pitch_contour_changed_ratio_repair_objective_completed": (
                 changed_ratio_repair_supported
             ),
+            "outside_soloing_repair_objective_completed": outside_soloing_repair_supported,
             "readme_evidence_boundary_refreshed": True,
             "musical_quality_mvp_completed": musical_complete,
             "human_audio_preference_completed": False,
@@ -103,6 +105,20 @@ def mvp_completion_audit(
             ),
             "model_conditioned_pitch_contour_changed_ratio_repair_audio_review_required": True,
             "model_conditioned_pitch_contour_changed_ratio_repair_preference_fill_allowed": False,
+            "outside_soloing_repair_objective_path_ready": outside_soloing_repair_supported,
+            "outside_soloing_repair_current_evidence_ready": outside_soloing_repair_supported,
+            "outside_soloing_repair_rendered_audio_file_count": 6,
+            "outside_soloing_repair_changed_note_total": 2,
+            "outside_soloing_repair_pitch_role_risk_count_after": (
+                0 if outside_soloing_repair_supported else 1
+            ),
+            "outside_soloing_repair_pitch_role_risk_delta": 2,
+            "outside_soloing_repair_objective_path_supported": outside_soloing_repair_supported,
+            "outside_soloing_repair_target_supported": outside_soloing_repair_supported,
+            "outside_soloing_repair_weak_landing_target_supported": True,
+            "outside_soloing_repair_final_landing_target_supported": True,
+            "outside_soloing_repair_non_chord_run_target_supported": True,
+            "outside_soloing_repair_preference_fill_allowed": False,
         },
         "decision": {
             "next_boundary": "stage_b_midi_to_solo_quality_gap_decision",
@@ -134,6 +150,7 @@ class StageBMidiToSoloQualityGapDecisionTest(unittest.TestCase):
         self.assertTrue(
             summary["model_conditioned_pitch_contour_changed_ratio_repair_objective_completed"]
         )
+        self.assertTrue(summary["outside_soloing_repair_objective_completed"])
         self.assertTrue(summary["model_conditioned_pitch_contour_objective_path_ready"])
         self.assertTrue(summary["pitch_contour_changed_ratio_review_required"])
         self.assertTrue(summary["pitch_contour_changed_ratio_repair_objective_path_ready"])
@@ -161,6 +178,16 @@ class StageBMidiToSoloQualityGapDecisionTest(unittest.TestCase):
             places=4,
         )
         self.assertTrue(summary["model_conditioned_pitch_contour_target_supported"])
+        self.assertTrue(summary["outside_soloing_repair_objective_path_ready"])
+        self.assertTrue(summary["outside_soloing_repair_target_supported"])
+        self.assertEqual(summary["outside_soloing_repair_rendered_audio_file_count"], 6)
+        self.assertEqual(summary["outside_soloing_repair_changed_note_total"], 2)
+        self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_count_after"], 0)
+        self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_delta"], 2)
+        self.assertTrue(summary["outside_soloing_repair_objective_path_supported"])
+        self.assertTrue(summary["outside_soloing_repair_weak_landing_target_supported"])
+        self.assertTrue(summary["outside_soloing_repair_final_landing_target_supported"])
+        self.assertTrue(summary["outside_soloing_repair_non_chord_run_target_supported"])
         self.assertFalse(summary["human_review_required_now"])
         self.assertTrue(summary["technical_model_core_mvp_completed"])
         self.assertTrue(summary["phrase_bank_cli_technical_path_completed"])
@@ -282,6 +309,16 @@ class StageBMidiToSoloQualityGapDecisionTest(unittest.TestCase):
                 mvp_completion_audit=source,
                 output_dir=Path("outputs/quality_gap"),
                 issue_number=734,
+            )
+
+    def test_rejects_missing_outside_soloing_repair_support(self) -> None:
+        with self.assertRaises(StageBMidiToSoloQualityGapDecisionError):
+            build_quality_gap_decision_report(
+                mvp_completion_audit=mvp_completion_audit(
+                    outside_soloing_repair_supported=False
+                ),
+                output_dir=Path("outputs/quality_gap"),
+                issue_number=818,
             )
 
     def test_boundary_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary

- quality gap decision 입력 검증에 outside-soloing repair objective path 추가
- changed-ratio repair와 outside-soloing repair target support를 함께 확인
- summary, markdown, harness, README/status/core plan 갱신

## Context

- Issue #816 MVP completion audit 결과, outside-soloing repair objective path가 completion 조건에 포함
- outside-soloing repair 주요 값: rendered WAV `6`, changed note total `2`, pitch-role risk after `0`, pitch-role risk delta `2`
- 기존 quality gap decision은 changed-ratio repair evidence까지만 summary와 target 판단에 반영

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_gap_decision`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_quality_gap.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-gap-decision`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- musical quality, human/audio preference, broad trained-model quality claim 제외 유지
- selected target은 objective/technical evidence 범위에서만 판단