### PR TITLE
Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,10 +27,11 @@ Current handoff scope:
 - Latest targeted quality repair listening review package completed: Issue #924, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh.
 - Latest targeted quality repair listening review input guard completed: Issue #926, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh.
 - Latest targeted quality repair objective-only next decision completed: Issue #928, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh.
+- Latest targeted quality repair follow-up decision completed: Issue #930, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh.
 - Latest documentation issue completed: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after targeted quality repair objective-only next decision source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh.
+- Open issue queue after targeted quality repair follow-up decision source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -242,6 +243,16 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-objec
 This harness routes pending listening review input to the next objective-only
 follow-up boundary, preserves source/current outside-soloing repair context,
 and avoids preference or musical quality claims.
+
+For Stage B MIDI-to-solo targeted quality repair follow-up decision changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-followup-decision
+```
+
+This harness selects the dominant remaining repair target, preserves
+source/current outside-soloing repair context, and avoids preference or musical
+quality claims.
 
 For Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep changes, run:
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest targeted quality repair listening review package: `Issue #924`
 - latest targeted quality repair listening review input guard: `Issue #926`
 - latest targeted quality repair objective-only next decision: `Issue #928`
+- latest targeted quality repair follow-up decision: `Issue #930`
 - latest README evidence refresh: `Issue #900`
-- latest functional boundary: `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
-- open issue queue after targeted quality repair objective-only next decision source-context refresh merge: `0`
+- latest functional boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- open issue queue after targeted quality repair follow-up decision source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -184,6 +185,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - targeted quality repair preference fill allowed: `false`
 - targeted quality repair objective-only next decision completed: `true`
 - targeted quality repair follow-up required: `true`
+- targeted quality repair follow-up decision completed: `true`
+- targeted quality repair selected next target: `songlike_melody_contour_repair_sweep`
 - targeted quality repair source risk: `5 -> 2`
 - targeted quality repair current risk after / delta: `0 / 2`
 - outside-soloing repair objective path supported: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -407,7 +407,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo targeted quality repair listening review package: review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after `0`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
 - MIDI-to-solo targeted quality repair listening review input guard: review items `6`, preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
 - MIDI-to-solo targeted quality repair objective-only next decision: follow-up required `true`, current quality claim ready `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
-- MIDI-to-solo targeted quality repair follow-up decision: selected target `songlike_melody_contour_repair_sweep`, dominant label/count `songlike_melody_not_soloing/5`, objective and repair sweep outside-soloing not evaluable `6/6`, pitch-role risk after `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- MIDI-to-solo targeted quality repair follow-up decision: selected target `songlike_melody_contour_repair_sweep`, dominant label/count `songlike_melody_not_soloing/5`, objective and repair sweep source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
 - MIDI-to-solo songlike melody contour repair sweep: songlike failure `5 -> 0`, total failure labels `8 -> 4`, repaired outside-soloing not evaluable `6`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
 - MIDI-to-solo songlike melody contour repair audio package: rendered WAV `6`, duration `18.849s-18.992s`, source/repaired outside-soloing not evaluable `6/6`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
 - MIDI-to-solo songlike melody contour repair listening review package: review items `6`, validated input `false`, source/repaired outside-soloing not evaluable `6/6`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
@@ -8407,6 +8407,66 @@ Issue #928은 Issue #926 targeted quality repair listening review input guard의
 다음 작업:
 
 - `Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh`
+
+## 9.155 Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh
+
+Issue #930은 Issue #928 objective-only next decision과 targeted repair sweep의 source/current outside-soloing context를 follow-up decision까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
+- repair sweep boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- selected target: `songlike_melody_contour_repair_sweep`
+- dominant remaining failure label: `songlike_melody_not_soloing`
+- dominant remaining failure count: `5`
+- candidate count: `6`
+- source total failure labels: `12`
+- repaired total failure labels: `8`
+- failure label delta: `4`
+- technical regression count: `0`
+- objective source outside-soloing repair evidence ready: `true`
+- objective source outside-soloing repair WAV count: `6`
+- objective source outside-soloing source pitch-role risk count: `5 -> 2`
+- objective source outside-soloing source pitch-role risk delta: `3`
+- objective source outside-soloing source repair targeted: `false`
+- objective source outside-soloing source residual risk preserved: `true`
+- objective source outside-soloing current repair pitch-role risk count after: `0`
+- objective source outside-soloing current repair pitch-role risk delta: `2`
+- objective source outside-soloing not evaluable count: `6`
+- objective repaired outside-soloing not evaluable count: `6`
+- repair sweep source outside-soloing repair evidence ready: `true`
+- repair sweep source outside-soloing source pitch-role risk count: `5 -> 2`
+- repair sweep source outside-soloing source pitch-role risk delta: `3`
+- repair sweep source outside-soloing source repair targeted: `false`
+- repair sweep source outside-soloing source residual risk preserved: `true`
+- repair sweep source outside-soloing current repair pitch-role risk count after: `0`
+- repair sweep source outside-soloing current repair pitch-role risk delta: `2`
+- repair sweep source outside-soloing not evaluable count: `6`
+- repair sweep repaired outside-soloing not evaluable count: `6`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- dominant remaining failure label 기준 songlike melody contour repair sweep 선택 유지.
+- objective summary와 repair sweep summary의 source/current risk 분리 보존.
+- technical regression count `0`, failure label delta `4` 조건 유지.
+- human/audio preference와 musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-followup-decision`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -27,10 +27,11 @@
 - latest targeted quality repair listening review package: Issue #924, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh
 - latest targeted quality repair listening review input guard: Issue #926, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh
 - latest targeted quality repair objective-only next decision: Issue #928, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh
+- latest targeted quality repair follow-up decision: Issue #930, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh
 - latest README evidence refresh: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after targeted quality repair objective-only next decision source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh`
+- open issue queue after targeted quality repair follow-up decision source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -732,12 +733,35 @@
 - audio rendered quality claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 follow-up target: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
-- targeted quality repair follow-up decision outside-soloing context refresh 완료
+- targeted quality repair follow-up decision source-context refresh 완료
 - selected target: `songlike_melody_contour_repair_sweep`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
 - dominant remaining failure label: `songlike_melody_not_soloing`
 - dominant remaining failure count: `5`
 - candidate count: `6`
+- source total failure label count: `12`
+- repaired total failure label count: `8`
+- failure label delta: `4`
+- technical regression count: `0`
+- objective source outside-soloing repair evidence ready: `true`
+- objective source outside-soloing repair WAV count: `6`
+- objective source outside-soloing source pitch-role risk count: `5 -> 2`
+- objective source outside-soloing source pitch-role risk delta: `3`
+- objective source outside-soloing source repair targeted: `false`
+- objective source outside-soloing source residual risk preserved: `true`
+- objective source outside-soloing current repair pitch-role risk count after: `0`
+- objective source outside-soloing current repair pitch-role risk delta: `2`
+- objective source outside-soloing not evaluable count: `6`
+- objective repaired outside-soloing not evaluable count: `6`
+- repair sweep source outside-soloing repair evidence ready: `true`
+- repair sweep source outside-soloing source pitch-role risk count: `5 -> 2`
+- repair sweep source outside-soloing source pitch-role risk delta: `3`
+- repair sweep source outside-soloing source repair targeted: `false`
+- repair sweep source outside-soloing source residual risk preserved: `true`
+- repair sweep source outside-soloing current repair pitch-role risk count after: `0`
+- repair sweep source outside-soloing current repair pitch-role risk delta: `2`
+- repair sweep source outside-soloing not evaluable count: `6`
+- repair sweep repaired outside-soloing not evaluable count: `6`
 - failure label delta: `4`
 - technical regression count: `0`
 - objective source outside-soloing repair pitch-role risk count after: `0`

--- a/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -1,0 +1,62 @@
+# Stage B MIDI-to-Solo Targeted Quality Repair Follow-Up Decision Source Context Refresh
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
+- repair sweep boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- selected target: `songlike_melody_contour_repair_sweep`
+- dominant remaining failure label: `songlike_melody_not_soloing`
+- dominant remaining failure count: `5`
+- candidate count: `6`
+- source total failure labels: `12`
+- repaired total failure labels: `8`
+- failure label delta: `4`
+- technical regression count: `0`
+- objective source outside-soloing repair evidence ready: `true`
+- objective source outside-soloing repair WAV count: `6`
+- objective source outside-soloing source objective pitch-role risk: `5`
+- objective source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
+- objective source outside-soloing source repair targeted: `false`
+- objective source outside-soloing source residual risk preserved: `true`
+- objective source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- objective source outside-soloing not evaluable count: `6`
+- objective repaired outside-soloing not evaluable count: `6`
+- repair sweep source outside-soloing repair evidence ready: `true`
+- repair sweep source outside-soloing source objective pitch-role risk: `5`
+- repair sweep source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
+- repair sweep source outside-soloing source repair targeted: `false`
+- repair sweep source outside-soloing source residual risk preserved: `true`
+- repair sweep source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- repair sweep source outside-soloing not evaluable count: `6`
+- repair sweep repaired outside-soloing not evaluable count: `6`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Remaining Failure Counts
+
+- `dead_air_or_density_gap`: `1`
+- `phrase_shape_missing_tension_release`: `2`
+- `songlike_melody_not_soloing`: `5`
+
+## Not Evaluable Counts
+
+- `outside_soloing_without_context`: `6`
+- `weak_chord_tone_landing`: `6`
+
+## Decision
+
+- reason: `remaining objective failure labels route to follow-up repair without quality claim`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh`
+
+## Claim Boundary
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `outside_soloing_without_context`
+- `weak_chord_tone_landing`
+- `broad_trained_model_quality`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6306,9 +6306,9 @@ run_stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision() 
 }
 
 run_stage_b_midi_to_solo_targeted_quality_repair_followup_decision() {
-  local objective_run_id="${OBJECTIVE_RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision}"
-  local sweep_run_id="${SWEEP_RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_sweep}"
-  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_followup_decision}"
+  local objective_run_id="${OBJECTIVE_RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision_source_context_refresh}"
+  local sweep_run_id="${SWEEP_RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_sweep_source_context_refresh}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_followup_decision_source_context_refresh}"
   local objective_report="outputs/stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision/${objective_run_id}/stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision.json"
   local sweep_report="outputs/stage_b_midi_to_solo_targeted_quality_repair_sweep/${sweep_run_id}/stage_b_midi_to_solo_targeted_quality_repair_sweep.json"
   if [[ ! -f "$objective_report" ]]; then
@@ -6324,8 +6324,8 @@ run_stage_b_midi_to_solo_targeted_quality_repair_followup_decision() {
     --run_id "$run_id" \
     --objective_next_report "$objective_report" \
     --repair_sweep_report "$sweep_report" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_FOLLOWUP_DECISION_2026-06-10.md \
-    --issue_number 844 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
+    --issue_number 930 \
     --expected_boundary stage_b_midi_to_solo_targeted_quality_repair_followup_decision \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_sweep \
     --expected_target songlike_melody_contour_repair_sweep \

--- a/scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py
+++ b/scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py
@@ -30,7 +30,7 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(ValueError):
 BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_followup_decision"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_sweep"
 SELECTED_TARGET = "songlike_melody_contour_repair_sweep"
-SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v1"
+SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v2"
 DOMINANT_TARGET_LABEL = "songlike_melody_not_soloing"
 
 QUALITY_CLAIM_KEYS = [
@@ -71,6 +71,79 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
         raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
             f"unexpected quality claim in {label}: {claimed}"
         )
+
+
+def _extract_source_context(
+    container: dict[str, Any],
+    *,
+    label: str,
+    minimum_wav_count: int | None = None,
+) -> dict[str, Any]:
+    source_objective_risk = _int(
+        container.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
+    )
+    source_risk_before = _int(
+        container.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
+    )
+    source_risk_after = _int(
+        container.get("source_outside_soloing_repair_source_pitch_role_risk_count_after")
+    )
+    source_risk_delta = _int(
+        container.get("source_outside_soloing_repair_source_pitch_role_risk_delta")
+    )
+    current_risk_delta = _int(
+        container.get("source_outside_soloing_repair_pitch_role_risk_delta")
+    )
+    if minimum_wav_count is not None:
+        source_wav_count = _int(container.get("source_outside_soloing_repair_wav_count"))
+        if source_wav_count < minimum_wav_count:
+            raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+                f"{label} outside-soloing source WAV count below expected count"
+            )
+    if source_objective_risk <= 0:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            f"{label} outside-soloing source objective pitch-role risk count required"
+        )
+    if source_risk_after > source_risk_before:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            f"{label} outside-soloing source pitch-role risk should not increase"
+        )
+    if source_risk_delta != source_risk_before - source_risk_after:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            f"{label} outside-soloing source pitch-role risk delta mismatch"
+        )
+    if bool(container.get("source_outside_soloing_repair_source_targeted", True)):
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            f"{label} outside-soloing source repair should remain non-targeted"
+        )
+    if not bool(
+        container.get("source_outside_soloing_repair_source_residual_risk_preserved", False)
+    ):
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            f"{label} outside-soloing source residual risk preservation required"
+        )
+    if current_risk_delta <= 0:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            f"{label} outside-soloing current pitch-role risk delta required"
+        )
+    result = {
+        "source_outside_soloing_repair_source_objective_pitch_role_risk_count": source_objective_risk,
+        "source_outside_soloing_repair_source_pitch_role_risk_count_before": source_risk_before,
+        "source_outside_soloing_repair_source_pitch_role_risk_count_after": source_risk_after,
+        "source_outside_soloing_repair_source_pitch_role_risk_delta": source_risk_delta,
+        "source_outside_soloing_repair_source_targeted": bool(
+            container.get("source_outside_soloing_repair_source_targeted", True)
+        ),
+        "source_outside_soloing_repair_source_residual_risk_preserved": bool(
+            container.get("source_outside_soloing_repair_source_residual_risk_preserved", False)
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_delta": current_risk_delta,
+    }
+    if minimum_wav_count is not None:
+        result["source_outside_soloing_repair_wav_count"] = _int(
+            container.get("source_outside_soloing_repair_wav_count")
+        )
+    return result
 
 
 def validate_objective_next_source(report: dict[str, Any]) -> dict[str, Any]:
@@ -117,6 +190,11 @@ def validate_objective_next_source(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
             "objective outside-soloing repair evidence readiness required"
         )
+    source_context = _extract_source_context(
+        summary,
+        label="objective",
+        minimum_wav_count=_int(summary.get("review_item_count")),
+    )
     if _int(summary.get("source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
         raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
             "objective outside-soloing residual pitch-role risk should be zero"
@@ -143,6 +221,7 @@ def validate_objective_next_source(report: dict[str, Any]) -> dict[str, Any]:
         "source_outside_soloing_repair_evidence_ready": bool(
             summary.get("source_outside_soloing_repair_evidence_ready", False)
         ),
+        **source_context,
         "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
             summary.get("source_outside_soloing_repair_pitch_role_risk_count_after")
         ),
@@ -203,6 +282,7 @@ def validate_repair_sweep_source(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
             "repair sweep outside-soloing repair evidence readiness required"
         )
+    source_context = _extract_source_context(aggregate, label="repair sweep")
     if _int(aggregate.get("source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
         raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
             "repair sweep outside-soloing residual pitch-role risk should be zero"
@@ -253,6 +333,7 @@ def validate_repair_sweep_source(report: dict[str, Any]) -> dict[str, Any]:
         "source_outside_soloing_repair_evidence_ready": bool(
             aggregate.get("source_outside_soloing_repair_evidence_ready", False)
         ),
+        **source_context,
         "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
             aggregate.get("source_outside_soloing_repair_pitch_role_risk_count_after")
         ),
@@ -333,8 +414,32 @@ def build_followup_decision_report(
             "objective_source_outside_soloing_repair_evidence_ready": bool(
                 objective["source_outside_soloing_repair_evidence_ready"]
             ),
+            "objective_source_outside_soloing_repair_wav_count": _int(
+                objective["source_outside_soloing_repair_wav_count"]
+            ),
+            "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+                objective["source_outside_soloing_repair_source_objective_pitch_role_risk_count"]
+            ),
+            "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+                objective["source_outside_soloing_repair_source_pitch_role_risk_count_before"]
+            ),
+            "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+                objective["source_outside_soloing_repair_source_pitch_role_risk_count_after"]
+            ),
+            "objective_source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+                objective["source_outside_soloing_repair_source_pitch_role_risk_delta"]
+            ),
+            "objective_source_outside_soloing_repair_source_targeted": bool(
+                objective["source_outside_soloing_repair_source_targeted"]
+            ),
+            "objective_source_outside_soloing_repair_source_residual_risk_preserved": bool(
+                objective["source_outside_soloing_repair_source_residual_risk_preserved"]
+            ),
             "objective_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
                 objective["source_outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
+            "objective_source_outside_soloing_repair_pitch_role_risk_delta": _int(
+                objective["source_outside_soloing_repair_pitch_role_risk_delta"]
             ),
             "objective_source_outside_soloing_not_evaluable_count": _int(
                 objective["source_outside_soloing_not_evaluable_count"]
@@ -345,8 +450,29 @@ def build_followup_decision_report(
             "repair_sweep_source_outside_soloing_repair_evidence_ready": bool(
                 sweep["source_outside_soloing_repair_evidence_ready"]
             ),
+            "repair_sweep_source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+                sweep["source_outside_soloing_repair_source_objective_pitch_role_risk_count"]
+            ),
+            "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+                sweep["source_outside_soloing_repair_source_pitch_role_risk_count_before"]
+            ),
+            "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+                sweep["source_outside_soloing_repair_source_pitch_role_risk_count_after"]
+            ),
+            "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+                sweep["source_outside_soloing_repair_source_pitch_role_risk_delta"]
+            ),
+            "repair_sweep_source_outside_soloing_repair_source_targeted": bool(
+                sweep["source_outside_soloing_repair_source_targeted"]
+            ),
+            "repair_sweep_source_outside_soloing_repair_source_residual_risk_preserved": bool(
+                sweep["source_outside_soloing_repair_source_residual_risk_preserved"]
+            ),
             "repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
                 sweep["source_outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
+            "repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta": _int(
+                sweep["source_outside_soloing_repair_pitch_role_risk_delta"]
             ),
             "repair_sweep_source_outside_soloing_not_evaluable_count": _int(
                 sweep["source_outside_soloing_not_evaluable_count"]
@@ -378,9 +504,9 @@ def build_followup_decision_report(
             "weak_chord_tone_landing",
             "broad_trained_model_quality",
         ],
-        "next_recommended_issue": "Stage B MIDI-to-solo songlike melody contour repair sweep"
+        "next_recommended_issue": "Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh"
         if next_boundary == NEXT_BOUNDARY
-        else "Stage B MIDI-to-solo targeted quality repair follow-up sweep",
+        else "Stage B MIDI-to-solo targeted quality repair follow-up sweep source-context refresh",
     }
 
 
@@ -471,8 +597,41 @@ def validate_followup_decision_report(
         "objective_source_outside_soloing_repair_evidence_ready": bool(
             readiness.get("objective_source_outside_soloing_repair_evidence_ready", False)
         ),
+        "objective_source_outside_soloing_repair_wav_count": _int(
+            readiness.get("objective_source_outside_soloing_repair_wav_count")
+        ),
+        "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+            readiness.get(
+                "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count"
+            )
+        ),
+        "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+            readiness.get(
+                "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"
+            )
+        ),
+        "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+            readiness.get(
+                "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after"
+            )
+        ),
+        "objective_source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+            readiness.get("objective_source_outside_soloing_repair_source_pitch_role_risk_delta")
+        ),
+        "objective_source_outside_soloing_repair_source_targeted": bool(
+            readiness.get("objective_source_outside_soloing_repair_source_targeted", True)
+        ),
+        "objective_source_outside_soloing_repair_source_residual_risk_preserved": bool(
+            readiness.get(
+                "objective_source_outside_soloing_repair_source_residual_risk_preserved",
+                False,
+            )
+        ),
         "objective_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
             readiness.get("objective_source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "objective_source_outside_soloing_repair_pitch_role_risk_delta": _int(
+            readiness.get("objective_source_outside_soloing_repair_pitch_role_risk_delta")
         ),
         "objective_source_outside_soloing_not_evaluable_count": _int(
             readiness.get("objective_source_outside_soloing_not_evaluable_count")
@@ -483,8 +642,38 @@ def validate_followup_decision_report(
         "repair_sweep_source_outside_soloing_repair_evidence_ready": bool(
             readiness.get("repair_sweep_source_outside_soloing_repair_evidence_ready", False)
         ),
+        "repair_sweep_source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+            readiness.get(
+                "repair_sweep_source_outside_soloing_repair_source_objective_pitch_role_risk_count"
+            )
+        ),
+        "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+            readiness.get(
+                "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before"
+            )
+        ),
+        "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+            readiness.get(
+                "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after"
+            )
+        ),
+        "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+            readiness.get("repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta")
+        ),
+        "repair_sweep_source_outside_soloing_repair_source_targeted": bool(
+            readiness.get("repair_sweep_source_outside_soloing_repair_source_targeted", True)
+        ),
+        "repair_sweep_source_outside_soloing_repair_source_residual_risk_preserved": bool(
+            readiness.get(
+                "repair_sweep_source_outside_soloing_repair_source_residual_risk_preserved",
+                False,
+            )
+        ),
         "repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
             readiness.get("repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta": _int(
+            readiness.get("repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta")
         ),
         "repair_sweep_source_outside_soloing_not_evaluable_count": _int(
             readiness.get("repair_sweep_source_outside_soloing_not_evaluable_count")
@@ -513,7 +702,7 @@ def markdown_report(report: dict[str, Any]) -> str:
     selected = report["selected_next_target"]
     sweep = report["repair_sweep_summary"]
     lines = [
-        "# Stage B MIDI-to-Solo Targeted Quality Repair Follow-Up Decision",
+        "# Stage B MIDI-to-Solo Targeted Quality Repair Follow-Up Decision Source Context Refresh",
         "",
         "## Summary",
         "",
@@ -530,11 +719,20 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- failure label delta: `{readiness['failure_label_delta']}`",
         f"- technical regression count: `{readiness['technical_regression_count']}`",
         f"- objective source outside-soloing repair evidence ready: `{_bool_token(readiness['objective_source_outside_soloing_repair_evidence_ready'])}`",
-        f"- objective source outside-soloing repair pitch-role risk after: `{readiness['objective_source_outside_soloing_repair_pitch_role_risk_count_after']}`",
+        f"- objective source outside-soloing repair WAV count: `{readiness['objective_source_outside_soloing_repair_wav_count']}`",
+        f"- objective source outside-soloing source objective pitch-role risk: `{readiness['objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count']}`",
+        f"- objective source outside-soloing source pitch-role risk before / after / delta: `{readiness['objective_source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{readiness['objective_source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{readiness['objective_source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
+        f"- objective source outside-soloing source repair targeted: `{_bool_token(readiness['objective_source_outside_soloing_repair_source_targeted'])}`",
+        f"- objective source outside-soloing source residual risk preserved: `{_bool_token(readiness['objective_source_outside_soloing_repair_source_residual_risk_preserved'])}`",
+        f"- objective source outside-soloing current repair pitch-role risk after / delta: `{readiness['objective_source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{readiness['objective_source_outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- objective source outside-soloing not evaluable count: `{readiness['objective_source_outside_soloing_not_evaluable_count']}`",
         f"- objective repaired outside-soloing not evaluable count: `{readiness['objective_repaired_outside_soloing_not_evaluable_count']}`",
         f"- repair sweep source outside-soloing repair evidence ready: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_evidence_ready'])}`",
-        f"- repair sweep source outside-soloing repair pitch-role risk after: `{readiness['repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after']}`",
+        f"- repair sweep source outside-soloing source objective pitch-role risk: `{readiness['repair_sweep_source_outside_soloing_repair_source_objective_pitch_role_risk_count']}`",
+        f"- repair sweep source outside-soloing source pitch-role risk before / after / delta: `{readiness['repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{readiness['repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{readiness['repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
+        f"- repair sweep source outside-soloing source repair targeted: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_source_targeted'])}`",
+        f"- repair sweep source outside-soloing source residual risk preserved: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_source_residual_risk_preserved'])}`",
+        f"- repair sweep source outside-soloing current repair pitch-role risk after / delta: `{readiness['repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{readiness['repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- repair sweep source outside-soloing not evaluable count: `{readiness['repair_sweep_source_outside_soloing_not_evaluable_count']}`",
         f"- repair sweep repaired outside-soloing not evaluable count: `{readiness['repair_sweep_repaired_outside_soloing_not_evaluable_count']}`",
         f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
@@ -587,7 +785,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=844)
+    parser.add_argument("--issue_number", type=int, default=930)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--expected_target", type=str, default="")

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision.py
@@ -32,7 +32,15 @@ def objective_next_report(*, quality_claim: bool = False) -> dict:
             "rendered_audio_file_count": 6,
             "failure_label_delta": 4,
             "source_outside_soloing_repair_evidence_ready": True,
+            "source_outside_soloing_repair_wav_count": 6,
+            "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
+            "source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
+            "source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
+            "source_outside_soloing_repair_source_targeted": False,
+            "source_outside_soloing_repair_source_residual_risk_preserved": True,
             "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "source_outside_soloing_not_evaluable_count": 6,
             "repaired_outside_soloing_not_evaluable_count": 6,
             "current_quality_claim_ready": False,
@@ -79,7 +87,14 @@ def repair_sweep_report(*, technical_regression_count: int = 0) -> dict:
             "improved_candidate_count": 4,
             "technical_regression_count": technical_regression_count,
             "source_outside_soloing_repair_evidence_ready": True,
+            "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
+            "source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
+            "source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
+            "source_outside_soloing_repair_source_targeted": False,
+            "source_outside_soloing_repair_source_residual_risk_preserved": True,
             "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "source_outside_soloing_not_evaluable_count": 6,
             "repaired_outside_soloing_not_evaluable_count": 6,
             "repaired_failure_counts": {
@@ -135,16 +150,74 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
             self.assertEqual(summary["failure_label_delta"], 4)
             self.assertEqual(summary["technical_regression_count"], 0)
             self.assertTrue(summary["objective_source_outside_soloing_repair_evidence_ready"])
+            self.assertEqual(summary["objective_source_outside_soloing_repair_wav_count"], 6)
+            self.assertEqual(
+                summary[
+                    "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count"
+                ],
+                5,
+            )
+            self.assertEqual(
+                summary[
+                    "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"
+                ],
+                5,
+            )
+            self.assertEqual(
+                summary[
+                    "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after"
+                ],
+                2,
+            )
+            self.assertEqual(
+                summary["objective_source_outside_soloing_repair_source_pitch_role_risk_delta"],
+                3,
+            )
+            self.assertFalse(summary["objective_source_outside_soloing_repair_source_targeted"])
+            self.assertTrue(
+                summary["objective_source_outside_soloing_repair_source_residual_risk_preserved"]
+            )
             self.assertEqual(
                 summary["objective_source_outside_soloing_repair_pitch_role_risk_count_after"],
                 0,
             )
+            self.assertEqual(summary["objective_source_outside_soloing_repair_pitch_role_risk_delta"], 2)
             self.assertEqual(summary["objective_source_outside_soloing_not_evaluable_count"], 6)
             self.assertEqual(summary["objective_repaired_outside_soloing_not_evaluable_count"], 6)
             self.assertTrue(summary["repair_sweep_source_outside_soloing_repair_evidence_ready"])
             self.assertEqual(
+                summary[
+                    "repair_sweep_source_outside_soloing_repair_source_objective_pitch_role_risk_count"
+                ],
+                5,
+            )
+            self.assertEqual(
+                summary[
+                    "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before"
+                ],
+                5,
+            )
+            self.assertEqual(
+                summary[
+                    "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after"
+                ],
+                2,
+            )
+            self.assertEqual(
+                summary["repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta"],
+                3,
+            )
+            self.assertFalse(summary["repair_sweep_source_outside_soloing_repair_source_targeted"])
+            self.assertTrue(
+                summary["repair_sweep_source_outside_soloing_repair_source_residual_risk_preserved"]
+            )
+            self.assertEqual(
                 summary["repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after"],
                 0,
+            )
+            self.assertEqual(
+                summary["repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta"],
+                2,
             )
             self.assertEqual(summary["repair_sweep_source_outside_soloing_not_evaluable_count"], 6)
             self.assertEqual(summary["repair_sweep_repaired_outside_soloing_not_evaluable_count"], 6)
@@ -152,6 +225,10 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
             self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
             self.assertFalse(summary["human_audio_preference_claimed"])
             self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
+            self.assertEqual(
+                summary["next_recommended_issue"],
+                "Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh",
+            )
 
     def test_rejects_objective_quality_claim(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -203,6 +280,22 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
                     repair_sweep_report=source,
                     output_dir=Path(tmp) / "followup",
                     issue_number=844,
+                )
+
+    def test_rejects_objective_source_risk_delta_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = objective_next_report()
+            source["objective_summary"][
+                "source_outside_soloing_repair_source_pitch_role_risk_delta"
+            ] = 1
+            with self.assertRaises(
+                StageBMidiToSoloTargetedQualityRepairFollowupDecisionError
+            ):
+                build_followup_decision_report(
+                    objective_next_report=source,
+                    repair_sweep_report=repair_sweep_report(),
+                    output_dir=Path(tmp) / "followup",
+                    issue_number=930,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary

- Targeted quality repair follow-up decision source/current outside-soloing context preservation
- Objective-only next decision and repair sweep source context carried into follow-up summary
- Songlike contour repair target selection preserved without quality or preference claim

## Context

- Previous boundary: Issue #928 targeted quality repair objective-only next decision source-context refresh
- Objective source outside-soloing pitch-role risk: `5 -> 2`, delta `3`
- Repair sweep source outside-soloing pitch-role risk: `5 -> 2`, delta `3`
- Current outside-soloing pitch-role risk after / delta: `0 / 2`
- Repair sweep failure labels: `12 -> 8`, delta `4`
- Dominant remaining failure label/count: `songlike_melody_not_soloing / 5`
- Technical regression count: `0`
- Human/audio preference: unclaimed
- MIDI-to-solo musical quality: unclaimed

## Scope

- Objective source context validation guard
- Repair sweep source context validation guard
- Follow-up readiness and validation summary field preservation
- Targeted unit fixture/assertion update
- `agent_harness.sh` issue/run-id/doc-path update
- README, current status, core plan, AGENTS handoff refresh

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-followup-decision`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- Follow-up routing only
- No validated human/audio preference input
- No musical quality claim
- Next boundary: songlike melody contour repair sweep source-context refresh

Closes #930