### PR TITLE
Stage B MIDI-to-solo listening review quality gap outside-soloing repair refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - current evidence outside-soloing repair objective path included: `true`
 - listening review quality gap completed: `true`
 - listening review quality gap open: `true`
+- listening review quality gap outside-soloing repair objective included: `true`
 - MVP delivery package completed: `true`
 - runnable CLI ready: `true`
 - input to ranked MIDI ready: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -5899,6 +5899,49 @@ Issue #818은 quality gap decision에 Issue #816 MVP completion audit의 outside
 
 - `Stage B MIDI-to-solo listening review quality gap refresh`
 
+## 9.101 Stage B MIDI-to-solo listening review quality gap outside-soloing repair refresh
+
+Issue #820은 listening review quality gap 경계에 Issue #818 quality gap decision의 outside-soloing repair evidence를 반영한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- source boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- next boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- selected target: `mvp_delivery_package`
+- listening review quality gap open: `true`
+- technical MVP delivery package ready: `true`
+- changed-ratio repair objective completed: `true`
+- outside-soloing repair objective completed: `true`
+- outside-soloing repair objective path ready: `true`
+- outside-soloing repair target supported: `true`
+- outside-soloing repair rendered audio file count: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing repair pitch-role risk count after: `0`
+- outside-soloing repair pitch-role risk delta: `2`
+- musical quality MVP completed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- delivery package 이전 quality gap summary에 outside-soloing repair objective evidence 추가.
+- changed-ratio repair와 outside-soloing repair target support를 모두 delivery package readiness 전제로 검증.
+- listening review quality gap은 open 유지.
+- musical quality, human/audio preference, broad trained-model quality claim 제외 유지.
+- 다음 boundary는 MVP delivery package refresh.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_listening_review_quality_gap`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-listening-review-quality-gap`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo MVP delivery package refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #818, Stage B MIDI-to-solo quality gap decision outside-soloing repair refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo listening review quality gap refresh`
+- latest functional result: Issue #820, Stage B MIDI-to-solo listening review quality gap outside-soloing repair refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo MVP delivery package refresh`
 
 현재 범위가 아닌 것:
 
@@ -383,6 +383,16 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 review target: `stage_b_midi_to_solo_listening_review_quality_gap`
+- listening review quality gap outside-soloing repair refresh 완료
+- selected target: `mvp_delivery_package`
+- technical MVP delivery package ready: `true`
+- outside-soloing repair objective completed: `true`
+- outside-soloing repair rendered audio file count: `6`
+- outside-soloing repair pitch-role risk count after: `0`
+- listening review quality gap open: `true`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 delivery target: `stage_b_midi_to_solo_mvp_delivery_package`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_OUTSIDE_SOLOING_REPAIR_REFRESH_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_OUTSIDE_SOLOING_REPAIR_REFRESH_2026-06-10.md
@@ -1,0 +1,45 @@
+# Stage B MIDI-to-Solo Listening Review Quality Gap
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- source boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- next boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- selected target: `mvp_delivery_package`
+- listening review quality gap open: `true`
+- technical MVP delivery package ready: `true`
+- human review required now: `false`
+
+## Evidence
+
+- technical model-core MVP completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- changed-ratio repair objective completed: `true`
+- outside-soloing repair objective completed: `true`
+- rendered WAV files: `3`
+- changed-ratio repair max interval / threshold: `12` / `12`
+- changed-ratio repair max ratio / target: `0.4348` / `0.5000`
+- outside-soloing repair objective path ready: `true`
+- outside-soloing repair target supported: `true`
+- outside-soloing repair rendered WAV files: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing pitch-role risk after / delta: `0` / `2`
+- outside-soloing repair objective path supported: `true`
+- outside-soloing repair weak landing target supported: `true`
+- outside-soloing repair final landing target supported: `true`
+- outside-soloing repair non-chord run target supported: `true`
+- musical quality MVP completed: `false`
+- human/audio preference completed: `false`
+- product MVP completed: `false`
+
+## Claim Boundary
+
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- broad trained model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo MVP delivery package`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6057,8 +6057,8 @@ run_stage_b_midi_to_solo_listening_review_quality_gap() {
   "$PYTHON_BIN" scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py \
     --run_id "$run_id" \
     --quality_gap_decision "$quality_gap" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_2026-06-09.md \
-    --issue_number 736 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_OUTSIDE_SOLOING_REPAIR_REFRESH_2026-06-10.md \
+    --issue_number 820 \
     --expected_boundary stage_b_midi_to_solo_listening_review_quality_gap \
     --expected_next_boundary stage_b_midi_to_solo_mvp_delivery_package \
     --expected_target mvp_delivery_package \

--- a/scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py
+++ b/scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py
@@ -114,6 +114,18 @@ def validate_quality_gap_decision(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloListeningReviewQualityGapError(
             "changed-ratio repair target support required"
         )
+    if not bool(quality_gap.get("outside_soloing_repair_objective_completed", False)):
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing repair objective completion required"
+        )
+    if not bool(quality_gap.get("outside_soloing_repair_objective_path_ready", False)):
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing repair objective path readiness required"
+        )
+    if not bool(quality_gap.get("outside_soloing_repair_target_supported", False)):
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing repair target support required"
+        )
     if bool(quality_gap.get("model_conditioned_input_path_alignment_required", True)):
         raise StageBMidiToSoloListeningReviewQualityGapError(
             "model-conditioned input path alignment should not be selected"
@@ -138,6 +150,25 @@ def validate_quality_gap_decision(report: dict[str, Any]) -> dict[str, Any]:
         summary.get("model_conditioned_pitch_contour_changed_ratio_repair_target_max_pitch_changed_ratio")
     ):
         raise StageBMidiToSoloListeningReviewQualityGapError("changed-ratio repair ratio threshold exceeded")
+    if _int(summary.get("outside_soloing_repair_rendered_audio_file_count")) < 6:
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing repair rendered WAV count below 6"
+        )
+    if _int(summary.get("outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing repair residual pitch-role risk should be zero"
+        )
+    outside_targets = [
+        "outside_soloing_repair_objective_path_supported",
+        "outside_soloing_repair_weak_landing_target_supported",
+        "outside_soloing_repair_final_landing_target_supported",
+        "outside_soloing_repair_non_chord_run_target_supported",
+    ]
+    missing_outside_targets = [name for name in outside_targets if not bool(summary.get(name, False))]
+    if missing_outside_targets:
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            f"outside-soloing repair targets missing: {missing_outside_targets}"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloListeningReviewQualityGapError("critical user input should not be required")
     _require_no_quality_claim(readiness, label="quality gap decision readiness")
@@ -148,6 +179,7 @@ def validate_quality_gap_decision(report: dict[str, Any]) -> dict[str, Any]:
         "phrase_bank_cli_technical_path_completed": True,
         "model_conditioned_pitch_contour_objective_completed": True,
         "changed_ratio_repair_objective_completed": True,
+        "outside_soloing_repair_objective_completed": True,
         "fallback_path_active": bool(quality_gap.get("fallback_path_active", False)),
         "model_conditioned_input_path_alignment_required": bool(
             quality_gap.get("model_conditioned_input_path_alignment_required", False)
@@ -166,6 +198,36 @@ def validate_quality_gap_decision(report: dict[str, Any]) -> dict[str, Any]:
         ),
         "target_max_pitch_changed_ratio": _float(
             summary.get("model_conditioned_pitch_contour_changed_ratio_repair_target_max_pitch_changed_ratio")
+        ),
+        "outside_soloing_repair_objective_path_ready": bool(
+            quality_gap.get("outside_soloing_repair_objective_path_ready", False)
+        ),
+        "outside_soloing_repair_target_supported": bool(
+            quality_gap.get("outside_soloing_repair_target_supported", False)
+        ),
+        "outside_soloing_repair_rendered_audio_file_count": _int(
+            summary.get("outside_soloing_repair_rendered_audio_file_count")
+        ),
+        "outside_soloing_repair_changed_note_total": _int(
+            summary.get("outside_soloing_repair_changed_note_total")
+        ),
+        "outside_soloing_repair_pitch_role_risk_count_after": _int(
+            summary.get("outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "outside_soloing_repair_pitch_role_risk_delta": _int(
+            summary.get("outside_soloing_repair_pitch_role_risk_delta")
+        ),
+        "outside_soloing_repair_objective_path_supported": bool(
+            summary.get("outside_soloing_repair_objective_path_supported", False)
+        ),
+        "outside_soloing_repair_weak_landing_target_supported": bool(
+            summary.get("outside_soloing_repair_weak_landing_target_supported", False)
+        ),
+        "outside_soloing_repair_final_landing_target_supported": bool(
+            summary.get("outside_soloing_repair_final_landing_target_supported", False)
+        ),
+        "outside_soloing_repair_non_chord_run_target_supported": bool(
+            summary.get("outside_soloing_repair_non_chord_run_target_supported", False)
         ),
         "human_review_required_now": bool(quality_gap.get("human_review_required_now", False)),
         "musical_quality_mvp_completed": False,
@@ -199,7 +261,7 @@ def build_listening_review_quality_gap_report(
             "selected_target": SELECTED_TARGET,
             "selected_next_boundary": NEXT_BOUNDARY,
             "reason": (
-                "technical MIDI-to-solo path and changed-ratio repair objective evidence are ready; "
+                "technical MIDI-to-solo path, changed-ratio repair, and outside-soloing repair objective evidence are ready; "
                 "delivery package can be prepared while listening and musical quality claims remain excluded"
             ),
         },
@@ -280,11 +342,44 @@ def validate_listening_review_quality_gap_report(
         "changed_ratio_repair_objective_completed": bool(
             summary.get("changed_ratio_repair_objective_completed", False)
         ),
+        "outside_soloing_repair_objective_completed": bool(
+            summary.get("outside_soloing_repair_objective_completed", False)
+        ),
         "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
         "max_repaired_interval": _int(summary.get("max_repaired_interval")),
         "max_interval_threshold": _int(summary.get("max_interval_threshold")),
         "max_repaired_pitch_changed_ratio": _float(summary.get("max_repaired_pitch_changed_ratio")),
         "target_max_pitch_changed_ratio": _float(summary.get("target_max_pitch_changed_ratio")),
+        "outside_soloing_repair_objective_path_ready": bool(
+            summary.get("outside_soloing_repair_objective_path_ready", False)
+        ),
+        "outside_soloing_repair_target_supported": bool(
+            summary.get("outside_soloing_repair_target_supported", False)
+        ),
+        "outside_soloing_repair_rendered_audio_file_count": _int(
+            summary.get("outside_soloing_repair_rendered_audio_file_count")
+        ),
+        "outside_soloing_repair_changed_note_total": _int(
+            summary.get("outside_soloing_repair_changed_note_total")
+        ),
+        "outside_soloing_repair_pitch_role_risk_count_after": _int(
+            summary.get("outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "outside_soloing_repair_pitch_role_risk_delta": _int(
+            summary.get("outside_soloing_repair_pitch_role_risk_delta")
+        ),
+        "outside_soloing_repair_objective_path_supported": bool(
+            summary.get("outside_soloing_repair_objective_path_supported", False)
+        ),
+        "outside_soloing_repair_weak_landing_target_supported": bool(
+            summary.get("outside_soloing_repair_weak_landing_target_supported", False)
+        ),
+        "outside_soloing_repair_final_landing_target_supported": bool(
+            summary.get("outside_soloing_repair_final_landing_target_supported", False)
+        ),
+        "outside_soloing_repair_non_chord_run_target_supported": bool(
+            summary.get("outside_soloing_repair_non_chord_run_target_supported", False)
+        ),
         "listening_review_quality_gap_open": bool(
             summary.get("listening_review_quality_gap_open", False)
         ),
@@ -325,9 +420,19 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- phrase-bank CLI technical path completed: `{_bool_token(summary['phrase_bank_cli_technical_path_completed'])}`",
         f"- model-conditioned pitch-contour objective completed: `{_bool_token(summary['model_conditioned_pitch_contour_objective_completed'])}`",
         f"- changed-ratio repair objective completed: `{_bool_token(summary['changed_ratio_repair_objective_completed'])}`",
+        f"- outside-soloing repair objective completed: `{_bool_token(summary['outside_soloing_repair_objective_completed'])}`",
         f"- rendered WAV files: `{summary['rendered_audio_file_count']}`",
         f"- changed-ratio repair max interval / threshold: `{summary['max_repaired_interval']}` / `{summary['max_interval_threshold']}`",
         f"- changed-ratio repair max ratio / target: `{summary['max_repaired_pitch_changed_ratio']:.4f}` / `{summary['target_max_pitch_changed_ratio']:.4f}`",
+        f"- outside-soloing repair objective path ready: `{_bool_token(summary['outside_soloing_repair_objective_path_ready'])}`",
+        f"- outside-soloing repair target supported: `{_bool_token(summary['outside_soloing_repair_target_supported'])}`",
+        f"- outside-soloing repair rendered WAV files: `{summary['outside_soloing_repair_rendered_audio_file_count']}`",
+        f"- outside-soloing repair changed note total: `{summary['outside_soloing_repair_changed_note_total']}`",
+        f"- outside-soloing pitch-role risk after / delta: `{summary['outside_soloing_repair_pitch_role_risk_count_after']}` / `{summary['outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- outside-soloing repair objective path supported: `{_bool_token(summary['outside_soloing_repair_objective_path_supported'])}`",
+        f"- outside-soloing repair weak landing target supported: `{_bool_token(summary['outside_soloing_repair_weak_landing_target_supported'])}`",
+        f"- outside-soloing repair final landing target supported: `{_bool_token(summary['outside_soloing_repair_final_landing_target_supported'])}`",
+        f"- outside-soloing repair non-chord run target supported: `{_bool_token(summary['outside_soloing_repair_non_chord_run_target_supported'])}`",
         f"- musical quality MVP completed: `{_bool_token(summary['musical_quality_mvp_completed'])}`",
         f"- human/audio preference completed: `{_bool_token(summary['human_audio_preference_completed'])}`",
         f"- product MVP completed: `{_bool_token(summary['product_mvp_completed'])}`",

--- a/tests/test_stage_b_midi_to_solo_listening_review_quality_gap.py
+++ b/tests/test_stage_b_midi_to_solo_listening_review_quality_gap.py
@@ -24,6 +24,7 @@ def quality_gap_decision(
     next_boundary: str = LISTENING_REVIEW_NEXT_BOUNDARY,
     quality_claim: bool = False,
     changed_ratio_supported: bool = True,
+    outside_soloing_repair_supported: bool = True,
 ) -> dict:
     return {
         "boundary": QUALITY_GAP_BOUNDARY,
@@ -34,6 +35,7 @@ def quality_gap_decision(
             "model_conditioned_pitch_contour_changed_ratio_repair_objective_completed": (
                 changed_ratio_supported
             ),
+            "outside_soloing_repair_objective_completed": outside_soloing_repair_supported,
             "musical_quality_mvp_completed": False,
             "human_audio_preference_completed": False,
             "product_mvp_completed": False,
@@ -45,6 +47,8 @@ def quality_gap_decision(
                 changed_ratio_supported
             ),
             "pitch_contour_changed_ratio_repair_target_supported": changed_ratio_supported,
+            "outside_soloing_repair_objective_path_ready": outside_soloing_repair_supported,
+            "outside_soloing_repair_target_supported": outside_soloing_repair_supported,
             "human_review_required_now": False,
         },
         "mvp_completion_summary": {
@@ -57,6 +61,16 @@ def quality_gap_decision(
                 0.4348 if changed_ratio_supported else 0.7174
             ),
             "model_conditioned_pitch_contour_changed_ratio_repair_target_max_pitch_changed_ratio": 0.5,
+            "outside_soloing_repair_rendered_audio_file_count": 6,
+            "outside_soloing_repair_changed_note_total": 2,
+            "outside_soloing_repair_pitch_role_risk_count_after": (
+                0 if outside_soloing_repair_supported else 1
+            ),
+            "outside_soloing_repair_pitch_role_risk_delta": 2,
+            "outside_soloing_repair_objective_path_supported": outside_soloing_repair_supported,
+            "outside_soloing_repair_weak_landing_target_supported": True,
+            "outside_soloing_repair_final_landing_target_supported": True,
+            "outside_soloing_repair_non_chord_run_target_supported": True,
         },
         "selected_target": {
             "selected_target": selected_target,
@@ -102,11 +116,22 @@ class StageBMidiToSoloListeningReviewQualityGapTest(unittest.TestCase):
         self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
         self.assertTrue(summary["technical_model_core_mvp_completed"])
         self.assertTrue(summary["changed_ratio_repair_objective_completed"])
+        self.assertTrue(summary["outside_soloing_repair_objective_completed"])
         self.assertEqual(summary["rendered_audio_file_count"], 3)
         self.assertEqual(summary["max_repaired_interval"], 12)
         self.assertEqual(summary["max_interval_threshold"], 12)
         self.assertAlmostEqual(summary["max_repaired_pitch_changed_ratio"], 0.4348, places=4)
         self.assertAlmostEqual(summary["target_max_pitch_changed_ratio"], 0.5, places=4)
+        self.assertTrue(summary["outside_soloing_repair_objective_path_ready"])
+        self.assertTrue(summary["outside_soloing_repair_target_supported"])
+        self.assertEqual(summary["outside_soloing_repair_rendered_audio_file_count"], 6)
+        self.assertEqual(summary["outside_soloing_repair_changed_note_total"], 2)
+        self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_count_after"], 0)
+        self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_delta"], 2)
+        self.assertTrue(summary["outside_soloing_repair_objective_path_supported"])
+        self.assertTrue(summary["outside_soloing_repair_weak_landing_target_supported"])
+        self.assertTrue(summary["outside_soloing_repair_final_landing_target_supported"])
+        self.assertTrue(summary["outside_soloing_repair_non_chord_run_target_supported"])
         self.assertTrue(summary["listening_review_quality_gap_open"])
         self.assertTrue(summary["technical_mvp_delivery_package_ready"])
         self.assertFalse(summary["human_review_required_now"])
@@ -140,6 +165,16 @@ class StageBMidiToSoloListeningReviewQualityGapTest(unittest.TestCase):
                 quality_gap_decision=quality_gap_decision(changed_ratio_supported=False),
                 output_dir=Path("outputs/listening_review_quality_gap"),
                 issue_number=736,
+            )
+
+    def test_rejects_missing_outside_soloing_repair_support(self) -> None:
+        with self.assertRaises(StageBMidiToSoloListeningReviewQualityGapError):
+            build_listening_review_quality_gap_report(
+                quality_gap_decision=quality_gap_decision(
+                    outside_soloing_repair_supported=False
+                ),
+                output_dir=Path("outputs/listening_review_quality_gap"),
+                issue_number=820,
             )
 
     def test_rejects_quality_claim(self) -> None:


### PR DESCRIPTION
## Summary

- listening review quality gap 입력 검증에 outside-soloing repair objective path 추가
- delivery package readiness summary와 markdown에 outside-soloing repair 수치 노출
- harness, README/status/core plan 갱신

## Context

- Issue #818 quality gap decision 결과, changed-ratio repair와 outside-soloing repair target support를 모두 만족할 때 listening review quality gap으로 이동
- outside-soloing repair 주요 값: rendered WAV `6`, changed note total `2`, pitch-role risk after `0`, pitch-role risk delta `2`
- 기존 listening review quality gap summary는 changed-ratio repair evidence 중심

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_listening_review_quality_gap`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-listening-review-quality-gap`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- listening review gap은 open 유지
- musical quality, human/audio preference, broad trained-model quality claim 제외 유지