### PR TITLE
Stage B MIDI-to-solo handoff status sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,10 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #798, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision.
+- Latest functional issue completed: Issue #894, Stage B MIDI-to-solo outside-soloing repair objective next source context refresh.
 - Current branch should be `main` before starting new work.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision.
+- Open issue queue after handoff sync merge: `0`.
+- Recommended next issue: none currently open; define the next quality target from the latest objective evidence before opening a new issue.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
+- latest functional result: `Issue #894`
+- latest functional boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_only_next_decision`
+- open issue queue after handoff sync merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,10 @@
 
 현재 active issue:
 
-- latest functional result: Issue #872, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision outside-soloing context refresh
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep refresh`
+- latest functional result: Issue #894, Stage B MIDI-to-solo outside-soloing repair objective next source context refresh
+- latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
+- open issue queue after sync merge: `0`
+- 다음 권장 이슈: 현재 open issue 없음. 다음 작업은 최신 objective evidence 기준으로 새 quality target 정의 후 시작
 
 현재 범위가 아닌 것:
 


### PR DESCRIPTION
## Summary

- handoff 상단 latest functional result를 Issue #894 기준으로 갱신
- open issue queue 정리 상태를 AGENTS, README, CURRENT_STATUS_AND_PLAN에 반영
- 다음 작업 경계를 새 quality target 정의 전제로 정리

## Context

- PR #895 merge 완료
- Issue #894 outside-soloing repair objective next source context refresh 완료
- Issue #509, #816, #818, #820, #822, #824 stale open 상태 정리 완료
- 기존 handoff 상단은 Issue #798/#872 기준으로 남아 있음

## Validation

- git diff --check
- bash scripts/agent_harness.sh quick

## Risk

- 문서-only 변경
- 생성 로직 변경 없음
- quality/preference claim 변경 없음

Closes #896

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project status and handoff documentation across multiple resources to reflect the latest completed work and current progress.
  * Refreshed current status metrics including recently completed issues, functional boundaries, and updated open issue queue counts.
  * Clarified next recommended action items and quality targets based on current project progress and completion status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->