### PR TITLE
Stage B MIDI-to-solo quality rubric outside-soloing repair evidence refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -6109,6 +6109,44 @@ Issue #828은 post-MVP quality iteration plan의 final status source validation�
 
 - `Stage B MIDI-to-solo quality rubric baseline refresh`
 
+## 9.106 Stage B MIDI-to-solo quality rubric outside-soloing repair evidence refresh
+
+Issue #830은 quality rubric baseline에 post-MVP outside-soloing repair evidence context를 반영한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
+- source boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- next boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
+- selected target: `candidate_failure_labeling`
+- rubric item count: `8`
+- required metric group count: `30`
+- candidate failure labeling ready: `true`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair WAV count: `6`
+- outside-soloing repair pitch-role risk count after: `0`
+- outside-soloing label scope: `remaining context/listening quality risk after objective pitch-role repair`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- quality rubric source validation이 post-MVP outside-soloing repair readiness/count/risk summary를 요구.
+- outside-soloing rubric은 residual pitch-role repair 대상이 아니라 context/listening quality risk labeling 대상으로 유지.
+- 음악적 품질, human/audio preference, broad trained-model quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_rubric_baseline`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_quality_rubric_baseline.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-rubric-baseline`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo candidate failure labeling refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #828, Stage B MIDI-to-solo post-MVP quality iteration outside-soloing repair refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo quality rubric baseline refresh`
+- latest functional result: Issue #830, Stage B MIDI-to-solo quality rubric outside-soloing repair evidence refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo candidate failure labeling refresh`
 
 현재 범위가 아닌 것:
 
@@ -436,6 +436,16 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 rubric target: `stage_b_midi_to_solo_quality_rubric_baseline`
+- quality rubric outside-soloing repair evidence refresh 완료
+- rubric item count: `8`
+- candidate failure labeling ready: `true`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair WAV count: `6`
+- outside-soloing repair pitch-role risk count after: `0`
+- outside-soloing label scope: `remaining context/listening quality risk after objective pitch-role repair`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 labeling target: `stage_b_midi_to_solo_candidate_failure_labeling`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_QUALITY_RUBRIC_BASELINE_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_QUALITY_RUBRIC_BASELINE_2026-06-10.md
@@ -1,0 +1,34 @@
+# Stage B MIDI-to-Solo Quality Rubric Baseline
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
+- source boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- next boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
+- selected target: `candidate_failure_labeling`
+- rubric item count: `8`
+- candidate failure labeling ready: `true`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair WAV count: `6`
+- outside-soloing pitch-role risk after / delta: `0` / `2`
+
+## Rubric Items
+
+- `sparse_or_empty_output`: note_count < 12 or active_bar_count < 2
+- `dead_air_or_density_gap`: dead_air_ratio > 0.35 or empty_bar_count > 0
+- `rhythmic_monotony`: duration_most_common_ratio >= 0.40 or ioi_most_common_ratio >= 0.40 or note_count_per_bar_most_common_ratio >= 0.95
+- `songlike_melody_not_soloing`: four_notes_per_bar_template or four_bar_rhythm_cycle_repeated or shared_rhythm_signature_count >= 3
+- `outside_soloing_without_context`: outside_pitch_run_length >= 4 or avoid_tone_landing_count > 0 when chord_context_available
+- `weak_chord_tone_landing`: cadence_landing_chord_tone == false or strong_beat_chord_tone_ratio < 0.40
+- `phrase_shape_missing_tension_release`: contour_turn_count == 0 or cadence_resolution_present == false
+- `technical_gate_regression`: grammar_valid == false or strict_valid == false or max_simultaneous_notes > 1
+
+## Claim Boundary
+
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- broad trained model quality claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo candidate failure labeling`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6155,8 +6155,8 @@ run_stage_b_midi_to_solo_quality_rubric_baseline() {
   "$PYTHON_BIN" scripts/build_stage_b_midi_to_solo_quality_rubric_baseline.py \
     --run_id "$run_id" \
     --post_mvp_quality_plan "$post_mvp_plan" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_QUALITY_RUBRIC_BASELINE_2026-06-09.md \
-    --issue_number 746 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_QUALITY_RUBRIC_BASELINE_2026-06-10.md \
+    --issue_number 830 \
     --expected_boundary stage_b_midi_to_solo_quality_rubric_baseline \
     --expected_next_boundary stage_b_midi_to_solo_candidate_failure_labeling \
     --expected_target candidate_failure_labeling \

--- a/scripts/build_stage_b_midi_to_solo_quality_rubric_baseline.py
+++ b/scripts/build_stage_b_midi_to_solo_quality_rubric_baseline.py
@@ -103,6 +103,18 @@ def validate_post_mvp_quality_iteration_plan_source(report: dict[str, Any]) -> d
         raise StageBMidiToSoloQualityRubricBaselineError("ordered work count below 4")
     if _int(summary.get("quality_failure_taxonomy_seed_count")) < 7:
         raise StageBMidiToSoloQualityRubricBaselineError("taxonomy seed count below 7")
+    if not bool(summary.get("outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloQualityRubricBaselineError(
+            "outside-soloing repair evidence readiness required"
+        )
+    if _int(summary.get("outside_soloing_repair_wav_count")) < 6:
+        raise StageBMidiToSoloQualityRubricBaselineError(
+            "outside-soloing repair WAV count below 6"
+        )
+    if _int(summary.get("outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloQualityRubricBaselineError(
+            "outside-soloing residual pitch-role risk should be zero"
+        )
     return summary
 
 
@@ -159,11 +171,16 @@ def build_rubric_items() -> list[dict[str, Any]]:
                 "non_chord_tone_ratio",
                 "avoid_tone_landing_count",
                 "outside_pitch_run_length",
+                "post_repair_pitch_role_risk_count_after",
                 "chord_context_available",
             ],
             "failure_rule": "outside_pitch_run_length >= 4 or avoid_tone_landing_count > 0 when chord_context_available",
-            "threshold": {"max_outside_pitch_run_length": 3, "max_avoid_tone_landing_count": 0},
-            "source_reason": "outside notes require chord-context support before being kept",
+            "threshold": {
+                "max_outside_pitch_run_length": 3,
+                "max_avoid_tone_landing_count": 0,
+                "max_post_repair_pitch_role_risk_count_after": 0,
+            },
+            "source_reason": "outside pitch-role repair evidence is complete; remaining label covers context/listening quality risk",
         },
         {
             "id": "weak_chord_tone_landing",
@@ -210,6 +227,24 @@ def build_quality_rubric_baseline_report(
 ) -> dict[str, Any]:
     source = validate_post_mvp_quality_iteration_plan_source(post_mvp_quality_plan)
     rubric_items = build_rubric_items()
+    outside_context = {
+        "outside_soloing_repair_evidence_ready": bool(
+            source["outside_soloing_repair_evidence_ready"]
+        ),
+        "outside_soloing_repair_wav_count": _int(
+            source["outside_soloing_repair_wav_count"]
+        ),
+        "outside_soloing_repair_changed_note_total": _int(
+            source["outside_soloing_repair_changed_note_total"]
+        ),
+        "outside_soloing_repair_pitch_role_risk_count_after": _int(
+            source["outside_soloing_repair_pitch_role_risk_count_after"]
+        ),
+        "outside_soloing_repair_pitch_role_risk_delta": _int(
+            source["outside_soloing_repair_pitch_role_risk_delta"]
+        ),
+        "outside_soloing_label_scope": "remaining context/listening quality risk after objective pitch-role repair",
+    }
     return {
         "schema_version": SCHEMA_VERSION,
         "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
@@ -218,12 +253,22 @@ def build_quality_rubric_baseline_report(
         "boundary": BOUNDARY,
         "source_boundary": POST_MVP_PLAN_BOUNDARY,
         "source_summary": source,
+        "source_quality_context": outside_context,
         "rubric_baseline": {
             "rubric_item_count": len(rubric_items),
             "required_metric_group_count": len(
                 {metric for item in rubric_items for metric in _list(item.get("metric_keys"))}
             ),
             "candidate_failure_labeling_ready": True,
+            "outside_soloing_repair_evidence_ready": bool(
+                outside_context["outside_soloing_repair_evidence_ready"]
+            ),
+            "outside_soloing_repair_wav_count": _int(
+                outside_context["outside_soloing_repair_wav_count"]
+            ),
+            "outside_soloing_repair_pitch_role_risk_count_after": _int(
+                outside_context["outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
         },
@@ -331,6 +376,15 @@ def validate_quality_rubric_baseline_report(
         ),
         "rubric_item_count": len(rubric_items),
         "required_metric_group_count": _int(baseline.get("required_metric_group_count")),
+        "outside_soloing_repair_evidence_ready": bool(
+            baseline.get("outside_soloing_repair_evidence_ready", False)
+        ),
+        "outside_soloing_repair_wav_count": _int(
+            baseline.get("outside_soloing_repair_wav_count")
+        ),
+        "outside_soloing_repair_pitch_role_risk_count_after": _int(
+            baseline.get("outside_soloing_repair_pitch_role_risk_count_after")
+        ),
         "human_audio_preference_claimed": bool(
             readiness.get("human_audio_preference_claimed", True)
         ),
@@ -344,6 +398,7 @@ def validate_quality_rubric_baseline_report(
 
 def markdown_report(report: dict[str, Any]) -> str:
     baseline = report["rubric_baseline"]
+    source_context = report["source_quality_context"]
     selected = report["selected_next_target"]
     readiness = report["readiness"]
     lines = [
@@ -357,6 +412,9 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- selected target: `{selected['selected_target']}`",
         f"- rubric item count: `{baseline['rubric_item_count']}`",
         f"- candidate failure labeling ready: `{_bool_token(baseline['candidate_failure_labeling_ready'])}`",
+        f"- outside-soloing repair evidence ready: `{_bool_token(source_context['outside_soloing_repair_evidence_ready'])}`",
+        f"- outside-soloing repair WAV count: `{source_context['outside_soloing_repair_wav_count']}`",
+        f"- outside-soloing pitch-role risk after / delta: `{source_context['outside_soloing_repair_pitch_role_risk_count_after']}` / `{source_context['outside_soloing_repair_pitch_role_risk_delta']}`",
         "",
         "## Rubric Items",
         "",

--- a/tests/test_stage_b_midi_to_solo_candidate_failure_labeling.py
+++ b/tests/test_stage_b_midi_to_solo_candidate_failure_labeling.py
@@ -58,6 +58,11 @@ def post_mvp_quality_plan() -> dict:
         "post_mvp_status": {
             "technical_mvp_complete": True,
             "local_review_ready": True,
+            "outside_soloing_repair_evidence_ready": True,
+            "outside_soloing_repair_wav_count": 6,
+            "outside_soloing_repair_changed_note_total": 2,
+            "outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "outside_soloing_repair_pitch_role_risk_delta": 2,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
         },

--- a/tests/test_stage_b_midi_to_solo_quality_rubric_baseline.py
+++ b/tests/test_stage_b_midi_to_solo_quality_rubric_baseline.py
@@ -24,6 +24,9 @@ def post_mvp_quality_plan(
     quality_claim: bool = False,
     ordered_work_count: int = 4,
     taxonomy_count: int = 7,
+    outside_ready: bool = True,
+    outside_wav_count: int = 6,
+    outside_risk_after: int = 0,
 ) -> dict:
     ordered_targets = [
         "quality_rubric_baseline",
@@ -37,6 +40,11 @@ def post_mvp_quality_plan(
         "post_mvp_status": {
             "technical_mvp_complete": True,
             "local_review_ready": True,
+            "outside_soloing_repair_evidence_ready": outside_ready,
+            "outside_soloing_repair_wav_count": outside_wav_count,
+            "outside_soloing_repair_changed_note_total": 2,
+            "outside_soloing_repair_pitch_role_risk_count_after": outside_risk_after,
+            "outside_soloing_repair_pitch_role_risk_delta": 2,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
         },
@@ -91,6 +99,9 @@ class StageBMidiToSoloQualityRubricBaselineTest(unittest.TestCase):
         self.assertEqual(summary["selected_target"], SELECTED_TARGET)
         self.assertEqual(summary["rubric_item_count"], 8)
         self.assertGreaterEqual(summary["required_metric_group_count"], 20)
+        self.assertTrue(summary["outside_soloing_repair_evidence_ready"])
+        self.assertEqual(summary["outside_soloing_repair_wav_count"], 6)
+        self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_count_after"], 0)
         self.assertFalse(summary["human_audio_preference_claimed"])
         self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
         self.assertEqual(
@@ -134,6 +145,26 @@ class StageBMidiToSoloQualityRubricBaselineTest(unittest.TestCase):
         with self.assertRaises(StageBMidiToSoloQualityRubricBaselineError):
             build_quality_rubric_baseline_report(
                 post_mvp_quality_plan=post_mvp_quality_plan(taxonomy_count=6),
+                output_dir=Path("outputs/quality_rubric"),
+                issue_number=746,
+            )
+
+    def test_rejects_incomplete_outside_soloing_repair_context(self) -> None:
+        with self.assertRaises(StageBMidiToSoloQualityRubricBaselineError):
+            build_quality_rubric_baseline_report(
+                post_mvp_quality_plan=post_mvp_quality_plan(outside_ready=False),
+                output_dir=Path("outputs/quality_rubric"),
+                issue_number=746,
+            )
+        with self.assertRaises(StageBMidiToSoloQualityRubricBaselineError):
+            build_quality_rubric_baseline_report(
+                post_mvp_quality_plan=post_mvp_quality_plan(outside_wav_count=5),
+                output_dir=Path("outputs/quality_rubric"),
+                issue_number=746,
+            )
+        with self.assertRaises(StageBMidiToSoloQualityRubricBaselineError):
+            build_quality_rubric_baseline_report(
+                post_mvp_quality_plan=post_mvp_quality_plan(outside_risk_after=1),
                 output_dir=Path("outputs/quality_rubric"),
                 issue_number=746,
             )

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py
@@ -48,6 +48,11 @@ def post_mvp_quality_plan() -> dict:
         "post_mvp_status": {
             "technical_mvp_complete": True,
             "local_review_ready": True,
+            "outside_soloing_repair_evidence_ready": True,
+            "outside_soloing_repair_wav_count": 6,
+            "outside_soloing_repair_changed_note_total": 2,
+            "outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "outside_soloing_repair_pitch_role_risk_delta": 2,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
         },

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
@@ -48,6 +48,11 @@ def post_mvp_quality_plan() -> dict:
         "post_mvp_status": {
             "technical_mvp_complete": True,
             "local_review_ready": True,
+            "outside_soloing_repair_evidence_ready": True,
+            "outside_soloing_repair_wav_count": 6,
+            "outside_soloing_repair_changed_note_total": 2,
+            "outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "outside_soloing_repair_pitch_role_risk_delta": 2,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
         },

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
@@ -57,6 +57,11 @@ def post_mvp_quality_plan() -> dict:
         "post_mvp_status": {
             "technical_mvp_complete": True,
             "local_review_ready": True,
+            "outside_soloing_repair_evidence_ready": True,
+            "outside_soloing_repair_wav_count": 6,
+            "outside_soloing_repair_changed_note_total": 2,
+            "outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "outside_soloing_repair_pitch_role_risk_delta": 2,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
         },


### PR DESCRIPTION
## Summary

- quality rubric source validation에 outside-soloing repair readiness/count/risk 조건 추가
- rubric source context와 summary에 outside-soloing repair evidence 추가
- outside-soloing rubric metric/source reason을 post-repair pitch-role risk 기준으로 갱신
- downstream test fixtures에 최신 post-MVP plan contract 반영
- harness doc path와 status/core plan 갱신

## Context

- #828 post-MVP plan이 outside-soloing repair evidence를 source validation에 포함
- post-MVP plan 주요 값: outside-soloing repair evidence ready `true`, WAV `6`, changed note total `2`, pitch-role risk after `0`
- 기존 quality rubric baseline은 outside-soloing repair evidence context를 보존하지 않음
- candidate failure labeling 전 residual pitch-role repair와 context/listening quality risk 분리 필요

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_rubric_baseline`
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_candidate_failure_labeling tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep tests.test_stage_b_midi_to_solo_targeted_quality_repair_sweep`
- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_quality_rubric_baseline.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-rubric-baseline`
- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- rubric/report validation 갱신 범위
- musical quality, human/audio preference, broad trained-model quality claim 제외 유지

Closes #830