### PR TITLE
Stage B MIDI-to-solo candidate failure labeling outside-soloing repair context refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -6147,6 +6147,45 @@ Issue #830은 quality rubric baseline에 post-MVP outside-soloing repair evidenc
 
 - `Stage B MIDI-to-solo candidate failure labeling refresh`
 
+## 9.107 Stage B MIDI-to-solo candidate failure labeling outside-soloing repair context refresh
+
+Issue #832는 candidate failure labeling에 quality rubric outside-soloing repair context를 반영한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
+- source boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- selected target: `targeted_quality_repair_sweep`
+- candidate count: `6`
+- failed candidate count: `6`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair WAV count: `6`
+- outside-soloing repair pitch-role risk count after: `0`
+- outside-soloing not evaluable count: `6`
+- targeted quality repair sweep ready: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- candidate failure labeling이 rubric outside-soloing repair readiness/count/risk summary를 요구.
+- current candidate의 `outside_soloing_without_context`는 chord context 부재로 not_evaluable 유지.
+- residual pitch-role repair failure와 context/listening quality labeling boundary 분리.
+- 다음 boundary는 targeted quality repair sweep refresh.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_candidate_failure_labeling`
+- `.venv/bin/python -m py_compile scripts/label_stage_b_midi_to_solo_candidate_failures.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-candidate-failure-labeling`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo targeted quality repair sweep refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #830, Stage B MIDI-to-solo quality rubric outside-soloing repair evidence refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo candidate failure labeling refresh`
+- latest functional result: Issue #832, Stage B MIDI-to-solo candidate failure labeling outside-soloing repair context refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair sweep refresh`
 
 현재 범위가 아닌 것:
 
@@ -446,6 +446,17 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 labeling target: `stage_b_midi_to_solo_candidate_failure_labeling`
+- candidate failure labeling outside-soloing repair context refresh 완료
+- candidate count: `6`
+- failed candidate count: `6`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair WAV count: `6`
+- outside-soloing repair pitch-role risk count after: `0`
+- outside-soloing not evaluable count: `6`
+- targeted quality repair sweep ready: `true`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 repair target: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_CANDIDATE_FAILURE_LABELING_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_CANDIDATE_FAILURE_LABELING_2026-06-10.md
@@ -1,0 +1,36 @@
+# Stage B MIDI-to-Solo Candidate Failure Labeling
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
+- source boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- selected target: `targeted_quality_repair_sweep`
+- candidate count: `6`
+- failed candidate count: `6`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair WAV count: `6`
+- outside-soloing pitch-role risk after: `0`
+- outside-soloing not evaluable count: `6`
+- targeted quality repair sweep ready: `true`
+
+## Failure Counts
+
+- `dead_air_or_density_gap`: `1`
+- `phrase_shape_missing_tension_release`: `2`
+- `rhythmic_monotony`: `3`
+- `songlike_melody_not_soloing`: `6`
+
+## Not Evaluable
+
+- `outside_soloing_without_context`: `6`
+- `weak_chord_tone_landing`: `6`
+
+## Claim Boundary
+
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo targeted quality repair sweep`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6184,8 +6184,8 @@ run_stage_b_midi_to_solo_candidate_failure_labeling() {
     --run_id "$run_id" \
     --rubric_baseline "$rubric" \
     --mvp_delivery_package "$delivery" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_CANDIDATE_FAILURE_LABELING_2026-06-09.md \
-    --issue_number 748 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_CANDIDATE_FAILURE_LABELING_2026-06-10.md \
+    --issue_number 832 \
     --expected_boundary stage_b_midi_to_solo_candidate_failure_labeling \
     --min_candidate_count 6 \
     --require_labeling_completed \

--- a/scripts/label_stage_b_midi_to_solo_candidate_failures.py
+++ b/scripts/label_stage_b_midi_to_solo_candidate_failures.py
@@ -105,6 +105,18 @@ def validate_rubric_baseline(report: dict[str, Any]) -> dict[str, Any]:
     rubric_items = [_dict(item) for item in _list(report.get("rubric_items"))]
     if len(rubric_items) < 8:
         raise StageBMidiToSoloCandidateFailureLabelingError("rubric items below 8")
+    if not bool(summary.get("outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloCandidateFailureLabelingError(
+            "outside-soloing repair evidence readiness required"
+        )
+    if _int(summary.get("outside_soloing_repair_wav_count")) < 6:
+        raise StageBMidiToSoloCandidateFailureLabelingError(
+            "outside-soloing repair WAV count below 6"
+        )
+    if _int(summary.get("outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloCandidateFailureLabelingError(
+            "outside-soloing residual pitch-role risk should be zero"
+        )
     return {**summary, "rubric_items": rubric_items}
 
 
@@ -464,6 +476,21 @@ def build_candidate_failure_labeling_report(
     not_evaluable_counts = Counter(
         label for item in labeled for label in _list(item.get("not_evaluable_labels"))
     )
+    outside_context = {
+        "outside_soloing_repair_evidence_ready": bool(
+            rubric_summary["outside_soloing_repair_evidence_ready"]
+        ),
+        "outside_soloing_repair_wav_count": _int(
+            rubric_summary["outside_soloing_repair_wav_count"]
+        ),
+        "outside_soloing_repair_pitch_role_risk_count_after": _int(
+            rubric_summary["outside_soloing_repair_pitch_role_risk_count_after"]
+        ),
+        "outside_soloing_not_evaluable_count": _int(
+            not_evaluable_counts.get("outside_soloing_without_context", 0)
+        ),
+        "outside_soloing_label_scope": "not_evaluable chord-context gap after objective pitch-role repair",
+    }
     failed_candidate_count = sum(1 for item in labeled if _list(item.get("failure_labels")))
     selected_target = REPAIR_TARGET if failed_candidate_count > 0 else AUDIO_REVIEW_TARGET
     next_boundary = REPAIR_NEXT_BOUNDARY if failed_candidate_count > 0 else AUDIO_REVIEW_NEXT_BOUNDARY
@@ -488,6 +515,7 @@ def build_candidate_failure_labeling_report(
             "candidate_sources": dict(
                 sorted(Counter(str(item.get("source") or "") for item in labeled).items())
             ),
+            **outside_context,
         },
         "selected_next_target": {
             "selected_target": selected_target,
@@ -581,6 +609,18 @@ def validate_candidate_failure_labeling_report(
         "failed_candidate_count": _int(aggregate.get("failed_candidate_count")),
         "failure_label_type_count": len(_dict(aggregate.get("failure_counts"))),
         "not_evaluable_label_type_count": len(_dict(aggregate.get("not_evaluable_counts"))),
+        "outside_soloing_repair_evidence_ready": bool(
+            aggregate.get("outside_soloing_repair_evidence_ready", False)
+        ),
+        "outside_soloing_repair_wav_count": _int(
+            aggregate.get("outside_soloing_repair_wav_count")
+        ),
+        "outside_soloing_repair_pitch_role_risk_count_after": _int(
+            aggregate.get("outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "outside_soloing_not_evaluable_count": _int(
+            aggregate.get("outside_soloing_not_evaluable_count")
+        ),
         "targeted_quality_repair_sweep_ready": bool(
             readiness.get("targeted_quality_repair_sweep_ready", False)
         ),
@@ -611,6 +651,10 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- selected target: `{selected['selected_target']}`",
         f"- candidate count: `{aggregate['candidate_count']}`",
         f"- failed candidate count: `{aggregate['failed_candidate_count']}`",
+        f"- outside-soloing repair evidence ready: `{_bool_token(aggregate['outside_soloing_repair_evidence_ready'])}`",
+        f"- outside-soloing repair WAV count: `{aggregate['outside_soloing_repair_wav_count']}`",
+        f"- outside-soloing pitch-role risk after: `{aggregate['outside_soloing_repair_pitch_role_risk_count_after']}`",
+        f"- outside-soloing not evaluable count: `{aggregate['outside_soloing_not_evaluable_count']}`",
         f"- targeted quality repair sweep ready: `{_bool_token(readiness['targeted_quality_repair_sweep_ready'])}`",
         "",
         "## Failure Counts",

--- a/tests/test_stage_b_midi_to_solo_candidate_failure_labeling.py
+++ b/tests/test_stage_b_midi_to_solo_candidate_failure_labeling.py
@@ -176,6 +176,10 @@ class StageBMidiToSoloCandidateFailureLabelingTest(unittest.TestCase):
             self.assertGreater(summary["failed_candidate_count"], 0)
             self.assertGreater(summary["failure_label_type_count"], 0)
             self.assertGreaterEqual(summary["not_evaluable_label_type_count"], 2)
+            self.assertTrue(summary["outside_soloing_repair_evidence_ready"])
+            self.assertEqual(summary["outside_soloing_repair_wav_count"], 6)
+            self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_count_after"], 0)
+            self.assertEqual(summary["outside_soloing_not_evaluable_count"], 3)
             self.assertEqual(summary["selected_target"], REPAIR_TARGET)
             self.assertEqual(summary["next_boundary"], REPAIR_NEXT_BOUNDARY)
             self.assertTrue(summary["targeted_quality_repair_sweep_ready"])
@@ -233,6 +237,22 @@ class StageBMidiToSoloCandidateFailureLabelingTest(unittest.TestCase):
                 build_candidate_failure_labeling_report(
                     rubric_baseline=source,
                     mvp_delivery_package=delivery_package([root / "a.mid"] * 3),
+                    output_dir=root / "labels",
+                    issue_number=748,
+                )
+
+    def test_rejects_incomplete_rubric_outside_soloing_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = [root / f"candidate_{index}.mid" for index in range(3)]
+            for path in paths:
+                write_midi(path, [60, 62, 64, 65] * 4)
+            source = rubric_baseline(root)
+            source["rubric_baseline"]["outside_soloing_repair_evidence_ready"] = False
+            with self.assertRaises(StageBMidiToSoloCandidateFailureLabelingError):
+                build_candidate_failure_labeling_report(
+                    rubric_baseline=source,
+                    mvp_delivery_package=delivery_package(paths),
                     output_dir=root / "labels",
                     issue_number=748,
                 )


### PR DESCRIPTION
## Summary

- rubric validation에 outside-soloing repair readiness/count/risk 조건 추가
- labeling aggregate와 validation summary에 outside-soloing repair context 추가
- markdown summary에 outside-soloing not_evaluable count와 post-repair risk 기록
- 전용 테스트 rejection/assertion 추가
- harness doc path와 status/core plan 갱신

## Context

- #830 quality rubric baseline에 outside-soloing repair evidence context 반영
- rubric 주요 값: outside-soloing repair evidence ready `true`, WAV `6`, pitch-role risk after `0`
- 기존 candidate failure labeling aggregate에는 outside-soloing repair context가 없음
- `outside_soloing_without_context`는 chord context 부재로 not_evaluable이며 residual pitch-role repair failure와 구분 필요

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_candidate_failure_labeling`
- `.venv/bin/python -m py_compile scripts/label_stage_b_midi_to_solo_candidate_failures.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-candidate-failure-labeling`
- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- labeling/report validation 갱신 범위
- musical quality, human/audio preference, broad trained-model quality claim 제외 유지

Closes #832