### PR TITLE
Stage B MIDI-to-solo listening review quality gap source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,10 +15,11 @@ Current handoff scope:
 - Latest functional issue completed: Issue #898, Stage B MIDI-to-solo current evidence source-context refresh.
 - Latest audit issue completed: Issue #902, Stage B MIDI-to-solo MVP completion audit source-context refresh.
 - Latest quality gap decision completed: Issue #904, Stage B MIDI-to-solo quality gap decision source-context refresh.
+- Latest listening review quality gap completed: Issue #906, Stage B MIDI-to-solo listening review quality gap source-context refresh.
 - Latest documentation issue completed: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after quality gap decision source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo listening review quality gap source-context refresh.
+- Open issue queue after listening review quality gap source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo MVP delivery package source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1152,6 +1153,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-gap-decision
 ```
 
 This harness selects the next quality-gap target after technical MVP completion, preserves source/current outside-soloing repair context, and avoids musical quality or immediate human-review claims.
+
+For Stage B MIDI-to-solo listening review quality gap changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-listening-review-quality-gap
+```
+
+This harness routes the listening review quality gap to MVP delivery packaging, preserves source/current outside-soloing repair context, and avoids musical quality or human/audio preference claims.
 
 For Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio review decision changes, run:
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest functional result: `Issue #898`
 - latest MVP completion audit: `Issue #902`
 - latest quality gap decision: `Issue #904`
+- latest listening review quality gap: `Issue #906`
 - latest README evidence refresh: `Issue #900`
-- latest functional boundary: `stage_b_midi_to_solo_quality_gap_decision`
-- open issue queue after quality gap decision source-context refresh merge: `0`
+- latest functional boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- open issue queue after listening review quality gap source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -152,6 +153,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - listening review quality gap completed: `true`
 - listening review quality gap open: `true`
 - listening review quality gap outside-soloing repair objective included: `true`
+- listening review quality gap outside-soloing source context included: `true`
 - MVP delivery package completed: `true`
 - runnable CLI ready: `true`
 - input to ranked MIDI ready: `true`
@@ -309,6 +311,10 @@ Listening review quality gap.
 - changed-ratio repair objective completed: `true`
 - changed-ratio repair max ratio / target: `0.4348 / 0.5000`
 - changed-ratio repair max interval / target: `12 / 12`
+- outside-soloing source pitch-role risk count: `5 -> 2`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
+- outside-soloing current repair pitch-role risk count after: `0`
 - listening review quality gap open: `true`
 - technical MVP delivery package ready: `true`
 - human/audio preference claimed: `false`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -7820,6 +7820,54 @@ Issue #904는 Issue #902 MVP completion audit의 source/current outside-soloing 
 
 - `Stage B MIDI-to-solo listening review quality gap source-context refresh`
 
+## 9.143 Stage B MIDI-to-solo listening review quality gap source-context refresh
+
+Issue #906은 Issue #904 quality gap decision의 source/current outside-soloing context를 listening review quality gap boundary까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- source boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- next boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- selected target: `mvp_delivery_package`
+- listening review quality gap open: `true`
+- technical MVP delivery package ready: `true`
+- technical model-core MVP completed: `true`
+- changed-ratio repair objective completed: `true`
+- changed-ratio repair max interval / threshold: `12 / 12`
+- changed-ratio repair max ratio / target: `0.4348 / 0.5000`
+- outside-soloing repair objective completed: `true`
+- outside-soloing repair rendered audio file count: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing source objective pitch-role risk count: `5`
+- outside-soloing source pitch-role risk count: `5 -> 2`
+- outside-soloing source pitch-role risk delta: `3`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
+- outside-soloing current repair pitch-role risk count after: `0`
+- outside-soloing current repair pitch-role risk delta: `2`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- listening review quality gap은 open 상태로 유지.
+- delivery package 준비는 technical evidence packaging 범위로 분리.
+- source repair는 targeted repair가 아니며 residual risk boundary로 보존.
+- current repair `2 -> 0`은 objective evidence 범위로 한정.
+- human/audio preference와 MIDI-to-solo musical quality claim 제외.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_listening_review_quality_gap`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-listening-review-quality-gap`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo MVP delivery package source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -15,10 +15,11 @@
 - latest functional result: Issue #898, Stage B MIDI-to-solo current evidence source-context refresh
 - latest MVP completion audit: Issue #902, Stage B MIDI-to-solo MVP completion audit source-context refresh
 - latest quality gap decision: Issue #904, Stage B MIDI-to-solo quality gap decision source-context refresh
+- latest listening review quality gap: Issue #906, Stage B MIDI-to-solo listening review quality gap source-context refresh
 - latest README evidence refresh: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after quality gap decision source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo listening review quality gap source-context refresh`
+- open issue queue after listening review quality gap source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo MVP delivery package source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -482,12 +483,18 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 review target: `stage_b_midi_to_solo_listening_review_quality_gap`
-- listening review quality gap outside-soloing repair refresh 완료
+- listening review quality gap source-context refresh 완료
 - selected target: `mvp_delivery_package`
 - technical MVP delivery package ready: `true`
 - outside-soloing repair objective completed: `true`
 - outside-soloing repair rendered audio file count: `6`
+- outside-soloing source objective pitch-role risk count: `5`
+- outside-soloing source pitch-role risk count: `5 -> 2`
+- outside-soloing source pitch-role risk delta: `3`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
 - outside-soloing repair pitch-role risk count after: `0`
+- outside-soloing repair pitch-role risk delta: `2`
 - listening review quality gap open: `true`
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`

--- a/docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -1,0 +1,49 @@
+# Stage B MIDI-to-Solo Listening Review Quality Gap
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- source boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- next boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- selected target: `mvp_delivery_package`
+- listening review quality gap open: `true`
+- technical MVP delivery package ready: `true`
+- human review required now: `false`
+
+## Evidence
+
+- technical model-core MVP completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- changed-ratio repair objective completed: `true`
+- outside-soloing repair objective completed: `true`
+- rendered WAV files: `3`
+- changed-ratio repair max interval / threshold: `12` / `12`
+- changed-ratio repair max ratio / target: `0.4348` / `0.5000`
+- outside-soloing repair objective path ready: `true`
+- outside-soloing repair target supported: `true`
+- outside-soloing repair rendered WAV files: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing source objective pitch-role risk: `5`
+- outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
+- outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- outside-soloing repair objective path supported: `true`
+- outside-soloing repair weak landing target supported: `true`
+- outside-soloing repair final landing target supported: `true`
+- outside-soloing repair non-chord run target supported: `true`
+- musical quality MVP completed: `false`
+- human/audio preference completed: `false`
+- product MVP completed: `false`
+
+## Claim Boundary
+
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- broad trained model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo MVP delivery package`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6057,8 +6057,8 @@ run_stage_b_midi_to_solo_listening_review_quality_gap() {
   "$PYTHON_BIN" scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py \
     --run_id "$run_id" \
     --quality_gap_decision "$quality_gap" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_OUTSIDE_SOLOING_REPAIR_REFRESH_2026-06-10.md \
-    --issue_number 820 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
+    --issue_number 906 \
     --expected_boundary stage_b_midi_to_solo_listening_review_quality_gap \
     --expected_next_boundary stage_b_midi_to_solo_mvp_delivery_package \
     --expected_target mvp_delivery_package \

--- a/scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py
+++ b/scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py
@@ -158,6 +158,38 @@ def validate_quality_gap_decision(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloListeningReviewQualityGapError(
             "outside-soloing repair residual pitch-role risk should be zero"
         )
+    source_objective_risk = _int(
+        quality_gap.get("outside_soloing_repair_source_objective_pitch_role_risk_count")
+    )
+    source_risk_before = _int(
+        quality_gap.get("outside_soloing_repair_source_pitch_role_risk_count_before")
+    )
+    source_risk_after = _int(
+        quality_gap.get("outside_soloing_repair_source_pitch_role_risk_count_after")
+    )
+    source_risk_delta = _int(
+        quality_gap.get("outside_soloing_repair_source_pitch_role_risk_delta")
+    )
+    if source_objective_risk <= 0:
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing source objective pitch-role risk count required"
+        )
+    if source_risk_after > source_risk_before:
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing source pitch-role risk should not increase"
+        )
+    if source_risk_delta != source_risk_before - source_risk_after:
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing source pitch-role risk delta mismatch"
+        )
+    if bool(quality_gap.get("outside_soloing_repair_source_targeted", True)):
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing source repair should remain non-targeted"
+        )
+    if not bool(quality_gap.get("outside_soloing_repair_source_residual_risk_preserved", False)):
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing source residual risk preservation required"
+        )
     outside_targets = [
         "outside_soloing_repair_objective_path_supported",
         "outside_soloing_repair_weak_landing_target_supported",
@@ -210,6 +242,16 @@ def validate_quality_gap_decision(report: dict[str, Any]) -> dict[str, Any]:
         ),
         "outside_soloing_repair_changed_note_total": _int(
             summary.get("outside_soloing_repair_changed_note_total")
+        ),
+        "outside_soloing_repair_source_objective_pitch_role_risk_count": source_objective_risk,
+        "outside_soloing_repair_source_pitch_role_risk_count_before": source_risk_before,
+        "outside_soloing_repair_source_pitch_role_risk_count_after": source_risk_after,
+        "outside_soloing_repair_source_pitch_role_risk_delta": source_risk_delta,
+        "outside_soloing_repair_source_targeted": bool(
+            quality_gap.get("outside_soloing_repair_source_targeted", True)
+        ),
+        "outside_soloing_repair_source_residual_risk_preserved": bool(
+            quality_gap.get("outside_soloing_repair_source_residual_risk_preserved", False)
         ),
         "outside_soloing_repair_pitch_role_risk_count_after": _int(
             summary.get("outside_soloing_repair_pitch_role_risk_count_after")
@@ -332,6 +374,38 @@ def validate_listening_review_quality_gap_report(
         raise StageBMidiToSoloListeningReviewQualityGapError("critical user input should not be required")
     if require_no_quality_claim:
         _require_no_quality_claim(readiness, label="listening review quality gap readiness")
+    source_objective_risk = _int(
+        summary.get("outside_soloing_repair_source_objective_pitch_role_risk_count")
+    )
+    source_risk_before = _int(
+        summary.get("outside_soloing_repair_source_pitch_role_risk_count_before")
+    )
+    source_risk_after = _int(
+        summary.get("outside_soloing_repair_source_pitch_role_risk_count_after")
+    )
+    source_risk_delta = _int(
+        summary.get("outside_soloing_repair_source_pitch_role_risk_delta")
+    )
+    if source_objective_risk <= 0:
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing source objective pitch-role risk count required"
+        )
+    if source_risk_after > source_risk_before:
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing source pitch-role risk should not increase"
+        )
+    if source_risk_delta != source_risk_before - source_risk_after:
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing source pitch-role risk delta mismatch"
+        )
+    if bool(summary.get("outside_soloing_repair_source_targeted", True)):
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing source repair should remain non-targeted"
+        )
+    if not bool(summary.get("outside_soloing_repair_source_residual_risk_preserved", False)):
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing source residual risk preservation required"
+        )
     return {
         "boundary": boundary,
         "next_boundary": str(decision.get("next_boundary") or ""),
@@ -361,6 +435,16 @@ def validate_listening_review_quality_gap_report(
         ),
         "outside_soloing_repair_changed_note_total": _int(
             summary.get("outside_soloing_repair_changed_note_total")
+        ),
+        "outside_soloing_repair_source_objective_pitch_role_risk_count": source_objective_risk,
+        "outside_soloing_repair_source_pitch_role_risk_count_before": source_risk_before,
+        "outside_soloing_repair_source_pitch_role_risk_count_after": source_risk_after,
+        "outside_soloing_repair_source_pitch_role_risk_delta": source_risk_delta,
+        "outside_soloing_repair_source_targeted": bool(
+            summary.get("outside_soloing_repair_source_targeted", True)
+        ),
+        "outside_soloing_repair_source_residual_risk_preserved": bool(
+            summary.get("outside_soloing_repair_source_residual_risk_preserved", False)
         ),
         "outside_soloing_repair_pitch_role_risk_count_after": _int(
             summary.get("outside_soloing_repair_pitch_role_risk_count_after")
@@ -428,7 +512,11 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- outside-soloing repair target supported: `{_bool_token(summary['outside_soloing_repair_target_supported'])}`",
         f"- outside-soloing repair rendered WAV files: `{summary['outside_soloing_repair_rendered_audio_file_count']}`",
         f"- outside-soloing repair changed note total: `{summary['outside_soloing_repair_changed_note_total']}`",
-        f"- outside-soloing pitch-role risk after / delta: `{summary['outside_soloing_repair_pitch_role_risk_count_after']}` / `{summary['outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- outside-soloing source objective pitch-role risk: `{summary['outside_soloing_repair_source_objective_pitch_role_risk_count']}`",
+        f"- outside-soloing source pitch-role risk before / after / delta: `{summary['outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{summary['outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{summary['outside_soloing_repair_source_pitch_role_risk_delta']}`",
+        f"- outside-soloing source repair targeted: `{_bool_token(summary['outside_soloing_repair_source_targeted'])}`",
+        f"- outside-soloing source residual risk preserved: `{_bool_token(summary['outside_soloing_repair_source_residual_risk_preserved'])}`",
+        f"- outside-soloing current repair pitch-role risk after / delta: `{summary['outside_soloing_repair_pitch_role_risk_count_after']}` / `{summary['outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- outside-soloing repair objective path supported: `{_bool_token(summary['outside_soloing_repair_objective_path_supported'])}`",
         f"- outside-soloing repair weak landing target supported: `{_bool_token(summary['outside_soloing_repair_weak_landing_target_supported'])}`",
         f"- outside-soloing repair final landing target supported: `{_bool_token(summary['outside_soloing_repair_final_landing_target_supported'])}`",

--- a/tests/test_stage_b_midi_to_solo_listening_review_quality_gap.py
+++ b/tests/test_stage_b_midi_to_solo_listening_review_quality_gap.py
@@ -49,6 +49,12 @@ def quality_gap_decision(
             "pitch_contour_changed_ratio_repair_target_supported": changed_ratio_supported,
             "outside_soloing_repair_objective_path_ready": outside_soloing_repair_supported,
             "outside_soloing_repair_target_supported": outside_soloing_repair_supported,
+            "outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "outside_soloing_repair_source_pitch_role_risk_count_before": 5,
+            "outside_soloing_repair_source_pitch_role_risk_count_after": 2,
+            "outside_soloing_repair_source_pitch_role_risk_delta": 3,
+            "outside_soloing_repair_source_targeted": False,
+            "outside_soloing_repair_source_residual_risk_preserved": True,
             "human_review_required_now": False,
         },
         "mvp_completion_summary": {
@@ -126,6 +132,21 @@ class StageBMidiToSoloListeningReviewQualityGapTest(unittest.TestCase):
         self.assertTrue(summary["outside_soloing_repair_target_supported"])
         self.assertEqual(summary["outside_soloing_repair_rendered_audio_file_count"], 6)
         self.assertEqual(summary["outside_soloing_repair_changed_note_total"], 2)
+        self.assertEqual(
+            summary["outside_soloing_repair_source_objective_pitch_role_risk_count"],
+            5,
+        )
+        self.assertEqual(
+            summary["outside_soloing_repair_source_pitch_role_risk_count_before"],
+            5,
+        )
+        self.assertEqual(
+            summary["outside_soloing_repair_source_pitch_role_risk_count_after"],
+            2,
+        )
+        self.assertEqual(summary["outside_soloing_repair_source_pitch_role_risk_delta"], 3)
+        self.assertFalse(summary["outside_soloing_repair_source_targeted"])
+        self.assertTrue(summary["outside_soloing_repair_source_residual_risk_preserved"])
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_count_after"], 0)
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_delta"], 2)
         self.assertTrue(summary["outside_soloing_repair_objective_path_supported"])
@@ -175,6 +196,41 @@ class StageBMidiToSoloListeningReviewQualityGapTest(unittest.TestCase):
                 ),
                 output_dir=Path("outputs/listening_review_quality_gap"),
                 issue_number=820,
+            )
+
+    def test_rejects_missing_outside_soloing_source_context(self) -> None:
+        source = quality_gap_decision()
+        source["quality_gap"].pop("outside_soloing_repair_source_residual_risk_preserved")
+
+        with self.assertRaises(StageBMidiToSoloListeningReviewQualityGapError):
+            build_listening_review_quality_gap_report(
+                quality_gap_decision=source,
+                output_dir=Path("outputs/listening_review_quality_gap"),
+                issue_number=906,
+            )
+
+    def test_rejects_targeted_outside_soloing_source_repair(self) -> None:
+        source = quality_gap_decision()
+        source["quality_gap"]["outside_soloing_repair_source_targeted"] = True
+
+        with self.assertRaises(StageBMidiToSoloListeningReviewQualityGapError):
+            build_listening_review_quality_gap_report(
+                quality_gap_decision=source,
+                output_dir=Path("outputs/listening_review_quality_gap"),
+                issue_number=906,
+            )
+
+    def test_rejects_outside_soloing_source_risk_delta_mismatch(self) -> None:
+        source = quality_gap_decision()
+        source["quality_gap"][
+            "outside_soloing_repair_source_pitch_role_risk_delta"
+        ] = 2
+
+        with self.assertRaises(StageBMidiToSoloListeningReviewQualityGapError):
+            build_listening_review_quality_gap_report(
+                quality_gap_decision=source,
+                output_dir=Path("outputs/listening_review_quality_gap"),
+                issue_number=906,
             )
 
     def test_rejects_quality_claim(self) -> None:


### PR DESCRIPTION
## Summary

- listening review quality gap source/current outside-soloing context 보존
- source pitch-role risk `5 -> 2`, current repair risk `2 -> 0` 분리 기록
- delivery package target 유지, musical quality claim 제외

## Context

- #904 quality gap decision 기준 source/current outside-soloing context 추가
- 기존 listening review quality gap 범위: delivery package target 선택과 quality claim 차단 중심
- 누락 지점: source repair가 targeted repair가 아니라 residual risk boundary라는 정보 미전달

## Scope

- `decide_stage_b_midi_to_solo_listening_review_quality_gap.py` validation/report 확장
- source risk before/after/delta 검증
- source targeted/residual preservation 검증
- generated markdown evidence source/current 구분
- harness doc path, README, CURRENT_STATUS, CORE_PLAN, AGENTS 갱신

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_listening_review_quality_gap`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-listening-review-quality-gap`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- report schema 확장
- MIDI 생성/후처리 로직 변경 없음
- musical quality, human/audio preference claim 제외

Closes #906