### PR TITLE
Stage B MIDI-to-solo post-MVP quality iteration outside-soloing repair refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -6068,6 +6068,47 @@ Issue #826은 final status audit에 Issue #822/#824 outside-soloing repair evide
 
 - `Stage B MIDI-to-solo post-MVP quality iteration plan refresh`
 
+## 9.105 Stage B MIDI-to-solo post-MVP quality iteration outside-soloing repair refresh
+
+Issue #828은 post-MVP quality iteration plan의 final status source validation에 outside-soloing repair evidence를 반영한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- source boundary: `stage_b_midi_to_solo_final_status_audit`
+- next boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
+- selected target: `quality_rubric_baseline`
+- technical MVP complete: `true`
+- local review ready: `true`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair WAV count: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing repair pitch-role risk count after: `0`
+- quality rubric required: `true`
+- candidate failure labeling required: `true`
+- targeted quality repair sweep required: `true`
+- audio review package required: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- post-MVP plan source validation이 final status outside-soloing repair readiness/count/risk summary를 요구.
+- 다음 quality rubric baseline에서 outside-soloing label을 현재 repair evidence와 분리해서 다룰 수 있음.
+- 음악적 품질, human/audio preference, broad trained-model quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- `.venv/bin/python -m py_compile scripts/plan_stage_b_midi_to_solo_post_mvp_quality_iteration.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-post-mvp-quality-iteration-plan`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo quality rubric baseline refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #826, Stage B MIDI-to-solo final status audit outside-soloing repair refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo post-MVP quality iteration plan refresh`
+- latest functional result: Issue #828, Stage B MIDI-to-solo post-MVP quality iteration outside-soloing repair refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo quality rubric baseline refresh`
 
 현재 범위가 아닌 것:
 
@@ -425,6 +425,17 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 plan target: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- post-MVP quality iteration outside-soloing repair refresh 완료
+- selected target: `quality_rubric_baseline`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair WAV count: `6`
+- outside-soloing repair pitch-role risk count after: `0`
+- quality rubric required: `true`
+- candidate failure labeling required: `true`
+- targeted quality repair sweep required: `true`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 rubric target: `stage_b_midi_to_solo_quality_rubric_baseline`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_POST_MVP_QUALITY_ITERATION_PLAN_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_POST_MVP_QUALITY_ITERATION_PLAN_2026-06-10.md
@@ -1,0 +1,30 @@
+# Stage B MIDI-to-Solo Post-MVP Quality Iteration Plan
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- source boundary: `stage_b_midi_to_solo_final_status_audit`
+- next boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
+- selected target: `quality_rubric_baseline`
+- technical MVP complete: `true`
+- local review ready: `true`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair WAV count: `6`
+- outside-soloing pitch-role risk after / delta: `0` / `2`
+
+## Required Work
+
+- `quality_rubric_baseline`: define MIDI-evidence quality rubric before another repair sweep
+- `candidate_failure_labeling`: label current candidates against sparse-output, songlike-melody, outside-soloing, monotony, and phrase-shape failures
+- `targeted_quality_repair_sweep`: run repair/generation sweep against the highest-count failure labels
+- `audio_review_package`: render selected repaired candidates for listening comparison
+
+## Claim Boundary
+
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- broad trained model quality claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo quality rubric baseline`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6134,8 +6134,8 @@ run_stage_b_midi_to_solo_post_mvp_quality_iteration_plan() {
   "$PYTHON_BIN" scripts/plan_stage_b_midi_to_solo_post_mvp_quality_iteration.py \
     --run_id "$run_id" \
     --final_status_audit "$final_status" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_POST_MVP_QUALITY_ITERATION_PLAN_2026-06-09.md \
-    --issue_number 744 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_POST_MVP_QUALITY_ITERATION_PLAN_2026-06-10.md \
+    --issue_number 828 \
     --expected_boundary stage_b_midi_to_solo_post_mvp_quality_iteration_plan \
     --expected_next_boundary stage_b_midi_to_solo_quality_rubric_baseline \
     --expected_target quality_rubric_baseline \

--- a/scripts/plan_stage_b_midi_to_solo_post_mvp_quality_iteration.py
+++ b/scripts/plan_stage_b_midi_to_solo_post_mvp_quality_iteration.py
@@ -107,6 +107,18 @@ def validate_final_status_source(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloPostMvpQualityIterationPlanError(
             "changed-ratio repair WAV count below 3"
         )
+    if not bool(summary.get("outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            "outside-soloing repair evidence readiness required"
+        )
+    if _int(summary.get("outside_soloing_repair_wav_count")) < 6:
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            "outside-soloing repair WAV count below 6"
+        )
+    if _int(summary.get("outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            "outside-soloing residual pitch-role risk should be zero"
+        )
     if not bool(summary.get("listening_review_quality_gap_open", False)):
         raise StageBMidiToSoloPostMvpQualityIterationPlanError(
             "listening review quality gap should remain open"
@@ -173,6 +185,21 @@ def build_post_mvp_quality_iteration_plan_report(
             "readme_final_evidence_reflected": bool(source["readme_final_evidence_reflected"]),
             "cli_candidate_count": _int(source["cli_candidate_count"]),
             "changed_ratio_repair_wav_count": _int(source["changed_ratio_repair_wav_count"]),
+            "outside_soloing_repair_evidence_ready": bool(
+                source["outside_soloing_repair_evidence_ready"]
+            ),
+            "outside_soloing_repair_wav_count": _int(
+                source["outside_soloing_repair_wav_count"]
+            ),
+            "outside_soloing_repair_changed_note_total": _int(
+                source["outside_soloing_repair_changed_note_total"]
+            ),
+            "outside_soloing_repair_pitch_role_risk_count_after": _int(
+                source["outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
+            "outside_soloing_repair_pitch_role_risk_delta": _int(
+                source["outside_soloing_repair_pitch_role_risk_delta"]
+            ),
             "listening_review_quality_gap_open": bool(
                 source["listening_review_quality_gap_open"]
             ),
@@ -285,6 +312,21 @@ def validate_post_mvp_quality_iteration_plan_report(
         "technical_mvp_complete": bool(post_mvp_status.get("technical_mvp_complete", False)),
         "local_review_ready": bool(post_mvp_status.get("local_review_ready", False)),
         "quality_rubric_required": bool(readiness.get("quality_rubric_required", False)),
+        "outside_soloing_repair_evidence_ready": bool(
+            post_mvp_status.get("outside_soloing_repair_evidence_ready", False)
+        ),
+        "outside_soloing_repair_wav_count": _int(
+            post_mvp_status.get("outside_soloing_repair_wav_count")
+        ),
+        "outside_soloing_repair_changed_note_total": _int(
+            post_mvp_status.get("outside_soloing_repair_changed_note_total")
+        ),
+        "outside_soloing_repair_pitch_role_risk_count_after": _int(
+            post_mvp_status.get("outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "outside_soloing_repair_pitch_role_risk_delta": _int(
+            post_mvp_status.get("outside_soloing_repair_pitch_role_risk_delta")
+        ),
         "candidate_failure_labeling_required": bool(
             readiness.get("candidate_failure_labeling_required", False)
         ),
@@ -326,6 +368,9 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- selected target: `{selected['selected_target']}`",
         f"- technical MVP complete: `{_bool_token(status['technical_mvp_complete'])}`",
         f"- local review ready: `{_bool_token(status['local_review_ready'])}`",
+        f"- outside-soloing repair evidence ready: `{_bool_token(status['outside_soloing_repair_evidence_ready'])}`",
+        f"- outside-soloing repair WAV count: `{status['outside_soloing_repair_wav_count']}`",
+        f"- outside-soloing pitch-role risk after / delta: `{status['outside_soloing_repair_pitch_role_risk_count_after']}` / `{status['outside_soloing_repair_pitch_role_risk_delta']}`",
         "",
         "## Required Work",
         "",

--- a/tests/test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan.py
+++ b/tests/test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan.py
@@ -23,6 +23,9 @@ def final_status_audit(
     listening_gap_open: bool = True,
     cli_count: int = 3,
     wav_count: int = 3,
+    outside_ready: bool = True,
+    outside_wav_count: int = 6,
+    outside_risk_after: int = 0,
 ) -> dict:
     return {
         "boundary": FINAL_STATUS_BOUNDARY,
@@ -36,6 +39,11 @@ def final_status_audit(
             "changed_ratio_repair_audio_evidence_ready": True,
             "cli_candidate_count": cli_count,
             "changed_ratio_repair_wav_count": wav_count,
+            "outside_soloing_repair_evidence_ready": outside_ready,
+            "outside_soloing_repair_wav_count": outside_wav_count,
+            "outside_soloing_repair_changed_note_total": 2,
+            "outside_soloing_repair_pitch_role_risk_count_after": outside_risk_after,
+            "outside_soloing_repair_pitch_role_risk_delta": 2,
             "listening_review_quality_gap_open": listening_gap_open,
             "raw_artifact_upload_required": False,
             "human_audio_preference_claimed": False,
@@ -84,6 +92,11 @@ class StageBMidiToSoloPostMvpQualityIterationPlanTest(unittest.TestCase):
         self.assertTrue(summary["local_review_ready"])
         self.assertEqual(summary["selected_target"], SELECTED_TARGET)
         self.assertTrue(summary["quality_rubric_required"])
+        self.assertTrue(summary["outside_soloing_repair_evidence_ready"])
+        self.assertEqual(summary["outside_soloing_repair_wav_count"], 6)
+        self.assertEqual(summary["outside_soloing_repair_changed_note_total"], 2)
+        self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_count_after"], 0)
+        self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_delta"], 2)
         self.assertTrue(summary["candidate_failure_labeling_required"])
         self.assertTrue(summary["targeted_quality_repair_sweep_required"])
         self.assertTrue(summary["audio_review_package_required"])
@@ -132,6 +145,26 @@ class StageBMidiToSoloPostMvpQualityIterationPlanTest(unittest.TestCase):
         with self.assertRaises(StageBMidiToSoloPostMvpQualityIterationPlanError):
             build_post_mvp_quality_iteration_plan_report(
                 final_status_audit=final_status_audit(wav_count=2),
+                output_dir=Path("outputs/post_mvp_quality"),
+                issue_number=744,
+            )
+
+    def test_rejects_incomplete_outside_soloing_repair_evidence(self) -> None:
+        with self.assertRaises(StageBMidiToSoloPostMvpQualityIterationPlanError):
+            build_post_mvp_quality_iteration_plan_report(
+                final_status_audit=final_status_audit(outside_ready=False),
+                output_dir=Path("outputs/post_mvp_quality"),
+                issue_number=744,
+            )
+        with self.assertRaises(StageBMidiToSoloPostMvpQualityIterationPlanError):
+            build_post_mvp_quality_iteration_plan_report(
+                final_status_audit=final_status_audit(outside_wav_count=5),
+                output_dir=Path("outputs/post_mvp_quality"),
+                issue_number=744,
+            )
+        with self.assertRaises(StageBMidiToSoloPostMvpQualityIterationPlanError):
+            build_post_mvp_quality_iteration_plan_report(
+                final_status_audit=final_status_audit(outside_risk_after=1),
                 output_dir=Path("outputs/post_mvp_quality"),
                 issue_number=744,
             )


### PR DESCRIPTION
## Summary

- post-MVP quality iteration plan source validation에 outside-soloing repair readiness/count/risk 조건 추가
- post-MVP status, validation summary, markdown에 outside-soloing repair summary 반영
- 전용 테스트 fixture와 incomplete outside-soloing repair rejection case 추가
- harness doc path와 status/core plan 갱신

## Context

- #826 final status audit에 outside-soloing repair evidence summary 반영
- final status 주요 값: technical MVP complete `true`, local review ready `true`, outside-soloing repair evidence ready `true`, outside-soloing repair WAV `6`, pitch-role risk after `0`
- 기존 post-MVP quality iteration plan source validation은 CLI/changed-ratio readiness 중심
- quality rubric baseline으로 넘기기 전 final status outside-soloing evidence 보존 필요

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
- `.venv/bin/python -m py_compile scripts/plan_stage_b_midi_to_solo_post_mvp_quality_iteration.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-post-mvp-quality-iteration-plan`
- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- plan/report validation 갱신 범위
- musical quality, human/audio preference, broad trained-model quality claim 제외 유지

Closes #828