### PR TITLE
Stage B MIDI-to-solo phrase rhythm followup source context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,10 +39,11 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm repair listening review package completed: Issue #948, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair listening review input guard completed: Issue #950, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair objective-only next decision completed: Issue #952, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh.
+- Latest songlike melody contour phrase/rhythm repair follow-up decision completed: Issue #954, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh.
 - Latest documentation issue completed: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh.
+- Open issue queue after songlike melody contour phrase/rhythm repair follow-up decision source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour phrase/rhythm repair listening review package: `Issue #948`
 - latest songlike melody contour phrase/rhythm repair listening review input guard: `Issue #950`
 - latest songlike melody contour phrase/rhythm repair objective-only next decision: `Issue #952`
+- latest songlike melody contour phrase/rhythm repair follow-up decision: `Issue #954`
 - latest README evidence refresh: `Issue #900`
-- latest functional boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
-- open issue queue after songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh merge: `0`
+- latest functional boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
+- open issue queue after songlike melody contour phrase/rhythm repair follow-up decision source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -61,6 +62,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - phrase/rhythm repair listening review required input fields: `4`
 - phrase/rhythm repair objective follow-up required: `true`
 - phrase/rhythm repair current quality claim ready: `false`
+- phrase/rhythm repair follow-up selected target: `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- phrase/rhythm repair residual rhythmic monotony count: `1`
+- phrase/rhythm repair context not-evaluable min count: `6`
 - phrase/rhythm repair technical WAV validation: `true`
 - phrase/rhythm repair source outside-soloing pitch-role risk: `5 -> 2`
 - phrase/rhythm repair current outside-soloing pitch-role risk after / delta: `0 / 2`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -419,7 +419,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package: review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard: preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision: follow-up required `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, current quality claim ready `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
-- MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision: selected target `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`, remaining label/count `rhythmic_monotony/1`, objective/sweep outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision: selected target `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`, remaining label/count `rhythmic_monotony/1`, objective/sweep source risk `5 -> 2`, current repair risk after/delta `0/2`, objective/sweep outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge: chord context/pitch-role metrics `6/6`, not evaluable `12 -> 0`, bridge flags `outside_soloing_pitch_role_risk=5`, `weak_chord_tone_landing_risk=6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision: primary risk `weak_chord_tone_landing_risk=6`, outside risk `5`, not evaluable `12 -> 0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
@@ -9065,6 +9065,66 @@ Issue #952는 Issue #950 input guard의 source/current outside-soloing context�
 다음 작업:
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh`
+
+## 9.167 Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh
+
+Issue #954는 Issue #952 objective-only next decision과 Issue #944 phrase/rhythm repair sweep의 source/current outside-soloing context를 follow-up decision까지 보존하고, 다음 boundary를 chord-context pitch-role bridge로 선택한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
+- repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- selected target: `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- primary remaining failure labels: `rhythmic_monotony`
+- primary remaining failure count: `1`
+- chord-context pitch-role bridge selected: `true`
+- candidate count: `6`
+- total failure labels: `4 -> 1`
+- failure label delta: `3`
+- phrase/rhythm failure count: `4 -> 1`
+- phrase/rhythm failure delta: `3`
+- residual rhythmic monotony count: `1`
+- context not-evaluable min count: `6`
+- objective source outside-soloing source pitch-role risk count: `5 -> 2`
+- objective source outside-soloing source pitch-role risk delta: `3`
+- objective source outside-soloing source repair targeted: `false`
+- objective source outside-soloing source residual risk preserved: `true`
+- objective source outside-soloing current repair pitch-role risk count after: `0`
+- objective source outside-soloing current repair pitch-role risk delta: `2`
+- objective source/repaired outside-soloing not evaluable count: `6/6`
+- repair sweep source outside-soloing source pitch-role risk count: `5 -> 2`
+- repair sweep source outside-soloing source pitch-role risk delta: `3`
+- repair sweep source outside-soloing source repair targeted: `false`
+- repair sweep source outside-soloing source residual risk preserved: `true`
+- repair sweep source outside-soloing current repair pitch-role risk count after: `0`
+- repair sweep source outside-soloing current repair pitch-role risk delta: `2`
+- repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- technical regression count: `0`
+- critical user input required: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- objective-only next decision과 repair sweep의 source/current outside-soloing risk context 보존.
+- 잔여 failure label은 `rhythmic_monotony=1`이나, context not-evaluable target count가 `6`으로 chord-context pitch-role bridge 선택.
+- outside-soloing과 weak chord-tone landing은 context 부재 상태의 not-evaluable boundary로 유지.
+- human/audio preference와 musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-followup-decision`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -39,10 +39,11 @@
 - latest songlike melody contour phrase/rhythm repair listening review package: Issue #948, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh
 - latest songlike melody contour phrase/rhythm repair listening review input guard: Issue #950, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh
 - latest songlike melody contour phrase/rhythm repair objective-only next decision: Issue #952, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh
+- latest songlike melody contour phrase/rhythm repair follow-up decision: Issue #954, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh
 - latest README evidence refresh: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh`
+- open issue queue after songlike melody contour phrase/rhythm repair follow-up decision source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -289,6 +290,35 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 follow-up target: `songlike_melody_contour_phrase_rhythm_repair_followup_decision`
+- songlike melody contour phrase/rhythm repair follow-up decision source-context refresh 완료
+- selected target: `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- primary remaining failure labels: `rhythmic_monotony`
+- primary remaining failure count: `1`
+- chord-context pitch-role bridge selected: `true`
+- candidate count: `6`
+- total failure labels: `4 -> 1`
+- failure label delta: `3`
+- phrase/rhythm failure count: `4 -> 1`
+- phrase/rhythm failure delta: `3`
+- residual rhythmic monotony count: `1`
+- context not-evaluable min count: `6`
+- objective source outside-soloing source pitch-role risk count: `5 -> 2`
+- objective source outside-soloing source pitch-role risk delta: `3`
+- objective source outside-soloing source repair targeted: `false`
+- objective source outside-soloing source residual risk preserved: `true`
+- objective source outside-soloing current repair pitch-role risk count after / delta: `0 / 2`
+- objective source/repaired outside-soloing not evaluable count: `6/6`
+- repair sweep source outside-soloing source pitch-role risk count: `5 -> 2`
+- repair sweep source outside-soloing source pitch-role risk delta: `3`
+- repair sweep source outside-soloing source repair targeted: `false`
+- repair sweep source outside-soloing source residual risk preserved: `true`
+- repair sweep source outside-soloing current repair pitch-role risk count after / delta: `0 / 2`
+- repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- technical regression count: `0`
+- critical user input required: `false`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 bridge target: `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
 - songlike melody contour repair follow-up decision 완료
 - primary remaining failure labels: `phrase_shape_missing_tension_release`, `rhythmic_monotony`
 - primary remaining failure count: `2`

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -1,0 +1,65 @@
+# Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Repair Follow-Up Decision
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
+- repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- selected target: `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- primary remaining failure labels: `rhythmic_monotony`
+- primary remaining failure count: `1`
+- chord-context pitch-role bridge selected: `true`
+- candidate count: `6`
+- source total failure labels: `4`
+- repaired total failure labels: `1`
+- failure label delta: `3`
+- phrase/rhythm failure count: `4 -> 1`
+- phrase/rhythm failure delta: `3`
+- residual rhythmic monotony count: `1`
+- context not-evaluable min count: `6`
+- objective source/repaired outside-soloing not evaluable count: `6/6`
+- objective source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
+- objective source outside-soloing source repair targeted: `false`
+- objective source outside-soloing source residual risk preserved: `true`
+- repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- repair sweep source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
+- repair sweep source outside-soloing source repair targeted: `false`
+- repair sweep source outside-soloing source residual risk preserved: `true`
+- objective source outside-soloing repair pitch-role risk count after: `0`
+- objective source outside-soloing current repair pitch-role risk delta: `2`
+- repair sweep source outside-soloing repair pitch-role risk count after: `0`
+- repair sweep source outside-soloing current repair pitch-role risk delta: `2`
+- technical regression count: `0`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Remaining Failure Counts
+
+- `rhythmic_monotony`: `1`
+
+## Not Evaluable Counts
+
+- `outside_soloing_without_context`: `6`
+- `weak_chord_tone_landing`: `6`
+
+## Context Target Labels
+
+- `outside_soloing_without_context`
+- `weak_chord_tone_landing`
+
+## Decision
+
+- reason: `chord-context not-evaluable labels dominate after phrase/rhythm repair`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh`
+
+## Claim Boundary
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `outside_soloing_without_context`
+- `weak_chord_tone_landing`
+- `broad_trained_model_quality`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6608,9 +6608,9 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_
 }
 
 run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision() {
-  local objective_run_id="${OBJECTIVE_NEXT_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision}"
-  local sweep_run_id="${REPAIR_SWEEP_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep}"
-  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision}"
+  local objective_run_id="${OBJECTIVE_NEXT_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision_source_context_refresh}"
+  local sweep_run_id="${REPAIR_SWEEP_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep_source_context_refresh}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision_source_context_refresh}"
   local objective_report="outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision/${objective_run_id}/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision.json"
   local sweep_report="outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/${sweep_run_id}/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.json"
   if [[ ! -f "$objective_report" ]]; then
@@ -6626,8 +6626,8 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_d
     --run_id "$run_id" \
     --objective_next_report "$objective_report" \
     --repair_sweep_report "$sweep_report" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_FOLLOWUP_DECISION_2026-06-10.md \
-    --issue_number 868 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
+    --issue_number 954 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge \
     --expected_target songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge \

--- a/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup.py
+++ b/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup.py
@@ -32,7 +32,7 @@ NEXT_BOUNDARY = (
     "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge"
 )
 SELECTED_TARGET = "songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge"
-SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision_v1"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision_v2"
 CONTEXT_TARGET_LABELS = (
     "outside_soloing_without_context",
     "weak_chord_tone_landing",
@@ -76,6 +76,82 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
     if claimed:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
             f"unexpected quality claim in {label}: {claimed}"
+        )
+
+
+def _source_context_fields(source: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+            source.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+            source.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+            source.get("source_outside_soloing_repair_source_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+            source.get("source_outside_soloing_repair_source_pitch_role_risk_delta")
+        ),
+        "source_outside_soloing_repair_source_targeted": bool(
+            source.get("source_outside_soloing_repair_source_targeted", True)
+        ),
+        "source_outside_soloing_repair_source_residual_risk_preserved": bool(
+            source.get("source_outside_soloing_repair_source_residual_risk_preserved", False)
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            source.get("source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "source_outside_soloing_repair_pitch_role_risk_delta": _int(
+            source.get("source_outside_soloing_repair_pitch_role_risk_delta")
+        ),
+    }
+
+
+def _validate_source_context(source: dict[str, Any], *, label: str) -> None:
+    objective_risk = _int(
+        source.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
+    )
+    source_before = _int(
+        source.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
+    )
+    source_after = _int(
+        source.get("source_outside_soloing_repair_source_pitch_role_risk_count_after")
+    )
+    source_delta = _int(source.get("source_outside_soloing_repair_source_pitch_role_risk_delta"))
+    current_after = _int(source.get("source_outside_soloing_repair_pitch_role_risk_count_after"))
+    current_delta = _int(source.get("source_outside_soloing_repair_pitch_role_risk_delta"))
+    if objective_risk <= 0 or source_before <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
+            f"{label} source pitch-role risk context required"
+        )
+    if objective_risk != source_before:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
+            f"{label} objective/source risk mismatch"
+        )
+    if source_before - source_after != source_delta:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
+            f"{label} source pitch-role risk delta mismatch"
+        )
+    if source_delta <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
+            f"{label} positive source pitch-role risk delta required"
+        )
+    if bool(source.get("source_outside_soloing_repair_source_targeted", True)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
+            f"{label} source-targeted flag should remain false"
+        )
+    if not bool(source.get("source_outside_soloing_repair_source_residual_risk_preserved", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
+            f"{label} source residual risk preservation required"
+        )
+    if current_after != 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
+            f"{label} current repair residual pitch-role risk should be zero"
+        )
+    if current_delta <= 0:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
+            f"{label} positive current repair pitch-role risk delta required"
         )
 
 
@@ -127,6 +203,8 @@ def validate_objective_next_source(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
             "objective source outside-soloing repair pitch-role risk should be resolved"
         )
+    source_context = _source_context_fields(summary)
+    _validate_source_context(source_context, label="objective source outside-soloing repair")
     if _int(summary.get("source_outside_soloing_not_evaluable_count")) <= 0:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
             "objective source outside-soloing not-evaluable count should be preserved"
@@ -150,6 +228,7 @@ def validate_objective_next_source(report: dict[str, Any]) -> dict[str, Any]:
         "source_outside_soloing_repair_evidence_ready": bool(
             summary.get("source_outside_soloing_repair_evidence_ready", False)
         ),
+        **source_context,
         "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
             summary.get("source_outside_soloing_repair_pitch_role_risk_count_after")
         ),
@@ -224,6 +303,8 @@ def validate_repair_sweep_source(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
             "repair sweep source outside-soloing repair pitch-role risk should be resolved"
         )
+    source_context = _source_context_fields(aggregate)
+    _validate_source_context(source_context, label="repair sweep source outside-soloing repair")
     if _int(aggregate.get("source_outside_soloing_not_evaluable_count")) <= 0:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
             "repair sweep source outside-soloing not-evaluable count should be preserved"
@@ -284,6 +365,7 @@ def validate_repair_sweep_source(report: dict[str, Any]) -> dict[str, Any]:
         "source_outside_soloing_repair_evidence_ready": bool(
             aggregate.get("source_outside_soloing_repair_evidence_ready", False)
         ),
+        **source_context,
         "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
             aggregate.get("source_outside_soloing_repair_pitch_role_risk_count_after")
         ),
@@ -404,8 +486,29 @@ def build_followup_decision_report(
             "objective_source_outside_soloing_repair_evidence_ready": bool(
                 objective["source_outside_soloing_repair_evidence_ready"]
             ),
+            "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+                objective["source_outside_soloing_repair_source_objective_pitch_role_risk_count"]
+            ),
+            "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+                objective["source_outside_soloing_repair_source_pitch_role_risk_count_before"]
+            ),
+            "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+                objective["source_outside_soloing_repair_source_pitch_role_risk_count_after"]
+            ),
+            "objective_source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+                objective["source_outside_soloing_repair_source_pitch_role_risk_delta"]
+            ),
+            "objective_source_outside_soloing_repair_source_targeted": bool(
+                objective["source_outside_soloing_repair_source_targeted"]
+            ),
+            "objective_source_outside_soloing_repair_source_residual_risk_preserved": bool(
+                objective["source_outside_soloing_repair_source_residual_risk_preserved"]
+            ),
             "objective_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
                 objective["source_outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
+            "objective_source_outside_soloing_repair_pitch_role_risk_delta": _int(
+                objective["source_outside_soloing_repair_pitch_role_risk_delta"]
             ),
             "objective_source_outside_soloing_not_evaluable_count": _int(
                 objective["source_outside_soloing_not_evaluable_count"]
@@ -416,8 +519,29 @@ def build_followup_decision_report(
             "repair_sweep_source_outside_soloing_repair_evidence_ready": bool(
                 sweep["source_outside_soloing_repair_evidence_ready"]
             ),
+            "repair_sweep_source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+                sweep["source_outside_soloing_repair_source_objective_pitch_role_risk_count"]
+            ),
+            "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+                sweep["source_outside_soloing_repair_source_pitch_role_risk_count_before"]
+            ),
+            "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+                sweep["source_outside_soloing_repair_source_pitch_role_risk_count_after"]
+            ),
+            "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+                sweep["source_outside_soloing_repair_source_pitch_role_risk_delta"]
+            ),
+            "repair_sweep_source_outside_soloing_repair_source_targeted": bool(
+                sweep["source_outside_soloing_repair_source_targeted"]
+            ),
+            "repair_sweep_source_outside_soloing_repair_source_residual_risk_preserved": bool(
+                sweep["source_outside_soloing_repair_source_residual_risk_preserved"]
+            ),
             "repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
                 sweep["source_outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
+            "repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta": _int(
+                sweep["source_outside_soloing_repair_pitch_role_risk_delta"]
             ),
             "repair_sweep_source_outside_soloing_not_evaluable_count": _int(
                 sweep["source_outside_soloing_not_evaluable_count"]
@@ -450,7 +574,7 @@ def build_followup_decision_report(
             "weak_chord_tone_landing",
             "broad_trained_model_quality",
         ],
-        "next_recommended_issue": "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge"
+        "next_recommended_issue": "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh"
         if next_boundary == NEXT_BOUNDARY
         else "Stage B MIDI-to-solo songlike melody contour phrase/rhythm residual rhythm repair sweep",
     }
@@ -569,8 +693,38 @@ def validate_followup_decision_report(
         "objective_source_outside_soloing_repair_evidence_ready": bool(
             readiness.get("objective_source_outside_soloing_repair_evidence_ready", False)
         ),
+        "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+            readiness.get(
+                "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count"
+            )
+        ),
+        "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+            readiness.get(
+                "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"
+            )
+        ),
+        "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+            readiness.get(
+                "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after"
+            )
+        ),
+        "objective_source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+            readiness.get("objective_source_outside_soloing_repair_source_pitch_role_risk_delta")
+        ),
+        "objective_source_outside_soloing_repair_source_targeted": bool(
+            readiness.get("objective_source_outside_soloing_repair_source_targeted", True)
+        ),
+        "objective_source_outside_soloing_repair_source_residual_risk_preserved": bool(
+            readiness.get(
+                "objective_source_outside_soloing_repair_source_residual_risk_preserved",
+                False,
+            )
+        ),
         "objective_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
             readiness.get("objective_source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "objective_source_outside_soloing_repair_pitch_role_risk_delta": _int(
+            readiness.get("objective_source_outside_soloing_repair_pitch_role_risk_delta")
         ),
         "objective_source_outside_soloing_not_evaluable_count": _int(
             readiness.get("objective_source_outside_soloing_not_evaluable_count")
@@ -581,8 +735,38 @@ def validate_followup_decision_report(
         "repair_sweep_source_outside_soloing_repair_evidence_ready": bool(
             readiness.get("repair_sweep_source_outside_soloing_repair_evidence_ready", False)
         ),
+        "repair_sweep_source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+            readiness.get(
+                "repair_sweep_source_outside_soloing_repair_source_objective_pitch_role_risk_count"
+            )
+        ),
+        "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+            readiness.get(
+                "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before"
+            )
+        ),
+        "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+            readiness.get(
+                "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after"
+            )
+        ),
+        "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+            readiness.get("repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta")
+        ),
+        "repair_sweep_source_outside_soloing_repair_source_targeted": bool(
+            readiness.get("repair_sweep_source_outside_soloing_repair_source_targeted", True)
+        ),
+        "repair_sweep_source_outside_soloing_repair_source_residual_risk_preserved": bool(
+            readiness.get(
+                "repair_sweep_source_outside_soloing_repair_source_residual_risk_preserved",
+                False,
+            )
+        ),
         "repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
             readiness.get("repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta": _int(
+            readiness.get("repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta")
         ),
         "repair_sweep_source_outside_soloing_not_evaluable_count": _int(
             readiness.get("repair_sweep_source_outside_soloing_not_evaluable_count")
@@ -630,9 +814,17 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- residual rhythmic monotony count: `{readiness['residual_rhythmic_monotony_count']}`",
         f"- context not-evaluable min count: `{readiness['context_not_evaluable_min_count']}`",
         f"- objective source/repaired outside-soloing not evaluable count: `{readiness['objective_source_outside_soloing_not_evaluable_count']}/{readiness['objective_repaired_outside_soloing_not_evaluable_count']}`",
+        f"- objective source outside-soloing source pitch-role risk before / after / delta: `{readiness['objective_source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{readiness['objective_source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{readiness['objective_source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
+        f"- objective source outside-soloing source repair targeted: `{_bool_token(readiness['objective_source_outside_soloing_repair_source_targeted'])}`",
+        f"- objective source outside-soloing source residual risk preserved: `{_bool_token(readiness['objective_source_outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- repair sweep source/repaired outside-soloing not evaluable count: `{readiness['repair_sweep_source_outside_soloing_not_evaluable_count']}/{readiness['repair_sweep_repaired_outside_soloing_not_evaluable_count']}`",
+        f"- repair sweep source outside-soloing source pitch-role risk before / after / delta: `{readiness['repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{readiness['repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{readiness['repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
+        f"- repair sweep source outside-soloing source repair targeted: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_source_targeted'])}`",
+        f"- repair sweep source outside-soloing source residual risk preserved: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- objective source outside-soloing repair pitch-role risk count after: `{readiness['objective_source_outside_soloing_repair_pitch_role_risk_count_after']}`",
+        f"- objective source outside-soloing current repair pitch-role risk delta: `{readiness['objective_source_outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- repair sweep source outside-soloing repair pitch-role risk count after: `{readiness['repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after']}`",
+        f"- repair sweep source outside-soloing current repair pitch-role risk delta: `{readiness['repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- technical regression count: `{readiness['technical_regression_count']}`",
         f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
         f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
@@ -693,7 +885,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=784)
+    parser.add_argument("--issue_number", type=int, default=954)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--expected_target", type=str, default="")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision.py
@@ -33,7 +33,14 @@ def objective_next_report(*, quality_claim: bool = False) -> dict:
             "failure_label_delta": 3,
             "phrase_rhythm_failure_delta": 3,
             "source_outside_soloing_repair_evidence_ready": True,
+            "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
+            "source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
+            "source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
+            "source_outside_soloing_repair_source_targeted": False,
+            "source_outside_soloing_repair_source_residual_risk_preserved": True,
             "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "source_outside_soloing_not_evaluable_count": 6,
             "repaired_outside_soloing_not_evaluable_count": 6,
             "repaired_not_evaluable_counts": {
@@ -87,7 +94,14 @@ def repair_sweep_report(*, technical_regression_count: int = 0) -> dict:
                 "rhythmic_monotony": 1,
             },
             "source_outside_soloing_repair_evidence_ready": True,
+            "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
+            "source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
+            "source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
+            "source_outside_soloing_repair_source_targeted": False,
+            "source_outside_soloing_repair_source_residual_risk_preserved": True,
             "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "source_outside_soloing_not_evaluable_count": 6,
             "repaired_outside_soloing_not_evaluable_count": 6,
             "repaired_not_evaluable_counts": {
@@ -120,7 +134,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionTes
                 objective_next_report=objective_next_report(),
                 repair_sweep_report=repair_sweep_report(),
                 output_dir=Path(tmp) / "followup",
-                issue_number=868,
+                issue_number=954,
             )
             summary = validate_followup_decision_report(
                 report,
@@ -148,12 +162,64 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionTes
                 summary["objective_source_outside_soloing_repair_pitch_role_risk_count_after"],
                 0,
             )
+            self.assertEqual(
+                summary[
+                    "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"
+                ],
+                5,
+            )
+            self.assertEqual(
+                summary[
+                    "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after"
+                ],
+                2,
+            )
+            self.assertEqual(
+                summary["objective_source_outside_soloing_repair_source_pitch_role_risk_delta"],
+                3,
+            )
+            self.assertFalse(summary["objective_source_outside_soloing_repair_source_targeted"])
+            self.assertTrue(
+                summary[
+                    "objective_source_outside_soloing_repair_source_residual_risk_preserved"
+                ]
+            )
+            self.assertEqual(
+                summary["objective_source_outside_soloing_repair_pitch_role_risk_delta"],
+                2,
+            )
             self.assertEqual(summary["objective_source_outside_soloing_not_evaluable_count"], 6)
             self.assertEqual(summary["objective_repaired_outside_soloing_not_evaluable_count"], 6)
             self.assertTrue(summary["repair_sweep_source_outside_soloing_repair_evidence_ready"])
             self.assertEqual(
                 summary["repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after"],
                 0,
+            )
+            self.assertEqual(
+                summary[
+                    "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before"
+                ],
+                5,
+            )
+            self.assertEqual(
+                summary[
+                    "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after"
+                ],
+                2,
+            )
+            self.assertEqual(
+                summary["repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta"],
+                3,
+            )
+            self.assertFalse(summary["repair_sweep_source_outside_soloing_repair_source_targeted"])
+            self.assertTrue(
+                summary[
+                    "repair_sweep_source_outside_soloing_repair_source_residual_risk_preserved"
+                ]
+            )
+            self.assertEqual(
+                summary["repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta"],
+                2,
             )
             self.assertEqual(summary["repair_sweep_source_outside_soloing_not_evaluable_count"], 6)
             self.assertEqual(
@@ -175,7 +241,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionTes
                     objective_next_report=objective_next_report(quality_claim=True),
                     repair_sweep_report=repair_sweep_report(),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=868,
+                    issue_number=954,
                 )
 
     def test_rejects_technical_regression(self) -> None:
@@ -187,7 +253,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionTes
                     objective_next_report=objective_next_report(),
                     repair_sweep_report=repair_sweep_report(technical_regression_count=1),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=868,
+                    issue_number=954,
                 )
 
     def test_rejects_missing_objective_outside_soloing_context(self) -> None:
@@ -202,7 +268,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionTes
                     objective_next_report=source,
                     repair_sweep_report=repair_sweep_report(),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=868,
+                    issue_number=954,
                 )
 
     def test_rejects_missing_repair_sweep_outside_soloing_context(self) -> None:
@@ -217,7 +283,22 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionTes
                     objective_next_report=objective_next_report(),
                     repair_sweep_report=source,
                     output_dir=Path(tmp) / "followup",
-                    issue_number=868,
+                    issue_number=954,
+                )
+
+    def test_rejects_repair_sweep_source_context_delta_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = repair_sweep_report()
+            source["aggregate"]["source_outside_soloing_repair_source_pitch_role_risk_delta"] = 1
+
+            with self.assertRaises(
+                StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError
+            ):
+                build_followup_decision_report(
+                    objective_next_report=objective_next_report(),
+                    repair_sweep_report=source,
+                    output_dir=Path(tmp) / "followup",
+                    issue_number=954,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
Summary
- phrase/rhythm repair follow-up decision source-context 보존 검증
- objective summary / repair sweep source pitch-role risk before/after/delta 검증 추가
- 다음 경계: chord-context pitch-role bridge source-context refresh

Context
- #952 objective-only next decision 결과, outside-soloing / chord-tone landing 판단은 chord context 부재로 보류
- repair sweep 기준 failure label: 4 -> 1, delta 3
- residual rhythmic_monotony count: 1
- context not-evaluable min count: 6
- source pitch-role risk before/after/delta: 5 / 2 / 3
- current repaired pitch-role risk after/delta: 0 / 2

Scope
- follow-up decision schema v2
- objective summary source-context validation
- repair sweep source-context validation
- generated decision report / README / current status / core plan 갱신

Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision
- .venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup.py
- bash -n scripts/agent_harness.sh
- git diff --check
- bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-followup-decision
- bash scripts/agent_harness.sh quick

Risk
- human/audio preference unclaimed
- MIDI-to-solo musical quality unclaimed
- outside-soloing / chord-tone landing 판단은 chord context bridge 이후 재검토

Follow-up
- Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh

Closes #954