### PR TITLE
Stage B MIDI-to-solo songlike review package outside-soloing context refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -410,6 +410,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo targeted quality repair follow-up decision: selected target `songlike_melody_contour_repair_sweep`, dominant label/count `songlike_melody_not_soloing/5`, objective and repair sweep outside-soloing not evaluable `6/6`, pitch-role risk after `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
 - MIDI-to-solo songlike melody contour repair sweep: songlike failure `5 -> 0`, total failure labels `8 -> 4`, repaired outside-soloing not evaluable `6`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
 - MIDI-to-solo songlike melody contour repair audio package: rendered WAV `6`, duration `18.849s-18.992s`, source/repaired outside-soloing not evaluable `6/6`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
+- MIDI-to-solo songlike melody contour repair listening review package: review items `6`, validated input `false`, source/repaired outside-soloing not evaluable `6/6`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
 - MIDI-to-solo pitch-contour changed-ratio repair probe: repaired/pass `3/3`, max pitch changed ratio `0.7174 -> 0.4348`, max interval `12`, dead-air max `0.0000`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
 - MIDI-to-solo pitch-contour changed-ratio repair audio package: rendered WAV `3`, duration `18.422s-18.978s`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
@@ -6521,6 +6522,51 @@ Issue #848은 songlike melody contour repair audio package에 repair sweep outsi
 다음 작업:
 
 - `Stage B MIDI-to-solo songlike melody contour repair listening review package refresh`
+
+## 9.116 Stage B MIDI-to-solo songlike melody contour repair listening review package outside-soloing context refresh
+
+Issue #850은 songlike melody contour repair listening review package에 audio package outside-soloing context를 반영한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
+- listening review package ready: `true`
+- review item count: `6`
+- validated review input: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- duration range: `18.849s-18.992s`
+- failure label delta: `4`
+- songlike failure count: `5 -> 0`
+- songlike failure delta: `5`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair pitch-role risk count after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- repaired not evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
+- human/audio preference claimed: `false`
+- audio rendered quality claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- listening review package에서 audio package의 outside-soloing repair evidence 유지.
+- review item `6`개 WAV/MIDI 경로와 필수 입력 필드 준비 완료.
+- outside-soloing without context와 weak chord-tone landing은 청취 입력 전까지 not-evaluable 경계로 유지.
+- 음악적 품질, human/audio preference, audio rendered quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-listening-review-package`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour repair listening review input guard refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #848, Stage B MIDI-to-solo songlike melody contour repair audio package outside-soloing context refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair listening review package refresh`
+- latest functional result: Issue #850, Stage B MIDI-to-solo songlike melody contour repair listening review package outside-soloing context refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair listening review input guard refresh`
 
 현재 범위가 아닌 것:
 
@@ -571,6 +571,23 @@
 - audio rendered quality claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 review target: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
+- songlike melody contour repair listening review package outside-soloing context refresh 완료
+- review item count: `6`
+- validated review input: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- WAV duration range: `18.849s-18.992s`
+- failure label delta: `4`
+- songlike failure count: `5 -> 0`
+- songlike failure delta: `5`
+- source outside-soloing repair pitch-role risk count after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- repaired not evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
+- human/audio preference claim: `false`
+- audio rendered quality claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 guard target: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_LISTENING_REVIEW_PACKAGE_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_LISTENING_REVIEW_PACKAGE_2026-06-10.md
@@ -1,0 +1,51 @@
+# Stage B MIDI-to-Solo Songlike Melody Contour Repair Listening Review Package
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
+- package ready: `true`
+- review item count: `6`
+- validated review input: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- duration range: `18.849s-18.992s`
+- failure label delta: `4`
+- songlike failure count: `5 -> 0`
+- songlike failure delta: `5`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair pitch-role risk after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- human/audio preference claimed: `false`
+
+## Review Items
+
+- candidate `1` `cli_repaired_midi` rank `1`: WAV `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package/audio/candidate_01_cli_repaired_midi_rank_01_songlike_contour_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/midi/01_songlike_melody_contour_repair.mid`, duration `18.975`, failure labels `none`
+- candidate `2` `cli_repaired_midi` rank `2`: WAV `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package/audio/candidate_02_cli_repaired_midi_rank_02_songlike_contour_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/midi/02_songlike_melody_contour_repair.mid`, duration `18.971`, failure labels `phrase_shape_missing_tension_release,rhythmic_monotony`
+- candidate `3` `cli_repaired_midi` rank `3`: WAV `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package/audio/candidate_03_cli_repaired_midi_rank_03_songlike_contour_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/midi/03_songlike_melody_contour_repair.mid`, duration `18.985`, failure labels `none`
+- candidate `4` `changed_ratio_repair` rank `4`: WAV `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package/audio/candidate_04_changed_ratio_repair_rank_04_songlike_contour_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/midi/04_songlike_melody_contour_repair.mid`, duration `18.849`, failure labels `rhythmic_monotony`
+- candidate `5` `changed_ratio_repair` rank `5`: WAV `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package/audio/candidate_05_changed_ratio_repair_rank_05_songlike_contour_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/midi/05_songlike_melody_contour_repair.mid`, duration `18.992`, failure labels `none`
+- candidate `6` `changed_ratio_repair` rank `6`: WAV `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package/audio/candidate_06_changed_ratio_repair_rank_06_songlike_contour_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/midi/06_songlike_melody_contour_repair.mid`, duration `18.985`, failure labels `phrase_shape_missing_tension_release`
+
+## Required Input Fields
+
+- `candidate_index`
+- `listening_status`
+- `preference`
+- `issue_notes`
+
+## Repaired Not Evaluable Counts
+
+- `outside_soloing_without_context`: `6`
+- `weak_chord_tone_landing`: `6`
+
+## Claim Boundary
+
+- MIDI-to-solo musical quality claimed: `false`
+- audio rendered quality claimed: `false`
+- broad trained-model quality claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo songlike melody contour repair listening review input guard`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6405,8 +6405,8 @@ run_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package
   "$PYTHON_BIN" scripts/build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py \
     --run_id "$review_run_id" \
     --audio_package_report "$audio_package_report" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_LISTENING_REVIEW_PACKAGE_2026-06-09.md \
-    --issue_number 766 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_LISTENING_REVIEW_PACKAGE_2026-06-10.md \
+    --issue_number 850 \
     --expected_review_item_count 6 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard \

--- a/scripts/build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py
+++ b/scripts/build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py
@@ -108,6 +108,22 @@ def validate_audio_package_report(
         raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
             "audio review requirement should be recorded"
         )
+    if not bool(summary.get("source_outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
+            "source outside-soloing repair evidence readiness required"
+        )
+    if _int(summary.get("source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
+            "source outside-soloing residual pitch-role risk should be zero"
+        )
+    if _int(summary.get("source_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
+            "source outside-soloing not-evaluable boundary required"
+        )
+    if _int(summary.get("repaired_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
+            "repaired outside-soloing not-evaluable boundary required"
+        )
     if _int(boundary.get("rendered_audio_file_count")) < int(expected_count):
         raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
             "rendered audio count below expected"
@@ -198,6 +214,21 @@ def build_listening_review_package_report(
             "songlike_failure_delta": _int(summary.get("songlike_failure_delta")),
             "improved_candidate_count": _int(summary.get("improved_candidate_count")),
             "technical_regression_count": _int(summary.get("technical_regression_count")),
+            "source_outside_soloing_repair_evidence_ready": bool(
+                summary.get("source_outside_soloing_repair_evidence_ready", False)
+            ),
+            "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+                summary.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+            ),
+            "source_outside_soloing_not_evaluable_count": _int(
+                summary.get("source_outside_soloing_not_evaluable_count")
+            ),
+            "repaired_outside_soloing_not_evaluable_count": _int(
+                summary.get("repaired_outside_soloing_not_evaluable_count")
+            ),
+            "repaired_not_evaluable_counts": _dict(
+                summary.get("repaired_not_evaluable_counts")
+            ),
             "remaining_failure_counts": _dict(summary.get("remaining_failure_counts")),
             "audio_review_required": bool(summary.get("audio_review_required", False)),
         },
@@ -300,6 +331,21 @@ def validate_listening_review_package_report(
         "duration_max_seconds": _float(source.get("duration_max_seconds")),
         "failure_label_delta": _int(source.get("failure_label_delta")),
         "songlike_failure_delta": _int(source.get("songlike_failure_delta")),
+        "source_outside_soloing_repair_evidence_ready": bool(
+            source.get("source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            source.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_not_evaluable_count": _int(
+            source.get("source_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_outside_soloing_not_evaluable_count": _int(
+            source.get("repaired_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_not_evaluable_counts": _dict(
+            source.get("repaired_not_evaluable_counts")
+        ),
         "audio_review_required": bool(source.get("audio_review_required", False)),
         "human_review_required_now": bool(readiness.get("human_review_required_now", True)),
         "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
@@ -333,6 +379,10 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- failure label delta: `{source['failure_label_delta']}`",
         f"- songlike failure count: `{source['source_songlike_failure_count']} -> {source['repaired_songlike_failure_count']}`",
         f"- songlike failure delta: `{source['songlike_failure_delta']}`",
+        f"- source outside-soloing repair evidence ready: `{_bool_token(source['source_outside_soloing_repair_evidence_ready'])}`",
+        f"- source outside-soloing repair pitch-role risk after: `{source['source_outside_soloing_repair_pitch_role_risk_count_after']}`",
+        f"- source outside-soloing not evaluable count: `{source['source_outside_soloing_not_evaluable_count']}`",
+        f"- repaired outside-soloing not evaluable count: `{source['repaired_outside_soloing_not_evaluable_count']}`",
         f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
         "",
         "## Review Items",
@@ -348,6 +398,9 @@ def markdown_report(report: dict[str, Any]) -> str:
     lines.extend(["", "## Required Input Fields", ""])
     for field in package["required_input_fields"]:
         lines.append(f"- `{field}`")
+    lines.extend(["", "## Repaired Not Evaluable Counts", ""])
+    for label, count in source["repaired_not_evaluable_counts"].items():
+        lines.append(f"- `{label}`: `{count}`")
     lines.extend(
         [
             "",
@@ -377,7 +430,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=766)
+    parser.add_argument("--issue_number", type=int, default=850)
     parser.add_argument("--expected_review_item_count", type=int, default=6)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py
@@ -115,6 +115,14 @@ def audio_package_report(root: Path, *, quality_claim: bool = False) -> dict:
             "songlike_failure_delta": 5,
             "improved_candidate_count": 6,
             "technical_regression_count": 0,
+            "source_outside_soloing_repair_evidence_ready": True,
+            "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "source_outside_soloing_not_evaluable_count": 6,
+            "repaired_outside_soloing_not_evaluable_count": 6,
+            "repaired_not_evaluable_counts": {
+                "outside_soloing_without_context": 6,
+                "weak_chord_tone_landing": 6,
+            },
             "remaining_failure_counts": {
                 "phrase_shape_missing_tension_release": 2,
                 "rhythmic_monotony": 3,
@@ -150,6 +158,14 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageTest(unit
             self.assertTrue(summary["technical_wav_validation"])
             self.assertEqual(summary["failure_label_delta"], 7)
             self.assertEqual(summary["songlike_failure_delta"], 5)
+            self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
+            self.assertEqual(summary["source_outside_soloing_repair_pitch_role_risk_count_after"], 0)
+            self.assertEqual(summary["source_outside_soloing_not_evaluable_count"], 6)
+            self.assertEqual(summary["repaired_outside_soloing_not_evaluable_count"], 6)
+            self.assertEqual(
+                summary["repaired_not_evaluable_counts"]["outside_soloing_without_context"],
+                6,
+            )
             self.assertFalse(summary["human_audio_preference_claimed"])
             self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
 
@@ -163,6 +179,21 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageTest(unit
                     audio_package_report=audio_package_report(root, quality_claim=True),
                     output_dir=root / "review_package",
                     issue_number=766,
+                    expected_count=6,
+                )
+
+    def test_rejects_missing_outside_soloing_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = audio_package_report(root)
+            source["summary"]["repaired_outside_soloing_not_evaluable_count"] = 0
+            with self.assertRaises(
+                StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError
+            ):
+                build_listening_review_package_report(
+                    audio_package_report=source,
+                    output_dir=root / "review_package",
+                    issue_number=850,
                     expected_count=6,
                 )
 


### PR DESCRIPTION
## Summary
- songlike melody contour repair listening review package outside-soloing context 보존
- audio package report의 source/repaired outside-soloing not-evaluable 경계 필수 검증
- review package markdown과 validation summary에 pitch-role risk/not-evaluable counts 기록

## Context
- Issue #848 audio package 결과: rendered WAV `6`, technical validation `true`
- source/repaired outside-soloing not evaluable: `6/6`
- source outside-soloing repair pitch-role risk after: `0`
- 청취 입력 전 quality/preference claim 제외 필요

## Scope
- listening review package builder 검증 조건 추가
- #850 기준 harness doc path/issue number 갱신
- Current Status, Core Plan, generated review package 문서 갱신
- missing outside-soloing context rejection test 추가

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-listening-review-package`
- `bash scripts/agent_harness.sh quick`

## Risk
- 음악적 품질 claim 없음
- human/audio preference claim 없음
- outside-soloing without context와 weak chord-tone landing은 listening input 전까지 not-evaluable 경계 유지

Closes #850

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Stage B progress tracking with latest milestone results.
  * Added listening review package documentation for melody contour repair validation.

* **Chores**
  * Enhanced validation constraints for listening review packages to ensure data quality.
  * Updated configuration references to latest documentation variants.

* **Tests**
  * Extended test coverage for listening review package validation with new constraint checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->