### PR TITLE
Stage B MIDI-to-solo MVP completion audit source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,11 @@ Primary goal:
 Current handoff scope:
 
 - Latest functional issue completed: Issue #898, Stage B MIDI-to-solo current evidence source-context refresh.
+- Latest audit issue completed: Issue #902, Stage B MIDI-to-solo MVP completion audit source-context refresh.
 - Latest documentation issue completed: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after README evidence refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo MVP completion audit source-context refresh.
+- Open issue queue after MVP completion audit refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo quality gap decision source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 ## 현재 상태
 
 - latest functional result: `Issue #898`
+- latest MVP completion audit: `Issue #902`
 - latest README evidence refresh: `Issue #900`
-- latest functional boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
-- open issue queue after README evidence refresh merge: `0`
+- latest functional boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- open issue queue after MVP completion audit refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -112,6 +113,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - MVP completion audit model-conditioned pitch-contour objective included: `true`
 - MVP completion audit changed-ratio repair objective included: `true`
 - MVP completion audit outside-soloing repair objective included: `true`
+- MVP completion audit outside-soloing source context included: `true`
 - quality gap decision completed: `true`
 - quality gap decision listening review target selected: `true`
 - quality gap decision outside-soloing repair objective included: `true`
@@ -239,6 +241,10 @@ MVP completion audit.
 - technical model-core MVP completed: `true`
 - input to ranked MIDI completed: `true`
 - input to rendered WAV completed: `true`
+- outside-soloing source pitch-role risk count: `5 -> 2`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
+- outside-soloing current repair pitch-role risk count after: `0`
 - selected-scale objective repair completed: `true`
 - phrase-bank CLI technical path included: `true`
 - phrase-bank CLI technical path completed: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -7727,6 +7727,52 @@ Issue #900은 Issue #898 current evidence source-context refresh 결과를 READM
 
 - `Stage B MIDI-to-solo MVP completion audit source-context refresh`
 
+## 9.141 Stage B MIDI-to-solo MVP completion audit source-context refresh
+
+Issue #902는 Issue #898 current evidence와 Issue #900 README evidence refresh의 source/current outside-soloing context를 MVP completion audit에 반영한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- next boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- technical model-core MVP completed: `true`
+- input to ranked MIDI completed: `true`
+- input to rendered WAV completed: `true`
+- selected-scale objective repair completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour changed-ratio repair objective completed: `true`
+- outside-soloing repair objective completed: `true`
+- outside-soloing repair rendered audio file count: `6`
+- outside-soloing repair changed note total: `2`
+- source objective outside-soloing pitch-role risk count: `5`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- source outside-soloing pitch-role risk delta: `3`
+- source outside-soloing repair targeted: `false`
+- source outside-soloing residual risk preserved: `true`
+- current repair outside-soloing pitch-role risk count after: `0`
+- current repair outside-soloing pitch-role risk delta: `2`
+- human/audio preference completed: `false`
+- MIDI-to-solo musical quality MVP completed: `false`
+
+판단:
+
+- completion audit 필수 evidence에 source/current outside-soloing context를 포함.
+- source repair는 targeted repair가 아니며 residual risk boundary로 보존.
+- technical model-core MVP completion은 objective evidence 범위로 한정.
+- human/audio preference와 MIDI-to-solo musical quality claim 제외.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
+- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_mvp_completion.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo quality gap decision source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -13,10 +13,11 @@
 현재 active issue:
 
 - latest functional result: Issue #898, Stage B MIDI-to-solo current evidence source-context refresh
+- latest MVP completion audit: Issue #902, Stage B MIDI-to-solo MVP completion audit source-context refresh
 - latest README evidence refresh: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after README evidence refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo MVP completion audit source-context refresh`
+- open issue queue after MVP completion audit refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo quality gap decision source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -452,10 +453,13 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 audit target: `stage_b_midi_to_solo_mvp_completion_audit`
-- MVP completion audit outside-soloing repair refresh 완료
+- MVP completion audit source-context refresh 완료
 - technical model-core MVP completed: `true`
 - outside-soloing repair objective completed: `true`
 - outside-soloing repair rendered audio file count: `6`
+- outside-soloing source pitch-role risk count: `5 -> 2`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
 - outside-soloing repair pitch-role risk count after: `0`
 - outside-soloing repair pitch-role risk delta: `2`
 - outside-soloing repair objective path supported: `true`

--- a/docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -1,0 +1,82 @@
+# Stage B MIDI-to-Solo MVP Completion Audit
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- next boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- technical model-core MVP completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour changed-ratio repair objective completed: `true`
+- outside-soloing repair objective completed: `true`
+- musical quality MVP completed: `false`
+- human/audio preference completed: `false`
+- product MVP completed: `false`
+
+## Evidence
+
+- source boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- generation source: `context_conditioned_fallback`
+- exported / qualified candidates: `3` / `3`
+- rendered WAV files: `3`
+- technical WAV validation: `true`
+- WAV duration range: `18.617s-18.991s`
+- objective sample / strict / grammar: `9` / `9` / `9`
+- objective dead-air / collapse failure: `0` / `0`
+- objective avg / target postprocess removal: `0.21759259259259262` / `0.3`
+- phrase-bank CLI technical path ready: `true`
+- CLI candidate / rendered WAV: `3` / `3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- model-conditioned pitch-contour objective path ready: `true`
+- model-conditioned pitch-contour rendered WAV files: `3`
+- model-conditioned pitch-contour technical WAV validation: `true`
+- model-conditioned pitch-contour max interval / threshold: `11` / `12`
+- model-conditioned pitch-contour target supported: `true`
+- model-conditioned pitch-contour max pitch changed ratio: `0.7174`
+- model-conditioned pitch-contour changed-ratio review required: `true`
+- model-conditioned pitch-contour audio review required: `true`
+- model-conditioned pitch-contour preference fill allowed: `false`
+- model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
+- model-conditioned pitch-contour changed-ratio repair rendered WAV files: `3`
+- model-conditioned pitch-contour changed-ratio repair technical WAV validation: `true`
+- model-conditioned pitch-contour changed-ratio repair max interval / threshold: `12` / `12`
+- model-conditioned pitch-contour changed-ratio repair max ratio / target: `0.4348` / `0.5000`
+- model-conditioned pitch-contour changed-ratio repair target supported: `true`
+- model-conditioned pitch-contour changed-ratio repair audio review required: `true`
+- model-conditioned pitch-contour changed-ratio repair preference fill allowed: `false`
+- outside-soloing repair objective path ready: `true`
+- outside-soloing repair current evidence ready: `true`
+- outside-soloing repair rendered WAV files: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing source objective pitch-role risk: `5`
+- outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
+- outside-soloing pitch-role risk after / delta: `0` / `2`
+- outside-soloing repair objective path supported: `true`
+- outside-soloing repair target supported: `true`
+- outside-soloing repair weak landing target supported: `true`
+- outside-soloing repair final landing target supported: `true`
+- outside-soloing repair non-chord run target supported: `true`
+- outside-soloing repair preference fill allowed: `false`
+
+## Claim Boundary
+
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- broad trained model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+- production ready claimed: `false`
+
+## Not Proven
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`
+- `production_ready_improviser`
+
+## Next
+
+- `Stage B MIDI-to-solo quality gap decision`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6014,8 +6014,8 @@ run_stage_b_midi_to_solo_mvp_completion_audit() {
     --run_id "$run_id" \
     --current_evidence "$current_evidence" \
     --readme_path README.md \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_OUTSIDE_SOLOING_REPAIR_REFRESH_2026-06-10.md \
-    --issue_number 816 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
+    --issue_number 902 \
     --expected_boundary stage_b_midi_to_solo_mvp_completion_audit \
     --expected_next_boundary stage_b_midi_to_solo_quality_gap_decision \
     --require_technical_mvp_completion \

--- a/scripts/audit_stage_b_midi_to_solo_mvp_completion.py
+++ b/scripts/audit_stage_b_midi_to_solo_mvp_completion.py
@@ -256,6 +256,22 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloMvpCompletionAuditError(
             "outside-soloing repair residual pitch-role risk should be zero"
         )
+    if _int(outside_soloing_repair.get("source_outside_soloing_pitch_role_risk_count_before")) < _int(
+        outside_soloing_repair.get("source_outside_soloing_pitch_role_risk_count_after")
+    ):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "source outside-soloing risk should not increase"
+        )
+    if bool(outside_soloing_repair.get("source_outside_soloing_repair_targeted", True)):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "source outside-soloing repair should remain non-targeted"
+        )
+    if not bool(
+        outside_soloing_repair.get("source_outside_soloing_residual_risk_preserved", False)
+    ):
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "source outside-soloing residual risk boundary should be preserved"
+        )
     if _int(outside_soloing_repair.get("weak_chord_tone_landing_risk_count_after")) != 0:
         raise StageBMidiToSoloMvpCompletionAuditError(
             "outside-soloing repair weak landing risk should be zero"
@@ -418,6 +434,33 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
         "outside_soloing_repair_changed_note_total": _int(
             outside_soloing_repair.get("changed_note_total")
         ),
+        "outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+            outside_soloing_repair.get(
+                "source_objective_outside_soloing_pitch_role_risk_count"
+            )
+        ),
+        "outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+            outside_soloing_repair.get(
+                "source_outside_soloing_pitch_role_risk_count_before"
+            )
+        ),
+        "outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+            outside_soloing_repair.get(
+                "source_outside_soloing_pitch_role_risk_count_after"
+            )
+        ),
+        "outside_soloing_repair_source_pitch_role_risk_delta": _int(
+            outside_soloing_repair.get("source_outside_soloing_pitch_role_risk_delta")
+        ),
+        "outside_soloing_repair_source_targeted": bool(
+            outside_soloing_repair.get("source_outside_soloing_repair_targeted", True)
+        ),
+        "outside_soloing_repair_source_residual_risk_preserved": bool(
+            outside_soloing_repair.get(
+                "source_outside_soloing_residual_risk_preserved",
+                False,
+            )
+        ),
         "outside_soloing_repair_pitch_role_risk_count_after": _int(
             outside_soloing_repair.get("outside_soloing_pitch_role_risk_count_after")
         ),
@@ -472,6 +515,18 @@ def validate_readme_refresh(readme_text: str) -> dict[str, Any]:
         ),
         "outside_soloing_repair_in_current_evidence": (
             "current evidence outside-soloing repair objective path included: `true`"
+        ),
+        "outside_soloing_source_context_reflected": (
+            "outside-soloing source-context evidence reflected: `true`"
+        ),
+        "outside_soloing_source_risk": (
+            "outside-soloing source pitch-role risk count: `5 -> 2`"
+        ),
+        "outside_soloing_source_residual": (
+            "outside-soloing source residual risk preserved: `true`"
+        ),
+        "outside_soloing_current_repair_risk_after": (
+            "outside-soloing current repair pitch-role risk count after: `0`"
         ),
         "readme_refresh": "README evidence refreshed: `true`",
         "human_preference_false": "human/audio preference claim: `false`",
@@ -766,6 +821,24 @@ def validate_mvp_completion_audit_report(
         "outside_soloing_repair_changed_note_total": _int(
             evidence.get("outside_soloing_repair_changed_note_total")
         ),
+        "outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+            evidence.get("outside_soloing_repair_source_objective_pitch_role_risk_count")
+        ),
+        "outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+            evidence.get("outside_soloing_repair_source_pitch_role_risk_count_before")
+        ),
+        "outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+            evidence.get("outside_soloing_repair_source_pitch_role_risk_count_after")
+        ),
+        "outside_soloing_repair_source_pitch_role_risk_delta": _int(
+            evidence.get("outside_soloing_repair_source_pitch_role_risk_delta")
+        ),
+        "outside_soloing_repair_source_targeted": bool(
+            evidence.get("outside_soloing_repair_source_targeted", True)
+        ),
+        "outside_soloing_repair_source_residual_risk_preserved": bool(
+            evidence.get("outside_soloing_repair_source_residual_risk_preserved", False)
+        ),
         "outside_soloing_repair_pitch_role_risk_count_after": _int(
             evidence.get("outside_soloing_repair_pitch_role_risk_count_after")
         ),
@@ -856,6 +929,10 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- outside-soloing repair current evidence ready: `{_bool_token(evidence['outside_soloing_repair_current_evidence_ready'])}`",
         f"- outside-soloing repair rendered WAV files: `{evidence['outside_soloing_repair_rendered_audio_file_count']}`",
         f"- outside-soloing repair changed note total: `{evidence['outside_soloing_repair_changed_note_total']}`",
+        f"- outside-soloing source objective pitch-role risk: `{evidence['outside_soloing_repair_source_objective_pitch_role_risk_count']}`",
+        f"- outside-soloing source pitch-role risk before / after / delta: `{evidence['outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{evidence['outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{evidence['outside_soloing_repair_source_pitch_role_risk_delta']}`",
+        f"- outside-soloing source repair targeted: `{_bool_token(evidence['outside_soloing_repair_source_targeted'])}`",
+        f"- outside-soloing source residual risk preserved: `{_bool_token(evidence['outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- outside-soloing pitch-role risk after / delta: `{evidence['outside_soloing_repair_pitch_role_risk_count_after']}` / `{evidence['outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- outside-soloing repair objective path supported: `{_bool_token(evidence['outside_soloing_repair_objective_path_supported'])}`",
         f"- outside-soloing repair target supported: `{_bool_token(evidence['outside_soloing_repair_target_supported'])}`",

--- a/tests/test_stage_b_midi_to_solo_mvp_completion_audit.py
+++ b/tests/test_stage_b_midi_to_solo_mvp_completion_audit.py
@@ -133,6 +133,12 @@ def current_evidence(
             "technical_wav_validation": True,
             "rendered_audio_file_count": 6,
             "changed_note_total": 2,
+            "source_objective_outside_soloing_pitch_role_risk_count": 5,
+            "source_outside_soloing_pitch_role_risk_count_before": 5,
+            "source_outside_soloing_pitch_role_risk_count_after": 2,
+            "source_outside_soloing_pitch_role_risk_delta": 3,
+            "source_outside_soloing_repair_targeted": False,
+            "source_outside_soloing_residual_risk_preserved": True,
             "outside_soloing_pitch_role_risk_count_after": (
                 0 if outside_soloing_repair_supported else 1
             ),
@@ -167,6 +173,10 @@ def readme_text(*, missing_boundary: bool = False) -> str:
             "- current evidence changed-ratio repair objective path included: `true`",
             "- outside-soloing repair objective path included in current evidence: `true`",
             "- current evidence outside-soloing repair objective path included: `true`",
+            "- outside-soloing source-context evidence reflected: `true`",
+            "- outside-soloing source pitch-role risk count: `5 -> 2`",
+            "- outside-soloing source residual risk preserved: `true`",
+            "- outside-soloing current repair pitch-role risk count after: `0`",
             "- README evidence refreshed: `true`",
             "- human/audio preference claim: `false`",
             "- MIDI-to-solo musical quality claim: `false`",
@@ -261,6 +271,24 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
         self.assertTrue(summary["outside_soloing_repair_current_evidence_ready"])
         self.assertEqual(summary["outside_soloing_repair_rendered_audio_file_count"], 6)
         self.assertEqual(summary["outside_soloing_repair_changed_note_total"], 2)
+        self.assertEqual(
+            summary["outside_soloing_repair_source_objective_pitch_role_risk_count"],
+            5,
+        )
+        self.assertEqual(
+            summary["outside_soloing_repair_source_pitch_role_risk_count_before"],
+            5,
+        )
+        self.assertEqual(
+            summary["outside_soloing_repair_source_pitch_role_risk_count_after"],
+            2,
+        )
+        self.assertEqual(
+            summary["outside_soloing_repair_source_pitch_role_risk_delta"],
+            3,
+        )
+        self.assertFalse(summary["outside_soloing_repair_source_targeted"])
+        self.assertTrue(summary["outside_soloing_repair_source_residual_risk_preserved"])
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_count_after"], 0)
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_delta"], 2)
         self.assertTrue(summary["outside_soloing_repair_objective_path_supported"])


### PR DESCRIPTION
## Summary

- MVP completion audit에 outside-soloing source/current repair context 추가
- source risk `5 -> 2`, current repair risk `2 -> 0` 분리 기록
- README required snippet, validation summary, markdown report, status/Core Plan 갱신

## Context

- Issue #900 README evidence refresh 결과, source/current outside-soloing context가 README에 반영
- current evidence 주요 값: source risk `5 -> 2`, current repair risk `2 -> 0`, source repair targeted `false`, residual risk preserved `true`
- 기존 MVP completion audit은 outside-soloing repair objective path completion만 확인

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_mvp_completion.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- audit summary 범위 변경
- 생성 로직 변경 없음
- human/audio preference claim 없음
- MIDI-to-solo musical quality claim 없음

Closes #902