### PR TITLE
Stage B MIDI-to-solo README evidence source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,9 +13,10 @@ Primary goal:
 Current handoff scope:
 
 - Latest functional issue completed: Issue #898, Stage B MIDI-to-solo current evidence source-context refresh.
+- Latest documentation issue completed: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after current evidence refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo README evidence source-context refresh.
+- Open issue queue after README evidence refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo MVP completion audit source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 ## 현재 상태
 
 - latest functional result: `Issue #898`
+- latest README evidence refresh: `Issue #900`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
-- open issue queue after current evidence refresh merge: `0`
+- open issue queue after README evidence refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -137,6 +138,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - outside-soloing repair objective path included in current evidence: `true`
 - outside-soloing repair WAV files: `6`
 - outside-soloing repair changed note total: `2`
+- outside-soloing source pitch-role risk: `5 -> 2`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
 - outside-soloing pitch-role risk count after: `0`
 - outside-soloing pitch-role risk delta: `2`
 - outside-soloing repair objective path supported: `true`
@@ -255,6 +259,11 @@ MVP current evidence refresh.
 - outside-soloing repair objective path ready: `true`
 - outside-soloing repair rendered audio file count: `6`
 - outside-soloing repair changed note total: `2`
+- outside-soloing source objective pitch-role risk count: `5`
+- outside-soloing source pitch-role risk count: `5 -> 2`
+- outside-soloing source pitch-role risk delta: `3`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
 - outside-soloing repair pitch-role risk count after: `0`
 - outside-soloing repair pitch-role risk delta: `2`
 - human/audio preference claimed: `false`
@@ -920,6 +929,10 @@ README evidence refresh.
 - model-conditioned pitch-contour changed-ratio review required: `true`
 - model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
 - model-conditioned pitch-contour changed-ratio repair max ratio / target: `0.4348 / 0.5000`
+- outside-soloing source-context evidence reflected: `true`
+- outside-soloing source pitch-role risk count: `5 -> 2`
+- outside-soloing source residual risk preserved: `true`
+- outside-soloing current repair pitch-role risk count after: `0`
 - quality/preference claim excluded: `true`
 - next boundary: `stage_b_midi_to_solo_mvp_completion_audit`
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -7690,6 +7690,43 @@ Issue #898은 Issue #894 outside-soloing repair objective-only next decision의 
 
 - `Stage B MIDI-to-solo README evidence source-context refresh`
 
+## 9.140 Stage B MIDI-to-solo README evidence source-context refresh
+
+Issue #900은 Issue #898 current evidence source-context refresh 결과를 README evidence block에 반영한 문서 작업이다.
+
+결과:
+
+- latest evidence boundary reflected: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- current MVP evidence supported: `true`
+- outside-soloing repair objective path ready: `true`
+- outside-soloing repair rendered audio file count: `6`
+- outside-soloing repair changed note total: `2`
+- source objective outside-soloing pitch-role risk count: `5`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- source outside-soloing pitch-role risk delta: `3`
+- source outside-soloing repair targeted: `false`
+- source outside-soloing residual risk preserved: `true`
+- current repair outside-soloing pitch-role risk count after: `0`
+- current repair outside-soloing pitch-role risk delta: `2`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+
+판단:
+
+- README current evidence block에 source/current repair context를 분리 기록.
+- source repair는 targeted repair가 아니며 residual risk boundary로 보존.
+- current repair `2 -> 0`은 objective evidence 범위에서만 반영.
+- human/audio preference와 MIDI-to-solo musical quality claim 제외.
+
+검증:
+
+- `git diff --check`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo MVP completion audit source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -13,9 +13,10 @@
 현재 active issue:
 
 - latest functional result: Issue #898, Stage B MIDI-to-solo current evidence source-context refresh
+- latest README evidence refresh: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after current evidence refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo README evidence source-context refresh`
+- open issue queue after README evidence refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo MVP completion audit source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -439,11 +440,13 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 README target: `stage_b_midi_to_solo_readme_evidence_refresh`
-- README evidence refresh outside-soloing repair path 완료
+- README evidence refresh source-context 완료
 - latest evidence boundary reflected: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence supported: `true`
 - outside-soloing repair objective path ready: `true`
 - outside-soloing repair rendered audio file count: `6`
+- outside-soloing source pitch-role risk count: `5 -> 2`
+- outside-soloing source residual risk preserved: `true`
 - outside-soloing repair pitch-role risk count after: `0`
 - outside-soloing repair pitch-role risk delta: `2`
 - human/audio preference claim: `false`

--- a/docs/STAGE_B_MIDI_TO_SOLO_README_EVIDENCE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_README_EVIDENCE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -1,0 +1,41 @@
+# Stage B MIDI-to-Solo README Evidence Source-Context Refresh
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
+- source boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- latest evidence boundary reflected: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- next boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+
+## Evidence
+
+- current MVP evidence supported: `true`
+- outside-soloing repair objective path ready: `true`
+- outside-soloing repair rendered audio file count: `6`
+- outside-soloing repair changed note total: `2`
+- source objective outside-soloing pitch-role risk count: `5`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- source outside-soloing pitch-role risk delta: `3`
+- source outside-soloing repair targeted: `false`
+- source outside-soloing residual risk preserved: `true`
+- current repair outside-soloing pitch-role risk count after: `0`
+- current repair outside-soloing pitch-role risk delta: `2`
+
+## Claim Boundary
+
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- broad trained-model quality claim: `false`
+- Brad style adaptation claim: `false`
+
+## Decision
+
+- README current evidence block에 source/current repair context 분리 기록
+- source repair residual risk boundary 보존
+- current repair objective support만 반영
+- 다음 boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+
+## Validation
+
+- `git diff --check`
+- `bash scripts/agent_harness.sh quick`


### PR DESCRIPTION
## Summary

- README current evidence block에 outside-soloing source/current repair context 추가
- source risk `5 -> 2`, current repair risk `2 -> 0` 분리 기록
- status/Core Plan과 README evidence refresh 문서 갱신

## Context

- Issue #898 current evidence 결과, outside-soloing repair source/current context가 summary에 포함
- 기존 README current evidence block은 outside-soloing current repair 결과 중심
- 누락 지점: source repair context와 residual risk boundary 미표시

## Validation

- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk

- 문서-only 변경
- 생성 로직 변경 없음
- human/audio preference claim 없음
- MIDI-to-solo musical quality claim 없음

Closes #900