### PR TITLE
Stage B MIDI-to-solo outside-soloing repair listening review source context refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -7489,6 +7489,55 @@ Issue #888은 Issue #886 outside-soloing repair sweep의 source/current repair c
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package refresh`
 
+## 9.136 Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review source context refresh
+
+Issue #890은 Issue #888 audio package의 source/current repair context를 listening review package까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_input_guard`
+- package ready: `true`
+- review item count: `6`
+- validated review input: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- duration range: `18.871s-19.000s`
+- changed note total: `2`
+- source objective outside-soloing pitch-role risk count: `5`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- source outside-soloing pitch-role risk delta: `3`
+- source outside-soloing repair targeted: `false`
+- source outside-soloing residual risk preserved: `true`
+- outside-soloing pitch-role risk count: `2 -> 0`
+- outside-soloing pitch-role risk delta: `2`
+- outside-soloing repair targeted: `true`
+- weak chord-tone landing risk count after: `0`
+- final landing chord-tone count after: `6`
+- max non-chord-tone run after: `3`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- WAV/MIDI review item `6`개 패키징 완료.
+- validated review input 없음.
+- source/current repair context 보존 완료.
+- preference fill과 musical quality claim 제외.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-outside-soloing-repair-listening-review-package`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -371,7 +371,12 @@
 - validated review input: `false`
 - technical WAV validation: `true`
 - rendered audio file count: `6`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- source outside-soloing repair targeted: `false`
+- source outside-soloing residual risk preserved: `true`
 - outside-soloing pitch-role risk count after: `0`
+- outside-soloing pitch-role risk delta: `2`
+- outside-soloing repair targeted: `true`
 - max non-chord-tone run after: `3`
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_LISTENING_REVIEW_PACKAGE_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_LISTENING_REVIEW_PACKAGE_2026-06-10.md
@@ -11,8 +11,14 @@
 - rendered audio file count: `6`
 - duration range: `18.871s-19.000s`
 - changed note total: `2`
+- source objective outside-soloing pitch-role risk count: `5`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- source outside-soloing pitch-role risk delta: `3`
+- source outside-soloing repair targeted: `false`
+- source outside-soloing residual risk preserved: `true`
 - outside-soloing pitch-role risk count after: `0`
 - outside-soloing pitch-role risk delta: `2`
+- outside-soloing repair targeted: `true`
 - weak chord-tone landing risk count after: `0`
 - final landing chord-tone count after: `6`
 - max non-chord-tone run after: `3`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6892,7 +6892,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landin
     --run_id "$review_run_id" \
     --audio_package_report "$audio_package_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_LISTENING_REVIEW_PACKAGE_2026-06-10.md \
-    --issue_number 806 \
+    --issue_number 890 \
     --expected_review_item_count 6 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_input_guard \

--- a/scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package.py
+++ b/scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package.py
@@ -122,6 +122,18 @@ def validate_audio_package_report(
         raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairListeningReviewPackageError(
             "critical user input should not be required"
         )
+    if bool(summary.get("source_outside_soloing_repair_targeted", True)):
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairListeningReviewPackageError(
+            "source outside-soloing repair target should remain false"
+        )
+    if not bool(summary.get("source_outside_soloing_residual_risk_preserved", False)):
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairListeningReviewPackageError(
+            "source outside-soloing residual risk context must be preserved"
+        )
+    if not bool(summary.get("outside_soloing_repair_targeted", False)):
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairListeningReviewPackageError(
+            "outside-soloing repair should be targeted before listening package"
+        )
     _require_no_quality_claim(boundary, label="audio package boundary")
 
     rendered = [_dict(item) for item in _list(report.get("rendered_audio_files"))]
@@ -193,6 +205,24 @@ def build_listening_review_package_report(
             "duration_min_seconds": _float(summary.get("duration_min_seconds")),
             "duration_max_seconds": _float(summary.get("duration_max_seconds")),
             "changed_note_total": _int(summary.get("changed_note_total")),
+            "source_objective_outside_soloing_pitch_role_risk_count": _int(
+                summary.get("source_objective_outside_soloing_pitch_role_risk_count")
+            ),
+            "source_outside_soloing_pitch_role_risk_count_before": _int(
+                summary.get("source_outside_soloing_pitch_role_risk_count_before")
+            ),
+            "source_outside_soloing_pitch_role_risk_count_after": _int(
+                summary.get("source_outside_soloing_pitch_role_risk_count_after")
+            ),
+            "source_outside_soloing_pitch_role_risk_delta": _int(
+                summary.get("source_outside_soloing_pitch_role_risk_delta")
+            ),
+            "source_outside_soloing_repair_targeted": bool(
+                summary.get("source_outside_soloing_repair_targeted", True)
+            ),
+            "source_outside_soloing_residual_risk_preserved": bool(
+                summary.get("source_outside_soloing_residual_risk_preserved", False)
+            ),
             "outside_soloing_pitch_role_risk_count_before": _int(
                 summary.get("outside_soloing_pitch_role_risk_count_before")
             ),
@@ -201,6 +231,9 @@ def build_listening_review_package_report(
             ),
             "outside_soloing_pitch_role_risk_delta": _int(
                 summary.get("outside_soloing_pitch_role_risk_delta")
+            ),
+            "outside_soloing_repair_targeted": bool(
+                summary.get("outside_soloing_repair_targeted", False)
             ),
             "weak_chord_tone_landing_risk_count_after": _int(
                 summary.get("weak_chord_tone_landing_risk_count_after")
@@ -301,6 +334,18 @@ def validate_listening_review_package_report(
         raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairListeningReviewPackageError(
             "critical user input should not be required"
         )
+    if bool(source.get("source_outside_soloing_repair_targeted", True)):
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairListeningReviewPackageError(
+            "source outside-soloing repair target should remain false"
+        )
+    if not bool(source.get("source_outside_soloing_residual_risk_preserved", False)):
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairListeningReviewPackageError(
+            "source outside-soloing residual risk context must be preserved"
+        )
+    if not bool(source.get("outside_soloing_repair_targeted", False)):
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairListeningReviewPackageError(
+            "outside-soloing repair should remain targeted in package summary"
+        )
     if require_no_quality_claim:
         _require_no_quality_claim(readiness, label="listening package readiness")
     return {
@@ -317,11 +362,32 @@ def validate_listening_review_package_report(
         "duration_min_seconds": _float(source.get("duration_min_seconds")),
         "duration_max_seconds": _float(source.get("duration_max_seconds")),
         "changed_note_total": _int(source.get("changed_note_total")),
+        "source_objective_outside_soloing_pitch_role_risk_count": _int(
+            source.get("source_objective_outside_soloing_pitch_role_risk_count")
+        ),
+        "source_outside_soloing_pitch_role_risk_count_before": _int(
+            source.get("source_outside_soloing_pitch_role_risk_count_before")
+        ),
+        "source_outside_soloing_pitch_role_risk_count_after": _int(
+            source.get("source_outside_soloing_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_pitch_role_risk_delta": _int(
+            source.get("source_outside_soloing_pitch_role_risk_delta")
+        ),
+        "source_outside_soloing_repair_targeted": bool(
+            source.get("source_outside_soloing_repair_targeted", True)
+        ),
+        "source_outside_soloing_residual_risk_preserved": bool(
+            source.get("source_outside_soloing_residual_risk_preserved", False)
+        ),
         "outside_soloing_pitch_role_risk_count_after": _int(
             source.get("outside_soloing_pitch_role_risk_count_after")
         ),
         "outside_soloing_pitch_role_risk_delta": _int(
             source.get("outside_soloing_pitch_role_risk_delta")
+        ),
+        "outside_soloing_repair_targeted": bool(
+            source.get("outside_soloing_repair_targeted", False)
         ),
         "weak_chord_tone_landing_risk_count_after": _int(
             source.get("weak_chord_tone_landing_risk_count_after")
@@ -369,8 +435,14 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- rendered audio file count: `{source['rendered_audio_file_count']}`",
         f"- duration range: `{source['duration_min_seconds']:.3f}s-{source['duration_max_seconds']:.3f}s`",
         f"- changed note total: `{source['changed_note_total']}`",
+        f"- source objective outside-soloing pitch-role risk count: `{source['source_objective_outside_soloing_pitch_role_risk_count']}`",
+        f"- source outside-soloing pitch-role risk count: `{source['source_outside_soloing_pitch_role_risk_count_before']} -> {source['source_outside_soloing_pitch_role_risk_count_after']}`",
+        f"- source outside-soloing pitch-role risk delta: `{source['source_outside_soloing_pitch_role_risk_delta']}`",
+        f"- source outside-soloing repair targeted: `{_bool_token(source['source_outside_soloing_repair_targeted'])}`",
+        f"- source outside-soloing residual risk preserved: `{_bool_token(source['source_outside_soloing_residual_risk_preserved'])}`",
         f"- outside-soloing pitch-role risk count after: `{source['outside_soloing_pitch_role_risk_count_after']}`",
         f"- outside-soloing pitch-role risk delta: `{source['outside_soloing_pitch_role_risk_delta']}`",
+        f"- outside-soloing repair targeted: `{_bool_token(source['outside_soloing_repair_targeted'])}`",
         f"- weak chord-tone landing risk count after: `{source['weak_chord_tone_landing_risk_count_after']}`",
         f"- final landing chord-tone count after: `{source['final_landing_chord_tone_count_after']}`",
         f"- max non-chord-tone run after: `{source['max_non_chord_tone_run_after']}`",
@@ -422,7 +494,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=806)
+    parser.add_argument("--issue_number", type=int, default=890)
     parser.add_argument("--expected_review_item_count", type=int, default=6)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package.py
@@ -104,9 +104,16 @@ def audio_package_report(root: Path, *, quality_claim: bool = False) -> dict:
             "duration_min_seconds": 0.1,
             "duration_max_seconds": 0.1,
             "changed_note_total": 2,
+            "source_objective_outside_soloing_pitch_role_risk_count": 5,
+            "source_outside_soloing_pitch_role_risk_count_before": 5,
+            "source_outside_soloing_pitch_role_risk_count_after": 2,
+            "source_outside_soloing_pitch_role_risk_delta": 3,
+            "source_outside_soloing_repair_targeted": False,
+            "source_outside_soloing_residual_risk_preserved": True,
             "outside_soloing_pitch_role_risk_count_before": 2,
             "outside_soloing_pitch_role_risk_count_after": 0,
             "outside_soloing_pitch_role_risk_delta": 2,
+            "outside_soloing_repair_targeted": True,
             "weak_chord_tone_landing_risk_count_after": 0,
             "final_landing_chord_tone_count_after": 6,
             "max_non_chord_tone_run_before": 4,
@@ -127,7 +134,7 @@ class StageBMidiToSoloChordToneLandingOutsideSoloingRepairListeningReviewPackage
             report = build_listening_review_package_report(
                 audio_package_report=audio_package_report(root),
                 output_dir=root / "review_package",
-                issue_number=806,
+                issue_number=890,
                 expected_count=6,
             )
             summary = validate_listening_review_package_report(
@@ -143,8 +150,17 @@ class StageBMidiToSoloChordToneLandingOutsideSoloingRepairListeningReviewPackage
             self.assertEqual(summary["review_item_count"], 6)
             self.assertFalse(summary["validated_review_input"])
             self.assertTrue(summary["technical_wav_validation"])
+            self.assertEqual(
+                summary["source_objective_outside_soloing_pitch_role_risk_count"], 5
+            )
+            self.assertEqual(summary["source_outside_soloing_pitch_role_risk_count_before"], 5)
+            self.assertEqual(summary["source_outside_soloing_pitch_role_risk_count_after"], 2)
+            self.assertEqual(summary["source_outside_soloing_pitch_role_risk_delta"], 3)
+            self.assertFalse(summary["source_outside_soloing_repair_targeted"])
+            self.assertTrue(summary["source_outside_soloing_residual_risk_preserved"])
             self.assertEqual(summary["outside_soloing_pitch_role_risk_delta"], 2)
             self.assertEqual(summary["outside_soloing_pitch_role_risk_count_after"], 0)
+            self.assertTrue(summary["outside_soloing_repair_targeted"])
             self.assertEqual(summary["weak_chord_tone_landing_risk_count_after"], 0)
             self.assertEqual(summary["final_landing_chord_tone_count_after"], 6)
             self.assertEqual(summary["max_non_chord_tone_run_after"], 3)
@@ -160,7 +176,7 @@ class StageBMidiToSoloChordToneLandingOutsideSoloingRepairListeningReviewPackage
                 build_listening_review_package_report(
                     audio_package_report=audio_package_report(root, quality_claim=True),
                     output_dir=root / "review_package",
-                    issue_number=806,
+                    issue_number=890,
                     expected_count=6,
                 )
 


### PR DESCRIPTION
## Summary
- outside-soloing repair listening review package source_summary에 source/current repair context 반영
- source outside-soloing 5 -> 2와 current repair 2 -> 0을 review package까지 보존
- validation summary와 generated markdown 필드 확장

## Context
- Issue #888 audio package summary: source outside-soloing 5 -> 2
- current outside-soloing repair result: 2 -> 0
- review item count: 6
- validated review input: false

## Scope
- listening review package source_summary 필드 확장
- validation summary 반환 필드 확장
- status/Core Plan과 generated doc 갱신
- harness issue number 갱신

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package
- .venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-outside-soloing-repair-listening-review-package
- bash scripts/agent_harness.sh quick

## Risk
- human/audio preference claim 없음
- MIDI-to-solo musical quality claim 없음
- validated review input 없음

Closes #890