### PR TITLE
Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,10 +25,11 @@ Current handoff scope:
 - Latest targeted quality repair sweep completed: Issue #920, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh.
 - Latest targeted quality repair audio package completed: Issue #922, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh.
 - Latest targeted quality repair listening review package completed: Issue #924, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh.
+- Latest targeted quality repair listening review input guard completed: Issue #926, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh.
 - Latest documentation issue completed: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after targeted quality repair listening review package source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh.
+- Open issue queue after targeted quality repair listening review input guard source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -220,6 +221,16 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-liste
 This harness packages targeted repair WAV/MIDI candidates for listening review,
 preserves source/current outside-soloing repair context, and avoids preference
 or musical quality claims.
+
+For Stage B MIDI-to-solo targeted quality repair listening review input guard changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-listening-review-input-guard
+```
+
+This harness blocks preference fill while validated listening review input is
+pending, preserves source/current outside-soloing repair context, and avoids
+preference or musical quality claims.
 
 For Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep changes, run:
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest targeted quality repair sweep: `Issue #920`
 - latest targeted quality repair audio package: `Issue #922`
 - latest targeted quality repair listening review package: `Issue #924`
+- latest targeted quality repair listening review input guard: `Issue #926`
 - latest README evidence refresh: `Issue #900`
-- latest functional boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
-- open issue queue after targeted quality repair listening review package source-context refresh merge: `0`
+- latest functional boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
+- open issue queue after targeted quality repair listening review input guard source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -178,6 +179,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - targeted quality repair listening review package ready: `true`
 - targeted quality repair listening review items: `6`
 - targeted quality repair validated review input: `false`
+- targeted quality repair listening review input guard completed: `true`
+- targeted quality repair preference fill allowed: `false`
+- targeted quality repair source risk: `5 -> 2`
+- targeted quality repair current risk after / delta: `0 / 2`
 - outside-soloing repair objective path supported: `true`
 - current evidence outside-soloing repair objective path included: `true`
 - listening review quality gap completed: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -405,7 +405,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo targeted quality repair sweep: candidates `6`, failure labels `12 -> 8`, improved candidates `4`, technical regression `0`, source risk `5 -> 2`, current repair risk after `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
 - MIDI-to-solo targeted quality repair audio package: rendered WAV `6`, duration `18.422s-18.984s`, source risk `5 -> 2`, current repair risk after `0`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
 - MIDI-to-solo targeted quality repair listening review package: review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after `0`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
-- MIDI-to-solo targeted quality repair listening review input guard: review items `6`, preference fill `false`, validated input `false`, source outside-soloing not evaluable `6`, repaired outside-soloing not evaluable `6`, source pitch-role risk after `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
+- MIDI-to-solo targeted quality repair listening review input guard: review items `6`, preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
 - MIDI-to-solo targeted quality repair objective-only next decision: follow-up required `true`, current quality claim ready `false`, source outside-soloing not evaluable `6`, repaired outside-soloing not evaluable `6`, source pitch-role risk after `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
 - MIDI-to-solo targeted quality repair follow-up decision: selected target `songlike_melody_contour_repair_sweep`, dominant label/count `songlike_melody_not_soloing/5`, objective and repair sweep outside-soloing not evaluable `6/6`, pitch-role risk after `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
 - MIDI-to-solo songlike melody contour repair sweep: songlike failure `5 -> 0`, total failure labels `8 -> 4`, repaired outside-soloing not evaluable `6`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
@@ -8303,6 +8303,58 @@ Issue #924는 Issue #922 targeted quality repair audio package의 source/current
 다음 작업:
 
 - `Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh`
+
+## 9.153 Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh
+
+Issue #926은 Issue #924 targeted quality repair listening review package의 source/current outside-soloing context를 input guard까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- sample rate: `44100`
+- duration range: `18.422s - 18.984s`
+- failure label delta: `4`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair WAV count: `6`
+- source outside-soloing source objective pitch-role risk count: `5`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing source pitch-role risk delta: `3`
+- source outside-soloing source repair targeted: `false`
+- source outside-soloing source residual risk preserved: `true`
+- source outside-soloing current repair pitch-role risk count after: `0`
+- source outside-soloing current repair pitch-role risk delta: `2`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- review input pending 상태에서 preference fill 차단 유지.
+- input guard source summary와 validation summary에 source/current risk 분리 반영.
+- source outside-soloing source repair는 non-targeted, residual risk preserved 상태로 보존.
+- human/audio preference와 musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
+- `.venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-listening-review-input-guard`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -25,10 +25,11 @@
 - latest targeted quality repair sweep: Issue #920, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh
 - latest targeted quality repair audio package: Issue #922, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh
 - latest targeted quality repair listening review package: Issue #924, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh
+- latest targeted quality repair listening review input guard: Issue #926, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh
 - latest README evidence refresh: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after targeted quality repair listening review package source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh`
+- open issue queue after targeted quality repair listening review input guard source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -680,17 +681,25 @@
 - repaired outside-soloing not evaluable count: `6`
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
-- human/audio preference claim: `false`
-- audio rendered quality claim: `false`
-- MIDI-to-solo musical quality claim: `false`
 - 다음 guard target: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
-- targeted quality repair listening review input guard outside-soloing context refresh 완료
+- targeted quality repair listening review input guard source-context refresh 완료
 - review item count: `6`
+- required input field count: `4`
 - validated review input present: `false`
 - preference fill allowed: `false`
 - technical WAV validation: `true`
+- rendered audio file count: `6`
+- duration range: `18.422s - 18.984s`
 - failure label delta: `4`
-- source outside-soloing repair pitch-role risk count after: `0`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair WAV count: `6`
+- source outside-soloing source objective pitch-role risk count: `5`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing source pitch-role risk delta: `3`
+- source outside-soloing source repair targeted: `false`
+- source outside-soloing source residual risk preserved: `true`
+- source outside-soloing current repair pitch-role risk count after: `0`
+- source outside-soloing current repair pitch-role risk delta: `2`
 - source outside-soloing not evaluable count: `6`
 - repaired outside-soloing not evaluable count: `6`
 - human/audio preference claim: `false`

--- a/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_LISTENING_REVIEW_INPUT_GUARD_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_LISTENING_REVIEW_INPUT_GUARD_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -1,0 +1,59 @@
+# Stage B MIDI-to-Solo Targeted Quality Repair Listening Review Input Guard Source Context Refresh
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- duration range: `18.422s-18.984s`
+- failure label delta: `4`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair WAV count: `6`
+- source outside-soloing source objective pitch-role risk: `5`
+- source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
+- source outside-soloing source repair targeted: `false`
+- source outside-soloing source residual risk preserved: `true`
+- source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- audio review required: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Decision
+
+- auto progress allowed: `true`
+- critical user input required: `false`
+- reason: `listening review input pending; preference fill blocked`
+- next recommended issue: `Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh`
+
+## Required Input Fields
+
+- `candidate_index`
+- `listening_status`
+- `preference`
+- `issue_notes`
+
+## Review WAV Paths
+
+- `outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package_source_context_refresh/audio/candidate_01_cli_repaired_midi_rank_01_targeted_quality_repair.wav`
+- `outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package_source_context_refresh/audio/candidate_02_cli_repaired_midi_rank_02_targeted_quality_repair.wav`
+- `outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package_source_context_refresh/audio/candidate_03_cli_repaired_midi_rank_03_targeted_quality_repair.wav`
+- `outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package_source_context_refresh/audio/candidate_04_changed_ratio_repair_rank_01_targeted_quality_repair.wav`
+- `outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package_source_context_refresh/audio/candidate_05_changed_ratio_repair_rank_02_targeted_quality_repair.wav`
+- `outputs/stage_b_midi_to_solo_targeted_quality_repair_audio_package/harness_stage_b_midi_to_solo_targeted_quality_repair_audio_package_source_context_refresh/audio/candidate_06_changed_ratio_repair_rank_03_targeted_quality_repair.wav`
+
+## Claim Boundary
+
+- `listening_review_completed`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6264,8 +6264,8 @@ run_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package() {
 }
 
 run_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard() {
-  local package_run_id="${PACKAGE_RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package}"
-  local guard_run_id="${RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard}"
+  local package_run_id="${PACKAGE_RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package_source_context_refresh}"
+  local guard_run_id="${RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard_source_context_refresh}"
   local source_package="outputs/stage_b_midi_to_solo_targeted_quality_repair_listening_review_package/${package_run_id}/stage_b_midi_to_solo_targeted_quality_repair_listening_review_package.json"
   if [[ ! -f "$source_package" ]]; then
     print_header "Stage B MIDI-to-solo targeted quality repair listening review package"
@@ -6275,8 +6275,8 @@ run_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard() 
   "$PYTHON_BIN" scripts/guard_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input.py \
     --run_id "$guard_run_id" \
     --source_package "$source_package" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_LISTENING_REVIEW_INPUT_GUARD_2026-06-10.md \
-    --issue_number 840 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_LISTENING_REVIEW_INPUT_GUARD_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
+    --issue_number 926 \
     --expected_boundary stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard \
     --expected_next_boundary stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision \
     --require_guard_completed \

--- a/scripts/guard_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input.py
+++ b/scripts/guard_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input.py
@@ -28,7 +28,7 @@ FILL_BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_listening_review_f
 OBJECTIVE_NEXT_BOUNDARY = (
     "stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision"
 )
-SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard_v1"
+SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard_v2"
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -121,9 +121,52 @@ def validate_source_package(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloTargetedQualityRepairListeningInputGuardError(
             "outside-soloing repair evidence readiness required"
         )
+    source_wav_count = _int(source.get("source_outside_soloing_repair_wav_count"))
+    if source_wav_count < review_item_count:
+        raise StageBMidiToSoloTargetedQualityRepairListeningInputGuardError(
+            "outside-soloing source WAV count below review item count"
+        )
+    source_objective_risk = _int(
+        source.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
+    )
+    source_risk_before = _int(
+        source.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
+    )
+    source_risk_after = _int(
+        source.get("source_outside_soloing_repair_source_pitch_role_risk_count_after")
+    )
+    source_risk_delta = _int(
+        source.get("source_outside_soloing_repair_source_pitch_role_risk_delta")
+    )
+    if source_objective_risk <= 0:
+        raise StageBMidiToSoloTargetedQualityRepairListeningInputGuardError(
+            "outside-soloing source objective pitch-role risk count required"
+        )
+    if source_risk_after > source_risk_before:
+        raise StageBMidiToSoloTargetedQualityRepairListeningInputGuardError(
+            "outside-soloing source pitch-role risk should not increase"
+        )
+    if source_risk_delta != source_risk_before - source_risk_after:
+        raise StageBMidiToSoloTargetedQualityRepairListeningInputGuardError(
+            "outside-soloing source pitch-role risk delta mismatch"
+        )
+    if bool(source.get("source_outside_soloing_repair_source_targeted", True)):
+        raise StageBMidiToSoloTargetedQualityRepairListeningInputGuardError(
+            "outside-soloing source repair should remain non-targeted"
+        )
+    if not bool(
+        source.get("source_outside_soloing_repair_source_residual_risk_preserved", False)
+    ):
+        raise StageBMidiToSoloTargetedQualityRepairListeningInputGuardError(
+            "outside-soloing source residual risk preservation required"
+        )
     if _int(source.get("source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
         raise StageBMidiToSoloTargetedQualityRepairListeningInputGuardError(
             "outside-soloing residual pitch-role risk should be zero"
+        )
+    if _int(source.get("source_outside_soloing_repair_pitch_role_risk_delta")) <= 0:
+        raise StageBMidiToSoloTargetedQualityRepairListeningInputGuardError(
+            "outside-soloing current pitch-role risk delta required"
         )
     if _int(source.get("source_outside_soloing_not_evaluable_count")) <= 0:
         raise StageBMidiToSoloTargetedQualityRepairListeningInputGuardError(
@@ -157,8 +200,22 @@ def validate_source_package(report: dict[str, Any]) -> dict[str, Any]:
             "source_outside_soloing_repair_evidence_ready": bool(
                 source.get("source_outside_soloing_repair_evidence_ready", False)
             ),
+            "source_outside_soloing_repair_wav_count": source_wav_count,
+            "source_outside_soloing_repair_source_objective_pitch_role_risk_count": source_objective_risk,
+            "source_outside_soloing_repair_source_pitch_role_risk_count_before": source_risk_before,
+            "source_outside_soloing_repair_source_pitch_role_risk_count_after": source_risk_after,
+            "source_outside_soloing_repair_source_pitch_role_risk_delta": source_risk_delta,
+            "source_outside_soloing_repair_source_targeted": bool(
+                source.get("source_outside_soloing_repair_source_targeted", True)
+            ),
+            "source_outside_soloing_repair_source_residual_risk_preserved": bool(
+                source.get("source_outside_soloing_repair_source_residual_risk_preserved", False)
+            ),
             "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
                 source.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+            ),
+            "source_outside_soloing_repair_pitch_role_risk_delta": _int(
+                source.get("source_outside_soloing_repair_pitch_role_risk_delta")
             ),
             "source_outside_soloing_not_evaluable_count": _int(
                 source.get("source_outside_soloing_not_evaluable_count")
@@ -238,9 +295,9 @@ def build_listening_review_input_guard_report(
             "brad_style_adaptation",
         ],
         "next_recommended_issue": (
-            "Stage B MIDI-to-solo targeted quality repair listening review fill"
+            "Stage B MIDI-to-solo targeted quality repair listening review fill source-context refresh"
             if validated_input
-            else "Stage B MIDI-to-solo targeted quality repair objective-only next decision"
+            else "Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh"
         ),
     }
 
@@ -306,8 +363,32 @@ def validate_listening_review_input_guard_report(
         "source_outside_soloing_repair_evidence_ready": bool(
             source.get("source_outside_soloing_repair_evidence_ready", False)
         ),
+        "source_outside_soloing_repair_wav_count": _int(
+            source.get("source_outside_soloing_repair_wav_count")
+        ),
+        "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+            source.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+            source.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+            source.get("source_outside_soloing_repair_source_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+            source.get("source_outside_soloing_repair_source_pitch_role_risk_delta")
+        ),
+        "source_outside_soloing_repair_source_targeted": bool(
+            source.get("source_outside_soloing_repair_source_targeted", True)
+        ),
+        "source_outside_soloing_repair_source_residual_risk_preserved": bool(
+            source.get("source_outside_soloing_repair_source_residual_risk_preserved", False)
+        ),
         "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
             source.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_delta": _int(
+            source.get("source_outside_soloing_repair_pitch_role_risk_delta")
         ),
         "source_outside_soloing_not_evaluable_count": _int(
             source.get("source_outside_soloing_not_evaluable_count")
@@ -335,7 +416,7 @@ def markdown_report(report: dict[str, Any]) -> str:
     source = guard["source_summary"]
     package = report["source_package_summary"]
     lines = [
-        "# Stage B MIDI-to-Solo Targeted Quality Repair Listening Review Input Guard",
+        "# Stage B MIDI-to-Solo Targeted Quality Repair Listening Review Input Guard Source Context Refresh",
         "",
         "## Summary",
         "",
@@ -351,7 +432,12 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- duration range: `{source['duration_min_seconds']:.3f}s-{source['duration_max_seconds']:.3f}s`",
         f"- failure label delta: `{source['failure_label_delta']}`",
         f"- source outside-soloing repair evidence ready: `{_bool_token(source['source_outside_soloing_repair_evidence_ready'])}`",
-        f"- source outside-soloing repair pitch-role risk after: `{source['source_outside_soloing_repair_pitch_role_risk_count_after']}`",
+        f"- source outside-soloing repair WAV count: `{source['source_outside_soloing_repair_wav_count']}`",
+        f"- source outside-soloing source objective pitch-role risk: `{source['source_outside_soloing_repair_source_objective_pitch_role_risk_count']}`",
+        f"- source outside-soloing source pitch-role risk before / after / delta: `{source['source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{source['source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{source['source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
+        f"- source outside-soloing source repair targeted: `{_bool_token(source['source_outside_soloing_repair_source_targeted'])}`",
+        f"- source outside-soloing source residual risk preserved: `{_bool_token(source['source_outside_soloing_repair_source_residual_risk_preserved'])}`",
+        f"- source outside-soloing current repair pitch-role risk after / delta: `{source['source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{source['source_outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- source outside-soloing not evaluable count: `{source['source_outside_soloing_not_evaluable_count']}`",
         f"- repaired outside-soloing not evaluable count: `{source['repaired_outside_soloing_not_evaluable_count']}`",
         f"- audio review required: `{_bool_token(source['audio_review_required'])}`",
@@ -392,7 +478,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=840)
+    parser.add_argument("--issue_number", type=int, default=926)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--require_guard_completed", action="store_true")

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard.py
@@ -46,7 +46,15 @@ def source_package(*, quality_claim: bool = False, validated_input: bool = False
             "duration_max_seconds": 0.1,
             "failure_label_delta": 4,
             "source_outside_soloing_repair_evidence_ready": True,
+            "source_outside_soloing_repair_wav_count": 6,
+            "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
+            "source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
+            "source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
+            "source_outside_soloing_repair_source_targeted": False,
+            "source_outside_soloing_repair_source_residual_risk_preserved": True,
             "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "source_outside_soloing_not_evaluable_count": 6,
             "repaired_outside_soloing_not_evaluable_count": 6,
             "audio_review_required": True,
@@ -111,11 +119,29 @@ class StageBMidiToSoloTargetedQualityRepairListeningInputGuardTest(unittest.Test
             self.assertEqual(summary["required_input_field_count"], 4)
             self.assertEqual(summary["failure_label_delta"], 4)
             self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
+            self.assertEqual(summary["source_outside_soloing_repair_wav_count"], 6)
+            self.assertEqual(
+                summary["source_outside_soloing_repair_source_objective_pitch_role_risk_count"], 5
+            )
+            self.assertEqual(
+                summary["source_outside_soloing_repair_source_pitch_role_risk_count_before"], 5
+            )
+            self.assertEqual(
+                summary["source_outside_soloing_repair_source_pitch_role_risk_count_after"], 2
+            )
+            self.assertEqual(summary["source_outside_soloing_repair_source_pitch_role_risk_delta"], 3)
+            self.assertFalse(summary["source_outside_soloing_repair_source_targeted"])
+            self.assertTrue(summary["source_outside_soloing_repair_source_residual_risk_preserved"])
             self.assertEqual(summary["source_outside_soloing_repair_pitch_role_risk_count_after"], 0)
+            self.assertEqual(summary["source_outside_soloing_repair_pitch_role_risk_delta"], 2)
             self.assertEqual(summary["source_outside_soloing_not_evaluable_count"], 6)
             self.assertEqual(summary["repaired_outside_soloing_not_evaluable_count"], 6)
             self.assertFalse(summary["human_audio_preference_claimed"])
             self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+            self.assertEqual(
+                summary["next_recommended_issue"],
+                "Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh",
+            )
 
     def test_rejects_source_quality_claim(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -137,6 +163,18 @@ class StageBMidiToSoloTargetedQualityRepairListeningInputGuardTest(unittest.Test
                     source,
                     output_dir=root / "guard",
                     issue_number=840,
+                )
+
+    def test_rejects_source_risk_delta_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = source_package()
+            source["source_summary"]["source_outside_soloing_repair_source_pitch_role_risk_delta"] = 1
+            with self.assertRaises(StageBMidiToSoloTargetedQualityRepairListeningInputGuardError):
+                build_listening_review_input_guard_report(
+                    source,
+                    output_dir=root / "guard",
+                    issue_number=926,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary

- Targeted quality repair listening review input guard source/current outside-soloing context preservation
- Preference fill block maintained while validated review input is absent
- Issue #926 status docs and harness run-id refresh

## Context

- Previous boundary: Issue #924 targeted quality repair listening review package source-context refresh
- Review item count: `6`
- Validated review input: `false`
- Technical WAV validation: `true`
- Rendered audio file count: `6`
- Failure label delta: `4`
- Source outside-soloing pitch-role risk: `5 -> 2`, delta `3`
- Current outside-soloing pitch-role risk after / delta: `0 / 2`
- Human/audio preference: unclaimed
- MIDI-to-solo musical quality: unclaimed

## Scope

- Source package guard validation for source/current outside-soloing risk fields
- Input guard source summary and validation summary field preservation
- Targeted unit fixture/assertion update
- `agent_harness.sh` issue/run-id/doc-path update
- README, current status, core plan, AGENTS handoff refresh

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
- `.venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-listening-review-input-guard`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- No validated human/audio preference input
- No musical quality claim
- Next boundary: targeted quality repair objective-only next decision source-context refresh

Closes #926