### PR TITLE
Stage B MIDI-to-solo phrase rhythm review guard source context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,10 +37,11 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm repair sweep completed: Issue #944, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair audio package completed: Issue #946, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair listening review package completed: Issue #948, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh.
+- Latest songlike melody contour phrase/rhythm repair listening review input guard completed: Issue #950, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh.
 - Latest documentation issue completed: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after songlike melody contour phrase/rhythm repair listening review package source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh.
+- Open issue queue after songlike melody contour phrase/rhythm repair listening review input guard source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour phrase/rhythm repair sweep: `Issue #944`
 - latest songlike melody contour phrase/rhythm repair audio package: `Issue #946`
 - latest songlike melody contour phrase/rhythm repair listening review package: `Issue #948`
+- latest songlike melody contour phrase/rhythm repair listening review input guard: `Issue #950`
 - latest README evidence refresh: `Issue #900`
-- latest functional boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package`
-- open issue queue after songlike melody contour phrase/rhythm repair listening review package source-context refresh merge: `0`
+- latest functional boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
+- open issue queue after songlike melody contour phrase/rhythm repair listening review input guard source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -55,6 +56,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - listening review package ready: `true`
 - phrase/rhythm repair listening review item count: `6`
 - phrase/rhythm repair listening review input validated: `false`
+- phrase/rhythm repair listening review preference fill allowed: `false`
+- phrase/rhythm repair listening review required input fields: `4`
 - phrase/rhythm repair technical WAV validation: `true`
 - phrase/rhythm repair source outside-soloing pitch-role risk: `5 -> 2`
 - phrase/rhythm repair current outside-soloing pitch-role risk after / delta: `0 / 2`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -416,8 +416,8 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo songlike melody contour repair follow-up decision: selected target `songlike_melody_contour_phrase_rhythm_repair_sweep`, primary labels `phrase_shape_missing_tension_release,rhythmic_monotony`, objective and repair sweep source risk `5 -> 2`, current repair risk after/delta `0/2`, objective/sweep outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair sweep: phrase/rhythm failure `4 -> 1`, total failure labels `4 -> 1`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair audio package: rendered WAV `6`, duration `18.871s-19.000s`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package`
-- MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package: review items `6`, validated input `false`, source/repaired outside-soloing not evaluable `6/6`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
-- MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard: preference fill `false`, validated input `false`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
+- MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package: review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
+- MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard: preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision: follow-up required `true`, source/repaired outside-soloing not evaluable `6/6`, current quality claim ready `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision: selected target `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`, remaining label/count `rhythmic_monotony/1`, objective/sweep outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge: chord context/pitch-role metrics `6/6`, not evaluable `12 -> 0`, bridge flags `outside_soloing_pitch_role_risk=5`, `weak_chord_tone_landing_risk=6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
@@ -8961,6 +8961,57 @@ Issue #948은 Issue #946 phrase/rhythm repair audio package 결과의 WAV/MIDI �
 다음 작업:
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh`
+
+## 9.165 Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh
+
+Issue #950은 Issue #948 listening review package의 source/current outside-soloing context를 input guard까지 보존하고, validated review input 부재 상태에서 preference fill 차단을 확인한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- WAV duration range: `18.871s-19.000s`
+- failure label delta: `3`
+- phrase/rhythm failure count: `4 -> 1`
+- phrase/rhythm failure delta: `3`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing source pitch-role risk delta: `3`
+- source outside-soloing source repair targeted: `false`
+- source outside-soloing source residual risk preserved: `true`
+- source outside-soloing current repair pitch-role risk count after: `0`
+- source outside-soloing current repair pitch-role risk delta: `2`
+- source/repaired outside-soloing not evaluable count: `6/6`
+- audio review required: `true`
+- critical user input required: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- listening review input pending 상태에서 preference fill 차단 유지.
+- source/current outside-soloing risk context 보존.
+- critical user input required `false`, objective-only next decision route 유지.
+- technical WAV validation을 human/audio preference 또는 musical quality claim으로 승격하지 않음.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
+- `.venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-listening-review-input-guard`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -37,10 +37,11 @@
 - latest songlike melody contour phrase/rhythm repair sweep: Issue #944, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh
 - latest songlike melody contour phrase/rhythm repair audio package: Issue #946, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh
 - latest songlike melody contour phrase/rhythm repair listening review package: Issue #948, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh
+- latest songlike melody contour phrase/rhythm repair listening review input guard: Issue #950, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh
 - latest README evidence refresh: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after songlike melody contour phrase/rhythm repair listening review package source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh`
+- open issue queue after songlike melody contour phrase/rhythm repair listening review input guard source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -243,6 +244,27 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 guard target: `songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
+- songlike melody contour phrase/rhythm repair listening review input guard source-context refresh 완료
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- duration range: `18.871s-19.000s`
+- failure label delta: `3`
+- phrase/rhythm failure delta: `3`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing source pitch-role risk delta: `3`
+- source outside-soloing source repair targeted: `false`
+- source outside-soloing source residual risk preserved: `true`
+- source outside-soloing current repair pitch-role risk count after / delta: `0 / 2`
+- source/repaired outside-soloing not evaluable count: `6/6`
+- audio review required: `true`
+- critical user input required: `false`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 decision target: `songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
 - songlike melody contour repair follow-up decision 완료
 - primary remaining failure labels: `phrase_shape_missing_tension_release`, `rhythmic_monotony`
 - primary remaining failure count: `2`

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_LISTENING_REVIEW_INPUT_GUARD_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_LISTENING_REVIEW_INPUT_GUARD_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -1,0 +1,64 @@
+# Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Repair Listening Review Input Guard
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- duration range: `18.871s-19.000s`
+- failure label delta: `3`
+- phrase/rhythm failure count: `4 -> 1`
+- phrase/rhythm failure delta: `3`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
+- source outside-soloing source repair targeted: `false`
+- source outside-soloing source residual risk preserved: `true`
+- source outside-soloing repair pitch-role risk count after: `0`
+- source outside-soloing current repair pitch-role risk delta: `2`
+- source/repaired outside-soloing not evaluable count: `6/6`
+- audio review required: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Decision
+
+- auto progress allowed: `true`
+- critical user input required: `false`
+- reason: `listening review input pending; preference fill blocked`
+- next recommended issue: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh`
+
+## Required Input Fields
+
+- `candidate_index`
+- `listening_status`
+- `preference`
+- `issue_notes`
+
+## Repaired Not Evaluable Counts
+
+- `outside_soloing_without_context`: `6`
+- `weak_chord_tone_landing`: `6`
+
+## Review WAV Paths
+
+- `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package_source_context_refresh/audio/candidate_01_cli_repaired_midi_rank_01_phrase_rhythm_repair.wav`
+- `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package_source_context_refresh/audio/candidate_02_cli_repaired_midi_rank_02_phrase_rhythm_repair.wav`
+- `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package_source_context_refresh/audio/candidate_03_cli_repaired_midi_rank_03_phrase_rhythm_repair.wav`
+- `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package_source_context_refresh/audio/candidate_04_changed_ratio_repair_rank_04_phrase_rhythm_repair.wav`
+- `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package_source_context_refresh/audio/candidate_05_changed_ratio_repair_rank_05_phrase_rhythm_repair.wav`
+- `outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package/harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package_source_context_refresh/audio/candidate_06_changed_ratio_repair_rank_06_phrase_rhythm_repair.wav`
+
+## Claim Boundary
+
+- `listening_review_completed`
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6566,8 +6566,8 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_
 }
 
 run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard() {
-  local package_run_id="${PACKAGE_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package}"
-  local guard_run_id="${RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard}"
+  local package_run_id="${PACKAGE_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package_source_context_refresh}"
+  local guard_run_id="${RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard_source_context_refresh}"
   local source_package="outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package/${package_run_id}/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package.json"
   if [[ ! -f "$source_package" ]]; then
     print_header "Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package"
@@ -6577,8 +6577,8 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_
   "$PYTHON_BIN" scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input.py \
     --run_id "$guard_run_id" \
     --source_package "$source_package" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_LISTENING_REVIEW_INPUT_GUARD_2026-06-10.md \
-    --issue_number 864 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_LISTENING_REVIEW_INPUT_GUARD_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
+    --issue_number 950 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision \
     --require_guard_completed \

--- a/scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input.py
+++ b/scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input.py
@@ -28,7 +28,7 @@ FILL_BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repa
 OBJECTIVE_NEXT_BOUNDARY = (
     "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision"
 )
-SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard_v1"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard_v2"
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -74,6 +74,84 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
     if claimed:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
             f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def _source_context_fields(source: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+            source.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+            source.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+            source.get("source_outside_soloing_repair_source_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+            source.get("source_outside_soloing_repair_source_pitch_role_risk_delta")
+        ),
+        "source_outside_soloing_repair_source_targeted": bool(
+            source.get("source_outside_soloing_repair_source_targeted", True)
+        ),
+        "source_outside_soloing_repair_source_residual_risk_preserved": bool(
+            source.get("source_outside_soloing_repair_source_residual_risk_preserved", False)
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            source.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_delta": _int(
+            source.get("source_outside_soloing_repair_pitch_role_risk_delta")
+        ),
+    }
+
+
+def _validate_source_context(source: dict[str, Any], *, label: str) -> None:
+    objective_risk = _int(
+        source.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
+    )
+    source_before = _int(
+        source.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
+    )
+    source_after = _int(
+        source.get("source_outside_soloing_repair_source_pitch_role_risk_count_after")
+    )
+    source_delta = _int(
+        source.get("source_outside_soloing_repair_source_pitch_role_risk_delta")
+    )
+    current_after = _int(source.get("source_outside_soloing_repair_pitch_role_risk_count_after"))
+    current_delta = _int(source.get("source_outside_soloing_repair_pitch_role_risk_delta"))
+    if objective_risk <= 0 or source_before <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            f"{label} source pitch-role risk context required"
+        )
+    if objective_risk != source_before:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            f"{label} objective/source risk mismatch"
+        )
+    if source_before - source_after != source_delta:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            f"{label} source pitch-role risk delta mismatch"
+        )
+    if source_delta <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            f"{label} positive source pitch-role risk delta required"
+        )
+    if bool(source.get("source_outside_soloing_repair_source_targeted", True)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            f"{label} source-targeted flag should remain false"
+        )
+    if not bool(source.get("source_outside_soloing_repair_source_residual_risk_preserved", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            f"{label} source residual risk preservation required"
+        )
+    if current_after != 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            f"{label} current repair residual pitch-role risk should be zero"
+        )
+    if current_delta <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            f"{label} positive current repair pitch-role risk delta required"
         )
 
 
@@ -125,6 +203,8 @@ def validate_source_package(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
             "source outside-soloing repair pitch-role risk should be resolved"
         )
+    source_context = _source_context_fields(source)
+    _validate_source_context(source_context, label="source outside-soloing repair")
     if _int(source.get("source_outside_soloing_not_evaluable_count")) <= 0:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
             "source outside-soloing not-evaluable count should be preserved"
@@ -165,6 +245,7 @@ def validate_source_package(report: dict[str, Any]) -> dict[str, Any]:
             "source_outside_soloing_repair_evidence_ready": bool(
                 source.get("source_outside_soloing_repair_evidence_ready", False)
             ),
+            **source_context,
             "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
                 source.get("source_outside_soloing_repair_pitch_role_risk_count_after")
             ),
@@ -249,7 +330,7 @@ def build_listening_review_input_guard_report(
         "next_recommended_issue": (
             "Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review fill"
             if validated_input
-            else "Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision"
+            else "Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh"
         ),
     }
 
@@ -261,7 +342,8 @@ def validate_listening_review_input_guard_report(
     expected_next_boundary: str | None,
     require_guard_completed: bool,
     require_preference_blocked: bool,
-    require_no_quality_claim: bool,
+    require_pending_input: bool = False,
+    require_no_quality_claim: bool = False,
 ) -> dict[str, Any]:
     boundary = str(report.get("boundary") or "")
     readiness = _dict(report.get("readiness"))
@@ -285,6 +367,10 @@ def validate_listening_review_input_guard_report(
     if require_preference_blocked and bool(guard.get("preference_fill_allowed", True)):
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
             "preference fill should remain blocked"
+        )
+    if require_pending_input and bool(guard.get("validated_review_input_present", True)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            "validated input should remain pending"
         )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
@@ -313,6 +399,27 @@ def validate_listening_review_input_guard_report(
         ),
         "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
             source.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+            source.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+            source.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+            source.get("source_outside_soloing_repair_source_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+            source.get("source_outside_soloing_repair_source_pitch_role_risk_delta")
+        ),
+        "source_outside_soloing_repair_source_targeted": bool(
+            source.get("source_outside_soloing_repair_source_targeted", True)
+        ),
+        "source_outside_soloing_repair_source_residual_risk_preserved": bool(
+            source.get("source_outside_soloing_repair_source_residual_risk_preserved", False)
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_delta": _int(
+            source.get("source_outside_soloing_repair_pitch_role_risk_delta")
         ),
         "source_outside_soloing_not_evaluable_count": _int(
             source.get("source_outside_soloing_not_evaluable_count")
@@ -359,7 +466,11 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- phrase/rhythm failure count: `{source['source_phrase_rhythm_failure_count']} -> {source['repaired_phrase_rhythm_failure_count']}`",
         f"- phrase/rhythm failure delta: `{source['phrase_rhythm_failure_delta']}`",
         f"- source outside-soloing repair evidence ready: `{_bool_token(source['source_outside_soloing_repair_evidence_ready'])}`",
+        f"- source outside-soloing source pitch-role risk before / after / delta: `{source['source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{source['source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{source['source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
+        f"- source outside-soloing source repair targeted: `{_bool_token(source['source_outside_soloing_repair_source_targeted'])}`",
+        f"- source outside-soloing source residual risk preserved: `{_bool_token(source['source_outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- source outside-soloing repair pitch-role risk count after: `{source['source_outside_soloing_repair_pitch_role_risk_count_after']}`",
+        f"- source outside-soloing current repair pitch-role risk delta: `{source['source_outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- source/repaired outside-soloing not evaluable count: `{source['source_outside_soloing_not_evaluable_count']}/{source['repaired_outside_soloing_not_evaluable_count']}`",
         f"- audio review required: `{_bool_token(source['audio_review_required'])}`",
         f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
@@ -402,7 +513,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=864)
+    parser.add_argument("--issue_number", type=int, default=950)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--require_guard_completed", action="store_true")
@@ -429,6 +540,7 @@ def main() -> int:
         require_preference_blocked=bool(
             args.require_preference_blocked or args.require_pending_input
         ),
+        require_pending_input=bool(args.require_pending_input),
         require_no_quality_claim=bool(args.require_no_quality_claim),
     )
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard.py
@@ -50,7 +50,14 @@ def source_package(*, quality_claim: bool = False, validated_input: bool = False
                 "rhythmic_monotony": 1,
             },
             "source_outside_soloing_repair_evidence_ready": True,
+            "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
+            "source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
+            "source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
+            "source_outside_soloing_repair_source_targeted": False,
+            "source_outside_soloing_repair_source_residual_risk_preserved": True,
             "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "source_outside_soloing_not_evaluable_count": 6,
             "repaired_outside_soloing_not_evaluable_count": 6,
             "repaired_not_evaluable_counts": {
@@ -100,7 +107,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuard
             report = build_listening_review_input_guard_report(
                 source_package(),
                 output_dir=root / "guard",
-                issue_number=864,
+                issue_number=950,
             )
             summary = validate_listening_review_input_guard_report(
                 report,
@@ -108,6 +115,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuard
                 expected_next_boundary=OBJECTIVE_NEXT_BOUNDARY,
                 require_guard_completed=True,
                 require_preference_blocked=True,
+                require_pending_input=True,
                 require_no_quality_claim=True,
             )
 
@@ -120,9 +128,29 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuard
             self.assertEqual(summary["phrase_rhythm_failure_delta"], 3)
             self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
             self.assertEqual(
+                summary[
+                    "source_outside_soloing_repair_source_objective_pitch_role_risk_count"
+                ],
+                5,
+            )
+            self.assertEqual(
+                summary[
+                    "source_outside_soloing_repair_source_pitch_role_risk_count_before"
+                ],
+                5,
+            )
+            self.assertEqual(
+                summary["source_outside_soloing_repair_source_pitch_role_risk_count_after"],
+                2,
+            )
+            self.assertEqual(summary["source_outside_soloing_repair_source_pitch_role_risk_delta"], 3)
+            self.assertFalse(summary["source_outside_soloing_repair_source_targeted"])
+            self.assertTrue(summary["source_outside_soloing_repair_source_residual_risk_preserved"])
+            self.assertEqual(
                 summary["source_outside_soloing_repair_pitch_role_risk_count_after"],
                 0,
             )
+            self.assertEqual(summary["source_outside_soloing_repair_pitch_role_risk_delta"], 2)
             self.assertEqual(summary["source_outside_soloing_not_evaluable_count"], 6)
             self.assertEqual(summary["repaired_outside_soloing_not_evaluable_count"], 6)
             self.assertEqual(
@@ -142,7 +170,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuard
                 build_listening_review_input_guard_report(
                     source_package(quality_claim=True),
                     output_dir=root / "guard",
-                    issue_number=864,
+                    issue_number=950,
                 )
 
     def test_rejects_missing_outside_soloing_context(self) -> None:
@@ -155,7 +183,20 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuard
                 build_listening_review_input_guard_report(
                     source,
                     output_dir=root / "guard",
-                    issue_number=864,
+                    issue_number=950,
+                )
+
+    def test_rejects_source_context_delta_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = source_package()
+            source["source_summary"]["source_outside_soloing_repair_source_pitch_role_risk_delta"] = 1
+
+            with self.assertRaises(StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError):
+                build_listening_review_input_guard_report(
+                    source,
+                    output_dir=root / "guard",
+                    issue_number=950,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
Summary
- Stage B MIDI-to-solo phrase/rhythm repair listening review input guard source-context refresh
- #948 review package source/current outside-soloing risk context 보존
- Review input pending 상태에서 preference fill 차단 검증

Context
- #948 review package ready: `true`
- review item count: `6`
- validated review input: `false`
- source outside-soloing source pitch-role risk: `5 -> 2`
- source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
- source/repaired outside-soloing not evaluable count: `6/6`

Scope
- input guard schema v2 적용
- source pitch-role risk before/after/delta 검증 추가
- pending input 검증 추가
- generated guard markdown과 status docs에 #950 결과 반영

Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
- `.venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-listening-review-input-guard`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

Risk
- human/audio preference claim 없음
- MIDI-to-solo musical quality claim 없음
- 검증된 listening input 부재 상태 유지

Follow-up
- Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh

Closes #950