### PR TITLE
Stage B MIDI-to-solo targeted quality repair listening review package outside-soloing context refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -6266,6 +6266,43 @@ Issue #836은 targeted quality repair audio package에 repair sweep outside-solo
 
 - `Stage B MIDI-to-solo targeted quality repair listening review package refresh`
 
+## 9.110 Stage B MIDI-to-solo targeted quality repair listening review package outside-soloing context refresh
+
+Issue #838은 targeted quality repair listening review package에 audio package outside-soloing context를 반영한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
+- review item count: `6`
+- validated review input: `false`
+- technical WAV validation: `true`
+- source outside-soloing repair pitch-role risk count after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- human/audio preference claimed: `false`
+- audio rendered quality claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- listening review package가 audio package outside-soloing not_evaluable boundary를 보존.
+- review input은 pending 유지.
+- 음악적 품질, human/audio preference, audio rendered quality claim 제외 유지.
+- 다음 boundary는 listening review input guard refresh.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-listening-review-package`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo targeted quality repair listening review input guard refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #836, Stage B MIDI-to-solo targeted quality repair audio package outside-soloing context refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair listening review package refresh`
+- latest functional result: Issue #838, Stage B MIDI-to-solo targeted quality repair listening review package outside-soloing context refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair listening review input guard refresh`
 
 현재 범위가 아닌 것:
 
@@ -480,6 +480,16 @@
 - audio rendered quality claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 review target: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
+- targeted quality repair listening review package outside-soloing context refresh 완료
+- review item count: `6`
+- validated review input: `false`
+- source outside-soloing repair pitch-role risk count after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- human/audio preference claim: `false`
+- audio rendered quality claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 guard target: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_LISTENING_REVIEW_PACKAGE_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_LISTENING_REVIEW_PACKAGE_2026-06-10.md
@@ -1,0 +1,44 @@
+# Stage B MIDI-to-Solo Targeted Quality Repair Listening Review Package
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
+- package ready: `true`
+- review item count: `6`
+- validated review input: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- duration range: `18.422s-18.984s`
+- failure label delta: `4`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair pitch-role risk after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- human/audio preference claimed: `false`
+
+## Review Items
+
+- candidate `1` `cli_repaired_midi` rank `1`: WAV `outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package/audio/candidate_01_cli_repaired_midi_rank_01_targeted_quality_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_targeted_quality_repair_sweep/harness_stage_b_midi_to_solo_targeted_quality_repair_sweep/midi/01_cli_repaired_midi_rank_01_targeted_quality_repair.mid`, duration `18.907`, failure labels `songlike_melody_not_soloing`
+- candidate `2` `cli_repaired_midi` rank `2`: WAV `outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package/audio/candidate_02_cli_repaired_midi_rank_02_targeted_quality_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_targeted_quality_repair_sweep/harness_stage_b_midi_to_solo_targeted_quality_repair_sweep/midi/02_cli_repaired_midi_rank_02_targeted_quality_repair.mid`, duration `18.984`, failure labels `songlike_melody_not_soloing`
+- candidate `3` `cli_repaired_midi` rank `3`: WAV `outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package/audio/candidate_03_cli_repaired_midi_rank_03_targeted_quality_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_targeted_quality_repair_sweep/harness_stage_b_midi_to_solo_targeted_quality_repair_sweep/midi/03_cli_repaired_midi_rank_03_targeted_quality_repair.mid`, duration `18.977`, failure labels `songlike_melody_not_soloing`
+- candidate `4` `changed_ratio_repair` rank `1`: WAV `outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package/audio/candidate_04_changed_ratio_repair_rank_01_targeted_quality_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_targeted_quality_repair_sweep/harness_stage_b_midi_to_solo_targeted_quality_repair_sweep/midi/04_changed_ratio_repair_rank_01_targeted_quality_repair.mid`, duration `18.422`, failure labels `phrase_shape_missing_tension_release,songlike_melody_not_soloing`
+- candidate `5` `changed_ratio_repair` rank `2`: WAV `outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package/audio/candidate_05_changed_ratio_repair_rank_02_targeted_quality_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_targeted_quality_repair_sweep/harness_stage_b_midi_to_solo_targeted_quality_repair_sweep/midi/05_changed_ratio_repair_rank_02_targeted_quality_repair.mid`, duration `18.984`, failure labels `none`
+- candidate `6` `changed_ratio_repair` rank `3`: WAV `outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package/audio/candidate_06_changed_ratio_repair_rank_03_targeted_quality_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_targeted_quality_repair_sweep/harness_stage_b_midi_to_solo_targeted_quality_repair_sweep/midi/06_changed_ratio_repair_rank_03_targeted_quality_repair.mid`, duration `18.926`, failure labels `dead_air_or_density_gap,phrase_shape_missing_tension_release,songlike_melody_not_soloing`
+
+## Required Input Fields
+
+- `candidate_index`
+- `listening_status`
+- `preference`
+- `issue_notes`
+
+## Claim Boundary
+
+- MIDI-to-solo musical quality claimed: `false`
+- audio rendered quality claimed: `false`
+- broad trained-model quality claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo targeted quality repair listening review input guard`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6254,8 +6254,8 @@ run_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package() {
   "$PYTHON_BIN" scripts/build_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package.py \
     --run_id "$review_run_id" \
     --audio_package_report "$audio_package_report" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_LISTENING_REVIEW_PACKAGE_2026-06-09.md \
-    --issue_number 754 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_LISTENING_REVIEW_PACKAGE_2026-06-10.md \
+    --issue_number 838 \
     --expected_review_item_count 6 \
     --expected_boundary stage_b_midi_to_solo_targeted_quality_repair_listening_review_package \
     --expected_next_boundary stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard \

--- a/scripts/build_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package.py
+++ b/scripts/build_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package.py
@@ -108,6 +108,22 @@ def validate_audio_package_report(
         raise StageBMidiToSoloTargetedQualityRepairListeningReviewPackageError(
             "audio review requirement should be recorded"
         )
+    if not bool(summary.get("source_outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloTargetedQualityRepairListeningReviewPackageError(
+            "outside-soloing repair evidence readiness required"
+        )
+    if _int(summary.get("source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloTargetedQualityRepairListeningReviewPackageError(
+            "outside-soloing residual pitch-role risk should be zero"
+        )
+    if _int(summary.get("source_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloTargetedQualityRepairListeningReviewPackageError(
+            "source outside-soloing not-evaluable boundary required"
+        )
+    if _int(summary.get("repaired_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloTargetedQualityRepairListeningReviewPackageError(
+            "repaired outside-soloing not-evaluable boundary required"
+        )
     if _int(boundary.get("rendered_audio_file_count")) < int(expected_count):
         raise StageBMidiToSoloTargetedQualityRepairListeningReviewPackageError(
             "rendered audio count below expected"
@@ -191,6 +207,18 @@ def build_listening_review_package_report(
             "failure_label_delta": _int(summary.get("failure_label_delta")),
             "improved_candidate_count": _int(summary.get("improved_candidate_count")),
             "technical_regression_count": _int(summary.get("technical_regression_count")),
+            "source_outside_soloing_repair_evidence_ready": bool(
+                summary.get("source_outside_soloing_repair_evidence_ready", False)
+            ),
+            "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+                summary.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+            ),
+            "source_outside_soloing_not_evaluable_count": _int(
+                summary.get("source_outside_soloing_not_evaluable_count")
+            ),
+            "repaired_outside_soloing_not_evaluable_count": _int(
+                summary.get("repaired_outside_soloing_not_evaluable_count")
+            ),
             "audio_review_required": bool(summary.get("audio_review_required", False)),
         },
         "review_package": {
@@ -291,6 +319,18 @@ def validate_listening_review_package_report(
         "duration_min_seconds": _float(source.get("duration_min_seconds")),
         "duration_max_seconds": _float(source.get("duration_max_seconds")),
         "failure_label_delta": _int(source.get("failure_label_delta")),
+        "source_outside_soloing_repair_evidence_ready": bool(
+            source.get("source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            source.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_not_evaluable_count": _int(
+            source.get("source_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_outside_soloing_not_evaluable_count": _int(
+            source.get("repaired_outside_soloing_not_evaluable_count")
+        ),
         "audio_review_required": bool(source.get("audio_review_required", False)),
         "human_review_required_now": bool(readiness.get("human_review_required_now", True)),
         "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
@@ -322,6 +362,10 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- rendered audio file count: `{source['rendered_audio_file_count']}`",
         f"- duration range: `{source['duration_min_seconds']:.3f}s-{source['duration_max_seconds']:.3f}s`",
         f"- failure label delta: `{source['failure_label_delta']}`",
+        f"- source outside-soloing repair evidence ready: `{_bool_token(source['source_outside_soloing_repair_evidence_ready'])}`",
+        f"- source outside-soloing repair pitch-role risk after: `{source['source_outside_soloing_repair_pitch_role_risk_count_after']}`",
+        f"- source outside-soloing not evaluable count: `{source['source_outside_soloing_not_evaluable_count']}`",
+        f"- repaired outside-soloing not evaluable count: `{source['repaired_outside_soloing_not_evaluable_count']}`",
         f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
         "",
         "## Review Items",

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package.py
@@ -112,6 +112,10 @@ def audio_package_report(root: Path, *, quality_claim: bool = False) -> dict:
             "failure_label_delta": 7,
             "improved_candidate_count": 6,
             "technical_regression_count": 0,
+            "source_outside_soloing_repair_evidence_ready": True,
+            "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "source_outside_soloing_not_evaluable_count": 6,
+            "repaired_outside_soloing_not_evaluable_count": 6,
             "audio_review_required": True,
         },
         "rendered_audio_files": rendered,
@@ -142,6 +146,10 @@ class StageBMidiToSoloTargetedQualityRepairListeningReviewPackageTest(unittest.T
             self.assertFalse(summary["validated_review_input"])
             self.assertTrue(summary["technical_wav_validation"])
             self.assertEqual(summary["failure_label_delta"], 7)
+            self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
+            self.assertEqual(summary["source_outside_soloing_repair_pitch_role_risk_count_after"], 0)
+            self.assertEqual(summary["source_outside_soloing_not_evaluable_count"], 6)
+            self.assertEqual(summary["repaired_outside_soloing_not_evaluable_count"], 6)
             self.assertFalse(summary["human_audio_preference_claimed"])
             self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
 
@@ -153,6 +161,21 @@ class StageBMidiToSoloTargetedQualityRepairListeningReviewPackageTest(unittest.T
             ):
                 build_listening_review_package_report(
                     audio_package_report=audio_package_report(root, quality_claim=True),
+                    output_dir=root / "review_package",
+                    issue_number=754,
+                    expected_count=6,
+                )
+
+    def test_rejects_missing_outside_soloing_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = audio_package_report(root)
+            source["summary"]["repaired_outside_soloing_not_evaluable_count"] = 0
+            with self.assertRaises(
+                StageBMidiToSoloTargetedQualityRepairListeningReviewPackageError
+            ):
+                build_listening_review_package_report(
+                    audio_package_report=source,
                     output_dir=root / "review_package",
                     issue_number=754,
                     expected_count=6,


### PR DESCRIPTION
## Summary

- audio package validation에 outside-soloing context 조건 추가
- listening review source summary와 validation summary에 source/repaired outside-soloing not_evaluable count 추가
- markdown summary에 outside-soloing post-repair risk와 not_evaluable count 기록
- 전용 테스트 fixture/assertion/rejection case 추가
- harness doc path와 status/core plan 갱신

## Context

- #836 audio package에 outside-soloing not_evaluable context 반영
- audio package 주요 값: rendered WAV `6`, technical WAV validation `true`, source/repaired outside-soloing not_evaluable `6/6`, pitch-role risk after `0`
- 기존 listening review package source summary에는 outside-soloing context가 없음
- input guard 전 단계에서 review package metadata에 경계 보존 필요

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-listening-review-package`
- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- listening review package metadata/validation 갱신 범위
- musical quality, human/audio preference, audio rendered quality claim 제외 유지

Closes #838