### PR TITLE
Stage B MIDI-to-solo phrase rhythm follow-up decision outside-soloing context refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -419,6 +419,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package: review items `6`, validated input `false`, source/repaired outside-soloing not evaluable `6/6`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard: preference fill `false`, validated input `false`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision: follow-up required `true`, source/repaired outside-soloing not evaluable `6/6`, current quality claim ready `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
+- MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision: selected target `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`, remaining label/count `rhythmic_monotony/1`, objective/sweep outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
 - MIDI-to-solo pitch-contour changed-ratio repair probe: repaired/pass `3/3`, max pitch changed ratio `0.7174 -> 0.4348`, max interval `12`, dead-air max `0.0000`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
 - MIDI-to-solo pitch-contour changed-ratio repair audio package: rendered WAV `3`, duration `18.422s-18.978s`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
@@ -6960,6 +6961,57 @@ Issue #866은 Issue #864 input guard의 outside-soloing context를 objective-onl
 다음 작업:
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision refresh`
+
+## 9.125 Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision outside-soloing context refresh
+
+Issue #868은 Issue #866 objective-only next decision과 phrase/rhythm repair sweep의 outside-soloing context를 follow-up decision까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
+- repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- selected target: `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- follow-up decision completed: `true`
+- primary remaining failure labels: `rhythmic_monotony`
+- primary remaining failure count: `1`
+- candidate count: `6`
+- total failure labels: `4 -> 1`
+- phrase/rhythm failure count: `4 -> 1`
+- phrase/rhythm failure delta: `3`
+- residual rhythmic monotony count: `1`
+- not evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
+- objective source/repaired outside-soloing not evaluable count: `6/6`
+- repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- objective source outside-soloing repair pitch-role risk count after: `0`
+- repair sweep source outside-soloing repair pitch-role risk count after: `0`
+- chord-context pitch-role bridge selected: `true`
+- context not-evaluable min count: `6`
+- technical regression count: `0`
+- critical user input required: `false`
+- human/audio preference claimed: `false`
+- audio rendered quality claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- remaining objective failure label은 `rhythmic_monotony=1`.
+- outside-soloing과 weak chord-tone landing은 chord-context/pitch-role bridge 전까지 not-evaluable 경계 유지.
+- objective next decision과 repair sweep 양쪽 outside-soloing context 보존.
+- 다음 boundary는 chord-context pitch-role bridge.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-followup-decision`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #866, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision outside-soloing context refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision refresh`
+- latest functional result: Issue #868, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision outside-soloing context refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge refresh`
 
 현재 범위가 아닌 것:
 
@@ -202,6 +202,10 @@
 - primary remaining failure labels: `rhythmic_monotony`
 - primary remaining failure count: `1`
 - not evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
+- objective source/repaired outside-soloing not evaluable count: `6/6`
+- repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- objective source outside-soloing repair pitch-role risk count after: `0`
+- repair sweep source outside-soloing repair pitch-role risk count after: `0`
 - chord-context pitch-role bridge selected: `true`
 - context not-evaluable min count: `6`
 - technical regression count: `0`

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_FOLLOWUP_DECISION_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_FOLLOWUP_DECISION_2026-06-10.md
@@ -1,0 +1,57 @@
+# Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Repair Follow-Up Decision
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
+- repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- selected target: `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- primary remaining failure labels: `rhythmic_monotony`
+- primary remaining failure count: `1`
+- chord-context pitch-role bridge selected: `true`
+- candidate count: `6`
+- source total failure labels: `4`
+- repaired total failure labels: `1`
+- failure label delta: `3`
+- phrase/rhythm failure count: `4 -> 1`
+- phrase/rhythm failure delta: `3`
+- residual rhythmic monotony count: `1`
+- context not-evaluable min count: `6`
+- objective source/repaired outside-soloing not evaluable count: `6/6`
+- repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- objective source outside-soloing repair pitch-role risk count after: `0`
+- repair sweep source outside-soloing repair pitch-role risk count after: `0`
+- technical regression count: `0`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Remaining Failure Counts
+
+- `rhythmic_monotony`: `1`
+
+## Not Evaluable Counts
+
+- `outside_soloing_without_context`: `6`
+- `weak_chord_tone_landing`: `6`
+
+## Context Target Labels
+
+- `outside_soloing_without_context`
+- `weak_chord_tone_landing`
+
+## Decision
+
+- reason: `chord-context not-evaluable labels dominate after phrase/rhythm repair`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge`
+
+## Claim Boundary
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `outside_soloing_without_context`
+- `weak_chord_tone_landing`
+- `broad_trained_model_quality`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6626,8 +6626,8 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_d
     --run_id "$run_id" \
     --objective_next_report "$objective_report" \
     --repair_sweep_report "$sweep_report" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_FOLLOWUP_DECISION_2026-06-09.md \
-    --issue_number 784 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_FOLLOWUP_DECISION_2026-06-10.md \
+    --issue_number 868 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge \
     --expected_target songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge \

--- a/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup.py
+++ b/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup.py
@@ -119,6 +119,22 @@ def validate_objective_next_source(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
             "technical WAV validation required"
         )
+    if not bool(summary.get("source_outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
+            "objective outside-soloing repair evidence should be ready"
+        )
+    if _int(summary.get("source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
+            "objective source outside-soloing repair pitch-role risk should be resolved"
+        )
+    if _int(summary.get("source_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
+            "objective source outside-soloing not-evaluable count should be preserved"
+        )
+    if _int(summary.get("repaired_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
+            "objective repaired outside-soloing not-evaluable count should be preserved"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
             "critical user input should not be required"
@@ -131,6 +147,19 @@ def validate_objective_next_source(report: dict[str, Any]) -> dict[str, Any]:
         "failure_label_delta": _int(summary.get("failure_label_delta")),
         "phrase_rhythm_failure_delta": _int(summary.get("phrase_rhythm_failure_delta")),
         "technical_wav_validation": bool(summary.get("technical_wav_validation", False)),
+        "source_outside_soloing_repair_evidence_ready": bool(
+            summary.get("source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            summary.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_not_evaluable_count": _int(
+            summary.get("source_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_outside_soloing_not_evaluable_count": _int(
+            summary.get("repaired_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_not_evaluable_counts": _dict(summary.get("repaired_not_evaluable_counts")),
         "validated_review_input_present": bool(
             summary.get("validated_review_input_present", False)
         ),
@@ -187,6 +216,22 @@ def validate_repair_sweep_source(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
             "technical regression must remain zero"
         )
+    if not bool(aggregate.get("source_outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
+            "repair sweep outside-soloing repair evidence should be ready"
+        )
+    if _int(aggregate.get("source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
+            "repair sweep source outside-soloing repair pitch-role risk should be resolved"
+        )
+    if _int(aggregate.get("source_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
+            "repair sweep source outside-soloing not-evaluable count should be preserved"
+        )
+    if _int(aggregate.get("repaired_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
+            "repair sweep repaired outside-soloing not-evaluable count should be preserved"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
             "critical user input should not be required"
@@ -236,6 +281,19 @@ def validate_repair_sweep_source(report: dict[str, Any]) -> dict[str, Any]:
         "phrase_rhythm_failure_delta": _int(aggregate.get("phrase_rhythm_failure_delta")),
         "improved_candidate_count": _int(aggregate.get("improved_candidate_count")),
         "technical_regression_count": _int(aggregate.get("technical_regression_count")),
+        "source_outside_soloing_repair_evidence_ready": bool(
+            aggregate.get("source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            aggregate.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_not_evaluable_count": _int(
+            aggregate.get("source_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_outside_soloing_not_evaluable_count": _int(
+            aggregate.get("repaired_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_not_evaluable_counts": _dict(aggregate.get("repaired_not_evaluable_counts")),
         "remaining_failure_counts": remaining_counts,
         "primary_remaining_failure_labels": primary_labels,
         "primary_remaining_failure_count": primary_count,
@@ -342,6 +400,30 @@ def build_followup_decision_report(
             ),
             "context_not_evaluable_min_count": _int(
                 sweep["context_not_evaluable_min_count"]
+            ),
+            "objective_source_outside_soloing_repair_evidence_ready": bool(
+                objective["source_outside_soloing_repair_evidence_ready"]
+            ),
+            "objective_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+                objective["source_outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
+            "objective_source_outside_soloing_not_evaluable_count": _int(
+                objective["source_outside_soloing_not_evaluable_count"]
+            ),
+            "objective_repaired_outside_soloing_not_evaluable_count": _int(
+                objective["repaired_outside_soloing_not_evaluable_count"]
+            ),
+            "repair_sweep_source_outside_soloing_repair_evidence_ready": bool(
+                sweep["source_outside_soloing_repair_evidence_ready"]
+            ),
+            "repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+                sweep["source_outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
+            "repair_sweep_source_outside_soloing_not_evaluable_count": _int(
+                sweep["source_outside_soloing_not_evaluable_count"]
+            ),
+            "repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
+                sweep["repaired_outside_soloing_not_evaluable_count"]
             ),
             "technical_regression_count": _int(sweep["technical_regression_count"]),
             "human_audio_preference_claimed": False,
@@ -484,6 +566,30 @@ def validate_followup_decision_report(
         "technical_regression_count": _int(readiness.get("technical_regression_count")),
         "remaining_failure_counts": _dict(sweep.get("remaining_failure_counts")),
         "not_evaluable_counts": _dict(sweep.get("not_evaluable_counts")),
+        "objective_source_outside_soloing_repair_evidence_ready": bool(
+            readiness.get("objective_source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "objective_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            readiness.get("objective_source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "objective_source_outside_soloing_not_evaluable_count": _int(
+            readiness.get("objective_source_outside_soloing_not_evaluable_count")
+        ),
+        "objective_repaired_outside_soloing_not_evaluable_count": _int(
+            readiness.get("objective_repaired_outside_soloing_not_evaluable_count")
+        ),
+        "repair_sweep_source_outside_soloing_repair_evidence_ready": bool(
+            readiness.get("repair_sweep_source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            readiness.get("repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "repair_sweep_source_outside_soloing_not_evaluable_count": _int(
+            readiness.get("repair_sweep_source_outside_soloing_not_evaluable_count")
+        ),
+        "repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
+            readiness.get("repair_sweep_repaired_outside_soloing_not_evaluable_count")
+        ),
         "human_audio_preference_claimed": bool(
             readiness.get("human_audio_preference_claimed", True)
         ),
@@ -523,6 +629,10 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- phrase/rhythm failure delta: `{readiness['phrase_rhythm_failure_delta']}`",
         f"- residual rhythmic monotony count: `{readiness['residual_rhythmic_monotony_count']}`",
         f"- context not-evaluable min count: `{readiness['context_not_evaluable_min_count']}`",
+        f"- objective source/repaired outside-soloing not evaluable count: `{readiness['objective_source_outside_soloing_not_evaluable_count']}/{readiness['objective_repaired_outside_soloing_not_evaluable_count']}`",
+        f"- repair sweep source/repaired outside-soloing not evaluable count: `{readiness['repair_sweep_source_outside_soloing_not_evaluable_count']}/{readiness['repair_sweep_repaired_outside_soloing_not_evaluable_count']}`",
+        f"- objective source outside-soloing repair pitch-role risk count after: `{readiness['objective_source_outside_soloing_repair_pitch_role_risk_count_after']}`",
+        f"- repair sweep source outside-soloing repair pitch-role risk count after: `{readiness['repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after']}`",
         f"- technical regression count: `{readiness['technical_regression_count']}`",
         f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
         f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision.py
@@ -32,6 +32,14 @@ def objective_next_report(*, quality_claim: bool = False) -> dict:
             "rendered_audio_file_count": 6,
             "failure_label_delta": 3,
             "phrase_rhythm_failure_delta": 3,
+            "source_outside_soloing_repair_evidence_ready": True,
+            "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "source_outside_soloing_not_evaluable_count": 6,
+            "repaired_outside_soloing_not_evaluable_count": 6,
+            "repaired_not_evaluable_counts": {
+                "outside_soloing_without_context": 6,
+                "weak_chord_tone_landing": 6,
+            },
             "current_quality_claim_ready": False,
         },
         "readiness": {
@@ -78,6 +86,14 @@ def repair_sweep_report(*, technical_regression_count: int = 0) -> dict:
             "repaired_failure_counts": {
                 "rhythmic_monotony": 1,
             },
+            "source_outside_soloing_repair_evidence_ready": True,
+            "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "source_outside_soloing_not_evaluable_count": 6,
+            "repaired_outside_soloing_not_evaluable_count": 6,
+            "repaired_not_evaluable_counts": {
+                "outside_soloing_without_context": 6,
+                "weak_chord_tone_landing": 6,
+            },
         },
         "readiness": {
             "songlike_melody_contour_phrase_rhythm_repair_sweep_completed": True,
@@ -104,7 +120,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionTes
                 objective_next_report=objective_next_report(),
                 repair_sweep_report=repair_sweep_report(),
                 output_dir=Path(tmp) / "followup",
-                issue_number=784,
+                issue_number=868,
             )
             summary = validate_followup_decision_report(
                 report,
@@ -127,6 +143,23 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionTes
             self.assertEqual(summary["failure_label_delta"], 3)
             self.assertEqual(summary["phrase_rhythm_failure_delta"], 3)
             self.assertEqual(summary["context_not_evaluable_min_count"], 6)
+            self.assertTrue(summary["objective_source_outside_soloing_repair_evidence_ready"])
+            self.assertEqual(
+                summary["objective_source_outside_soloing_repair_pitch_role_risk_count_after"],
+                0,
+            )
+            self.assertEqual(summary["objective_source_outside_soloing_not_evaluable_count"], 6)
+            self.assertEqual(summary["objective_repaired_outside_soloing_not_evaluable_count"], 6)
+            self.assertTrue(summary["repair_sweep_source_outside_soloing_repair_evidence_ready"])
+            self.assertEqual(
+                summary["repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after"],
+                0,
+            )
+            self.assertEqual(summary["repair_sweep_source_outside_soloing_not_evaluable_count"], 6)
+            self.assertEqual(
+                summary["repair_sweep_repaired_outside_soloing_not_evaluable_count"],
+                6,
+            )
             self.assertEqual(summary["technical_regression_count"], 0)
             self.assertEqual(summary["selected_target"], SELECTED_TARGET)
             self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
@@ -142,7 +175,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionTes
                     objective_next_report=objective_next_report(quality_claim=True),
                     repair_sweep_report=repair_sweep_report(),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=772,
+                    issue_number=868,
                 )
 
     def test_rejects_technical_regression(self) -> None:
@@ -154,7 +187,37 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionTes
                     objective_next_report=objective_next_report(),
                     repair_sweep_report=repair_sweep_report(technical_regression_count=1),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=772,
+                    issue_number=868,
+                )
+
+    def test_rejects_missing_objective_outside_soloing_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = objective_next_report()
+            del source["objective_summary"]["source_outside_soloing_not_evaluable_count"]
+
+            with self.assertRaises(
+                StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError
+            ):
+                build_followup_decision_report(
+                    objective_next_report=source,
+                    repair_sweep_report=repair_sweep_report(),
+                    output_dir=Path(tmp) / "followup",
+                    issue_number=868,
+                )
+
+    def test_rejects_missing_repair_sweep_outside_soloing_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = repair_sweep_report()
+            del source["aggregate"]["repaired_outside_soloing_not_evaluable_count"]
+
+            with self.assertRaises(
+                StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError
+            ):
+                build_followup_decision_report(
+                    objective_next_report=objective_next_report(),
+                    repair_sweep_report=source,
+                    output_dir=Path(tmp) / "followup",
+                    issue_number=868,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary
- phrase/rhythm repair follow-up decision outside-soloing context 보존
- objective-only next decision과 repair sweep의 outside-soloing evidence 동시 검증
- chord-context pitch-role bridge 라우팅 유지

## Context
- Issue #866 objective-only next decision 결과: follow-up required true, current quality claim ready false
- objective source/repaired outside-soloing not evaluable: 6/6
- repair sweep source/repaired outside-soloing not evaluable: 6/6
- objective/repair sweep source outside-soloing repair pitch-role risk count after: 0/0
- remaining failure label: rhythmic_monotony=1
- context not-evaluable min count: 6

## Scope
- follow-up decision objective/sweep source validation 강화
- readiness/markdown에 objective/sweep outside-soloing context 기록
- missing objective/sweep outside context rejection test 추가
- #868 harness issue/doc path 갱신
- CURRENT_STATUS_AND_PLAN, CORE_PLAN 결과 기록

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-followup-decision`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- `rg -n "Codex|codex|코덱스" <changed public files>`

## Risk
- listening preference 미기록
- musical quality claim 제외
- 다음 검증 대상: chord-context pitch-role bridge outside-soloing context refresh

Closes #868

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated progress tracking for Stage B melody contour phrase/rhythm repair follow-up decisions.
  * Added new decision documentation recording repair outcomes and next target selections.

* **Chores**
  * Updated internal automation scripts and test validation to reflect latest issue tracking and repair evidence metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->