### PR TITLE
Stage B MIDI-to-solo MVP delivery package outside-soloing repair refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - input to ranked MIDI ready: `true`
 - input to rendered WAV evidence ready: `true`
 - changed-ratio repair audio evidence ready: `true`
+- outside-soloing repair evidence ready: `true`
 - MVP delivery CLI candidates: `3`
 - MVP delivery changed-ratio repair WAV files: `3`
+- MVP delivery outside-soloing repair WAV files: `6`
 - MVP delivery raw artifact upload required: `false`
 - model-conditioned input path quality alignment decision completed: `true`
 - next boundary: `stage_b_midi_to_solo_readme_final_evidence_refresh`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -5942,6 +5942,50 @@ Issue #820은 listening review quality gap 경계에 Issue #818 quality gap deci
 
 - `Stage B MIDI-to-solo MVP delivery package refresh`
 
+## 9.102 Stage B MIDI-to-solo MVP delivery package outside-soloing repair refresh
+
+Issue #822는 MVP delivery package manifest에 outside-soloing repair evidence를 반영한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- next boundary: `stage_b_midi_to_solo_readme_final_evidence_refresh`
+- technical MVP delivery package completed: `true`
+- runnable CLI ready: `true`
+- input to ranked MIDI ready: `true`
+- input to rendered WAV evidence ready: `true`
+- changed-ratio repair audio evidence ready: `true`
+- outside-soloing repair evidence ready: `true`
+- CLI candidate count: `3`
+- changed-ratio repair WAV count: `3`
+- outside-soloing repair WAV count: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing repair pitch-role risk count after: `0`
+- outside-soloing repair pitch-role risk delta: `2`
+- listening review quality gap open: `true`
+- raw artifact upload required: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- delivery package validation에 outside-soloing repair evidence readiness 추가.
+- local artifact path 기록 범위는 기존 CLI repaired MIDI와 changed-ratio repair WAV 유지.
+- outside-soloing repair evidence는 count/risk summary로 delivery manifest에 포함.
+- raw artifact upload와 품질 claim 제외 유지.
+- 다음 boundary는 README final evidence refresh.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_delivery_package`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_mvp_delivery_package.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-delivery-package`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo README final evidence refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #820, Stage B MIDI-to-solo listening review quality gap outside-soloing repair refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo MVP delivery package refresh`
+- latest functional result: Issue #822, Stage B MIDI-to-solo MVP delivery package outside-soloing repair refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo README final evidence refresh`
 
 현재 범위가 아닌 것:
 
@@ -393,6 +393,18 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 delivery target: `stage_b_midi_to_solo_mvp_delivery_package`
+- MVP delivery package outside-soloing repair refresh 완료
+- runnable CLI ready: `true`
+- input to ranked MIDI ready: `true`
+- input to rendered WAV evidence ready: `true`
+- changed-ratio repair audio evidence ready: `true`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair WAV count: `6`
+- outside-soloing repair pitch-role risk count after: `0`
+- raw artifact upload required: `false`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 README target: `stage_b_midi_to_solo_readme_final_evidence_refresh`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MVP_DELIVERY_PACKAGE_OUTSIDE_SOLOING_REPAIR_REFRESH_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MVP_DELIVERY_PACKAGE_OUTSIDE_SOLOING_REPAIR_REFRESH_2026-06-10.md
@@ -1,0 +1,42 @@
+# Stage B MIDI-to-Solo MVP Delivery Package
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- next boundary: `stage_b_midi_to_solo_readme_final_evidence_refresh`
+- technical MVP delivery package completed: `true`
+- runnable CLI ready: `true`
+- input to ranked MIDI ready: `true`
+- input to rendered WAV evidence ready: `true`
+- changed-ratio repair audio evidence ready: `true`
+- outside-soloing repair evidence ready: `true`
+- listening review quality gap open: `true`
+
+## Run Command
+
+- `.venv/bin/python scripts/run_stage_b_midi_to_solo_phrase_bank_cli_mvp_package.py --input_midi outputs/stage_b_midi_to_solo_phrase_bank_cli_mvp_package/harness_stage_b_midi_to_solo_phrase_bank_cli_mvp_package/input/fixture.mid --run_id harness_stage_b_midi_to_solo_phrase_bank_cli_mvp_package`
+
+## Evidence
+
+- CLI candidate count: `3`
+- CLI objective-supported candidate count: `3`
+- CLI dead-air ratio range: `0.1895` - `0.2211`
+- changed-ratio repair WAV count: `3`
+- changed-ratio repair max ratio / target: `0.4348` / `0.5000`
+- changed-ratio repair max interval / target: `12` / `12`
+- changed-ratio repair WAV duration range: `18.422s` - `18.978s`
+- outside-soloing repair WAV count: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing pitch-role risk after / delta: `0` / `2`
+
+## Claim Boundary
+
+- raw artifact upload required: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- broad trained model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo README final evidence refresh`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6092,8 +6092,8 @@ run_stage_b_midi_to_solo_mvp_delivery_package() {
     --listening_review_quality_gap "$listening_gap" \
     --cli_mvp_package "$cli_package" \
     --changed_ratio_audio_package "$changed_ratio_audio" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_DELIVERY_PACKAGE_2026-06-09.md \
-    --issue_number 738 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_DELIVERY_PACKAGE_OUTSIDE_SOLOING_REPAIR_REFRESH_2026-06-10.md \
+    --issue_number 822 \
     --expected_boundary stage_b_midi_to_solo_mvp_delivery_package \
     --expected_next_boundary stage_b_midi_to_solo_readme_final_evidence_refresh \
     --require_delivery_completed \

--- a/scripts/build_stage_b_midi_to_solo_mvp_delivery_package.py
+++ b/scripts/build_stage_b_midi_to_solo_mvp_delivery_package.py
@@ -105,6 +105,10 @@ def validate_listening_gap(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloMvpDeliveryPackageError("technical model-core MVP completion required")
     if not bool(summary.get("changed_ratio_repair_objective_completed", False)):
         raise StageBMidiToSoloMvpDeliveryPackageError("changed-ratio repair objective completion required")
+    if not bool(summary.get("outside_soloing_repair_objective_completed", False)):
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "outside-soloing repair objective completion required"
+        )
     if _int(summary.get("rendered_audio_file_count")) < 3:
         raise StageBMidiToSoloMvpDeliveryPackageError("changed-ratio repair rendered WAV count below 3")
     if _int(summary.get("max_repaired_interval")) > _int(summary.get("max_interval_threshold")):
@@ -113,12 +117,29 @@ def validate_listening_gap(report: dict[str, Any]) -> dict[str, Any]:
         summary.get("target_max_pitch_changed_ratio")
     ):
         raise StageBMidiToSoloMvpDeliveryPackageError("changed-ratio repair ratio threshold exceeded")
+    if not bool(summary.get("outside_soloing_repair_objective_path_ready", False)):
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "outside-soloing repair objective path readiness required"
+        )
+    if not bool(summary.get("outside_soloing_repair_target_supported", False)):
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "outside-soloing repair target support required"
+        )
+    if _int(summary.get("outside_soloing_repair_rendered_audio_file_count")) < 6:
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "outside-soloing repair rendered WAV count below 6"
+        )
+    if _int(summary.get("outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "outside-soloing repair residual pitch-role risk should be zero"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloMvpDeliveryPackageError("critical user input should not be required")
     _require_no_quality_claim(readiness, label="listening gap readiness")
     return {
         "technical_model_core_mvp_completed": True,
         "changed_ratio_repair_objective_completed": True,
+        "outside_soloing_repair_objective_completed": True,
         "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
         "max_repaired_interval": _int(summary.get("max_repaired_interval")),
         "max_interval_threshold": _int(summary.get("max_interval_threshold")),
@@ -126,6 +147,24 @@ def validate_listening_gap(report: dict[str, Any]) -> dict[str, Any]:
         "target_max_pitch_changed_ratio": _float(summary.get("target_max_pitch_changed_ratio")),
         "listening_review_quality_gap_open": bool(
             summary.get("listening_review_quality_gap_open", False)
+        ),
+        "outside_soloing_repair_objective_path_ready": bool(
+            summary.get("outside_soloing_repair_objective_path_ready", False)
+        ),
+        "outside_soloing_repair_target_supported": bool(
+            summary.get("outside_soloing_repair_target_supported", False)
+        ),
+        "outside_soloing_repair_rendered_audio_file_count": _int(
+            summary.get("outside_soloing_repair_rendered_audio_file_count")
+        ),
+        "outside_soloing_repair_changed_note_total": _int(
+            summary.get("outside_soloing_repair_changed_note_total")
+        ),
+        "outside_soloing_repair_pitch_role_risk_count_after": _int(
+            summary.get("outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "outside_soloing_repair_pitch_role_risk_delta": _int(
+            summary.get("outside_soloing_repair_pitch_role_risk_delta")
         ),
     }
 
@@ -270,6 +309,7 @@ def build_delivery_package_report(
             "input_to_ranked_midi_ready": True,
             "input_to_rendered_wav_evidence_ready": True,
             "changed_ratio_repair_audio_evidence_ready": True,
+            "outside_soloing_repair_evidence_ready": True,
             "listening_review_quality_gap_open": bool(
                 listening["listening_review_quality_gap_open"]
             ),
@@ -295,6 +335,18 @@ def build_delivery_package_report(
             "changed_ratio_repair_wav_duration_range": [
                 audio["duration_min_seconds"],
                 audio["duration_max_seconds"],
+            ],
+            "outside_soloing_repair_wav_count": listening[
+                "outside_soloing_repair_rendered_audio_file_count"
+            ],
+            "outside_soloing_repair_changed_note_total": listening[
+                "outside_soloing_repair_changed_note_total"
+            ],
+            "outside_soloing_repair_pitch_role_risk_count_after": listening[
+                "outside_soloing_repair_pitch_role_risk_count_after"
+            ],
+            "outside_soloing_repair_pitch_role_risk_delta": listening[
+                "outside_soloing_repair_pitch_role_risk_delta"
             ],
         },
         "artifact_manifest": {
@@ -369,6 +421,18 @@ def validate_delivery_package_report(
         raise StageBMidiToSoloMvpDeliveryPackageError("CLI candidate manifest below 3")
     if _int(package.get("changed_ratio_repair_wav_count")) < 3 or len(audio_candidates) < 3:
         raise StageBMidiToSoloMvpDeliveryPackageError("changed-ratio audio manifest below 3")
+    if not bool(package.get("outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "outside-soloing repair evidence readiness required"
+        )
+    if _int(package.get("outside_soloing_repair_wav_count")) < 6:
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "outside-soloing repair WAV count below 6"
+        )
+    if _int(package.get("outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "outside-soloing repair residual pitch-role risk should be zero"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloMvpDeliveryPackageError("critical user input should not be required")
     if require_no_quality_claim:
@@ -387,8 +451,23 @@ def validate_delivery_package_report(
         "changed_ratio_repair_audio_evidence_ready": bool(
             package.get("changed_ratio_repair_audio_evidence_ready", False)
         ),
+        "outside_soloing_repair_evidence_ready": bool(
+            package.get("outside_soloing_repair_evidence_ready", False)
+        ),
         "cli_candidate_count": _int(package.get("cli_candidate_count")),
         "changed_ratio_repair_wav_count": _int(package.get("changed_ratio_repair_wav_count")),
+        "outside_soloing_repair_wav_count": _int(
+            package.get("outside_soloing_repair_wav_count")
+        ),
+        "outside_soloing_repair_changed_note_total": _int(
+            package.get("outside_soloing_repair_changed_note_total")
+        ),
+        "outside_soloing_repair_pitch_role_risk_count_after": _int(
+            package.get("outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "outside_soloing_repair_pitch_role_risk_delta": _int(
+            package.get("outside_soloing_repair_pitch_role_risk_delta")
+        ),
         "listening_review_quality_gap_open": bool(
             package.get("listening_review_quality_gap_open", False)
         ),
@@ -418,6 +497,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- input to ranked MIDI ready: `{_bool_token(package['input_to_ranked_midi_ready'])}`",
         f"- input to rendered WAV evidence ready: `{_bool_token(package['input_to_rendered_wav_evidence_ready'])}`",
         f"- changed-ratio repair audio evidence ready: `{_bool_token(package['changed_ratio_repair_audio_evidence_ready'])}`",
+        f"- outside-soloing repair evidence ready: `{_bool_token(package['outside_soloing_repair_evidence_ready'])}`",
         f"- listening review quality gap open: `{_bool_token(package['listening_review_quality_gap_open'])}`",
         "",
         "## Run Command",
@@ -433,6 +513,9 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- changed-ratio repair max ratio / target: `{package['changed_ratio_repair_ratio_target'][0]:.4f}` / `{package['changed_ratio_repair_ratio_target'][1]:.4f}`",
         f"- changed-ratio repair max interval / target: `{package['changed_ratio_repair_interval_target'][0]}` / `{package['changed_ratio_repair_interval_target'][1]}`",
         f"- changed-ratio repair WAV duration range: `{package['changed_ratio_repair_wav_duration_range'][0]:.3f}s` - `{package['changed_ratio_repair_wav_duration_range'][1]:.3f}s`",
+        f"- outside-soloing repair WAV count: `{package['outside_soloing_repair_wav_count']}`",
+        f"- outside-soloing repair changed note total: `{package['outside_soloing_repair_changed_note_total']}`",
+        f"- outside-soloing pitch-role risk after / delta: `{package['outside_soloing_repair_pitch_role_risk_count_after']}` / `{package['outside_soloing_repair_pitch_role_risk_delta']}`",
         "",
         "## Claim Boundary",
         "",

--- a/tests/test_stage_b_midi_to_solo_final_status_audit.py
+++ b/tests/test_stage_b_midi_to_solo_final_status_audit.py
@@ -30,8 +30,13 @@ def delivery_package(*, quality_claim: bool = False, cli_count: int = 3) -> dict
             "input_to_ranked_midi_ready": True,
             "input_to_rendered_wav_evidence_ready": True,
             "changed_ratio_repair_audio_evidence_ready": True,
+            "outside_soloing_repair_evidence_ready": True,
             "cli_candidate_count": cli_count,
             "changed_ratio_repair_wav_count": 3,
+            "outside_soloing_repair_wav_count": 6,
+            "outside_soloing_repair_changed_note_total": 2,
+            "outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "outside_soloing_repair_pitch_role_risk_delta": 2,
             "listening_review_quality_gap_open": True,
         },
         "artifact_manifest": {

--- a/tests/test_stage_b_midi_to_solo_mvp_delivery_package.py
+++ b/tests/test_stage_b_midi_to_solo_mvp_delivery_package.py
@@ -26,18 +26,31 @@ def touch(path: Path) -> str:
     return str(path)
 
 
-def listening_gap_report(*, quality_claim: bool = False) -> dict:
+def listening_gap_report(
+    *,
+    quality_claim: bool = False,
+    outside_soloing_repair_supported: bool = True,
+) -> dict:
     return {
         "boundary": LISTENING_GAP_BOUNDARY,
         "quality_gap_summary": {
             "technical_model_core_mvp_completed": True,
             "changed_ratio_repair_objective_completed": True,
+            "outside_soloing_repair_objective_completed": outside_soloing_repair_supported,
             "rendered_audio_file_count": 3,
             "max_repaired_interval": 12,
             "max_interval_threshold": 12,
             "max_repaired_pitch_changed_ratio": 0.4348,
             "target_max_pitch_changed_ratio": 0.5,
             "listening_review_quality_gap_open": True,
+            "outside_soloing_repair_objective_path_ready": outside_soloing_repair_supported,
+            "outside_soloing_repair_target_supported": outside_soloing_repair_supported,
+            "outside_soloing_repair_rendered_audio_file_count": 6,
+            "outside_soloing_repair_changed_note_total": 2,
+            "outside_soloing_repair_pitch_role_risk_count_after": (
+                0 if outside_soloing_repair_supported else 1
+            ),
+            "outside_soloing_repair_pitch_role_risk_delta": 2,
         },
         "readiness": {
             "listening_review_quality_gap_completed": True,
@@ -161,8 +174,13 @@ class StageBMidiToSoloMvpDeliveryPackageTest(unittest.TestCase):
         self.assertTrue(summary["input_to_ranked_midi_ready"])
         self.assertTrue(summary["input_to_rendered_wav_evidence_ready"])
         self.assertTrue(summary["changed_ratio_repair_audio_evidence_ready"])
+        self.assertTrue(summary["outside_soloing_repair_evidence_ready"])
         self.assertEqual(summary["cli_candidate_count"], 3)
         self.assertEqual(summary["changed_ratio_repair_wav_count"], 3)
+        self.assertEqual(summary["outside_soloing_repair_wav_count"], 6)
+        self.assertEqual(summary["outside_soloing_repair_changed_note_total"], 2)
+        self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_count_after"], 0)
+        self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_delta"], 2)
         self.assertTrue(summary["listening_review_quality_gap_open"])
         self.assertFalse(summary["raw_artifact_upload_required"])
         self.assertFalse(summary["human_audio_preference_claimed"])
@@ -206,6 +224,20 @@ class StageBMidiToSoloMvpDeliveryPackageTest(unittest.TestCase):
                     changed_ratio_audio_package=changed_ratio_audio_report(tmp_path, rendered_count=2),
                     output_dir=tmp_path / "delivery",
                     issue_number=738,
+                )
+
+    def test_rejects_missing_outside_soloing_repair_support(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            with self.assertRaises(StageBMidiToSoloMvpDeliveryPackageError):
+                build_delivery_package_report(
+                    listening_review_quality_gap=listening_gap_report(
+                        outside_soloing_repair_supported=False
+                    ),
+                    cli_mvp_package=cli_package_report(tmp_path),
+                    changed_ratio_audio_package=changed_ratio_audio_report(tmp_path),
+                    output_dir=tmp_path / "delivery",
+                    issue_number=822,
                 )
 
     def test_boundary_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary

- MVP delivery package validation에 outside-soloing repair evidence readiness 추가
- delivery manifest와 markdown에 outside-soloing repair count/risk summary 추가
- downstream final status test fixture, harness, README/status/core plan 갱신

## Context

- Issue #820 listening review quality gap 결과, outside-soloing repair evidence가 delivery package 전제에 포함
- outside-soloing repair 주요 값: rendered WAV `6`, changed note total `2`, pitch-role risk after `0`, pitch-role risk delta `2`
- 기존 delivery package manifest는 CLI package와 changed-ratio repair audio evidence 중심

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_delivery_package`
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_final_status_audit`
- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_mvp_delivery_package.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-delivery-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- raw artifact upload 없음
- musical quality, human/audio preference, broad trained-model quality claim 제외 유지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Stage B MIDI-to-solo MVP delivery package documentation with comprehensive status tracking
  * Added evidence readiness metrics and validation for outside-soloing repair functionality
  * Updated project status plan reflecting current delivery package completion state

* **Tests**
  * Extended validation test coverage for delivery package manifest with outside-soloing repair metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->