### PR TITLE
Stage B MIDI-to-solo pitch-role objective outside-soloing context refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -421,6 +421,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision: follow-up required `true`, source/repaired outside-soloing not evaluable `6/6`, current quality claim ready `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision: selected target `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`, remaining label/count `rhythmic_monotony/1`, objective/sweep outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge: chord context/pitch-role metrics `6/6`, not evaluable `12 -> 0`, bridge flags `outside_soloing_pitch_role_risk=5`, `weak_chord_tone_landing_risk=6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision: primary risk `weak_chord_tone_landing_risk=6`, outside risk `5`, not evaluable `12 -> 0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
 - MIDI-to-solo pitch-contour changed-ratio repair probe: repaired/pass `3/3`, max pitch changed ratio `0.7174 -> 0.4348`, max interval `12`, dead-air max `0.0000`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
 - MIDI-to-solo pitch-contour changed-ratio repair audio package: rendered WAV `3`, duration `18.422s-18.978s`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
@@ -7061,6 +7062,52 @@ Issue #870은 Issue #868 follow-up decision의 outside-soloing context를 chord-
 다음 작업:
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision refresh`
+
+## 9.127 Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision outside-soloing context refresh
+
+Issue #872는 Issue #870 chord-context pitch-role bridge의 outside-soloing context를 objective decision까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
+- selected target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
+- pitch-role objective decision completed: `true`
+- candidate count: `6`
+- primary risk label: `weak_chord_tone_landing_risk`
+- weak chord-tone landing risk count: `6`
+- outside-soloing pitch-role risk count: `5`
+- not evaluable count: `12 -> 0`
+- follow-up objective source/repaired outside-soloing not evaluable count: `6/6`
+- follow-up repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- bridge repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- min chord-tone ratio: `0.216`
+- max outside ratio: `0.027`
+- max non-chord run: `5`
+- critical user input required: `false`
+- human/audio preference claimed: `false`
+- audio rendered quality claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- pitch-role context 적용 후 not-evaluable label은 `0`.
+- 최대 risk count 기준 primary target은 `weak_chord_tone_landing_risk=6`.
+- outside-soloing pitch-role risk는 `5`로 잔존하지만 primary repair target은 chord-tone landing.
+- 다음 boundary는 chord-tone landing repair sweep.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-context-pitch-role-objective-decision`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #870, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge outside-soloing context refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision refresh`
+- latest functional result: Issue #872, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision outside-soloing context refresh
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep refresh`
 
 현재 범위가 아닌 것:
 
@@ -233,6 +233,9 @@
 - weak chord-tone landing risk count: `6`
 - outside-soloing pitch-role risk count: `5`
 - not evaluable count: `12 -> 0`
+- follow-up objective source/repaired outside-soloing not evaluable count: `6/6`
+- follow-up repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- bridge repair sweep source/repaired outside-soloing not evaluable count: `6/6`
 - min chord-tone ratio: `0.216`
 - max outside ratio: `0.027`
 - max non-chord run: `5`

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_CONTEXT_PITCH_ROLE_OBJECTIVE_DECISION_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_CONTEXT_PITCH_ROLE_OBJECTIVE_DECISION_2026-06-10.md
@@ -1,0 +1,36 @@
+# Stage B MIDI-to-Solo Pitch-Role Objective Decision
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
+- selected target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
+- primary risk label: `weak_chord_tone_landing_risk`
+- candidate count: `6`
+- not evaluable count: `12 -> 0`
+- follow-up objective source/repaired outside-soloing not evaluable count: `6/6`
+- follow-up repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- bridge repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- weak chord-tone landing risk count: `6`
+- outside-soloing pitch-role risk count: `5`
+- min chord-tone ratio: `0.216`
+- max outside ratio: `0.027`
+- max non-chord run: `5`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Decision
+
+- reason: `largest pitch-role risk count selected as next repair target`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep`
+
+## Claim Boundary
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6678,8 +6678,8 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pit
   "$PYTHON_BIN" scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective.py \
     --run_id "$run_id" \
     --bridge_report "$bridge_report" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_CONTEXT_PITCH_ROLE_OBJECTIVE_DECISION_2026-06-09.md \
-    --issue_number 788 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_CONTEXT_PITCH_ROLE_OBJECTIVE_DECISION_2026-06-10.md \
+    --issue_number 872 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep \
     --expected_target songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep \

--- a/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective.py
+++ b/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective.py
@@ -110,6 +110,18 @@ def validate_bridge_source(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
             "not-evaluable labels must be cleared before objective decision"
         )
+    if _int(readiness.get("followup_objective_source_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+            "follow-up objective outside-soloing not-evaluable count should be preserved"
+        )
+    if _int(readiness.get("followup_repair_sweep_source_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+            "follow-up repair sweep outside-soloing not-evaluable count should be preserved"
+        )
+    if _int(readiness.get("repair_sweep_source_outside_soloing_not_evaluable_count")) <= 0:
+        raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+            "bridge repair sweep outside-soloing not-evaluable count should be preserved"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
             "critical user input should not be required"
@@ -122,6 +134,24 @@ def validate_bridge_source(report: dict[str, Any]) -> dict[str, Any]:
         "not_evaluable_after_count": _int(readiness.get("not_evaluable_after_count")),
         "weak_chord_tone_landing_risk_count": _int(flags.get(PRIMARY_RISK_LABEL)),
         "outside_soloing_pitch_role_risk_count": _int(flags.get(SECONDARY_RISK_LABEL)),
+        "followup_objective_source_outside_soloing_not_evaluable_count": _int(
+            readiness.get("followup_objective_source_outside_soloing_not_evaluable_count")
+        ),
+        "followup_objective_repaired_outside_soloing_not_evaluable_count": _int(
+            readiness.get("followup_objective_repaired_outside_soloing_not_evaluable_count")
+        ),
+        "followup_repair_sweep_source_outside_soloing_not_evaluable_count": _int(
+            readiness.get("followup_repair_sweep_source_outside_soloing_not_evaluable_count")
+        ),
+        "followup_repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
+            readiness.get("followup_repair_sweep_repaired_outside_soloing_not_evaluable_count")
+        ),
+        "repair_sweep_source_outside_soloing_not_evaluable_count": _int(
+            readiness.get("repair_sweep_source_outside_soloing_not_evaluable_count")
+        ),
+        "repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
+            readiness.get("repair_sweep_repaired_outside_soloing_not_evaluable_count")
+        ),
         "min_chord_tone_ratio": _float(summary.get("min_chord_tone_ratio")),
         "max_outside_ratio": _float(summary.get("max_outside_ratio")),
         "max_non_chord_tone_run": _int(summary.get("max_non_chord_tone_run")),
@@ -178,6 +208,24 @@ def build_objective_decision_report(
             "primary_risk_label": primary_label,
             "weak_chord_tone_landing_risk_count": weak_count,
             "outside_soloing_pitch_role_risk_count": outside_count,
+            "followup_objective_source_outside_soloing_not_evaluable_count": _int(
+                bridge["followup_objective_source_outside_soloing_not_evaluable_count"]
+            ),
+            "followup_objective_repaired_outside_soloing_not_evaluable_count": _int(
+                bridge["followup_objective_repaired_outside_soloing_not_evaluable_count"]
+            ),
+            "followup_repair_sweep_source_outside_soloing_not_evaluable_count": _int(
+                bridge["followup_repair_sweep_source_outside_soloing_not_evaluable_count"]
+            ),
+            "followup_repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
+                bridge["followup_repair_sweep_repaired_outside_soloing_not_evaluable_count"]
+            ),
+            "repair_sweep_source_outside_soloing_not_evaluable_count": _int(
+                bridge["repair_sweep_source_outside_soloing_not_evaluable_count"]
+            ),
+            "repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
+                bridge["repair_sweep_repaired_outside_soloing_not_evaluable_count"]
+            ),
             "not_evaluable_after_count": _int(bridge["not_evaluable_after_count"]),
             "human_audio_preference_claimed": False,
             "audio_rendered_quality_claimed": False,
@@ -273,6 +321,24 @@ def validate_objective_decision_report(
             readiness.get("outside_soloing_pitch_role_risk_count")
         ),
         "not_evaluable_after_count": _int(readiness.get("not_evaluable_after_count")),
+        "followup_objective_source_outside_soloing_not_evaluable_count": _int(
+            readiness.get("followup_objective_source_outside_soloing_not_evaluable_count")
+        ),
+        "followup_objective_repaired_outside_soloing_not_evaluable_count": _int(
+            readiness.get("followup_objective_repaired_outside_soloing_not_evaluable_count")
+        ),
+        "followup_repair_sweep_source_outside_soloing_not_evaluable_count": _int(
+            readiness.get("followup_repair_sweep_source_outside_soloing_not_evaluable_count")
+        ),
+        "followup_repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
+            readiness.get("followup_repair_sweep_repaired_outside_soloing_not_evaluable_count")
+        ),
+        "repair_sweep_source_outside_soloing_not_evaluable_count": _int(
+            readiness.get("repair_sweep_source_outside_soloing_not_evaluable_count")
+        ),
+        "repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
+            readiness.get("repair_sweep_repaired_outside_soloing_not_evaluable_count")
+        ),
         "human_audio_preference_claimed": bool(
             readiness.get("human_audio_preference_claimed", True)
         ),
@@ -303,6 +369,9 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- primary risk label: `{selected['primary_risk_label']}`",
         f"- candidate count: `{summary['candidate_count']}`",
         f"- not evaluable count: `{summary['not_evaluable_before_count']} -> {summary['not_evaluable_after_count']}`",
+        f"- follow-up objective source/repaired outside-soloing not evaluable count: `{summary['followup_objective_source_outside_soloing_not_evaluable_count']}/{summary['followup_objective_repaired_outside_soloing_not_evaluable_count']}`",
+        f"- follow-up repair sweep source/repaired outside-soloing not evaluable count: `{summary['followup_repair_sweep_source_outside_soloing_not_evaluable_count']}/{summary['followup_repair_sweep_repaired_outside_soloing_not_evaluable_count']}`",
+        f"- bridge repair sweep source/repaired outside-soloing not evaluable count: `{summary['repair_sweep_source_outside_soloing_not_evaluable_count']}/{summary['repair_sweep_repaired_outside_soloing_not_evaluable_count']}`",
         f"- weak chord-tone landing risk count: `{summary['weak_chord_tone_landing_risk_count']}`",
         f"- outside-soloing pitch-role risk count: `{summary['outside_soloing_pitch_role_risk_count']}`",
         f"- min chord-tone ratio: `{summary['min_chord_tone_ratio']:.3f}`",
@@ -339,7 +408,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=788)
+    parser.add_argument("--issue_number", type=int, default=872)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--expected_target", type=str, default="")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision.py
@@ -43,6 +43,12 @@ def bridge_report(*, quality_claim: bool = False, weak_count: int = 6, outside_c
             "pitch_role_metrics_defined_count": 6,
             "not_evaluable_before_count": 12,
             "not_evaluable_after_count": 0,
+            "followup_objective_source_outside_soloing_not_evaluable_count": 6,
+            "followup_objective_repaired_outside_soloing_not_evaluable_count": 6,
+            "followup_repair_sweep_source_outside_soloing_not_evaluable_count": 6,
+            "followup_repair_sweep_repaired_outside_soloing_not_evaluable_count": 6,
+            "repair_sweep_source_outside_soloing_not_evaluable_count": 6,
+            "repair_sweep_repaired_outside_soloing_not_evaluable_count": 6,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
             "audio_rendered_quality_claimed": False,
@@ -65,7 +71,7 @@ class StageBMidiToSoloPitchRoleObjectiveDecisionTest(unittest.TestCase):
             report = build_objective_decision_report(
                 bridge_report=bridge_report(),
                 output_dir=Path(tmp) / "decision",
-                issue_number=788,
+                issue_number=872,
             )
             summary = validate_objective_decision_report(
                 report,
@@ -81,6 +87,27 @@ class StageBMidiToSoloPitchRoleObjectiveDecisionTest(unittest.TestCase):
             self.assertEqual(summary["weak_chord_tone_landing_risk_count"], 6)
             self.assertEqual(summary["outside_soloing_pitch_role_risk_count"], 5)
             self.assertEqual(summary["not_evaluable_after_count"], 0)
+            self.assertEqual(
+                summary["followup_objective_source_outside_soloing_not_evaluable_count"],
+                6,
+            )
+            self.assertEqual(
+                summary["followup_objective_repaired_outside_soloing_not_evaluable_count"],
+                6,
+            )
+            self.assertEqual(
+                summary["followup_repair_sweep_source_outside_soloing_not_evaluable_count"],
+                6,
+            )
+            self.assertEqual(
+                summary["followup_repair_sweep_repaired_outside_soloing_not_evaluable_count"],
+                6,
+            )
+            self.assertEqual(summary["repair_sweep_source_outside_soloing_not_evaluable_count"], 6)
+            self.assertEqual(
+                summary["repair_sweep_repaired_outside_soloing_not_evaluable_count"],
+                6,
+            )
             self.assertEqual(summary["selected_target"], SELECTED_TARGET)
             self.assertFalse(summary["human_audio_preference_claimed"])
             self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
@@ -91,7 +118,7 @@ class StageBMidiToSoloPitchRoleObjectiveDecisionTest(unittest.TestCase):
                 build_objective_decision_report(
                     bridge_report=bridge_report(quality_claim=True),
                     output_dir=Path(tmp) / "decision",
-                    issue_number=788,
+                    issue_number=872,
                 )
 
     def test_routes_outside_soloing_when_it_dominates(self) -> None:
@@ -99,7 +126,7 @@ class StageBMidiToSoloPitchRoleObjectiveDecisionTest(unittest.TestCase):
             report = build_objective_decision_report(
                 bridge_report=bridge_report(weak_count=2, outside_count=5),
                 output_dir=Path(tmp) / "decision",
-                issue_number=788,
+                issue_number=872,
             )
             summary = validate_objective_decision_report(
                 report,
@@ -115,6 +142,18 @@ class StageBMidiToSoloPitchRoleObjectiveDecisionTest(unittest.TestCase):
             )
 
             self.assertEqual(summary["primary_risk_label"], "outside_soloing_pitch_role_risk")
+
+    def test_rejects_missing_bridge_outside_soloing_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = bridge_report()
+            del source["readiness"]["followup_objective_source_outside_soloing_not_evaluable_count"]
+
+            with self.assertRaises(StageBMidiToSoloPitchRoleObjectiveDecisionError):
+                build_objective_decision_report(
+                    bridge_report=source,
+                    output_dir=Path(tmp) / "decision",
+                    issue_number=872,
+                )
 
     def test_constants_are_stable(self) -> None:
         self.assertEqual(


### PR DESCRIPTION
## Summary
- chord-context pitch-role objective decision outside-soloing context 보존
- bridge report의 follow-up/sweep outside-soloing not-evaluable count 필수 검증
- weak chord-tone landing risk 기준 chord-tone landing repair sweep 라우팅 유지

## Context
- Issue #870 bridge 결과: not-evaluable 12 -> 0
- weak chord-tone landing risk count: 6
- outside-soloing pitch-role risk count: 5
- follow-up objective/sweep source/repaired outside-soloing not evaluable: 6/6
- min chord-tone ratio: 0.216
- max outside ratio: 0.027
- max non-chord run: 5

## Scope
- pitch-role objective bridge source validation 강화
- objective summary/markdown에 bridge outside-soloing context 기록
- missing bridge outside context rejection test 추가
- #872 harness issue/doc path 갱신
- CURRENT_STATUS_AND_PLAN, CORE_PLAN 결과 기록

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-context-pitch-role-objective-decision`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- `rg -n "Codex|codex|코덱스" <changed public files>`

## Risk
- listening preference 미기록
- musical quality claim 제외
- 다음 검증 대상: chord-tone landing repair sweep outside-soloing context refresh

Closes #872