### PR TITLE
Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,10 +24,11 @@ Current handoff scope:
 - Latest candidate failure labeling completed: Issue #918, Stage B MIDI-to-solo candidate failure labeling source-context refresh.
 - Latest targeted quality repair sweep completed: Issue #920, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh.
 - Latest targeted quality repair audio package completed: Issue #922, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh.
+- Latest targeted quality repair listening review package completed: Issue #924, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh.
 - Latest documentation issue completed: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after targeted quality repair audio package source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh.
+- Open issue queue after targeted quality repair listening review package source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -209,6 +210,16 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-audio
 This harness renders targeted repair MIDI candidates to WAV, preserves
 source/current outside-soloing repair context, and avoids audio quality or
 preference claims.
+
+For Stage B MIDI-to-solo targeted quality repair listening review package changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-listening-review-package
+```
+
+This harness packages targeted repair WAV/MIDI candidates for listening review,
+preserves source/current outside-soloing repair context, and avoids preference
+or musical quality claims.
 
 For Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep changes, run:
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest candidate failure labeling: `Issue #918`
 - latest targeted quality repair sweep: `Issue #920`
 - latest targeted quality repair audio package: `Issue #922`
+- latest targeted quality repair listening review package: `Issue #924`
 - latest README evidence refresh: `Issue #900`
-- latest functional boundary: `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
-- open issue queue after targeted quality repair audio package source-context refresh merge: `0`
+- latest functional boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
+- open issue queue after targeted quality repair listening review package source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -174,6 +175,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - targeted quality repair audio WAV files: `6`
 - targeted quality repair audio WAV technical validation: `true`
 - targeted quality repair audio duration range: `18.422s - 18.984s`
+- targeted quality repair listening review package ready: `true`
+- targeted quality repair listening review items: `6`
+- targeted quality repair validated review input: `false`
 - outside-soloing repair objective path supported: `true`
 - current evidence outside-soloing repair objective path included: `true`
 - listening review quality gap completed: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -404,7 +404,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo candidate failure labeling: candidates `6`, failed `6`, failure label types `4`, not-evaluable types `2`, source risk `5 -> 2`, current repair risk after `0`, targeted repair ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_sweep`
 - MIDI-to-solo targeted quality repair sweep: candidates `6`, failure labels `12 -> 8`, improved candidates `4`, technical regression `0`, source risk `5 -> 2`, current repair risk after `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
 - MIDI-to-solo targeted quality repair audio package: rendered WAV `6`, duration `18.422s-18.984s`, source risk `5 -> 2`, current repair risk after `0`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
-- MIDI-to-solo targeted quality repair listening review package: review items `6`, validated input `false`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
+- MIDI-to-solo targeted quality repair listening review package: review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after `0`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
 - MIDI-to-solo targeted quality repair listening review input guard: review items `6`, preference fill `false`, validated input `false`, source outside-soloing not evaluable `6`, repaired outside-soloing not evaluable `6`, source pitch-role risk after `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
 - MIDI-to-solo targeted quality repair objective-only next decision: follow-up required `true`, current quality claim ready `false`, source outside-soloing not evaluable `6`, repaired outside-soloing not evaluable `6`, source pitch-role risk after `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
 - MIDI-to-solo targeted quality repair follow-up decision: selected target `songlike_melody_contour_repair_sweep`, dominant label/count `songlike_melody_not_soloing/5`, objective and repair sweep outside-soloing not evaluable `6/6`, pitch-role risk after `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
@@ -8253,6 +8253,56 @@ Issue #922는 Issue #920 targeted quality repair sweep의 source/current outside
 다음 작업:
 
 - `Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh`
+
+## 9.152 Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh
+
+Issue #924는 Issue #922 targeted quality repair audio package의 source/current outside-soloing context를 listening review package까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
+- package ready: `true`
+- review item count: `6`
+- validated review input: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- sample rate: `44100`
+- duration range: `18.422s - 18.984s`
+- failure label delta: `4`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair WAV count: `6`
+- source outside-soloing source objective pitch-role risk count: `5`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing source pitch-role risk delta: `3`
+- source outside-soloing source repair targeted: `false`
+- source outside-soloing source residual risk preserved: `true`
+- source outside-soloing current repair pitch-role risk count after: `0`
+- source outside-soloing current repair pitch-role risk delta: `2`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- audio package source validation에 source/current outside-soloing risk guard 추가.
+- listening review package source summary와 validation summary에 source/current risk 분리 반영.
+- WAV/MIDI review item 6개 패키징 완료.
+- validated review input은 `false`, human/audio preference와 musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-listening-review-package`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -24,10 +24,11 @@
 - latest candidate failure labeling: Issue #918, Stage B MIDI-to-solo candidate failure labeling source-context refresh
 - latest targeted quality repair sweep: Issue #920, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh
 - latest targeted quality repair audio package: Issue #922, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh
+- latest targeted quality repair listening review package: Issue #924, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh
 - latest README evidence refresh: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after targeted quality repair audio package source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh`
+- open issue queue after targeted quality repair listening review package source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -657,12 +658,28 @@
 - audio rendered quality claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 review target: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
-- targeted quality repair listening review package outside-soloing context refresh 완료
+- targeted quality repair listening review package source-context refresh 완료
+- package ready: `true`
 - review item count: `6`
 - validated review input: `false`
-- source outside-soloing repair pitch-role risk count after: `0`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- sample rate: `44100`
+- duration range: `18.422s - 18.984s`
+- failure label delta: `4`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair WAV count: `6`
+- source outside-soloing source objective pitch-role risk count: `5`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing source pitch-role risk delta: `3`
+- source outside-soloing source repair targeted: `false`
+- source outside-soloing source residual risk preserved: `true`
+- source outside-soloing current repair pitch-role risk count after: `0`
+- source outside-soloing current repair pitch-role risk delta: `2`
 - source outside-soloing not evaluable count: `6`
 - repaired outside-soloing not evaluable count: `6`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
 - human/audio preference claim: `false`
 - audio rendered quality claim: `false`
 - MIDI-to-solo musical quality claim: `false`

--- a/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_LISTENING_REVIEW_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_LISTENING_REVIEW_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -1,0 +1,48 @@
+# Stage B MIDI-to-Solo Targeted Quality Repair Listening Review Package Source Context Refresh
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
+- package ready: `true`
+- review item count: `6`
+- validated review input: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- duration range: `18.422s-18.984s`
+- failure label delta: `4`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing source objective pitch-role risk: `5`
+- source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
+- source outside-soloing source repair targeted: `false`
+- source outside-soloing source residual risk preserved: `true`
+- source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- human/audio preference claimed: `false`
+
+## Review Items
+
+- candidate `1` `cli_repaired_midi` rank `1`: WAV `outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package_source_context_refresh/audio/candidate_01_cli_repaired_midi_rank_01_targeted_quality_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_targeted_quality_repair_sweep/harness_stage_b_midi_to_solo_targeted_quality_repair_sweep_source_context_refresh/midi/01_cli_repaired_midi_rank_01_targeted_quality_repair.mid`, duration `18.907`, failure labels `songlike_melody_not_soloing`
+- candidate `2` `cli_repaired_midi` rank `2`: WAV `outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package_source_context_refresh/audio/candidate_02_cli_repaired_midi_rank_02_targeted_quality_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_targeted_quality_repair_sweep/harness_stage_b_midi_to_solo_targeted_quality_repair_sweep_source_context_refresh/midi/02_cli_repaired_midi_rank_02_targeted_quality_repair.mid`, duration `18.984`, failure labels `songlike_melody_not_soloing`
+- candidate `3` `cli_repaired_midi` rank `3`: WAV `outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package_source_context_refresh/audio/candidate_03_cli_repaired_midi_rank_03_targeted_quality_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_targeted_quality_repair_sweep/harness_stage_b_midi_to_solo_targeted_quality_repair_sweep_source_context_refresh/midi/03_cli_repaired_midi_rank_03_targeted_quality_repair.mid`, duration `18.977`, failure labels `songlike_melody_not_soloing`
+- candidate `4` `changed_ratio_repair` rank `1`: WAV `outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package_source_context_refresh/audio/candidate_04_changed_ratio_repair_rank_01_targeted_quality_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_targeted_quality_repair_sweep/harness_stage_b_midi_to_solo_targeted_quality_repair_sweep_source_context_refresh/midi/04_changed_ratio_repair_rank_01_targeted_quality_repair.mid`, duration `18.422`, failure labels `phrase_shape_missing_tension_release,songlike_melody_not_soloing`
+- candidate `5` `changed_ratio_repair` rank `2`: WAV `outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package_source_context_refresh/audio/candidate_05_changed_ratio_repair_rank_02_targeted_quality_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_targeted_quality_repair_sweep/harness_stage_b_midi_to_solo_targeted_quality_repair_sweep_source_context_refresh/midi/05_changed_ratio_repair_rank_02_targeted_quality_repair.mid`, duration `18.984`, failure labels `none`
+- candidate `6` `changed_ratio_repair` rank `3`: WAV `outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package_source_context_refresh/audio/candidate_06_changed_ratio_repair_rank_03_targeted_quality_repair.wav`, MIDI `outputs/stage_b_midi_to_solo_targeted_quality_repair_sweep/harness_stage_b_midi_to_solo_targeted_quality_repair_sweep_source_context_refresh/midi/06_changed_ratio_repair_rank_03_targeted_quality_repair.mid`, duration `18.926`, failure labels `dead_air_or_density_gap,phrase_shape_missing_tension_release,songlike_melody_not_soloing`
+
+## Required Input Fields
+
+- `candidate_index`
+- `listening_status`
+- `preference`
+- `issue_notes`
+
+## Claim Boundary
+
+- MIDI-to-solo musical quality claimed: `false`
+- audio rendered quality claimed: `false`
+- broad trained-model quality claimed: `false`
+
+## Next
+
+- `Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6243,8 +6243,8 @@ run_stage_b_midi_to_solo_targeted_quality_repair_audio_package() {
 }
 
 run_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package() {
-  local audio_package_run_id="${AUDIO_PACKAGE_RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package}"
-  local review_run_id="${RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package}"
+  local audio_package_run_id="${AUDIO_PACKAGE_RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package_source_context_refresh}"
+  local review_run_id="${RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package_source_context_refresh}"
   local audio_package_report="outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/${audio_package_run_id}/stage_b_midi_to_solo_targeted_quality_repair_audio_package.json"
   if [[ ! -f "$audio_package_report" ]]; then
     print_header "Stage B MIDI-to-solo targeted quality repair audio package"
@@ -6254,8 +6254,8 @@ run_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package() {
   "$PYTHON_BIN" scripts/build_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package.py \
     --run_id "$review_run_id" \
     --audio_package_report "$audio_package_report" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_LISTENING_REVIEW_PACKAGE_2026-06-10.md \
-    --issue_number 838 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_LISTENING_REVIEW_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
+    --issue_number 924 \
     --expected_review_item_count 6 \
     --expected_boundary stage_b_midi_to_solo_targeted_quality_repair_listening_review_package \
     --expected_next_boundary stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard \

--- a/scripts/build_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package.py
+++ b/scripts/build_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package.py
@@ -25,7 +25,7 @@ class StageBMidiToSoloTargetedQualityRepairListeningReviewPackageError(ValueErro
 
 BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_listening_review_package"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard"
-SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_listening_review_package_v1"
+SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_listening_review_package_v2"
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -115,6 +115,40 @@ def validate_audio_package_report(
     if _int(summary.get("source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
         raise StageBMidiToSoloTargetedQualityRepairListeningReviewPackageError(
             "outside-soloing residual pitch-role risk should be zero"
+        )
+    source_objective_risk = _int(
+        summary.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
+    )
+    source_risk_before = _int(
+        summary.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
+    )
+    source_risk_after = _int(
+        summary.get("source_outside_soloing_repair_source_pitch_role_risk_count_after")
+    )
+    source_risk_delta = _int(
+        summary.get("source_outside_soloing_repair_source_pitch_role_risk_delta")
+    )
+    if source_objective_risk <= 0:
+        raise StageBMidiToSoloTargetedQualityRepairListeningReviewPackageError(
+            "outside-soloing source objective pitch-role risk count required"
+        )
+    if source_risk_after > source_risk_before:
+        raise StageBMidiToSoloTargetedQualityRepairListeningReviewPackageError(
+            "outside-soloing source pitch-role risk should not increase"
+        )
+    if source_risk_delta != source_risk_before - source_risk_after:
+        raise StageBMidiToSoloTargetedQualityRepairListeningReviewPackageError(
+            "outside-soloing source pitch-role risk delta mismatch"
+        )
+    if bool(summary.get("source_outside_soloing_repair_source_targeted", True)):
+        raise StageBMidiToSoloTargetedQualityRepairListeningReviewPackageError(
+            "outside-soloing source repair should remain non-targeted"
+        )
+    if not bool(
+        summary.get("source_outside_soloing_repair_source_residual_risk_preserved", False)
+    ):
+        raise StageBMidiToSoloTargetedQualityRepairListeningReviewPackageError(
+            "outside-soloing source residual risk preservation required"
         )
     if _int(summary.get("source_outside_soloing_not_evaluable_count")) <= 0:
         raise StageBMidiToSoloTargetedQualityRepairListeningReviewPackageError(
@@ -210,8 +244,32 @@ def build_listening_review_package_report(
             "source_outside_soloing_repair_evidence_ready": bool(
                 summary.get("source_outside_soloing_repair_evidence_ready", False)
             ),
+            "source_outside_soloing_repair_wav_count": _int(
+                summary.get("source_outside_soloing_repair_wav_count")
+            ),
+            "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+                summary.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
+            ),
+            "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+                summary.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
+            ),
+            "source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+                summary.get("source_outside_soloing_repair_source_pitch_role_risk_count_after")
+            ),
+            "source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+                summary.get("source_outside_soloing_repair_source_pitch_role_risk_delta")
+            ),
+            "source_outside_soloing_repair_source_targeted": bool(
+                summary.get("source_outside_soloing_repair_source_targeted", True)
+            ),
+            "source_outside_soloing_repair_source_residual_risk_preserved": bool(
+                summary.get("source_outside_soloing_repair_source_residual_risk_preserved", False)
+            ),
             "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
                 summary.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+            ),
+            "source_outside_soloing_repair_pitch_role_risk_delta": _int(
+                summary.get("source_outside_soloing_repair_pitch_role_risk_delta")
             ),
             "source_outside_soloing_not_evaluable_count": _int(
                 summary.get("source_outside_soloing_not_evaluable_count")
@@ -263,7 +321,7 @@ def build_listening_review_package_report(
             "brad_style_adaptation",
         ],
         "next_recommended_issue": (
-            "Stage B MIDI-to-solo targeted quality repair listening review input guard"
+            "Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh"
         ),
     }
 
@@ -322,8 +380,32 @@ def validate_listening_review_package_report(
         "source_outside_soloing_repair_evidence_ready": bool(
             source.get("source_outside_soloing_repair_evidence_ready", False)
         ),
+        "source_outside_soloing_repair_wav_count": _int(
+            source.get("source_outside_soloing_repair_wav_count")
+        ),
+        "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+            source.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+            source.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+            source.get("source_outside_soloing_repair_source_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+            source.get("source_outside_soloing_repair_source_pitch_role_risk_delta")
+        ),
+        "source_outside_soloing_repair_source_targeted": bool(
+            source.get("source_outside_soloing_repair_source_targeted", True)
+        ),
+        "source_outside_soloing_repair_source_residual_risk_preserved": bool(
+            source.get("source_outside_soloing_repair_source_residual_risk_preserved", False)
+        ),
         "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
             source.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_delta": _int(
+            source.get("source_outside_soloing_repair_pitch_role_risk_delta")
         ),
         "source_outside_soloing_not_evaluable_count": _int(
             source.get("source_outside_soloing_not_evaluable_count")
@@ -349,7 +431,7 @@ def markdown_report(report: dict[str, Any]) -> str:
     package = report["review_package"]
     source = report["source_summary"]
     lines = [
-        "# Stage B MIDI-to-Solo Targeted Quality Repair Listening Review Package",
+        "# Stage B MIDI-to-Solo Targeted Quality Repair Listening Review Package Source Context Refresh",
         "",
         "## Summary",
         "",
@@ -363,7 +445,11 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- duration range: `{source['duration_min_seconds']:.3f}s-{source['duration_max_seconds']:.3f}s`",
         f"- failure label delta: `{source['failure_label_delta']}`",
         f"- source outside-soloing repair evidence ready: `{_bool_token(source['source_outside_soloing_repair_evidence_ready'])}`",
-        f"- source outside-soloing repair pitch-role risk after: `{source['source_outside_soloing_repair_pitch_role_risk_count_after']}`",
+        f"- source outside-soloing source objective pitch-role risk: `{source['source_outside_soloing_repair_source_objective_pitch_role_risk_count']}`",
+        f"- source outside-soloing source pitch-role risk before / after / delta: `{source['source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{source['source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{source['source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
+        f"- source outside-soloing source repair targeted: `{_bool_token(source['source_outside_soloing_repair_source_targeted'])}`",
+        f"- source outside-soloing source residual risk preserved: `{_bool_token(source['source_outside_soloing_repair_source_residual_risk_preserved'])}`",
+        f"- source outside-soloing current repair pitch-role risk after / delta: `{source['source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{source['source_outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- source outside-soloing not evaluable count: `{source['source_outside_soloing_not_evaluable_count']}`",
         f"- repaired outside-soloing not evaluable count: `{source['repaired_outside_soloing_not_evaluable_count']}`",
         f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package.py
@@ -113,7 +113,15 @@ def audio_package_report(root: Path, *, quality_claim: bool = False) -> dict:
             "improved_candidate_count": 6,
             "technical_regression_count": 0,
             "source_outside_soloing_repair_evidence_ready": True,
+            "source_outside_soloing_repair_wav_count": 6,
+            "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
+            "source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
+            "source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
+            "source_outside_soloing_repair_source_targeted": False,
+            "source_outside_soloing_repair_source_residual_risk_preserved": True,
             "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "source_outside_soloing_not_evaluable_count": 6,
             "repaired_outside_soloing_not_evaluable_count": 6,
             "audio_review_required": True,
@@ -147,11 +155,29 @@ class StageBMidiToSoloTargetedQualityRepairListeningReviewPackageTest(unittest.T
             self.assertTrue(summary["technical_wav_validation"])
             self.assertEqual(summary["failure_label_delta"], 7)
             self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
+            self.assertEqual(summary["source_outside_soloing_repair_wav_count"], 6)
+            self.assertEqual(
+                summary["source_outside_soloing_repair_source_objective_pitch_role_risk_count"], 5
+            )
+            self.assertEqual(
+                summary["source_outside_soloing_repair_source_pitch_role_risk_count_before"], 5
+            )
+            self.assertEqual(
+                summary["source_outside_soloing_repair_source_pitch_role_risk_count_after"], 2
+            )
+            self.assertEqual(summary["source_outside_soloing_repair_source_pitch_role_risk_delta"], 3)
+            self.assertFalse(summary["source_outside_soloing_repair_source_targeted"])
+            self.assertTrue(summary["source_outside_soloing_repair_source_residual_risk_preserved"])
             self.assertEqual(summary["source_outside_soloing_repair_pitch_role_risk_count_after"], 0)
+            self.assertEqual(summary["source_outside_soloing_repair_pitch_role_risk_delta"], 2)
             self.assertEqual(summary["source_outside_soloing_not_evaluable_count"], 6)
             self.assertEqual(summary["repaired_outside_soloing_not_evaluable_count"], 6)
             self.assertFalse(summary["human_audio_preference_claimed"])
             self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+            self.assertEqual(
+                summary["next_recommended_issue"],
+                "Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh",
+            )
 
     def test_rejects_audio_package_quality_claim(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- Targeted quality repair listening review package source/current outside-soloing context preservation
- Audio package summary guard expansion for source risk before/after/delta fields
- Issue #924 status docs and harness run-id refresh

## Context

- Previous completed boundary: Issue #922 targeted quality repair audio package
- Rendered WAV count: `6`
- Technical WAV validation: `true`
- Failure label delta: `4`
- Source outside-soloing pitch-role risk: `5 -> 2`, delta `3`
- Current outside-soloing pitch-role risk after / delta: `0 / 2`
- Human/audio preference: unclaimed
- MIDI-to-solo musical quality: unclaimed

## Scope

- `build_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package.py` validation/source summary contract update
- Listening review package markdown output update
- Targeted unit fixture and assertions update
- `agent_harness.sh` issue/run-id/doc-path update
- README, current status, core plan, AGENTS handoff refresh

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-listening-review-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- Listening review package readiness only
- No validated human/audio preference input
- No broad model quality claim
- Next boundary: targeted quality repair listening review input guard source-context refresh

Closes #924