### PR TITLE
Stage B MIDI-to-solo songlike sweep outside-soloing context refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -408,6 +408,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo targeted quality repair listening review input guard: review items `6`, preference fill `false`, validated input `false`, source outside-soloing not evaluable `6`, repaired outside-soloing not evaluable `6`, source pitch-role risk after `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
 - MIDI-to-solo targeted quality repair objective-only next decision: follow-up required `true`, current quality claim ready `false`, source outside-soloing not evaluable `6`, repaired outside-soloing not evaluable `6`, source pitch-role risk after `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
 - MIDI-to-solo targeted quality repair follow-up decision: selected target `songlike_melody_contour_repair_sweep`, dominant label/count `songlike_melody_not_soloing/5`, objective and repair sweep outside-soloing not evaluable `6/6`, pitch-role risk after `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- MIDI-to-solo songlike melody contour repair sweep: songlike failure `5 -> 0`, total failure labels `8 -> 4`, repaired outside-soloing not evaluable `6`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
 - MIDI-to-solo pitch-contour changed-ratio repair probe: repaired/pass `3/3`, max pitch changed ratio `0.7174 -> 0.4348`, max interval `12`, dead-air max `0.0000`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
 - MIDI-to-solo pitch-contour changed-ratio repair audio package: rendered WAV `3`, duration `18.422s-18.978s`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
@@ -6428,6 +6429,54 @@ Issue #844는 targeted quality repair follow-up decision에 objective next와 re
 다음 작업:
 
 - `Stage B MIDI-to-solo songlike melody contour repair sweep refresh`
+
+## 9.114 Stage B MIDI-to-solo songlike melody contour repair sweep outside-soloing context refresh
+
+Issue #846은 songlike melody contour repair sweep에 follow-up decision outside-soloing context를 반영한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- targeted repair sweep boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
+- selected target: `songlike_melody_contour_repair_audio_package`
+- candidate count: `6`
+- total failure labels: `8 -> 4`
+- failure label delta: `4`
+- songlike failure count: `5 -> 0`
+- songlike failure delta: `5`
+- improved candidate count: `4`
+- technical regression count: `0`
+- source outside-soloing repair pitch-role risk count after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- repaired not evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
+- repaired failure counts: `phrase_shape_missing_tension_release=2`, `rhythmic_monotony=2`
+- audio package ready: `true`
+- human/audio preference claimed: `false`
+- audio rendered quality claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- songlike melody label은 `5 -> 0`으로 제거.
+- total failure labels는 `8 -> 4`로 감소.
+- outside-soloing without context와 weak chord-tone landing은 not_evaluable `6` 유지.
+- 다음 boundary는 rendered WAV technical package.
+- 음악적 품질, human/audio preference, audio rendered quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-sweep`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour repair audio package refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #844, Stage B MIDI-to-solo targeted quality repair follow-up decision outside-soloing context refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair sweep refresh`
+- latest functional result: Issue #846, Stage B MIDI-to-solo songlike melody contour repair sweep outside-soloing context refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair audio package refresh`
 
 현재 범위가 아닌 것:
 
@@ -536,6 +536,24 @@
 - audio rendered quality claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 repair target: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- songlike melody contour repair sweep outside-soloing context refresh 완료
+- candidate count: `6`
+- total failure labels: `8 -> 4`
+- failure label delta: `4`
+- songlike failure count: `5 -> 0`
+- songlike failure delta: `5`
+- improved candidate count: `4`
+- technical regression count: `0`
+- source outside-soloing repair pitch-role risk count after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- repaired not evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
+- repaired failure counts: `phrase_shape_missing_tension_release=2`, `rhythmic_monotony=2`
+- audio package ready: `true`
+- human/audio preference claim: `false`
+- audio rendered quality claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 audio target: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_SWEEP_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_SWEEP_2026-06-10.md
@@ -1,0 +1,57 @@
+# Stage B MIDI-to-Solo Songlike Melody Contour Repair Sweep
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
+- selected target: `songlike_melody_contour_repair_audio_package`
+- candidate count: `6`
+- total failure labels: `8 -> 4`
+- failure label delta: `4`
+- songlike failure count: `5 -> 0`
+- songlike failure delta: `5`
+- improved candidate count: `4`
+- technical regression count: `0`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair pitch-role risk after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- target supported: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Repaired Failure Counts
+
+- `phrase_shape_missing_tension_release`: `2`
+- `rhythmic_monotony`: `2`
+
+## Repaired Not Evaluable Counts
+
+- `outside_soloing_without_context`: `6`
+- `weak_chord_tone_landing`: `6`
+
+## MIDI Files
+
+- rank `1`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/midi/01_songlike_melody_contour_repair.mid`
+- rank `2`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/midi/02_songlike_melody_contour_repair.mid`
+- rank `3`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/midi/03_songlike_melody_contour_repair.mid`
+- rank `4`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/midi/04_songlike_melody_contour_repair.mid`
+- rank `5`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/midi/05_songlike_melody_contour_repair.mid`
+- rank `6`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/midi/06_songlike_melody_contour_repair.mid`
+
+## Decision
+
+- reason: `songlike contour repair sweep completed without musical quality claim`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo songlike melody contour repair audio package`
+
+## Claim Boundary
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `outside_soloing_without_context`
+- `weak_chord_tone_landing`
+- `broad_trained_model_quality`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6360,8 +6360,8 @@ run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep() {
     --followup_decision "$followup_report" \
     --targeted_repair_sweep "$targeted_sweep_report" \
     --rubric_baseline "$rubric_report" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_SWEEP_2026-06-09.md \
-    --issue_number 762 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_SWEEP_2026-06-10.md \
+    --issue_number 846 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_sweep \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package \
     --min_candidate_count 6 \

--- a/scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
+++ b/scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
@@ -122,6 +122,38 @@ def validate_followup_decision(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
             "dominant remaining songlike count required"
         )
+    if not bool(readiness.get("objective_source_outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "objective outside-soloing repair evidence readiness required"
+        )
+    if _int(readiness.get("objective_source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "objective outside-soloing residual pitch-role risk should be zero"
+        )
+    if _int(readiness.get("objective_source_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "objective source outside-soloing not-evaluable boundary required"
+        )
+    if _int(readiness.get("objective_repaired_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "objective repaired outside-soloing not-evaluable boundary required"
+        )
+    if not bool(readiness.get("repair_sweep_source_outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "repair sweep outside-soloing repair evidence readiness required"
+        )
+    if _int(readiness.get("repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "repair sweep outside-soloing residual pitch-role risk should be zero"
+        )
+    if _int(readiness.get("repair_sweep_source_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "repair sweep source outside-soloing not-evaluable boundary required"
+        )
+    if _int(readiness.get("repair_sweep_repaired_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "repair sweep repaired outside-soloing not-evaluable boundary required"
+        )
     _require_no_quality_claim(readiness, label="follow-up readiness")
     return {
         "candidate_count": _int(readiness.get("candidate_count")),
@@ -135,6 +167,30 @@ def validate_followup_decision(report: dict[str, Any]) -> dict[str, Any]:
         "remaining_failure_counts": _dict(sweep.get("remaining_failure_counts")),
         "source_songlike_failure_count": _int(
             _dict(sweep.get("remaining_failure_counts")).get(SONGLIKE_LABEL)
+        ),
+        "objective_source_outside_soloing_repair_evidence_ready": bool(
+            readiness.get("objective_source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "objective_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            readiness.get("objective_source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "objective_source_outside_soloing_not_evaluable_count": _int(
+            readiness.get("objective_source_outside_soloing_not_evaluable_count")
+        ),
+        "objective_repaired_outside_soloing_not_evaluable_count": _int(
+            readiness.get("objective_repaired_outside_soloing_not_evaluable_count")
+        ),
+        "repair_sweep_source_outside_soloing_repair_evidence_ready": bool(
+            readiness.get("repair_sweep_source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            readiness.get("repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "repair_sweep_source_outside_soloing_not_evaluable_count": _int(
+            readiness.get("repair_sweep_source_outside_soloing_not_evaluable_count")
+        ),
+        "repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
+            readiness.get("repair_sweep_repaired_outside_soloing_not_evaluable_count")
         ),
     }
 
@@ -154,6 +210,22 @@ def validate_targeted_repair_sweep(report: dict[str, Any]) -> list[dict[str, Any
     if _int(aggregate.get("technical_regression_count")) != 0:
         raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
             "source technical regression must remain zero"
+        )
+    if not bool(aggregate.get("source_outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "source outside-soloing repair evidence readiness required"
+        )
+    if _int(aggregate.get("source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "source outside-soloing residual pitch-role risk should be zero"
+        )
+    if _int(aggregate.get("source_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "source outside-soloing not-evaluable boundary required"
+        )
+    if _int(aggregate.get("repaired_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "repaired outside-soloing not-evaluable boundary required"
         )
     if len(rows) < 6:
         raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
@@ -337,6 +409,14 @@ def failure_counts(rows: list[dict[str, Any]], *, key: str) -> Counter[str]:
     )
 
 
+def not_evaluable_counts(rows: list[dict[str, Any]], *, key: str) -> Counter[str]:
+    return Counter(
+        label
+        for row in rows
+        for label in _list(_dict(row.get(key)).get("not_evaluable_labels"))
+    )
+
+
 def build_songlike_melody_contour_repair_sweep_report(
     *,
     followup_decision: dict[str, Any],
@@ -398,6 +478,14 @@ def build_songlike_melody_contour_repair_sweep_report(
         < _int(item.get("source_failure_label_count"))
     )
     technical_regression_count = repaired_failures.get("technical_gate_regression", 0)
+    repaired_not_evaluable = not_evaluable_counts(
+        relabeled,
+        key="contour_repaired_labeling",
+    )
+    repaired_outside_soloing_count = repaired_not_evaluable.get(
+        "outside_soloing_without_context",
+        0,
+    )
     target_supported = (
         total_after < total_before
         and repaired_songlike_count < source_songlike_count
@@ -424,6 +512,19 @@ def build_songlike_melody_contour_repair_sweep_report(
             "songlike_failure_delta": source_songlike_count - repaired_songlike_count,
             "improved_candidate_count": improved_count,
             "technical_regression_count": technical_regression_count,
+            "source_outside_soloing_repair_evidence_ready": bool(
+                followup["repair_sweep_source_outside_soloing_repair_evidence_ready"]
+            ),
+            "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+                followup["repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
+            "source_outside_soloing_not_evaluable_count": _int(
+                followup["repair_sweep_repaired_outside_soloing_not_evaluable_count"]
+            ),
+            "repaired_outside_soloing_not_evaluable_count": _int(
+                repaired_outside_soloing_count
+            ),
+            "repaired_not_evaluable_counts": dict(sorted(repaired_not_evaluable.items())),
             "repaired_failure_counts": dict(sorted(repaired_failures.items())),
             "target_supported": target_supported,
         },
@@ -446,6 +547,18 @@ def build_songlike_melody_contour_repair_sweep_report(
             "failure_label_delta": total_before - total_after,
             "songlike_failure_delta": source_songlike_count - repaired_songlike_count,
             "technical_regression_count": technical_regression_count,
+            "source_outside_soloing_repair_evidence_ready": bool(
+                followup["repair_sweep_source_outside_soloing_repair_evidence_ready"]
+            ),
+            "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+                followup["repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
+            "source_outside_soloing_not_evaluable_count": _int(
+                followup["repair_sweep_repaired_outside_soloing_not_evaluable_count"]
+            ),
+            "repaired_outside_soloing_not_evaluable_count": _int(
+                repaired_outside_soloing_count
+            ),
             "audio_package_ready": target_supported,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
@@ -565,6 +678,21 @@ def validate_songlike_melody_contour_repair_sweep_report(
         "songlike_failure_delta": _int(aggregate.get("songlike_failure_delta")),
         "improved_candidate_count": _int(aggregate.get("improved_candidate_count")),
         "technical_regression_count": _int(aggregate.get("technical_regression_count")),
+        "source_outside_soloing_repair_evidence_ready": bool(
+            aggregate.get("source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            aggregate.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_not_evaluable_count": _int(
+            aggregate.get("source_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_outside_soloing_not_evaluable_count": _int(
+            aggregate.get("repaired_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_not_evaluable_counts": _dict(
+            aggregate.get("repaired_not_evaluable_counts")
+        ),
         "repaired_failure_counts": _dict(aggregate.get("repaired_failure_counts")),
         "audio_package_ready": bool(readiness.get("audio_package_ready", False)),
         "human_audio_preference_claimed": bool(
@@ -601,6 +729,10 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- songlike failure delta: `{aggregate['songlike_failure_delta']}`",
         f"- improved candidate count: `{aggregate['improved_candidate_count']}`",
         f"- technical regression count: `{aggregate['technical_regression_count']}`",
+        f"- source outside-soloing repair evidence ready: `{_bool_token(aggregate['source_outside_soloing_repair_evidence_ready'])}`",
+        f"- source outside-soloing repair pitch-role risk after: `{aggregate['source_outside_soloing_repair_pitch_role_risk_count_after']}`",
+        f"- source outside-soloing not evaluable count: `{aggregate['source_outside_soloing_not_evaluable_count']}`",
+        f"- repaired outside-soloing not evaluable count: `{aggregate['repaired_outside_soloing_not_evaluable_count']}`",
         f"- target supported: `{_bool_token(aggregate['target_supported'])}`",
         f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
         f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
@@ -609,6 +741,15 @@ def markdown_report(report: dict[str, Any]) -> str:
         "",
     ]
     for label, count in aggregate["repaired_failure_counts"].items():
+        lines.append(f"- `{label}`: `{count}`")
+    lines.extend(
+        [
+            "",
+            "## Repaired Not Evaluable Counts",
+            "",
+        ]
+    )
+    for label, count in aggregate["repaired_not_evaluable_counts"].items():
         lines.append(f"- `{label}`: `{count}`")
     lines.extend(["", "## MIDI Files", ""])
     for item in report.get("candidate_repairs", []):
@@ -647,7 +788,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=762)
+    parser.add_argument("--issue_number", type=int, default=846)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--min_candidate_count", type=int, default=6)

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
@@ -110,6 +110,14 @@ def followup_decision(*, quality_claim: bool = False) -> dict:
             "repaired_total_failure_label_count": 8,
             "failure_label_delta": 4,
             "technical_regression_count": 0,
+            "objective_source_outside_soloing_repair_evidence_ready": True,
+            "objective_source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "objective_source_outside_soloing_not_evaluable_count": 6,
+            "objective_repaired_outside_soloing_not_evaluable_count": 6,
+            "repair_sweep_source_outside_soloing_repair_evidence_ready": True,
+            "repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "repair_sweep_source_outside_soloing_not_evaluable_count": 6,
+            "repair_sweep_repaired_outside_soloing_not_evaluable_count": 6,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
             "audio_rendered_quality_claimed": False,
@@ -159,6 +167,10 @@ def targeted_repair_sweep(*, technical_regression_count: int = 0) -> dict:
             "failure_label_delta": 4,
             "improved_candidate_count": 4,
             "technical_regression_count": technical_regression_count,
+            "source_outside_soloing_repair_evidence_ready": True,
+            "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "source_outside_soloing_not_evaluable_count": 6,
+            "repaired_outside_soloing_not_evaluable_count": 6,
             "repaired_failure_counts": {
                 "dead_air_or_density_gap": 1,
                 "phrase_shape_missing_tension_release": 2,
@@ -208,6 +220,14 @@ class StageBMidiToSoloSonglikeMelodyContourRepairSweepTest(unittest.TestCase):
             self.assertLess(summary["repaired_songlike_failure_count"], 5)
             self.assertGreater(summary["songlike_failure_delta"], 0)
             self.assertEqual(summary["technical_regression_count"], 0)
+            self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
+            self.assertEqual(summary["source_outside_soloing_repair_pitch_role_risk_count_after"], 0)
+            self.assertEqual(summary["source_outside_soloing_not_evaluable_count"], 6)
+            self.assertEqual(summary["repaired_outside_soloing_not_evaluable_count"], 6)
+            self.assertEqual(
+                summary["repaired_not_evaluable_counts"]["outside_soloing_without_context"],
+                6,
+            )
             self.assertEqual(summary["selected_target"], SELECTED_TARGET)
             self.assertFalse(summary["human_audio_preference_claimed"])
             self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
@@ -232,6 +252,32 @@ class StageBMidiToSoloSonglikeMelodyContourRepairSweepTest(unittest.TestCase):
                     rubric_baseline=rubric_baseline(Path(tmp)),
                     output_dir=Path(tmp) / "songlike_repair",
                     issue_number=762,
+                )
+
+    def test_rejects_missing_followup_outside_soloing_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = followup_decision()
+            source["readiness"]["repair_sweep_repaired_outside_soloing_not_evaluable_count"] = 0
+            with self.assertRaises(StageBMidiToSoloSonglikeMelodyContourRepairSweepError):
+                build_songlike_melody_contour_repair_sweep_report(
+                    followup_decision=source,
+                    targeted_repair_sweep=targeted_repair_sweep(),
+                    rubric_baseline=rubric_baseline(Path(tmp)),
+                    output_dir=Path(tmp) / "songlike_repair",
+                    issue_number=846,
+                )
+
+    def test_rejects_missing_targeted_sweep_outside_soloing_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = targeted_repair_sweep()
+            source["aggregate"]["source_outside_soloing_not_evaluable_count"] = 0
+            with self.assertRaises(StageBMidiToSoloSonglikeMelodyContourRepairSweepError):
+                build_songlike_melody_contour_repair_sweep_report(
+                    followup_decision=followup_decision(),
+                    targeted_repair_sweep=source,
+                    rubric_baseline=rubric_baseline(Path(tmp)),
+                    output_dir=Path(tmp) / "songlike_repair",
+                    issue_number=846,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary

- songlike melody contour repair sweep 입력 검증 강화
- follow-up/targeted sweep outside-soloing context 보존
- contour repair 후 repaired not_evaluable counts 기록

## Context

- Issue #844 follow-up decision selected target `songlike_melody_contour_repair_sweep`
- dominant remaining failure label/count `songlike_melody_not_soloing/5`
- source outside-soloing repair pitch-role risk count after `0`
- source/repaired outside-soloing not evaluable count `6/6`
- songlike contour repair 결과 songlike failure `5 -> 0`
- total failure labels `8 -> 4`

## Scope

- follow-up decision source validation에 outside-soloing 필수값 추가
- targeted repair sweep source validation에 outside-soloing aggregate 필수값 추가
- repaired not_evaluable counts aggregate/markdown/validation summary 추가
- harness issue/doc path를 #846 기준으로 갱신
- current status/core plan 결과 기록 추가

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-sweep`
- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- human/audio preference claim 없음
- MIDI-to-solo musical quality claim 없음
- outside-soloing without context 및 weak chord-tone landing은 not_evaluable label로 유지

Closes #846
