### PR TITLE
Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,10 +28,11 @@ Current handoff scope:
 - Latest targeted quality repair listening review input guard completed: Issue #926, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh.
 - Latest targeted quality repair objective-only next decision completed: Issue #928, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh.
 - Latest targeted quality repair follow-up decision completed: Issue #930, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh.
+- Latest songlike melody contour repair sweep completed: Issue #932, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh.
 - Latest documentation issue completed: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after targeted quality repair follow-up decision source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh.
+- Open issue queue after songlike melody contour repair sweep source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 
@@ -253,6 +254,16 @@ bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-follo
 This harness selects the dominant remaining repair target, preserves
 source/current outside-soloing repair context, and avoids preference or musical
 quality claims.
+
+For Stage B MIDI-to-solo songlike melody contour repair sweep changes, run:
+
+```bash
+bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-sweep
+```
+
+This harness reduces songlike melody labels, preserves source/current
+outside-soloing repair context, and avoids preference or musical quality
+claims.
 
 For Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep changes, run:
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest targeted quality repair listening review input guard: `Issue #926`
 - latest targeted quality repair objective-only next decision: `Issue #928`
 - latest targeted quality repair follow-up decision: `Issue #930`
+- latest songlike melody contour repair sweep: `Issue #932`
 - latest README evidence refresh: `Issue #900`
-- latest functional boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
-- open issue queue after targeted quality repair follow-up decision source-context refresh merge: `0`
+- latest functional boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- open issue queue after songlike melody contour repair sweep source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -189,6 +190,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - targeted quality repair selected next target: `songlike_melody_contour_repair_sweep`
 - targeted quality repair source risk: `5 -> 2`
 - targeted quality repair current risk after / delta: `0 / 2`
+- songlike melody contour repair sweep completed: `true`
+- songlike failure count: `5 -> 0`
+- songlike contour total failure labels: `8 -> 4`
+- songlike contour audio package ready: `true`
 - outside-soloing repair objective path supported: `true`
 - current evidence outside-soloing repair objective path included: `true`
 - listening review quality gap completed: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -408,7 +408,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo targeted quality repair listening review input guard: review items `6`, preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
 - MIDI-to-solo targeted quality repair objective-only next decision: follow-up required `true`, current quality claim ready `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
 - MIDI-to-solo targeted quality repair follow-up decision: selected target `songlike_melody_contour_repair_sweep`, dominant label/count `songlike_melody_not_soloing/5`, objective and repair sweep source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
-- MIDI-to-solo songlike melody contour repair sweep: songlike failure `5 -> 0`, total failure labels `8 -> 4`, repaired outside-soloing not evaluable `6`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
+- MIDI-to-solo songlike melody contour repair sweep: songlike failure `5 -> 0`, total failure labels `8 -> 4`, source risk `5 -> 2`, current repair risk after/delta `0/2`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
 - MIDI-to-solo songlike melody contour repair audio package: rendered WAV `6`, duration `18.849s-18.992s`, source/repaired outside-soloing not evaluable `6/6`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
 - MIDI-to-solo songlike melody contour repair listening review package: review items `6`, validated input `false`, source/repaired outside-soloing not evaluable `6/6`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
 - MIDI-to-solo songlike melody contour repair listening review input guard: preference fill `false`, validated input `false`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
@@ -8467,6 +8467,65 @@ Issue #930은 Issue #928 objective-only next decision과 targeted repair sweep�
 다음 작업:
 
 - `Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh`
+
+## 9.156 Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh
+
+Issue #932는 Issue #930 targeted quality repair follow-up decision의 source/current outside-soloing context를 songlike melody contour repair sweep까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- targeted repair sweep boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
+- selected target: `songlike_melody_contour_repair_audio_package`
+- candidate count: `6`
+- total failure labels: `8 -> 4`
+- failure label delta: `4`
+- songlike failure count: `5 -> 0`
+- songlike failure delta: `5`
+- improved candidate count: `4`
+- technical regression count: `0`
+- objective source outside-soloing repair WAV count: `6`
+- objective source outside-soloing source pitch-role risk count: `5 -> 2`
+- objective source outside-soloing source pitch-role risk delta: `3`
+- objective source outside-soloing source repair targeted: `false`
+- objective source outside-soloing source residual risk preserved: `true`
+- objective source outside-soloing current repair pitch-role risk count after: `0`
+- objective source outside-soloing current repair pitch-role risk delta: `2`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing source pitch-role risk delta: `3`
+- source outside-soloing source repair targeted: `false`
+- source outside-soloing source residual risk preserved: `true`
+- source outside-soloing current repair pitch-role risk count after: `0`
+- source outside-soloing current repair pitch-role risk delta: `2`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- repaired not evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
+- repaired failure counts: `phrase_shape_missing_tension_release=2`, `rhythmic_monotony=2`
+- audio package ready: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- songlike label count `5 -> 0`, total failure labels `8 -> 4`.
+- follow-up decision의 objective/sweep source-current risk 필드 보존.
+- remaining failure labels는 phrase/rhythm 계열로 분리.
+- human/audio preference와 musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-sweep`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -28,10 +28,11 @@
 - latest targeted quality repair listening review input guard: Issue #926, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh
 - latest targeted quality repair objective-only next decision: Issue #928, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh
 - latest targeted quality repair follow-up decision: Issue #930, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh
+- latest songlike melody contour repair sweep: Issue #932, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh
 - latest README evidence refresh: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after targeted quality repair follow-up decision source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh`
+- open issue queue after songlike melody contour repair sweep source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -774,7 +775,7 @@
 - audio rendered quality claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 repair target: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
-- songlike melody contour repair sweep outside-soloing context refresh 완료
+- songlike melody contour repair sweep source-context refresh 완료
 - candidate count: `6`
 - total failure labels: `8 -> 4`
 - failure label delta: `4`
@@ -782,7 +783,19 @@
 - songlike failure delta: `5`
 - improved candidate count: `4`
 - technical regression count: `0`
-- source outside-soloing repair pitch-role risk count after: `0`
+- objective source outside-soloing repair WAV count: `6`
+- objective source outside-soloing source pitch-role risk count: `5 -> 2`
+- objective source outside-soloing source pitch-role risk delta: `3`
+- objective source outside-soloing source repair targeted: `false`
+- objective source outside-soloing source residual risk preserved: `true`
+- objective source outside-soloing current repair pitch-role risk count after: `0`
+- objective source outside-soloing current repair pitch-role risk delta: `2`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing source pitch-role risk delta: `3`
+- source outside-soloing source repair targeted: `false`
+- source outside-soloing source residual risk preserved: `true`
+- source outside-soloing current repair pitch-role risk count after: `0`
+- source outside-soloing current repair pitch-role risk delta: `2`
 - source outside-soloing not evaluable count: `6`
 - repaired outside-soloing not evaluable count: `6`
 - repaired not evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -1,0 +1,65 @@
+# Stage B MIDI-to-Solo Songlike Melody Contour Repair Sweep Source Context Refresh
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
+- selected target: `songlike_melody_contour_repair_audio_package`
+- candidate count: `6`
+- total failure labels: `8 -> 4`
+- failure label delta: `4`
+- songlike failure count: `5 -> 0`
+- songlike failure delta: `5`
+- improved candidate count: `4`
+- technical regression count: `0`
+- source outside-soloing repair evidence ready: `true`
+- objective source outside-soloing repair WAV count: `6`
+- objective source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
+- objective source outside-soloing source repair targeted: `false`
+- objective source outside-soloing source residual risk preserved: `true`
+- objective source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
+- source outside-soloing source repair targeted: `false`
+- source outside-soloing source residual risk preserved: `true`
+- source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- target supported: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Repaired Failure Counts
+
+- `phrase_shape_missing_tension_release`: `2`
+- `rhythmic_monotony`: `2`
+
+## Repaired Not Evaluable Counts
+
+- `outside_soloing_without_context`: `6`
+- `weak_chord_tone_landing`: `6`
+
+## MIDI Files
+
+- rank `1`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_source_context_refresh/midi/01_songlike_melody_contour_repair.mid`
+- rank `2`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_source_context_refresh/midi/02_songlike_melody_contour_repair.mid`
+- rank `3`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_source_context_refresh/midi/03_songlike_melody_contour_repair.mid`
+- rank `4`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_source_context_refresh/midi/04_songlike_melody_contour_repair.mid`
+- rank `5`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_source_context_refresh/midi/05_songlike_melody_contour_repair.mid`
+- rank `6`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_source_context_refresh/midi/06_songlike_melody_contour_repair.mid`
+
+## Decision
+
+- reason: `songlike contour repair sweep completed without musical quality claim`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh`
+
+## Claim Boundary
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `outside_soloing_without_context`
+- `weak_chord_tone_landing`
+- `broad_trained_model_quality`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6335,10 +6335,10 @@ run_stage_b_midi_to_solo_targeted_quality_repair_followup_decision() {
 }
 
 run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep() {
-  local followup_run_id="${FOLLOWUP_RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_followup_decision}"
-  local targeted_sweep_run_id="${TARGETED_SWEEP_RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_sweep}"
+  local followup_run_id="${FOLLOWUP_RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_followup_decision_source_context_refresh}"
+  local targeted_sweep_run_id="${TARGETED_SWEEP_RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_sweep_source_context_refresh}"
   local rubric_run_id="${RUBRIC_RUN_ID:-harness_stage_b_midi_to_solo_quality_rubric_baseline}"
-  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_source_context_refresh}"
   local followup_report="outputs/stage_b_midi_to_solo_targeted_quality_repair_followup_decision/${followup_run_id}/stage_b_midi_to_solo_targeted_quality_repair_followup_decision.json"
   local targeted_sweep_report="outputs/stage_b_midi_to_solo_targeted_quality_repair_sweep/${targeted_sweep_run_id}/stage_b_midi_to_solo_targeted_quality_repair_sweep.json"
   local rubric_report="outputs/stage_b_midi_to_solo_quality_rubric_baseline/${rubric_run_id}/stage_b_midi_to_solo_quality_rubric_baseline.json"
@@ -6360,8 +6360,8 @@ run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep() {
     --followup_decision "$followup_report" \
     --targeted_repair_sweep "$targeted_sweep_report" \
     --rubric_baseline "$rubric_report" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_SWEEP_2026-06-10.md \
-    --issue_number 846 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
+    --issue_number 932 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_sweep \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package \
     --min_candidate_count 6 \

--- a/scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
+++ b/scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
@@ -38,7 +38,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairSweepError(ValueError):
 BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_sweep"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package"
 SELECTED_TARGET = "songlike_melody_contour_repair_audio_package"
-SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v1"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v2"
 SONGLIKE_LABEL = "songlike_melody_not_soloing"
 BAR_SECONDS = 2.0
 
@@ -89,6 +89,77 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
         )
 
 
+def _extract_prefixed_source_context(
+    readiness: dict[str, Any],
+    *,
+    prefix: str,
+    label: str,
+    minimum_wav_count: int | None = None,
+) -> dict[str, Any]:
+    field_prefix = f"{prefix}_source_outside_soloing_repair"
+    source_objective_risk = _int(
+        readiness.get(f"{field_prefix}_source_objective_pitch_role_risk_count")
+    )
+    source_risk_before = _int(
+        readiness.get(f"{field_prefix}_source_pitch_role_risk_count_before")
+    )
+    source_risk_after = _int(
+        readiness.get(f"{field_prefix}_source_pitch_role_risk_count_after")
+    )
+    source_risk_delta = _int(
+        readiness.get(f"{field_prefix}_source_pitch_role_risk_delta")
+    )
+    current_risk_delta = _int(readiness.get(f"{field_prefix}_pitch_role_risk_delta"))
+    if minimum_wav_count is not None:
+        source_wav_count = _int(readiness.get(f"{field_prefix}_wav_count"))
+        if source_wav_count < minimum_wav_count:
+            raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+                f"{label} outside-soloing source WAV count below expected count"
+            )
+    if source_objective_risk <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            f"{label} outside-soloing source objective pitch-role risk count required"
+        )
+    if source_risk_after > source_risk_before:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            f"{label} outside-soloing source pitch-role risk should not increase"
+        )
+    if source_risk_delta != source_risk_before - source_risk_after:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            f"{label} outside-soloing source pitch-role risk delta mismatch"
+        )
+    if bool(readiness.get(f"{field_prefix}_source_targeted", True)):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            f"{label} outside-soloing source repair should remain non-targeted"
+        )
+    if not bool(readiness.get(f"{field_prefix}_source_residual_risk_preserved", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            f"{label} outside-soloing source residual risk preservation required"
+        )
+    if current_risk_delta <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            f"{label} outside-soloing current pitch-role risk delta required"
+        )
+    result = {
+        f"{prefix}_source_outside_soloing_repair_source_objective_pitch_role_risk_count": source_objective_risk,
+        f"{prefix}_source_outside_soloing_repair_source_pitch_role_risk_count_before": source_risk_before,
+        f"{prefix}_source_outside_soloing_repair_source_pitch_role_risk_count_after": source_risk_after,
+        f"{prefix}_source_outside_soloing_repair_source_pitch_role_risk_delta": source_risk_delta,
+        f"{prefix}_source_outside_soloing_repair_source_targeted": bool(
+            readiness.get(f"{field_prefix}_source_targeted", True)
+        ),
+        f"{prefix}_source_outside_soloing_repair_source_residual_risk_preserved": bool(
+            readiness.get(f"{field_prefix}_source_residual_risk_preserved", False)
+        ),
+        f"{prefix}_source_outside_soloing_repair_pitch_role_risk_delta": current_risk_delta,
+    }
+    if minimum_wav_count is not None:
+        result[f"{prefix}_source_outside_soloing_repair_wav_count"] = _int(
+            readiness.get(f"{field_prefix}_wav_count")
+        )
+    return result
+
+
 def validate_followup_decision(report: dict[str, Any]) -> dict[str, Any]:
     readiness = _dict(report.get("readiness"))
     decision = _dict(report.get("decision"))
@@ -126,6 +197,12 @@ def validate_followup_decision(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
             "objective outside-soloing repair evidence readiness required"
         )
+    objective_context = _extract_prefixed_source_context(
+        readiness,
+        prefix="objective",
+        label="objective",
+        minimum_wav_count=_int(readiness.get("candidate_count")),
+    )
     if _int(readiness.get("objective_source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
         raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
             "objective outside-soloing residual pitch-role risk should be zero"
@@ -142,6 +219,11 @@ def validate_followup_decision(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
             "repair sweep outside-soloing repair evidence readiness required"
         )
+    repair_sweep_context = _extract_prefixed_source_context(
+        readiness,
+        prefix="repair_sweep",
+        label="repair sweep",
+    )
     if _int(readiness.get("repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
         raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
             "repair sweep outside-soloing residual pitch-role risk should be zero"
@@ -171,6 +253,7 @@ def validate_followup_decision(report: dict[str, Any]) -> dict[str, Any]:
         "objective_source_outside_soloing_repair_evidence_ready": bool(
             readiness.get("objective_source_outside_soloing_repair_evidence_ready", False)
         ),
+        **objective_context,
         "objective_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
             readiness.get("objective_source_outside_soloing_repair_pitch_role_risk_count_after")
         ),
@@ -183,6 +266,7 @@ def validate_followup_decision(report: dict[str, Any]) -> dict[str, Any]:
         "repair_sweep_source_outside_soloing_repair_evidence_ready": bool(
             readiness.get("repair_sweep_source_outside_soloing_repair_evidence_ready", False)
         ),
+        **repair_sweep_context,
         "repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
             readiness.get("repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after")
         ),
@@ -515,8 +599,58 @@ def build_songlike_melody_contour_repair_sweep_report(
             "source_outside_soloing_repair_evidence_ready": bool(
                 followup["repair_sweep_source_outside_soloing_repair_evidence_ready"]
             ),
+            "objective_source_outside_soloing_repair_wav_count": _int(
+                followup["objective_source_outside_soloing_repair_wav_count"]
+            ),
+            "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+                followup["objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count"]
+            ),
+            "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+                followup["objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"]
+            ),
+            "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+                followup["objective_source_outside_soloing_repair_source_pitch_role_risk_count_after"]
+            ),
+            "objective_source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+                followup["objective_source_outside_soloing_repair_source_pitch_role_risk_delta"]
+            ),
+            "objective_source_outside_soloing_repair_source_targeted": bool(
+                followup["objective_source_outside_soloing_repair_source_targeted"]
+            ),
+            "objective_source_outside_soloing_repair_source_residual_risk_preserved": bool(
+                followup["objective_source_outside_soloing_repair_source_residual_risk_preserved"]
+            ),
+            "objective_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+                followup["objective_source_outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
+            "objective_source_outside_soloing_repair_pitch_role_risk_delta": _int(
+                followup["objective_source_outside_soloing_repair_pitch_role_risk_delta"]
+            ),
+            "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+                followup[
+                    "repair_sweep_source_outside_soloing_repair_source_objective_pitch_role_risk_count"
+                ]
+            ),
+            "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+                followup["repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before"]
+            ),
+            "source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+                followup["repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after"]
+            ),
+            "source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+                followup["repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta"]
+            ),
+            "source_outside_soloing_repair_source_targeted": bool(
+                followup["repair_sweep_source_outside_soloing_repair_source_targeted"]
+            ),
+            "source_outside_soloing_repair_source_residual_risk_preserved": bool(
+                followup["repair_sweep_source_outside_soloing_repair_source_residual_risk_preserved"]
+            ),
             "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
                 followup["repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
+            "source_outside_soloing_repair_pitch_role_risk_delta": _int(
+                followup["repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta"]
             ),
             "source_outside_soloing_not_evaluable_count": _int(
                 followup["repair_sweep_repaired_outside_soloing_not_evaluable_count"]
@@ -550,8 +684,58 @@ def build_songlike_melody_contour_repair_sweep_report(
             "source_outside_soloing_repair_evidence_ready": bool(
                 followup["repair_sweep_source_outside_soloing_repair_evidence_ready"]
             ),
+            "objective_source_outside_soloing_repair_wav_count": _int(
+                followup["objective_source_outside_soloing_repair_wav_count"]
+            ),
+            "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+                followup["objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count"]
+            ),
+            "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+                followup["objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"]
+            ),
+            "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+                followup["objective_source_outside_soloing_repair_source_pitch_role_risk_count_after"]
+            ),
+            "objective_source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+                followup["objective_source_outside_soloing_repair_source_pitch_role_risk_delta"]
+            ),
+            "objective_source_outside_soloing_repair_source_targeted": bool(
+                followup["objective_source_outside_soloing_repair_source_targeted"]
+            ),
+            "objective_source_outside_soloing_repair_source_residual_risk_preserved": bool(
+                followup["objective_source_outside_soloing_repair_source_residual_risk_preserved"]
+            ),
+            "objective_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+                followup["objective_source_outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
+            "objective_source_outside_soloing_repair_pitch_role_risk_delta": _int(
+                followup["objective_source_outside_soloing_repair_pitch_role_risk_delta"]
+            ),
+            "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+                followup[
+                    "repair_sweep_source_outside_soloing_repair_source_objective_pitch_role_risk_count"
+                ]
+            ),
+            "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+                followup["repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before"]
+            ),
+            "source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+                followup["repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after"]
+            ),
+            "source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+                followup["repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta"]
+            ),
+            "source_outside_soloing_repair_source_targeted": bool(
+                followup["repair_sweep_source_outside_soloing_repair_source_targeted"]
+            ),
+            "source_outside_soloing_repair_source_residual_risk_preserved": bool(
+                followup["repair_sweep_source_outside_soloing_repair_source_residual_risk_preserved"]
+            ),
             "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
                 followup["repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
+            "source_outside_soloing_repair_pitch_role_risk_delta": _int(
+                followup["repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta"]
             ),
             "source_outside_soloing_not_evaluable_count": _int(
                 followup["repair_sweep_repaired_outside_soloing_not_evaluable_count"]
@@ -586,9 +770,9 @@ def build_songlike_melody_contour_repair_sweep_report(
             "weak_chord_tone_landing",
             "broad_trained_model_quality",
         ],
-        "next_recommended_issue": "Stage B MIDI-to-solo songlike melody contour repair audio package"
+        "next_recommended_issue": "Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh"
         if target_supported
-        else "Stage B MIDI-to-solo songlike melody contour repair follow-up decision",
+        else "Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh",
         "source_summary": followup,
     }
 
@@ -681,8 +865,61 @@ def validate_songlike_melody_contour_repair_sweep_report(
         "source_outside_soloing_repair_evidence_ready": bool(
             aggregate.get("source_outside_soloing_repair_evidence_ready", False)
         ),
+        "objective_source_outside_soloing_repair_wav_count": _int(
+            aggregate.get("objective_source_outside_soloing_repair_wav_count")
+        ),
+        "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+            aggregate.get(
+                "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count"
+            )
+        ),
+        "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+            aggregate.get("objective_source_outside_soloing_repair_source_pitch_role_risk_count_before")
+        ),
+        "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+            aggregate.get("objective_source_outside_soloing_repair_source_pitch_role_risk_count_after")
+        ),
+        "objective_source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+            aggregate.get("objective_source_outside_soloing_repair_source_pitch_role_risk_delta")
+        ),
+        "objective_source_outside_soloing_repair_source_targeted": bool(
+            aggregate.get("objective_source_outside_soloing_repair_source_targeted", True)
+        ),
+        "objective_source_outside_soloing_repair_source_residual_risk_preserved": bool(
+            aggregate.get(
+                "objective_source_outside_soloing_repair_source_residual_risk_preserved",
+                False,
+            )
+        ),
+        "objective_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            aggregate.get("objective_source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "objective_source_outside_soloing_repair_pitch_role_risk_delta": _int(
+            aggregate.get("objective_source_outside_soloing_repair_pitch_role_risk_delta")
+        ),
+        "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+            aggregate.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+            aggregate.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+            aggregate.get("source_outside_soloing_repair_source_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+            aggregate.get("source_outside_soloing_repair_source_pitch_role_risk_delta")
+        ),
+        "source_outside_soloing_repair_source_targeted": bool(
+            aggregate.get("source_outside_soloing_repair_source_targeted", True)
+        ),
+        "source_outside_soloing_repair_source_residual_risk_preserved": bool(
+            aggregate.get("source_outside_soloing_repair_source_residual_risk_preserved", False)
+        ),
         "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
             aggregate.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_delta": _int(
+            aggregate.get("source_outside_soloing_repair_pitch_role_risk_delta")
         ),
         "source_outside_soloing_not_evaluable_count": _int(
             aggregate.get("source_outside_soloing_not_evaluable_count")
@@ -714,7 +951,7 @@ def markdown_report(report: dict[str, Any]) -> str:
     decision = report["decision"]
     selected = report["selected_next_target"]
     lines = [
-        "# Stage B MIDI-to-Solo Songlike Melody Contour Repair Sweep",
+        "# Stage B MIDI-to-Solo Songlike Melody Contour Repair Sweep Source Context Refresh",
         "",
         "## Summary",
         "",
@@ -730,7 +967,15 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- improved candidate count: `{aggregate['improved_candidate_count']}`",
         f"- technical regression count: `{aggregate['technical_regression_count']}`",
         f"- source outside-soloing repair evidence ready: `{_bool_token(aggregate['source_outside_soloing_repair_evidence_ready'])}`",
-        f"- source outside-soloing repair pitch-role risk after: `{aggregate['source_outside_soloing_repair_pitch_role_risk_count_after']}`",
+        f"- objective source outside-soloing repair WAV count: `{aggregate['objective_source_outside_soloing_repair_wav_count']}`",
+        f"- objective source outside-soloing source pitch-role risk before / after / delta: `{aggregate['objective_source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{aggregate['objective_source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{aggregate['objective_source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
+        f"- objective source outside-soloing source repair targeted: `{_bool_token(aggregate['objective_source_outside_soloing_repair_source_targeted'])}`",
+        f"- objective source outside-soloing source residual risk preserved: `{_bool_token(aggregate['objective_source_outside_soloing_repair_source_residual_risk_preserved'])}`",
+        f"- objective source outside-soloing current repair pitch-role risk after / delta: `{aggregate['objective_source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{aggregate['objective_source_outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- source outside-soloing source pitch-role risk before / after / delta: `{aggregate['source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{aggregate['source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{aggregate['source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
+        f"- source outside-soloing source repair targeted: `{_bool_token(aggregate['source_outside_soloing_repair_source_targeted'])}`",
+        f"- source outside-soloing source residual risk preserved: `{_bool_token(aggregate['source_outside_soloing_repair_source_residual_risk_preserved'])}`",
+        f"- source outside-soloing current repair pitch-role risk after / delta: `{aggregate['source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{aggregate['source_outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- source outside-soloing not evaluable count: `{aggregate['source_outside_soloing_not_evaluable_count']}`",
         f"- repaired outside-soloing not evaluable count: `{aggregate['repaired_outside_soloing_not_evaluable_count']}`",
         f"- target supported: `{_bool_token(aggregate['target_supported'])}`",
@@ -788,7 +1033,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=846)
+    parser.add_argument("--issue_number", type=int, default=932)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--min_candidate_count", type=int, default=6)

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
@@ -117,11 +117,26 @@ def followup_decision(*, quality_claim: bool = False) -> dict:
             "failure_label_delta": 4,
             "technical_regression_count": 0,
             "objective_source_outside_soloing_repair_evidence_ready": True,
+            "objective_source_outside_soloing_repair_wav_count": 6,
+            "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
+            "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
+            "objective_source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
+            "objective_source_outside_soloing_repair_source_targeted": False,
+            "objective_source_outside_soloing_repair_source_residual_risk_preserved": True,
             "objective_source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "objective_source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "objective_source_outside_soloing_not_evaluable_count": 6,
             "objective_repaired_outside_soloing_not_evaluable_count": 6,
             "repair_sweep_source_outside_soloing_repair_evidence_ready": True,
+            "repair_sweep_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
+            "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
+            "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
+            "repair_sweep_source_outside_soloing_repair_source_targeted": False,
+            "repair_sweep_source_outside_soloing_repair_source_residual_risk_preserved": True,
             "repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "repair_sweep_source_outside_soloing_not_evaluable_count": 6,
             "repair_sweep_repaired_outside_soloing_not_evaluable_count": 6,
             "human_audio_preference_claimed": False,
@@ -227,7 +242,53 @@ class StageBMidiToSoloSonglikeMelodyContourRepairSweepTest(unittest.TestCase):
             self.assertGreater(summary["songlike_failure_delta"], 0)
             self.assertEqual(summary["technical_regression_count"], 0)
             self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
+            self.assertEqual(summary["objective_source_outside_soloing_repair_wav_count"], 6)
+            self.assertEqual(
+                summary[
+                    "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count"
+                ],
+                5,
+            )
+            self.assertEqual(
+                summary[
+                    "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"
+                ],
+                5,
+            )
+            self.assertEqual(
+                summary[
+                    "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after"
+                ],
+                2,
+            )
+            self.assertEqual(
+                summary["objective_source_outside_soloing_repair_source_pitch_role_risk_delta"],
+                3,
+            )
+            self.assertFalse(summary["objective_source_outside_soloing_repair_source_targeted"])
+            self.assertTrue(
+                summary["objective_source_outside_soloing_repair_source_residual_risk_preserved"]
+            )
+            self.assertEqual(
+                summary["objective_source_outside_soloing_repair_pitch_role_risk_count_after"],
+                0,
+            )
+            self.assertEqual(summary["objective_source_outside_soloing_repair_pitch_role_risk_delta"], 2)
+            self.assertEqual(
+                summary["source_outside_soloing_repair_source_objective_pitch_role_risk_count"],
+                5,
+            )
+            self.assertEqual(
+                summary["source_outside_soloing_repair_source_pitch_role_risk_count_before"], 5
+            )
+            self.assertEqual(
+                summary["source_outside_soloing_repair_source_pitch_role_risk_count_after"], 2
+            )
+            self.assertEqual(summary["source_outside_soloing_repair_source_pitch_role_risk_delta"], 3)
+            self.assertFalse(summary["source_outside_soloing_repair_source_targeted"])
+            self.assertTrue(summary["source_outside_soloing_repair_source_residual_risk_preserved"])
             self.assertEqual(summary["source_outside_soloing_repair_pitch_role_risk_count_after"], 0)
+            self.assertEqual(summary["source_outside_soloing_repair_pitch_role_risk_delta"], 2)
             self.assertEqual(summary["source_outside_soloing_not_evaluable_count"], 6)
             self.assertEqual(summary["repaired_outside_soloing_not_evaluable_count"], 6)
             self.assertEqual(
@@ -235,6 +296,10 @@ class StageBMidiToSoloSonglikeMelodyContourRepairSweepTest(unittest.TestCase):
                 6,
             )
             self.assertEqual(summary["selected_target"], SELECTED_TARGET)
+            self.assertEqual(
+                summary["next_recommended_issue"],
+                "Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh",
+            )
             self.assertFalse(summary["human_audio_preference_claimed"])
             self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
 
@@ -284,6 +349,21 @@ class StageBMidiToSoloSonglikeMelodyContourRepairSweepTest(unittest.TestCase):
                     rubric_baseline=rubric_baseline(Path(tmp)),
                     output_dir=Path(tmp) / "songlike_repair",
                     issue_number=846,
+                )
+
+    def test_rejects_followup_source_risk_delta_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = followup_decision()
+            source["readiness"][
+                "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta"
+            ] = 1
+            with self.assertRaises(StageBMidiToSoloSonglikeMelodyContourRepairSweepError):
+                build_songlike_melody_contour_repair_sweep_report(
+                    followup_decision=source,
+                    targeted_repair_sweep=targeted_repair_sweep(),
+                    rubric_baseline=rubric_baseline(Path(tmp)),
+                    output_dir=Path(tmp) / "songlike_repair",
+                    issue_number=932,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary

- Songlike melody contour repair sweep source/current outside-soloing context preservation
- Follow-up decision source context carried into songlike sweep aggregate and validation summary
- Songlike repair result retained without quality or preference claim

## Context

- Previous boundary: Issue #930 targeted quality repair follow-up decision source-context refresh
- Selected target: `songlike_melody_contour_repair_sweep`
- Songlike failure count: `5 -> 0`
- Total failure labels: `8 -> 4`
- Source outside-soloing pitch-role risk: `5 -> 2`, delta `3`
- Current outside-soloing pitch-role risk after / delta: `0 / 2`
- Technical regression count: `0`
- Human/audio preference: unclaimed
- MIDI-to-solo musical quality: unclaimed

## Scope

- Follow-up decision source context validation guard
- Songlike sweep aggregate/readiness/validation summary field preservation
- Targeted unit fixture/assertion update
- `agent_harness.sh` issue/run-id/doc-path update
- README, current status, core plan, AGENTS handoff refresh

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-sweep`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- Objective repair sweep only
- No validated human/audio preference input
- No musical quality claim
- Next boundary: songlike melody contour repair audio package source-context refresh

Closes #932