### PR TITLE
Stage B MIDI-to-solo README final evidence outside-soloing repair refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -298,8 +298,13 @@ MVP delivery package.
 - input to ranked MIDI ready: `true`
 - input to rendered WAV evidence ready: `true`
 - changed-ratio repair audio evidence ready: `true`
+- outside-soloing repair evidence ready: `true`
 - CLI candidate count: `3`
 - changed-ratio repair WAV count: `3`
+- outside-soloing repair WAV count: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing pitch-role risk count after: `0`
+- outside-soloing pitch-role risk delta: `2`
 - CLI dead-air ratio range: `0.1895 - 0.2211`
 - changed-ratio repair max ratio / target: `0.4348 / 0.5000`
 - changed-ratio repair max interval / target: `12 / 12`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -5986,6 +5986,44 @@ Issue #822는 MVP delivery package manifest에 outside-soloing repair evidence�
 
 - `Stage B MIDI-to-solo README final evidence refresh`
 
+## 9.103 Stage B MIDI-to-solo README final evidence outside-soloing repair refresh
+
+Issue #824는 README final evidence에 Issue #822 MVP delivery package outside-soloing repair evidence를 반영한 문서 작업이다.
+
+결과:
+
+- latest evidence boundary reflected: `stage_b_midi_to_solo_mvp_delivery_package`
+- source boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- next boundary: `stage_b_midi_to_solo_final_status_audit`
+- runnable CLI ready: `true`
+- input to ranked MIDI ready: `true`
+- input to rendered WAV evidence ready: `true`
+- changed-ratio repair audio evidence ready: `true`
+- outside-soloing repair evidence ready: `true`
+- CLI candidate count: `3`
+- changed-ratio repair WAV count: `3`
+- outside-soloing repair WAV count: `6`
+- outside-soloing repair pitch-role risk count after: `0`
+- raw artifact upload required: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- README 상단 latest evidence boundary를 delivery package 기준으로 갱신.
+- README delivery package section에 outside-soloing repair evidence 추가.
+- quality/preference claim 제외 유지.
+- 다음 boundary는 final status audit refresh.
+
+검증:
+
+- `git diff --check`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo final status audit refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #822, Stage B MIDI-to-solo MVP delivery package outside-soloing repair refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo README final evidence refresh`
+- latest functional result: Issue #824, Stage B MIDI-to-solo README final evidence outside-soloing repair refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo final status audit refresh`
 
 현재 범위가 아닌 것:
 
@@ -405,6 +405,15 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 README target: `stage_b_midi_to_solo_readme_final_evidence_refresh`
+- README final evidence outside-soloing repair refresh 완료
+- latest evidence boundary reflected: `stage_b_midi_to_solo_mvp_delivery_package`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair WAV count: `6`
+- outside-soloing repair pitch-role risk count after: `0`
+- raw artifact upload required: `false`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 audit target: `stage_b_midi_to_solo_final_status_audit`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 


### PR DESCRIPTION
## Summary

- README latest evidence boundary를 MVP delivery package 기준으로 갱신
- README delivery package section에 outside-soloing repair count/risk summary 추가
- status/core plan에 Issue #824 결과와 다음 final status audit 경계 기록

## Context

- Issue #822 MVP delivery package 결과, outside-soloing repair evidence가 delivery manifest에 포함
- delivery package 주요 값: runnable CLI `true`, changed-ratio WAV `3`, outside-soloing repair WAV `6`, pitch-role risk after `0`, raw artifact upload `false`
- README 상단 latest evidence boundary가 previous current evidence boundary 기준으로 남아 있음

## Validation

- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- 문서-only 변경
- musical quality, human/audio preference, broad trained-model quality claim 제외 유지