### PR TITLE
Stage B MIDI-to-solo targeted quality repair outside-soloing context refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -6186,6 +6186,47 @@ Issue #832는 candidate failure labeling에 quality rubric outside-soloing repai
 
 - `Stage B MIDI-to-solo targeted quality repair sweep refresh`
 
+## 9.108 Stage B MIDI-to-solo targeted quality repair outside-soloing context refresh
+
+Issue #834는 targeted quality repair sweep에 candidate failure labeling outside-soloing context를 반영한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
+- candidate count: `6`
+- source total failure label count: `12`
+- repaired total failure label count: `8`
+- failure label delta: `4`
+- improved candidate count: `4`
+- technical regression count: `0`
+- source outside-soloing repair pitch-role risk count after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- audio package ready: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- repair sweep는 failure label 총합을 줄였지만 chord-context 부재 outside-soloing not_evaluable boundary는 유지.
+- residual pitch-role repair failure는 source 기준 `0`으로 분리.
+- 음악적 품질, human/audio preference, broad trained-model quality claim 제외 유지.
+- 다음 boundary는 targeted quality repair audio package refresh.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-sweep`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo targeted quality repair audio package refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #832, Stage B MIDI-to-solo candidate failure labeling outside-soloing repair context refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair sweep refresh`
+- latest functional result: Issue #834, Stage B MIDI-to-solo targeted quality repair outside-soloing context refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair audio package refresh`
 
 현재 범위가 아닌 것:
 
@@ -457,6 +457,17 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 repair target: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- targeted quality repair outside-soloing context refresh 완료
+- candidate count: `6`
+- failure label delta: `4`
+- technical regression count: `0`
+- source outside-soloing repair pitch-role risk count after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- audio package ready: `true`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 audio target: `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_SWEEP_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_SWEEP_2026-06-10.md
@@ -1,0 +1,34 @@
+# Stage B MIDI-to-Solo Targeted Quality Repair Sweep
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
+- selected target: `targeted_quality_repair_audio_package`
+- candidate count: `6`
+- source total failure label count: `12`
+- repaired total failure label count: `8`
+- failure label delta: `4`
+- improved candidate count: `4`
+- technical regression count: `0`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair pitch-role risk after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- target supported: `true`
+
+## Repaired Failure Counts
+
+- `dead_air_or_density_gap`: `1`
+- `phrase_shape_missing_tension_release`: `2`
+- `songlike_melody_not_soloing`: `5`
+
+## Claim Boundary
+
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo targeted quality repair audio package`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6211,8 +6211,8 @@ run_stage_b_midi_to_solo_targeted_quality_repair_sweep() {
     --run_id "$run_id" \
     --candidate_failure_labeling "$labeling" \
     --rubric_baseline "$rubric" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_SWEEP_2026-06-09.md \
-    --issue_number 750 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_SWEEP_2026-06-10.md \
+    --issue_number 834 \
     --expected_boundary stage_b_midi_to_solo_targeted_quality_repair_sweep \
     --min_candidate_count 6 \
     --require_sweep_completed \

--- a/scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
+++ b/scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
@@ -109,6 +109,22 @@ def validate_labeling_source(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloTargetedQualityRepairSweepError("targeted repair boundary required")
     if _int(summary.get("failed_candidate_count")) <= 0:
         raise StageBMidiToSoloTargetedQualityRepairSweepError("failure labels required")
+    if not bool(summary.get("outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "outside-soloing repair evidence readiness required"
+        )
+    if _int(summary.get("outside_soloing_repair_wav_count")) < 6:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "outside-soloing repair WAV count below 6"
+        )
+    if _int(summary.get("outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "outside-soloing residual pitch-role risk should be zero"
+        )
+    if _int(summary.get("outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "outside-soloing not-evaluable boundary required"
+        )
     return summary
 
 
@@ -291,6 +307,11 @@ def build_targeted_quality_repair_sweep_report(
         for item in relabeled
         for label in _list(_dict(item.get("repaired_labeling")).get("failure_labels"))
     )
+    not_evaluable_counts_after = Counter(
+        label
+        for item in relabeled
+        for label in _list(_dict(item.get("repaired_labeling")).get("not_evaluable_labels"))
+    )
     target_supported = total_after < total_before and technical_regression_count == 0
     next_boundary = NEXT_BOUNDARY if target_supported else FOLLOWUP_BOUNDARY
     return {
@@ -309,6 +330,21 @@ def build_targeted_quality_repair_sweep_report(
             "improved_candidate_count": improved_count,
             "technical_regression_count": technical_regression_count,
             "repaired_failure_counts": dict(sorted(failure_counts_after.items())),
+            "source_outside_soloing_repair_evidence_ready": bool(
+                source_summary["outside_soloing_repair_evidence_ready"]
+            ),
+            "source_outside_soloing_repair_wav_count": _int(
+                source_summary["outside_soloing_repair_wav_count"]
+            ),
+            "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+                source_summary["outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
+            "source_outside_soloing_not_evaluable_count": _int(
+                source_summary["outside_soloing_not_evaluable_count"]
+            ),
+            "repaired_outside_soloing_not_evaluable_count": _int(
+                not_evaluable_counts_after.get("outside_soloing_without_context", 0)
+            ),
             "target_supported": target_supported,
         },
         "selected_next_target": {
@@ -412,6 +448,21 @@ def validate_targeted_quality_repair_sweep_report(
         "failure_label_delta": _int(aggregate.get("failure_label_delta")),
         "improved_candidate_count": _int(aggregate.get("improved_candidate_count")),
         "technical_regression_count": _int(aggregate.get("technical_regression_count")),
+        "source_outside_soloing_repair_evidence_ready": bool(
+            aggregate.get("source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "source_outside_soloing_repair_wav_count": _int(
+            aggregate.get("source_outside_soloing_repair_wav_count")
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            aggregate.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_not_evaluable_count": _int(
+            aggregate.get("source_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_outside_soloing_not_evaluable_count": _int(
+            aggregate.get("repaired_outside_soloing_not_evaluable_count")
+        ),
         "audio_package_ready": bool(readiness.get("audio_package_ready", False)),
         "human_audio_preference_claimed": bool(
             readiness.get("human_audio_preference_claimed", True)
@@ -443,6 +494,10 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- failure label delta: `{aggregate['failure_label_delta']}`",
         f"- improved candidate count: `{aggregate['improved_candidate_count']}`",
         f"- technical regression count: `{aggregate['technical_regression_count']}`",
+        f"- source outside-soloing repair evidence ready: `{_bool_token(aggregate['source_outside_soloing_repair_evidence_ready'])}`",
+        f"- source outside-soloing repair pitch-role risk after: `{aggregate['source_outside_soloing_repair_pitch_role_risk_count_after']}`",
+        f"- source outside-soloing not evaluable count: `{aggregate['source_outside_soloing_not_evaluable_count']}`",
+        f"- repaired outside-soloing not evaluable count: `{aggregate['repaired_outside_soloing_not_evaluable_count']}`",
         f"- target supported: `{_bool_token(aggregate['target_supported'])}`",
         "",
         "## Repaired Failure Counts",

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
@@ -179,6 +179,11 @@ class StageBMidiToSoloTargetedQualityRepairSweepTest(unittest.TestCase):
             self.assertEqual(summary["candidate_count"], 6)
             self.assertGreater(summary["failure_label_delta"], 0)
             self.assertEqual(summary["technical_regression_count"], 0)
+            self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
+            self.assertEqual(summary["source_outside_soloing_repair_wav_count"], 6)
+            self.assertEqual(summary["source_outside_soloing_repair_pitch_role_risk_count_after"], 0)
+            self.assertEqual(summary["source_outside_soloing_not_evaluable_count"], 6)
+            self.assertEqual(summary["repaired_outside_soloing_not_evaluable_count"], 6)
             self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
             self.assertTrue(summary["audio_package_ready"])
             self.assertFalse(summary["human_audio_preference_claimed"])
@@ -193,6 +198,19 @@ class StageBMidiToSoloTargetedQualityRepairSweepTest(unittest.TestCase):
                         root,
                         quality_claim=True,
                     ),
+                    rubric_baseline=rubric_baseline(root),
+                    output_dir=root / "sweep",
+                    issue_number=750,
+                )
+
+    def test_rejects_missing_outside_soloing_labeling_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = candidate_failure_labeling(root)
+            source["aggregate"]["outside_soloing_not_evaluable_count"] = 0
+            with self.assertRaises(StageBMidiToSoloTargetedQualityRepairSweepError):
+                build_targeted_quality_repair_sweep_report(
+                    candidate_failure_labeling=source,
                     rubric_baseline=rubric_baseline(root),
                     output_dir=root / "sweep",
                     issue_number=750,


### PR DESCRIPTION
## Summary

- labeling source validation에 outside-soloing repair readiness/count/risk/not_evaluable 조건 추가
- repair aggregate와 validation summary에 source/repaired outside-soloing not_evaluable count 추가
- markdown summary에 post-repair pitch-role risk와 not_evaluable count 기록
- 전용 테스트 assertion/rejection case 추가
- harness doc path와 status/core plan 갱신

## Context

- #832 candidate failure labeling에 outside-soloing repair context 반영
- labeling 주요 값: candidate `6`, failed candidate `6`, outside-soloing repair evidence ready `true`, pitch-role risk after `0`, outside-soloing not_evaluable `6`
- 기존 targeted quality repair sweep aggregate에는 outside-soloing not_evaluable boundary가 없음
- 현재 sweep은 failure label delta를 줄이지만 chord-context 부재 outside-soloing label은 repair 대상이 아니라 not_evaluable 범위

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_sweep`
- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-sweep`
- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- repair sweep/report validation 갱신 범위
- musical quality, human/audio preference, broad trained-model quality claim 제외 유지

Closes #834