### PR TITLE
Stage B MIDI-to-solo outside-soloing repair input guard source context refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -7538,6 +7538,56 @@ Issue #890은 Issue #888 audio package의 source/current repair context를 liste
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard refresh`
 
+## 9.137 Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair input guard source context refresh
+
+Issue #892는 Issue #890 listening review package의 source/current repair context를 input guard까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_input_guard`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_only_next_decision`
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- changed note total: `2`
+- source objective outside-soloing pitch-role risk count: `5`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- source outside-soloing pitch-role risk delta: `3`
+- source outside-soloing repair targeted: `false`
+- source outside-soloing residual risk preserved: `true`
+- outside-soloing pitch-role risk count after: `0`
+- outside-soloing pitch-role risk delta: `2`
+- outside-soloing repair targeted: `true`
+- weak chord-tone landing risk count after: `0`
+- final landing chord-tone count after: `6`
+- max non-chord-tone run after: `3`
+- audio review required: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- validated review input pending 상태로 preference fill 차단.
+- source/current repair context 보존 완료.
+- human/audio preference와 MIDI-to-solo musical quality claim 제외.
+- 다음 boundary는 objective-only next decision.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_input`
+- `.venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_input.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-outside-soloing-repair-listening-review-input-guard`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -389,8 +389,12 @@
 - technical WAV validation: `true`
 - rendered audio file count: `6`
 - changed note total: `2`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- source outside-soloing repair targeted: `false`
+- source outside-soloing residual risk preserved: `true`
 - outside-soloing pitch-role risk count after: `0`
 - outside-soloing pitch-role risk delta: `2`
+- outside-soloing repair targeted: `true`
 - weak chord-tone landing risk count after: `0`
 - final landing chord-tone count after: `6`
 - max non-chord-tone run after: `3`

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_LISTENING_REVIEW_INPUT_GUARD_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_LISTENING_REVIEW_INPUT_GUARD_2026-06-10.md
@@ -13,8 +13,14 @@
 - rendered audio file count: `6`
 - duration range: `18.871s-19.000s`
 - changed note total: `2`
+- source objective outside-soloing pitch-role risk count: `5`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- source outside-soloing pitch-role risk delta: `3`
+- source outside-soloing repair targeted: `false`
+- source outside-soloing residual risk preserved: `true`
 - outside-soloing pitch-role risk count after: `0`
 - outside-soloing pitch-role risk delta: `2`
+- outside-soloing repair targeted: `true`
 - weak chord-tone landing risk count after: `0`
 - final landing chord-tone count after: `6`
 - max non-chord-tone run after: `3`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6913,7 +6913,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landin
     --run_id "$guard_run_id" \
     --source_package "$review_package_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_LISTENING_REVIEW_INPUT_GUARD_2026-06-10.md \
-    --issue_number 808 \
+    --issue_number 892 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_input_guard \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_only_next_decision \
     --require_guard_completed \

--- a/scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_input.py
+++ b/scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_input.py
@@ -131,6 +131,18 @@ def validate_source_package(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloOutsideSoloingRepairListeningInputGuardError(
             "critical user input should not be required"
         )
+    if bool(source.get("source_outside_soloing_repair_targeted", True)):
+        raise StageBMidiToSoloOutsideSoloingRepairListeningInputGuardError(
+            "source outside-soloing repair target should remain false"
+        )
+    if not bool(source.get("source_outside_soloing_residual_risk_preserved", False)):
+        raise StageBMidiToSoloOutsideSoloingRepairListeningInputGuardError(
+            "source outside-soloing residual risk context must be preserved"
+        )
+    if not bool(source.get("outside_soloing_repair_targeted", False)):
+        raise StageBMidiToSoloOutsideSoloingRepairListeningInputGuardError(
+            "outside-soloing repair should remain targeted before input guard"
+        )
     _require_no_quality_claim(readiness, label="outside-soloing repair listening package readiness")
     return {
         "boundary": SOURCE_BOUNDARY,
@@ -148,11 +160,32 @@ def validate_source_package(report: dict[str, Any]) -> dict[str, Any]:
             "duration_min_seconds": _float(source.get("duration_min_seconds")),
             "duration_max_seconds": _float(source.get("duration_max_seconds")),
             "changed_note_total": _int(source.get("changed_note_total")),
+            "source_objective_outside_soloing_pitch_role_risk_count": _int(
+                source.get("source_objective_outside_soloing_pitch_role_risk_count")
+            ),
+            "source_outside_soloing_pitch_role_risk_count_before": _int(
+                source.get("source_outside_soloing_pitch_role_risk_count_before")
+            ),
+            "source_outside_soloing_pitch_role_risk_count_after": _int(
+                source.get("source_outside_soloing_pitch_role_risk_count_after")
+            ),
+            "source_outside_soloing_pitch_role_risk_delta": _int(
+                source.get("source_outside_soloing_pitch_role_risk_delta")
+            ),
+            "source_outside_soloing_repair_targeted": bool(
+                source.get("source_outside_soloing_repair_targeted", True)
+            ),
+            "source_outside_soloing_residual_risk_preserved": bool(
+                source.get("source_outside_soloing_residual_risk_preserved", False)
+            ),
             "outside_soloing_pitch_role_risk_count_after": _int(
                 source.get("outside_soloing_pitch_role_risk_count_after")
             ),
             "outside_soloing_pitch_role_risk_delta": _int(
                 source.get("outside_soloing_pitch_role_risk_delta")
+            ),
+            "outside_soloing_repair_targeted": bool(
+                source.get("outside_soloing_repair_targeted", False)
             ),
             "weak_chord_tone_landing_risk_count_after": _int(
                 source.get("weak_chord_tone_landing_risk_count_after")
@@ -283,6 +316,18 @@ def validate_listening_review_input_guard_report(
         raise StageBMidiToSoloOutsideSoloingRepairListeningInputGuardError(
             "critical user input should not be required"
         )
+    if bool(source.get("source_outside_soloing_repair_targeted", True)):
+        raise StageBMidiToSoloOutsideSoloingRepairListeningInputGuardError(
+            "source outside-soloing repair target should remain false"
+        )
+    if not bool(source.get("source_outside_soloing_residual_risk_preserved", False)):
+        raise StageBMidiToSoloOutsideSoloingRepairListeningInputGuardError(
+            "source outside-soloing residual risk context must be preserved"
+        )
+    if not bool(source.get("outside_soloing_repair_targeted", False)):
+        raise StageBMidiToSoloOutsideSoloingRepairListeningInputGuardError(
+            "outside-soloing repair should remain targeted in guard summary"
+        )
     if require_no_quality_claim:
         _require_no_quality_claim(readiness, label="outside-soloing repair input guard readiness")
     return {
@@ -300,11 +345,32 @@ def validate_listening_review_input_guard_report(
         "duration_min_seconds": _float(source.get("duration_min_seconds")),
         "duration_max_seconds": _float(source.get("duration_max_seconds")),
         "changed_note_total": _int(source.get("changed_note_total")),
+        "source_objective_outside_soloing_pitch_role_risk_count": _int(
+            source.get("source_objective_outside_soloing_pitch_role_risk_count")
+        ),
+        "source_outside_soloing_pitch_role_risk_count_before": _int(
+            source.get("source_outside_soloing_pitch_role_risk_count_before")
+        ),
+        "source_outside_soloing_pitch_role_risk_count_after": _int(
+            source.get("source_outside_soloing_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_pitch_role_risk_delta": _int(
+            source.get("source_outside_soloing_pitch_role_risk_delta")
+        ),
+        "source_outside_soloing_repair_targeted": bool(
+            source.get("source_outside_soloing_repair_targeted", True)
+        ),
+        "source_outside_soloing_residual_risk_preserved": bool(
+            source.get("source_outside_soloing_residual_risk_preserved", False)
+        ),
         "outside_soloing_pitch_role_risk_count_after": _int(
             source.get("outside_soloing_pitch_role_risk_count_after")
         ),
         "outside_soloing_pitch_role_risk_delta": _int(
             source.get("outside_soloing_pitch_role_risk_delta")
+        ),
+        "outside_soloing_repair_targeted": bool(
+            source.get("outside_soloing_repair_targeted", False)
         ),
         "weak_chord_tone_landing_risk_count_after": _int(
             source.get("weak_chord_tone_landing_risk_count_after")
@@ -348,8 +414,14 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- rendered audio file count: `{source['rendered_audio_file_count']}`",
         f"- duration range: `{source['duration_min_seconds']:.3f}s-{source['duration_max_seconds']:.3f}s`",
         f"- changed note total: `{source['changed_note_total']}`",
+        f"- source objective outside-soloing pitch-role risk count: `{source['source_objective_outside_soloing_pitch_role_risk_count']}`",
+        f"- source outside-soloing pitch-role risk count: `{source['source_outside_soloing_pitch_role_risk_count_before']} -> {source['source_outside_soloing_pitch_role_risk_count_after']}`",
+        f"- source outside-soloing pitch-role risk delta: `{source['source_outside_soloing_pitch_role_risk_delta']}`",
+        f"- source outside-soloing repair targeted: `{_bool_token(source['source_outside_soloing_repair_targeted'])}`",
+        f"- source outside-soloing residual risk preserved: `{_bool_token(source['source_outside_soloing_residual_risk_preserved'])}`",
         f"- outside-soloing pitch-role risk count after: `{source['outside_soloing_pitch_role_risk_count_after']}`",
         f"- outside-soloing pitch-role risk delta: `{source['outside_soloing_pitch_role_risk_delta']}`",
+        f"- outside-soloing repair targeted: `{_bool_token(source['outside_soloing_repair_targeted'])}`",
         f"- weak chord-tone landing risk count after: `{source['weak_chord_tone_landing_risk_count_after']}`",
         f"- final landing chord-tone count after: `{source['final_landing_chord_tone_count_after']}`",
         f"- max non-chord-tone run after: `{source['max_non_chord_tone_run_after']}`",
@@ -394,7 +466,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=808)
+    parser.add_argument("--issue_number", type=int, default=892)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--require_guard_completed", action="store_true")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_input.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_input.py
@@ -35,8 +35,15 @@ def source_package(*, quality_claim: bool = False, validated_input: bool = False
             "duration_min_seconds": 18.871,
             "duration_max_seconds": 19.000,
             "changed_note_total": 2,
+            "source_objective_outside_soloing_pitch_role_risk_count": 5,
+            "source_outside_soloing_pitch_role_risk_count_before": 5,
+            "source_outside_soloing_pitch_role_risk_count_after": 2,
+            "source_outside_soloing_pitch_role_risk_delta": 3,
+            "source_outside_soloing_repair_targeted": False,
+            "source_outside_soloing_residual_risk_preserved": True,
             "outside_soloing_pitch_role_risk_count_after": 0,
             "outside_soloing_pitch_role_risk_delta": 2,
+            "outside_soloing_repair_targeted": True,
             "weak_chord_tone_landing_risk_count_after": 0,
             "final_landing_chord_tone_count_after": 6,
             "max_non_chord_tone_run_after": 3,
@@ -82,7 +89,7 @@ class StageBMidiToSoloOutsideSoloingRepairListeningInputGuardTest(unittest.TestC
         report = build_listening_review_input_guard_report(
             source_package(),
             output_dir="unused",
-            issue_number=808,
+            issue_number=892,
         )
         summary = validate_listening_review_input_guard_report(
             report,
@@ -101,8 +108,17 @@ class StageBMidiToSoloOutsideSoloingRepairListeningInputGuardTest(unittest.TestC
         self.assertTrue(summary["technical_wav_validation"])
         self.assertEqual(summary["rendered_audio_file_count"], 6)
         self.assertEqual(summary["changed_note_total"], 2)
+        self.assertEqual(
+            summary["source_objective_outside_soloing_pitch_role_risk_count"], 5
+        )
+        self.assertEqual(summary["source_outside_soloing_pitch_role_risk_count_before"], 5)
+        self.assertEqual(summary["source_outside_soloing_pitch_role_risk_count_after"], 2)
+        self.assertEqual(summary["source_outside_soloing_pitch_role_risk_delta"], 3)
+        self.assertFalse(summary["source_outside_soloing_repair_targeted"])
+        self.assertTrue(summary["source_outside_soloing_residual_risk_preserved"])
         self.assertEqual(summary["outside_soloing_pitch_role_risk_count_after"], 0)
         self.assertEqual(summary["outside_soloing_pitch_role_risk_delta"], 2)
+        self.assertTrue(summary["outside_soloing_repair_targeted"])
         self.assertEqual(summary["weak_chord_tone_landing_risk_count_after"], 0)
         self.assertEqual(summary["final_landing_chord_tone_count_after"], 6)
         self.assertEqual(summary["max_non_chord_tone_run_after"], 3)
@@ -114,14 +130,14 @@ class StageBMidiToSoloOutsideSoloingRepairListeningInputGuardTest(unittest.TestC
             build_listening_review_input_guard_report(
                 source_package(quality_claim=True),
                 output_dir="unused",
-                issue_number=808,
+                issue_number=892,
             )
 
     def test_routes_to_fill_when_validated_input_exists(self) -> None:
         report = build_listening_review_input_guard_report(
             source_package(validated_input=True),
             output_dir="unused",
-            issue_number=808,
+            issue_number=892,
         )
         self.assertTrue(report["guard_result"]["preference_fill_allowed"])
         self.assertTrue(report["guard_result"]["validated_review_input_present"])


### PR DESCRIPTION
## Summary
- outside-soloing repair input guard source_summary에 source/current repair context 반영
- pending review input 상태에서 preference fill blocked 유지
- validation summary와 generated markdown 필드 확장

## Context
- Issue #890 listening review package source_summary: source outside-soloing 5 -> 2
- current outside-soloing repair result: 2 -> 0
- validated review input present: false
- preference fill allowed: false

## Scope
- input guard source_summary/readiness 필드 확장
- validation summary 반환 필드 확장
- status/Core Plan과 generated doc 갱신
- harness issue number 갱신

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_input
- .venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_input.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-outside-soloing-repair-listening-review-input-guard
- bash scripts/agent_harness.sh quick

## Risk
- human/audio preference claim 없음
- MIDI-to-solo musical quality claim 없음
- validated review input 없음

Closes #892