### PR TITLE
Stage B MIDI-to-solo phrase rhythm sweep outside-soloing context refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -414,6 +414,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo songlike melody contour repair listening review input guard: preference fill `false`, validated input `false`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
 - MIDI-to-solo songlike melody contour repair objective-only next decision: follow-up required `true`, source/repaired outside-soloing not evaluable `6/6`, current quality claim ready `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
 - MIDI-to-solo songlike melody contour repair follow-up decision: selected target `songlike_melody_contour_phrase_rhythm_repair_sweep`, primary labels `phrase_shape_missing_tension_release,rhythmic_monotony`, objective/sweep outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- MIDI-to-solo songlike melody contour phrase/rhythm repair sweep: phrase/rhythm failure `4 -> 1`, total failure labels `4 -> 1`, source/repaired outside-soloing not evaluable `6/6`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
 - MIDI-to-solo pitch-contour changed-ratio repair probe: repaired/pass `3/3`, max pitch changed ratio `0.7174 -> 0.4348`, max interval `12`, dead-air max `0.0000`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
 - MIDI-to-solo pitch-contour changed-ratio repair audio package: rendered WAV `3`, duration `18.422s-18.978s`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
@@ -6712,6 +6713,54 @@ Issue #856은 songlike melody contour repair follow-up decision에 #854 objectiv
 다음 작업:
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep refresh`
+
+## 9.120 Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep outside-soloing context refresh
+
+Issue #858은 songlike melody contour phrase/rhythm repair sweep에 #856 follow-up decision outside-soloing context를 반영한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
+- source repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
+- selected target: `songlike_melody_contour_phrase_rhythm_repair_audio_package`
+- candidate count: `6`
+- total failure labels: `4 -> 1`
+- failure label delta: `3`
+- phrase/rhythm failure count: `4 -> 1`
+- phrase/rhythm failure delta: `3`
+- improved candidate count: `2`
+- technical regression count: `0`
+- repaired failure counts: `rhythmic_monotony=1`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair pitch-role risk count after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- repaired not evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
+- audio package ready: `true`
+- critical user input required: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- phrase/rhythm repair target supported.
+- remaining objective failure label은 `rhythmic_monotony=1`.
+- outside-soloing과 weak chord-tone landing은 context/role 평가 전까지 not-evaluable 경계 유지.
+- 음악적 품질, human/audio preference claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-sweep`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #856, Stage B MIDI-to-solo songlike melody contour repair follow-up decision outside-soloing context refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep refresh`
+- latest functional result: Issue #858, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep outside-soloing context refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package refresh`
 
 현재 범위가 아닌 것:
 
@@ -639,6 +639,23 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 repair target: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- songlike melody contour phrase/rhythm repair sweep outside-soloing context refresh 완료
+- candidate count: `6`
+- total failure labels: `4 -> 1`
+- failure label delta: `3`
+- phrase/rhythm failure count: `4 -> 1`
+- phrase/rhythm failure delta: `3`
+- improved candidate count: `2`
+- technical regression count: `0`
+- repaired failure counts: `rhythmic_monotony=1`
+- source outside-soloing repair pitch-role risk count after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- repaired not evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
+- audio package ready: `true`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 audio target: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_SWEEP_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_SWEEP_2026-06-10.md
@@ -1,0 +1,56 @@
+# Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Repair Sweep
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
+- selected target: `songlike_melody_contour_phrase_rhythm_repair_audio_package`
+- candidate count: `6`
+- total failure labels: `4 -> 1`
+- failure label delta: `3`
+- phrase/rhythm failure count: `4 -> 1`
+- phrase/rhythm failure delta: `3`
+- improved candidate count: `2`
+- technical regression count: `0`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair pitch-role risk after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- target supported: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Repaired Failure Counts
+
+- `rhythmic_monotony`: `1`
+
+## Repaired Not Evaluable Counts
+
+- `outside_soloing_without_context`: `6`
+- `weak_chord_tone_landing`: `6`
+
+## MIDI Files
+
+- rank `1`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/midi/01_songlike_melody_contour_phrase_rhythm_repair.mid`
+- rank `2`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/midi/02_songlike_melody_contour_phrase_rhythm_repair.mid`
+- rank `3`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/midi/03_songlike_melody_contour_phrase_rhythm_repair.mid`
+- rank `4`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/midi/04_songlike_melody_contour_phrase_rhythm_repair.mid`
+- rank `5`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/midi/05_songlike_melody_contour_phrase_rhythm_repair.mid`
+- rank `6`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/midi/06_songlike_melody_contour_phrase_rhythm_repair.mid`
+
+## Decision
+
+- reason: `phrase/rhythm repair sweep completed without musical quality claim`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package`
+
+## Claim Boundary
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `outside_soloing_without_context`
+- `weak_chord_tone_landing`
+- `broad_trained_model_quality`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6511,8 +6511,8 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep() {
     --followup_decision "$followup_report" \
     --source_repair_sweep "$source_sweep_report" \
     --rubric_baseline "$rubric_report" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_SWEEP_2026-06-09.md \
-    --issue_number 774 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_SWEEP_2026-06-10.md \
+    --issue_number 858 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package \
     --min_candidate_count 6 \

--- a/scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py
+++ b/scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py
@@ -120,6 +120,38 @@ def validate_followup_decision(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
             "source technical regression must remain zero"
         )
+    if not bool(readiness.get("objective_source_outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            "objective outside-soloing repair evidence readiness required"
+        )
+    if _int(readiness.get("objective_source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            "objective outside-soloing residual pitch-role risk should be zero"
+        )
+    if _int(readiness.get("objective_source_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            "objective source outside-soloing not-evaluable boundary required"
+        )
+    if _int(readiness.get("objective_repaired_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            "objective repaired outside-soloing not-evaluable boundary required"
+        )
+    if not bool(readiness.get("repair_sweep_source_outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            "repair sweep outside-soloing repair evidence readiness required"
+        )
+    if _int(readiness.get("repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            "repair sweep outside-soloing residual pitch-role risk should be zero"
+        )
+    if _int(readiness.get("repair_sweep_source_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            "repair sweep source outside-soloing not-evaluable boundary required"
+        )
+    if _int(readiness.get("repair_sweep_repaired_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            "repair sweep repaired outside-soloing not-evaluable boundary required"
+        )
     primary_labels = [str(label) for label in _list(selected.get("primary_remaining_failure_labels"))]
     if not all(label in primary_labels for label in TARGET_LABELS):
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
@@ -142,6 +174,30 @@ def validate_followup_decision(report: dict[str, Any]) -> dict[str, Any]:
         "remaining_failure_counts": _dict(sweep.get("remaining_failure_counts")),
         "primary_remaining_failure_labels": primary_labels,
         "primary_remaining_failure_count": _int(selected.get("primary_remaining_failure_count")),
+        "objective_source_outside_soloing_repair_evidence_ready": bool(
+            readiness.get("objective_source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "objective_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            readiness.get("objective_source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "objective_source_outside_soloing_not_evaluable_count": _int(
+            readiness.get("objective_source_outside_soloing_not_evaluable_count")
+        ),
+        "objective_repaired_outside_soloing_not_evaluable_count": _int(
+            readiness.get("objective_repaired_outside_soloing_not_evaluable_count")
+        ),
+        "repair_sweep_source_outside_soloing_repair_evidence_ready": bool(
+            readiness.get("repair_sweep_source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            readiness.get("repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "repair_sweep_source_outside_soloing_not_evaluable_count": _int(
+            readiness.get("repair_sweep_source_outside_soloing_not_evaluable_count")
+        ),
+        "repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
+            readiness.get("repair_sweep_repaired_outside_soloing_not_evaluable_count")
+        ),
     }
 
 
@@ -164,6 +220,22 @@ def validate_source_repair_sweep(report: dict[str, Any]) -> list[dict[str, Any]]
     if _int(aggregate.get("technical_regression_count")) != 0:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
             "source technical regression must remain zero"
+        )
+    if not bool(aggregate.get("source_outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            "source outside-soloing repair evidence readiness required"
+        )
+    if _int(aggregate.get("source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            "source outside-soloing residual pitch-role risk should be zero"
+        )
+    if _int(aggregate.get("source_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            "source outside-soloing not-evaluable boundary required"
+        )
+    if _int(aggregate.get("repaired_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            "repaired outside-soloing not-evaluable boundary required"
         )
     if len(rows) < 6:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
@@ -349,6 +421,14 @@ def failure_counts(rows: list[dict[str, Any]], *, key: str) -> Counter[str]:
     )
 
 
+def not_evaluable_counts(rows: list[dict[str, Any]], *, key: str) -> Counter[str]:
+    return Counter(
+        label
+        for row in rows
+        for label in _list(_dict(row.get(key)).get("not_evaluable_labels"))
+    )
+
+
 def build_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
     *,
     followup_decision: dict[str, Any],
@@ -404,7 +484,15 @@ def build_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
         _int(item.get("source_phrase_rhythm_label_count")) for item in relabeled
     )
     repaired_failures = failure_counts(relabeled, key="phrase_rhythm_repaired_labeling")
+    repaired_not_evaluable = not_evaluable_counts(
+        relabeled,
+        key="phrase_rhythm_repaired_labeling",
+    )
     repaired_phrase_rhythm_count = sum(repaired_failures.get(label, 0) for label in TARGET_LABELS)
+    repaired_outside_soloing_count = repaired_not_evaluable.get(
+        "outside_soloing_without_context",
+        0,
+    )
     improved_count = sum(
         1
         for item in relabeled
@@ -441,6 +529,19 @@ def build_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
             "improved_candidate_count": improved_count,
             "technical_regression_count": technical_regression_count,
             "repaired_failure_counts": dict(sorted(repaired_failures.items())),
+            "source_outside_soloing_repair_evidence_ready": bool(
+                followup["repair_sweep_source_outside_soloing_repair_evidence_ready"]
+            ),
+            "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+                followup["repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
+            "source_outside_soloing_not_evaluable_count": _int(
+                followup["repair_sweep_repaired_outside_soloing_not_evaluable_count"]
+            ),
+            "repaired_outside_soloing_not_evaluable_count": _int(
+                repaired_outside_soloing_count
+            ),
+            "repaired_not_evaluable_counts": dict(sorted(repaired_not_evaluable.items())),
             "target_supported": target_supported,
         },
         "selected_next_target": {
@@ -465,6 +566,18 @@ def build_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
             ),
             "technical_regression_count": technical_regression_count,
             "audio_package_ready": target_supported,
+            "source_outside_soloing_repair_evidence_ready": bool(
+                followup["repair_sweep_source_outside_soloing_repair_evidence_ready"]
+            ),
+            "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+                followup["repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
+            "source_outside_soloing_not_evaluable_count": _int(
+                followup["repair_sweep_repaired_outside_soloing_not_evaluable_count"]
+            ),
+            "repaired_outside_soloing_not_evaluable_count": _int(
+                repaired_outside_soloing_count
+            ),
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
             "audio_rendered_quality_claimed": False,
@@ -548,6 +661,22 @@ def validate_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
             "technical regression should be zero"
         )
+    if not bool(aggregate.get("source_outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            "outside-soloing repair evidence readiness required"
+        )
+    if _int(aggregate.get("source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            "outside-soloing residual pitch-role risk should be zero"
+        )
+    if _int(aggregate.get("source_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            "source outside-soloing not-evaluable boundary required"
+        )
+    if _int(aggregate.get("repaired_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            "repaired outside-soloing not-evaluable boundary required"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
             "critical user input should not be required"
@@ -592,6 +721,21 @@ def validate_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
         "improved_candidate_count": _int(aggregate.get("improved_candidate_count")),
         "technical_regression_count": _int(aggregate.get("technical_regression_count")),
         "repaired_failure_counts": _dict(aggregate.get("repaired_failure_counts")),
+        "source_outside_soloing_repair_evidence_ready": bool(
+            aggregate.get("source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            aggregate.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_not_evaluable_count": _int(
+            aggregate.get("source_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_outside_soloing_not_evaluable_count": _int(
+            aggregate.get("repaired_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_not_evaluable_counts": _dict(
+            aggregate.get("repaired_not_evaluable_counts")
+        ),
         "audio_package_ready": bool(readiness.get("audio_package_ready", False)),
         "human_audio_preference_claimed": bool(
             readiness.get("human_audio_preference_claimed", True)
@@ -627,6 +771,10 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- phrase/rhythm failure delta: `{aggregate['phrase_rhythm_failure_delta']}`",
         f"- improved candidate count: `{aggregate['improved_candidate_count']}`",
         f"- technical regression count: `{aggregate['technical_regression_count']}`",
+        f"- source outside-soloing repair evidence ready: `{_bool_token(aggregate['source_outside_soloing_repair_evidence_ready'])}`",
+        f"- source outside-soloing repair pitch-role risk after: `{aggregate['source_outside_soloing_repair_pitch_role_risk_count_after']}`",
+        f"- source outside-soloing not evaluable count: `{aggregate['source_outside_soloing_not_evaluable_count']}`",
+        f"- repaired outside-soloing not evaluable count: `{aggregate['repaired_outside_soloing_not_evaluable_count']}`",
         f"- target supported: `{_bool_token(aggregate['target_supported'])}`",
         f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
         f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
@@ -635,6 +783,9 @@ def markdown_report(report: dict[str, Any]) -> str:
         "",
     ]
     for label, count in aggregate["repaired_failure_counts"].items():
+        lines.append(f"- `{label}`: `{count}`")
+    lines.extend(["", "## Repaired Not Evaluable Counts", ""])
+    for label, count in aggregate["repaired_not_evaluable_counts"].items():
         lines.append(f"- `{label}`: `{count}`")
     lines.extend(["", "## MIDI Files", ""])
     for item in report.get("candidate_repairs", []):
@@ -675,7 +826,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=774)
+    parser.add_argument("--issue_number", type=int, default=858)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--min_candidate_count", type=int, default=6)

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio.py
@@ -73,6 +73,10 @@ def source_report(root: Path, *, quality_claim: bool = False) -> dict:
                 "density_pattern": [5, 3, 6, 4, 5, 4, 6, 3],
                 "phrase_rhythm_repaired_labeling": {
                     "failure_labels": labels,
+                    "not_evaluable_labels": [
+                        "outside_soloing_without_context",
+                        "weak_chord_tone_landing",
+                    ],
                     "metrics": {
                         "note_count": 24,
                         "unique_pitch_count": 6,
@@ -98,6 +102,14 @@ def source_report(root: Path, *, quality_claim: bool = False) -> dict:
             "technical_regression_count": 0,
             "repaired_failure_counts": {
                 "rhythmic_monotony": 1,
+            },
+            "source_outside_soloing_repair_evidence_ready": True,
+            "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "source_outside_soloing_not_evaluable_count": 6,
+            "repaired_outside_soloing_not_evaluable_count": 6,
+            "repaired_not_evaluable_counts": {
+                "outside_soloing_without_context": 6,
+                "weak_chord_tone_landing": 6,
             },
             "target_supported": True,
         },

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py
@@ -109,6 +109,14 @@ def followup_decision(*, quality_claim: bool = False) -> dict:
             "repaired_total_failure_label_count": 4,
             "failure_label_delta": 4,
             "technical_regression_count": 0,
+            "objective_source_outside_soloing_repair_evidence_ready": True,
+            "objective_source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "objective_source_outside_soloing_not_evaluable_count": 6,
+            "objective_repaired_outside_soloing_not_evaluable_count": 6,
+            "repair_sweep_source_outside_soloing_repair_evidence_ready": True,
+            "repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "repair_sweep_source_outside_soloing_not_evaluable_count": 6,
+            "repair_sweep_repaired_outside_soloing_not_evaluable_count": 6,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
             "audio_rendered_quality_claimed": False,
@@ -165,6 +173,10 @@ def source_repair_sweep(*, technical_regression_count: int = 0) -> dict:
                 "phrase_shape_missing_tension_release": 2,
                 "rhythmic_monotony": 2,
             },
+            "source_outside_soloing_repair_evidence_ready": True,
+            "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "source_outside_soloing_not_evaluable_count": 6,
+            "repaired_outside_soloing_not_evaluable_count": 6,
             "target_supported": True,
         },
         "readiness": {
@@ -193,7 +205,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepTest(
                 source_repair_sweep=source_repair_sweep(),
                 rubric_baseline=rubric_baseline(root),
                 output_dir=root / "phrase_rhythm_repair",
-                issue_number=774,
+                issue_number=858,
             )
             summary = validate_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
                 report,
@@ -221,6 +233,14 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepTest(
             self.assertLess(summary["repaired_phrase_rhythm_failure_count"], 4)
             self.assertGreater(summary["phrase_rhythm_failure_delta"], 0)
             self.assertEqual(summary["technical_regression_count"], 0)
+            self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
+            self.assertEqual(summary["source_outside_soloing_repair_pitch_role_risk_count_after"], 0)
+            self.assertEqual(summary["source_outside_soloing_not_evaluable_count"], 6)
+            self.assertEqual(summary["repaired_outside_soloing_not_evaluable_count"], 6)
+            self.assertEqual(
+                summary["repaired_not_evaluable_counts"]["outside_soloing_without_context"],
+                6,
+            )
             self.assertEqual(summary["selected_target"], SELECTED_TARGET)
             self.assertFalse(summary["human_audio_preference_claimed"])
             self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
@@ -235,7 +255,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepTest(
                     source_repair_sweep=source_repair_sweep(),
                     rubric_baseline=rubric_baseline(Path(tmp)),
                     output_dir=Path(tmp) / "phrase_rhythm_repair",
-                    issue_number=774,
+                    issue_number=858,
                 )
 
     def test_rejects_source_technical_regression(self) -> None:
@@ -248,7 +268,22 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepTest(
                     source_repair_sweep=source_repair_sweep(technical_regression_count=1),
                     rubric_baseline=rubric_baseline(Path(tmp)),
                     output_dir=Path(tmp) / "phrase_rhythm_repair",
-                    issue_number=774,
+                    issue_number=858,
+                )
+
+    def test_rejects_missing_outside_soloing_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = source_repair_sweep()
+            source["aggregate"]["source_outside_soloing_not_evaluable_count"] = 0
+            with self.assertRaises(
+                StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError
+            ):
+                build_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
+                    followup_decision=followup_decision(),
+                    source_repair_sweep=source,
+                    rubric_baseline=rubric_baseline(Path(tmp)),
+                    output_dir=Path(tmp) / "phrase_rhythm_repair",
+                    issue_number=858,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary
- songlike melody contour phrase/rhythm repair sweep outside-soloing context 보존
- phrase/rhythm failure labels `4 -> 1` 기록
- repaired not-evaluable counts와 downstream audio fixture metadata 반영

## Context
- Issue #856 follow-up decision 결과: selected target `songlike_melody_contour_phrase_rhythm_repair_sweep`
- primary labels: `phrase_shape_missing_tension_release`, `rhythmic_monotony`
- objective/sweep outside-soloing not evaluable: `6/6`
- technical regression count: `0`

## Scope
- phrase/rhythm repair sweep 입력 검증 조건 추가
- aggregate/readiness/markdown에 outside-soloing context 기록
- downstream audio source fixture에 새 필수 metadata 추가
- #858 기준 harness doc path/issue number 갱신
- Current Status, Core Plan, generated sweep 문서 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio`
- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-sweep`
- `bash scripts/agent_harness.sh quick`

## Risk
- 음악적 품질 claim 없음
- human/audio preference claim 없음
- outside-soloing과 weak chord-tone landing은 context/role 평가 전까지 not-evaluable 경계 유지
- 다음 경계: phrase/rhythm repair audio package

Closes #858