### PR TITLE
Stage B MIDI-to-solo follow-up decision outside-soloing context refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -407,6 +407,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo targeted quality repair listening review package: review items `6`, validated input `false`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
 - MIDI-to-solo targeted quality repair listening review input guard: review items `6`, preference fill `false`, validated input `false`, source outside-soloing not evaluable `6`, repaired outside-soloing not evaluable `6`, source pitch-role risk after `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
 - MIDI-to-solo targeted quality repair objective-only next decision: follow-up required `true`, current quality claim ready `false`, source outside-soloing not evaluable `6`, repaired outside-soloing not evaluable `6`, source pitch-role risk after `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- MIDI-to-solo targeted quality repair follow-up decision: selected target `songlike_melody_contour_repair_sweep`, dominant label/count `songlike_melody_not_soloing/5`, objective and repair sweep outside-soloing not evaluable `6/6`, pitch-role risk after `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
 - MIDI-to-solo pitch-contour changed-ratio repair probe: repaired/pass `3/3`, max pitch changed ratio `0.7174 -> 0.4348`, max interval `12`, dead-air max `0.0000`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
 - MIDI-to-solo pitch-contour changed-ratio repair audio package: rendered WAV `3`, duration `18.422s-18.978s`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
@@ -6382,6 +6383,51 @@ Issue #842는 targeted quality repair objective-only next decision에 input guar
 다음 작업:
 
 - `Stage B MIDI-to-solo targeted quality repair follow-up decision refresh`
+
+## 9.113 Stage B MIDI-to-solo targeted quality repair follow-up decision outside-soloing context refresh
+
+Issue #844는 targeted quality repair follow-up decision에 objective next와 repair sweep outside-soloing context를 반영한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
+- repair sweep boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- selected target: `songlike_melody_contour_repair_sweep`
+- dominant remaining failure label: `songlike_melody_not_soloing`
+- dominant remaining failure count: `5`
+- candidate count: `6`
+- failure label delta: `4`
+- technical regression count: `0`
+- objective source outside-soloing repair pitch-role risk count after: `0`
+- objective source outside-soloing not evaluable count: `6`
+- objective repaired outside-soloing not evaluable count: `6`
+- repair sweep source outside-soloing repair pitch-role risk count after: `0`
+- repair sweep source outside-soloing not evaluable count: `6`
+- repair sweep repaired outside-soloing not evaluable count: `6`
+- human/audio preference claimed: `false`
+- audio rendered quality claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- follow-up decision이 objective next와 repair sweep의 outside-soloing not_evaluable boundary를 보존.
+- 잔여 failure 중 `songlike_melody_not_soloing` count `5`가 dominant target.
+- selected target과 next boundary는 기존 songlike melody contour repair sweep 유지.
+- 음악적 품질, human/audio preference, audio rendered quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-followup-decision`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour repair sweep refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #842, Stage B MIDI-to-solo targeted quality repair objective-only next decision outside-soloing context refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair follow-up decision refresh`
+- latest functional result: Issue #844, Stage B MIDI-to-solo targeted quality repair follow-up decision outside-soloing context refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair sweep refresh`
 
 현재 범위가 아닌 것:
 
@@ -518,6 +518,24 @@
 - audio rendered quality claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 follow-up target: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- targeted quality repair follow-up decision outside-soloing context refresh 완료
+- selected target: `songlike_melody_contour_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- dominant remaining failure label: `songlike_melody_not_soloing`
+- dominant remaining failure count: `5`
+- candidate count: `6`
+- failure label delta: `4`
+- technical regression count: `0`
+- objective source outside-soloing repair pitch-role risk count after: `0`
+- objective source outside-soloing not evaluable count: `6`
+- objective repaired outside-soloing not evaluable count: `6`
+- repair sweep source outside-soloing repair pitch-role risk count after: `0`
+- repair sweep source outside-soloing not evaluable count: `6`
+- repair sweep repaired outside-soloing not evaluable count: `6`
+- human/audio preference claim: `false`
+- audio rendered quality claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 repair target: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_FOLLOWUP_DECISION_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_FOLLOWUP_DECISION_2026-06-10.md
@@ -1,0 +1,53 @@
+# Stage B MIDI-to-Solo Targeted Quality Repair Follow-Up Decision
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
+- repair sweep boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- selected target: `songlike_melody_contour_repair_sweep`
+- dominant remaining failure label: `songlike_melody_not_soloing`
+- dominant remaining failure count: `5`
+- candidate count: `6`
+- source total failure labels: `12`
+- repaired total failure labels: `8`
+- failure label delta: `4`
+- technical regression count: `0`
+- objective source outside-soloing repair evidence ready: `true`
+- objective source outside-soloing repair pitch-role risk after: `0`
+- objective source outside-soloing not evaluable count: `6`
+- objective repaired outside-soloing not evaluable count: `6`
+- repair sweep source outside-soloing repair evidence ready: `true`
+- repair sweep source outside-soloing repair pitch-role risk after: `0`
+- repair sweep source outside-soloing not evaluable count: `6`
+- repair sweep repaired outside-soloing not evaluable count: `6`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Remaining Failure Counts
+
+- `dead_air_or_density_gap`: `1`
+- `phrase_shape_missing_tension_release`: `2`
+- `songlike_melody_not_soloing`: `5`
+
+## Not Evaluable Counts
+
+- `outside_soloing_without_context`: `6`
+- `weak_chord_tone_landing`: `6`
+
+## Decision
+
+- reason: `remaining objective failure labels route to follow-up repair without quality claim`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo songlike melody contour repair sweep`
+
+## Claim Boundary
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `outside_soloing_without_context`
+- `weak_chord_tone_landing`
+- `broad_trained_model_quality`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6324,8 +6324,8 @@ run_stage_b_midi_to_solo_targeted_quality_repair_followup_decision() {
     --run_id "$run_id" \
     --objective_next_report "$objective_report" \
     --repair_sweep_report "$sweep_report" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_FOLLOWUP_DECISION_2026-06-09.md \
-    --issue_number 760 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_FOLLOWUP_DECISION_2026-06-10.md \
+    --issue_number 844 \
     --expected_boundary stage_b_midi_to_solo_targeted_quality_repair_followup_decision \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_sweep \
     --expected_target songlike_melody_contour_repair_sweep \

--- a/scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py
+++ b/scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py
@@ -113,6 +113,22 @@ def validate_objective_next_source(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
             "technical WAV validation required"
         )
+    if not bool(summary.get("source_outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "objective outside-soloing repair evidence readiness required"
+        )
+    if _int(summary.get("source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "objective outside-soloing residual pitch-role risk should be zero"
+        )
+    if _int(summary.get("source_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "objective source outside-soloing not-evaluable boundary required"
+        )
+    if _int(summary.get("repaired_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "objective repaired outside-soloing not-evaluable boundary required"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
             "critical user input should not be required"
@@ -124,6 +140,18 @@ def validate_objective_next_source(report: dict[str, Any]) -> dict[str, Any]:
         "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
         "failure_label_delta": _int(summary.get("failure_label_delta")),
         "technical_wav_validation": bool(summary.get("technical_wav_validation", False)),
+        "source_outside_soloing_repair_evidence_ready": bool(
+            summary.get("source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            summary.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_not_evaluable_count": _int(
+            summary.get("source_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_outside_soloing_not_evaluable_count": _int(
+            summary.get("repaired_outside_soloing_not_evaluable_count")
+        ),
         "validated_review_input_present": bool(
             summary.get("validated_review_input_present", False)
         ),
@@ -171,6 +199,22 @@ def validate_repair_sweep_source(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
             "technical regression must remain zero"
         )
+    if not bool(aggregate.get("source_outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "repair sweep outside-soloing repair evidence readiness required"
+        )
+    if _int(aggregate.get("source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "repair sweep outside-soloing residual pitch-role risk should be zero"
+        )
+    if _int(aggregate.get("source_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "repair sweep source outside-soloing not-evaluable boundary required"
+        )
+    if _int(aggregate.get("repaired_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "repair sweep repaired outside-soloing not-evaluable boundary required"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
             "critical user input should not be required"
@@ -206,6 +250,18 @@ def validate_repair_sweep_source(report: dict[str, Any]) -> dict[str, Any]:
         "failure_label_delta": _int(aggregate.get("failure_label_delta")),
         "improved_candidate_count": _int(aggregate.get("improved_candidate_count")),
         "technical_regression_count": _int(aggregate.get("technical_regression_count")),
+        "source_outside_soloing_repair_evidence_ready": bool(
+            aggregate.get("source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            aggregate.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_not_evaluable_count": _int(
+            aggregate.get("source_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_outside_soloing_not_evaluable_count": _int(
+            aggregate.get("repaired_outside_soloing_not_evaluable_count")
+        ),
         "remaining_failure_counts": remaining_counts,
         "dominant_remaining_failure_label": dominant_label,
         "dominant_remaining_failure_count": dominant_count,
@@ -274,6 +330,30 @@ def build_followup_decision_report(
             ),
             "failure_label_delta": _int(sweep["failure_label_delta"]),
             "technical_regression_count": _int(sweep["technical_regression_count"]),
+            "objective_source_outside_soloing_repair_evidence_ready": bool(
+                objective["source_outside_soloing_repair_evidence_ready"]
+            ),
+            "objective_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+                objective["source_outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
+            "objective_source_outside_soloing_not_evaluable_count": _int(
+                objective["source_outside_soloing_not_evaluable_count"]
+            ),
+            "objective_repaired_outside_soloing_not_evaluable_count": _int(
+                objective["repaired_outside_soloing_not_evaluable_count"]
+            ),
+            "repair_sweep_source_outside_soloing_repair_evidence_ready": bool(
+                sweep["source_outside_soloing_repair_evidence_ready"]
+            ),
+            "repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+                sweep["source_outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
+            "repair_sweep_source_outside_soloing_not_evaluable_count": _int(
+                sweep["source_outside_soloing_not_evaluable_count"]
+            ),
+            "repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
+                sweep["repaired_outside_soloing_not_evaluable_count"]
+            ),
             "human_audio_preference_claimed": False,
             "audio_rendered_quality_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
@@ -388,6 +468,30 @@ def validate_followup_decision_report(
         ),
         "failure_label_delta": _int(readiness.get("failure_label_delta")),
         "technical_regression_count": _int(readiness.get("technical_regression_count")),
+        "objective_source_outside_soloing_repair_evidence_ready": bool(
+            readiness.get("objective_source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "objective_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            readiness.get("objective_source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "objective_source_outside_soloing_not_evaluable_count": _int(
+            readiness.get("objective_source_outside_soloing_not_evaluable_count")
+        ),
+        "objective_repaired_outside_soloing_not_evaluable_count": _int(
+            readiness.get("objective_repaired_outside_soloing_not_evaluable_count")
+        ),
+        "repair_sweep_source_outside_soloing_repair_evidence_ready": bool(
+            readiness.get("repair_sweep_source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            readiness.get("repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "repair_sweep_source_outside_soloing_not_evaluable_count": _int(
+            readiness.get("repair_sweep_source_outside_soloing_not_evaluable_count")
+        ),
+        "repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
+            readiness.get("repair_sweep_repaired_outside_soloing_not_evaluable_count")
+        ),
         "remaining_failure_counts": _dict(sweep.get("remaining_failure_counts")),
         "not_evaluable_counts": _dict(sweep.get("not_evaluable_counts")),
         "human_audio_preference_claimed": bool(
@@ -425,6 +529,14 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- repaired total failure labels: `{readiness['repaired_total_failure_label_count']}`",
         f"- failure label delta: `{readiness['failure_label_delta']}`",
         f"- technical regression count: `{readiness['technical_regression_count']}`",
+        f"- objective source outside-soloing repair evidence ready: `{_bool_token(readiness['objective_source_outside_soloing_repair_evidence_ready'])}`",
+        f"- objective source outside-soloing repair pitch-role risk after: `{readiness['objective_source_outside_soloing_repair_pitch_role_risk_count_after']}`",
+        f"- objective source outside-soloing not evaluable count: `{readiness['objective_source_outside_soloing_not_evaluable_count']}`",
+        f"- objective repaired outside-soloing not evaluable count: `{readiness['objective_repaired_outside_soloing_not_evaluable_count']}`",
+        f"- repair sweep source outside-soloing repair evidence ready: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_evidence_ready'])}`",
+        f"- repair sweep source outside-soloing repair pitch-role risk after: `{readiness['repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after']}`",
+        f"- repair sweep source outside-soloing not evaluable count: `{readiness['repair_sweep_source_outside_soloing_not_evaluable_count']}`",
+        f"- repair sweep repaired outside-soloing not evaluable count: `{readiness['repair_sweep_repaired_outside_soloing_not_evaluable_count']}`",
         f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
         f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
         "",
@@ -475,7 +587,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=760)
+    parser.add_argument("--issue_number", type=int, default=844)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--expected_target", type=str, default="")

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision.py
@@ -31,6 +31,10 @@ def objective_next_report(*, quality_claim: bool = False) -> dict:
             "technical_wav_validation": True,
             "rendered_audio_file_count": 6,
             "failure_label_delta": 4,
+            "source_outside_soloing_repair_evidence_ready": True,
+            "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "source_outside_soloing_not_evaluable_count": 6,
+            "repaired_outside_soloing_not_evaluable_count": 6,
             "current_quality_claim_ready": False,
         },
         "readiness": {
@@ -74,6 +78,10 @@ def repair_sweep_report(*, technical_regression_count: int = 0) -> dict:
             "failure_label_delta": 4,
             "improved_candidate_count": 4,
             "technical_regression_count": technical_regression_count,
+            "source_outside_soloing_repair_evidence_ready": True,
+            "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "source_outside_soloing_not_evaluable_count": 6,
+            "repaired_outside_soloing_not_evaluable_count": 6,
             "repaired_failure_counts": {
                 "dead_air_or_density_gap": 1,
                 "phrase_shape_missing_tension_release": 2,
@@ -126,6 +134,20 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
             self.assertEqual(summary["dominant_remaining_failure_count"], 5)
             self.assertEqual(summary["failure_label_delta"], 4)
             self.assertEqual(summary["technical_regression_count"], 0)
+            self.assertTrue(summary["objective_source_outside_soloing_repair_evidence_ready"])
+            self.assertEqual(
+                summary["objective_source_outside_soloing_repair_pitch_role_risk_count_after"],
+                0,
+            )
+            self.assertEqual(summary["objective_source_outside_soloing_not_evaluable_count"], 6)
+            self.assertEqual(summary["objective_repaired_outside_soloing_not_evaluable_count"], 6)
+            self.assertTrue(summary["repair_sweep_source_outside_soloing_repair_evidence_ready"])
+            self.assertEqual(
+                summary["repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after"],
+                0,
+            )
+            self.assertEqual(summary["repair_sweep_source_outside_soloing_not_evaluable_count"], 6)
+            self.assertEqual(summary["repair_sweep_repaired_outside_soloing_not_evaluable_count"], 6)
             self.assertEqual(summary["selected_target"], SELECTED_TARGET)
             self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
             self.assertFalse(summary["human_audio_preference_claimed"])
@@ -153,6 +175,34 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
                     repair_sweep_report=repair_sweep_report(technical_regression_count=1),
                     output_dir=Path(tmp) / "followup",
                     issue_number=760,
+                )
+
+    def test_rejects_missing_objective_outside_soloing_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = objective_next_report()
+            source["objective_summary"]["source_outside_soloing_not_evaluable_count"] = 0
+            with self.assertRaises(
+                StageBMidiToSoloTargetedQualityRepairFollowupDecisionError
+            ):
+                build_followup_decision_report(
+                    objective_next_report=source,
+                    repair_sweep_report=repair_sweep_report(),
+                    output_dir=Path(tmp) / "followup",
+                    issue_number=844,
+                )
+
+    def test_rejects_missing_sweep_outside_soloing_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = repair_sweep_report()
+            source["aggregate"]["repaired_outside_soloing_not_evaluable_count"] = 0
+            with self.assertRaises(
+                StageBMidiToSoloTargetedQualityRepairFollowupDecisionError
+            ):
+                build_followup_decision_report(
+                    objective_next_report=objective_next_report(),
+                    repair_sweep_report=source,
+                    output_dir=Path(tmp) / "followup",
+                    issue_number=844,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary

- targeted quality repair follow-up decision source validation 강화
- objective next 및 repair sweep outside-soloing context 보존
- selected target `songlike_melody_contour_repair_sweep` 유지

## Context

- Issue #842 objective next 기준 source outside-soloing repair pitch-role risk after `0`
- objective source outside-soloing not evaluable count `6`
- objective repaired outside-soloing not evaluable count `6`
- repair sweep source/repaired outside-soloing not evaluable count `6/6`
- dominant remaining failure label `songlike_melody_not_soloing` / count `5`

## Scope

- objective next source validation에 outside-soloing 필수값 추가
- repair sweep source validation에 outside-soloing aggregate 필수값 추가
- readiness/validation summary/markdown output에 outside-soloing context 추가
- harness issue/doc path를 #844 기준으로 갱신
- current status/core plan 결과 기록 추가

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-followup-decision`
- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- human/audio preference claim 없음
- MIDI-to-solo musical quality claim 없음
- next repair target은 remaining objective failure label 기준 유지

Closes #844
