### PR TITLE
Stage B MIDI-to-solo quality rubric baseline source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,10 +20,11 @@ Current handoff scope:
 - Latest README final evidence refresh completed: Issue #910, Stage B MIDI-to-solo README final evidence source-context refresh.
 - Latest final status audit completed: Issue #912, Stage B MIDI-to-solo final status audit source-context refresh.
 - Latest post-MVP quality iteration plan completed: Issue #914, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh.
+- Latest quality rubric baseline completed: Issue #916, Stage B MIDI-to-solo quality rubric baseline source-context refresh.
 - Latest documentation issue completed: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo quality rubric baseline source-context refresh.
+- Open issue queue after quality rubric baseline source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo candidate failure labeling source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -167,6 +168,15 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-post-mvp-quality-iteration-pl
 This harness selects the quality rubric baseline after technical MVP completion,
 preserves source/current outside-soloing repair context, and avoids musical
 quality or preference claims.
+
+For Stage B MIDI-to-solo quality rubric baseline changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-rubric-baseline
+```
+
+This harness prepares candidate failure labeling, preserves source/current
+outside-soloing repair context, and avoids musical quality or preference claims.
 
 For Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep changes, run:
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest README final evidence refresh: `Issue #910`
 - latest final status audit: `Issue #912`
 - latest post-MVP quality iteration plan: `Issue #914`
+- latest quality rubric baseline: `Issue #916`
 - latest README evidence refresh: `Issue #900`
-- latest functional boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
-- open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`
+- latest functional boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
+- open issue queue after quality rubric baseline source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -156,6 +157,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - post-MVP quality iteration plan completed: `true`
 - post-MVP selected target: `quality_rubric_baseline`
 - post-MVP quality rubric required: `true`
+- quality rubric baseline completed: `true`
+- quality rubric item / metric group count: `8 / 30`
+- quality rubric candidate failure labeling ready: `true`
 - outside-soloing repair objective path supported: `true`
 - current evidence outside-soloing repair objective path included: `true`
 - listening review quality gap completed: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -400,7 +400,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo README final evidence refresh: latest evidence boundary `stage_b_midi_to_solo_mvp_delivery_package`, runnable CLI `true`, input ranked MIDI/WAV evidence `true/true`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_final_status_audit`
 - MIDI-to-solo final status audit: technical MVP complete `true`, local review ready `true`, README final evidence reflected `true`, CLI/WAV count `3/3`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
 - MIDI-to-solo post-MVP quality iteration plan: selected target `quality_rubric_baseline`, source risk `5 -> 2`, current repair risk after `0`, ordered work `4`, taxonomy seed `7`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_rubric_baseline`
-- MIDI-to-solo quality rubric baseline: rubric items `8`, metric groups `29`, candidate failure labeling ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_candidate_failure_labeling`
+- MIDI-to-solo quality rubric baseline: rubric items `8`, metric groups `30`, source risk `5 -> 2`, current repair risk after `0`, candidate failure labeling ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_candidate_failure_labeling`
 - MIDI-to-solo candidate failure labeling: candidates `6`, failed `6`, failure label types `4`, not-evaluable types `2`, targeted repair ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_sweep`
 - MIDI-to-solo targeted quality repair sweep: candidates `6`, failure labels `12 -> 8`, improved candidates `4`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
 - MIDI-to-solo targeted quality repair audio package: rendered WAV `6`, duration `18.422s-18.984s`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
@@ -8053,6 +8053,51 @@ Issue #914는 Issue #912 final status audit의 source/current outside-soloing co
 다음 작업:
 
 - `Stage B MIDI-to-solo quality rubric baseline source-context refresh`
+
+## 9.148 Stage B MIDI-to-solo quality rubric baseline source-context refresh
+
+Issue #916은 Issue #914 post-MVP quality iteration plan의 source/current outside-soloing context를 quality rubric baseline까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
+- source boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- next boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
+- selected target: `candidate_failure_labeling`
+- rubric item count: `8`
+- required metric group count: `30`
+- candidate failure labeling ready: `true`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair WAV count: `6`
+- outside-soloing source objective pitch-role risk count: `5`
+- outside-soloing source pitch-role risk count: `5 -> 2`
+- outside-soloing source pitch-role risk delta: `3`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
+- outside-soloing current repair pitch-role risk count after: `0`
+- outside-soloing current repair pitch-role risk delta: `2`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- quality rubric baseline source validation에 #914 post-MVP plan 검증 결과 사용.
+- source/current outside-soloing risk를 quality rubric context와 validation summary에 분리 반영.
+- outside-soloing rubric은 residual pitch-role repair 대상이 아니라 context/listening quality risk labeling 대상으로 유지.
+- candidate failure labeling 진입 전 품질/선호 claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_rubric_baseline`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_quality_rubric_baseline.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-rubric-baseline`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo candidate failure labeling source-context refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -20,10 +20,11 @@
 - latest README final evidence refresh: Issue #910, Stage B MIDI-to-solo README final evidence source-context refresh
 - latest final status audit: Issue #912, Stage B MIDI-to-solo final status audit source-context refresh
 - latest post-MVP quality iteration plan: Issue #914, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh
+- latest quality rubric baseline: Issue #916, Stage B MIDI-to-solo quality rubric baseline source-context refresh
 - latest README evidence refresh: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo quality rubric baseline source-context refresh`
+- open issue queue after quality rubric baseline source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo candidate failure labeling source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -99,7 +100,7 @@
 - README final evidence refresh 완료
 - final status audit 완료
 - post-MVP quality iteration plan source-context refresh 완료
-- quality rubric baseline 완료
+- quality rubric baseline source-context refresh 완료
 - candidate failure labeling 완료
 - targeted quality repair objective-only next decision 완료
 - targeted quality repair follow-up decision 완료
@@ -568,12 +569,19 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 rubric target: `stage_b_midi_to_solo_quality_rubric_baseline`
-- quality rubric outside-soloing repair evidence refresh 완료
+- quality rubric baseline source-context refresh 완료
 - rubric item count: `8`
+- required metric group count: `30`
 - candidate failure labeling ready: `true`
 - outside-soloing repair evidence ready: `true`
 - outside-soloing repair WAV count: `6`
-- outside-soloing repair pitch-role risk count after: `0`
+- outside-soloing source objective pitch-role risk count: `5`
+- outside-soloing source pitch-role risk count: `5 -> 2`
+- outside-soloing source pitch-role risk delta: `3`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
+- outside-soloing current repair pitch-role risk count after: `0`
+- outside-soloing current repair pitch-role risk delta: `2`
 - outside-soloing label scope: `remaining context/listening quality risk after objective pitch-role repair`
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`

--- a/docs/STAGE_B_MIDI_TO_SOLO_QUALITY_RUBRIC_BASELINE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_QUALITY_RUBRIC_BASELINE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -1,0 +1,38 @@
+# Stage B MIDI-to-Solo Quality Rubric Baseline Source Context Refresh
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
+- source boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- next boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
+- selected target: `candidate_failure_labeling`
+- rubric item count: `8`
+- candidate failure labeling ready: `true`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair WAV count: `6`
+- outside-soloing source objective pitch-role risk: `5`
+- outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
+- outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+
+## Rubric Items
+
+- `sparse_or_empty_output`: note_count < 12 or active_bar_count < 2
+- `dead_air_or_density_gap`: dead_air_ratio > 0.35 or empty_bar_count > 0
+- `rhythmic_monotony`: duration_most_common_ratio >= 0.40 or ioi_most_common_ratio >= 0.40 or note_count_per_bar_most_common_ratio >= 0.95
+- `songlike_melody_not_soloing`: four_notes_per_bar_template or four_bar_rhythm_cycle_repeated or shared_rhythm_signature_count >= 3
+- `outside_soloing_without_context`: outside_pitch_run_length >= 4 or avoid_tone_landing_count > 0 when chord_context_available
+- `weak_chord_tone_landing`: cadence_landing_chord_tone == false or strong_beat_chord_tone_ratio < 0.40
+- `phrase_shape_missing_tension_release`: contour_turn_count == 0 or cadence_resolution_present == false
+- `technical_gate_regression`: grammar_valid == false or strict_valid == false or max_simultaneous_notes > 1
+
+## Claim Boundary
+
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+- broad trained model quality claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo candidate failure labeling source-context refresh`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6155,8 +6155,8 @@ run_stage_b_midi_to_solo_quality_rubric_baseline() {
   "$PYTHON_BIN" scripts/build_stage_b_midi_to_solo_quality_rubric_baseline.py \
     --run_id "$run_id" \
     --post_mvp_quality_plan "$post_mvp_plan" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_QUALITY_RUBRIC_BASELINE_2026-06-10.md \
-    --issue_number 830 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_QUALITY_RUBRIC_BASELINE_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
+    --issue_number 916 \
     --expected_boundary stage_b_midi_to_solo_quality_rubric_baseline \
     --expected_next_boundary stage_b_midi_to_solo_candidate_failure_labeling \
     --expected_target candidate_failure_labeling \

--- a/scripts/build_stage_b_midi_to_solo_quality_rubric_baseline.py
+++ b/scripts/build_stage_b_midi_to_solo_quality_rubric_baseline.py
@@ -29,7 +29,7 @@ class StageBMidiToSoloQualityRubricBaselineError(ValueError):
 BOUNDARY = "stage_b_midi_to_solo_quality_rubric_baseline"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_candidate_failure_labeling"
 SELECTED_TARGET = "candidate_failure_labeling"
-SCHEMA_VERSION = "stage_b_midi_to_solo_quality_rubric_baseline_v1"
+SCHEMA_VERSION = "stage_b_midi_to_solo_quality_rubric_baseline_v2"
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -237,6 +237,24 @@ def build_quality_rubric_baseline_report(
         "outside_soloing_repair_changed_note_total": _int(
             source["outside_soloing_repair_changed_note_total"]
         ),
+        "outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+            source["outside_soloing_repair_source_objective_pitch_role_risk_count"]
+        ),
+        "outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+            source["outside_soloing_repair_source_pitch_role_risk_count_before"]
+        ),
+        "outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+            source["outside_soloing_repair_source_pitch_role_risk_count_after"]
+        ),
+        "outside_soloing_repair_source_pitch_role_risk_delta": _int(
+            source["outside_soloing_repair_source_pitch_role_risk_delta"]
+        ),
+        "outside_soloing_repair_source_targeted": bool(
+            source["outside_soloing_repair_source_targeted"]
+        ),
+        "outside_soloing_repair_source_residual_risk_preserved": bool(
+            source["outside_soloing_repair_source_residual_risk_preserved"]
+        ),
         "outside_soloing_repair_pitch_role_risk_count_after": _int(
             source["outside_soloing_repair_pitch_role_risk_count_after"]
         ),
@@ -265,6 +283,24 @@ def build_quality_rubric_baseline_report(
             ),
             "outside_soloing_repair_wav_count": _int(
                 outside_context["outside_soloing_repair_wav_count"]
+            ),
+            "outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+                outside_context["outside_soloing_repair_source_objective_pitch_role_risk_count"]
+            ),
+            "outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+                outside_context["outside_soloing_repair_source_pitch_role_risk_count_before"]
+            ),
+            "outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+                outside_context["outside_soloing_repair_source_pitch_role_risk_count_after"]
+            ),
+            "outside_soloing_repair_source_pitch_role_risk_delta": _int(
+                outside_context["outside_soloing_repair_source_pitch_role_risk_delta"]
+            ),
+            "outside_soloing_repair_source_targeted": bool(
+                outside_context["outside_soloing_repair_source_targeted"]
+            ),
+            "outside_soloing_repair_source_residual_risk_preserved": bool(
+                outside_context["outside_soloing_repair_source_residual_risk_preserved"]
             ),
             "outside_soloing_repair_pitch_role_risk_count_after": _int(
                 outside_context["outside_soloing_repair_pitch_role_risk_count_after"]
@@ -307,7 +343,7 @@ def build_quality_rubric_baseline_report(
             "midi_to_solo_musical_quality",
             "broad_trained_model_quality",
         ],
-        "next_recommended_issue": "Stage B MIDI-to-solo candidate failure labeling",
+        "next_recommended_issue": "Stage B MIDI-to-solo candidate failure labeling source-context refresh",
     }
 
 
@@ -382,6 +418,24 @@ def validate_quality_rubric_baseline_report(
         "outside_soloing_repair_wav_count": _int(
             baseline.get("outside_soloing_repair_wav_count")
         ),
+        "outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+            baseline.get("outside_soloing_repair_source_objective_pitch_role_risk_count")
+        ),
+        "outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+            baseline.get("outside_soloing_repair_source_pitch_role_risk_count_before")
+        ),
+        "outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+            baseline.get("outside_soloing_repair_source_pitch_role_risk_count_after")
+        ),
+        "outside_soloing_repair_source_pitch_role_risk_delta": _int(
+            baseline.get("outside_soloing_repair_source_pitch_role_risk_delta")
+        ),
+        "outside_soloing_repair_source_targeted": bool(
+            baseline.get("outside_soloing_repair_source_targeted", True)
+        ),
+        "outside_soloing_repair_source_residual_risk_preserved": bool(
+            baseline.get("outside_soloing_repair_source_residual_risk_preserved", False)
+        ),
         "outside_soloing_repair_pitch_role_risk_count_after": _int(
             baseline.get("outside_soloing_repair_pitch_role_risk_count_after")
         ),
@@ -402,7 +456,7 @@ def markdown_report(report: dict[str, Any]) -> str:
     selected = report["selected_next_target"]
     readiness = report["readiness"]
     lines = [
-        "# Stage B MIDI-to-Solo Quality Rubric Baseline",
+        "# Stage B MIDI-to-Solo Quality Rubric Baseline Source Context Refresh",
         "",
         "## Summary",
         "",
@@ -414,7 +468,11 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- candidate failure labeling ready: `{_bool_token(baseline['candidate_failure_labeling_ready'])}`",
         f"- outside-soloing repair evidence ready: `{_bool_token(source_context['outside_soloing_repair_evidence_ready'])}`",
         f"- outside-soloing repair WAV count: `{source_context['outside_soloing_repair_wav_count']}`",
-        f"- outside-soloing pitch-role risk after / delta: `{source_context['outside_soloing_repair_pitch_role_risk_count_after']}` / `{source_context['outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- outside-soloing source objective pitch-role risk: `{source_context['outside_soloing_repair_source_objective_pitch_role_risk_count']}`",
+        f"- outside-soloing source pitch-role risk before / after / delta: `{source_context['outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{source_context['outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{source_context['outside_soloing_repair_source_pitch_role_risk_delta']}`",
+        f"- outside-soloing source repair targeted: `{_bool_token(source_context['outside_soloing_repair_source_targeted'])}`",
+        f"- outside-soloing source residual risk preserved: `{_bool_token(source_context['outside_soloing_repair_source_residual_risk_preserved'])}`",
+        f"- outside-soloing current repair pitch-role risk after / delta: `{source_context['outside_soloing_repair_pitch_role_risk_count_after']}` / `{source_context['outside_soloing_repair_pitch_role_risk_delta']}`",
         "",
         "## Rubric Items",
         "",

--- a/tests/test_stage_b_midi_to_solo_quality_rubric_baseline.py
+++ b/tests/test_stage_b_midi_to_solo_quality_rubric_baseline.py
@@ -43,6 +43,12 @@ def post_mvp_quality_plan(
             "outside_soloing_repair_evidence_ready": outside_ready,
             "outside_soloing_repair_wav_count": outside_wav_count,
             "outside_soloing_repair_changed_note_total": 2,
+            "outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "outside_soloing_repair_source_pitch_role_risk_count_before": 5,
+            "outside_soloing_repair_source_pitch_role_risk_count_after": 2,
+            "outside_soloing_repair_source_pitch_role_risk_delta": 3,
+            "outside_soloing_repair_source_targeted": False,
+            "outside_soloing_repair_source_residual_risk_preserved": True,
             "outside_soloing_repair_pitch_role_risk_count_after": outside_risk_after,
             "outside_soloing_repair_pitch_role_risk_delta": 2,
             "human_audio_preference_claimed": False,
@@ -73,7 +79,7 @@ def post_mvp_quality_plan(
             "next_boundary": POST_MVP_NEXT_BOUNDARY,
             "critical_user_input_required": False,
         },
-        "next_recommended_issue": "Stage B MIDI-to-solo quality rubric baseline",
+        "next_recommended_issue": "Stage B MIDI-to-solo quality rubric baseline source-context refresh",
     }
 
 
@@ -101,12 +107,18 @@ class StageBMidiToSoloQualityRubricBaselineTest(unittest.TestCase):
         self.assertGreaterEqual(summary["required_metric_group_count"], 20)
         self.assertTrue(summary["outside_soloing_repair_evidence_ready"])
         self.assertEqual(summary["outside_soloing_repair_wav_count"], 6)
+        self.assertEqual(summary["outside_soloing_repair_source_objective_pitch_role_risk_count"], 5)
+        self.assertEqual(summary["outside_soloing_repair_source_pitch_role_risk_count_before"], 5)
+        self.assertEqual(summary["outside_soloing_repair_source_pitch_role_risk_count_after"], 2)
+        self.assertEqual(summary["outside_soloing_repair_source_pitch_role_risk_delta"], 3)
+        self.assertFalse(summary["outside_soloing_repair_source_targeted"])
+        self.assertTrue(summary["outside_soloing_repair_source_residual_risk_preserved"])
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_count_after"], 0)
         self.assertFalse(summary["human_audio_preference_claimed"])
         self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
         self.assertEqual(
             summary["next_recommended_issue"],
-            "Stage B MIDI-to-solo candidate failure labeling",
+            "Stage B MIDI-to-solo candidate failure labeling source-context refresh",
         )
 
     def test_rejects_wrong_source_boundary(self) -> None:


### PR DESCRIPTION
## Summary
- quality rubric baseline source validation에 source/current outside-soloing context 보존 추가
- source risk `5 -> 2`, source delta `3`, current repair risk after/delta `0/2` 분리 기록
- #916 산출 문서와 README/CURRENT_STATUS/CORE_PLAN/AGENTS handoff 갱신

## Context
- #914 post-MVP quality iteration plan source-context refresh 완료
- selected target: `quality_rubric_baseline`
- rubric next target: `candidate_failure_labeling`
- outside-soloing source objective pitch-role risk: `5`
- outside-soloing source pitch-role risk: `5 -> 2`
- outside-soloing source repair targeted: `false`
- outside-soloing source residual risk preserved: `true`
- current repair pitch-role risk after/delta: `0/2`

## Scope
- quality rubric baseline schema `v2` 갱신
- source/current outside-soloing fields를 source quality context, baseline summary, validation summary에 반영
- generated rubric document source-context refresh 경로 갱신
- 다음 권장 이슈를 `Stage B MIDI-to-solo candidate failure labeling source-context refresh`로 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_rubric_baseline`
- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_quality_rubric_baseline.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-rubric-baseline`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- musical quality claim 없음
- human/audio preference claim 없음
- raw artifact upload 없음

Closes #916