### PR TITLE
Stage B MIDI-to-solo phrase rhythm objective decision outside-soloing context refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -418,6 +418,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo songlike melody contour phrase/rhythm repair audio package: rendered WAV `6`, duration `18.871s-19.000s`, source/repaired outside-soloing not evaluable `6/6`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package: review items `6`, validated input `false`, source/repaired outside-soloing not evaluable `6/6`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard: preference fill `false`, validated input `false`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
+- MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision: follow-up required `true`, source/repaired outside-soloing not evaluable `6/6`, current quality claim ready `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
 - MIDI-to-solo pitch-contour changed-ratio repair probe: repaired/pass `3/3`, max pitch changed ratio `0.7174 -> 0.4348`, max interval `12`, dead-air max `0.0000`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
 - MIDI-to-solo pitch-contour changed-ratio repair audio package: rendered WAV `3`, duration `18.422s-18.978s`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
@@ -6907,6 +6908,58 @@ Issue #864는 Issue #862 listening review package의 outside-soloing context를 
 다음 작업:
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision refresh`
+
+## 9.124 Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision outside-soloing context refresh
+
+Issue #866은 Issue #864 input guard의 outside-soloing context를 objective-only next decision까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
+- selected target: `songlike_melody_contour_phrase_rhythm_repair_followup_decision`
+- objective next decision completed: `true`
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- sample rate: `44100`
+- duration range: `18.871s-19.000s`
+- failure label delta: `3`
+- phrase/rhythm failure delta: `3`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair pitch-role risk count after: `0`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- repaired not evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
+- phrase/rhythm follow-up required: `true`
+- current quality claim ready: `false`
+- critical user input required: `false`
+- human/audio preference claimed: `false`
+- audio rendered quality claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- pending listening review input 상태에서 preference fill 제외 유지.
+- objective-only 경계에서 quality claim 없이 follow-up decision으로 라우팅.
+- input guard의 outside-soloing repair evidence와 not-evaluable count 보존.
+- 다음 boundary는 follow-up decision.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-objective-only-next-decision`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #864, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard outside-soloing context refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision refresh`
+- latest functional result: Issue #866, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision outside-soloing context refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision refresh`
 
 현재 범위가 아닌 것:
 
@@ -180,6 +180,17 @@
 - MIDI-to-solo musical quality claim: `false`
 - 다음 decision target: `songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
 - songlike melody contour phrase/rhythm repair objective-only next decision 완료
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- duration range: `18.871s-19.000s`
+- phrase/rhythm failure delta: `3`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair pitch-role risk count after: `0`
+- source/repaired outside-soloing not evaluable count: `6/6`
+- repaired not evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
 - phrase/rhythm follow-up required: `true`
 - current quality claim ready: `false`
 - preference fill allowed: `false`

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-10.md
@@ -1,0 +1,46 @@
+# Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Repair Objective-Only Next Decision
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
+- selected target: `songlike_melody_contour_phrase_rhythm_repair_followup_decision`
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- duration range: `18.871s-19.000s`
+- failure label delta: `3`
+- phrase/rhythm failure count: `4 -> 1`
+- phrase/rhythm failure delta: `3`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair pitch-role risk count after: `0`
+- source/repaired outside-soloing not evaluable count: `6/6`
+- phrase/rhythm follow-up required: `true`
+- current quality claim ready: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Decision
+
+- reason: `listening preference pending and quality claim unavailable; route to follow-up repair decision`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision`
+
+## Repaired Not Evaluable Counts
+
+- `outside_soloing_without_context`: `6`
+- `weak_chord_tone_landing`: `6`
+
+## Claim Boundary
+
+- `listening_review_completed`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6598,8 +6598,8 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_
   "$PYTHON_BIN" scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next.py \
     --run_id "$run_id" \
     --input_guard_report "$input_guard_report" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-09.md \
-    --issue_number 782 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-10.md \
+    --issue_number 866 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision \
     --require_objective_decision \

--- a/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next.py
+++ b/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next.py
@@ -105,6 +105,22 @@ def validate_input_guard_report(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
             "rendered WAV count below 6"
         )
+    if not bool(source.get("source_outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
+            "outside-soloing repair evidence should be ready"
+        )
+    if _int(source.get("source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
+            "source outside-soloing repair pitch-role risk should be resolved"
+        )
+    if _int(source.get("source_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
+            "source outside-soloing not-evaluable count should be preserved"
+        )
+    if _int(source.get("repaired_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
+            "repaired outside-soloing not-evaluable count should be preserved"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
             "critical user input should not be required"
@@ -129,6 +145,19 @@ def validate_input_guard_report(report: dict[str, Any]) -> dict[str, Any]:
             source.get("repaired_phrase_rhythm_failure_count")
         ),
         "phrase_rhythm_failure_delta": _int(source.get("phrase_rhythm_failure_delta")),
+        "source_outside_soloing_repair_evidence_ready": bool(
+            source.get("source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            source.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_not_evaluable_count": _int(
+            source.get("source_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_outside_soloing_not_evaluable_count": _int(
+            source.get("repaired_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_not_evaluable_counts": _dict(source.get("repaired_not_evaluable_counts")),
         "audio_review_required": bool(source.get("audio_review_required", False)),
     }
 
@@ -170,6 +199,19 @@ def build_objective_next_report(
                 source["repaired_phrase_rhythm_failure_count"]
             ),
             "phrase_rhythm_failure_delta": _int(source["phrase_rhythm_failure_delta"]),
+            "source_outside_soloing_repair_evidence_ready": bool(
+                source["source_outside_soloing_repair_evidence_ready"]
+            ),
+            "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+                source["source_outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
+            "source_outside_soloing_not_evaluable_count": _int(
+                source["source_outside_soloing_not_evaluable_count"]
+            ),
+            "repaired_outside_soloing_not_evaluable_count": _int(
+                source["repaired_outside_soloing_not_evaluable_count"]
+            ),
+            "repaired_not_evaluable_counts": _dict(source["repaired_not_evaluable_counts"]),
             "audio_review_required": bool(source["audio_review_required"]),
             "phrase_rhythm_followup_required": bool(followup_required),
             "current_quality_claim_ready": False,
@@ -279,8 +321,24 @@ def validate_objective_next_report(
         "preference_fill_allowed": bool(summary.get("preference_fill_allowed", True)),
         "technical_wav_validation": bool(summary.get("technical_wav_validation", False)),
         "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
+        "sample_rate": _int(summary.get("sample_rate")),
+        "duration_min_seconds": _float(summary.get("duration_min_seconds")),
+        "duration_max_seconds": _float(summary.get("duration_max_seconds")),
         "failure_label_delta": _int(summary.get("failure_label_delta")),
         "phrase_rhythm_failure_delta": _int(summary.get("phrase_rhythm_failure_delta")),
+        "source_outside_soloing_repair_evidence_ready": bool(
+            summary.get("source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            summary.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_not_evaluable_count": _int(
+            summary.get("source_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_outside_soloing_not_evaluable_count": _int(
+            summary.get("repaired_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_not_evaluable_counts": _dict(summary.get("repaired_not_evaluable_counts")),
         "audio_review_required": bool(summary.get("audio_review_required", False)),
         "phrase_rhythm_followup_required": bool(
             summary.get("phrase_rhythm_followup_required", False)
@@ -317,9 +375,13 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- preference fill allowed: `{_bool_token(summary['preference_fill_allowed'])}`",
         f"- technical WAV validation: `{_bool_token(summary['technical_wav_validation'])}`",
         f"- rendered audio file count: `{summary['rendered_audio_file_count']}`",
+        f"- duration range: `{summary['duration_min_seconds']:.3f}s-{summary['duration_max_seconds']:.3f}s`",
         f"- failure label delta: `{summary['failure_label_delta']}`",
         f"- phrase/rhythm failure count: `{summary['source_phrase_rhythm_failure_count']} -> {summary['repaired_phrase_rhythm_failure_count']}`",
         f"- phrase/rhythm failure delta: `{summary['phrase_rhythm_failure_delta']}`",
+        f"- source outside-soloing repair evidence ready: `{_bool_token(summary['source_outside_soloing_repair_evidence_ready'])}`",
+        f"- source outside-soloing repair pitch-role risk count after: `{summary['source_outside_soloing_repair_pitch_role_risk_count_after']}`",
+        f"- source/repaired outside-soloing not evaluable count: `{summary['source_outside_soloing_not_evaluable_count']}/{summary['repaired_outside_soloing_not_evaluable_count']}`",
         f"- phrase/rhythm follow-up required: `{_bool_token(summary['phrase_rhythm_followup_required'])}`",
         f"- current quality claim ready: `{_bool_token(summary['current_quality_claim_ready'])}`",
         f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
@@ -332,9 +394,18 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- critical user input required: `{_bool_token(decision['critical_user_input_required'])}`",
         f"- next recommended issue: `{report['next_recommended_issue']}`",
         "",
-        "## Claim Boundary",
+        "## Repaired Not Evaluable Counts",
         "",
     ]
+    for label, count in sorted(summary["repaired_not_evaluable_counts"].items()):
+        lines.append(f"- `{label}`: `{count}`")
+    lines.extend(
+        [
+            "",
+            "## Claim Boundary",
+            "",
+        ]
+    )
     for item in report["not_proven"]:
         lines.append(f"- `{item}`")
     lines.append("")
@@ -353,7 +424,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=782)
+    parser.add_argument("--issue_number", type=int, default=866)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--require_objective_decision", action="store_true")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next.py
@@ -36,6 +36,14 @@ def input_guard_report(*, quality_claim: bool = False) -> dict:
                 "source_phrase_rhythm_failure_count": 4,
                 "repaired_phrase_rhythm_failure_count": 1,
                 "phrase_rhythm_failure_delta": 3,
+                "source_outside_soloing_repair_evidence_ready": True,
+                "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+                "source_outside_soloing_not_evaluable_count": 6,
+                "repaired_outside_soloing_not_evaluable_count": 6,
+                "repaired_not_evaluable_counts": {
+                    "outside_soloing_without_context": 6,
+                    "weak_chord_tone_landing": 6,
+                },
                 "audio_review_required": True,
             },
         },
@@ -67,7 +75,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextTest(u
             report = build_objective_next_report(
                 input_guard_report=input_guard_report(),
                 output_dir=root / "objective_next",
-                issue_number=782,
+                issue_number=866,
             )
             summary = validate_objective_next_report(
                 report,
@@ -83,8 +91,23 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextTest(u
             self.assertFalse(summary["preference_fill_allowed"])
             self.assertTrue(summary["technical_wav_validation"])
             self.assertEqual(summary["rendered_audio_file_count"], 6)
+            self.assertEqual(summary["sample_rate"], 44100)
             self.assertEqual(summary["failure_label_delta"], 3)
             self.assertEqual(summary["phrase_rhythm_failure_delta"], 3)
+            self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
+            self.assertEqual(
+                summary["source_outside_soloing_repair_pitch_role_risk_count_after"],
+                0,
+            )
+            self.assertEqual(summary["source_outside_soloing_not_evaluable_count"], 6)
+            self.assertEqual(summary["repaired_outside_soloing_not_evaluable_count"], 6)
+            self.assertEqual(
+                summary["repaired_not_evaluable_counts"],
+                {
+                    "outside_soloing_without_context": 6,
+                    "weak_chord_tone_landing": 6,
+                },
+            )
             self.assertTrue(summary["phrase_rhythm_followup_required"])
             self.assertFalse(summary["current_quality_claim_ready"])
             self.assertFalse(summary["human_audio_preference_claimed"])
@@ -97,7 +120,20 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextTest(u
                 build_objective_next_report(
                     input_guard_report=input_guard_report(quality_claim=True),
                     output_dir=root / "objective_next",
-                    issue_number=782,
+                    issue_number=866,
+                )
+
+    def test_rejects_missing_outside_soloing_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = input_guard_report()
+            del source["guard_result"]["source_summary"]["source_outside_soloing_not_evaluable_count"]
+
+            with self.assertRaises(StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError):
+                build_objective_next_report(
+                    input_guard_report=source,
+                    output_dir=root / "objective_next",
+                    issue_number=866,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary
- phrase/rhythm repair objective-only next decision outside-soloing context 보존
- input guard report의 outside-soloing repair evidence, pitch-role risk after, not-evaluable counts 필수 검증
- pending review input 상태에서 follow-up decision 라우팅 유지

## Context
- Issue #864 input guard 결과: preference fill false, validated input false
- review item count: 6
- technical WAV validation: true
- source/repaired outside-soloing not evaluable: 6/6
- repaired not-evaluable counts: outside_soloing_without_context=6, weak_chord_tone_landing=6
- source outside-soloing repair pitch-role risk count after: 0

## Scope
- objective decision input validation 강화
- objective summary/markdown에 outside-soloing context 기록
- missing outside context rejection test 추가
- #866 harness issue/doc path 갱신
- CURRENT_STATUS_AND_PLAN, CORE_PLAN 결과 기록

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-objective-only-next-decision`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- `rg -n "Codex|codex|코덱스" <changed public files>`

## Risk
- listening preference 미기록
- musical quality claim 제외
- 다음 검증 대상: follow-up decision outside-soloing context refresh

Closes #866