### PR TITLE
Stage B MIDI-to-solo phrase rhythm review package outside-soloing context refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -416,6 +416,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo songlike melody contour repair follow-up decision: selected target `songlike_melody_contour_phrase_rhythm_repair_sweep`, primary labels `phrase_shape_missing_tension_release,rhythmic_monotony`, objective/sweep outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair sweep: phrase/rhythm failure `4 -> 1`, total failure labels `4 -> 1`, source/repaired outside-soloing not evaluable `6/6`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair audio package: rendered WAV `6`, duration `18.871s-19.000s`, source/repaired outside-soloing not evaluable `6/6`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package`
+- MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package: review items `6`, validated input `false`, source/repaired outside-soloing not evaluable `6/6`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
 - MIDI-to-solo pitch-contour changed-ratio repair probe: repaired/pass `3/3`, max pitch changed ratio `0.7174 -> 0.4348`, max interval `12`, dead-air max `0.0000`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
 - MIDI-to-solo pitch-contour changed-ratio repair audio package: rendered WAV `3`, duration `18.422s-18.978s`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
@@ -6808,6 +6809,54 @@ Issue #860은 songlike melody contour phrase/rhythm repair audio package에 #858
 다음 작업:
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package refresh`
+
+## 9.122 Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package outside-soloing context refresh
+
+Issue #862는 Issue #860 phrase/rhythm repair audio package의 outside-soloing context를 listening review package까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
+- package ready: `true`
+- review item count: `6`
+- validated review input: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- sample rate: `44100`
+- duration range: `18.871s-19.000s`
+- failure label delta: `3`
+- phrase/rhythm failure delta: `3`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair pitch-role risk count after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- repaired not evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
+- audio review required: `true`
+- critical user input required: `false`
+- human/audio preference claimed: `false`
+- audio rendered quality claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- #860 WAV/MIDI 후보 `6`개를 listening review item으로 등록.
+- audio package의 technical WAV validation과 outside-soloing not-evaluable 경계 보존.
+- review input pending 상태에서 preference, musical quality claim 제외.
+- 다음 boundary는 listening review input guard.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-listening-review-package`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #860, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package outside-soloing context refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package refresh`
+- latest functional result: Issue #862, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package outside-soloing context refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard refresh`
 
 현재 범위가 아닌 것:
 
@@ -152,7 +152,14 @@
 - validated review input: `false`
 - technical WAV validation: `true`
 - rendered audio file count: `6`
+- duration range: `18.871s-19.000s`
+- phrase/rhythm failure delta: `3`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair pitch-role risk count after: `0`
+- source/repaired outside-soloing not evaluable count: `6/6`
+- repaired not evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
 - human/audio preference claim: `false`
+- audio rendered quality claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 guard target: `songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
 - songlike melody contour phrase/rhythm repair listening review input guard 완료

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_LISTENING_REVIEW_PACKAGE_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_LISTENING_REVIEW_PACKAGE_2026-06-10.md
@@ -1,0 +1,50 @@
+# Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Repair Listening Review Package
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
+- package ready: `true`
+- review item count: `6`
+- validated review input: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- duration range: `18.871s-19.000s`
+- failure label delta: `3`
+- phrase/rhythm failure count: `4 -> 1`
+- phrase/rhythm failure delta: `3`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair pitch-role risk count after: `0`
+- source/repaired outside-soloing not evaluable count: `6/6`
+- human/audio preference claimed: `false`
+
+## Review Items
+
+- candidate `1` `cli_repaired_midi` rank `1`: WAV `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/audio/candidate_01_cli_repaired_midi_rank_01_phrase_rhythm_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/midi/01_songlike_melody_contour_phrase_rhythm_repair.mid`, duration `18.990`, failure labels `none`
+- candidate `2` `cli_repaired_midi` rank `2`: WAV `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/audio/candidate_02_cli_repaired_midi_rank_02_phrase_rhythm_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/midi/02_songlike_melody_contour_phrase_rhythm_repair.mid`, duration `18.974`, failure labels `none`
+- candidate `3` `cli_repaired_midi` rank `3`: WAV `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/audio/candidate_03_cli_repaired_midi_rank_03_phrase_rhythm_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/midi/03_songlike_melody_contour_phrase_rhythm_repair.mid`, duration `19.000`, failure labels `none`
+- candidate `4` `changed_ratio_repair` rank `4`: WAV `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/audio/candidate_04_changed_ratio_repair_rank_04_phrase_rhythm_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/midi/04_songlike_melody_contour_phrase_rhythm_repair.mid`, duration `18.871`, failure labels `rhythmic_monotony`
+- candidate `5` `changed_ratio_repair` rank `5`: WAV `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/audio/candidate_05_changed_ratio_repair_rank_05_phrase_rhythm_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/midi/05_songlike_melody_contour_phrase_rhythm_repair.mid`, duration `18.985`, failure labels `none`
+- candidate `6` `changed_ratio_repair` rank `6`: WAV `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/audio/candidate_06_changed_ratio_repair_rank_06_phrase_rhythm_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/midi/06_songlike_melody_contour_phrase_rhythm_repair.mid`, duration `18.992`, failure labels `none`
+
+## Required Input Fields
+
+- `candidate_index`
+- `listening_status`
+- `preference`
+- `issue_notes`
+
+## Repaired Not Evaluable Counts
+
+- `outside_soloing_without_context`: `6`
+- `weak_chord_tone_landing`: `6`
+
+## Claim Boundary
+
+- MIDI-to-solo musical quality claimed: `false`
+- audio rendered quality claimed: `false`
+- broad trained-model quality claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6556,8 +6556,8 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_
   "$PYTHON_BIN" scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package.py \
     --run_id "$review_run_id" \
     --audio_package_report "$audio_package_report" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_LISTENING_REVIEW_PACKAGE_2026-06-09.md \
-    --issue_number 778 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_LISTENING_REVIEW_PACKAGE_2026-06-10.md \
+    --issue_number 862 \
     --expected_review_item_count 6 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard \

--- a/scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package.py
+++ b/scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package.py
@@ -112,6 +112,22 @@ def validate_audio_package_report(
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningReviewPackageError(
             "rendered audio count below expected"
         )
+    if not bool(summary.get("source_outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningReviewPackageError(
+            "outside-soloing repair evidence should be ready"
+        )
+    if _int(summary.get("source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningReviewPackageError(
+            "source outside-soloing repair pitch-role risk should be resolved"
+        )
+    if _int(summary.get("source_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningReviewPackageError(
+            "source outside-soloing not-evaluable count should be preserved"
+        )
+    if _int(summary.get("repaired_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningReviewPackageError(
+            "repaired outside-soloing not-evaluable count should be preserved"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningReviewPackageError(
             "critical user input should not be required"
@@ -199,6 +215,19 @@ def build_listening_review_package_report(
             "improved_candidate_count": _int(summary.get("improved_candidate_count")),
             "technical_regression_count": _int(summary.get("technical_regression_count")),
             "remaining_failure_counts": _dict(summary.get("remaining_failure_counts")),
+            "source_outside_soloing_repair_evidence_ready": bool(
+                summary.get("source_outside_soloing_repair_evidence_ready", False)
+            ),
+            "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+                summary.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+            ),
+            "source_outside_soloing_not_evaluable_count": _int(
+                summary.get("source_outside_soloing_not_evaluable_count")
+            ),
+            "repaired_outside_soloing_not_evaluable_count": _int(
+                summary.get("repaired_outside_soloing_not_evaluable_count")
+            ),
+            "repaired_not_evaluable_counts": _dict(summary.get("repaired_not_evaluable_counts")),
             "audio_review_required": bool(summary.get("audio_review_required", False)),
         },
         "review_package": {
@@ -300,6 +329,19 @@ def validate_listening_review_package_report(
         "duration_max_seconds": _float(source.get("duration_max_seconds")),
         "failure_label_delta": _int(source.get("failure_label_delta")),
         "phrase_rhythm_failure_delta": _int(source.get("phrase_rhythm_failure_delta")),
+        "source_outside_soloing_repair_evidence_ready": bool(
+            source.get("source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            source.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_not_evaluable_count": _int(
+            source.get("source_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_outside_soloing_not_evaluable_count": _int(
+            source.get("repaired_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_not_evaluable_counts": _dict(source.get("repaired_not_evaluable_counts")),
         "audio_review_required": bool(source.get("audio_review_required", False)),
         "human_review_required_now": bool(readiness.get("human_review_required_now", True)),
         "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
@@ -333,6 +375,9 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- failure label delta: `{source['failure_label_delta']}`",
         f"- phrase/rhythm failure count: `{source['source_phrase_rhythm_failure_count']} -> {source['repaired_phrase_rhythm_failure_count']}`",
         f"- phrase/rhythm failure delta: `{source['phrase_rhythm_failure_delta']}`",
+        f"- source outside-soloing repair evidence ready: `{_bool_token(source['source_outside_soloing_repair_evidence_ready'])}`",
+        f"- source outside-soloing repair pitch-role risk count after: `{source['source_outside_soloing_repair_pitch_role_risk_count_after']}`",
+        f"- source/repaired outside-soloing not evaluable count: `{source['source_outside_soloing_not_evaluable_count']}/{source['repaired_outside_soloing_not_evaluable_count']}`",
         f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
         "",
         "## Review Items",
@@ -348,6 +393,9 @@ def markdown_report(report: dict[str, Any]) -> str:
     lines.extend(["", "## Required Input Fields", ""])
     for field in package["required_input_fields"]:
         lines.append(f"- `{field}`")
+    lines.extend(["", "## Repaired Not Evaluable Counts", ""])
+    for label, count in sorted(source["repaired_not_evaluable_counts"].items()):
+        lines.append(f"- `{label}`: `{count}`")
     lines.extend(
         [
             "",
@@ -377,7 +425,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=778)
+    parser.add_argument("--issue_number", type=int, default=862)
     parser.add_argument("--expected_review_item_count", type=int, default=6)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package.py
@@ -118,6 +118,14 @@ def audio_package_report(root: Path, *, quality_claim: bool = False) -> dict:
             "remaining_failure_counts": {
                 "rhythmic_monotony": 1,
             },
+            "source_outside_soloing_repair_evidence_ready": True,
+            "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "source_outside_soloing_not_evaluable_count": 6,
+            "repaired_outside_soloing_not_evaluable_count": 6,
+            "repaired_not_evaluable_counts": {
+                "outside_soloing_without_context": 6,
+                "weak_chord_tone_landing": 6,
+            },
             "audio_review_required": True,
         },
         "rendered_audio_files": rendered,
@@ -131,7 +139,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningReviewPack
             report = build_listening_review_package_report(
                 audio_package_report=audio_package_report(root),
                 output_dir=root / "review_package",
-                issue_number=778,
+                issue_number=862,
                 expected_count=6,
             )
             summary = validate_listening_review_package_report(
@@ -149,6 +157,20 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningReviewPack
             self.assertTrue(summary["technical_wav_validation"])
             self.assertEqual(summary["failure_label_delta"], 3)
             self.assertEqual(summary["phrase_rhythm_failure_delta"], 3)
+            self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
+            self.assertEqual(
+                summary["source_outside_soloing_repair_pitch_role_risk_count_after"],
+                0,
+            )
+            self.assertEqual(summary["source_outside_soloing_not_evaluable_count"], 6)
+            self.assertEqual(summary["repaired_outside_soloing_not_evaluable_count"], 6)
+            self.assertEqual(
+                summary["repaired_not_evaluable_counts"],
+                {
+                    "outside_soloing_without_context": 6,
+                    "weak_chord_tone_landing": 6,
+                },
+            )
             self.assertFalse(summary["human_audio_preference_claimed"])
             self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
 
@@ -161,7 +183,23 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningReviewPack
                 build_listening_review_package_report(
                     audio_package_report=audio_package_report(root, quality_claim=True),
                     output_dir=root / "review_package",
-                    issue_number=778,
+                    issue_number=862,
+                    expected_count=6,
+                )
+
+    def test_rejects_missing_outside_soloing_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = audio_package_report(root)
+            del source["summary"]["source_outside_soloing_not_evaluable_count"]
+
+            with self.assertRaises(
+                StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningReviewPackageError
+            ):
+                build_listening_review_package_report(
+                    audio_package_report=source,
+                    output_dir=root / "review_package",
+                    issue_number=862,
                     expected_count=6,
                 )
 


### PR DESCRIPTION
## Summary
- phrase/rhythm repair listening review package outside-soloing context 보존
- audio package report의 outside-soloing repair evidence, pitch-role risk after, not-evaluable counts 필수 검증
- review package markdown/summary에 repaired not-evaluable counts 기록

## Context
- Issue #860 audio package 결과: rendered WAV 6개, technical WAV validation true
- duration range: 18.871s-19.000s
- phrase/rhythm failure delta: 3
- source/repaired outside-soloing not evaluable: 6/6
- source outside-soloing repair pitch-role risk count after: 0
- human/audio preference, MIDI-to-solo musical quality claim 제외

## Scope
- listening review package validation 강화
- unit fixture와 missing-context rejection test 추가
- #862 harness issue/doc path 갱신
- CURRENT_STATUS_AND_PLAN, CORE_PLAN 결과 기록

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package`
- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-listening-review-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- `rg -n "Codex|codex|코덱스" <changed public files>`

## Risk
- listening preference 미기록
- musical quality claim 제외
- 다음 검증 대상: listening review input guard outside-soloing context refresh

Closes #862