### PR TITLE
Stage B MIDI-to-solo outside-soloing repair objective next source context refresh

### DIFF
--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -7588,6 +7588,60 @@ Issue #892는 Issue #890 listening review package의 source/current repair conte
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision refresh`
 
+## 9.138 Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective next source context refresh
+
+Issue #894는 Issue #892 input guard의 source/current repair context를 outside-soloing repair objective-only next decision까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- selected target: `current_evidence_consolidation`
+- review item count: `6`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- changed note total: `2`
+- source objective outside-soloing pitch-role risk count: `5`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- source outside-soloing pitch-role risk delta: `3`
+- source outside-soloing repair targeted: `false`
+- source outside-soloing residual risk preserved: `true`
+- outside-soloing pitch-role risk count after: `0`
+- outside-soloing pitch-role risk delta: `2`
+- outside-soloing repair targeted: `true`
+- outside-soloing target supported: `true`
+- weak chord-tone landing risk count after: `0`
+- weak landing target supported: `true`
+- final landing chord-tone count after: `6`
+- final landing target supported: `true`
+- max non-chord-tone run after: `3`
+- non-chord run target supported: `true`
+- current evidence consolidation ready: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- objective targets 통과: outside-soloing risk `0`, weak landing risk `0`, max non-chord run `3`, final landing count `6`.
+- source/current repair context 보존 완료.
+- current evidence consolidation은 quality claim이 아니라 evidence boundary.
+- human/audio preference와 MIDI-to-solo musical quality claim 제외.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-outside-soloing-repair-objective-only-next-decision`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo MVP current evidence consolidation refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -403,6 +403,11 @@
 - 다음 decision target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_only_next_decision`
 - songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision 완료
 - selected target: `current_evidence_consolidation`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- source outside-soloing repair targeted: `false`
+- source outside-soloing residual risk preserved: `true`
+- outside-soloing pitch-role risk count after: `0`
+- outside-soloing repair targeted: `true`
 - outside-soloing target supported: `true`
 - weak landing target supported: `true`
 - final landing target supported: `true`

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-10.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-10.md
@@ -12,8 +12,14 @@
 - technical WAV validation: `true`
 - rendered audio file count: `6`
 - changed note total: `2`
+- source objective outside-soloing pitch-role risk count: `5`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- source outside-soloing pitch-role risk delta: `3`
+- source outside-soloing repair targeted: `false`
+- source outside-soloing residual risk preserved: `true`
 - outside-soloing pitch-role risk count after: `0`
 - outside-soloing pitch-role risk delta: `2`
+- outside-soloing repair targeted: `true`
 - outside-soloing target supported: `true`
 - weak chord-tone landing risk count after: `0`
 - weak landing target supported: `true`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6935,7 +6935,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landin
     --run_id "$run_id" \
     --input_guard_report "$input_guard_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-10.md \
-    --issue_number 810 \
+    --issue_number 894 \
     --max_non_chord_tone_run_threshold 3 \
     --min_final_landing_chord_tone_count 6 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_only_next_decision \

--- a/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next.py
+++ b/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next.py
@@ -113,6 +113,18 @@ def validate_input_guard_report(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloOutsideSoloingRepairObjectiveNextError(
             "rendered WAV count below 6"
         )
+    if bool(source.get("source_outside_soloing_repair_targeted", True)):
+        raise StageBMidiToSoloOutsideSoloingRepairObjectiveNextError(
+            "source outside-soloing repair target should remain false"
+        )
+    if not bool(source.get("source_outside_soloing_residual_risk_preserved", False)):
+        raise StageBMidiToSoloOutsideSoloingRepairObjectiveNextError(
+            "source outside-soloing residual risk context must be preserved"
+        )
+    if not bool(source.get("outside_soloing_repair_targeted", False)):
+        raise StageBMidiToSoloOutsideSoloingRepairObjectiveNextError(
+            "outside-soloing repair should be targeted before objective decision"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloOutsideSoloingRepairObjectiveNextError(
             "critical user input should not be required"
@@ -132,11 +144,32 @@ def validate_input_guard_report(report: dict[str, Any]) -> dict[str, Any]:
         "duration_min_seconds": _float(source.get("duration_min_seconds")),
         "duration_max_seconds": _float(source.get("duration_max_seconds")),
         "changed_note_total": _int(source.get("changed_note_total")),
+        "source_objective_outside_soloing_pitch_role_risk_count": _int(
+            source.get("source_objective_outside_soloing_pitch_role_risk_count")
+        ),
+        "source_outside_soloing_pitch_role_risk_count_before": _int(
+            source.get("source_outside_soloing_pitch_role_risk_count_before")
+        ),
+        "source_outside_soloing_pitch_role_risk_count_after": _int(
+            source.get("source_outside_soloing_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_pitch_role_risk_delta": _int(
+            source.get("source_outside_soloing_pitch_role_risk_delta")
+        ),
+        "source_outside_soloing_repair_targeted": bool(
+            source.get("source_outside_soloing_repair_targeted", True)
+        ),
+        "source_outside_soloing_residual_risk_preserved": bool(
+            source.get("source_outside_soloing_residual_risk_preserved", False)
+        ),
         "outside_soloing_pitch_role_risk_count_after": _int(
             source.get("outside_soloing_pitch_role_risk_count_after")
         ),
         "outside_soloing_pitch_role_risk_delta": _int(
             source.get("outside_soloing_pitch_role_risk_delta")
+        ),
+        "outside_soloing_repair_targeted": bool(
+            source.get("outside_soloing_repair_targeted", False)
         ),
         "weak_chord_tone_landing_risk_count_after": _int(
             source.get("weak_chord_tone_landing_risk_count_after")
@@ -202,11 +235,32 @@ def build_objective_next_report(
             "duration_min_seconds": _float(source["duration_min_seconds"]),
             "duration_max_seconds": _float(source["duration_max_seconds"]),
             "changed_note_total": _int(source["changed_note_total"]),
+            "source_objective_outside_soloing_pitch_role_risk_count": _int(
+                source["source_objective_outside_soloing_pitch_role_risk_count"]
+            ),
+            "source_outside_soloing_pitch_role_risk_count_before": _int(
+                source["source_outside_soloing_pitch_role_risk_count_before"]
+            ),
+            "source_outside_soloing_pitch_role_risk_count_after": _int(
+                source["source_outside_soloing_pitch_role_risk_count_after"]
+            ),
+            "source_outside_soloing_pitch_role_risk_delta": _int(
+                source["source_outside_soloing_pitch_role_risk_delta"]
+            ),
+            "source_outside_soloing_repair_targeted": bool(
+                source["source_outside_soloing_repair_targeted"]
+            ),
+            "source_outside_soloing_residual_risk_preserved": bool(
+                source["source_outside_soloing_residual_risk_preserved"]
+            ),
             "outside_soloing_pitch_role_risk_count_after": _int(
                 source["outside_soloing_pitch_role_risk_count_after"]
             ),
             "outside_soloing_pitch_role_risk_delta": _int(
                 source["outside_soloing_pitch_role_risk_delta"]
+            ),
+            "outside_soloing_repair_targeted": bool(
+                source["outside_soloing_repair_targeted"]
             ),
             "outside_soloing_target_supported": bool(outside_target_supported),
             "weak_chord_tone_landing_risk_count_after": _int(
@@ -247,6 +301,27 @@ def build_objective_next_report(
             "objective_next_completed": True,
             "objective_next_decision_completed": True,
             "technical_wav_validation": bool(source["technical_wav_validation"]),
+            "source_objective_outside_soloing_pitch_role_risk_count": _int(
+                source["source_objective_outside_soloing_pitch_role_risk_count"]
+            ),
+            "source_outside_soloing_pitch_role_risk_count_before": _int(
+                source["source_outside_soloing_pitch_role_risk_count_before"]
+            ),
+            "source_outside_soloing_pitch_role_risk_count_after": _int(
+                source["source_outside_soloing_pitch_role_risk_count_after"]
+            ),
+            "source_outside_soloing_pitch_role_risk_delta": _int(
+                source["source_outside_soloing_pitch_role_risk_delta"]
+            ),
+            "source_outside_soloing_repair_targeted": bool(
+                source["source_outside_soloing_repair_targeted"]
+            ),
+            "source_outside_soloing_residual_risk_preserved": bool(
+                source["source_outside_soloing_residual_risk_preserved"]
+            ),
+            "outside_soloing_repair_targeted": bool(
+                source["outside_soloing_repair_targeted"]
+            ),
             "outside_soloing_target_supported": bool(outside_target_supported),
             "weak_landing_target_supported": bool(weak_landing_target_supported),
             "non_chord_run_target_supported": bool(non_chord_run_target_supported),
@@ -329,6 +404,18 @@ def validate_objective_next_report(
         raise StageBMidiToSoloOutsideSoloingRepairObjectiveNextError(
             "critical user input should not be required"
         )
+    if bool(summary.get("source_outside_soloing_repair_targeted", True)):
+        raise StageBMidiToSoloOutsideSoloingRepairObjectiveNextError(
+            "source outside-soloing repair target should remain false"
+        )
+    if not bool(summary.get("source_outside_soloing_residual_risk_preserved", False)):
+        raise StageBMidiToSoloOutsideSoloingRepairObjectiveNextError(
+            "source outside-soloing residual risk context must be preserved"
+        )
+    if not bool(summary.get("outside_soloing_repair_targeted", False)):
+        raise StageBMidiToSoloOutsideSoloingRepairObjectiveNextError(
+            "outside-soloing repair should remain targeted in objective summary"
+        )
     if require_no_quality_claim:
         _require_no_quality_claim(readiness, label="outside-soloing objective next readiness")
     return {
@@ -344,11 +431,32 @@ def validate_objective_next_report(
         "technical_wav_validation": bool(summary.get("technical_wav_validation", False)),
         "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
         "changed_note_total": _int(summary.get("changed_note_total")),
+        "source_objective_outside_soloing_pitch_role_risk_count": _int(
+            summary.get("source_objective_outside_soloing_pitch_role_risk_count")
+        ),
+        "source_outside_soloing_pitch_role_risk_count_before": _int(
+            summary.get("source_outside_soloing_pitch_role_risk_count_before")
+        ),
+        "source_outside_soloing_pitch_role_risk_count_after": _int(
+            summary.get("source_outside_soloing_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_pitch_role_risk_delta": _int(
+            summary.get("source_outside_soloing_pitch_role_risk_delta")
+        ),
+        "source_outside_soloing_repair_targeted": bool(
+            summary.get("source_outside_soloing_repair_targeted", True)
+        ),
+        "source_outside_soloing_residual_risk_preserved": bool(
+            summary.get("source_outside_soloing_residual_risk_preserved", False)
+        ),
         "outside_soloing_pitch_role_risk_count_after": _int(
             summary.get("outside_soloing_pitch_role_risk_count_after")
         ),
         "outside_soloing_pitch_role_risk_delta": _int(
             summary.get("outside_soloing_pitch_role_risk_delta")
+        ),
+        "outside_soloing_repair_targeted": bool(
+            summary.get("outside_soloing_repair_targeted", False)
         ),
         "outside_soloing_target_supported": bool(
             summary.get("outside_soloing_target_supported", False)
@@ -405,8 +513,14 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- technical WAV validation: `{_bool_token(summary['technical_wav_validation'])}`",
         f"- rendered audio file count: `{summary['rendered_audio_file_count']}`",
         f"- changed note total: `{summary['changed_note_total']}`",
+        f"- source objective outside-soloing pitch-role risk count: `{summary['source_objective_outside_soloing_pitch_role_risk_count']}`",
+        f"- source outside-soloing pitch-role risk count: `{summary['source_outside_soloing_pitch_role_risk_count_before']} -> {summary['source_outside_soloing_pitch_role_risk_count_after']}`",
+        f"- source outside-soloing pitch-role risk delta: `{summary['source_outside_soloing_pitch_role_risk_delta']}`",
+        f"- source outside-soloing repair targeted: `{_bool_token(summary['source_outside_soloing_repair_targeted'])}`",
+        f"- source outside-soloing residual risk preserved: `{_bool_token(summary['source_outside_soloing_residual_risk_preserved'])}`",
         f"- outside-soloing pitch-role risk count after: `{summary['outside_soloing_pitch_role_risk_count_after']}`",
         f"- outside-soloing pitch-role risk delta: `{summary['outside_soloing_pitch_role_risk_delta']}`",
+        f"- outside-soloing repair targeted: `{_bool_token(summary['outside_soloing_repair_targeted'])}`",
         f"- outside-soloing target supported: `{_bool_token(summary['outside_soloing_target_supported'])}`",
         f"- weak chord-tone landing risk count after: `{summary['weak_chord_tone_landing_risk_count_after']}`",
         f"- weak landing target supported: `{_bool_token(summary['weak_landing_target_supported'])}`",
@@ -449,7 +563,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=810)
+    parser.add_argument("--issue_number", type=int, default=894)
     parser.add_argument("--max_non_chord_tone_run_threshold", type=int, default=3)
     parser.add_argument("--min_final_landing_chord_tone_count", type=int, default=6)
     parser.add_argument("--expected_boundary", type=str, default="")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next.py
@@ -23,8 +23,15 @@ SOURCE_SUMMARY = {
     "duration_min_seconds": 18.871,
     "duration_max_seconds": 19.000,
     "changed_note_total": 2,
+    "source_objective_outside_soloing_pitch_role_risk_count": 5,
+    "source_outside_soloing_pitch_role_risk_count_before": 5,
+    "source_outside_soloing_pitch_role_risk_count_after": 2,
+    "source_outside_soloing_pitch_role_risk_delta": 3,
+    "source_outside_soloing_repair_targeted": False,
+    "source_outside_soloing_residual_risk_preserved": True,
     "outside_soloing_pitch_role_risk_count_after": 0,
     "outside_soloing_pitch_role_risk_delta": 2,
+    "outside_soloing_repair_targeted": True,
     "weak_chord_tone_landing_risk_count_after": 0,
     "final_landing_chord_tone_count_after": 6,
     "max_non_chord_tone_run_after": 3,
@@ -71,7 +78,7 @@ class StageBMidiToSoloOutsideSoloingRepairObjectiveNextTest(unittest.TestCase):
         report = build_objective_next_report(
             input_guard_report=input_guard(),
             output_dir="out",
-            issue_number=810,
+            issue_number=894,
             max_non_chord_tone_run_threshold=3,
             min_final_landing_chord_tone_count=6,
         )
@@ -91,8 +98,17 @@ class StageBMidiToSoloOutsideSoloingRepairObjectiveNextTest(unittest.TestCase):
         self.assertTrue(summary["technical_wav_validation"])
         self.assertEqual(summary["rendered_audio_file_count"], 6)
         self.assertEqual(summary["changed_note_total"], 2)
+        self.assertEqual(
+            summary["source_objective_outside_soloing_pitch_role_risk_count"], 5
+        )
+        self.assertEqual(summary["source_outside_soloing_pitch_role_risk_count_before"], 5)
+        self.assertEqual(summary["source_outside_soloing_pitch_role_risk_count_after"], 2)
+        self.assertEqual(summary["source_outside_soloing_pitch_role_risk_delta"], 3)
+        self.assertFalse(summary["source_outside_soloing_repair_targeted"])
+        self.assertTrue(summary["source_outside_soloing_residual_risk_preserved"])
         self.assertEqual(summary["outside_soloing_pitch_role_risk_count_after"], 0)
         self.assertEqual(summary["outside_soloing_pitch_role_risk_delta"], 2)
+        self.assertTrue(summary["outside_soloing_repair_targeted"])
         self.assertTrue(summary["outside_soloing_target_supported"])
         self.assertEqual(summary["weak_chord_tone_landing_risk_count_after"], 0)
         self.assertTrue(summary["weak_landing_target_supported"])
@@ -111,7 +127,7 @@ class StageBMidiToSoloOutsideSoloingRepairObjectiveNextTest(unittest.TestCase):
         report = build_objective_next_report(
             input_guard_report=input_guard(source_summary=broken_summary),
             output_dir="out",
-            issue_number=810,
+            issue_number=894,
             max_non_chord_tone_run_threshold=3,
             min_final_landing_chord_tone_count=6,
         )
@@ -133,7 +149,7 @@ class StageBMidiToSoloOutsideSoloingRepairObjectiveNextTest(unittest.TestCase):
             build_objective_next_report(
                 input_guard_report=input_guard(preference_fill_allowed=True),
                 output_dir="out",
-                issue_number=810,
+                issue_number=894,
                 max_non_chord_tone_run_threshold=3,
                 min_final_landing_chord_tone_count=6,
             )
@@ -143,7 +159,7 @@ class StageBMidiToSoloOutsideSoloingRepairObjectiveNextTest(unittest.TestCase):
             build_objective_next_report(
                 input_guard_report=input_guard(quality_claim=True),
                 output_dir="out",
-                issue_number=810,
+                issue_number=894,
                 max_non_chord_tone_run_threshold=3,
                 min_final_landing_chord_tone_count=6,
             )


### PR DESCRIPTION
## Summary
- outside-soloing repair objective-only next decision에 source/current repair context 반영
- current evidence consolidation readiness 판단 근거에 source 5 -> 2, current repair 2 -> 0 기록
- validation summary와 generated markdown 필드 확장

## Context
- Issue #892 input guard source_summary: source outside-soloing 5 -> 2
- current outside-soloing repair result: 2 -> 0
- objective target support: outside risk 0, weak landing 0, max non-chord run 3, final landing count 6
- current evidence consolidation ready: true

## Scope
- objective-only next 입력 검증 강화
- objective_summary/readiness/validation summary 필드 확장
- status/Core Plan과 generated doc 갱신
- harness issue number 갱신

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next
- .venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-outside-soloing-repair-objective-only-next-decision
- bash scripts/agent_harness.sh quick

## Risk
- human/audio preference claim 없음
- MIDI-to-solo musical quality claim 없음
- current evidence consolidation은 quality claim이 아닌 evidence boundary

Closes #894