### PR TITLE
Stage B MIDI-to-solo chord context bridge source context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,10 +40,11 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm repair listening review input guard completed: Issue #950, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair objective-only next decision completed: Issue #952, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair follow-up decision completed: Issue #954, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh.
+- Latest songlike melody contour phrase/rhythm chord-context pitch-role bridge completed: Issue #956, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh.
 - Latest documentation issue completed: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after songlike melody contour phrase/rhythm repair follow-up decision source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh.
+- Open issue queue after songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour phrase/rhythm repair listening review input guard: `Issue #950`
 - latest songlike melody contour phrase/rhythm repair objective-only next decision: `Issue #952`
 - latest songlike melody contour phrase/rhythm repair follow-up decision: `Issue #954`
+- latest songlike melody contour phrase/rhythm chord-context pitch-role bridge: `Issue #956`
 - latest README evidence refresh: `Issue #900`
-- latest functional boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
-- open issue queue after songlike melody contour phrase/rhythm repair follow-up decision source-context refresh merge: `0`
+- latest functional boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- open issue queue after songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -65,6 +66,12 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - phrase/rhythm repair follow-up selected target: `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
 - phrase/rhythm repair residual rhythmic monotony count: `1`
 - phrase/rhythm repair context not-evaluable min count: `6`
+- phrase/rhythm chord-context bridge completed: `true`
+- phrase/rhythm chord-context available / pitch-role metrics defined: `6 / 6`
+- phrase/rhythm chord-context not-evaluable count: `12 -> 0`
+- phrase/rhythm chord-context bridge flags: `outside_soloing_pitch_role_risk=5`, `weak_chord_tone_landing_risk=6`
+- phrase/rhythm chord-context source outside-soloing pitch-role risk: `5 -> 2`
+- phrase/rhythm chord-context current outside-soloing pitch-role risk after / delta: `0 / 2`
 - phrase/rhythm repair technical WAV validation: `true`
 - phrase/rhythm repair source outside-soloing pitch-role risk: `5 -> 2`
 - phrase/rhythm repair current outside-soloing pitch-role risk after / delta: `0 / 2`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -420,7 +420,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard: preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision: follow-up required `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, current quality claim ready `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision: selected target `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`, remaining label/count `rhythmic_monotony/1`, objective/sweep source risk `5 -> 2`, current repair risk after/delta `0/2`, objective/sweep outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
-- MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge: chord context/pitch-role metrics `6/6`, not evaluable `12 -> 0`, bridge flags `outside_soloing_pitch_role_risk=5`, `weak_chord_tone_landing_risk=6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge: chord context/pitch-role metrics `6/6`, not evaluable `12 -> 0`, source risk `5 -> 2`, current repair risk after/delta `0/2`, bridge flags `outside_soloing_pitch_role_risk=5`, `weak_chord_tone_landing_risk=6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision: primary risk `weak_chord_tone_landing_risk=6`, outside risk `5`, not evaluable `12 -> 0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
 - MIDI-to-solo pitch-contour changed-ratio repair probe: repaired/pass `3/3`, max pitch changed ratio `0.7174 -> 0.4348`, max interval `12`, dead-air max `0.0000`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
@@ -9125,6 +9125,74 @@ Issue #954는 Issue #952 objective-only next decision과 Issue #944 phrase/rhyth
 다음 작업:
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh`
+
+## 9.168 Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh
+
+Issue #956은 Issue #954 follow-up decision과 Issue #944 phrase/rhythm repair sweep의 source/current outside-soloing context를 chord-context pitch-role bridge까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
+- repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- selected target: `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- chord progression: `Cm7,Fm7,Bb7,Ebmaj7`
+- context source: `fallback_default_harness_chords`
+- candidate count: `6`
+- chord context available count: `6/6`
+- pitch-role metrics defined count: `6/6`
+- not evaluable count: `12 -> 0`
+- follow-up objective source/repaired outside-soloing not evaluable count: `6/6`
+- follow-up repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- bridge repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- follow-up objective source outside-soloing source pitch-role risk count: `5 -> 2`
+- follow-up objective source outside-soloing source pitch-role risk delta: `3`
+- follow-up objective source outside-soloing source repair targeted: `false`
+- follow-up objective source outside-soloing source residual risk preserved: `true`
+- follow-up objective source outside-soloing current repair pitch-role risk count after: `0`
+- follow-up objective source outside-soloing current repair pitch-role risk delta: `2`
+- follow-up repair sweep source outside-soloing source pitch-role risk count: `5 -> 2`
+- follow-up repair sweep source outside-soloing source pitch-role risk delta: `3`
+- follow-up repair sweep source outside-soloing source repair targeted: `false`
+- follow-up repair sweep source outside-soloing source residual risk preserved: `true`
+- follow-up repair sweep source outside-soloing current repair pitch-role risk count after: `0`
+- follow-up repair sweep source outside-soloing current repair pitch-role risk delta: `2`
+- bridge repair sweep source outside-soloing source pitch-role risk count: `5 -> 2`
+- bridge repair sweep source outside-soloing source pitch-role risk delta: `3`
+- bridge repair sweep source outside-soloing source repair targeted: `false`
+- bridge repair sweep source outside-soloing source residual risk preserved: `true`
+- bridge repair sweep source outside-soloing current repair pitch-role risk count after: `0`
+- bridge repair sweep source outside-soloing current repair pitch-role risk delta: `2`
+- min chord-tone ratio: `0.216`
+- max outside ratio: `0.027`
+- max non-chord run: `5`
+- bridge flags: `outside_soloing_pitch_role_risk=5`, `weak_chord_tone_landing_risk=6`
+- critical user input required: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- chord context와 pitch-role metrics가 후보 `6/6`개에 정의됨.
+- context 부재로 인한 not-evaluable label은 `12 -> 0`으로 해소.
+- follow-up decision과 repair sweep의 source/current outside-soloing risk context 일치 검증 추가.
+- 남은 objective risk는 `outside_soloing_pitch_role_risk=5`, `weak_chord_tone_landing_risk=6`.
+- 다음 boundary는 chord-context pitch-role objective decision.
+- human/audio preference와 musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-context-pitch-role-bridge`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -40,10 +40,11 @@
 - latest songlike melody contour phrase/rhythm repair listening review input guard: Issue #950, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh
 - latest songlike melody contour phrase/rhythm repair objective-only next decision: Issue #952, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh
 - latest songlike melody contour phrase/rhythm repair follow-up decision: Issue #954, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh
+- latest songlike melody contour phrase/rhythm chord-context pitch-role bridge: Issue #956, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh
 - latest README evidence refresh: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after songlike melody contour phrase/rhythm repair follow-up decision source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh`
+- open issue queue after songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -319,6 +320,38 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 bridge target: `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh 완료
+- selected target: `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- candidate count: `6`
+- chord context available count: `6/6`
+- pitch-role metrics defined count: `6/6`
+- not evaluable count: `12 -> 0`
+- follow-up objective source/repaired outside-soloing not evaluable count: `6/6`
+- follow-up repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- bridge repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- follow-up objective source outside-soloing source pitch-role risk count: `5 -> 2`
+- follow-up objective source outside-soloing source pitch-role risk delta: `3`
+- follow-up objective source outside-soloing source repair targeted: `false`
+- follow-up objective source outside-soloing source residual risk preserved: `true`
+- follow-up objective source outside-soloing current repair pitch-role risk count after / delta: `0 / 2`
+- follow-up repair sweep source outside-soloing source pitch-role risk count: `5 -> 2`
+- follow-up repair sweep source outside-soloing source pitch-role risk delta: `3`
+- follow-up repair sweep source outside-soloing source repair targeted: `false`
+- follow-up repair sweep source outside-soloing source residual risk preserved: `true`
+- follow-up repair sweep source outside-soloing current repair pitch-role risk count after / delta: `0 / 2`
+- bridge repair sweep source outside-soloing source pitch-role risk count: `5 -> 2`
+- bridge repair sweep source outside-soloing source pitch-role risk delta: `3`
+- bridge repair sweep source outside-soloing source repair targeted: `false`
+- bridge repair sweep source outside-soloing source residual risk preserved: `true`
+- bridge repair sweep source outside-soloing current repair pitch-role risk count after / delta: `0 / 2`
+- min chord-tone ratio: `0.216`
+- max outside ratio: `0.027`
+- max non-chord run: `5`
+- bridge flags: `outside_soloing_pitch_role_risk=5`, `weak_chord_tone_landing_risk=6`
+- critical user input required: `false`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 objective target: `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
 - songlike melody contour repair follow-up decision 완료
 - primary remaining failure labels: `phrase_shape_missing_tension_release`, `rhythmic_monotony`
 - primary remaining failure count: `2`

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_CONTEXT_PITCH_ROLE_BRIDGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_CONTEXT_PITCH_ROLE_BRIDGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -1,0 +1,69 @@
+# Stage B MIDI-to-Solo Phrase/Rhythm Chord-Context Pitch-Role Bridge
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
+- repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- selected target: `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- chord progression: `Cm7,Fm7,Bb7,Ebmaj7`
+- context source: `fallback_default_harness_chords`
+- candidate count: `6`
+- chord context available count: `6`
+- pitch-role metrics defined count: `6`
+- not evaluable count: `12 -> 0`
+- follow-up objective source/repaired outside-soloing not evaluable count: `6/6`
+- follow-up repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- bridge repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up objective source outside-soloing source pitch-role risk delta: `3`
+- follow-up objective source outside-soloing source targeted: `false`
+- follow-up objective source outside-soloing source residual risk preserved: `true`
+- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- follow-up repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up repair sweep source outside-soloing source pitch-role risk delta: `3`
+- follow-up repair sweep source outside-soloing source targeted: `false`
+- follow-up repair sweep source outside-soloing source residual risk preserved: `true`
+- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- bridge repair sweep source outside-soloing source pitch-role risk delta: `3`
+- bridge repair sweep source outside-soloing source targeted: `false`
+- bridge repair sweep source outside-soloing source residual risk preserved: `true`
+- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- min chord-tone ratio: `0.216`
+- max outside ratio: `0.027`
+- max non-chord run: `5`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Bridge Flags
+
+- `outside_soloing_pitch_role_risk`: `5`
+- `weak_chord_tone_landing_risk`: `6`
+
+## Candidates
+
+| rank | chord-tone | tension | approach | outside | strong beat chord-tone | final role | flags |
+|---:|---:|---:|---:|---:|---:|---|---|
+| 1 | 0.297 | 0.270 | 0.432 | 0.000 | 0.545 | `approach` | `weak_chord_tone_landing_risk` |
+| 2 | 0.457 | 0.086 | 0.457 | 0.000 | 0.300 | `approach` | `outside_soloing_pitch_role_risk,weak_chord_tone_landing_risk` |
+| 3 | 0.378 | 0.108 | 0.486 | 0.027 | 0.400 | `approach` | `outside_soloing_pitch_role_risk,weak_chord_tone_landing_risk` |
+| 4 | 0.216 | 0.243 | 0.541 | 0.000 | 0.333 | `guide` | `outside_soloing_pitch_role_risk,weak_chord_tone_landing_risk` |
+| 5 | 0.237 | 0.211 | 0.526 | 0.026 | 0.000 | `approach` | `outside_soloing_pitch_role_risk,weak_chord_tone_landing_risk` |
+| 6 | 0.324 | 0.270 | 0.405 | 0.000 | 0.167 | `approach` | `outside_soloing_pitch_role_risk,weak_chord_tone_landing_risk` |
+
+## Decision
+
+- reason: `chord-context bridge produced pitch-role metrics without quality claim`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh`
+
+## Claim Boundary
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6637,9 +6637,9 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_d
 }
 
 run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge() {
-  local followup_run_id="${FOLLOWUP_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision}"
-  local sweep_run_id="${REPAIR_SWEEP_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep}"
-  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge}"
+  local followup_run_id="${FOLLOWUP_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision_source_context_refresh}"
+  local sweep_run_id="${REPAIR_SWEEP_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep_source_context_refresh}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge_source_context_refresh}"
   local followup_report="outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision/${followup_run_id}/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision.json"
   local sweep_report="outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep/${sweep_run_id}/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.json"
   if [[ ! -f "$followup_report" ]]; then
@@ -6657,8 +6657,8 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pit
     --repair_sweep_report "$sweep_report" \
     --chords Cm7,Fm7,Bb7,Ebmaj7 \
     --bpm 124 \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_CONTEXT_PITCH_ROLE_BRIDGE_2026-06-10.md \
-    --issue_number 870 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_CONTEXT_PITCH_ROLE_BRIDGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
+    --issue_number 956 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision \
     --require_bridge_completed \

--- a/scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge.py
+++ b/scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge.py
@@ -41,9 +41,42 @@ NEXT_BOUNDARY = (
 SELECTED_TARGET = (
     "songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision"
 )
-SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge_v1"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge_v2"
 DEFAULT_CHORDS = ["Cm7", "Fm7", "Bb7", "Ebmaj7"]
 CONTEXT_LABELS = ["outside_soloing_without_context", "weak_chord_tone_landing"]
+SOURCE_CONTEXT_SUFFIXES = [
+    "source_objective_pitch_role_risk_count",
+    "source_pitch_role_risk_count_before",
+    "source_pitch_role_risk_count_after",
+    "source_pitch_role_risk_delta",
+    "source_targeted",
+    "source_residual_risk_preserved",
+    "pitch_role_risk_count_after",
+    "pitch_role_risk_delta",
+]
+BRIDGE_SOURCE_CONTEXT_KEYS = [
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before",
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after",
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_delta",
+    "followup_objective_source_outside_soloing_source_targeted",
+    "followup_objective_source_outside_soloing_source_residual_risk_preserved",
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after",
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_delta",
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before",
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after",
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta",
+    "followup_repair_sweep_source_outside_soloing_source_targeted",
+    "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved",
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after",
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta",
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before",
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after",
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta",
+    "repair_sweep_source_outside_soloing_source_targeted",
+    "repair_sweep_source_outside_soloing_source_residual_risk_preserved",
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after",
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta",
+]
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
     "midi_to_solo_musical_quality_claimed",
@@ -89,6 +122,69 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
         raise StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError(
             f"unexpected quality claim in {label}: {claimed}"
         )
+
+
+def _source_context_fields(
+    container: dict[str, Any], *, base: str, label: str
+) -> dict[str, Any]:
+    objective = _int(container.get(f"{base}_source_objective_pitch_role_risk_count"))
+    before = _int(container.get(f"{base}_source_pitch_role_risk_count_before"))
+    after = _int(container.get(f"{base}_source_pitch_role_risk_count_after"))
+    delta = _int(container.get(f"{base}_source_pitch_role_risk_delta"))
+    source_targeted = bool(container.get(f"{base}_source_targeted", True))
+    residual_preserved = bool(container.get(f"{base}_source_residual_risk_preserved", False))
+    current_after = _int(container.get(f"{base}_pitch_role_risk_count_after"))
+    current_delta = _int(container.get(f"{base}_pitch_role_risk_delta"))
+    if objective <= 0:
+        raise StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError(
+            f"{label} source objective pitch-role risk count required"
+        )
+    if before != objective:
+        raise StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError(
+            f"{label} source before count must match objective risk count"
+        )
+    if before - after != delta:
+        raise StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError(
+            f"{label} source pitch-role risk delta mismatch"
+        )
+    if source_targeted:
+        raise StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError(
+            f"{label} source should remain untargeted"
+        )
+    if not residual_preserved:
+        raise StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError(
+            f"{label} source residual risk should be preserved"
+        )
+    if current_after != 0:
+        raise StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError(
+            f"{label} current repair pitch-role risk should be resolved before bridge"
+        )
+    if current_delta <= 0:
+        raise StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError(
+            f"{label} current repair pitch-role risk delta required"
+        )
+    return {
+        f"{base}_source_objective_pitch_role_risk_count": objective,
+        f"{base}_source_pitch_role_risk_count_before": before,
+        f"{base}_source_pitch_role_risk_count_after": after,
+        f"{base}_source_pitch_role_risk_delta": delta,
+        f"{base}_source_targeted": source_targeted,
+        f"{base}_source_residual_risk_preserved": residual_preserved,
+        f"{base}_pitch_role_risk_count_after": current_after,
+        f"{base}_pitch_role_risk_delta": current_delta,
+    }
+
+
+def _validate_bridge_source_context_consistency(
+    followup: dict[str, Any], sweep: dict[str, Any]
+) -> None:
+    for suffix in SOURCE_CONTEXT_SUFFIXES:
+        followup_key = f"repair_sweep_source_outside_soloing_repair_{suffix}"
+        sweep_key = f"source_outside_soloing_repair_{suffix}"
+        if followup.get(followup_key) != sweep.get(sweep_key):
+            raise StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError(
+                f"repair sweep source context mismatch for {suffix}"
+            )
 
 
 def expand_chords(chords: list[str], bar_count: int) -> list[str]:
@@ -149,6 +245,16 @@ def validate_followup_source(report: dict[str, Any]) -> dict[str, Any]:
             "repair sweep outside-soloing not-evaluable count should be preserved"
         )
     _require_no_quality_claim(readiness, label="follow-up readiness")
+    objective_source_context = _source_context_fields(
+        readiness,
+        base="objective_source_outside_soloing_repair",
+        label="follow-up objective outside-soloing repair",
+    )
+    repair_sweep_source_context = _source_context_fields(
+        readiness,
+        base="repair_sweep_source_outside_soloing_repair",
+        label="follow-up repair sweep outside-soloing repair",
+    )
     return {
         "boundary": FOLLOWUP_BOUNDARY,
         "candidate_count": _int(readiness.get("candidate_count")),
@@ -181,6 +287,8 @@ def validate_followup_source(report: dict[str, Any]) -> dict[str, Any]:
         "repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
             readiness.get("repair_sweep_repaired_outside_soloing_not_evaluable_count")
         ),
+        **objective_source_context,
+        **repair_sweep_source_context,
     }
 
 
@@ -254,6 +362,11 @@ def validate_repair_sweep_source(report: dict[str, Any]) -> dict[str, Any]:
             "critical user input should not be required"
         )
     _require_no_quality_claim(readiness, label="repair sweep readiness")
+    source_context = _source_context_fields(
+        aggregate,
+        base="source_outside_soloing_repair",
+        label="repair sweep outside-soloing repair",
+    )
     not_evaluable_counts = Counter()
     for row in rows:
         labels = _list(repaired_labeling(row).get("not_evaluable_labels"))
@@ -295,6 +408,7 @@ def validate_repair_sweep_source(report: dict[str, Any]) -> dict[str, Any]:
         ),
         "repaired_not_evaluable_counts": _dict(aggregate.get("repaired_not_evaluable_counts")),
         "not_evaluable_counts_before": dict(sorted(not_evaluable_counts.items())),
+        **source_context,
     }
 
 
@@ -400,6 +514,7 @@ def build_bridge_report(
 ) -> dict[str, Any]:
     followup = validate_followup_source(followup_report)
     sweep = validate_repair_sweep_source(repair_sweep_report)
+    _validate_bridge_source_context_consistency(followup, sweep)
     manifest_path = ROOT_DIR / "stage_b_midi_to_solo_phrase_rhythm_bridge_manifest.json"
     candidates = [
         bridge_candidate(
@@ -460,6 +575,81 @@ def build_bridge_report(
         "repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
             sweep["repaired_outside_soloing_not_evaluable_count"]
         ),
+        "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": _int(
+            followup[
+                "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"
+            ]
+        ),
+        "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after": _int(
+            followup[
+                "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after"
+            ]
+        ),
+        "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": _int(
+            followup["objective_source_outside_soloing_repair_source_pitch_role_risk_delta"]
+        ),
+        "followup_objective_source_outside_soloing_source_targeted": bool(
+            followup["objective_source_outside_soloing_repair_source_targeted"]
+        ),
+        "followup_objective_source_outside_soloing_source_residual_risk_preserved": bool(
+            followup[
+                "objective_source_outside_soloing_repair_source_residual_risk_preserved"
+            ]
+        ),
+        "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": _int(
+            followup["objective_source_outside_soloing_repair_pitch_role_risk_count_after"]
+        ),
+        "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": _int(
+            followup["objective_source_outside_soloing_repair_pitch_role_risk_delta"]
+        ),
+        "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": _int(
+            followup[
+                "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before"
+            ]
+        ),
+        "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": _int(
+            followup[
+                "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after"
+            ]
+        ),
+        "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": _int(
+            followup["repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta"]
+        ),
+        "followup_repair_sweep_source_outside_soloing_source_targeted": bool(
+            followup["repair_sweep_source_outside_soloing_repair_source_targeted"]
+        ),
+        "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": bool(
+            followup[
+                "repair_sweep_source_outside_soloing_repair_source_residual_risk_preserved"
+            ]
+        ),
+        "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": _int(
+            followup["repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after"]
+        ),
+        "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": _int(
+            followup["repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta"]
+        ),
+        "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": _int(
+            sweep["source_outside_soloing_repair_source_pitch_role_risk_count_before"]
+        ),
+        "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": _int(
+            sweep["source_outside_soloing_repair_source_pitch_role_risk_count_after"]
+        ),
+        "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": _int(
+            sweep["source_outside_soloing_repair_source_pitch_role_risk_delta"]
+        ),
+        "repair_sweep_source_outside_soloing_source_targeted": bool(
+            sweep["source_outside_soloing_repair_source_targeted"]
+        ),
+        "repair_sweep_source_outside_soloing_source_residual_risk_preserved": bool(
+            sweep["source_outside_soloing_repair_source_residual_risk_preserved"]
+        ),
+        "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": _int(
+            sweep["source_outside_soloing_repair_pitch_role_risk_count_after"]
+        ),
+        "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": _int(
+            sweep["source_outside_soloing_repair_pitch_role_risk_delta"]
+        ),
         "bridge_flag_counts": dict(sorted(bridge_flag_counts.items())),
         "min_chord_tone_ratio": min_chord_tone_ratio,
         "max_outside_ratio": max_outside_ratio,
@@ -516,6 +706,7 @@ def build_bridge_report(
             "repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
                 sweep["repaired_outside_soloing_not_evaluable_count"]
             ),
+            **{key: summary[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
             "human_audio_preference_claimed": False,
             "audio_rendered_quality_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
@@ -541,7 +732,7 @@ def build_bridge_report(
             "brad_style_adaptation",
         ],
         "next_recommended_issue": (
-            "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision"
+            "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh"
         ),
     }
 
@@ -622,6 +813,11 @@ def validate_bridge_report(
         )
     if require_no_quality_claim:
         _require_no_quality_claim(readiness, label="bridge readiness")
+    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+        if key not in readiness:
+            raise StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError(
+                f"bridge source-context field required: {key}"
+            )
     return {
         "boundary": boundary,
         "source_boundary": str(report.get("source_boundary") or ""),
@@ -662,6 +858,7 @@ def validate_bridge_report(
         "max_outside_ratio": _float(summary.get("max_outside_ratio")),
         "max_non_chord_tone_run": _int(summary.get("max_non_chord_tone_run")),
         "bridge_flag_counts": _dict(summary.get("bridge_flag_counts")),
+        **{key: readiness.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
         "human_audio_preference_claimed": bool(
             readiness.get("human_audio_preference_claimed", True)
         ),
@@ -699,6 +896,21 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- follow-up objective source/repaired outside-soloing not evaluable count: `{readiness['followup_objective_source_outside_soloing_not_evaluable_count']}/{readiness['followup_objective_repaired_outside_soloing_not_evaluable_count']}`",
         f"- follow-up repair sweep source/repaired outside-soloing not evaluable count: `{readiness['followup_repair_sweep_source_outside_soloing_not_evaluable_count']}/{readiness['followup_repair_sweep_repaired_outside_soloing_not_evaluable_count']}`",
         f"- bridge repair sweep source/repaired outside-soloing not evaluable count: `{readiness['repair_sweep_source_outside_soloing_not_evaluable_count']}/{readiness['repair_sweep_repaired_outside_soloing_not_evaluable_count']}`",
+        f"- follow-up objective source outside-soloing source pitch-role risk: `{readiness['followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {readiness['followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up objective source outside-soloing source pitch-role risk delta: `{readiness['followup_objective_source_outside_soloing_source_pitch_role_risk_delta']}`",
+        f"- follow-up objective source outside-soloing source targeted: `{_bool_token(readiness['followup_objective_source_outside_soloing_source_targeted'])}`",
+        f"- follow-up objective source outside-soloing source residual risk preserved: `{_bool_token(readiness['followup_objective_source_outside_soloing_source_residual_risk_preserved'])}`",
+        f"- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `{readiness['followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']} / {readiness['followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- follow-up repair sweep source outside-soloing source pitch-role risk: `{readiness['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {readiness['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up repair sweep source outside-soloing source pitch-role risk delta: `{readiness['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta']}`",
+        f"- follow-up repair sweep source outside-soloing source targeted: `{_bool_token(readiness['followup_repair_sweep_source_outside_soloing_source_targeted'])}`",
+        f"- follow-up repair sweep source outside-soloing source residual risk preserved: `{_bool_token(readiness['followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved'])}`",
+        f"- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `{readiness['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {readiness['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- bridge repair sweep source outside-soloing source pitch-role risk: `{readiness['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {readiness['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- bridge repair sweep source outside-soloing source pitch-role risk delta: `{readiness['repair_sweep_source_outside_soloing_source_pitch_role_risk_delta']}`",
+        f"- bridge repair sweep source outside-soloing source targeted: `{_bool_token(readiness['repair_sweep_source_outside_soloing_source_targeted'])}`",
+        f"- bridge repair sweep source outside-soloing source residual risk preserved: `{_bool_token(readiness['repair_sweep_source_outside_soloing_source_residual_risk_preserved'])}`",
+        f"- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `{readiness['repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {readiness['repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- min chord-tone ratio: `{summary['min_chord_tone_ratio']:.3f}`",
         f"- max outside ratio: `{summary['max_outside_ratio']:.3f}`",
         f"- max non-chord run: `{summary['max_non_chord_tone_run']}`",
@@ -770,7 +982,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=870)
+    parser.add_argument("--issue_number", type=int, default=956)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--require_bridge_completed", action="store_true")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge.py
@@ -61,11 +61,25 @@ def followup_report(*, quality_claim: bool = False) -> dict:
             "phrase_rhythm_failure_delta": 3,
             "context_not_evaluable_min_count": 6,
             "objective_source_outside_soloing_repair_evidence_ready": True,
+            "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
+            "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
+            "objective_source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
+            "objective_source_outside_soloing_repair_source_targeted": False,
+            "objective_source_outside_soloing_repair_source_residual_risk_preserved": True,
             "objective_source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "objective_source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "objective_source_outside_soloing_not_evaluable_count": 6,
             "objective_repaired_outside_soloing_not_evaluable_count": 6,
             "repair_sweep_source_outside_soloing_repair_evidence_ready": True,
+            "repair_sweep_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
+            "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
+            "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
+            "repair_sweep_source_outside_soloing_repair_source_targeted": False,
+            "repair_sweep_source_outside_soloing_repair_source_residual_risk_preserved": True,
             "repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "repair_sweep_source_outside_soloing_not_evaluable_count": 6,
             "repair_sweep_repaired_outside_soloing_not_evaluable_count": 6,
             "human_audio_preference_claimed": False,
@@ -116,7 +130,14 @@ def repair_sweep_report(midi_paths: list[Path], *, technical_regression_count: i
             "phrase_rhythm_failure_delta": 3,
             "technical_regression_count": technical_regression_count,
             "source_outside_soloing_repair_evidence_ready": True,
+            "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
+            "source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
+            "source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
+            "source_outside_soloing_repair_source_targeted": False,
+            "source_outside_soloing_repair_source_residual_risk_preserved": True,
             "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "source_outside_soloing_not_evaluable_count": 6,
             "repaired_outside_soloing_not_evaluable_count": 6,
             "repaired_not_evaluable_counts": {
@@ -157,7 +178,7 @@ class StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeTest(unittest.TestC
                 chords=list(DEFAULT_CHORDS),
                 bpm=124.0,
                 output_dir=root / "bridge",
-                issue_number=870,
+                issue_number=956,
             )
             summary = validate_bridge_report(
                 report,
@@ -195,6 +216,56 @@ class StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeTest(unittest.TestC
                 summary["repair_sweep_repaired_outside_soloing_not_evaluable_count"],
                 6,
             )
+            self.assertEqual(
+                summary[
+                    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before"
+                ],
+                5,
+            )
+            self.assertEqual(
+                summary[
+                    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after"
+                ],
+                2,
+            )
+            self.assertEqual(
+                summary["followup_objective_source_outside_soloing_source_pitch_role_risk_delta"],
+                3,
+            )
+            self.assertFalse(
+                summary["followup_objective_source_outside_soloing_source_targeted"]
+            )
+            self.assertTrue(
+                summary[
+                    "followup_objective_source_outside_soloing_source_residual_risk_preserved"
+                ]
+            )
+            self.assertEqual(
+                summary[
+                    "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after"
+                ],
+                0,
+            )
+            self.assertEqual(
+                summary["followup_objective_source_outside_soloing_current_pitch_role_risk_delta"],
+                2,
+            )
+            self.assertEqual(
+                summary[
+                    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before"
+                ],
+                5,
+            )
+            self.assertEqual(
+                summary[
+                    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after"
+                ],
+                2,
+            )
+            self.assertEqual(
+                summary["repair_sweep_source_outside_soloing_source_pitch_role_risk_delta"],
+                3,
+            )
             self.assertGreater(summary["min_chord_tone_ratio"], 0.0)
             self.assertEqual(summary["selected_target"], SELECTED_TARGET)
             self.assertFalse(summary["human_audio_preference_claimed"])
@@ -216,7 +287,7 @@ class StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeTest(unittest.TestC
                     chords=list(DEFAULT_CHORDS),
                     bpm=124.0,
                     output_dir=root / "bridge",
-                    issue_number=870,
+                    issue_number=956,
                 )
 
     def test_rejects_technical_regression(self) -> None:
@@ -237,7 +308,7 @@ class StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeTest(unittest.TestC
                     chords=list(DEFAULT_CHORDS),
                     bpm=124.0,
                     output_dir=root / "bridge",
-                    issue_number=870,
+                    issue_number=956,
                 )
 
     def test_rejects_missing_followup_outside_soloing_context(self) -> None:
@@ -258,7 +329,7 @@ class StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeTest(unittest.TestC
                     chords=list(DEFAULT_CHORDS),
                     bpm=124.0,
                     output_dir=root / "bridge",
-                    issue_number=870,
+                    issue_number=956,
                 )
 
     def test_rejects_missing_repair_sweep_outside_soloing_context(self) -> None:
@@ -279,7 +350,54 @@ class StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeTest(unittest.TestC
                     chords=list(DEFAULT_CHORDS),
                     bpm=124.0,
                     output_dir=root / "bridge",
-                    issue_number=870,
+                    issue_number=956,
+                )
+
+    def test_rejects_followup_source_context_delta_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            midi_paths = []
+            for index in range(6):
+                midi_path = root / f"candidate_{index}.mid"
+                write_fixture_midi(midi_path)
+                midi_paths.append(midi_path)
+            source = followup_report()
+            source["readiness"][
+                "objective_source_outside_soloing_repair_source_pitch_role_risk_delta"
+            ] = 99
+
+            with self.assertRaises(StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError):
+                build_bridge_report(
+                    followup_report=source,
+                    repair_sweep_report=repair_sweep_report(midi_paths),
+                    chords=list(DEFAULT_CHORDS),
+                    bpm=124.0,
+                    output_dir=root / "bridge",
+                    issue_number=956,
+                )
+
+    def test_rejects_repair_sweep_source_context_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            midi_paths = []
+            for index in range(6):
+                midi_path = root / f"candidate_{index}.mid"
+                write_fixture_midi(midi_path)
+                midi_paths.append(midi_path)
+            source = repair_sweep_report(midi_paths)
+            source["aggregate"][
+                "source_outside_soloing_repair_source_pitch_role_risk_count_after"
+            ] = 1
+            source["aggregate"]["source_outside_soloing_repair_source_pitch_role_risk_delta"] = 4
+
+            with self.assertRaises(StageBMidiToSoloPhraseRhythmChordContextPitchRoleBridgeError):
+                build_bridge_report(
+                    followup_report=followup_report(),
+                    repair_sweep_report=source,
+                    chords=list(DEFAULT_CHORDS),
+                    bpm=124.0,
+                    output_dir=root / "bridge",
+                    issue_number=956,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
Summary
- phrase/rhythm chord-context pitch-role bridge source-context 보존 검증
- follow-up decision / repair sweep source outside-soloing risk context 일치 검증 추가
- bridge readiness, summary, markdown에 source/current pitch-role risk 지표 반영

Context
- #954 follow-up decision 이후 next boundary: chord-context pitch-role bridge
- candidate count: 6
- chord context available / pitch-role metrics defined: 6 / 6
- context not-evaluable count: 12 -> 0
- source outside-soloing pitch-role risk: 5 -> 2, delta 3
- current outside-soloing pitch-role risk after/delta: 0 / 2
- bridge flags: outside_soloing_pitch_role_risk=5, weak_chord_tone_landing_risk=6

Scope
- bridge input source-context validation
- follow-up report와 repair sweep aggregate source-context consistency guard
- generated bridge report / README / current status / core plan 갱신
- harness run id, doc path, issue number 갱신

Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge
- .venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge.py
- bash -n scripts/agent_harness.sh
- git diff --check
- bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-context-pitch-role-bridge
- bash scripts/agent_harness.sh quick

Risk
- human/audio preference unclaimed
- MIDI-to-solo musical quality unclaimed
- fallback default harness chords 기준 pitch-role metrics
- 잔여 objective risk: outside_soloing_pitch_role_risk=5, weak_chord_tone_landing_risk=6

Follow-up
- Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh

Closes #956