### PR TITLE
Stage B MIDI-to-solo landing repair input guard outside-soloing context refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -7246,6 +7246,51 @@ Issue #878은 Issue #876 audio package의 outside-soloing residual context를 li
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard refresh`
 
+## 9.131 Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair input guard outside-soloing context refresh
+
+Issue #880은 Issue #878 listening review package의 outside-soloing residual context를 input guard까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_only_next_decision`
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- changed note total: `40`
+- objective outside-soloing pitch-role risk count: `5`
+- weak chord-tone landing risk delta: `6`
+- outside-soloing pitch-role risk count: `5 -> 2`
+- outside-soloing repair targeted: `false`
+- outside-soloing residual risk preserved: `true`
+- final landing chord-tone count after: `6`
+- critical user input required: `false`
+- human/audio preference claimed: `false`
+- audio rendered quality claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- validated review input이 없으므로 preference fill 차단.
+- human/audio preference claim 제외.
+- residual outside-soloing risk는 `2`로 objective-only next decision까지 전달 필요.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input`
+- `.venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-repair-listening-review-input-guard`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -295,7 +295,10 @@
 - rendered audio file count: `6`
 - changed note total: `40`
 - weak chord-tone landing risk delta: `6`
-- outside-soloing pitch-role risk count after: `2`
+- objective outside-soloing pitch-role risk count: `5`
+- outside-soloing pitch-role risk count: `5 -> 2`
+- outside-soloing repair targeted: `false`
+- outside-soloing residual risk preserved: `true`
 - final landing chord-tone count after: `6`
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_LISTENING_REVIEW_INPUT_GUARD_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_LISTENING_REVIEW_INPUT_GUARD_2026-06-10.md
@@ -13,8 +13,11 @@
 - rendered audio file count: `6`
 - duration range: `18.871s-19.000s`
 - changed note total: `40`
+- objective outside-soloing pitch-role risk count: `5`
 - weak chord-tone landing risk delta: `6`
-- outside-soloing pitch-role risk count after: `2`
+- outside-soloing pitch-role risk count: `5 -> 2`
+- outside-soloing repair targeted: `false`
+- outside-soloing residual risk preserved: `true`
 - final landing chord-tone count after: `6`
 - audio review required: `true`
 - human/audio preference claimed: `false`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6771,7 +6771,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landin
     --run_id "$guard_run_id" \
     --source_package "$source_package" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_LISTENING_REVIEW_INPUT_GUARD_2026-06-10.md \
-    --issue_number 796 \
+    --issue_number 880 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_only_next_decision \
     --require_guard_completed \

--- a/scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input.py
+++ b/scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input.py
@@ -123,6 +123,20 @@ def validate_source_package(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloChordToneLandingRepairListeningInputGuardError(
             "audio review requirement should remain recorded"
         )
+    if _int(source.get("objective_outside_soloing_pitch_role_risk_count")) != _int(
+        source.get("outside_soloing_pitch_role_risk_count_before")
+    ):
+        raise StageBMidiToSoloChordToneLandingRepairListeningInputGuardError(
+            "outside-soloing objective and source counts must match"
+        )
+    if bool(source.get("outside_soloing_repair_targeted", True)):
+        raise StageBMidiToSoloChordToneLandingRepairListeningInputGuardError(
+            "outside-soloing repair target should remain false in input guard"
+        )
+    if not bool(source.get("outside_soloing_residual_risk_preserved", False)):
+        raise StageBMidiToSoloChordToneLandingRepairListeningInputGuardError(
+            "outside-soloing residual risk context must be preserved"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloChordToneLandingRepairListeningInputGuardError(
             "critical user input should not be required"
@@ -144,11 +158,26 @@ def validate_source_package(report: dict[str, Any]) -> dict[str, Any]:
             "duration_min_seconds": _float(source.get("duration_min_seconds")),
             "duration_max_seconds": _float(source.get("duration_max_seconds")),
             "changed_note_total": _int(source.get("changed_note_total")),
+            "objective_outside_soloing_pitch_role_risk_count": _int(
+                source.get("objective_outside_soloing_pitch_role_risk_count")
+            ),
             "weak_chord_tone_landing_risk_delta": _int(
                 source.get("weak_chord_tone_landing_risk_delta")
             ),
+            "outside_soloing_pitch_role_risk_count_before": _int(
+                source.get("outside_soloing_pitch_role_risk_count_before")
+            ),
             "outside_soloing_pitch_role_risk_count_after": _int(
                 source.get("outside_soloing_pitch_role_risk_count_after")
+            ),
+            "outside_soloing_pitch_role_risk_delta": _int(
+                source.get("outside_soloing_pitch_role_risk_delta")
+            ),
+            "outside_soloing_repair_targeted": bool(
+                source.get("outside_soloing_repair_targeted", True)
+            ),
+            "outside_soloing_residual_risk_preserved": bool(
+                source.get("outside_soloing_residual_risk_preserved", False)
             ),
             "final_landing_chord_tone_count_after": _int(
                 source.get("final_landing_chord_tone_count_after")
@@ -290,11 +319,26 @@ def validate_listening_review_input_guard_report(
         "duration_min_seconds": _float(source.get("duration_min_seconds")),
         "duration_max_seconds": _float(source.get("duration_max_seconds")),
         "changed_note_total": _int(source.get("changed_note_total")),
+        "objective_outside_soloing_pitch_role_risk_count": _int(
+            source.get("objective_outside_soloing_pitch_role_risk_count")
+        ),
         "weak_chord_tone_landing_risk_delta": _int(
             source.get("weak_chord_tone_landing_risk_delta")
         ),
+        "outside_soloing_pitch_role_risk_count_before": _int(
+            source.get("outside_soloing_pitch_role_risk_count_before")
+        ),
         "outside_soloing_pitch_role_risk_count_after": _int(
             source.get("outside_soloing_pitch_role_risk_count_after")
+        ),
+        "outside_soloing_pitch_role_risk_delta": _int(
+            source.get("outside_soloing_pitch_role_risk_delta")
+        ),
+        "outside_soloing_repair_targeted": bool(
+            source.get("outside_soloing_repair_targeted", True)
+        ),
+        "outside_soloing_residual_risk_preserved": bool(
+            source.get("outside_soloing_residual_risk_preserved", False)
         ),
         "final_landing_chord_tone_count_after": _int(
             source.get("final_landing_chord_tone_count_after")
@@ -334,8 +378,11 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- rendered audio file count: `{source['rendered_audio_file_count']}`",
         f"- duration range: `{source['duration_min_seconds']:.3f}s-{source['duration_max_seconds']:.3f}s`",
         f"- changed note total: `{source['changed_note_total']}`",
+        f"- objective outside-soloing pitch-role risk count: `{source['objective_outside_soloing_pitch_role_risk_count']}`",
         f"- weak chord-tone landing risk delta: `{source['weak_chord_tone_landing_risk_delta']}`",
-        f"- outside-soloing pitch-role risk count after: `{source['outside_soloing_pitch_role_risk_count_after']}`",
+        f"- outside-soloing pitch-role risk count: `{source['outside_soloing_pitch_role_risk_count_before']} -> {source['outside_soloing_pitch_role_risk_count_after']}`",
+        f"- outside-soloing repair targeted: `{_bool_token(source['outside_soloing_repair_targeted'])}`",
+        f"- outside-soloing residual risk preserved: `{_bool_token(source['outside_soloing_residual_risk_preserved'])}`",
         f"- final landing chord-tone count after: `{source['final_landing_chord_tone_count_after']}`",
         f"- audio review required: `{_bool_token(source['audio_review_required'])}`",
         f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input.py
@@ -35,8 +35,13 @@ def source_package(*, quality_claim: bool = False, validated_input: bool = False
             "duration_min_seconds": 18.871,
             "duration_max_seconds": 19.000,
             "changed_note_total": 40,
+            "objective_outside_soloing_pitch_role_risk_count": 5,
             "weak_chord_tone_landing_risk_delta": 6,
+            "outside_soloing_pitch_role_risk_count_before": 5,
             "outside_soloing_pitch_role_risk_count_after": 2,
+            "outside_soloing_pitch_role_risk_delta": 3,
+            "outside_soloing_repair_targeted": False,
+            "outside_soloing_residual_risk_preserved": True,
             "final_landing_chord_tone_count_after": 6,
             "audio_review_required": True,
         },
@@ -97,7 +102,12 @@ class StageBMidiToSoloChordToneLandingRepairListeningInputGuardTest(unittest.Tes
         self.assertEqual(summary["review_item_count"], 6)
         self.assertEqual(summary["required_input_field_count"], 4)
         self.assertEqual(summary["weak_chord_tone_landing_risk_delta"], 6)
+        self.assertEqual(summary["objective_outside_soloing_pitch_role_risk_count"], 5)
+        self.assertEqual(summary["outside_soloing_pitch_role_risk_count_before"], 5)
         self.assertEqual(summary["outside_soloing_pitch_role_risk_count_after"], 2)
+        self.assertEqual(summary["outside_soloing_pitch_role_risk_delta"], 3)
+        self.assertFalse(summary["outside_soloing_repair_targeted"])
+        self.assertTrue(summary["outside_soloing_residual_risk_preserved"])
         self.assertEqual(summary["final_landing_chord_tone_count_after"], 6)
         self.assertFalse(summary["human_audio_preference_claimed"])
         self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])


### PR DESCRIPTION
## Summary

- chord-tone landing repair input guard summary에 outside-soloing residual context 전달
- validated input 없음 상태에서 preference fill 차단 유지
- #880 문서와 하네스 issue number 갱신

## Context

- #878 listening review package 결과: review item `6`, validated input `false`, outside-soloing residual risk `5 -> 2`
- input guard는 preference fill 전 validated review input 존재 여부 확인 범위
- objective-only next decision에서 동일 residual context를 확인할 수 있도록 source summary 보존 필요

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input`
- `.venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-repair-listening-review-input-guard`
- `bash scripts/agent_harness.sh quick`

## Risk

- preference fill blocked 유지
- human/audio preference, MIDI-to-solo musical quality claim 제외 유지

Closes #880