### PR TITLE
Stage B MIDI-to-solo landing repair objective outside-soloing context refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -7291,6 +7291,54 @@ Issue #880은 Issue #878 listening review package의 outside-soloing residual co
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision refresh`
 
+## 9.132 Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing objective next outside-soloing context refresh
+
+Issue #882는 Issue #880 input guard의 outside-soloing residual context를 objective-only next decision까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup_decision`
+- selected target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup_decision`
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- changed note total: `40`
+- objective outside-soloing pitch-role risk count: `5`
+- weak chord-tone landing risk delta: `6`
+- outside-soloing pitch-role risk count: `5 -> 2`
+- outside-soloing repair targeted: `false`
+- outside-soloing residual risk preserved: `true`
+- final landing chord-tone count after: `6`
+- chord-tone landing follow-up required: `true`
+- current quality claim ready: `false`
+- critical user input required: `false`
+- human/audio preference claimed: `false`
+- audio rendered quality claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- validated review input pending 상태로 preference/quality claim 제외.
+- residual outside-soloing risk `2`로 follow-up decision 필요.
+- 다음 경계: chord-tone landing repair follow-up decision.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_next`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_next.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-repair-objective-only-next-decision`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -312,7 +312,10 @@
 - rendered audio file count: `6`
 - changed note total: `40`
 - weak chord-tone landing risk delta: `6`
-- outside-soloing pitch-role risk count after: `2`
+- objective outside-soloing pitch-role risk count: `5`
+- outside-soloing pitch-role risk count: `5 -> 2`
+- outside-soloing repair targeted: `false`
+- outside-soloing residual risk preserved: `true`
 - final landing chord-tone count after: `6`
 - chord-tone landing follow-up required: `true`
 - current quality claim ready: `false`

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-10.md
@@ -13,8 +13,11 @@
 - technical WAV validation: `true`
 - rendered audio file count: `6`
 - changed note total: `40`
+- objective outside-soloing pitch-role risk count: `5`
 - weak chord-tone landing risk delta: `6`
-- outside-soloing pitch-role risk count after: `2`
+- outside-soloing pitch-role risk count: `5 -> 2`
+- outside-soloing repair targeted: `false`
+- outside-soloing residual risk preserved: `true`
 - final landing chord-tone count after: `6`
 - chord-tone landing follow-up required: `true`
 - current quality claim ready: `false`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6792,7 +6792,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landin
     --run_id "$run_id" \
     --input_guard_report "$input_guard_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-10.md \
-    --issue_number 798 \
+    --issue_number 882 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_only_next_decision \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup_decision \
     --require_objective_decision \

--- a/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_next.py
+++ b/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_next.py
@@ -110,6 +110,20 @@ def validate_input_guard_report(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloChordToneLandingRepairObjectiveNextError(
             "rendered WAV count below 6"
         )
+    if _int(source.get("objective_outside_soloing_pitch_role_risk_count")) != _int(
+        source.get("outside_soloing_pitch_role_risk_count_before")
+    ):
+        raise StageBMidiToSoloChordToneLandingRepairObjectiveNextError(
+            "outside-soloing objective and source counts must match"
+        )
+    if bool(source.get("outside_soloing_repair_targeted", True)):
+        raise StageBMidiToSoloChordToneLandingRepairObjectiveNextError(
+            "outside-soloing repair target should remain false in objective next"
+        )
+    if not bool(source.get("outside_soloing_residual_risk_preserved", False)):
+        raise StageBMidiToSoloChordToneLandingRepairObjectiveNextError(
+            "outside-soloing residual risk context must be preserved"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloChordToneLandingRepairObjectiveNextError(
             "critical user input should not be required"
@@ -129,11 +143,26 @@ def validate_input_guard_report(report: dict[str, Any]) -> dict[str, Any]:
         "duration_min_seconds": _float(source.get("duration_min_seconds")),
         "duration_max_seconds": _float(source.get("duration_max_seconds")),
         "changed_note_total": _int(source.get("changed_note_total")),
+        "objective_outside_soloing_pitch_role_risk_count": _int(
+            source.get("objective_outside_soloing_pitch_role_risk_count")
+        ),
         "weak_chord_tone_landing_risk_delta": _int(
             source.get("weak_chord_tone_landing_risk_delta")
         ),
+        "outside_soloing_pitch_role_risk_count_before": _int(
+            source.get("outside_soloing_pitch_role_risk_count_before")
+        ),
         "outside_soloing_pitch_role_risk_count_after": _int(
             source.get("outside_soloing_pitch_role_risk_count_after")
+        ),
+        "outside_soloing_pitch_role_risk_delta": _int(
+            source.get("outside_soloing_pitch_role_risk_delta")
+        ),
+        "outside_soloing_repair_targeted": bool(
+            source.get("outside_soloing_repair_targeted", True)
+        ),
+        "outside_soloing_residual_risk_preserved": bool(
+            source.get("outside_soloing_residual_risk_preserved", False)
         ),
         "final_landing_chord_tone_count_after": _int(
             source.get("final_landing_chord_tone_count_after")
@@ -173,10 +202,25 @@ def build_objective_next_report(
             "duration_min_seconds": _float(source["duration_min_seconds"]),
             "duration_max_seconds": _float(source["duration_max_seconds"]),
             "changed_note_total": _int(source["changed_note_total"]),
+            "objective_outside_soloing_pitch_role_risk_count": _int(
+                source["objective_outside_soloing_pitch_role_risk_count"]
+            ),
             "weak_chord_tone_landing_risk_delta": _int(
                 source["weak_chord_tone_landing_risk_delta"]
             ),
+            "outside_soloing_pitch_role_risk_count_before": _int(
+                source["outside_soloing_pitch_role_risk_count_before"]
+            ),
             "outside_soloing_pitch_role_risk_count_after": residual_outside_risk,
+            "outside_soloing_pitch_role_risk_delta": _int(
+                source["outside_soloing_pitch_role_risk_delta"]
+            ),
+            "outside_soloing_repair_targeted": bool(
+                source["outside_soloing_repair_targeted"]
+            ),
+            "outside_soloing_residual_risk_preserved": bool(
+                source["outside_soloing_residual_risk_preserved"]
+            ),
             "final_landing_chord_tone_count_after": _int(
                 source["final_landing_chord_tone_count_after"]
             ),
@@ -195,6 +239,19 @@ def build_objective_next_report(
             "boundary": BOUNDARY,
             "objective_next_decision_completed": True,
             "technical_wav_validation": bool(source["technical_wav_validation"]),
+            "objective_outside_soloing_pitch_role_risk_count": _int(
+                source["objective_outside_soloing_pitch_role_risk_count"]
+            ),
+            "outside_soloing_pitch_role_risk_count_before": _int(
+                source["outside_soloing_pitch_role_risk_count_before"]
+            ),
+            "outside_soloing_pitch_role_risk_count_after": residual_outside_risk,
+            "outside_soloing_repair_targeted": bool(
+                source["outside_soloing_repair_targeted"]
+            ),
+            "outside_soloing_residual_risk_preserved": bool(
+                source["outside_soloing_residual_risk_preserved"]
+            ),
             "chord_tone_landing_followup_required": bool(followup_required),
             "current_quality_claim_ready": False,
             "human_audio_preference_claimed": False,
@@ -268,6 +325,20 @@ def validate_objective_next_report(
         raise StageBMidiToSoloChordToneLandingRepairObjectiveNextError(
             "quality claim readiness must remain false"
         )
+    if _int(summary.get("objective_outside_soloing_pitch_role_risk_count")) != _int(
+        summary.get("outside_soloing_pitch_role_risk_count_before")
+    ):
+        raise StageBMidiToSoloChordToneLandingRepairObjectiveNextError(
+            "outside-soloing objective and source counts must match"
+        )
+    if bool(summary.get("outside_soloing_repair_targeted", True)):
+        raise StageBMidiToSoloChordToneLandingRepairObjectiveNextError(
+            "outside-soloing repair target should remain false in objective next"
+        )
+    if not bool(summary.get("outside_soloing_residual_risk_preserved", False)):
+        raise StageBMidiToSoloChordToneLandingRepairObjectiveNextError(
+            "outside-soloing residual risk context must be preserved"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloChordToneLandingRepairObjectiveNextError(
             "critical user input should not be required"
@@ -291,11 +362,26 @@ def validate_objective_next_report(
         "technical_wav_validation": bool(summary.get("technical_wav_validation", False)),
         "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
         "changed_note_total": _int(summary.get("changed_note_total")),
+        "objective_outside_soloing_pitch_role_risk_count": _int(
+            summary.get("objective_outside_soloing_pitch_role_risk_count")
+        ),
         "weak_chord_tone_landing_risk_delta": _int(
             summary.get("weak_chord_tone_landing_risk_delta")
         ),
+        "outside_soloing_pitch_role_risk_count_before": _int(
+            summary.get("outside_soloing_pitch_role_risk_count_before")
+        ),
         "outside_soloing_pitch_role_risk_count_after": _int(
             summary.get("outside_soloing_pitch_role_risk_count_after")
+        ),
+        "outside_soloing_pitch_role_risk_delta": _int(
+            summary.get("outside_soloing_pitch_role_risk_delta")
+        ),
+        "outside_soloing_repair_targeted": bool(
+            summary.get("outside_soloing_repair_targeted", True)
+        ),
+        "outside_soloing_residual_risk_preserved": bool(
+            summary.get("outside_soloing_residual_risk_preserved", False)
         ),
         "final_landing_chord_tone_count_after": _int(
             summary.get("final_landing_chord_tone_count_after")
@@ -337,8 +423,11 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- technical WAV validation: `{_bool_token(summary['technical_wav_validation'])}`",
         f"- rendered audio file count: `{summary['rendered_audio_file_count']}`",
         f"- changed note total: `{summary['changed_note_total']}`",
+        f"- objective outside-soloing pitch-role risk count: `{summary['objective_outside_soloing_pitch_role_risk_count']}`",
         f"- weak chord-tone landing risk delta: `{summary['weak_chord_tone_landing_risk_delta']}`",
-        f"- outside-soloing pitch-role risk count after: `{summary['outside_soloing_pitch_role_risk_count_after']}`",
+        f"- outside-soloing pitch-role risk count: `{summary['outside_soloing_pitch_role_risk_count_before']} -> {summary['outside_soloing_pitch_role_risk_count_after']}`",
+        f"- outside-soloing repair targeted: `{_bool_token(summary['outside_soloing_repair_targeted'])}`",
+        f"- outside-soloing residual risk preserved: `{_bool_token(summary['outside_soloing_residual_risk_preserved'])}`",
         f"- final landing chord-tone count after: `{summary['final_landing_chord_tone_count_after']}`",
         f"- chord-tone landing follow-up required: `{_bool_token(summary['chord_tone_landing_followup_required'])}`",
         f"- current quality claim ready: `{_bool_token(summary['current_quality_claim_ready'])}`",
@@ -376,7 +465,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=798)
+    parser.add_argument("--issue_number", type=int, default=882)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--require_objective_decision", action="store_true")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_next.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_next.py
@@ -34,8 +34,13 @@ def input_guard_report(*, quality_claim: bool = False, outside_after: int = 2) -
                 "duration_min_seconds": 18.871,
                 "duration_max_seconds": 19.000,
                 "changed_note_total": 40,
+                "objective_outside_soloing_pitch_role_risk_count": 5,
                 "weak_chord_tone_landing_risk_delta": 6,
+                "outside_soloing_pitch_role_risk_count_before": 5,
                 "outside_soloing_pitch_role_risk_count_after": outside_after,
+                "outside_soloing_pitch_role_risk_delta": 5 - outside_after,
+                "outside_soloing_repair_targeted": False,
+                "outside_soloing_residual_risk_preserved": True,
                 "final_landing_chord_tone_count_after": 6,
                 "audio_review_required": True,
             },
@@ -69,7 +74,7 @@ class StageBMidiToSoloChordToneLandingRepairObjectiveNextTest(unittest.TestCase)
             report = build_objective_next_report(
                 input_guard_report=input_guard_report(),
                 output_dir=root / "objective_next",
-                issue_number=798,
+                issue_number=882,
             )
             summary = validate_objective_next_report(
                 report,
@@ -87,7 +92,12 @@ class StageBMidiToSoloChordToneLandingRepairObjectiveNextTest(unittest.TestCase)
             self.assertTrue(summary["technical_wav_validation"])
             self.assertEqual(summary["rendered_audio_file_count"], 6)
             self.assertEqual(summary["weak_chord_tone_landing_risk_delta"], 6)
+            self.assertEqual(summary["objective_outside_soloing_pitch_role_risk_count"], 5)
+            self.assertEqual(summary["outside_soloing_pitch_role_risk_count_before"], 5)
             self.assertEqual(summary["outside_soloing_pitch_role_risk_count_after"], 2)
+            self.assertEqual(summary["outside_soloing_pitch_role_risk_delta"], 3)
+            self.assertFalse(summary["outside_soloing_repair_targeted"])
+            self.assertTrue(summary["outside_soloing_residual_risk_preserved"])
             self.assertTrue(summary["chord_tone_landing_followup_required"])
             self.assertFalse(summary["current_quality_claim_ready"])
             self.assertFalse(summary["human_audio_preference_claimed"])
@@ -100,7 +110,7 @@ class StageBMidiToSoloChordToneLandingRepairObjectiveNextTest(unittest.TestCase)
                 build_objective_next_report(
                     input_guard_report=input_guard_report(quality_claim=True),
                     output_dir=root / "objective_next",
-                    issue_number=798,
+                    issue_number=882,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary
- chord-tone landing repair objective-only next decision의 outside-soloing residual context 보존
- objective/source outside-soloing count 일치 검증 추가
- follow-up decision 선택 근거에 residual outside-soloing risk 유지

## Context
- Issue #880 input guard 결과: weak chord-tone landing risk delta 6
- outside-soloing pitch-role risk count: 5 -> 2
- outside-soloing repair targeted: false
- outside-soloing residual risk preserved: true
- validated review input present: false

## Scope
- objective-only next decision 입력 검증 강화
- report/markdown validation summary 필드 확장
- status/Core Plan 기록 갱신
- harness issue number 갱신

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_next
- .venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_next.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-repair-objective-only-next-decision
- bash scripts/agent_harness.sh quick

## Risk
- human/audio preference claim 없음
- MIDI-to-solo musical quality claim 없음
- residual outside-soloing risk 2 후속 decision 필요

Closes #882