### PR TITLE
Stage B MIDI-to-solo final status audit source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,10 +18,11 @@ Current handoff scope:
 - Latest listening review quality gap completed: Issue #906, Stage B MIDI-to-solo listening review quality gap source-context refresh.
 - Latest MVP delivery package completed: Issue #908, Stage B MIDI-to-solo MVP delivery package source-context refresh.
 - Latest README final evidence refresh completed: Issue #910, Stage B MIDI-to-solo README final evidence source-context refresh.
+- Latest final status audit completed: Issue #912, Stage B MIDI-to-solo final status audit source-context refresh.
 - Latest documentation issue completed: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after README final evidence source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo final status audit source-context refresh.
+- Open issue queue after final status audit source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -1171,6 +1172,14 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-delivery-package
 ```
 
 This harness records the runnable CLI and local artifact evidence for MVP delivery, preserves source/current outside-soloing repair context, and avoids raw artifact upload or quality claims.
+
+For Stage B MIDI-to-solo final status audit changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-final-status-audit
+```
+
+This harness audits technical MVP completion and README evidence reflection, preserves source/current outside-soloing repair context, and avoids musical quality or human/audio preference claims.
 
 For Stage B MIDI-to-solo model-conditioned pitch-contour changed-ratio review decision changes, run:
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest listening review quality gap: `Issue #906`
 - latest MVP delivery package: `Issue #908`
 - latest README final evidence refresh: `Issue #910`
+- latest final status audit: `Issue #912`
 - latest README evidence refresh: `Issue #900`
-- latest functional boundary: `stage_b_midi_to_solo_readme_final_evidence_refresh`
-- open issue queue after README final evidence source-context refresh merge: `0`
+- latest functional boundary: `stage_b_midi_to_solo_final_status_audit`
+- open issue queue after final status audit source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -7959,6 +7959,52 @@ Issue #910은 Issue #908 MVP delivery package의 source/current outside-soloing 
 
 - `Stage B MIDI-to-solo final status audit source-context refresh`
 
+## 9.146 Stage B MIDI-to-solo final status audit source-context refresh
+
+Issue #912는 Issue #910 README final evidence와 Issue #908 delivery package 결과를 기준으로 final status audit summary에 source/current outside-soloing context를 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_final_status_audit`
+- source boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- next boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- technical MVP complete: `true`
+- technical MVP ready for local review: `true`
+- README final evidence reflected: `true`
+- CLI candidate count: `3`
+- changed-ratio repair WAV count: `3`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair WAV count: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing source objective pitch-role risk count: `5`
+- outside-soloing source pitch-role risk count: `5 -> 2`
+- outside-soloing source pitch-role risk delta: `3`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
+- outside-soloing current repair pitch-role risk count after: `0`
+- outside-soloing current repair pitch-role risk delta: `2`
+- raw artifact upload required: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- final status audit summary에 delivery package source/current context 반영.
+- technical MVP complete는 local review 가능한 execution evidence 범위로 한정.
+- listening review와 musical quality claim은 post-MVP iteration 대상으로 유지.
+- human/audio preference와 MIDI-to-solo musical quality claim 제외.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_final_status_audit`
+- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_final_status.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-final-status-audit`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -18,10 +18,11 @@
 - latest listening review quality gap: Issue #906, Stage B MIDI-to-solo listening review quality gap source-context refresh
 - latest MVP delivery package: Issue #908, Stage B MIDI-to-solo MVP delivery package source-context refresh
 - latest README final evidence refresh: Issue #910, Stage B MIDI-to-solo README final evidence source-context refresh
+- latest final status audit: Issue #912, Stage B MIDI-to-solo final status audit source-context refresh
 - latest README evidence refresh: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after README final evidence source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo final status audit source-context refresh`
+- open issue queue after final status audit source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -532,13 +533,19 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 audit target: `stage_b_midi_to_solo_final_status_audit`
-- final status audit outside-soloing repair refresh 완료
+- final status audit source-context refresh 완료
 - technical MVP complete: `true`
 - README final evidence reflected: `true`
 - outside-soloing repair evidence ready: `true`
 - outside-soloing repair WAV count: `6`
 - outside-soloing repair changed note total: `2`
+- outside-soloing source objective pitch-role risk count: `5`
+- outside-soloing source pitch-role risk count: `5 -> 2`
+- outside-soloing source pitch-role risk delta: `3`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
 - outside-soloing repair pitch-role risk count after: `0`
+- outside-soloing repair pitch-role risk delta: `2`
 - raw artifact upload required: `false`
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`

--- a/docs/STAGE_B_MIDI_TO_SOLO_FINAL_STATUS_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_FINAL_STATUS_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -1,0 +1,39 @@
+# Stage B MIDI-to-Solo Final Status Audit
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_final_status_audit`
+- source boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- next boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- technical MVP complete: `true`
+- technical MVP ready for local review: `true`
+- README final evidence reflected: `true`
+
+## Evidence
+
+- input to ranked MIDI ready: `true`
+- input to rendered WAV evidence ready: `true`
+- changed-ratio repair audio evidence ready: `true`
+- outside-soloing repair evidence ready: `true`
+- CLI candidate count: `3`
+- changed-ratio repair WAV count: `3`
+- outside-soloing repair WAV count: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing source objective pitch-role risk: `5`
+- outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
+- outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- listening review quality gap open: `true`
+- raw artifact upload required: `false`
+
+## Claim Boundary
+
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- broad trained model quality claimed: `false`
+- Brad style adaptation claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo post-MVP musical quality iteration plan`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6113,8 +6113,8 @@ run_stage_b_midi_to_solo_final_status_audit() {
     --run_id "$run_id" \
     --delivery_package "$delivery_package" \
     --readme_path README.md \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_FINAL_STATUS_AUDIT_2026-06-10.md \
-    --issue_number 826 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_FINAL_STATUS_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
+    --issue_number 912 \
     --expected_boundary stage_b_midi_to_solo_final_status_audit \
     --expected_next_boundary stage_b_midi_to_solo_post_mvp_quality_iteration_plan \
     --require_technical_mvp_complete \

--- a/scripts/audit_stage_b_midi_to_solo_final_status.py
+++ b/scripts/audit_stage_b_midi_to_solo_final_status.py
@@ -142,6 +142,24 @@ def build_final_status_audit_report(
         "outside_soloing_repair_changed_note_total": _int(
             delivery["outside_soloing_repair_changed_note_total"]
         ),
+        "outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+            delivery["outside_soloing_repair_source_objective_pitch_role_risk_count"]
+        ),
+        "outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+            delivery["outside_soloing_repair_source_pitch_role_risk_count_before"]
+        ),
+        "outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+            delivery["outside_soloing_repair_source_pitch_role_risk_count_after"]
+        ),
+        "outside_soloing_repair_source_pitch_role_risk_delta": _int(
+            delivery["outside_soloing_repair_source_pitch_role_risk_delta"]
+        ),
+        "outside_soloing_repair_source_targeted": bool(
+            delivery["outside_soloing_repair_source_targeted"]
+        ),
+        "outside_soloing_repair_source_residual_risk_preserved": bool(
+            delivery["outside_soloing_repair_source_residual_risk_preserved"]
+        ),
         "outside_soloing_repair_pitch_role_risk_count_after": _int(
             delivery["outside_soloing_repair_pitch_role_risk_count_after"]
         ),
@@ -259,6 +277,24 @@ def validate_final_status_audit_report(
         "outside_soloing_repair_changed_note_total": _int(
             final_status.get("outside_soloing_repair_changed_note_total")
         ),
+        "outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+            final_status.get("outside_soloing_repair_source_objective_pitch_role_risk_count")
+        ),
+        "outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+            final_status.get("outside_soloing_repair_source_pitch_role_risk_count_before")
+        ),
+        "outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+            final_status.get("outside_soloing_repair_source_pitch_role_risk_count_after")
+        ),
+        "outside_soloing_repair_source_pitch_role_risk_delta": _int(
+            final_status.get("outside_soloing_repair_source_pitch_role_risk_delta")
+        ),
+        "outside_soloing_repair_source_targeted": bool(
+            final_status.get("outside_soloing_repair_source_targeted", True)
+        ),
+        "outside_soloing_repair_source_residual_risk_preserved": bool(
+            final_status.get("outside_soloing_repair_source_residual_risk_preserved", False)
+        ),
         "outside_soloing_repair_pitch_role_risk_count_after": _int(
             final_status.get("outside_soloing_repair_pitch_role_risk_count_after")
         ),
@@ -306,7 +342,11 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- changed-ratio repair WAV count: `{final_status['changed_ratio_repair_wav_count']}`",
         f"- outside-soloing repair WAV count: `{final_status['outside_soloing_repair_wav_count']}`",
         f"- outside-soloing repair changed note total: `{final_status['outside_soloing_repair_changed_note_total']}`",
-        f"- outside-soloing pitch-role risk after / delta: `{final_status['outside_soloing_repair_pitch_role_risk_count_after']}` / `{final_status['outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- outside-soloing source objective pitch-role risk: `{final_status['outside_soloing_repair_source_objective_pitch_role_risk_count']}`",
+        f"- outside-soloing source pitch-role risk before / after / delta: `{final_status['outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{final_status['outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{final_status['outside_soloing_repair_source_pitch_role_risk_delta']}`",
+        f"- outside-soloing source repair targeted: `{_bool_token(final_status['outside_soloing_repair_source_targeted'])}`",
+        f"- outside-soloing source residual risk preserved: `{_bool_token(final_status['outside_soloing_repair_source_residual_risk_preserved'])}`",
+        f"- outside-soloing current repair pitch-role risk after / delta: `{final_status['outside_soloing_repair_pitch_role_risk_count_after']}` / `{final_status['outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- listening review quality gap open: `{_bool_token(final_status['listening_review_quality_gap_open'])}`",
         f"- raw artifact upload required: `{_bool_token(final_status['raw_artifact_upload_required'])}`",
         "",

--- a/tests/test_stage_b_midi_to_solo_final_status_audit.py
+++ b/tests/test_stage_b_midi_to_solo_final_status_audit.py
@@ -93,6 +93,21 @@ class StageBMidiToSoloFinalStatusAuditTest(unittest.TestCase):
         self.assertTrue(summary["outside_soloing_repair_evidence_ready"])
         self.assertEqual(summary["outside_soloing_repair_wav_count"], 6)
         self.assertEqual(summary["outside_soloing_repair_changed_note_total"], 2)
+        self.assertEqual(
+            summary["outside_soloing_repair_source_objective_pitch_role_risk_count"],
+            5,
+        )
+        self.assertEqual(
+            summary["outside_soloing_repair_source_pitch_role_risk_count_before"],
+            5,
+        )
+        self.assertEqual(
+            summary["outside_soloing_repair_source_pitch_role_risk_count_after"],
+            2,
+        )
+        self.assertEqual(summary["outside_soloing_repair_source_pitch_role_risk_delta"], 3)
+        self.assertFalse(summary["outside_soloing_repair_source_targeted"])
+        self.assertTrue(summary["outside_soloing_repair_source_residual_risk_preserved"])
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_count_after"], 0)
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_delta"], 2)
         self.assertTrue(summary["listening_review_quality_gap_open"])


### PR DESCRIPTION
## Summary

- final status audit source/current outside-soloing context 보존
- source pitch-role risk `5 -> 2`, current repair risk `2 -> 0` 분리 기록
- technical MVP completion claim 범위 유지, musical quality claim 제외

## Context

- #910 README final evidence source-context 반영
- #908 delivery package source/current outside-soloing context 반영
- 기존 final status audit 범위: technical MVP/readme reflection 중심, source context summary 미전달

## Scope

- `audit_stage_b_midi_to_solo_final_status.py` final_status/validation summary 확장
- generated markdown evidence source/current 구분
- test fixture/assertion 갱신
- harness doc path, README, CURRENT_STATUS, CORE_PLAN, AGENTS 갱신

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_final_status_audit`
- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_final_status.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-final-status-audit`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- final status audit schema 확장
- MIDI 생성/후처리 로직 변경 없음
- musical quality, human/audio preference claim 제외

Closes #912