### PR TITLE
Stage B MIDI-to-solo current evidence source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,10 +12,10 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #894, Stage B MIDI-to-solo outside-soloing repair objective next source context refresh.
+- Latest functional issue completed: Issue #898, Stage B MIDI-to-solo current evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after handoff sync merge: `0`.
-- Recommended next issue: none currently open; define the next quality target from the latest objective evidence before opening a new issue.
+- Open issue queue after current evidence refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo README evidence source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest functional result: `Issue #894`
-- latest functional boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_only_next_decision`
-- open issue queue after handoff sync merge: `0`
+- latest functional result: `Issue #898`
+- latest functional boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- open issue queue after current evidence refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -7642,6 +7642,54 @@ Issue #894는 Issue #892 input guard의 source/current repair context를 outside
 
 - `Stage B MIDI-to-solo MVP current evidence consolidation refresh`
 
+## 9.139 Stage B MIDI-to-solo current evidence source-context refresh
+
+Issue #898은 Issue #894 outside-soloing repair objective-only next decision의 source/current repair context를 MVP current evidence consolidation에 반영한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- next boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
+- current MVP evidence supported: `true`
+- selected-scale objective path complete: `true`
+- phrase-bank CLI technical path ready: `true`
+- model-conditioned pitch-contour objective path ready: `true`
+- model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
+- outside-soloing repair objective path ready: `true`
+- outside-soloing repair rendered audio file count: `6`
+- outside-soloing repair changed note total: `2`
+- source objective outside-soloing pitch-role risk count: `5`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- source outside-soloing pitch-role risk delta: `3`
+- source outside-soloing repair targeted: `false`
+- source outside-soloing residual risk preserved: `true`
+- outside-soloing pitch-role risk count after: `0`
+- outside-soloing pitch-role risk delta: `2`
+- outside-soloing repair target supported: `true`
+- weak landing target supported: `true`
+- final landing target supported: `true`
+- non-chord run target supported: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- current evidence에 current repair 결과 `2 -> 0`뿐 아니라 source repair context `5 -> 2`를 함께 보존.
+- source outside-soloing repair는 targeted repair가 아니며 residual risk 보존 경계로 분리.
+- README evidence refresh는 current evidence의 source/current context를 반영하는 방향.
+- human/audio preference와 MIDI-to-solo musical quality claim 제외.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- `.venv/bin/python -m py_compile scripts/consolidate_stage_b_midi_to_solo_mvp_current_evidence.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-current-evidence-consolidation`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo README evidence source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,10 +12,10 @@
 
 현재 active issue:
 
-- latest functional result: Issue #894, Stage B MIDI-to-solo outside-soloing repair objective next source context refresh
+- latest functional result: Issue #898, Stage B MIDI-to-solo current evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after sync merge: `0`
-- 다음 권장 이슈: 현재 open issue 없음. 다음 작업은 최신 objective evidence 기준으로 새 quality target 정의 후 시작
+- open issue queue after current evidence refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo README evidence source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -419,7 +419,7 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 consolidation target: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
-- MVP current evidence consolidation outside-soloing repair refresh 완료
+- MVP current evidence consolidation source-context refresh 완료
 - current MVP evidence supported: `true`
 - selected-scale objective path complete: `true`
 - phrase-bank CLI technical path ready: `true`
@@ -428,6 +428,11 @@
 - outside-soloing repair objective path ready: `true`
 - outside-soloing repair rendered audio file count: `6`
 - outside-soloing repair changed note total: `2`
+- source objective outside-soloing pitch-role risk count: `5`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- source outside-soloing pitch-role risk delta: `3`
+- source outside-soloing repair targeted: `false`
+- source outside-soloing residual risk preserved: `true`
 - outside-soloing repair pitch-role risk count after: `0`
 - outside-soloing repair pitch-role risk delta: `2`
 - outside-soloing repair objective path supported: `true`

--- a/docs/STAGE_B_MIDI_TO_SOLO_MVP_CURRENT_EVIDENCE_CONSOLIDATION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MVP_CURRENT_EVIDENCE_CONSOLIDATION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -1,0 +1,128 @@
+# Stage B MIDI-to-Solo MVP Current Evidence Consolidation
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- next boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
+- current MVP evidence supported: `true`
+- technical execution evidence supported: `true`
+- selected-scale objective path complete: `true`
+- phrase-bank CLI technical path ready: `true`
+- model-conditioned pitch-contour objective path ready: `true`
+- model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
+- outside-soloing repair objective path ready: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Input Contract
+
+- candidate count: `32`
+- exported MIDI candidates: `3`
+- target solo bars: `8`
+- min note count: `24`
+- min unique pitch count: `8`
+- max simultaneous notes: `1`
+- fallback path: `phrase_retrieval_data_motif_hybrid`
+
+## Context and Ranked MIDI
+
+- context bars / events: `8` / `128`
+- low-confidence chord bars: `4`
+- generation source: `context_conditioned_fallback`
+- exported / qualified candidates: `3` / `3`
+- best note / unique pitch / max simultaneous notes: `60` / `14` / `1`
+
+## Technical Audio Path
+
+- rendered WAV files: `3`
+- sample rate: `44100`
+- duration range: `18.617s-18.991s`
+- technical WAV validation: `true`
+
+## Selected-Scale Objective Path
+
+- final boundary: `stage_b_midi_to_solo_controlled_scale_checkpoint_training_scale_postprocess_removal_dead_air_repair_objective_path_complete`
+- sample / seed count: `9` / `3`
+- valid / strict / grammar: `9` / `9` / `9`
+- dead-air / collapse failure count: `0` / `0`
+- avg / max postprocess removal ratio: `0.21759259259259262` / `0.2916666666666667`
+- target avg postprocess removal ratio: `0.3`
+- validated review input present: `false`
+- preference fill allowed: `false`
+
+## Phrase-Bank CLI Technical Path
+
+- technical MIDI-to-solo CLI path ready: `true`
+- explicit input used: `true`
+- candidate / objective supported: `3` / `3`
+- repaired MIDI / rendered WAV: `3` / `3`
+- input context bars: `228`
+- dead-air range: `0.1895-0.2211`
+- preference fill allowed: `false`
+
+## Model-Conditioned Pitch-Contour Objective Path
+
+- current evidence consolidation ready: `true`
+- rendered WAV files: `3`
+- technical WAV validation: `true`
+- max interval / threshold: `11` / `12`
+- pitch-contour target supported: `true`
+- max pitch changed ratio: `0.7174`
+- pitch changed ratio review required: `true`
+- audio review required: `true`
+- preference fill allowed: `false`
+
+## Model-Conditioned Pitch-Contour Changed-Ratio Repair Objective Path
+
+- current evidence consolidation ready: `true`
+- objective path supported: `true`
+- rendered WAV files: `3`
+- technical WAV validation: `true`
+- max interval / threshold: `12` / `12`
+- max pitch changed ratio / target: `0.4348` / `0.5000`
+- changed-ratio target supported: `true`
+- audio review required: `true`
+- preference fill allowed: `false`
+
+## Outside-Soloing Repair Objective Path
+
+- current evidence consolidation ready: `true`
+- objective path supported: `true`
+- rendered WAV files: `6`
+- technical WAV validation: `true`
+- changed note total: `2`
+- source objective outside-soloing pitch-role risk: `5`
+- source outside-soloing pitch-role risk before / after / delta: `5` / `2` / `3`
+- source outside-soloing repair targeted: `false`
+- source outside-soloing residual risk preserved: `true`
+- outside-soloing pitch-role risk after / delta: `0` / `2`
+- outside-soloing target supported: `true`
+- weak landing target supported: `true`
+- final landing chord-tone count after: `6`
+- max non-chord-tone run after: `3`
+- non-chord run target supported: `true`
+- preference fill allowed: `false`
+
+## MIDI Paths
+
+- `outputs/stage_b_midi_to_solo_conditioned_generation_probe/harness_stage_b_midi_to_solo_conditioned_generation_probe/midi/rank_01_seed_489.mid`
+- `outputs/stage_b_midi_to_solo_conditioned_generation_probe/harness_stage_b_midi_to_solo_conditioned_generation_probe/midi/rank_02_seed_488.mid`
+- `outputs/stage_b_midi_to_solo_conditioned_generation_probe/harness_stage_b_midi_to_solo_conditioned_generation_probe/midi/rank_03_seed_487.mid`
+
+## WAV Paths
+
+- `outputs/stage_b_midi_to_solo_candidate_audio_render_package/harness_stage_b_midi_to_solo_candidate_audio_render_package/audio/rank_01_seed_489.wav`
+- `outputs/stage_b_midi_to_solo_candidate_audio_render_package/harness_stage_b_midi_to_solo_candidate_audio_render_package/audio/rank_02_seed_488.wav`
+- `outputs/stage_b_midi_to_solo_candidate_audio_render_package/harness_stage_b_midi_to_solo_candidate_audio_render_package/audio/rank_03_seed_487.wav`
+
+## Not Proven
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`
+- `production_ready_improviser`
+
+## Next
+
+- `Stage B MIDI-to-solo README evidence refresh`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -5987,8 +5987,8 @@ run_stage_b_midi_to_solo_mvp_current_evidence_consolidation() {
     --model_conditioned_pitch_contour_objective_next "$model_conditioned_pitch_contour_objective_next" \
     --model_conditioned_pitch_contour_changed_ratio_repair_objective_next "$model_conditioned_pitch_contour_changed_ratio_repair_objective_next" \
     --outside_soloing_repair_objective_next "$outside_soloing_repair_objective_next" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_CURRENT_EVIDENCE_CONSOLIDATION_OUTSIDE_SOLOING_REPAIR_REFRESH_2026-06-10.md \
-    --issue_number 812 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_CURRENT_EVIDENCE_CONSOLIDATION_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
+    --issue_number 898 \
     --expected_boundary stage_b_midi_to_solo_mvp_current_evidence_consolidation \
     --expected_next_boundary stage_b_midi_to_solo_readme_evidence_refresh \
     --min_exported_candidates 3 \

--- a/scripts/consolidate_stage_b_midi_to_solo_mvp_current_evidence.py
+++ b/scripts/consolidate_stage_b_midi_to_solo_mvp_current_evidence.py
@@ -668,6 +668,20 @@ def validate_outside_soloing_repair_objective_next(
         raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
             "outside-soloing repair residual pitch-role risk should be zero"
         )
+    if _int(summary.get("source_outside_soloing_pitch_role_risk_count_before")) < _int(
+        summary.get("source_outside_soloing_pitch_role_risk_count_after")
+    ):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "source outside-soloing risk should not increase"
+        )
+    if not bool(summary.get("source_outside_soloing_residual_risk_preserved", False)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "source outside-soloing residual risk boundary should be preserved"
+        )
+    if bool(summary.get("source_outside_soloing_repair_targeted", True)):
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "source outside-soloing repair should remain non-targeted"
+        )
     if _int(summary.get("weak_chord_tone_landing_risk_count_after")) != 0:
         raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
             "outside-soloing repair weak landing risk should be zero"
@@ -735,6 +749,24 @@ def validate_outside_soloing_repair_objective_next(
         "technical_wav_validation": bool(summary.get("technical_wav_validation", False)),
         "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
         "changed_note_total": _int(summary.get("changed_note_total")),
+        "source_objective_outside_soloing_pitch_role_risk_count": _int(
+            summary.get("source_objective_outside_soloing_pitch_role_risk_count")
+        ),
+        "source_outside_soloing_pitch_role_risk_count_before": _int(
+            summary.get("source_outside_soloing_pitch_role_risk_count_before")
+        ),
+        "source_outside_soloing_pitch_role_risk_count_after": _int(
+            summary.get("source_outside_soloing_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_pitch_role_risk_delta": _int(
+            summary.get("source_outside_soloing_pitch_role_risk_delta")
+        ),
+        "source_outside_soloing_repair_targeted": bool(
+            summary.get("source_outside_soloing_repair_targeted", True)
+        ),
+        "source_outside_soloing_residual_risk_preserved": bool(
+            summary.get("source_outside_soloing_residual_risk_preserved", False)
+        ),
         "outside_soloing_pitch_role_risk_count_after": _int(
             summary.get("outside_soloing_pitch_role_risk_count_after")
         ),
@@ -990,7 +1022,6 @@ def validate_current_evidence_consolidation_report(
         report.get("model_conditioned_pitch_contour_changed_ratio_repair_objective_path")
     )
     outside_soloing_repair = _dict(report.get("outside_soloing_repair_objective_path"))
-    outside_soloing_repair = _dict(report.get("outside_soloing_repair_objective_path"))
     if expected_boundary and boundary != expected_boundary:
         raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
             f"expected boundary {expected_boundary}, got {boundary}"
@@ -1149,6 +1180,33 @@ def validate_current_evidence_consolidation_report(
         ),
         "outside_soloing_repair_changed_note_total": _int(
             outside_soloing_repair.get("changed_note_total")
+        ),
+        "outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+            outside_soloing_repair.get(
+                "source_objective_outside_soloing_pitch_role_risk_count"
+            )
+        ),
+        "outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+            outside_soloing_repair.get(
+                "source_outside_soloing_pitch_role_risk_count_before"
+            )
+        ),
+        "outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+            outside_soloing_repair.get(
+                "source_outside_soloing_pitch_role_risk_count_after"
+            )
+        ),
+        "outside_soloing_repair_source_pitch_role_risk_delta": _int(
+            outside_soloing_repair.get("source_outside_soloing_pitch_role_risk_delta")
+        ),
+        "outside_soloing_repair_source_targeted": bool(
+            outside_soloing_repair.get("source_outside_soloing_repair_targeted", True)
+        ),
+        "outside_soloing_repair_source_residual_risk_preserved": bool(
+            outside_soloing_repair.get(
+                "source_outside_soloing_residual_risk_preserved",
+                False,
+            )
         ),
         "outside_soloing_repair_pitch_role_risk_count_after": _int(
             outside_soloing_repair.get("outside_soloing_pitch_role_risk_count_after")
@@ -1331,6 +1389,10 @@ def markdown_report(report: dict[str, Any]) -> str:
                 f"- rendered WAV files: `{outside_soloing_repair['rendered_audio_file_count']}`",
                 f"- technical WAV validation: `{_bool_token(outside_soloing_repair['technical_wav_validation'])}`",
                 f"- changed note total: `{outside_soloing_repair['changed_note_total']}`",
+                f"- source objective outside-soloing pitch-role risk: `{outside_soloing_repair['source_objective_outside_soloing_pitch_role_risk_count']}`",
+                f"- source outside-soloing pitch-role risk before / after / delta: `{outside_soloing_repair['source_outside_soloing_pitch_role_risk_count_before']}` / `{outside_soloing_repair['source_outside_soloing_pitch_role_risk_count_after']}` / `{outside_soloing_repair['source_outside_soloing_pitch_role_risk_delta']}`",
+                f"- source outside-soloing repair targeted: `{_bool_token(outside_soloing_repair['source_outside_soloing_repair_targeted'])}`",
+                f"- source outside-soloing residual risk preserved: `{_bool_token(outside_soloing_repair['source_outside_soloing_residual_risk_preserved'])}`",
                 f"- outside-soloing pitch-role risk after / delta: `{outside_soloing_repair['outside_soloing_pitch_role_risk_count_after']}` / `{outside_soloing_repair['outside_soloing_pitch_role_risk_delta']}`",
                 f"- outside-soloing target supported: `{_bool_token(outside_soloing_repair['outside_soloing_target_supported'])}`",
                 f"- weak landing target supported: `{_bool_token(outside_soloing_repair['weak_landing_target_supported'])}`",

--- a/tests/test_stage_b_midi_to_solo_mvp_current_evidence_consolidation.py
+++ b/tests/test_stage_b_midi_to_solo_mvp_current_evidence_consolidation.py
@@ -310,6 +310,12 @@ def reports(
                 "technical_wav_validation": True,
                 "rendered_audio_file_count": 6,
                 "changed_note_total": 2,
+                "source_objective_outside_soloing_pitch_role_risk_count": 5,
+                "source_outside_soloing_pitch_role_risk_count_before": 5,
+                "source_outside_soloing_pitch_role_risk_count_after": 2,
+                "source_outside_soloing_pitch_role_risk_delta": 3,
+                "source_outside_soloing_repair_targeted": False,
+                "source_outside_soloing_residual_risk_preserved": True,
                 "outside_soloing_pitch_role_risk_count_after": 0
                 if outside_soloing_repair_supported
                 else 1,
@@ -439,6 +445,28 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationTest(unittest.TestCase):
             )
             self.assertEqual(summary["outside_soloing_repair_rendered_audio_file_count"], 6)
             self.assertEqual(summary["outside_soloing_repair_changed_note_total"], 2)
+            self.assertEqual(
+                summary[
+                    "outside_soloing_repair_source_objective_pitch_role_risk_count"
+                ],
+                5,
+            )
+            self.assertEqual(
+                summary["outside_soloing_repair_source_pitch_role_risk_count_before"],
+                5,
+            )
+            self.assertEqual(
+                summary["outside_soloing_repair_source_pitch_role_risk_count_after"],
+                2,
+            )
+            self.assertEqual(
+                summary["outside_soloing_repair_source_pitch_role_risk_delta"],
+                3,
+            )
+            self.assertFalse(summary["outside_soloing_repair_source_targeted"])
+            self.assertTrue(
+                summary["outside_soloing_repair_source_residual_risk_preserved"]
+            )
             self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_count_after"], 0)
             self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_delta"], 2)
             self.assertTrue(summary["outside_soloing_repair_target_supported"])
@@ -578,6 +606,61 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationTest(unittest.TestCase):
                     ],
                     output_dir=Path(tmp) / "out",
                     issue_number=812,
+                )
+
+    def test_rejects_missing_outside_soloing_source_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            data = reports(Path(tmp))
+            data["outside_soloing_repair_objective"]["objective_summary"][
+                "source_outside_soloing_residual_risk_preserved"
+            ] = False
+            with self.assertRaises(StageBMidiToSoloMvpCurrentEvidenceConsolidationError):
+                build_current_evidence_consolidation_report(
+                    contract_report=data["contract"],
+                    context_report=data["context"],
+                    resource_probe=data["resource"],
+                    generation_probe=data["generation"],
+                    audio_render=data["audio"],
+                    objective_next=data["objective"],
+                    cli_objective_next=data["cli_objective"],
+                    model_conditioned_pitch_contour_objective_next=data[
+                        "model_conditioned_pitch_contour_objective"
+                    ],
+                    model_conditioned_pitch_contour_changed_ratio_repair_objective_next=data[
+                        "model_conditioned_pitch_contour_changed_ratio_repair_objective"
+                    ],
+                    outside_soloing_repair_objective_next=data[
+                        "outside_soloing_repair_objective"
+                    ],
+                    output_dir=Path(tmp) / "out",
+                    issue_number=898,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            data = reports(Path(tmp))
+            data["outside_soloing_repair_objective"]["objective_summary"][
+                "source_outside_soloing_pitch_role_risk_count_after"
+            ] = 6
+            with self.assertRaises(StageBMidiToSoloMvpCurrentEvidenceConsolidationError):
+                build_current_evidence_consolidation_report(
+                    contract_report=data["contract"],
+                    context_report=data["context"],
+                    resource_probe=data["resource"],
+                    generation_probe=data["generation"],
+                    audio_render=data["audio"],
+                    objective_next=data["objective"],
+                    cli_objective_next=data["cli_objective"],
+                    model_conditioned_pitch_contour_objective_next=data[
+                        "model_conditioned_pitch_contour_objective"
+                    ],
+                    model_conditioned_pitch_contour_changed_ratio_repair_objective_next=data[
+                        "model_conditioned_pitch_contour_changed_ratio_repair_objective"
+                    ],
+                    outside_soloing_repair_objective_next=data[
+                        "outside_soloing_repair_objective"
+                    ],
+                    output_dir=Path(tmp) / "out",
+                    issue_number=898,
                 )
 
     def test_boundary_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary

- current evidence consolidation에 outside-soloing source/current repair context 추가
- source risk `5 -> 2`, current repair risk `2 -> 0` 분리 기록
- validation summary, markdown report, harness doc path, status/Core Plan 갱신

## Context

- Issue #894 objective-only next decision 결과, outside-soloing repair objective path가 current evidence consolidation으로 이동
- 최신 objective evidence: source outside-soloing risk `5 -> 2`, current repair risk `2 -> 0`, changed note total `2`, max non-chord-tone run `4 -> 3`
- 기존 current evidence summary는 current repair 결과 중심
- 누락 지점: source repair context와 residual risk 보존 여부 미노출

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_current_evidence_consolidation`
- `.venv/bin/python -m py_compile scripts/consolidate_stage_b_midi_to_solo_mvp_current_evidence.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-current-evidence-consolidation`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- evidence summary 범위 변경
- 생성 로직 변경 없음
- human/audio preference claim 없음
- MIDI-to-solo musical quality claim 없음

Closes #898