### PR TITLE
Stage B MIDI-to-solo landing repair follow-up outside-soloing context refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -7339,6 +7339,56 @@ Issue #882는 Issue #880 input guard의 outside-soloing residual context를 obje
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision refresh`
 
+## 9.133 Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair follow-up outside-soloing context refresh
+
+Issue #884는 Issue #882 objective-only next decision과 Issue #874 repair sweep의 outside-soloing residual context를 follow-up decision까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_only_next_decision`
+- repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep`
+- selected target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep`
+- primary remaining risk label: `outside_soloing_pitch_role_risk`
+- primary remaining risk count: `2`
+- weak chord-tone landing resolved: `true`
+- outside-soloing repair selected: `true`
+- candidate count: `6`
+- repaired MIDI count: `6`
+- changed note total: `40`
+- weak chord-tone landing risk delta: `6`
+- objective outside-soloing pitch-role risk count: `5`
+- outside-soloing pitch-role risk count: `5 -> 2`
+- outside-soloing pitch-role risk delta: `3`
+- outside-soloing repair targeted: `false`
+- outside-soloing residual risk preserved: `true`
+- final landing chord-tone count after: `6`
+- technical WAV validation: `true`
+- critical user input required: `false`
+- human/audio preference claimed: `false`
+- audio rendered quality claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- weak chord-tone landing risk는 `6 -> 0`으로 resolved.
+- outside-soloing pitch-role risk `2` 잔여.
+- outside-soloing repair는 아직 targeted `false`이며 다음 sweep에서 처리 대상.
+- listening preference와 musical quality claim 제외.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-repair-followup-decision`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -328,6 +328,10 @@
 - weak chord-tone landing resolved: `true`
 - outside-soloing repair selected: `true`
 - technical WAV validation: `true`
+- objective outside-soloing pitch-role risk count: `5`
+- outside-soloing pitch-role risk delta: `3`
+- outside-soloing repair targeted: `false`
+- outside-soloing residual risk preserved: `true`
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 repair target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep`

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_FOLLOWUP_DECISION_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_FOLLOWUP_DECISION_2026-06-10.md
@@ -15,7 +15,11 @@
 - repaired MIDI count: `6`
 - changed note total: `40`
 - weak chord-tone landing risk delta: `6`
+- objective outside-soloing pitch-role risk count: `5`
 - outside-soloing pitch-role risk count: `5 -> 2`
+- outside-soloing pitch-role risk delta: `3`
+- outside-soloing repair targeted: `false`
+- outside-soloing residual risk preserved: `true`
 - final landing chord-tone count after: `6`
 - technical WAV validation: `true`
 - human/audio preference claimed: `false`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6820,7 +6820,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landin
     --objective_next_report "$objective_report" \
     --repair_sweep_report "$sweep_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_FOLLOWUP_DECISION_2026-06-10.md \
-    --issue_number 800 \
+    --issue_number 884 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup_decision \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep \
     --expected_target songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep \

--- a/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup.py
+++ b/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup.py
@@ -133,6 +133,20 @@ def validate_objective_next_source(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloChordToneLandingRepairFollowupDecisionError(
             "residual outside-soloing pitch-role risk required"
         )
+    if _int(summary.get("objective_outside_soloing_pitch_role_risk_count")) != _int(
+        summary.get("outside_soloing_pitch_role_risk_count_before")
+    ):
+        raise StageBMidiToSoloChordToneLandingRepairFollowupDecisionError(
+            "objective outside-soloing count must match source count"
+        )
+    if bool(summary.get("outside_soloing_repair_targeted", True)):
+        raise StageBMidiToSoloChordToneLandingRepairFollowupDecisionError(
+            "outside-soloing repair target should remain false before follow-up"
+        )
+    if not bool(summary.get("outside_soloing_residual_risk_preserved", False)):
+        raise StageBMidiToSoloChordToneLandingRepairFollowupDecisionError(
+            "outside-soloing residual risk context must be preserved"
+        )
     if _int(summary.get("weak_chord_tone_landing_risk_delta")) <= 0:
         raise StageBMidiToSoloChordToneLandingRepairFollowupDecisionError(
             "weak chord-tone landing risk delta required"
@@ -163,8 +177,23 @@ def validate_objective_next_source(report: dict[str, Any]) -> dict[str, Any]:
         "weak_chord_tone_landing_risk_delta": _int(
             summary.get("weak_chord_tone_landing_risk_delta")
         ),
+        "objective_outside_soloing_pitch_role_risk_count": _int(
+            summary.get("objective_outside_soloing_pitch_role_risk_count")
+        ),
+        "outside_soloing_pitch_role_risk_count_before": _int(
+            summary.get("outside_soloing_pitch_role_risk_count_before")
+        ),
         "outside_soloing_pitch_role_risk_count_after": _int(
             summary.get("outside_soloing_pitch_role_risk_count_after")
+        ),
+        "outside_soloing_pitch_role_risk_delta": _int(
+            summary.get("outside_soloing_pitch_role_risk_delta")
+        ),
+        "outside_soloing_repair_targeted": bool(
+            summary.get("outside_soloing_repair_targeted", True)
+        ),
+        "outside_soloing_residual_risk_preserved": bool(
+            summary.get("outside_soloing_residual_risk_preserved", False)
         ),
         "final_landing_chord_tone_count_after": _int(
             summary.get("final_landing_chord_tone_count_after")
@@ -217,6 +246,20 @@ def validate_repair_sweep_source(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloChordToneLandingRepairFollowupDecisionError(
             "residual outside-soloing pitch-role risk required"
         )
+    if _int(aggregate.get("objective_outside_soloing_pitch_role_risk_count")) != _int(
+        aggregate.get("outside_soloing_pitch_role_risk_count_before")
+    ):
+        raise StageBMidiToSoloChordToneLandingRepairFollowupDecisionError(
+            "repair sweep objective outside-soloing count must match source count"
+        )
+    if bool(aggregate.get("outside_soloing_repair_targeted", True)):
+        raise StageBMidiToSoloChordToneLandingRepairFollowupDecisionError(
+            "repair sweep must preserve outside-soloing as untargeted"
+        )
+    if not bool(aggregate.get("outside_soloing_residual_risk_preserved", False)):
+        raise StageBMidiToSoloChordToneLandingRepairFollowupDecisionError(
+            "repair sweep must preserve outside-soloing residual risk context"
+        )
     if _int(aggregate.get("final_landing_chord_tone_count_after")) <= _int(
         aggregate.get("final_landing_chord_tone_count_before")
     ):
@@ -242,11 +285,23 @@ def validate_repair_sweep_source(report: dict[str, Any]) -> dict[str, Any]:
         "weak_chord_tone_landing_risk_delta": _int(
             aggregate.get("weak_chord_tone_landing_risk_delta")
         ),
+        "objective_outside_soloing_pitch_role_risk_count": _int(
+            aggregate.get("objective_outside_soloing_pitch_role_risk_count")
+        ),
         "outside_soloing_pitch_role_risk_count_before": _int(
             aggregate.get("outside_soloing_pitch_role_risk_count_before")
         ),
         "outside_soloing_pitch_role_risk_count_after": _int(
             aggregate.get("outside_soloing_pitch_role_risk_count_after")
+        ),
+        "outside_soloing_pitch_role_risk_delta": _int(
+            aggregate.get("outside_soloing_pitch_role_risk_delta")
+        ),
+        "outside_soloing_repair_targeted": bool(
+            aggregate.get("outside_soloing_repair_targeted", True)
+        ),
+        "outside_soloing_residual_risk_preserved": bool(
+            aggregate.get("outside_soloing_residual_risk_preserved", False)
         ),
         "final_landing_chord_tone_count_before": _int(
             aggregate.get("final_landing_chord_tone_count_before")
@@ -267,6 +322,22 @@ def build_followup_decision_report(
 ) -> dict[str, Any]:
     objective = validate_objective_next_source(objective_next_report)
     sweep = validate_repair_sweep_source(repair_sweep_report)
+    if _int(objective["outside_soloing_pitch_role_risk_count_before"]) != _int(
+        sweep["outside_soloing_pitch_role_risk_count_before"]
+    ) or _int(objective["outside_soloing_pitch_role_risk_count_after"]) != _int(
+        sweep["outside_soloing_pitch_role_risk_count_after"]
+    ):
+        raise StageBMidiToSoloChordToneLandingRepairFollowupDecisionError(
+            "objective and repair sweep outside-soloing risk counts must match"
+        )
+    if bool(objective["outside_soloing_repair_targeted"]) != bool(
+        sweep["outside_soloing_repair_targeted"]
+    ) or bool(objective["outside_soloing_residual_risk_preserved"]) != bool(
+        sweep["outside_soloing_residual_risk_preserved"]
+    ):
+        raise StageBMidiToSoloChordToneLandingRepairFollowupDecisionError(
+            "objective and repair sweep outside-soloing context flags must match"
+        )
     primary_risk_count = _int(objective["outside_soloing_pitch_role_risk_count_after"])
     weak_resolved = _int(sweep["weak_chord_tone_landing_risk_count_after"]) == 0
     return {
@@ -319,11 +390,23 @@ def build_followup_decision_report(
             "weak_chord_tone_landing_risk_delta": _int(
                 sweep["weak_chord_tone_landing_risk_delta"]
             ),
+            "objective_outside_soloing_pitch_role_risk_count": _int(
+                sweep["objective_outside_soloing_pitch_role_risk_count"]
+            ),
             "outside_soloing_pitch_role_risk_count_before": _int(
                 sweep["outside_soloing_pitch_role_risk_count_before"]
             ),
             "outside_soloing_pitch_role_risk_count_after": _int(
                 sweep["outside_soloing_pitch_role_risk_count_after"]
+            ),
+            "outside_soloing_pitch_role_risk_delta": _int(
+                sweep["outside_soloing_pitch_role_risk_delta"]
+            ),
+            "outside_soloing_repair_targeted": bool(
+                sweep["outside_soloing_repair_targeted"]
+            ),
+            "outside_soloing_residual_risk_preserved": bool(
+                sweep["outside_soloing_residual_risk_preserved"]
             ),
             "final_landing_chord_tone_count_after": _int(
                 sweep["final_landing_chord_tone_count_after"]
@@ -444,11 +527,23 @@ def validate_followup_decision_report(
         "weak_chord_tone_landing_risk_delta": _int(
             readiness.get("weak_chord_tone_landing_risk_delta")
         ),
+        "objective_outside_soloing_pitch_role_risk_count": _int(
+            readiness.get("objective_outside_soloing_pitch_role_risk_count")
+        ),
         "outside_soloing_pitch_role_risk_count_before": _int(
             readiness.get("outside_soloing_pitch_role_risk_count_before")
         ),
         "outside_soloing_pitch_role_risk_count_after": _int(
             readiness.get("outside_soloing_pitch_role_risk_count_after")
+        ),
+        "outside_soloing_pitch_role_risk_delta": _int(
+            readiness.get("outside_soloing_pitch_role_risk_delta")
+        ),
+        "outside_soloing_repair_targeted": bool(
+            readiness.get("outside_soloing_repair_targeted", True)
+        ),
+        "outside_soloing_residual_risk_preserved": bool(
+            readiness.get("outside_soloing_residual_risk_preserved", False)
         ),
         "final_landing_chord_tone_count_after": _int(
             readiness.get("final_landing_chord_tone_count_after")
@@ -489,7 +584,11 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- repaired MIDI count: `{readiness['repaired_midi_count']}`",
         f"- changed note total: `{readiness['changed_note_total']}`",
         f"- weak chord-tone landing risk delta: `{readiness['weak_chord_tone_landing_risk_delta']}`",
+        f"- objective outside-soloing pitch-role risk count: `{readiness['objective_outside_soloing_pitch_role_risk_count']}`",
         f"- outside-soloing pitch-role risk count: `{readiness['outside_soloing_pitch_role_risk_count_before']} -> {readiness['outside_soloing_pitch_role_risk_count_after']}`",
+        f"- outside-soloing pitch-role risk delta: `{readiness['outside_soloing_pitch_role_risk_delta']}`",
+        f"- outside-soloing repair targeted: `{_bool_token(readiness['outside_soloing_repair_targeted'])}`",
+        f"- outside-soloing residual risk preserved: `{_bool_token(readiness['outside_soloing_residual_risk_preserved'])}`",
         f"- final landing chord-tone count after: `{readiness['final_landing_chord_tone_count_after']}`",
         f"- technical WAV validation: `{_bool_token(readiness['technical_wav_validation'])}`",
         f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
@@ -530,7 +629,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=800)
+    parser.add_argument("--issue_number", type=int, default=884)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--expected_target", type=str, default="")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup.py
@@ -39,7 +39,12 @@ def objective_next_report(*, quality_claim: bool = False, outside_after: int = 2
             "duration_max_seconds": 19.0,
             "changed_note_total": 40,
             "weak_chord_tone_landing_risk_delta": 6,
+            "objective_outside_soloing_pitch_role_risk_count": 5,
+            "outside_soloing_pitch_role_risk_count_before": 5,
             "outside_soloing_pitch_role_risk_count_after": outside_after,
+            "outside_soloing_pitch_role_risk_delta": 5 - outside_after,
+            "outside_soloing_repair_targeted": False,
+            "outside_soloing_residual_risk_preserved": True,
             "final_landing_chord_tone_count_after": 6,
             "audio_review_required": True,
             "chord_tone_landing_followup_required": True,
@@ -122,7 +127,7 @@ class StageBMidiToSoloChordToneLandingRepairFollowupDecisionTest(unittest.TestCa
                 objective_next_report=objective_next_report(),
                 repair_sweep_report=repair_sweep_report(),
                 output_dir=Path(tmp) / "followup",
-                issue_number=800,
+                issue_number=884,
             )
             summary = validate_followup_decision_report(
                 report,
@@ -141,7 +146,12 @@ class StageBMidiToSoloChordToneLandingRepairFollowupDecisionTest(unittest.TestCa
             self.assertTrue(summary["weak_chord_tone_landing_resolved"])
             self.assertEqual(summary["changed_note_total"], 40)
             self.assertEqual(summary["weak_chord_tone_landing_risk_delta"], 6)
+            self.assertEqual(summary["objective_outside_soloing_pitch_role_risk_count"], 5)
+            self.assertEqual(summary["outside_soloing_pitch_role_risk_count_before"], 5)
             self.assertEqual(summary["outside_soloing_pitch_role_risk_count_after"], 2)
+            self.assertEqual(summary["outside_soloing_pitch_role_risk_delta"], 3)
+            self.assertFalse(summary["outside_soloing_repair_targeted"])
+            self.assertTrue(summary["outside_soloing_residual_risk_preserved"])
             self.assertEqual(summary["final_landing_chord_tone_count_after"], 6)
             self.assertTrue(summary["technical_wav_validation"])
             self.assertFalse(summary["human_audio_preference_claimed"])
@@ -156,7 +166,7 @@ class StageBMidiToSoloChordToneLandingRepairFollowupDecisionTest(unittest.TestCa
                     objective_next_report=objective_next_report(quality_claim=True),
                     repair_sweep_report=repair_sweep_report(),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=800,
+                    issue_number=884,
                 )
 
     def test_rejects_missing_repair_support(self) -> None:
@@ -168,7 +178,7 @@ class StageBMidiToSoloChordToneLandingRepairFollowupDecisionTest(unittest.TestCa
                     objective_next_report=objective_next_report(),
                     repair_sweep_report=repair_sweep_report(target_supported=False),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=800,
+                    issue_number=884,
                 )
 
     def test_rejects_missing_outside_soloing_risk(self) -> None:
@@ -180,7 +190,7 @@ class StageBMidiToSoloChordToneLandingRepairFollowupDecisionTest(unittest.TestCa
                     objective_next_report=objective_next_report(outside_after=0),
                     repair_sweep_report=repair_sweep_report(),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=800,
+                    issue_number=884,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary
- chord-tone landing repair follow-up decision의 outside-soloing residual context 보존
- objective next source와 repair sweep source의 outside-soloing count/flag 일치 검증 추가
- follow-up report/readiness/markdown에 objective count, delta, targeted, residual preserved 필드 반영

## Context
- Issue #882 objective-only next decision 결과: outside-soloing pitch-role risk 5 -> 2
- outside-soloing pitch-role risk delta: 3
- outside-soloing repair targeted: false
- outside-soloing residual risk preserved: true
- weak chord-tone landing risk delta: 6

## Scope
- follow-up decision 입력 검증 강화
- validation summary와 generated markdown 필드 확장
- status/Core Plan 기록 갱신
- harness issue number 갱신

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup
- .venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-repair-followup-decision
- bash scripts/agent_harness.sh quick

## Risk
- human/audio preference claim 없음
- MIDI-to-solo musical quality claim 없음
- outside-soloing repair execution은 다음 sweep 범위

Closes #884