### PR TITLE
Stage B MIDI-to-solo quality gap decision source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,10 +14,11 @@ Current handoff scope:
 
 - Latest functional issue completed: Issue #898, Stage B MIDI-to-solo current evidence source-context refresh.
 - Latest audit issue completed: Issue #902, Stage B MIDI-to-solo MVP completion audit source-context refresh.
+- Latest quality gap decision completed: Issue #904, Stage B MIDI-to-solo quality gap decision source-context refresh.
 - Latest documentation issue completed: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after MVP completion audit refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo quality gap decision source-context refresh.
+- Open issue queue after quality gap decision source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo listening review quality gap source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1150,7 +1151,7 @@ For Stage B MIDI-to-solo quality gap decision changes, run:
 bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-gap-decision
 ```
 
-This harness selects the next quality-gap target after technical MVP completion without claiming musical quality or requiring immediate human review.
+This harness selects the next quality-gap target after technical MVP completion, preserves source/current outside-soloing repair context, and avoids musical quality or immediate human-review claims.
 
 For Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio review decision changes, run:
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 - latest functional result: `Issue #898`
 - latest MVP completion audit: `Issue #902`
+- latest quality gap decision: `Issue #904`
 - latest README evidence refresh: `Issue #900`
-- latest functional boundary: `stage_b_midi_to_solo_mvp_completion_audit`
-- open issue queue after MVP completion audit refresh merge: `0`
+- latest functional boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- open issue queue after quality gap decision source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -117,6 +118,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - quality gap decision completed: `true`
 - quality gap decision listening review target selected: `true`
 - quality gap decision outside-soloing repair objective included: `true`
+- quality gap decision outside-soloing source context included: `true`
 - pitch-contour changed-ratio review decision completed: `true`
 - pitch-contour changed-ratio repair probe required: `true`
 - pitch-contour changed-ratio repair probe completed: `true`
@@ -289,6 +291,10 @@ Quality gap decision.
 - model-conditioned pitch-contour changed-ratio review required: `true`
 - model-conditioned pitch-contour changed-ratio repair max ratio / target: `0.4348 / 0.5000`
 - model-conditioned pitch-contour changed-ratio repair max interval / target: `12 / 12`
+- outside-soloing source pitch-role risk count: `5 -> 2`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
+- outside-soloing current repair pitch-role risk count after: `0`
 - musical quality MVP completed: `false`
 - CLI candidate / rendered WAV: `3 / 3`
 - CLI preference fill allowed: `false`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -7773,6 +7773,53 @@ Issue #902는 Issue #898 current evidence와 Issue #900 README evidence refresh�
 
 - `Stage B MIDI-to-solo quality gap decision source-context refresh`
 
+## 9.142 Stage B MIDI-to-solo quality gap decision source-context refresh
+
+Issue #904는 Issue #902 MVP completion audit의 source/current outside-soloing context를 quality gap decision까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- source boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- next boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- selected target: `listening_review_quality_gap`
+- fallback path active: `true`
+- model-conditioned input path alignment required: `false`
+- technical model-core MVP completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour changed-ratio repair objective completed: `true`
+- outside-soloing repair objective completed: `true`
+- outside-soloing source objective pitch-role risk count: `5`
+- outside-soloing source pitch-role risk count: `5 -> 2`
+- outside-soloing source pitch-role risk delta: `3`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
+- outside-soloing current repair pitch-role risk count after: `0`
+- outside-soloing current repair pitch-role risk delta: `2`
+- outside-soloing repair target supported: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- quality gap decision 입력 검증에 source/current outside-soloing context 필수화.
+- source repair는 targeted repair가 아니며 residual risk boundary로 보존.
+- current repair `2 -> 0`은 objective evidence 범위로 한정.
+- 다음 작업은 listening review quality gap의 source-context 반영.
+- human/audio preference와 MIDI-to-solo musical quality claim 제외.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_gap_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_quality_gap.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-gap-decision`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo listening review quality gap source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -14,10 +14,11 @@
 
 - latest functional result: Issue #898, Stage B MIDI-to-solo current evidence source-context refresh
 - latest MVP completion audit: Issue #902, Stage B MIDI-to-solo MVP completion audit source-context refresh
+- latest quality gap decision: Issue #904, Stage B MIDI-to-solo quality gap decision source-context refresh
 - latest README evidence refresh: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after MVP completion audit refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo quality gap decision source-context refresh`
+- open issue queue after quality gap decision source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo listening review quality gap source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -466,12 +467,18 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 decision target: `stage_b_midi_to_solo_quality_gap_decision`
-- quality gap decision outside-soloing repair refresh 완료
+- quality gap decision source-context refresh 완료
 - selected target: `listening_review_quality_gap`
 - next boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
 - outside-soloing repair objective completed: `true`
 - outside-soloing repair target supported: `true`
+- outside-soloing source objective pitch-role risk count: `5`
+- outside-soloing source pitch-role risk count: `5 -> 2`
+- outside-soloing source pitch-role risk delta: `3`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
 - outside-soloing repair pitch-role risk count after: `0`
+- outside-soloing repair pitch-role risk delta: `2`
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 review target: `stage_b_midi_to_solo_listening_review_quality_gap`

--- a/docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -1,0 +1,63 @@
+# Stage B MIDI-to-Solo Quality Gap Decision
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- next boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- selected target: `listening_review_quality_gap`
+- fallback path active: `true`
+- pitch-contour changed-ratio review required: `true`
+- human review required now: `false`
+
+## Evidence
+
+- technical model-core MVP completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour changed-ratio repair objective completed: `true`
+- outside-soloing repair objective completed: `true`
+- musical quality MVP completed: `false`
+- generation source: `context_conditioned_fallback`
+- exported candidates: `3`
+- rendered WAV files: `3`
+- objective strict/sample: `9` / `9`
+- objective dead-air failure: `0`
+- CLI candidate / rendered WAV: `3` / `3`
+- CLI input context bars: `228`
+- CLI preference fill allowed: `false`
+- model-conditioned pitch-contour max interval / threshold: `11` / `12`
+- model-conditioned pitch-contour target supported: `true`
+- model-conditioned pitch-contour changed-ratio review required: `true`
+- model-conditioned pitch-contour audio review required: `true`
+- model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
+- model-conditioned pitch-contour changed-ratio repair rendered WAV files: `3`
+- model-conditioned pitch-contour changed-ratio repair technical WAV validation: `true`
+- model-conditioned pitch-contour changed-ratio repair max interval / threshold: `12` / `12`
+- model-conditioned pitch-contour changed-ratio repair max ratio / target: `0.4348` / `0.5000`
+- model-conditioned pitch-contour changed-ratio repair target supported: `true`
+- model-conditioned pitch-contour changed-ratio repair audio review required: `true`
+- model-conditioned pitch-contour changed-ratio repair preference fill allowed: `false`
+- outside-soloing repair objective path ready: `true`
+- outside-soloing repair rendered WAV files: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing source objective pitch-role risk: `5`
+- outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
+- outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- outside-soloing repair objective path supported: `true`
+- outside-soloing repair target supported: `true`
+- outside-soloing repair weak landing target supported: `true`
+- outside-soloing repair final landing target supported: `true`
+- outside-soloing repair non-chord run target supported: `true`
+
+## Claim Boundary
+
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- broad trained model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo listening review quality gap`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6037,8 +6037,8 @@ run_stage_b_midi_to_solo_quality_gap_decision() {
   "$PYTHON_BIN" scripts/decide_stage_b_midi_to_solo_quality_gap.py \
     --run_id "$run_id" \
     --mvp_completion_audit "$completion_audit" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_OUTSIDE_SOLOING_REPAIR_REFRESH_2026-06-10.md \
-    --issue_number 818 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
+    --issue_number 904 \
     --expected_boundary stage_b_midi_to_solo_quality_gap_decision \
     --expected_next_boundary stage_b_midi_to_solo_listening_review_quality_gap \
     --expected_target listening_review_quality_gap \

--- a/scripts/decide_stage_b_midi_to_solo_quality_gap.py
+++ b/scripts/decide_stage_b_midi_to_solo_quality_gap.py
@@ -173,6 +173,38 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloQualityGapDecisionError(
             "outside-soloing repair residual pitch-role risk should be zero"
         )
+    source_objective_risk = _int(
+        evidence.get("outside_soloing_repair_source_objective_pitch_role_risk_count")
+    )
+    source_risk_before = _int(
+        evidence.get("outside_soloing_repair_source_pitch_role_risk_count_before")
+    )
+    source_risk_after = _int(
+        evidence.get("outside_soloing_repair_source_pitch_role_risk_count_after")
+    )
+    source_risk_delta = _int(
+        evidence.get("outside_soloing_repair_source_pitch_role_risk_delta")
+    )
+    if source_objective_risk <= 0:
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing source objective pitch-role risk count required"
+        )
+    if source_risk_after > source_risk_before:
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing source pitch-role risk should not increase"
+        )
+    if source_risk_delta != source_risk_before - source_risk_after:
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing source pitch-role risk delta mismatch"
+        )
+    if bool(evidence.get("outside_soloing_repair_source_targeted", True)):
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing source repair should remain non-targeted"
+        )
+    if not bool(evidence.get("outside_soloing_repair_source_residual_risk_preserved", False)):
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing source residual risk preservation required"
+        )
     outside_targets = [
         "outside_soloing_repair_objective_path_supported",
         "outside_soloing_repair_target_supported",
@@ -297,6 +329,16 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
         ),
         "outside_soloing_repair_changed_note_total": _int(
             evidence.get("outside_soloing_repair_changed_note_total")
+        ),
+        "outside_soloing_repair_source_objective_pitch_role_risk_count": source_objective_risk,
+        "outside_soloing_repair_source_pitch_role_risk_count_before": source_risk_before,
+        "outside_soloing_repair_source_pitch_role_risk_count_after": source_risk_after,
+        "outside_soloing_repair_source_pitch_role_risk_delta": source_risk_delta,
+        "outside_soloing_repair_source_targeted": bool(
+            evidence.get("outside_soloing_repair_source_targeted", True)
+        ),
+        "outside_soloing_repair_source_residual_risk_preserved": bool(
+            evidence.get("outside_soloing_repair_source_residual_risk_preserved", False)
         ),
         "outside_soloing_repair_pitch_role_risk_count_after": _int(
             evidence.get("outside_soloing_repair_pitch_role_risk_count_after")
@@ -452,6 +494,24 @@ def build_quality_gap_decision_report(
             "outside_soloing_repair_target_supported": bool(
                 target["outside_soloing_repair_target_supported"]
             ),
+            "outside_soloing_repair_source_objective_pitch_role_risk_count": int(
+                audit_summary["outside_soloing_repair_source_objective_pitch_role_risk_count"]
+            ),
+            "outside_soloing_repair_source_pitch_role_risk_count_before": int(
+                audit_summary["outside_soloing_repair_source_pitch_role_risk_count_before"]
+            ),
+            "outside_soloing_repair_source_pitch_role_risk_count_after": int(
+                audit_summary["outside_soloing_repair_source_pitch_role_risk_count_after"]
+            ),
+            "outside_soloing_repair_source_pitch_role_risk_delta": int(
+                audit_summary["outside_soloing_repair_source_pitch_role_risk_delta"]
+            ),
+            "outside_soloing_repair_source_targeted": bool(
+                audit_summary["outside_soloing_repair_source_targeted"]
+            ),
+            "outside_soloing_repair_source_residual_risk_preserved": bool(
+                audit_summary["outside_soloing_repair_source_residual_risk_preserved"]
+            ),
             "human_review_required_now": False,
         },
         "selected_target": target,
@@ -527,6 +587,38 @@ def validate_quality_gap_decision_report(
         raise StageBMidiToSoloQualityGapDecisionError("musical quality should remain incomplete")
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloQualityGapDecisionError("critical user input should not be required")
+    source_objective_risk = _int(
+        quality_gap.get("outside_soloing_repair_source_objective_pitch_role_risk_count")
+    )
+    source_risk_before = _int(
+        quality_gap.get("outside_soloing_repair_source_pitch_role_risk_count_before")
+    )
+    source_risk_after = _int(
+        quality_gap.get("outside_soloing_repair_source_pitch_role_risk_count_after")
+    )
+    source_risk_delta = _int(
+        quality_gap.get("outside_soloing_repair_source_pitch_role_risk_delta")
+    )
+    if source_objective_risk <= 0:
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing source objective pitch-role risk count required"
+        )
+    if source_risk_after > source_risk_before:
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing source pitch-role risk should not increase"
+        )
+    if source_risk_delta != source_risk_before - source_risk_after:
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing source pitch-role risk delta mismatch"
+        )
+    if bool(quality_gap.get("outside_soloing_repair_source_targeted", True)):
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing source repair should remain non-targeted"
+        )
+    if not bool(quality_gap.get("outside_soloing_repair_source_residual_risk_preserved", False)):
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing source residual risk preservation required"
+        )
     if require_no_quality_claim:
         blocked = [
             "human_audio_preference_claimed",
@@ -582,6 +674,24 @@ def validate_quality_gap_decision_report(
         ),
         "outside_soloing_repair_target_supported": bool(
             quality_gap.get("outside_soloing_repair_target_supported", False)
+        ),
+        "outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+            source_objective_risk
+        ),
+        "outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+            source_risk_before
+        ),
+        "outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+            source_risk_after
+        ),
+        "outside_soloing_repair_source_pitch_role_risk_delta": _int(
+            source_risk_delta
+        ),
+        "outside_soloing_repair_source_targeted": bool(
+            quality_gap.get("outside_soloing_repair_source_targeted", True)
+        ),
+        "outside_soloing_repair_source_residual_risk_preserved": bool(
+            quality_gap.get("outside_soloing_repair_source_residual_risk_preserved", False)
         ),
         "musical_quality_mvp_completed": bool(quality_gap.get("musical_quality_mvp_completed", True)),
         "cli_candidate_count": _int(_dict(report.get("mvp_completion_summary")).get("cli_candidate_count")),
@@ -734,7 +844,11 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- outside-soloing repair objective path ready: `{_bool_token(summary['outside_soloing_repair_objective_path_ready'])}`",
         f"- outside-soloing repair rendered WAV files: `{summary['outside_soloing_repair_rendered_audio_file_count']}`",
         f"- outside-soloing repair changed note total: `{summary['outside_soloing_repair_changed_note_total']}`",
-        f"- outside-soloing pitch-role risk after / delta: `{summary['outside_soloing_repair_pitch_role_risk_count_after']}` / `{summary['outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- outside-soloing source objective pitch-role risk: `{summary['outside_soloing_repair_source_objective_pitch_role_risk_count']}`",
+        f"- outside-soloing source pitch-role risk before / after / delta: `{summary['outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{summary['outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{summary['outside_soloing_repair_source_pitch_role_risk_delta']}`",
+        f"- outside-soloing source repair targeted: `{_bool_token(summary['outside_soloing_repair_source_targeted'])}`",
+        f"- outside-soloing source residual risk preserved: `{_bool_token(summary['outside_soloing_repair_source_residual_risk_preserved'])}`",
+        f"- outside-soloing current repair pitch-role risk after / delta: `{summary['outside_soloing_repair_pitch_role_risk_count_after']}` / `{summary['outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- outside-soloing repair objective path supported: `{_bool_token(summary['outside_soloing_repair_objective_path_supported'])}`",
         f"- outside-soloing repair target supported: `{_bool_token(summary['outside_soloing_repair_target_supported'])}`",
         f"- outside-soloing repair weak landing target supported: `{_bool_token(summary['outside_soloing_repair_weak_landing_target_supported'])}`",

--- a/tests/test_stage_b_midi_to_solo_quality_gap_decision.py
+++ b/tests/test_stage_b_midi_to_solo_quality_gap_decision.py
@@ -109,6 +109,12 @@ def mvp_completion_audit(
             "outside_soloing_repair_current_evidence_ready": outside_soloing_repair_supported,
             "outside_soloing_repair_rendered_audio_file_count": 6,
             "outside_soloing_repair_changed_note_total": 2,
+            "outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "outside_soloing_repair_source_pitch_role_risk_count_before": 5,
+            "outside_soloing_repair_source_pitch_role_risk_count_after": 2,
+            "outside_soloing_repair_source_pitch_role_risk_delta": 3,
+            "outside_soloing_repair_source_targeted": False,
+            "outside_soloing_repair_source_residual_risk_preserved": True,
             "outside_soloing_repair_pitch_role_risk_count_after": (
                 0 if outside_soloing_repair_supported else 1
             ),
@@ -182,6 +188,21 @@ class StageBMidiToSoloQualityGapDecisionTest(unittest.TestCase):
         self.assertTrue(summary["outside_soloing_repair_target_supported"])
         self.assertEqual(summary["outside_soloing_repair_rendered_audio_file_count"], 6)
         self.assertEqual(summary["outside_soloing_repair_changed_note_total"], 2)
+        self.assertEqual(
+            summary["outside_soloing_repair_source_objective_pitch_role_risk_count"],
+            5,
+        )
+        self.assertEqual(
+            summary["outside_soloing_repair_source_pitch_role_risk_count_before"],
+            5,
+        )
+        self.assertEqual(
+            summary["outside_soloing_repair_source_pitch_role_risk_count_after"],
+            2,
+        )
+        self.assertEqual(summary["outside_soloing_repair_source_pitch_role_risk_delta"], 3)
+        self.assertFalse(summary["outside_soloing_repair_source_targeted"])
+        self.assertTrue(summary["outside_soloing_repair_source_residual_risk_preserved"])
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_count_after"], 0)
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_delta"], 2)
         self.assertTrue(summary["outside_soloing_repair_objective_path_supported"])
@@ -319,6 +340,43 @@ class StageBMidiToSoloQualityGapDecisionTest(unittest.TestCase):
                 ),
                 output_dir=Path("outputs/quality_gap"),
                 issue_number=818,
+            )
+
+    def test_rejects_missing_outside_soloing_source_context(self) -> None:
+        source = mvp_completion_audit()
+        source["current_evidence"].pop(
+            "outside_soloing_repair_source_residual_risk_preserved"
+        )
+
+        with self.assertRaises(StageBMidiToSoloQualityGapDecisionError):
+            build_quality_gap_decision_report(
+                mvp_completion_audit=source,
+                output_dir=Path("outputs/quality_gap"),
+                issue_number=904,
+            )
+
+    def test_rejects_targeted_outside_soloing_source_repair(self) -> None:
+        source = mvp_completion_audit()
+        source["current_evidence"]["outside_soloing_repair_source_targeted"] = True
+
+        with self.assertRaises(StageBMidiToSoloQualityGapDecisionError):
+            build_quality_gap_decision_report(
+                mvp_completion_audit=source,
+                output_dir=Path("outputs/quality_gap"),
+                issue_number=904,
+            )
+
+    def test_rejects_outside_soloing_source_risk_delta_mismatch(self) -> None:
+        source = mvp_completion_audit()
+        source["current_evidence"][
+            "outside_soloing_repair_source_pitch_role_risk_delta"
+        ] = 2
+
+        with self.assertRaises(StageBMidiToSoloQualityGapDecisionError):
+            build_quality_gap_decision_report(
+                mvp_completion_audit=source,
+                output_dir=Path("outputs/quality_gap"),
+                issue_number=904,
             )
 
     def test_boundary_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary

- quality gap decision source/current outside-soloing context 보존
- source pitch-role risk `5 -> 2`, current repair risk `2 -> 0` 분리 기록
- source repair targeted=false, residual risk preserved=true guard 추가

## Context

- #902 MVP completion audit 기준 source/current outside-soloing context 추가
- 기존 quality gap decision 범위: outside-soloing repair readiness와 target support 중심
- 누락 지점: source repair가 targeted repair가 아니라 residual risk boundary라는 정보 미전달

## Scope

- `decide_stage_b_midi_to_solo_quality_gap.py` validation/report 확장
- source risk before/after/delta 검증
- source targeted/residual preservation 검증
- generated markdown evidence source/current 구분
- harness doc path, README, CURRENT_STATUS, CORE_PLAN, AGENTS 갱신

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_gap_decision`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_quality_gap.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-gap-decision`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- report schema 확장
- MIDI 생성/후처리 로직 변경 없음
- musical quality, human/audio preference claim 제외

Closes #904