### PR TITLE
Stage B MIDI-to-solo songlike audio outside-soloing context refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -409,6 +409,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo targeted quality repair objective-only next decision: follow-up required `true`, current quality claim ready `false`, source outside-soloing not evaluable `6`, repaired outside-soloing not evaluable `6`, source pitch-role risk after `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
 - MIDI-to-solo targeted quality repair follow-up decision: selected target `songlike_melody_contour_repair_sweep`, dominant label/count `songlike_melody_not_soloing/5`, objective and repair sweep outside-soloing not evaluable `6/6`, pitch-role risk after `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
 - MIDI-to-solo songlike melody contour repair sweep: songlike failure `5 -> 0`, total failure labels `8 -> 4`, repaired outside-soloing not evaluable `6`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
+- MIDI-to-solo songlike melody contour repair audio package: rendered WAV `6`, duration `18.849s-18.992s`, source/repaired outside-soloing not evaluable `6/6`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
 - MIDI-to-solo pitch-contour changed-ratio repair probe: repaired/pass `3/3`, max pitch changed ratio `0.7174 -> 0.4348`, max interval `12`, dead-air max `0.0000`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
 - MIDI-to-solo pitch-contour changed-ratio repair audio package: rendered WAV `3`, duration `18.422s-18.978s`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
@@ -6477,6 +6478,49 @@ Issue #846은 songlike melody contour repair sweep에 follow-up decision outside
 다음 작업:
 
 - `Stage B MIDI-to-solo songlike melody contour repair audio package refresh`
+
+## 9.115 Stage B MIDI-to-solo songlike melody contour repair audio package outside-soloing context refresh
+
+Issue #848은 songlike melody contour repair audio package에 repair sweep outside-soloing context를 반영한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
+- rendered audio file count: `6`
+- technical WAV validation: `true`
+- sample rate: `44100`
+- duration range: `18.849s-18.992s`
+- total failure labels: `8 -> 4`
+- songlike failure count: `5 -> 0`
+- songlike failure delta: `5`
+- source outside-soloing repair pitch-role risk count after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- repaired not evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
+- audio review required: `true`
+- human/audio preference claimed: `false`
+- audio rendered quality claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- songlike contour repaired MIDI 후보 `6`개 WAV 렌더 완료.
+- WAV technical metadata 검증 완료.
+- outside-soloing without context와 weak chord-tone landing은 listening review package 대상 경계로 유지.
+- 음악적 품질, human/audio preference, audio rendered quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_audio`
+- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_songlike_melody_contour_repair_audio.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-audio-package`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour repair listening review package refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #846, Stage B MIDI-to-solo songlike melody contour repair sweep outside-soloing context refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair audio package refresh`
+- latest functional result: Issue #848, Stage B MIDI-to-solo songlike melody contour repair audio package outside-soloing context refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair listening review package refresh`
 
 현재 범위가 아닌 것:
 
@@ -554,6 +554,23 @@
 - audio rendered quality claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 audio target: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
+- songlike melody contour repair audio package outside-soloing context refresh 완료
+- rendered audio file count: `6`
+- technical WAV validation: `true`
+- WAV sample rate: `44100`
+- WAV duration range: `18.849s-18.992s`
+- total failure labels: `8 -> 4`
+- songlike failure count: `5 -> 0`
+- songlike failure delta: `5`
+- source outside-soloing repair pitch-role risk count after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- repaired not evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
+- audio review required: `true`
+- human/audio preference claim: `false`
+- audio rendered quality claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 review target: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_AUDIO_PACKAGE_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_AUDIO_PACKAGE_2026-06-10.md
@@ -1,0 +1,49 @@
+# Stage B MIDI-to-Solo Songlike Melody Contour Repair Audio Package
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
+- render attempted: `true`
+- rendered audio file count: `6`
+- technical WAV validation: `true`
+- duration range: `18.849s-18.992s`
+- failure labels: `8 -> 4`
+- songlike failure count: `5 -> 0`
+- songlike failure delta: `5`
+- improved candidate count: `4`
+- technical regression count: `0`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair pitch-role risk after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- audio review required: `true`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+
+## Rendered Files
+
+- candidate `1` rank `1`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package/audio/candidate_01_cli_repaired_midi_rank_01_songlike_contour_repair.wav`, duration `18.975`, sample rate `44100`, failure labels `none`, sha256 `5aa78379d336`
+- candidate `2` rank `2`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package/audio/candidate_02_cli_repaired_midi_rank_02_songlike_contour_repair.wav`, duration `18.971`, sample rate `44100`, failure labels `phrase_shape_missing_tension_release,rhythmic_monotony`, sha256 `3c2cd10766d6`
+- candidate `3` rank `3`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package/audio/candidate_03_cli_repaired_midi_rank_03_songlike_contour_repair.wav`, duration `18.985`, sample rate `44100`, failure labels `none`, sha256 `4b7887d41190`
+- candidate `4` rank `4`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package/audio/candidate_04_changed_ratio_repair_rank_04_songlike_contour_repair.wav`, duration `18.849`, sample rate `44100`, failure labels `rhythmic_monotony`, sha256 `65bbfa67e33e`
+- candidate `5` rank `5`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package/audio/candidate_05_changed_ratio_repair_rank_05_songlike_contour_repair.wav`, duration `18.992`, sample rate `44100`, failure labels `none`, sha256 `d387e54c9d56`
+- candidate `6` rank `6`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package/audio/candidate_06_changed_ratio_repair_rank_06_songlike_contour_repair.wav`, duration `18.985`, sample rate `44100`, failure labels `phrase_shape_missing_tension_release`, sha256 `c36a0b9316eb`
+
+## Repaired Not Evaluable Counts
+
+- `outside_soloing_without_context`: `6`
+- `weak_chord_tone_landing`: `6`
+
+## Claim Boundary
+
+- `audio_rendered_quality`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `model_checkpoint_generation_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`
+
+## Next
+
+- `Stage B MIDI-to-solo songlike melody contour repair listening review package`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6383,8 +6383,8 @@ run_stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package() {
   "$PYTHON_BIN" scripts/render_stage_b_midi_to_solo_songlike_melody_contour_repair_audio.py \
     --run_id "$run_id" \
     --songlike_repair_sweep_report "$sweep_report" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_AUDIO_PACKAGE_2026-06-09.md \
-    --issue_number 764 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_AUDIO_PACKAGE_2026-06-10.md \
+    --issue_number 848 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package \
     --expected_file_count 6 \

--- a/scripts/render_stage_b_midi_to_solo_songlike_melody_contour_repair_audio.py
+++ b/scripts/render_stage_b_midi_to_solo_songlike_melody_contour_repair_audio.py
@@ -130,6 +130,22 @@ def validate_source_report(
         raise StageBMidiToSoloSonglikeMelodyContourRepairAudioError(
             "technical regression count should be zero"
         )
+    if not bool(aggregate.get("source_outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairAudioError(
+            "source outside-soloing repair evidence readiness required"
+        )
+    if _int(aggregate.get("source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairAudioError(
+            "source outside-soloing residual pitch-role risk should be zero"
+        )
+    if _int(aggregate.get("source_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairAudioError(
+            "source outside-soloing not-evaluable boundary required"
+        )
+    if _int(aggregate.get("repaired_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairAudioError(
+            "repaired outside-soloing not-evaluable boundary required"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloSonglikeMelodyContourRepairAudioError(
             "critical user input should not be required"
@@ -343,6 +359,21 @@ def build_audio_render_report(
             "songlike_failure_delta": _int(aggregate.get("songlike_failure_delta")),
             "improved_candidate_count": _int(aggregate.get("improved_candidate_count")),
             "technical_regression_count": _int(aggregate.get("technical_regression_count")),
+            "source_outside_soloing_repair_evidence_ready": bool(
+                aggregate.get("source_outside_soloing_repair_evidence_ready", False)
+            ),
+            "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+                aggregate.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+            ),
+            "source_outside_soloing_not_evaluable_count": _int(
+                aggregate.get("source_outside_soloing_not_evaluable_count")
+            ),
+            "repaired_outside_soloing_not_evaluable_count": _int(
+                aggregate.get("repaired_outside_soloing_not_evaluable_count")
+            ),
+            "repaired_not_evaluable_counts": _dict(
+                aggregate.get("repaired_not_evaluable_counts")
+            ),
             "remaining_failure_counts": dict(sorted(failure_counts.items())),
             "audio_review_required": True,
         },
@@ -469,6 +500,21 @@ def validate_audio_render_report(
         "songlike_failure_delta": _int(summary.get("songlike_failure_delta")),
         "improved_candidate_count": _int(summary.get("improved_candidate_count")),
         "technical_regression_count": _int(summary.get("technical_regression_count")),
+        "source_outside_soloing_repair_evidence_ready": bool(
+            summary.get("source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            summary.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_not_evaluable_count": _int(
+            summary.get("source_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_outside_soloing_not_evaluable_count": _int(
+            summary.get("repaired_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_not_evaluable_counts": _dict(
+            summary.get("repaired_not_evaluable_counts")
+        ),
         "audio_review_required": bool(summary.get("audio_review_required", False)),
         "audio_rendered_quality_claimed": bool(
             boundary.get("audio_rendered_quality_claimed", True)
@@ -507,6 +553,10 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- songlike failure delta: `{summary['songlike_failure_delta']}`",
         f"- improved candidate count: `{summary['improved_candidate_count']}`",
         f"- technical regression count: `{summary['technical_regression_count']}`",
+        f"- source outside-soloing repair evidence ready: `{_bool_token(summary['source_outside_soloing_repair_evidence_ready'])}`",
+        f"- source outside-soloing repair pitch-role risk after: `{summary['source_outside_soloing_repair_pitch_role_risk_count_after']}`",
+        f"- source outside-soloing not evaluable count: `{summary['source_outside_soloing_not_evaluable_count']}`",
+        f"- repaired outside-soloing not evaluable count: `{summary['repaired_outside_soloing_not_evaluable_count']}`",
         f"- audio review required: `{_bool_token(summary['audio_review_required'])}`",
         f"- audio rendered quality claimed: `{_bool_token(boundary['audio_rendered_quality_claimed'])}`",
         f"- human/audio preference claimed: `{_bool_token(boundary['human_audio_preference_claimed'])}`",
@@ -523,6 +573,9 @@ def markdown_report(report: dict[str, Any]) -> str:
             f"`{','.join(item['repaired_failure_labels']) or 'none'}`, "
             f"sha256 `{str(wav_file['sha256'])[:12]}`"
         )
+    lines.extend(["", "## Repaired Not Evaluable Counts", ""])
+    for label, count in summary["repaired_not_evaluable_counts"].items():
+        lines.append(f"- `{label}`: `{count}`")
     lines.extend(["", "## Claim Boundary", ""])
     for item in report.get("not_proven", []):
         lines.append(f"- `{item}`")
@@ -542,7 +595,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=764)
+    parser.add_argument("--issue_number", type=int, default=848)
     parser.add_argument("--renderer", type=str, default=shutil.which("fluidsynth") or "")
     parser.add_argument("--soundfont", type=str, default="")
     parser.add_argument("--sample_rate", type=int, default=44100)

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_audio.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_audio.py
@@ -70,6 +70,10 @@ def source_report(root: Path, *, quality_claim: bool = False) -> dict:
                 "density_pattern": [5, 3, 6, 4, 5, 4, 6, 3],
                 "contour_repaired_labeling": {
                     "failure_labels": labels,
+                    "not_evaluable_labels": [
+                        "outside_soloing_without_context",
+                        "weak_chord_tone_landing",
+                    ],
                     "metrics": {
                         "note_count": 24,
                         "unique_pitch_count": 6,
@@ -93,6 +97,14 @@ def source_report(root: Path, *, quality_claim: bool = False) -> dict:
             "songlike_failure_delta": 5,
             "improved_candidate_count": 4,
             "technical_regression_count": 0,
+            "source_outside_soloing_repair_evidence_ready": True,
+            "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "source_outside_soloing_not_evaluable_count": 6,
+            "repaired_outside_soloing_not_evaluable_count": 6,
+            "repaired_not_evaluable_counts": {
+                "outside_soloing_without_context": 6,
+                "weak_chord_tone_landing": 6,
+            },
             "repaired_failure_counts": {
                 "phrase_shape_missing_tension_release": 2,
                 "rhythmic_monotony": 2,
@@ -163,6 +175,14 @@ class StageBMidiToSoloSonglikeMelodyContourRepairAudioTest(unittest.TestCase):
             self.assertTrue(summary["technical_wav_validation"])
             self.assertEqual(summary["songlike_failure_delta"], 5)
             self.assertEqual(summary["technical_regression_count"], 0)
+            self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
+            self.assertEqual(summary["source_outside_soloing_repair_pitch_role_risk_count_after"], 0)
+            self.assertEqual(summary["source_outside_soloing_not_evaluable_count"], 6)
+            self.assertEqual(summary["repaired_outside_soloing_not_evaluable_count"], 6)
+            self.assertEqual(
+                summary["repaired_not_evaluable_counts"]["outside_soloing_without_context"],
+                6,
+            )
             self.assertTrue(summary["audio_review_required"])
             self.assertFalse(summary["human_audio_preference_claimed"])
             self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
@@ -177,6 +197,26 @@ class StageBMidiToSoloSonglikeMelodyContourRepairAudioTest(unittest.TestCase):
             with self.assertRaises(StageBMidiToSoloSonglikeMelodyContourRepairAudioError):
                 build_audio_render_report(
                     source_report(root, quality_claim=True),
+                    output_dir=root / "audio_package",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(soundfont),
+                    sample_rate=44100,
+                    expected_file_count=6,
+                    runner=fake_runner,
+                )
+
+    def test_rejects_missing_outside_soloing_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = root / "fluidsynth"
+            soundfont = root / "soundfont.sf2"
+            renderer.write_text("#!/bin/sh\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            source = source_report(root)
+            source["aggregate"]["repaired_outside_soloing_not_evaluable_count"] = 0
+            with self.assertRaises(StageBMidiToSoloSonglikeMelodyContourRepairAudioError):
+                build_audio_render_report(
+                    source,
                     output_dir=root / "audio_package",
                     renderer_path=str(renderer),
                     soundfont_path=str(soundfont),


### PR DESCRIPTION
## Summary

- songlike melody contour repair audio package source validation 강화
- repair sweep outside-soloing/not_evaluable context 보존
- WAV technical package summary에 repaired not_evaluable counts 기록

## Context

- Issue #846 songlike repair sweep 결과 candidate count `6`
- songlike failure count `5 -> 0`
- total failure labels `8 -> 4`
- source/repaired outside-soloing not evaluable count `6/6`
- WAV technical validation `true`

## Scope

- audio source validation에 outside-soloing 필수값 추가
- audio summary/validation/markdown output에 outside-soloing context 추가
- harness issue/doc path를 #848 기준으로 갱신
- current status/core plan 결과 기록 추가

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_audio`
- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_songlike_melody_contour_repair_audio.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-audio-package`
- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- audio rendered quality claim 없음
- human/audio preference claim 없음
- outside-soloing without context 및 weak chord-tone landing은 listening review package 대상으로 유지

Closes #848
