### PR TITLE
Stage B MIDI-to-solo songlike contour phrase rhythm source context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,10 +34,11 @@ Current handoff scope:
 - Latest songlike melody contour repair listening review input guard completed: Issue #938, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh.
 - Latest songlike melody contour repair objective-only next decision completed: Issue #940, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh.
 - Latest songlike melody contour repair follow-up decision completed: Issue #942, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh.
+- Latest songlike melody contour phrase/rhythm repair sweep completed: Issue #944, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh.
 - Latest documentation issue completed: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after songlike melody contour repair follow-up decision source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh.
+- Open issue queue after songlike melody contour phrase/rhythm repair sweep source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour repair listening review input guard: `Issue #938`
 - latest songlike melody contour repair objective-only next decision: `Issue #940`
 - latest songlike melody contour repair follow-up decision: `Issue #942`
+- latest songlike melody contour phrase/rhythm repair sweep: `Issue #944`
 - latest README evidence refresh: `Issue #900`
-- latest functional boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
-- open issue queue after songlike melody contour repair follow-up decision source-context refresh merge: `0`
+- latest functional boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- open issue queue after songlike melody contour phrase/rhythm repair sweep source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -214,6 +215,14 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - songlike contour follow-up source risk: `5 -> 2`
 - songlike contour follow-up current risk after / delta: `0 / 2`
 - songlike contour follow-up technical regression count: `0`
+- songlike contour phrase/rhythm repair sweep completed: `true`
+- songlike contour phrase/rhythm failure count: `4 -> 1`
+- songlike contour phrase/rhythm failure delta: `3`
+- songlike contour phrase/rhythm total failure labels: `4 -> 1`
+- songlike contour phrase/rhythm source risk: `5 -> 2`
+- songlike contour phrase/rhythm current risk after / delta: `0 / 2`
+- songlike contour phrase/rhythm technical regression count: `0`
+- songlike contour phrase/rhythm audio package ready: `true`
 - songlike contour current quality claim ready: `false`
 - outside-soloing repair objective path supported: `true`
 - current evidence outside-soloing repair objective path included: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -414,7 +414,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo songlike melody contour repair listening review input guard: preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
 - MIDI-to-solo songlike melody contour repair objective-only next decision: follow-up required `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, current quality claim ready `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
 - MIDI-to-solo songlike melody contour repair follow-up decision: selected target `songlike_melody_contour_phrase_rhythm_repair_sweep`, primary labels `phrase_shape_missing_tension_release,rhythmic_monotony`, objective and repair sweep source risk `5 -> 2`, current repair risk after/delta `0/2`, objective/sweep outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
-- MIDI-to-solo songlike melody contour phrase/rhythm repair sweep: phrase/rhythm failure `4 -> 1`, total failure labels `4 -> 1`, source/repaired outside-soloing not evaluable `6/6`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
+- MIDI-to-solo songlike melody contour phrase/rhythm repair sweep: phrase/rhythm failure `4 -> 1`, total failure labels `4 -> 1`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair audio package: rendered WAV `6`, duration `18.871s-19.000s`, source/repaired outside-soloing not evaluable `6/6`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package: review items `6`, validated input `false`, source/repaired outside-soloing not evaluable `6/6`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard: preference fill `false`, validated input `false`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
@@ -8810,6 +8810,57 @@ Issue #942는 Issue #940 objective-only next decision과 songlike melody contour
 다음 작업:
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh`
+
+## 9.162 Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh
+
+Issue #944는 Issue #942 follow-up decision에서 선택된 phrase/rhythm repair sweep에 source/current outside-soloing context를 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
+- source repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
+- selected target: `songlike_melody_contour_phrase_rhythm_repair_audio_package`
+- candidate count: `6`
+- total failure labels: `4 -> 1`
+- failure label delta: `3`
+- phrase/rhythm failure count: `4 -> 1`
+- phrase/rhythm failure delta: `3`
+- improved candidate count: `2`
+- technical regression count: `0`
+- repaired failure counts: `rhythmic_monotony=1`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing source pitch-role risk delta: `3`
+- source outside-soloing source repair targeted: `false`
+- source outside-soloing source residual risk preserved: `true`
+- source outside-soloing current repair pitch-role risk count after: `0`
+- source outside-soloing current repair pitch-role risk delta: `2`
+- source/repaired outside-soloing not evaluable count: `6/6`
+- repaired not evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
+- audio package ready: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- phrase shape와 rhythmic monotony 잔여 라벨 감소 확인.
+- source/current outside-soloing risk context 보존.
+- outside-soloing과 weak chord-tone landing은 context 부재 상태에서 not-evaluable boundary 유지.
+- audio package로 진행 가능하나, listening preference와 musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-sweep`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -34,10 +34,11 @@
 - latest songlike melody contour repair listening review input guard: Issue #938, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh
 - latest songlike melody contour repair objective-only next decision: Issue #940, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh
 - latest songlike melody contour repair follow-up decision: Issue #942, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh
+- latest songlike melody contour phrase/rhythm repair sweep: Issue #944, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh
 - latest README evidence refresh: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after songlike melody contour repair follow-up decision source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh`
+- open issue queue after songlike melody contour phrase/rhythm repair sweep source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -182,6 +183,26 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 repair target: `songlike_melody_contour_phrase_rhythm_repair_sweep`
+- songlike melody contour phrase/rhythm repair sweep source-context refresh 완료
+- candidate count: `6`
+- total failure labels: `4 -> 1`
+- failure label delta: `3`
+- phrase/rhythm failure count: `4 -> 1`
+- phrase/rhythm failure delta: `3`
+- improved candidate count: `2`
+- technical regression count: `0`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing source pitch-role risk delta: `3`
+- source outside-soloing source repair targeted: `false`
+- source outside-soloing source residual risk preserved: `true`
+- source outside-soloing current repair pitch-role risk count after / delta: `0 / 2`
+- source/repaired outside-soloing not evaluable count: `6/6`
+- repaired not evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
+- repaired failure counts: `rhythmic_monotony=1`
+- audio package ready: `true`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 audio target: `songlike_melody_contour_phrase_rhythm_repair_audio_package`
 - songlike melody contour repair follow-up decision 완료
 - primary remaining failure labels: `phrase_shape_missing_tension_release`, `rhythmic_monotony`
 - primary remaining failure count: `2`

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -1,0 +1,60 @@
+# Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Repair Sweep
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
+- selected target: `songlike_melody_contour_phrase_rhythm_repair_audio_package`
+- candidate count: `6`
+- total failure labels: `4 -> 1`
+- failure label delta: `3`
+- phrase/rhythm failure count: `4 -> 1`
+- phrase/rhythm failure delta: `3`
+- improved candidate count: `2`
+- technical regression count: `0`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
+- source outside-soloing source repair targeted: `false`
+- source outside-soloing source residual risk preserved: `true`
+- source outside-soloing repair pitch-role risk after: `0`
+- source outside-soloing current repair pitch-role risk delta: `2`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- target supported: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Repaired Failure Counts
+
+- `rhythmic_monotony`: `1`
+
+## Repaired Not Evaluable Counts
+
+- `outside_soloing_without_context`: `6`
+- `weak_chord_tone_landing`: `6`
+
+## MIDI Files
+
+- rank `1`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep_source_context_refresh/midi/01_songlike_melody_contour_phrase_rhythm_repair.mid`
+- rank `2`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep_source_context_refresh/midi/02_songlike_melody_contour_phrase_rhythm_repair.mid`
+- rank `3`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep_source_context_refresh/midi/03_songlike_melody_contour_phrase_rhythm_repair.mid`
+- rank `4`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep_source_context_refresh/midi/04_songlike_melody_contour_phrase_rhythm_repair.mid`
+- rank `5`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep_source_context_refresh/midi/05_songlike_melody_contour_phrase_rhythm_repair.mid`
+- rank `6`: `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep_source_context_refresh/midi/06_songlike_melody_contour_phrase_rhythm_repair.mid`
+
+## Decision
+
+- reason: `phrase/rhythm repair sweep completed without musical quality claim`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh`
+
+## Claim Boundary
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `outside_soloing_without_context`
+- `weak_chord_tone_landing`
+- `broad_trained_model_quality`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6486,10 +6486,10 @@ run_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision() {
 }
 
 run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep() {
-  local followup_run_id="${FOLLOWUP_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision}"
-  local source_sweep_run_id="${SOURCE_SWEEP_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep}"
+  local followup_run_id="${FOLLOWUP_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision_source_context_refresh}"
+  local source_sweep_run_id="${SOURCE_SWEEP_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_source_context_refresh}"
   local rubric_run_id="${RUBRIC_RUN_ID:-harness_stage_b_midi_to_solo_quality_rubric_baseline}"
-  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep_source_context_refresh}"
   local followup_report="outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision/${followup_run_id}/stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision.json"
   local source_sweep_report="outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/${source_sweep_run_id}/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.json"
   local rubric_report="outputs/stage_b_midi_to_solo_quality_rubric_baseline/${rubric_run_id}/stage_b_midi_to_solo_quality_rubric_baseline.json"
@@ -6511,8 +6511,8 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep() {
     --followup_decision "$followup_report" \
     --source_repair_sweep "$source_sweep_report" \
     --rubric_baseline "$rubric_report" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_SWEEP_2026-06-10.md \
-    --issue_number 858 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
+    --issue_number 944 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package \
     --min_candidate_count 6 \

--- a/scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py
+++ b/scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py
@@ -38,7 +38,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(ValueErr
 BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package"
 SELECTED_TARGET = "songlike_melody_contour_phrase_rhythm_repair_audio_package"
-SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep_v1"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep_v2"
 PHRASE_LABEL = "phrase_shape_missing_tension_release"
 RHYTHM_LABEL = "rhythmic_monotony"
 TARGET_LABELS = (PHRASE_LABEL, RHYTHM_LABEL)
@@ -89,6 +89,111 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
             f"unexpected quality claim in {label}: {claimed}"
         )
+
+
+def _source_context_fields(
+    source: dict[str, Any],
+    *,
+    prefix: str = "source_outside_soloing_repair",
+) -> dict[str, Any]:
+    return {
+        "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+            source.get(f"{prefix}_source_objective_pitch_role_risk_count")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+            source.get(f"{prefix}_source_pitch_role_risk_count_before")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+            source.get(f"{prefix}_source_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+            source.get(f"{prefix}_source_pitch_role_risk_delta")
+        ),
+        "source_outside_soloing_repair_source_targeted": bool(
+            source.get(f"{prefix}_source_targeted", True)
+        ),
+        "source_outside_soloing_repair_source_residual_risk_preserved": bool(
+            source.get(f"{prefix}_source_residual_risk_preserved", False)
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            source.get(f"{prefix}_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_delta": _int(
+            source.get(f"{prefix}_pitch_role_risk_delta")
+        ),
+    }
+
+
+def _validate_source_context(context: dict[str, Any], *, label: str) -> None:
+    objective_risk = _int(
+        context.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
+    )
+    source_before = _int(
+        context.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
+    )
+    source_after = _int(
+        context.get("source_outside_soloing_repair_source_pitch_role_risk_count_after")
+    )
+    source_delta = _int(
+        context.get("source_outside_soloing_repair_source_pitch_role_risk_delta")
+    )
+    current_after = _int(
+        context.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+    )
+    current_delta = _int(context.get("source_outside_soloing_repair_pitch_role_risk_delta"))
+    if objective_risk <= 0 or source_before <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            f"{label} source pitch-role risk context required"
+        )
+    if objective_risk != source_before:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            f"{label} objective/source risk mismatch"
+        )
+    if source_before - source_after != source_delta:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            f"{label} source pitch-role risk delta mismatch"
+        )
+    if source_delta <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            f"{label} positive source pitch-role risk delta required"
+        )
+    if bool(context.get("source_outside_soloing_repair_source_targeted", True)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            f"{label} source-targeted flag should remain false"
+        )
+    if not bool(
+        context.get("source_outside_soloing_repair_source_residual_risk_preserved", False)
+    ):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            f"{label} source residual risk preservation required"
+        )
+    if current_after != 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            f"{label} current repair residual pitch-role risk should be zero"
+        )
+    if current_delta <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            f"{label} positive current repair pitch-role risk delta required"
+        )
+
+
+def _require_matching_source_context(
+    left: dict[str, Any],
+    right: dict[str, Any],
+    *,
+    label: str,
+) -> None:
+    for key, left_value in left.items():
+        right_value = right.get(key)
+        mismatch = (
+            bool(left_value) != bool(right_value)
+            if isinstance(left_value, bool)
+            else left_value != right_value
+        )
+        if mismatch:
+            raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+                f"{label} mismatch for {key}"
+            )
 
 
 def validate_followup_decision(report: dict[str, Any]) -> dict[str, Any]:
@@ -152,6 +257,11 @@ def validate_followup_decision(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
             "repair sweep repaired outside-soloing not-evaluable boundary required"
         )
+    source_context = _source_context_fields(
+        readiness,
+        prefix="repair_sweep_source_outside_soloing_repair",
+    )
+    _validate_source_context(source_context, label="follow-up repair sweep source context")
     primary_labels = [str(label) for label in _list(selected.get("primary_remaining_failure_labels"))]
     if not all(label in primary_labels for label in TARGET_LABELS):
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
@@ -198,10 +308,11 @@ def validate_followup_decision(report: dict[str, Any]) -> dict[str, Any]:
         "repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
             readiness.get("repair_sweep_repaired_outside_soloing_not_evaluable_count")
         ),
+        **source_context,
     }
 
 
-def validate_source_repair_sweep(report: dict[str, Any]) -> list[dict[str, Any]]:
+def validate_source_repair_sweep(report: dict[str, Any]) -> dict[str, Any]:
     readiness = _dict(report.get("readiness"))
     aggregate = _dict(report.get("aggregate"))
     rows = [_dict(item) for item in _list(report.get("candidate_repairs"))]
@@ -229,6 +340,8 @@ def validate_source_repair_sweep(report: dict[str, Any]) -> list[dict[str, Any]]
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
             "source outside-soloing residual pitch-role risk should be zero"
         )
+    source_context = _source_context_fields(aggregate)
+    _validate_source_context(source_context, label="source repair sweep context")
     if _int(aggregate.get("source_outside_soloing_not_evaluable_count")) <= 0:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
             "source outside-soloing not-evaluable boundary required"
@@ -242,7 +355,7 @@ def validate_source_repair_sweep(report: dict[str, Any]) -> list[dict[str, Any]]
             "source repair row count below 6"
         )
     _require_no_quality_claim(readiness, label="songlike contour repair readiness")
-    return rows
+    return {"rows": rows, **source_context}
 
 
 def density_patterns() -> list[list[int]]:
@@ -438,7 +551,23 @@ def build_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
     issue_number: int,
 ) -> dict[str, Any]:
     followup = validate_followup_decision(followup_decision)
-    source_rows = validate_source_repair_sweep(source_repair_sweep)
+    source = validate_source_repair_sweep(source_repair_sweep)
+    source_rows = [_dict(item) for item in _list(source.get("rows"))]
+    source_context = {
+        key: value
+        for key, value in source.items()
+        if key.startswith("source_outside_soloing_repair_")
+    }
+    followup_context = {
+        key: value
+        for key, value in followup.items()
+        if key.startswith("source_outside_soloing_repair_")
+    }
+    _require_matching_source_context(
+        followup_context,
+        source_context,
+        label="follow-up/source repair sweep source context",
+    )
     rubric_summary = validate_rubric_baseline(rubric_baseline)
     rubric_items = [_dict(item) for item in _list(rubric_summary.get("rubric_items"))]
     if len(source_rows) < followup["candidate_count"]:
@@ -535,6 +664,7 @@ def build_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
             "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
                 followup["repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after"]
             ),
+            **source_context,
             "source_outside_soloing_not_evaluable_count": _int(
                 followup["repair_sweep_repaired_outside_soloing_not_evaluable_count"]
             ),
@@ -572,6 +702,7 @@ def build_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
             "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
                 followup["repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after"]
             ),
+            **source_context,
             "source_outside_soloing_not_evaluable_count": _int(
                 followup["repair_sweep_repaired_outside_soloing_not_evaluable_count"]
             ),
@@ -605,7 +736,7 @@ def build_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
             "broad_trained_model_quality",
         ],
         "next_recommended_issue": (
-            "Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package"
+            "Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh"
         )
         if target_supported
         else "Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision",
@@ -727,6 +858,27 @@ def validate_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
         "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
             aggregate.get("source_outside_soloing_repair_pitch_role_risk_count_after")
         ),
+        "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+            aggregate.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+            aggregate.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+            aggregate.get("source_outside_soloing_repair_source_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+            aggregate.get("source_outside_soloing_repair_source_pitch_role_risk_delta")
+        ),
+        "source_outside_soloing_repair_source_targeted": bool(
+            aggregate.get("source_outside_soloing_repair_source_targeted", True)
+        ),
+        "source_outside_soloing_repair_source_residual_risk_preserved": bool(
+            aggregate.get("source_outside_soloing_repair_source_residual_risk_preserved", False)
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_delta": _int(
+            aggregate.get("source_outside_soloing_repair_pitch_role_risk_delta")
+        ),
         "source_outside_soloing_not_evaluable_count": _int(
             aggregate.get("source_outside_soloing_not_evaluable_count")
         ),
@@ -772,7 +924,11 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- improved candidate count: `{aggregate['improved_candidate_count']}`",
         f"- technical regression count: `{aggregate['technical_regression_count']}`",
         f"- source outside-soloing repair evidence ready: `{_bool_token(aggregate['source_outside_soloing_repair_evidence_ready'])}`",
+        f"- source outside-soloing source pitch-role risk before / after / delta: `{aggregate['source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{aggregate['source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{aggregate['source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
+        f"- source outside-soloing source repair targeted: `{_bool_token(aggregate['source_outside_soloing_repair_source_targeted'])}`",
+        f"- source outside-soloing source residual risk preserved: `{_bool_token(aggregate['source_outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- source outside-soloing repair pitch-role risk after: `{aggregate['source_outside_soloing_repair_pitch_role_risk_count_after']}`",
+        f"- source outside-soloing current repair pitch-role risk delta: `{aggregate['source_outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- source outside-soloing not evaluable count: `{aggregate['source_outside_soloing_not_evaluable_count']}`",
         f"- repaired outside-soloing not evaluable count: `{aggregate['repaired_outside_soloing_not_evaluable_count']}`",
         f"- target supported: `{_bool_token(aggregate['target_supported'])}`",
@@ -826,7 +982,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=858)
+    parser.add_argument("--issue_number", type=int, default=944)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--min_candidate_count", type=int, default=6)

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py
@@ -116,11 +116,26 @@ def followup_decision(*, quality_claim: bool = False) -> dict:
             "failure_label_delta": 4,
             "technical_regression_count": 0,
             "objective_source_outside_soloing_repair_evidence_ready": True,
+            "objective_source_outside_soloing_repair_wav_count": 6,
+            "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
+            "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
+            "objective_source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
+            "objective_source_outside_soloing_repair_source_targeted": False,
+            "objective_source_outside_soloing_repair_source_residual_risk_preserved": True,
             "objective_source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "objective_source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "objective_source_outside_soloing_not_evaluable_count": 6,
             "objective_repaired_outside_soloing_not_evaluable_count": 6,
             "repair_sweep_source_outside_soloing_repair_evidence_ready": True,
+            "repair_sweep_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
+            "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
+            "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
+            "repair_sweep_source_outside_soloing_repair_source_targeted": False,
+            "repair_sweep_source_outside_soloing_repair_source_residual_risk_preserved": True,
             "repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "repair_sweep_source_outside_soloing_not_evaluable_count": 6,
             "repair_sweep_repaired_outside_soloing_not_evaluable_count": 6,
             "human_audio_preference_claimed": False,
@@ -180,7 +195,14 @@ def source_repair_sweep(*, technical_regression_count: int = 0) -> dict:
                 "rhythmic_monotony": 2,
             },
             "source_outside_soloing_repair_evidence_ready": True,
+            "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
+            "source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
+            "source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
+            "source_outside_soloing_repair_source_targeted": False,
+            "source_outside_soloing_repair_source_residual_risk_preserved": True,
             "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "source_outside_soloing_not_evaluable_count": 6,
             "repaired_outside_soloing_not_evaluable_count": 6,
             "target_supported": True,
@@ -240,7 +262,28 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepTest(
             self.assertGreater(summary["phrase_rhythm_failure_delta"], 0)
             self.assertEqual(summary["technical_regression_count"], 0)
             self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
+            self.assertEqual(
+                summary[
+                    "source_outside_soloing_repair_source_pitch_role_risk_count_before"
+                ],
+                5,
+            )
+            self.assertEqual(
+                summary[
+                    "source_outside_soloing_repair_source_pitch_role_risk_count_after"
+                ],
+                2,
+            )
+            self.assertEqual(
+                summary["source_outside_soloing_repair_source_pitch_role_risk_delta"],
+                3,
+            )
+            self.assertFalse(summary["source_outside_soloing_repair_source_targeted"])
+            self.assertTrue(
+                summary["source_outside_soloing_repair_source_residual_risk_preserved"]
+            )
             self.assertEqual(summary["source_outside_soloing_repair_pitch_role_risk_count_after"], 0)
+            self.assertEqual(summary["source_outside_soloing_repair_pitch_role_risk_delta"], 2)
             self.assertEqual(summary["source_outside_soloing_not_evaluable_count"], 6)
             self.assertEqual(summary["repaired_outside_soloing_not_evaluable_count"], 6)
             self.assertEqual(
@@ -290,6 +333,23 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepTest(
                     rubric_baseline=rubric_baseline(Path(tmp)),
                     output_dir=Path(tmp) / "phrase_rhythm_repair",
                     issue_number=858,
+                )
+
+    def test_rejects_source_context_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = source_repair_sweep()
+            source["aggregate"][
+                "source_outside_soloing_repair_source_pitch_role_risk_delta"
+            ] = 1
+            with self.assertRaises(
+                StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError
+            ):
+                build_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
+                    followup_decision=followup_decision(),
+                    source_repair_sweep=source,
+                    rubric_baseline=rubric_baseline(Path(tmp)),
+                    output_dir=Path(tmp) / "phrase_rhythm_repair",
+                    issue_number=944,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary
- songlike melody contour phrase/rhythm repair sweep source/current outside-soloing context 보존
- #942 follow-up decision과 source repair sweep의 source-context 필드 대조
- phrase/rhythm repair sweep 결과 문서와 handoff 갱신

## Context
- #942 follow-up decision selected target: `songlike_melody_contour_phrase_rhythm_repair_sweep`
- primary remaining failure labels: `phrase_shape_missing_tension_release`, `rhythmic_monotony`
- phrase/rhythm repair sweep 결과: `4 -> 1`
- total failure labels: `4 -> 1`
- source outside-soloing source pitch-role risk: `5 -> 2`
- current repair pitch-role risk after/delta: `0 / 2`
- source/repaired outside-soloing not evaluable: `6 / 6`
- quality/preference claim: `false`

## Scope
- phrase/rhythm repair sweep source-context validation 추가
- follow-up decision과 source sweep context mismatch 차단
- validation summary/readiness/markdown source-context 필드 보존
- #944 harness run id, doc path, issue number 갱신
- README, Current Status, Core Plan, AGENTS handoff 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-sweep`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- human/audio preference claim 없음
- MIDI-to-solo musical quality claim 없음
- outside-soloing, weak chord-tone landing 판단은 context-aware 후속 검증 범위

## Follow-up
- Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh

Closes #944
