### PR TITLE
Stage B MIDI-to-solo phrase rhythm bridge outside-soloing context refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -420,6 +420,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard: preference fill `false`, validated input `false`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision: follow-up required `true`, source/repaired outside-soloing not evaluable `6/6`, current quality claim ready `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision: selected target `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`, remaining label/count `rhythmic_monotony/1`, objective/sweep outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge: chord context/pitch-role metrics `6/6`, not evaluable `12 -> 0`, bridge flags `outside_soloing_pitch_role_risk=5`, `weak_chord_tone_landing_risk=6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
 - MIDI-to-solo pitch-contour changed-ratio repair probe: repaired/pass `3/3`, max pitch changed ratio `0.7174 -> 0.4348`, max interval `12`, dead-air max `0.0000`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
 - MIDI-to-solo pitch-contour changed-ratio repair audio package: rendered WAV `3`, duration `18.422s-18.978s`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
@@ -7012,6 +7013,54 @@ Issue #868은 Issue #866 objective-only next decision과 phrase/rhythm repair sw
 다음 작업:
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge refresh`
+
+## 9.126 Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge outside-soloing context refresh
+
+Issue #870은 Issue #868 follow-up decision의 outside-soloing context를 chord-context pitch-role bridge까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
+- repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- selected target: `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- chord progression: `Cm7,Fm7,Bb7,Ebmaj7`
+- context source: `fallback_default_harness_chords`
+- candidate count: `6`
+- chord context available count: `6/6`
+- pitch-role metrics defined count: `6/6`
+- not evaluable count: `12 -> 0`
+- follow-up objective source/repaired outside-soloing not evaluable count: `6/6`
+- follow-up repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- bridge repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- min chord-tone ratio: `0.216`
+- max outside ratio: `0.027`
+- max non-chord run: `5`
+- bridge flags: `outside_soloing_pitch_role_risk=5`, `weak_chord_tone_landing_risk=6`
+- critical user input required: `false`
+- human/audio preference claimed: `false`
+- audio rendered quality claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- chord context와 pitch-role metrics가 후보 `6/6`개에 정의됨.
+- context 부재로 인한 not-evaluable label은 `12 -> 0`으로 해소.
+- 남은 objective risk는 `outside_soloing_pitch_role_risk=5`, `weak_chord_tone_landing_risk=6`.
+- 다음 boundary는 chord-context pitch-role objective decision.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-context-pitch-role-bridge`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #868, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision outside-soloing context refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge refresh`
+- latest functional result: Issue #870, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge outside-soloing context refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision refresh`
 
 현재 범위가 아닌 것:
 
@@ -218,6 +218,9 @@
 - chord context available count: `6/6`
 - pitch-role metrics defined count: `6/6`
 - not evaluable count: `12 -> 0`
+- follow-up objective source/repaired outside-soloing not evaluable count: `6/6`
+- follow-up repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- bridge repair sweep source/repaired outside-soloing not evaluable count: `6/6`
 - min chord-tone ratio: `0.216`
 - max outside ratio: `0.027`
 - max non-chord run: `5`

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_CONTEXT_PITCH_ROLE_BRIDGE_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_CONTEXT_PITCH_ROLE_BRIDGE_2026-06-10.md
@@ -1,0 +1,54 @@
+# Stage B MIDI-to-Solo Phrase/Rhythm Chord-Context Pitch-Role Bridge
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
+- repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- selected target: `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- chord progression: `Cm7,Fm7,Bb7,Ebmaj7`
+- context source: `fallback_default_harness_chords`
+- candidate count: `6`
+- chord context available count: `6`
+- pitch-role metrics defined count: `6`
+- not evaluable count: `12 -> 0`
+- follow-up objective source/repaired outside-soloing not evaluable count: `6/6`
+- follow-up repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- bridge repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- min chord-tone ratio: `0.216`
+- max outside ratio: `0.027`
+- max non-chord run: `5`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Bridge Flags
+
+- `outside_soloing_pitch_role_risk`: `5`
+- `weak_chord_tone_landing_risk`: `6`
+
+## Candidates
+
+| rank | chord-tone | tension | approach | outside | strong beat chord-tone | final role | flags |
+|---:|---:|---:|---:|---:|---:|---|---|
+| 1 | 0.297 | 0.270 | 0.432 | 0.000 | 0.545 | `approach` | `weak_chord_tone_landing_risk` |
+| 2 | 0.457 | 0.086 | 0.457 | 0.000 | 0.300 | `approach` | `outside_soloing_pitch_role_risk,weak_chord_tone_landing_risk` |
+| 3 | 0.378 | 0.108 | 0.486 | 0.027 | 0.400 | `approach` | `outside_soloing_pitch_role_risk,weak_chord_tone_landing_risk` |
+| 4 | 0.216 | 0.243 | 0.541 | 0.000 | 0.333 | `guide` | `outside_soloing_pitch_role_risk,weak_chord_tone_landing_risk` |
+| 5 | 0.237 | 0.211 | 0.526 | 0.026 | 0.000 | `approach` | `outside_soloing_pitch_role_risk,weak_chord_tone_landing_risk` |
+| 6 | 0.324 | 0.270 | 0.405 | 0.000 | 0.167 | `approach` | `outside_soloing_pitch_role_risk,weak_chord_tone_landing_risk` |
+
+## Decision
+
+- reason: `chord-context bridge produced pitch-role metrics without quality claim`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision`
+
+## Claim Boundary
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6657,8 +6657,8 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pit
     --repair_sweep_report "$sweep_report" \
     --chords Cm7,Fm7,Bb7,Ebmaj7 \
     --bpm 124 \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_CONTEXT_PITCH_ROLE_BRIDGE_2026-06-09.md \
-    --issue_number 786 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_CONTEXT_PITCH_ROLE_BRIDGE_2026-06-10.md \
+    --issue_number 870 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision \
     --require_bridge_completed \

--- a/scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge.py
+++ b/scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge.py
@@ -132,6 +132,22 @@ def validate_followup_source(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError(
             "critical user input should not be required"
         )
+    if not bool(readiness.get("objective_source_outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError(
+            "objective outside-soloing repair evidence should be ready"
+        )
+    if _int(readiness.get("objective_source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError(
+            "objective outside-soloing repair pitch-role risk should be resolved"
+        )
+    if _int(readiness.get("objective_source_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError(
+            "objective outside-soloing not-evaluable count should be preserved"
+        )
+    if _int(readiness.get("repair_sweep_source_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError(
+            "repair sweep outside-soloing not-evaluable count should be preserved"
+        )
     _require_no_quality_claim(readiness, label="follow-up readiness")
     return {
         "boundary": FOLLOWUP_BOUNDARY,
@@ -140,6 +156,30 @@ def validate_followup_source(report: dict[str, Any]) -> dict[str, Any]:
         "phrase_rhythm_failure_delta": _int(readiness.get("phrase_rhythm_failure_delta")),
         "context_not_evaluable_min_count": _int(
             readiness.get("context_not_evaluable_min_count")
+        ),
+        "objective_source_outside_soloing_repair_evidence_ready": bool(
+            readiness.get("objective_source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "objective_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            readiness.get("objective_source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "objective_source_outside_soloing_not_evaluable_count": _int(
+            readiness.get("objective_source_outside_soloing_not_evaluable_count")
+        ),
+        "objective_repaired_outside_soloing_not_evaluable_count": _int(
+            readiness.get("objective_repaired_outside_soloing_not_evaluable_count")
+        ),
+        "repair_sweep_source_outside_soloing_repair_evidence_ready": bool(
+            readiness.get("repair_sweep_source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            readiness.get("repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "repair_sweep_source_outside_soloing_not_evaluable_count": _int(
+            readiness.get("repair_sweep_source_outside_soloing_not_evaluable_count")
+        ),
+        "repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
+            readiness.get("repair_sweep_repaired_outside_soloing_not_evaluable_count")
         ),
     }
 
@@ -193,6 +233,22 @@ def validate_repair_sweep_source(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError(
             "positive phrase/rhythm failure delta required"
         )
+    if not bool(aggregate.get("source_outside_soloing_repair_evidence_ready", False)):
+        raise StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError(
+            "repair sweep outside-soloing repair evidence should be ready"
+        )
+    if _int(aggregate.get("source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
+        raise StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError(
+            "repair sweep outside-soloing repair pitch-role risk should be resolved"
+        )
+    if _int(aggregate.get("source_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError(
+            "repair sweep source outside-soloing not-evaluable count should be preserved"
+        )
+    if _int(aggregate.get("repaired_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError(
+            "repair sweep repaired outside-soloing not-evaluable count should be preserved"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError(
             "critical user input should not be required"
@@ -225,6 +281,19 @@ def validate_repair_sweep_source(report: dict[str, Any]) -> dict[str, Any]:
         ),
         "phrase_rhythm_failure_delta": _int(aggregate.get("phrase_rhythm_failure_delta")),
         "technical_regression_count": _int(aggregate.get("technical_regression_count")),
+        "source_outside_soloing_repair_evidence_ready": bool(
+            aggregate.get("source_outside_soloing_repair_evidence_ready", False)
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            aggregate.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_not_evaluable_count": _int(
+            aggregate.get("source_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_outside_soloing_not_evaluable_count": _int(
+            aggregate.get("repaired_outside_soloing_not_evaluable_count")
+        ),
+        "repaired_not_evaluable_counts": _dict(aggregate.get("repaired_not_evaluable_counts")),
         "not_evaluable_counts_before": dict(sorted(not_evaluable_counts.items())),
     }
 
@@ -373,6 +442,24 @@ def build_bridge_report(
         "not_evaluable_before_count": not_evaluable_before_count,
         "not_evaluable_after_count": not_evaluable_after_count,
         "not_evaluable_counts_before": sweep["not_evaluable_counts_before"],
+        "followup_objective_source_outside_soloing_not_evaluable_count": _int(
+            followup["objective_source_outside_soloing_not_evaluable_count"]
+        ),
+        "followup_objective_repaired_outside_soloing_not_evaluable_count": _int(
+            followup["objective_repaired_outside_soloing_not_evaluable_count"]
+        ),
+        "followup_repair_sweep_source_outside_soloing_not_evaluable_count": _int(
+            followup["repair_sweep_source_outside_soloing_not_evaluable_count"]
+        ),
+        "followup_repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
+            followup["repair_sweep_repaired_outside_soloing_not_evaluable_count"]
+        ),
+        "repair_sweep_source_outside_soloing_not_evaluable_count": _int(
+            sweep["source_outside_soloing_not_evaluable_count"]
+        ),
+        "repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
+            sweep["repaired_outside_soloing_not_evaluable_count"]
+        ),
         "bridge_flag_counts": dict(sorted(bridge_flag_counts.items())),
         "min_chord_tone_ratio": min_chord_tone_ratio,
         "max_outside_ratio": max_outside_ratio,
@@ -411,6 +498,24 @@ def build_bridge_report(
             "pitch_role_metrics_defined_count": pitch_role_metrics_defined_count,
             "not_evaluable_before_count": not_evaluable_before_count,
             "not_evaluable_after_count": not_evaluable_after_count,
+            "followup_objective_source_outside_soloing_not_evaluable_count": _int(
+                followup["objective_source_outside_soloing_not_evaluable_count"]
+            ),
+            "followup_objective_repaired_outside_soloing_not_evaluable_count": _int(
+                followup["objective_repaired_outside_soloing_not_evaluable_count"]
+            ),
+            "followup_repair_sweep_source_outside_soloing_not_evaluable_count": _int(
+                followup["repair_sweep_source_outside_soloing_not_evaluable_count"]
+            ),
+            "followup_repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
+                followup["repair_sweep_repaired_outside_soloing_not_evaluable_count"]
+            ),
+            "repair_sweep_source_outside_soloing_not_evaluable_count": _int(
+                sweep["source_outside_soloing_not_evaluable_count"]
+            ),
+            "repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
+                sweep["repaired_outside_soloing_not_evaluable_count"]
+            ),
             "human_audio_preference_claimed": False,
             "audio_rendered_quality_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
@@ -535,6 +640,24 @@ def validate_bridge_report(
         ),
         "not_evaluable_before_count": _int(readiness.get("not_evaluable_before_count")),
         "not_evaluable_after_count": _int(readiness.get("not_evaluable_after_count")),
+        "followup_objective_source_outside_soloing_not_evaluable_count": _int(
+            readiness.get("followup_objective_source_outside_soloing_not_evaluable_count")
+        ),
+        "followup_objective_repaired_outside_soloing_not_evaluable_count": _int(
+            readiness.get("followup_objective_repaired_outside_soloing_not_evaluable_count")
+        ),
+        "followup_repair_sweep_source_outside_soloing_not_evaluable_count": _int(
+            readiness.get("followup_repair_sweep_source_outside_soloing_not_evaluable_count")
+        ),
+        "followup_repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
+            readiness.get("followup_repair_sweep_repaired_outside_soloing_not_evaluable_count")
+        ),
+        "repair_sweep_source_outside_soloing_not_evaluable_count": _int(
+            readiness.get("repair_sweep_source_outside_soloing_not_evaluable_count")
+        ),
+        "repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
+            readiness.get("repair_sweep_repaired_outside_soloing_not_evaluable_count")
+        ),
         "min_chord_tone_ratio": _float(summary.get("min_chord_tone_ratio")),
         "max_outside_ratio": _float(summary.get("max_outside_ratio")),
         "max_non_chord_tone_run": _int(summary.get("max_non_chord_tone_run")),
@@ -573,6 +696,9 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- chord context available count: `{readiness['chord_context_available_count']}`",
         f"- pitch-role metrics defined count: `{readiness['pitch_role_metrics_defined_count']}`",
         f"- not evaluable count: `{readiness['not_evaluable_before_count']} -> {readiness['not_evaluable_after_count']}`",
+        f"- follow-up objective source/repaired outside-soloing not evaluable count: `{readiness['followup_objective_source_outside_soloing_not_evaluable_count']}/{readiness['followup_objective_repaired_outside_soloing_not_evaluable_count']}`",
+        f"- follow-up repair sweep source/repaired outside-soloing not evaluable count: `{readiness['followup_repair_sweep_source_outside_soloing_not_evaluable_count']}/{readiness['followup_repair_sweep_repaired_outside_soloing_not_evaluable_count']}`",
+        f"- bridge repair sweep source/repaired outside-soloing not evaluable count: `{readiness['repair_sweep_source_outside_soloing_not_evaluable_count']}/{readiness['repair_sweep_repaired_outside_soloing_not_evaluable_count']}`",
         f"- min chord-tone ratio: `{summary['min_chord_tone_ratio']:.3f}`",
         f"- max outside ratio: `{summary['max_outside_ratio']:.3f}`",
         f"- max non-chord run: `{summary['max_non_chord_tone_run']}`",
@@ -644,7 +770,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=786)
+    parser.add_argument("--issue_number", type=int, default=870)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--require_bridge_completed", action="store_true")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge.py
@@ -60,6 +60,14 @@ def followup_report(*, quality_claim: bool = False) -> dict:
             "failure_label_delta": 3,
             "phrase_rhythm_failure_delta": 3,
             "context_not_evaluable_min_count": 6,
+            "objective_source_outside_soloing_repair_evidence_ready": True,
+            "objective_source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "objective_source_outside_soloing_not_evaluable_count": 6,
+            "objective_repaired_outside_soloing_not_evaluable_count": 6,
+            "repair_sweep_source_outside_soloing_repair_evidence_ready": True,
+            "repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "repair_sweep_source_outside_soloing_not_evaluable_count": 6,
+            "repair_sweep_repaired_outside_soloing_not_evaluable_count": 6,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
             "audio_rendered_quality_claimed": False,
@@ -107,6 +115,14 @@ def repair_sweep_report(midi_paths: list[Path], *, technical_regression_count: i
             "repaired_phrase_rhythm_failure_count": 1,
             "phrase_rhythm_failure_delta": 3,
             "technical_regression_count": technical_regression_count,
+            "source_outside_soloing_repair_evidence_ready": True,
+            "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "source_outside_soloing_not_evaluable_count": 6,
+            "repaired_outside_soloing_not_evaluable_count": 6,
+            "repaired_not_evaluable_counts": {
+                "outside_soloing_without_context": 6,
+                "weak_chord_tone_landing": 6,
+            },
         },
         "readiness": {
             "songlike_melody_contour_phrase_rhythm_repair_sweep_completed": True,
@@ -141,7 +157,7 @@ class StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeTest(unittest.TestC
                 chords=list(DEFAULT_CHORDS),
                 bpm=124.0,
                 output_dir=root / "bridge",
-                issue_number=786,
+                issue_number=870,
             )
             summary = validate_bridge_report(
                 report,
@@ -158,6 +174,27 @@ class StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeTest(unittest.TestC
             self.assertEqual(summary["pitch_role_metrics_defined_count"], 6)
             self.assertEqual(summary["not_evaluable_before_count"], 12)
             self.assertEqual(summary["not_evaluable_after_count"], 0)
+            self.assertEqual(
+                summary["followup_objective_source_outside_soloing_not_evaluable_count"],
+                6,
+            )
+            self.assertEqual(
+                summary["followup_objective_repaired_outside_soloing_not_evaluable_count"],
+                6,
+            )
+            self.assertEqual(
+                summary["followup_repair_sweep_source_outside_soloing_not_evaluable_count"],
+                6,
+            )
+            self.assertEqual(
+                summary["followup_repair_sweep_repaired_outside_soloing_not_evaluable_count"],
+                6,
+            )
+            self.assertEqual(summary["repair_sweep_source_outside_soloing_not_evaluable_count"], 6)
+            self.assertEqual(
+                summary["repair_sweep_repaired_outside_soloing_not_evaluable_count"],
+                6,
+            )
             self.assertGreater(summary["min_chord_tone_ratio"], 0.0)
             self.assertEqual(summary["selected_target"], SELECTED_TARGET)
             self.assertFalse(summary["human_audio_preference_claimed"])
@@ -179,7 +216,7 @@ class StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeTest(unittest.TestC
                     chords=list(DEFAULT_CHORDS),
                     bpm=124.0,
                     output_dir=root / "bridge",
-                    issue_number=786,
+                    issue_number=870,
                 )
 
     def test_rejects_technical_regression(self) -> None:
@@ -200,7 +237,49 @@ class StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeTest(unittest.TestC
                     chords=list(DEFAULT_CHORDS),
                     bpm=124.0,
                     output_dir=root / "bridge",
-                    issue_number=786,
+                    issue_number=870,
+                )
+
+    def test_rejects_missing_followup_outside_soloing_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            midi_paths = []
+            for index in range(6):
+                midi_path = root / f"candidate_{index}.mid"
+                write_fixture_midi(midi_path)
+                midi_paths.append(midi_path)
+            source = followup_report()
+            del source["readiness"]["objective_source_outside_soloing_not_evaluable_count"]
+
+            with self.assertRaises(StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError):
+                build_bridge_report(
+                    followup_report=source,
+                    repair_sweep_report=repair_sweep_report(midi_paths),
+                    chords=list(DEFAULT_CHORDS),
+                    bpm=124.0,
+                    output_dir=root / "bridge",
+                    issue_number=870,
+                )
+
+    def test_rejects_missing_repair_sweep_outside_soloing_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            midi_paths = []
+            for index in range(6):
+                midi_path = root / f"candidate_{index}.mid"
+                write_fixture_midi(midi_path)
+                midi_paths.append(midi_path)
+            source = repair_sweep_report(midi_paths)
+            del source["aggregate"]["source_outside_soloing_not_evaluable_count"]
+
+            with self.assertRaises(StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError):
+                build_bridge_report(
+                    followup_report=followup_report(),
+                    repair_sweep_report=source,
+                    chords=list(DEFAULT_CHORDS),
+                    bpm=124.0,
+                    output_dir=root / "bridge",
+                    issue_number=870,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary
- phrase/rhythm chord-context pitch-role bridge outside-soloing context 보존
- follow-up decision과 repair sweep의 outside-soloing not-evaluable count 필수 검증
- bridge 결과에서 context not-evaluable label 해소와 pitch-role risk 기록 유지

## Context
- Issue #868 follow-up decision 결과: selected target chord-context pitch-role bridge
- follow-up objective/sweep source/repaired outside-soloing not evaluable: 6/6
- bridge not-evaluable count: 12 -> 0
- chord context available / pitch-role metrics defined: 6/6
- bridge flags: outside_soloing_pitch_role_risk=5, weak_chord_tone_landing_risk=6

## Scope
- bridge follow-up and repair sweep source validation 강화
- bridge readiness/markdown에 outside-soloing not-evaluable count 기록
- missing follow-up/sweep outside context rejection test 추가
- #870 harness issue/doc path 갱신
- CURRENT_STATUS_AND_PLAN, CORE_PLAN 결과 기록

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-context-pitch-role-bridge`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- `rg -n "Codex|codex|코덱스" <changed public files>`

## Risk
- listening preference 미기록
- musical quality claim 제외
- 다음 검증 대상: chord-context pitch-role objective decision outside-soloing context refresh

Closes #870