### PR TITLE
Stage B MIDI-to-solo outside-soloing repair audio source context refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -7441,6 +7441,54 @@ Issue #886은 Issue #884 follow-up decision에서 전달한 source outside-soloi
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package refresh`
 
+## 9.135 Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio source context refresh
+
+Issue #888은 Issue #886 outside-soloing repair sweep의 source/current repair context를 WAV audio package summary까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package`
+- rendered audio file count: `6`
+- technical WAV validation: `true`
+- sample rate: `44100`
+- duration range: `18.871s-19.000s`
+- changed note total: `2`
+- source objective outside-soloing pitch-role risk count: `5`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- source outside-soloing pitch-role risk delta: `3`
+- source outside-soloing repair targeted: `false`
+- source outside-soloing residual risk preserved: `true`
+- outside-soloing pitch-role risk count: `2 -> 0`
+- outside-soloing pitch-role risk delta: `2`
+- outside-soloing repair targeted: `true`
+- weak chord-tone landing risk count after: `0`
+- final landing chord-tone count after: `6`
+- max non-chord-tone run: `4 -> 3`
+- audio review required: `true`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- WAV technical metadata는 유효하지만 audio quality/preference claim 제외.
+- source outside-soloing context `5 -> 2`와 current repair result `2 -> 0`을 분리 보존.
+- 다음 boundary는 rendered WAV/MIDI 후보의 listening review package.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio`
+- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-outside-soloing-repair-audio-package`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -355,7 +355,11 @@
 - WAV duration range: `18.871s-19.000s`
 - technical WAV validation: `true`
 - changed note total: `2`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- source outside-soloing repair targeted: `false`
+- source outside-soloing residual risk preserved: `true`
 - outside-soloing pitch-role risk count: `2 -> 0`
+- outside-soloing repair targeted: `true`
 - weak chord-tone landing risk count after: `0`
 - final landing chord-tone count after: `6`
 - audio rendered quality claim: `false`

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_AUDIO_PACKAGE_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_AUDIO_PACKAGE_2026-06-10.md
@@ -9,8 +9,14 @@
 - technical WAV validation: `true`
 - duration range: `18.871s-19.000s`
 - changed note total: `2`
+- source objective outside-soloing pitch-role risk count: `5`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- source outside-soloing pitch-role risk delta: `3`
+- source outside-soloing repair targeted: `false`
+- source outside-soloing residual risk preserved: `true`
 - outside-soloing pitch-role risk count: `2 -> 0`
 - outside-soloing pitch-role risk delta: `2`
+- outside-soloing repair targeted: `true`
 - weak chord-tone landing risk count after: `0`
 - final landing chord-tone count after: `6`
 - max non-chord-tone run: `4 -> 3`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6870,7 +6870,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landin
     --run_id "$run_id" \
     --outside_soloing_repair_sweep_report "$sweep_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_AUDIO_PACKAGE_2026-06-10.md \
-    --issue_number 804 \
+    --issue_number 888 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package \
     --expected_file_count 6 \

--- a/scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio.py
+++ b/scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio.py
@@ -310,6 +310,24 @@ def build_audio_render_report(
             "duration_min_seconds": min(durations, default=0.0),
             "duration_max_seconds": max(durations, default=0.0),
             "changed_note_total": _int(aggregate.get("changed_note_total")),
+            "source_objective_outside_soloing_pitch_role_risk_count": _int(
+                aggregate.get("source_objective_outside_soloing_pitch_role_risk_count")
+            ),
+            "source_outside_soloing_pitch_role_risk_count_before": _int(
+                aggregate.get("source_outside_soloing_pitch_role_risk_count_before")
+            ),
+            "source_outside_soloing_pitch_role_risk_count_after": _int(
+                aggregate.get("source_outside_soloing_pitch_role_risk_count_after")
+            ),
+            "source_outside_soloing_pitch_role_risk_delta": _int(
+                aggregate.get("source_outside_soloing_pitch_role_risk_delta")
+            ),
+            "source_outside_soloing_repair_targeted": bool(
+                aggregate.get("source_outside_soloing_repair_targeted", True)
+            ),
+            "source_outside_soloing_residual_risk_preserved": bool(
+                aggregate.get("source_outside_soloing_residual_risk_preserved", False)
+            ),
             "outside_soloing_pitch_role_risk_count_before": _int(
                 aggregate.get("outside_soloing_pitch_role_risk_count_before")
             ),
@@ -318,6 +336,9 @@ def build_audio_render_report(
             ),
             "outside_soloing_pitch_role_risk_delta": _int(
                 aggregate.get("outside_soloing_pitch_role_risk_delta")
+            ),
+            "outside_soloing_repair_targeted": bool(
+                aggregate.get("outside_soloing_repair_targeted", False)
             ),
             "weak_chord_tone_landing_risk_count_after": _int(
                 aggregate.get("weak_chord_tone_landing_risk_count_after")
@@ -340,6 +361,27 @@ def build_audio_render_report(
             "rendered_audio_file_count": int(len(rendered)),
             "technical_wav_validation": True,
             "outside_soloing_repair_audio_package_completed": True,
+            "source_objective_outside_soloing_pitch_role_risk_count": _int(
+                aggregate.get("source_objective_outside_soloing_pitch_role_risk_count")
+            ),
+            "source_outside_soloing_pitch_role_risk_count_before": _int(
+                aggregate.get("source_outside_soloing_pitch_role_risk_count_before")
+            ),
+            "source_outside_soloing_pitch_role_risk_count_after": _int(
+                aggregate.get("source_outside_soloing_pitch_role_risk_count_after")
+            ),
+            "source_outside_soloing_pitch_role_risk_delta": _int(
+                aggregate.get("source_outside_soloing_pitch_role_risk_delta")
+            ),
+            "source_outside_soloing_repair_targeted": bool(
+                aggregate.get("source_outside_soloing_repair_targeted", True)
+            ),
+            "source_outside_soloing_residual_risk_preserved": bool(
+                aggregate.get("source_outside_soloing_residual_risk_preserved", False)
+            ),
+            "outside_soloing_repair_targeted": bool(
+                aggregate.get("outside_soloing_repair_targeted", False)
+            ),
             "human_audio_preference_claimed": False,
             "audio_rendered_quality_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
@@ -425,6 +467,18 @@ def validate_audio_render_report(
         raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
             "critical user input should not be required"
         )
+    if bool(summary.get("source_outside_soloing_repair_targeted", True)):
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+            "source outside-soloing repair target should remain false"
+        )
+    if not bool(summary.get("source_outside_soloing_residual_risk_preserved", False)):
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+            "source outside-soloing residual risk context must be preserved"
+        )
+    if not bool(summary.get("outside_soloing_repair_targeted", False)):
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+            "outside-soloing repair must be targeted before audio package"
+        )
     if require_no_quality_claim:
         _require_no_quality_claim(boundary, label="audio render boundary")
     return {
@@ -440,6 +494,24 @@ def validate_audio_render_report(
         "duration_min_seconds": _float(summary.get("duration_min_seconds")),
         "duration_max_seconds": _float(summary.get("duration_max_seconds")),
         "changed_note_total": _int(summary.get("changed_note_total")),
+        "source_objective_outside_soloing_pitch_role_risk_count": _int(
+            summary.get("source_objective_outside_soloing_pitch_role_risk_count")
+        ),
+        "source_outside_soloing_pitch_role_risk_count_before": _int(
+            summary.get("source_outside_soloing_pitch_role_risk_count_before")
+        ),
+        "source_outside_soloing_pitch_role_risk_count_after": _int(
+            summary.get("source_outside_soloing_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_pitch_role_risk_delta": _int(
+            summary.get("source_outside_soloing_pitch_role_risk_delta")
+        ),
+        "source_outside_soloing_repair_targeted": bool(
+            summary.get("source_outside_soloing_repair_targeted", True)
+        ),
+        "source_outside_soloing_residual_risk_preserved": bool(
+            summary.get("source_outside_soloing_residual_risk_preserved", False)
+        ),
         "outside_soloing_pitch_role_risk_count_before": _int(
             summary.get("outside_soloing_pitch_role_risk_count_before")
         ),
@@ -448,6 +520,9 @@ def validate_audio_render_report(
         ),
         "outside_soloing_pitch_role_risk_delta": _int(
             summary.get("outside_soloing_pitch_role_risk_delta")
+        ),
+        "outside_soloing_repair_targeted": bool(
+            summary.get("outside_soloing_repair_targeted", False)
         ),
         "weak_chord_tone_landing_risk_count_after": _int(
             summary.get("weak_chord_tone_landing_risk_count_after")
@@ -496,8 +571,14 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- technical WAV validation: `{_bool_token(boundary['technical_wav_validation'])}`",
         f"- duration range: `{summary['duration_min_seconds']:.3f}s-{summary['duration_max_seconds']:.3f}s`",
         f"- changed note total: `{summary['changed_note_total']}`",
+        f"- source objective outside-soloing pitch-role risk count: `{summary['source_objective_outside_soloing_pitch_role_risk_count']}`",
+        f"- source outside-soloing pitch-role risk count: `{summary['source_outside_soloing_pitch_role_risk_count_before']} -> {summary['source_outside_soloing_pitch_role_risk_count_after']}`",
+        f"- source outside-soloing pitch-role risk delta: `{summary['source_outside_soloing_pitch_role_risk_delta']}`",
+        f"- source outside-soloing repair targeted: `{_bool_token(summary['source_outside_soloing_repair_targeted'])}`",
+        f"- source outside-soloing residual risk preserved: `{_bool_token(summary['source_outside_soloing_residual_risk_preserved'])}`",
         f"- outside-soloing pitch-role risk count: `{summary['outside_soloing_pitch_role_risk_count_before']} -> {summary['outside_soloing_pitch_role_risk_count_after']}`",
         f"- outside-soloing pitch-role risk delta: `{summary['outside_soloing_pitch_role_risk_delta']}`",
+        f"- outside-soloing repair targeted: `{_bool_token(summary['outside_soloing_repair_targeted'])}`",
         f"- weak chord-tone landing risk count after: `{summary['weak_chord_tone_landing_risk_count_after']}`",
         f"- final landing chord-tone count after: `{summary['final_landing_chord_tone_count_after']}`",
         f"- max non-chord-tone run: `{summary['max_non_chord_tone_run_before']} -> {summary['max_non_chord_tone_run_after']}`",
@@ -541,7 +622,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=804)
+    parser.add_argument("--issue_number", type=int, default=888)
     parser.add_argument("--renderer", type=str, default=shutil.which("fluidsynth") or "")
     parser.add_argument("--soundfont", type=str, default="")
     parser.add_argument("--sample_rate", type=int, default=44100)

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio.py
@@ -169,8 +169,17 @@ class StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioTest(unittest.Tes
             self.assertTrue(summary["outside_soloing_repair_audio_package_completed"])
             self.assertEqual(summary["rendered_audio_file_count"], 6)
             self.assertTrue(summary["technical_wav_validation"])
+            self.assertEqual(
+                summary["source_objective_outside_soloing_pitch_role_risk_count"], 5
+            )
+            self.assertEqual(summary["source_outside_soloing_pitch_role_risk_count_before"], 5)
+            self.assertEqual(summary["source_outside_soloing_pitch_role_risk_count_after"], 2)
+            self.assertEqual(summary["source_outside_soloing_pitch_role_risk_delta"], 3)
+            self.assertFalse(summary["source_outside_soloing_repair_targeted"])
+            self.assertTrue(summary["source_outside_soloing_residual_risk_preserved"])
             self.assertEqual(summary["outside_soloing_pitch_role_risk_delta"], 2)
             self.assertEqual(summary["outside_soloing_pitch_role_risk_count_after"], 0)
+            self.assertTrue(summary["outside_soloing_repair_targeted"])
             self.assertEqual(summary["weak_chord_tone_landing_risk_count_after"], 0)
             self.assertEqual(summary["max_non_chord_tone_run_after"], 3)
             self.assertTrue(summary["audio_review_required"])


### PR DESCRIPTION
## Summary
- outside-soloing repair audio package summary에 source/current repair context 반영
- source outside-soloing 5 -> 2와 current repair 2 -> 0을 분리 기록
- validation summary와 generated markdown 필드 확장

## Context
- Issue #886 outside-soloing repair sweep source context: 5 -> 2
- current outside-soloing repair result: 2 -> 0
- changed note total: 2
- rendered audio file count: 6
- technical WAV validation: true

## Scope
- audio package summary/boundary 필드 확장
- validation summary 반환 필드 확장
- status/Core Plan과 generated doc 갱신
- harness issue number 갱신

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio
- .venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-outside-soloing-repair-audio-package
- bash scripts/agent_harness.sh quick

## Risk
- audio rendered quality claim 없음
- human/audio preference claim 없음
- MIDI-to-solo musical quality claim 없음

Closes #888