### PR TITLE
Stage B MIDI-to-solo pitch role objective source context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,10 +41,11 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm repair objective-only next decision completed: Issue #952, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair follow-up decision completed: Issue #954, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-context pitch-role bridge completed: Issue #956, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh.
+- Latest songlike melody contour phrase/rhythm chord-context pitch-role objective decision completed: Issue #958, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh.
 - Latest documentation issue completed: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh.
+- Open issue queue after songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour phrase/rhythm repair objective-only next decision: `Issue #952`
 - latest songlike melody contour phrase/rhythm repair follow-up decision: `Issue #954`
 - latest songlike melody contour phrase/rhythm chord-context pitch-role bridge: `Issue #956`
+- latest songlike melody contour phrase/rhythm chord-context pitch-role objective decision: `Issue #958`
 - latest README evidence refresh: `Issue #900`
-- latest functional boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
-- open issue queue after songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh merge: `0`
+- latest functional boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- open issue queue after songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -72,6 +73,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - phrase/rhythm chord-context bridge flags: `outside_soloing_pitch_role_risk=5`, `weak_chord_tone_landing_risk=6`
 - phrase/rhythm chord-context source outside-soloing pitch-role risk: `5 -> 2`
 - phrase/rhythm chord-context current outside-soloing pitch-role risk after / delta: `0 / 2`
+- phrase/rhythm pitch-role objective decision completed: `true`
+- phrase/rhythm pitch-role primary risk: `weak_chord_tone_landing_risk=6`
+- phrase/rhythm pitch-role secondary risk: `outside_soloing_pitch_role_risk=5`
+- phrase/rhythm pitch-role selected target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
 - phrase/rhythm repair technical WAV validation: `true`
 - phrase/rhythm repair source outside-soloing pitch-role risk: `5 -> 2`
 - phrase/rhythm repair current outside-soloing pitch-role risk after / delta: `0 / 2`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -421,7 +421,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision: follow-up required `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, current quality claim ready `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision: selected target `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`, remaining label/count `rhythmic_monotony/1`, objective/sweep source risk `5 -> 2`, current repair risk after/delta `0/2`, objective/sweep outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge: chord context/pitch-role metrics `6/6`, not evaluable `12 -> 0`, source risk `5 -> 2`, current repair risk after/delta `0/2`, bridge flags `outside_soloing_pitch_role_risk=5`, `weak_chord_tone_landing_risk=6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
-- MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision: primary risk `weak_chord_tone_landing_risk=6`, outside risk `5`, not evaluable `12 -> 0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
+- MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision: primary risk `weak_chord_tone_landing_risk=6`, outside risk `5`, not evaluable `12 -> 0`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
 - MIDI-to-solo pitch-contour changed-ratio repair probe: repaired/pass `3/3`, max pitch changed ratio `0.7174 -> 0.4348`, max interval `12`, dead-air max `0.0000`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package`
 - MIDI-to-solo pitch-contour changed-ratio repair audio package: rendered WAV `3`, duration `18.422s-18.978s`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_listening_review_package`
@@ -9193,6 +9193,71 @@ Issue #956은 Issue #954 follow-up decision과 Issue #944 phrase/rhythm repair s
 다음 작업:
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh`
+
+## 9.169 Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh
+
+Issue #958은 Issue #956 chord-context pitch-role bridge의 source/current outside-soloing context를 objective decision까지 보존하고, 다음 repair target을 weak chord-tone landing repair sweep으로 선택한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
+- selected target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
+- primary risk label: `weak_chord_tone_landing_risk`
+- candidate count: `6`
+- not evaluable count: `12 -> 0`
+- follow-up objective source/repaired outside-soloing not evaluable count: `6/6`
+- follow-up repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- bridge repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- follow-up objective source outside-soloing source pitch-role risk count: `5 -> 2`
+- follow-up objective source outside-soloing source pitch-role risk delta: `3`
+- follow-up objective source outside-soloing source repair targeted: `false`
+- follow-up objective source outside-soloing source residual risk preserved: `true`
+- follow-up objective source outside-soloing current repair pitch-role risk count after: `0`
+- follow-up objective source outside-soloing current repair pitch-role risk delta: `2`
+- follow-up repair sweep source outside-soloing source pitch-role risk count: `5 -> 2`
+- follow-up repair sweep source outside-soloing source pitch-role risk delta: `3`
+- follow-up repair sweep source outside-soloing source repair targeted: `false`
+- follow-up repair sweep source outside-soloing source residual risk preserved: `true`
+- follow-up repair sweep source outside-soloing current repair pitch-role risk count after: `0`
+- follow-up repair sweep source outside-soloing current repair pitch-role risk delta: `2`
+- bridge repair sweep source outside-soloing source pitch-role risk count: `5 -> 2`
+- bridge repair sweep source outside-soloing source pitch-role risk delta: `3`
+- bridge repair sweep source outside-soloing source repair targeted: `false`
+- bridge repair sweep source outside-soloing source residual risk preserved: `true`
+- bridge repair sweep source outside-soloing current repair pitch-role risk count after: `0`
+- bridge repair sweep source outside-soloing current repair pitch-role risk delta: `2`
+- weak chord-tone landing risk count: `6`
+- outside-soloing pitch-role risk count: `5`
+- min chord-tone ratio: `0.216`
+- max outside ratio: `0.027`
+- max non-chord run: `5`
+- critical user input required: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- context 부재 not-evaluable label은 bridge 단계에서 `12 -> 0`으로 해소된 상태.
+- objective risk count 기준 primary target은 `weak_chord_tone_landing_risk=6`.
+- secondary risk는 `outside_soloing_pitch_role_risk=5`.
+- source/current outside-soloing risk context는 objective decision까지 보존.
+- 다음 boundary는 chord-tone landing repair sweep.
+- human/audio preference와 musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-context-pitch-role-objective-decision`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep source-context refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -41,10 +41,11 @@
 - latest songlike melody contour phrase/rhythm repair objective-only next decision: Issue #952, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh
 - latest songlike melody contour phrase/rhythm repair follow-up decision: Issue #954, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh
 - latest songlike melody contour phrase/rhythm chord-context pitch-role bridge: Issue #956, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh
+- latest songlike melody contour phrase/rhythm chord-context pitch-role objective decision: Issue #958, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh
 - latest README evidence refresh: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh`
+- open issue queue after songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -352,6 +353,35 @@
 - human/audio preference claim: `false`
 - MIDI-to-solo musical quality claim: `false`
 - 다음 objective target: `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh 완료
+- selected target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
+- primary risk label: `weak_chord_tone_landing_risk`
+- candidate count: `6`
+- weak chord-tone landing risk count: `6`
+- outside-soloing pitch-role risk count: `5`
+- not evaluable count: `12 -> 0`
+- follow-up objective source/repaired outside-soloing not evaluable count: `6/6`
+- follow-up repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- bridge repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- follow-up objective source outside-soloing source pitch-role risk count: `5 -> 2`
+- follow-up objective source outside-soloing source pitch-role risk delta: `3`
+- follow-up objective source outside-soloing source repair targeted: `false`
+- follow-up objective source outside-soloing source residual risk preserved: `true`
+- follow-up objective source outside-soloing current repair pitch-role risk count after / delta: `0 / 2`
+- follow-up repair sweep source outside-soloing source pitch-role risk count: `5 -> 2`
+- follow-up repair sweep source outside-soloing source pitch-role risk delta: `3`
+- follow-up repair sweep source outside-soloing source repair targeted: `false`
+- follow-up repair sweep source outside-soloing source residual risk preserved: `true`
+- follow-up repair sweep source outside-soloing current repair pitch-role risk count after / delta: `0 / 2`
+- bridge repair sweep source outside-soloing source pitch-role risk count: `5 -> 2`
+- bridge repair sweep source outside-soloing source pitch-role risk delta: `3`
+- bridge repair sweep source outside-soloing source repair targeted: `false`
+- bridge repair sweep source outside-soloing source residual risk preserved: `true`
+- bridge repair sweep source outside-soloing current repair pitch-role risk count after / delta: `0 / 2`
+- critical user input required: `false`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+- 다음 repair target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
 - songlike melody contour repair follow-up decision 완료
 - primary remaining failure labels: `phrase_shape_missing_tension_release`, `rhythmic_monotony`
 - primary remaining failure count: `2`

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_CONTEXT_PITCH_ROLE_OBJECTIVE_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_CONTEXT_PITCH_ROLE_OBJECTIVE_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -1,0 +1,51 @@
+# Stage B MIDI-to-Solo Pitch-Role Objective Decision
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
+- selected target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
+- primary risk label: `weak_chord_tone_landing_risk`
+- candidate count: `6`
+- not evaluable count: `12 -> 0`
+- follow-up objective source/repaired outside-soloing not evaluable count: `6/6`
+- follow-up repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- bridge repair sweep source/repaired outside-soloing not evaluable count: `6/6`
+- follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up objective source outside-soloing source pitch-role risk delta: `3`
+- follow-up objective source outside-soloing source targeted: `false`
+- follow-up objective source outside-soloing source residual risk preserved: `true`
+- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- follow-up repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up repair sweep source outside-soloing source pitch-role risk delta: `3`
+- follow-up repair sweep source outside-soloing source targeted: `false`
+- follow-up repair sweep source outside-soloing source residual risk preserved: `true`
+- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- bridge repair sweep source outside-soloing source pitch-role risk delta: `3`
+- bridge repair sweep source outside-soloing source targeted: `false`
+- bridge repair sweep source outside-soloing source residual risk preserved: `true`
+- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- weak chord-tone landing risk count: `6`
+- outside-soloing pitch-role risk count: `5`
+- min chord-tone ratio: `0.216`
+- max outside ratio: `0.027`
+- max non-chord run: `5`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Decision
+
+- reason: `largest pitch-role risk count selected as next repair target`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep source-context refresh`
+
+## Claim Boundary
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6667,8 +6667,8 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pit
 }
 
 run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision() {
-  local bridge_run_id="${BRIDGE_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge}"
-  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision}"
+  local bridge_run_id="${BRIDGE_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge_source_context_refresh}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision_source_context_refresh}"
   local bridge_report="outputs/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge/${bridge_run_id}/stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge.json"
   if [[ ! -f "$bridge_report" ]]; then
     print_header "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge"
@@ -6678,8 +6678,8 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pit
   "$PYTHON_BIN" scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective.py \
     --run_id "$run_id" \
     --bridge_report "$bridge_report" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_CONTEXT_PITCH_ROLE_OBJECTIVE_DECISION_2026-06-10.md \
-    --issue_number 872 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_CONTEXT_PITCH_ROLE_OBJECTIVE_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
+    --issue_number 958 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep \
     --expected_target songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep \

--- a/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective.py
+++ b/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(ROOT_DIR))
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
 from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge import (  # noqa: E402
     BOUNDARY as BRIDGE_BOUNDARY,
+    BRIDGE_SOURCE_CONTEXT_KEYS,
     NEXT_BOUNDARY as BRIDGE_NEXT_BOUNDARY,
 )
 
@@ -30,7 +31,7 @@ NEXT_BOUNDARY = (
     "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep"
 )
 SELECTED_TARGET = "songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep"
-SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision_v1"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision_v2"
 PRIMARY_RISK_LABEL = "weak_chord_tone_landing_risk"
 SECONDARY_RISK_LABEL = "outside_soloing_pitch_role_risk"
 QUALITY_CLAIM_KEYS = [
@@ -127,6 +128,38 @@ def validate_bridge_source(report: dict[str, Any]) -> dict[str, Any]:
             "critical user input should not be required"
         )
     _require_no_quality_claim(readiness, label="bridge readiness")
+    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+        if key not in readiness:
+            raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+                f"bridge source-context field required: {key}"
+            )
+    for key in (
+        "followup_objective_source_outside_soloing_source_targeted",
+        "followup_repair_sweep_source_outside_soloing_source_targeted",
+        "repair_sweep_source_outside_soloing_source_targeted",
+    ):
+        if bool(readiness.get(key, True)):
+            raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+                f"source outside-soloing target should remain false: {key}"
+            )
+    for key in (
+        "followup_objective_source_outside_soloing_source_residual_risk_preserved",
+        "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved",
+        "repair_sweep_source_outside_soloing_source_residual_risk_preserved",
+    ):
+        if not bool(readiness.get(key, False)):
+            raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+                f"source outside-soloing residual risk should be preserved: {key}"
+            )
+    for key in (
+        "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after",
+        "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after",
+        "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after",
+    ):
+        if _int(readiness.get(key)) != 0:
+            raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+                f"current outside-soloing risk should remain resolved: {key}"
+            )
     return {
         "boundary": BRIDGE_BOUNDARY,
         "candidate_count": candidate_count,
@@ -155,6 +188,7 @@ def validate_bridge_source(report: dict[str, Any]) -> dict[str, Any]:
         "min_chord_tone_ratio": _float(summary.get("min_chord_tone_ratio")),
         "max_outside_ratio": _float(summary.get("max_outside_ratio")),
         "max_non_chord_tone_run": _int(summary.get("max_non_chord_tone_run")),
+        **{key: readiness.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
     }
 
 
@@ -226,6 +260,7 @@ def build_objective_decision_report(
             "repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
                 bridge["repair_sweep_repaired_outside_soloing_not_evaluable_count"]
             ),
+            **{key: bridge[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
             "not_evaluable_after_count": _int(bridge["not_evaluable_after_count"]),
             "human_audio_preference_claimed": False,
             "audio_rendered_quality_claimed": False,
@@ -252,9 +287,9 @@ def build_objective_decision_report(
             "brad_style_adaptation",
         ],
         "next_recommended_issue": (
-            "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep"
+            "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep source-context refresh"
             if next_boundary == NEXT_BOUNDARY
-            else "Stage B MIDI-to-solo songlike melody contour phrase/rhythm outside-soloing pitch-role repair sweep"
+            else "Stage B MIDI-to-solo songlike melody contour phrase/rhythm outside-soloing pitch-role repair sweep source-context refresh"
         ),
     }
 
@@ -304,6 +339,11 @@ def validate_objective_decision_report(
         )
     if require_no_quality_claim:
         _require_no_quality_claim(readiness, label="objective decision readiness")
+    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+        if key not in readiness:
+            raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+                f"objective source-context field required: {key}"
+            )
     return {
         "boundary": boundary,
         "source_boundary": str(report.get("source_boundary") or ""),
@@ -339,6 +379,7 @@ def validate_objective_decision_report(
         "repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
             readiness.get("repair_sweep_repaired_outside_soloing_not_evaluable_count")
         ),
+        **{key: readiness.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
         "human_audio_preference_claimed": bool(
             readiness.get("human_audio_preference_claimed", True)
         ),
@@ -372,6 +413,21 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- follow-up objective source/repaired outside-soloing not evaluable count: `{summary['followup_objective_source_outside_soloing_not_evaluable_count']}/{summary['followup_objective_repaired_outside_soloing_not_evaluable_count']}`",
         f"- follow-up repair sweep source/repaired outside-soloing not evaluable count: `{summary['followup_repair_sweep_source_outside_soloing_not_evaluable_count']}/{summary['followup_repair_sweep_repaired_outside_soloing_not_evaluable_count']}`",
         f"- bridge repair sweep source/repaired outside-soloing not evaluable count: `{summary['repair_sweep_source_outside_soloing_not_evaluable_count']}/{summary['repair_sweep_repaired_outside_soloing_not_evaluable_count']}`",
+        f"- follow-up objective source outside-soloing source pitch-role risk: `{summary['followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up objective source outside-soloing source pitch-role risk delta: `{summary['followup_objective_source_outside_soloing_source_pitch_role_risk_delta']}`",
+        f"- follow-up objective source outside-soloing source targeted: `{_bool_token(summary['followup_objective_source_outside_soloing_source_targeted'])}`",
+        f"- follow-up objective source outside-soloing source residual risk preserved: `{_bool_token(summary['followup_objective_source_outside_soloing_source_residual_risk_preserved'])}`",
+        f"- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `{summary['followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']} / {summary['followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- follow-up repair sweep source outside-soloing source pitch-role risk: `{summary['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up repair sweep source outside-soloing source pitch-role risk delta: `{summary['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta']}`",
+        f"- follow-up repair sweep source outside-soloing source targeted: `{_bool_token(summary['followup_repair_sweep_source_outside_soloing_source_targeted'])}`",
+        f"- follow-up repair sweep source outside-soloing source residual risk preserved: `{_bool_token(summary['followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved'])}`",
+        f"- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `{summary['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {summary['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- bridge repair sweep source outside-soloing source pitch-role risk: `{summary['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- bridge repair sweep source outside-soloing source pitch-role risk delta: `{summary['repair_sweep_source_outside_soloing_source_pitch_role_risk_delta']}`",
+        f"- bridge repair sweep source outside-soloing source targeted: `{_bool_token(summary['repair_sweep_source_outside_soloing_source_targeted'])}`",
+        f"- bridge repair sweep source outside-soloing source residual risk preserved: `{_bool_token(summary['repair_sweep_source_outside_soloing_source_residual_risk_preserved'])}`",
+        f"- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `{summary['repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {summary['repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- weak chord-tone landing risk count: `{summary['weak_chord_tone_landing_risk_count']}`",
         f"- outside-soloing pitch-role risk count: `{summary['outside_soloing_pitch_role_risk_count']}`",
         f"- min chord-tone ratio: `{summary['min_chord_tone_ratio']:.3f}`",
@@ -408,7 +464,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=872)
+    parser.add_argument("--issue_number", type=int, default=958)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--expected_target", type=str, default="")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision.py
@@ -49,6 +49,27 @@ def bridge_report(*, quality_claim: bool = False, weak_count: int = 6, outside_c
             "followup_repair_sweep_repaired_outside_soloing_not_evaluable_count": 6,
             "repair_sweep_source_outside_soloing_not_evaluable_count": 6,
             "repair_sweep_repaired_outside_soloing_not_evaluable_count": 6,
+            "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+            "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+            "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
+            "followup_objective_source_outside_soloing_source_targeted": False,
+            "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+            "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+            "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+            "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+            "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+            "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+            "followup_repair_sweep_source_outside_soloing_source_targeted": False,
+            "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+            "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+            "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+            "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+            "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+            "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+            "repair_sweep_source_outside_soloing_source_targeted": False,
+            "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+            "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+            "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
             "audio_rendered_quality_claimed": False,
@@ -71,7 +92,7 @@ class StageBMidiToSoloPitchRoleObjectiveDecisionTest(unittest.TestCase):
             report = build_objective_decision_report(
                 bridge_report=bridge_report(),
                 output_dir=Path(tmp) / "decision",
-                issue_number=872,
+                issue_number=958,
             )
             summary = validate_objective_decision_report(
                 report,
@@ -108,6 +129,50 @@ class StageBMidiToSoloPitchRoleObjectiveDecisionTest(unittest.TestCase):
                 summary["repair_sweep_repaired_outside_soloing_not_evaluable_count"],
                 6,
             )
+            self.assertEqual(
+                summary[
+                    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before"
+                ],
+                5,
+            )
+            self.assertEqual(
+                summary[
+                    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after"
+                ],
+                2,
+            )
+            self.assertEqual(
+                summary["followup_objective_source_outside_soloing_source_pitch_role_risk_delta"],
+                3,
+            )
+            self.assertFalse(
+                summary["followup_objective_source_outside_soloing_source_targeted"]
+            )
+            self.assertTrue(
+                summary[
+                    "followup_objective_source_outside_soloing_source_residual_risk_preserved"
+                ]
+            )
+            self.assertEqual(
+                summary[
+                    "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after"
+                ],
+                0,
+            )
+            self.assertEqual(
+                summary["followup_objective_source_outside_soloing_current_pitch_role_risk_delta"],
+                2,
+            )
+            self.assertEqual(
+                summary[
+                    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before"
+                ],
+                5,
+            )
+            self.assertEqual(
+                summary["repair_sweep_source_outside_soloing_source_pitch_role_risk_delta"],
+                3,
+            )
             self.assertEqual(summary["selected_target"], SELECTED_TARGET)
             self.assertFalse(summary["human_audio_preference_claimed"])
             self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
@@ -118,7 +183,7 @@ class StageBMidiToSoloPitchRoleObjectiveDecisionTest(unittest.TestCase):
                 build_objective_decision_report(
                     bridge_report=bridge_report(quality_claim=True),
                     output_dir=Path(tmp) / "decision",
-                    issue_number=872,
+                    issue_number=958,
                 )
 
     def test_routes_outside_soloing_when_it_dominates(self) -> None:
@@ -126,7 +191,7 @@ class StageBMidiToSoloPitchRoleObjectiveDecisionTest(unittest.TestCase):
             report = build_objective_decision_report(
                 bridge_report=bridge_report(weak_count=2, outside_count=5),
                 output_dir=Path(tmp) / "decision",
-                issue_number=872,
+                issue_number=958,
             )
             summary = validate_objective_decision_report(
                 report,
@@ -152,7 +217,35 @@ class StageBMidiToSoloPitchRoleObjectiveDecisionTest(unittest.TestCase):
                 build_objective_decision_report(
                     bridge_report=source,
                     output_dir=Path(tmp) / "decision",
-                    issue_number=872,
+                    issue_number=958,
+                )
+
+    def test_rejects_missing_bridge_source_context_field(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = bridge_report()
+            del source["readiness"][
+                "followup_objective_source_outside_soloing_source_pitch_role_risk_delta"
+            ]
+
+            with self.assertRaises(StageBMidiToSoloPitchRoleObjectiveDecisionError):
+                build_objective_decision_report(
+                    bridge_report=source,
+                    output_dir=Path(tmp) / "decision",
+                    issue_number=958,
+                )
+
+    def test_rejects_source_context_targeted_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = bridge_report()
+            source["readiness"][
+                "repair_sweep_source_outside_soloing_source_targeted"
+            ] = True
+
+            with self.assertRaises(StageBMidiToSoloPitchRoleObjectiveDecisionError):
+                build_objective_decision_report(
+                    bridge_report=source,
+                    output_dir=Path(tmp) / "decision",
+                    issue_number=958,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
Summary
- chord-context pitch-role objective decision source-context 보존 검증
- bridge report의 source/current outside-soloing risk context를 objective decision readiness와 summary에 반영
- weak chord-tone landing repair sweep을 다음 target으로 선택

Context
- #956 bridge 결과, context not-evaluable count: 12 -> 0
- candidate count: 6
- weak chord-tone landing risk count: 6
- outside-soloing pitch-role risk count: 5
- source outside-soloing pitch-role risk: 5 -> 2, delta 3
- current outside-soloing pitch-role risk after/delta: 0 / 2
- human/audio preference claim: false
- MIDI-to-solo musical quality claim: false

Scope
- objective decision bridge source-context validation
- objective readiness / validation summary / markdown source-context field propagation
- generated objective decision report / README / current status / core plan 갱신
- harness run id, doc path, issue number 갱신

Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision
- .venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective.py
- bash -n scripts/agent_harness.sh
- git diff --check
- bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-context-pitch-role-objective-decision
- bash scripts/agent_harness.sh quick

Risk
- human/audio preference unclaimed
- MIDI-to-solo musical quality unclaimed
- selected repair target is objective-count based, not listening preference based

Follow-up
- Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep source-context refresh

Closes #958