### PR TITLE
Stage B MIDI-to-solo songlike objective decision outside-soloing context refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -412,6 +412,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo songlike melody contour repair audio package: rendered WAV `6`, duration `18.849s-18.992s`, source/repaired outside-soloing not evaluable `6/6`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
 - MIDI-to-solo songlike melody contour repair listening review package: review items `6`, validated input `false`, source/repaired outside-soloing not evaluable `6/6`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
 - MIDI-to-solo songlike melody contour repair listening review input guard: preference fill `false`, validated input `false`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
+- MIDI-to-solo songlike melody contour repair objective-only next decision: follow-up required `true`, source/repaired outside-soloing not evaluable `6/6`, current quality claim ready `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
 - MIDI-to-solo pitch-contour changed-ratio repair probe: repaired/pass `3/3`, max pitch changed ratio `0.7174 -> 0.4348`, max interval `12`, dead-air max `0.0000`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
 - MIDI-to-solo pitch-contour changed-ratio repair audio package: rendered WAV `3`, duration `18.422s-18.978s`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
@@ -6614,6 +6615,54 @@ Issue #852는 songlike melody contour repair listening review input guard에 #85
 다음 작업:
 
 - `Stage B MIDI-to-solo songlike melody contour repair objective-only next decision refresh`
+
+## 9.118 Stage B MIDI-to-solo songlike melody contour repair objective-only next decision outside-soloing context refresh
+
+Issue #854는 songlike melody contour repair objective-only next decision에 #852 input guard outside-soloing context를 반영한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
+- objective next decision completed: `true`
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- failure label delta: `4`
+- songlike failure delta: `5`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair pitch-role risk count after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- audio review required: `true`
+- songlike contour follow-up required: `true`
+- current quality claim ready: `false`
+- critical user input required: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- pending listening review input 상태에서 preference fill 제외 유지.
+- objective-only 경계에서 quality claim 없이 follow-up decision으로 라우팅.
+- input guard의 outside-soloing repair evidence와 not-evaluable count 보존.
+- 음악적 품질, human/audio preference claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-objective-only-next-decision`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour repair follow-up decision refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #852, Stage B MIDI-to-solo songlike melody contour repair listening review input guard outside-soloing context refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair objective-only next decision refresh`
+- latest functional result: Issue #854, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision outside-soloing context refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair follow-up decision refresh`
 
 현재 범위가 아닌 것:
 
@@ -605,6 +605,24 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 decision target: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
+- songlike melody contour repair objective-only next decision outside-soloing context refresh 완료
+- objective next decision completed: `true`
+- review item count: `6`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- failure label delta: `4`
+- songlike failure delta: `5`
+- source outside-soloing repair pitch-role risk count after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- songlike contour follow-up required: `true`
+- current quality claim ready: `false`
+- critical user input required: `false`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 follow-up target: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-10.md
@@ -1,0 +1,41 @@
+# Stage B MIDI-to-Solo Songlike Melody Contour Repair Objective-Only Next Decision
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
+- selected target: `songlike_melody_contour_repair_followup_decision`
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- failure label delta: `4`
+- songlike failure count: `5 -> 0`
+- songlike failure delta: `5`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair pitch-role risk after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- songlike contour follow-up required: `true`
+- current quality claim ready: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Decision
+
+- reason: `listening preference pending and quality claim unavailable; route to follow-up repair decision`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo songlike melody contour repair follow-up decision`
+
+## Claim Boundary
+
+- `listening_review_completed`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6447,8 +6447,8 @@ run_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_deci
   "$PYTHON_BIN" scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next.py \
     --run_id "$run_id" \
     --input_guard_report "$input_guard_report" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-09.md \
-    --issue_number 770 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-10.md \
+    --issue_number 854 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision \
     --require_objective_decision \

--- a/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next.py
+++ b/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next.py
@@ -105,6 +105,22 @@ def validate_input_guard_report(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextError(
             "rendered WAV count below 6"
         )
+    if not bool(source.get("source_outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextError(
+            "outside-soloing repair evidence readiness required"
+        )
+    if _int(source.get("source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextError(
+            "outside-soloing residual pitch-role risk should be zero"
+        )
+    if _int(source.get("source_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextError(
+            "source outside-soloing not-evaluable boundary required"
+        )
+    if _int(source.get("repaired_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextError(
+            "repaired outside-soloing not-evaluable boundary required"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextError(
             "critical user input should not be required"
@@ -129,6 +145,18 @@ def validate_input_guard_report(report: dict[str, Any]) -> dict[str, Any]:
             source.get("repaired_songlike_failure_count")
         ),
         "songlike_failure_delta": _int(source.get("songlike_failure_delta")),
+        "source_outside_soloing_repair_evidence_ready": bool(
+            source.get("source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            source.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_not_evaluable_count": _int(
+            source.get("source_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_outside_soloing_not_evaluable_count": _int(
+            source.get("repaired_outside_soloing_not_evaluable_count")
+        ),
         "audio_review_required": bool(source.get("audio_review_required", False)),
     }
 
@@ -170,6 +198,18 @@ def build_objective_next_report(
                 source["repaired_songlike_failure_count"]
             ),
             "songlike_failure_delta": _int(source["songlike_failure_delta"]),
+            "source_outside_soloing_repair_evidence_ready": bool(
+                source["source_outside_soloing_repair_evidence_ready"]
+            ),
+            "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+                source["source_outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
+            "source_outside_soloing_not_evaluable_count": _int(
+                source["source_outside_soloing_not_evaluable_count"]
+            ),
+            "repaired_outside_soloing_not_evaluable_count": _int(
+                source["repaired_outside_soloing_not_evaluable_count"]
+            ),
             "audio_review_required": bool(source["audio_review_required"]),
             "songlike_contour_followup_required": bool(followup_required),
             "current_quality_claim_ready": False,
@@ -187,6 +227,18 @@ def build_objective_next_report(
             "technical_wav_validation": bool(source["technical_wav_validation"]),
             "songlike_contour_followup_required": bool(followup_required),
             "current_quality_claim_ready": False,
+            "source_outside_soloing_repair_evidence_ready": bool(
+                source["source_outside_soloing_repair_evidence_ready"]
+            ),
+            "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+                source["source_outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
+            "source_outside_soloing_not_evaluable_count": _int(
+                source["source_outside_soloing_not_evaluable_count"]
+            ),
+            "repaired_outside_soloing_not_evaluable_count": _int(
+                source["repaired_outside_soloing_not_evaluable_count"]
+            ),
             "human_audio_preference_claimed": False,
             "audio_rendered_quality_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
@@ -281,6 +333,18 @@ def validate_objective_next_report(
         "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
         "failure_label_delta": _int(summary.get("failure_label_delta")),
         "songlike_failure_delta": _int(summary.get("songlike_failure_delta")),
+        "source_outside_soloing_repair_evidence_ready": bool(
+            summary.get("source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            summary.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_not_evaluable_count": _int(
+            summary.get("source_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_outside_soloing_not_evaluable_count": _int(
+            summary.get("repaired_outside_soloing_not_evaluable_count")
+        ),
         "audio_review_required": bool(summary.get("audio_review_required", False)),
         "songlike_contour_followup_required": bool(
             summary.get("songlike_contour_followup_required", False)
@@ -320,6 +384,10 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- failure label delta: `{summary['failure_label_delta']}`",
         f"- songlike failure count: `{summary['source_songlike_failure_count']} -> {summary['repaired_songlike_failure_count']}`",
         f"- songlike failure delta: `{summary['songlike_failure_delta']}`",
+        f"- source outside-soloing repair evidence ready: `{_bool_token(summary['source_outside_soloing_repair_evidence_ready'])}`",
+        f"- source outside-soloing repair pitch-role risk after: `{summary['source_outside_soloing_repair_pitch_role_risk_count_after']}`",
+        f"- source outside-soloing not evaluable count: `{summary['source_outside_soloing_not_evaluable_count']}`",
+        f"- repaired outside-soloing not evaluable count: `{summary['repaired_outside_soloing_not_evaluable_count']}`",
         f"- songlike contour follow-up required: `{_bool_token(summary['songlike_contour_followup_required'])}`",
         f"- current quality claim ready: `{_bool_token(summary['current_quality_claim_ready'])}`",
         f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
@@ -353,7 +421,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=770)
+    parser.add_argument("--issue_number", type=int, default=854)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--require_objective_decision", action="store_true")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next.py
@@ -36,6 +36,10 @@ def input_guard_report(*, quality_claim: bool = False) -> dict:
                 "source_songlike_failure_count": 5,
                 "repaired_songlike_failure_count": 0,
                 "songlike_failure_delta": 5,
+                "source_outside_soloing_repair_evidence_ready": True,
+                "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+                "source_outside_soloing_not_evaluable_count": 6,
+                "repaired_outside_soloing_not_evaluable_count": 6,
                 "audio_review_required": True,
             },
         },
@@ -67,7 +71,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextTest(unittest.Test
             report = build_objective_next_report(
                 input_guard_report=input_guard_report(),
                 output_dir=root / "objective_next",
-                issue_number=770,
+                issue_number=854,
             )
             summary = validate_objective_next_report(
                 report,
@@ -85,6 +89,10 @@ class StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextTest(unittest.Test
             self.assertEqual(summary["rendered_audio_file_count"], 6)
             self.assertEqual(summary["failure_label_delta"], 4)
             self.assertEqual(summary["songlike_failure_delta"], 5)
+            self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
+            self.assertEqual(summary["source_outside_soloing_repair_pitch_role_risk_count_after"], 0)
+            self.assertEqual(summary["source_outside_soloing_not_evaluable_count"], 6)
+            self.assertEqual(summary["repaired_outside_soloing_not_evaluable_count"], 6)
             self.assertTrue(summary["songlike_contour_followup_required"])
             self.assertFalse(summary["current_quality_claim_ready"])
             self.assertFalse(summary["human_audio_preference_claimed"])
@@ -97,7 +105,19 @@ class StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextTest(unittest.Test
                 build_objective_next_report(
                     input_guard_report=input_guard_report(quality_claim=True),
                     output_dir=root / "objective_next",
-                    issue_number=770,
+                    issue_number=854,
+                )
+
+    def test_rejects_missing_outside_soloing_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = input_guard_report()
+            source["guard_result"]["source_summary"]["repaired_outside_soloing_not_evaluable_count"] = 0
+            with self.assertRaises(StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextError):
+                build_objective_next_report(
+                    input_guard_report=source,
+                    output_dir=root / "objective_next",
+                    issue_number=854,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary
- songlike melody contour repair objective-only next decision outside-soloing context 보존
- pending review input 상태에서 follow-up decision 경계로 라우팅
- validation summary와 markdown에 pitch-role risk/not-evaluable counts 기록

## Context
- Issue #852 input guard 결과: validated input `false`, preference fill `false`
- source/repaired outside-soloing not evaluable: `6/6`
- source outside-soloing repair pitch-role risk after: `0`
- 청취 입력 전 quality/preference claim 제외 필요

## Scope
- objective decision 입력 검증 조건 추가
- objective summary/readiness/markdown에 outside-soloing context 기록
- #854 기준 harness doc path/issue number 갱신
- Current Status, Core Plan, generated objective decision 문서 갱신
- missing outside-soloing context rejection test 추가

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-objective-only-next-decision`
- `bash scripts/agent_harness.sh quick`

## Risk
- 청취 입력 부재 상태 유지
- 음악적 품질 claim 없음
- human/audio preference claim 없음
- 다음 경계: follow-up decision

Closes #854