### PR TITLE
Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,10 +26,11 @@ Current handoff scope:
 - Latest targeted quality repair audio package completed: Issue #922, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh.
 - Latest targeted quality repair listening review package completed: Issue #924, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh.
 - Latest targeted quality repair listening review input guard completed: Issue #926, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh.
+- Latest targeted quality repair objective-only next decision completed: Issue #928, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after targeted quality repair listening review input guard source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh.
+- Open issue queue after targeted quality repair objective-only next decision source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -231,6 +232,16 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-liste
 This harness blocks preference fill while validated listening review input is
 pending, preserves source/current outside-soloing repair context, and avoids
 preference or musical quality claims.
+
+For Stage B MIDI-to-solo targeted quality repair objective-only next decision changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-objective-only-next-decision
+```
+
+This harness routes pending listening review input to the next objective-only
+follow-up boundary, preserves source/current outside-soloing repair context,
+and avoids preference or musical quality claims.
 
 For Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep changes, run:
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest targeted quality repair audio package: `Issue #922`
 - latest targeted quality repair listening review package: `Issue #924`
 - latest targeted quality repair listening review input guard: `Issue #926`
+- latest targeted quality repair objective-only next decision: `Issue #928`
 - latest README evidence refresh: `Issue #900`
-- latest functional boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
-- open issue queue after targeted quality repair listening review input guard source-context refresh merge: `0`
+- latest functional boundary: `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
+- open issue queue after targeted quality repair objective-only next decision source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -181,6 +182,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - targeted quality repair validated review input: `false`
 - targeted quality repair listening review input guard completed: `true`
 - targeted quality repair preference fill allowed: `false`
+- targeted quality repair objective-only next decision completed: `true`
+- targeted quality repair follow-up required: `true`
 - targeted quality repair source risk: `5 -> 2`
 - targeted quality repair current risk after / delta: `0 / 2`
 - outside-soloing repair objective path supported: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -406,7 +406,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo targeted quality repair audio package: rendered WAV `6`, duration `18.422s-18.984s`, source risk `5 -> 2`, current repair risk after `0`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
 - MIDI-to-solo targeted quality repair listening review package: review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after `0`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
 - MIDI-to-solo targeted quality repair listening review input guard: review items `6`, preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
-- MIDI-to-solo targeted quality repair objective-only next decision: follow-up required `true`, current quality claim ready `false`, source outside-soloing not evaluable `6`, repaired outside-soloing not evaluable `6`, source pitch-role risk after `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- MIDI-to-solo targeted quality repair objective-only next decision: follow-up required `true`, current quality claim ready `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
 - MIDI-to-solo targeted quality repair follow-up decision: selected target `songlike_melody_contour_repair_sweep`, dominant label/count `songlike_melody_not_soloing/5`, objective and repair sweep outside-soloing not evaluable `6/6`, pitch-role risk after `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
 - MIDI-to-solo songlike melody contour repair sweep: songlike failure `5 -> 0`, total failure labels `8 -> 4`, repaired outside-soloing not evaluable `6`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
 - MIDI-to-solo songlike melody contour repair audio package: rendered WAV `6`, duration `18.849s-18.992s`, source/repaired outside-soloing not evaluable `6/6`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
@@ -8355,6 +8355,58 @@ Issue #926은 Issue #924 targeted quality repair listening review package의 sou
 다음 작업:
 
 - `Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh`
+
+## 9.154 Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh
+
+Issue #928은 Issue #926 targeted quality repair listening review input guard의 source/current outside-soloing context를 objective-only next decision까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- failure label delta: `4`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair WAV count: `6`
+- source outside-soloing source objective pitch-role risk count: `5`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing source pitch-role risk delta: `3`
+- source outside-soloing source repair targeted: `false`
+- source outside-soloing source residual risk preserved: `true`
+- source outside-soloing current repair pitch-role risk count after: `0`
+- source outside-soloing current repair pitch-role risk delta: `2`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- targeted quality follow-up required: `true`
+- current quality claim ready: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- listening input pending 상태에서 objective-only 경로 유지.
+- objective summary와 validation summary에 source/current risk 분리 반영.
+- follow-up decision routing 유지.
+- human/audio preference와 musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_objective_next`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_objective_next.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-objective-only-next-decision`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -26,10 +26,11 @@
 - latest targeted quality repair audio package: Issue #922, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh
 - latest targeted quality repair listening review package: Issue #924, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh
 - latest targeted quality repair listening review input guard: Issue #926, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh
+- latest targeted quality repair objective-only next decision: Issue #928, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh
 - latest README evidence refresh: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after targeted quality repair listening review input guard source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh`
+- open issue queue after targeted quality repair objective-only next decision source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -706,13 +707,23 @@
 - audio rendered quality claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 objective target: `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
-- targeted quality repair objective-only next decision outside-soloing context refresh 완료
+- targeted quality repair objective-only next decision source-context refresh 완료
 - review item count: `6`
+- required input field count: `4`
 - validated review input present: `false`
 - preference fill allowed: `false`
 - technical WAV validation: `true`
+- rendered audio file count: `6`
 - failure label delta: `4`
-- source outside-soloing repair pitch-role risk count after: `0`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair WAV count: `6`
+- source outside-soloing source objective pitch-role risk count: `5`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing source pitch-role risk delta: `3`
+- source outside-soloing source repair targeted: `false`
+- source outside-soloing source residual risk preserved: `true`
+- source outside-soloing current repair pitch-role risk count after: `0`
+- source outside-soloing current repair pitch-role risk delta: `2`
 - source outside-soloing not evaluable count: `6`
 - repaired outside-soloing not evaluable count: `6`
 - targeted quality follow-up required: `true`

--- a/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -1,0 +1,44 @@
+# Stage B MIDI-to-Solo Targeted Quality Repair Objective-Only Next Decision Source Context Refresh
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- selected target: `targeted_quality_repair_followup_decision`
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- failure label delta: `4`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair WAV count: `6`
+- source outside-soloing source objective pitch-role risk: `5`
+- source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
+- source outside-soloing source repair targeted: `false`
+- source outside-soloing source residual risk preserved: `true`
+- source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- targeted quality follow-up required: `true`
+- current quality claim ready: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Decision
+
+- reason: `listening preference pending and quality claim unavailable; route to follow-up repair decision`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh`
+
+## Claim Boundary
+
+- `listening_review_completed`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6285,8 +6285,8 @@ run_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard() 
 }
 
 run_stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision() {
-  local input_guard_run_id="${INPUT_GUARD_RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard}"
-  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision}"
+  local input_guard_run_id="${INPUT_GUARD_RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard_source_context_refresh}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision_source_context_refresh}"
   local input_guard_report="outputs/stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard/${input_guard_run_id}/stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard.json"
   if [[ ! -f "$input_guard_report" ]]; then
     print_header "Stage B MIDI-to-solo targeted quality repair listening review input guard"
@@ -6296,8 +6296,8 @@ run_stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision() 
   "$PYTHON_BIN" scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_objective_next.py \
     --run_id "$run_id" \
     --input_guard_report "$input_guard_report" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-10.md \
-    --issue_number 842 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
+    --issue_number 928 \
     --expected_boundary stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision \
     --expected_next_boundary stage_b_midi_to_solo_targeted_quality_repair_followup_decision \
     --require_objective_decision \

--- a/scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_objective_next.py
+++ b/scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_objective_next.py
@@ -27,7 +27,7 @@ BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_dec
 FOLLOWUP_DECISION_NEXT_BOUNDARY = (
     "stage_b_midi_to_solo_targeted_quality_repair_followup_decision"
 )
-SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_objective_next_v1"
+SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_objective_next_v2"
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -109,9 +109,52 @@ def validate_input_guard_report(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloTargetedQualityRepairObjectiveNextError(
             "outside-soloing repair evidence readiness required"
         )
+    source_wav_count = _int(source.get("source_outside_soloing_repair_wav_count"))
+    if source_wav_count < _int(guard.get("review_item_count")):
+        raise StageBMidiToSoloTargetedQualityRepairObjectiveNextError(
+            "outside-soloing source WAV count below review item count"
+        )
+    source_objective_risk = _int(
+        source.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
+    )
+    source_risk_before = _int(
+        source.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
+    )
+    source_risk_after = _int(
+        source.get("source_outside_soloing_repair_source_pitch_role_risk_count_after")
+    )
+    source_risk_delta = _int(
+        source.get("source_outside_soloing_repair_source_pitch_role_risk_delta")
+    )
+    if source_objective_risk <= 0:
+        raise StageBMidiToSoloTargetedQualityRepairObjectiveNextError(
+            "outside-soloing source objective pitch-role risk count required"
+        )
+    if source_risk_after > source_risk_before:
+        raise StageBMidiToSoloTargetedQualityRepairObjectiveNextError(
+            "outside-soloing source pitch-role risk should not increase"
+        )
+    if source_risk_delta != source_risk_before - source_risk_after:
+        raise StageBMidiToSoloTargetedQualityRepairObjectiveNextError(
+            "outside-soloing source pitch-role risk delta mismatch"
+        )
+    if bool(source.get("source_outside_soloing_repair_source_targeted", True)):
+        raise StageBMidiToSoloTargetedQualityRepairObjectiveNextError(
+            "outside-soloing source repair should remain non-targeted"
+        )
+    if not bool(
+        source.get("source_outside_soloing_repair_source_residual_risk_preserved", False)
+    ):
+        raise StageBMidiToSoloTargetedQualityRepairObjectiveNextError(
+            "outside-soloing source residual risk preservation required"
+        )
     if _int(source.get("source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
         raise StageBMidiToSoloTargetedQualityRepairObjectiveNextError(
             "outside-soloing residual pitch-role risk should be zero"
+        )
+    if _int(source.get("source_outside_soloing_repair_pitch_role_risk_delta")) <= 0:
+        raise StageBMidiToSoloTargetedQualityRepairObjectiveNextError(
+            "outside-soloing current pitch-role risk delta required"
         )
     if _int(source.get("source_outside_soloing_not_evaluable_count")) <= 0:
         raise StageBMidiToSoloTargetedQualityRepairObjectiveNextError(
@@ -143,8 +186,22 @@ def validate_input_guard_report(report: dict[str, Any]) -> dict[str, Any]:
         "source_outside_soloing_repair_evidence_ready": bool(
             source.get("source_outside_soloing_repair_evidence_ready", False)
         ),
+        "source_outside_soloing_repair_wav_count": source_wav_count,
+        "source_outside_soloing_repair_source_objective_pitch_role_risk_count": source_objective_risk,
+        "source_outside_soloing_repair_source_pitch_role_risk_count_before": source_risk_before,
+        "source_outside_soloing_repair_source_pitch_role_risk_count_after": source_risk_after,
+        "source_outside_soloing_repair_source_pitch_role_risk_delta": source_risk_delta,
+        "source_outside_soloing_repair_source_targeted": bool(
+            source.get("source_outside_soloing_repair_source_targeted", True)
+        ),
+        "source_outside_soloing_repair_source_residual_risk_preserved": bool(
+            source.get("source_outside_soloing_repair_source_residual_risk_preserved", False)
+        ),
         "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
             source.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_delta": _int(
+            source.get("source_outside_soloing_repair_pitch_role_risk_delta")
         ),
         "source_outside_soloing_not_evaluable_count": _int(
             source.get("source_outside_soloing_not_evaluable_count")
@@ -189,8 +246,32 @@ def build_objective_next_report(
             "source_outside_soloing_repair_evidence_ready": bool(
                 source["source_outside_soloing_repair_evidence_ready"]
             ),
+            "source_outside_soloing_repair_wav_count": _int(
+                source["source_outside_soloing_repair_wav_count"]
+            ),
+            "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+                source["source_outside_soloing_repair_source_objective_pitch_role_risk_count"]
+            ),
+            "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+                source["source_outside_soloing_repair_source_pitch_role_risk_count_before"]
+            ),
+            "source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+                source["source_outside_soloing_repair_source_pitch_role_risk_count_after"]
+            ),
+            "source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+                source["source_outside_soloing_repair_source_pitch_role_risk_delta"]
+            ),
+            "source_outside_soloing_repair_source_targeted": bool(
+                source["source_outside_soloing_repair_source_targeted"]
+            ),
+            "source_outside_soloing_repair_source_residual_risk_preserved": bool(
+                source["source_outside_soloing_repair_source_residual_risk_preserved"]
+            ),
             "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
                 source["source_outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
+            "source_outside_soloing_repair_pitch_role_risk_delta": _int(
+                source["source_outside_soloing_repair_pitch_role_risk_delta"]
             ),
             "source_outside_soloing_not_evaluable_count": _int(
                 source["source_outside_soloing_not_evaluable_count"]
@@ -216,8 +297,32 @@ def build_objective_next_report(
             "source_outside_soloing_repair_evidence_ready": bool(
                 source["source_outside_soloing_repair_evidence_ready"]
             ),
+            "source_outside_soloing_repair_wav_count": _int(
+                source["source_outside_soloing_repair_wav_count"]
+            ),
+            "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+                source["source_outside_soloing_repair_source_objective_pitch_role_risk_count"]
+            ),
+            "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+                source["source_outside_soloing_repair_source_pitch_role_risk_count_before"]
+            ),
+            "source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+                source["source_outside_soloing_repair_source_pitch_role_risk_count_after"]
+            ),
+            "source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+                source["source_outside_soloing_repair_source_pitch_role_risk_delta"]
+            ),
+            "source_outside_soloing_repair_source_targeted": bool(
+                source["source_outside_soloing_repair_source_targeted"]
+            ),
+            "source_outside_soloing_repair_source_residual_risk_preserved": bool(
+                source["source_outside_soloing_repair_source_residual_risk_preserved"]
+            ),
             "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
                 source["source_outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
+            "source_outside_soloing_repair_pitch_role_risk_delta": _int(
+                source["source_outside_soloing_repair_pitch_role_risk_delta"]
             ),
             "source_outside_soloing_not_evaluable_count": _int(
                 source["source_outside_soloing_not_evaluable_count"]
@@ -252,7 +357,7 @@ def build_objective_next_report(
             "brad_style_adaptation",
         ],
         "next_recommended_issue": (
-            "Stage B MIDI-to-solo targeted quality repair follow-up decision"
+            "Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh"
         ),
     }
 
@@ -323,8 +428,32 @@ def validate_objective_next_report(
         "source_outside_soloing_repair_evidence_ready": bool(
             summary.get("source_outside_soloing_repair_evidence_ready", False)
         ),
+        "source_outside_soloing_repair_wav_count": _int(
+            summary.get("source_outside_soloing_repair_wav_count")
+        ),
+        "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+            summary.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+            summary.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+            summary.get("source_outside_soloing_repair_source_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+            summary.get("source_outside_soloing_repair_source_pitch_role_risk_delta")
+        ),
+        "source_outside_soloing_repair_source_targeted": bool(
+            summary.get("source_outside_soloing_repair_source_targeted", True)
+        ),
+        "source_outside_soloing_repair_source_residual_risk_preserved": bool(
+            summary.get("source_outside_soloing_repair_source_residual_risk_preserved", False)
+        ),
         "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
             summary.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_delta": _int(
+            summary.get("source_outside_soloing_repair_pitch_role_risk_delta")
         ),
         "source_outside_soloing_not_evaluable_count": _int(
             summary.get("source_outside_soloing_not_evaluable_count")
@@ -354,7 +483,7 @@ def markdown_report(report: dict[str, Any]) -> str:
     summary = report["objective_summary"]
     target = report["selected_next_target"]
     lines = [
-        "# Stage B MIDI-to-Solo Targeted Quality Repair Objective-Only Next Decision",
+        "# Stage B MIDI-to-Solo Targeted Quality Repair Objective-Only Next Decision Source Context Refresh",
         "",
         "## Summary",
         "",
@@ -370,7 +499,12 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- rendered audio file count: `{summary['rendered_audio_file_count']}`",
         f"- failure label delta: `{summary['failure_label_delta']}`",
         f"- source outside-soloing repair evidence ready: `{_bool_token(summary['source_outside_soloing_repair_evidence_ready'])}`",
-        f"- source outside-soloing repair pitch-role risk after: `{summary['source_outside_soloing_repair_pitch_role_risk_count_after']}`",
+        f"- source outside-soloing repair WAV count: `{summary['source_outside_soloing_repair_wav_count']}`",
+        f"- source outside-soloing source objective pitch-role risk: `{summary['source_outside_soloing_repair_source_objective_pitch_role_risk_count']}`",
+        f"- source outside-soloing source pitch-role risk before / after / delta: `{summary['source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{summary['source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{summary['source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
+        f"- source outside-soloing source repair targeted: `{_bool_token(summary['source_outside_soloing_repair_source_targeted'])}`",
+        f"- source outside-soloing source residual risk preserved: `{_bool_token(summary['source_outside_soloing_repair_source_residual_risk_preserved'])}`",
+        f"- source outside-soloing current repair pitch-role risk after / delta: `{summary['source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{summary['source_outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- source outside-soloing not evaluable count: `{summary['source_outside_soloing_not_evaluable_count']}`",
         f"- repaired outside-soloing not evaluable count: `{summary['repaired_outside_soloing_not_evaluable_count']}`",
         f"- targeted quality follow-up required: `{_bool_token(summary['targeted_quality_followup_required'])}`",
@@ -406,7 +540,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=842)
+    parser.add_argument("--issue_number", type=int, default=928)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--require_objective_decision", action="store_true")

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_objective_next.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_objective_next.py
@@ -34,7 +34,15 @@ def input_guard_report(*, quality_claim: bool = False) -> dict:
                 "duration_max_seconds": 18.984,
                 "failure_label_delta": 4,
                 "source_outside_soloing_repair_evidence_ready": True,
+                "source_outside_soloing_repair_wav_count": 6,
+                "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+                "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
+                "source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
+                "source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
+                "source_outside_soloing_repair_source_targeted": False,
+                "source_outside_soloing_repair_source_residual_risk_preserved": True,
                 "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+                "source_outside_soloing_repair_pitch_role_risk_delta": 2,
                 "source_outside_soloing_not_evaluable_count": 6,
                 "repaired_outside_soloing_not_evaluable_count": 6,
                 "audio_review_required": True,
@@ -86,13 +94,31 @@ class StageBMidiToSoloTargetedQualityRepairObjectiveNextTest(unittest.TestCase):
             self.assertEqual(summary["rendered_audio_file_count"], 6)
             self.assertEqual(summary["failure_label_delta"], 4)
             self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
+            self.assertEqual(summary["source_outside_soloing_repair_wav_count"], 6)
+            self.assertEqual(
+                summary["source_outside_soloing_repair_source_objective_pitch_role_risk_count"], 5
+            )
+            self.assertEqual(
+                summary["source_outside_soloing_repair_source_pitch_role_risk_count_before"], 5
+            )
+            self.assertEqual(
+                summary["source_outside_soloing_repair_source_pitch_role_risk_count_after"], 2
+            )
+            self.assertEqual(summary["source_outside_soloing_repair_source_pitch_role_risk_delta"], 3)
+            self.assertFalse(summary["source_outside_soloing_repair_source_targeted"])
+            self.assertTrue(summary["source_outside_soloing_repair_source_residual_risk_preserved"])
             self.assertEqual(summary["source_outside_soloing_repair_pitch_role_risk_count_after"], 0)
+            self.assertEqual(summary["source_outside_soloing_repair_pitch_role_risk_delta"], 2)
             self.assertEqual(summary["source_outside_soloing_not_evaluable_count"], 6)
             self.assertEqual(summary["repaired_outside_soloing_not_evaluable_count"], 6)
             self.assertTrue(summary["targeted_quality_followup_required"])
             self.assertFalse(summary["current_quality_claim_ready"])
             self.assertFalse(summary["human_audio_preference_claimed"])
             self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+            self.assertEqual(
+                summary["next_recommended_issue"],
+                "Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh",
+            )
 
     def test_rejects_source_quality_claim(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -116,6 +142,20 @@ class StageBMidiToSoloTargetedQualityRepairObjectiveNextTest(unittest.TestCase):
                     input_guard_report=source,
                     output_dir=root / "objective_next",
                     issue_number=842,
+                )
+
+    def test_rejects_source_risk_delta_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = input_guard_report()
+            source["guard_result"]["source_summary"][
+                "source_outside_soloing_repair_source_pitch_role_risk_delta"
+            ] = 1
+            with self.assertRaises(StageBMidiToSoloTargetedQualityRepairObjectiveNextError):
+                build_objective_next_report(
+                    input_guard_report=source,
+                    output_dir=root / "objective_next",
+                    issue_number=928,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary

- Targeted quality repair objective-only next decision source/current outside-soloing context preservation
- Follow-up decision routing retained while preference input remains pending
- Issue #928 status docs and harness run-id refresh

## Context

- Previous boundary: Issue #926 targeted quality repair listening review input guard source-context refresh
- Review item count: `6`
- Required input field count: `4`
- Validated review input: `false`
- Preference fill allowed: `false`
- Technical WAV validation: `true`
- Source outside-soloing pitch-role risk: `5 -> 2`, delta `3`
- Current outside-soloing pitch-role risk after / delta: `0 / 2`
- Human/audio preference: unclaimed
- MIDI-to-solo musical quality: unclaimed

## Scope

- Input guard report validation for source/current outside-soloing risk fields
- Objective summary, readiness, and validation summary field preservation
- Targeted unit fixture/assertion update
- `agent_harness.sh` issue/run-id/doc-path update
- README, current status, core plan, AGENTS handoff refresh

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_objective_next`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_objective_next.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-objective-only-next-decision`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- Objective-only routing only
- No validated human/audio preference input
- No musical quality claim
- Next boundary: targeted quality repair follow-up decision source-context refresh

Closes #928