### PR TITLE
Stage B MIDI-to-solo targeted quality repair audio package outside-soloing context refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -6227,6 +6227,45 @@ Issue #834는 targeted quality repair sweep에 candidate failure labeling outsid
 
 - `Stage B MIDI-to-solo targeted quality repair audio package refresh`
 
+## 9.109 Stage B MIDI-to-solo targeted quality repair audio package outside-soloing context refresh
+
+Issue #836은 targeted quality repair audio package에 repair sweep outside-soloing context를 반영한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
+- rendered audio file count: `6`
+- sample rate: `44100`
+- technical WAV validation: `true`
+- failure label delta: `4`
+- technical regression count: `0`
+- source outside-soloing repair pitch-role risk count after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- audio review required: `true`
+- human/audio preference claimed: `false`
+- audio rendered quality claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- WAV package가 repair sweep의 outside-soloing not_evaluable boundary를 보존.
+- audio rendered quality와 listening preference claim 제외 유지.
+- 다음 boundary는 targeted quality repair listening review package refresh.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_audio`
+- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_targeted_quality_repair_audio.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-audio-package`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo targeted quality repair listening review package refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #834, Stage B MIDI-to-solo targeted quality repair outside-soloing context refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair audio package refresh`
+- latest functional result: Issue #836, Stage B MIDI-to-solo targeted quality repair audio package outside-soloing context refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair listening review package refresh`
 
 현재 범위가 아닌 것:
 
@@ -468,6 +468,18 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 audio target: `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
+- targeted quality repair audio package outside-soloing context refresh 완료
+- rendered audio file count: `6`
+- technical WAV validation: `true`
+- failure label delta: `4`
+- source outside-soloing repair pitch-role risk count after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- audio review required: `true`
+- human/audio preference claim: `false`
+- audio rendered quality claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 review target: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_AUDIO_PACKAGE_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_AUDIO_PACKAGE_2026-06-10.md
@@ -1,0 +1,43 @@
+# Stage B MIDI-to-Solo Targeted Quality Repair Audio Package
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
+- render attempted: `true`
+- rendered audio file count: `6`
+- technical WAV validation: `true`
+- duration range: `18.422s-18.984s`
+- failure labels: `12 -> 8`
+- failure label delta: `4`
+- improved candidate count: `4`
+- technical regression count: `0`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair pitch-role risk after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- audio review required: `true`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+
+## Rendered Files
+
+- candidate `1` `cli_repaired_midi` rank `1`: `outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package/audio/candidate_01_cli_repaired_midi_rank_01_targeted_quality_repair.wav`, duration `18.907`, sample rate `44100`, failure labels `songlike_melody_not_soloing`, sha256 `5f1a65c17ec7`
+- candidate `2` `cli_repaired_midi` rank `2`: `outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package/audio/candidate_02_cli_repaired_midi_rank_02_targeted_quality_repair.wav`, duration `18.984`, sample rate `44100`, failure labels `songlike_melody_not_soloing`, sha256 `665ffcde7432`
+- candidate `3` `cli_repaired_midi` rank `3`: `outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package/audio/candidate_03_cli_repaired_midi_rank_03_targeted_quality_repair.wav`, duration `18.977`, sample rate `44100`, failure labels `songlike_melody_not_soloing`, sha256 `af04a0af9093`
+- candidate `4` `changed_ratio_repair` rank `1`: `outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package/audio/candidate_04_changed_ratio_repair_rank_01_targeted_quality_repair.wav`, duration `18.422`, sample rate `44100`, failure labels `phrase_shape_missing_tension_release,songlike_melody_not_soloing`, sha256 `7bd60749c516`
+- candidate `5` `changed_ratio_repair` rank `2`: `outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package/audio/candidate_05_changed_ratio_repair_rank_02_targeted_quality_repair.wav`, duration `18.984`, sample rate `44100`, failure labels `none`, sha256 `d9868392edd1`
+- candidate `6` `changed_ratio_repair` rank `3`: `outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package/audio/candidate_06_changed_ratio_repair_rank_03_targeted_quality_repair.wav`, duration `18.926`, sample rate `44100`, failure labels `dead_air_or_density_gap,phrase_shape_missing_tension_release,songlike_melody_not_soloing`, sha256 `ca1471d7e59f`
+
+## Claim Boundary
+
+- `audio_rendered_quality`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `model_checkpoint_generation_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`
+
+## Next
+
+- `Stage B MIDI-to-solo targeted quality repair listening review package`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6232,8 +6232,8 @@ run_stage_b_midi_to_solo_targeted_quality_repair_audio_package() {
   "$PYTHON_BIN" scripts/render_stage_b_midi_to_solo_targeted_quality_repair_audio.py \
     --run_id "$run_id" \
     --targeted_quality_repair_sweep_report "$repair_sweep_report" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_AUDIO_PACKAGE_2026-06-09.md \
-    --issue_number 752 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_AUDIO_PACKAGE_2026-06-10.md \
+    --issue_number 836 \
     --expected_boundary stage_b_midi_to_solo_targeted_quality_repair_audio_package \
     --expected_next_boundary stage_b_midi_to_solo_targeted_quality_repair_listening_review_package \
     --expected_file_count 6 \

--- a/scripts/render_stage_b_midi_to_solo_targeted_quality_repair_audio.py
+++ b/scripts/render_stage_b_midi_to_solo_targeted_quality_repair_audio.py
@@ -126,6 +126,22 @@ def validate_source_report(
         raise StageBMidiToSoloTargetedQualityRepairAudioError(
             "technical regression count should be zero"
         )
+    if not bool(aggregate.get("source_outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloTargetedQualityRepairAudioError(
+            "outside-soloing repair evidence readiness required"
+        )
+    if _int(aggregate.get("source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloTargetedQualityRepairAudioError(
+            "outside-soloing residual pitch-role risk should be zero"
+        )
+    if _int(aggregate.get("source_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloTargetedQualityRepairAudioError(
+            "source outside-soloing not-evaluable boundary required"
+        )
+    if _int(aggregate.get("repaired_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloTargetedQualityRepairAudioError(
+            "repaired outside-soloing not-evaluable boundary required"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloTargetedQualityRepairAudioError(
             "critical user input should not be required"
@@ -328,6 +344,18 @@ def build_audio_render_report(
             "failure_label_delta": _int(aggregate.get("failure_label_delta")),
             "improved_candidate_count": _int(aggregate.get("improved_candidate_count")),
             "technical_regression_count": _int(aggregate.get("technical_regression_count")),
+            "source_outside_soloing_repair_evidence_ready": bool(
+                aggregate.get("source_outside_soloing_repair_evidence_ready", False)
+            ),
+            "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+                aggregate.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+            ),
+            "source_outside_soloing_not_evaluable_count": _int(
+                aggregate.get("source_outside_soloing_not_evaluable_count")
+            ),
+            "repaired_outside_soloing_not_evaluable_count": _int(
+                aggregate.get("repaired_outside_soloing_not_evaluable_count")
+            ),
             "remaining_failure_counts": dict(sorted(failure_counts.items())),
             "audio_review_required": True,
         },
@@ -435,6 +463,18 @@ def validate_audio_render_report(
         "failure_label_delta": _int(summary.get("failure_label_delta")),
         "improved_candidate_count": _int(summary.get("improved_candidate_count")),
         "technical_regression_count": _int(summary.get("technical_regression_count")),
+        "source_outside_soloing_repair_evidence_ready": bool(
+            summary.get("source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            summary.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_not_evaluable_count": _int(
+            summary.get("source_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_outside_soloing_not_evaluable_count": _int(
+            summary.get("repaired_outside_soloing_not_evaluable_count")
+        ),
         "audio_review_required": bool(summary.get("audio_review_required", False)),
         "audio_rendered_quality_claimed": bool(boundary.get("audio_rendered_quality_claimed", True)),
         "human_audio_preference_claimed": bool(boundary.get("human_audio_preference_claimed", True)),
@@ -466,6 +506,10 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- failure label delta: `{summary['failure_label_delta']}`",
         f"- improved candidate count: `{summary['improved_candidate_count']}`",
         f"- technical regression count: `{summary['technical_regression_count']}`",
+        f"- source outside-soloing repair evidence ready: `{_bool_token(summary['source_outside_soloing_repair_evidence_ready'])}`",
+        f"- source outside-soloing repair pitch-role risk after: `{summary['source_outside_soloing_repair_pitch_role_risk_count_after']}`",
+        f"- source outside-soloing not evaluable count: `{summary['source_outside_soloing_not_evaluable_count']}`",
+        f"- repaired outside-soloing not evaluable count: `{summary['repaired_outside_soloing_not_evaluable_count']}`",
         f"- audio review required: `{_bool_token(summary['audio_review_required'])}`",
         f"- audio rendered quality claimed: `{_bool_token(boundary['audio_rendered_quality_claimed'])}`",
         f"- human/audio preference claimed: `{_bool_token(boundary['human_audio_preference_claimed'])}`",

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_audio.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_audio.py
@@ -90,6 +90,11 @@ def source_report(root: Path, *, quality_claim: bool = False) -> dict:
             "improved_candidate_count": 6,
             "technical_regression_count": 0,
             "repaired_failure_counts": {"songlike_melody_not_soloing": 5},
+            "source_outside_soloing_repair_evidence_ready": True,
+            "source_outside_soloing_repair_wav_count": 6,
+            "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "source_outside_soloing_not_evaluable_count": 6,
+            "repaired_outside_soloing_not_evaluable_count": 6,
             "target_supported": True,
         },
         "selected_next_target": {
@@ -153,6 +158,10 @@ class StageBMidiToSoloTargetedQualityRepairAudioTest(unittest.TestCase):
             self.assertTrue(summary["technical_wav_validation"])
             self.assertEqual(summary["failure_label_delta"], 7)
             self.assertEqual(summary["technical_regression_count"], 0)
+            self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
+            self.assertEqual(summary["source_outside_soloing_repair_pitch_role_risk_count_after"], 0)
+            self.assertEqual(summary["source_outside_soloing_not_evaluable_count"], 6)
+            self.assertEqual(summary["repaired_outside_soloing_not_evaluable_count"], 6)
             self.assertTrue(summary["audio_review_required"])
             self.assertFalse(summary["human_audio_preference_claimed"])
             self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
@@ -167,6 +176,26 @@ class StageBMidiToSoloTargetedQualityRepairAudioTest(unittest.TestCase):
             with self.assertRaises(StageBMidiToSoloTargetedQualityRepairAudioError):
                 build_audio_render_report(
                     source_report(root, quality_claim=True),
+                    output_dir=root / "audio_package",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(soundfont),
+                    sample_rate=44100,
+                    expected_file_count=6,
+                    runner=fake_runner,
+                )
+
+    def test_rejects_missing_outside_soloing_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = root / "fluidsynth"
+            soundfont = root / "soundfont.sf2"
+            renderer.write_text("#!/bin/sh\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            source = source_report(root)
+            source["aggregate"]["repaired_outside_soloing_not_evaluable_count"] = 0
+            with self.assertRaises(StageBMidiToSoloTargetedQualityRepairAudioError):
+                build_audio_render_report(
+                    source,
                     output_dir=root / "audio_package",
                     renderer_path=str(renderer),
                     soundfont_path=str(soundfont),


### PR DESCRIPTION
## Summary

- audio package source validation에 outside-soloing repair/not_evaluable context 조건 추가
- audio package summary와 validation summary에 source/repaired outside-soloing not_evaluable count 추가
- markdown summary에 outside-soloing post-repair risk와 not_evaluable count 기록
- 전용 테스트 fixture/assertion/rejection case 추가
- harness doc path와 status/core plan 갱신

## Context

- #834 targeted repair sweep에 outside-soloing context 반영
- repair sweep 주요 값: source not_evaluable `6`, repaired not_evaluable `6`, pitch-role risk after `0`, failure label delta `4`, technical regression `0`
- 기존 audio package summary에는 source/repaired outside-soloing not_evaluable boundary가 없음
- listening review package로 넘기기 전 WAV package metadata에 경계 보존 필요

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_audio`
- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_targeted_quality_repair_audio.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-audio-package`
- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- audio package metadata/validation 갱신 범위
- musical quality, human/audio preference, audio rendered quality claim 제외 유지

Closes #836