### PR TITLE
Stage B MIDI-to-solo current evidence source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #898, Stage B MIDI-to-solo current evidence source-context refresh.
+- Latest functional issue completed: Issue #982, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh.
 - Latest audit issue completed: Issue #902, Stage B MIDI-to-solo MVP completion audit source-context refresh.
 - Latest quality gap decision completed: Issue #904, Stage B MIDI-to-solo quality gap decision source-context refresh.
 - Latest listening review quality gap completed: Issue #906, Stage B MIDI-to-solo listening review quality gap source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #980, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh.
+- Open issue queue after MVP current evidence consolidation source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo README evidence source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest functional result: `Issue #898`
+- latest functional result: `Issue #982`
 - latest MVP completion audit: `Issue #902`
 - latest quality gap decision: `Issue #904`
 - latest listening review quality gap: `Issue #906`
@@ -47,9 +47,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package: `Issue #976`
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard: `Issue #978`
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision: `Issue #980`
+- latest MVP current evidence consolidation: `Issue #982`
 - latest README evidence refresh: `Issue #900`
-- latest functional boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_only_next_decision`
-- open issue queue after songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh merge: `0`
+- latest functional boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- open issue queue after MVP current evidence consolidation source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -128,6 +129,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - phrase/rhythm chord-tone landing outside-soloing repair selected target: `current_evidence_consolidation`
 - phrase/rhythm chord-tone landing outside-soloing repair objective path supported: `true`
 - phrase/rhythm chord-tone landing outside-soloing repair current evidence consolidation ready: `true`
+- phrase/rhythm chord-tone landing outside-soloing repair source context preserved: `true`
 - phrase/rhythm repair technical WAV validation: `true`
 - phrase/rhythm repair source outside-soloing pitch-role risk: `5 -> 2`
 - phrase/rhythm repair current outside-soloing pitch-role risk after / delta: `0 / 2`
@@ -241,6 +243,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - pitch-contour changed-ratio repair max pitch changed ratio / target: `0.4348 / 0.5000`
 - current evidence changed-ratio repair objective path included: `true`
 - outside-soloing repair objective path included in current evidence: `true`
+- outside-soloing repair source context preserved in current evidence: `true`
 - outside-soloing repair WAV files: `6`
 - outside-soloing repair changed note total: `2`
 - outside-soloing source pitch-role risk: `5 -> 2`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -9931,6 +9931,55 @@ Issue #980은 Issue #978 input guard의 pending listening review 상태와 sourc
 
 - `Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh`
 
+## 9.181 Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
+
+Issue #982는 Issue #980 outside-soloing repair objective-only next decision 결과를 MVP current evidence consolidation에 반영하고, source/current outside-soloing context 21개 필드를 current evidence report, validation summary, markdown report까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- next boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
+- current MVP evidence supported: `true`
+- technical execution evidence supported: `true`
+- selected-scale objective path complete: `true`
+- phrase-bank CLI technical path ready: `true`
+- model-conditioned pitch-contour objective path ready: `true`
+- model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
+- outside-soloing repair objective path ready: `true`
+- outside-soloing repair source context preserved: `true`
+- outside-soloing repair rendered audio file count: `6`
+- outside-soloing repair changed note total: `2`
+- source objective outside-soloing pitch-role risk count: `5`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- source outside-soloing pitch-role risk delta: `3`
+- source outside-soloing repair targeted: `false`
+- source outside-soloing residual risk preserved: `true`
+- outside-soloing pitch-role risk after / delta: `0 / 2`
+- outside-soloing repair objective path supported: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- #980 objective evidence를 current evidence 경계에 반영.
+- source outside-soloing context `5 -> 2`와 current repair result `2 -> 0` 분리 보존.
+- current evidence support는 objective proxy와 technical path 기준 true.
+- human/audio preference, MIDI-to-solo musical quality, broad trained model quality claim 제외.
+- 다음 boundary는 README evidence refresh.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- `.venv/bin/python -m py_compile scripts/consolidate_stage_b_midi_to_solo_mvp_current_evidence.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-current-evidence-consolidation`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo README evidence source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,7 +12,7 @@
 
 현재 active issue:
 
-- latest functional result: Issue #898, Stage B MIDI-to-solo current evidence source-context refresh
+- latest functional result: Issue #982, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest MVP completion audit: Issue #902, Stage B MIDI-to-solo MVP completion audit source-context refresh
 - latest quality gap decision: Issue #904, Stage B MIDI-to-solo quality gap decision source-context refresh
 - latest listening review quality gap: Issue #906, Stage B MIDI-to-solo listening review quality gap source-context refresh
@@ -53,10 +53,11 @@
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package: Issue #976, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard: Issue #978, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision: Issue #980, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh
+- latest MVP current evidence consolidation: Issue #982, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh`
+- open issue queue after MVP current evidence consolidation source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo README evidence source-context refresh`
 
 현재 범위가 아닌 것:
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MVP_CURRENT_EVIDENCE_CONSOLIDATION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MVP_CURRENT_EVIDENCE_CONSOLIDATION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -11,6 +11,7 @@
 - model-conditioned pitch-contour objective path ready: `true`
 - model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
 - outside-soloing repair objective path ready: `true`
+- outside-soloing repair source context preserved: `true`
 - human/audio preference claimed: `false`
 - MIDI-to-solo musical quality claimed: `false`
 
@@ -96,6 +97,12 @@
 - source outside-soloing repair targeted: `false`
 - source outside-soloing residual risk preserved: `true`
 - outside-soloing pitch-role risk after / delta: `0` / `2`
+- follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- follow-up repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
 - outside-soloing target supported: `true`
 - weak landing target supported: `true`
 - final landing chord-tone count after: `6`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -5922,8 +5922,8 @@ run_stage_b_midi_to_solo_mvp_current_evidence_consolidation() {
   local cli_objective_next_run_id="${CLI_OBJECTIVE_NEXT_RUN_ID:-harness_stage_b_midi_to_solo_phrase_bank_cli_objective_only_next_decision}"
   local model_conditioned_pitch_contour_objective_next_run_id="${MODEL_CONDITIONED_PITCH_CONTOUR_OBJECTIVE_NEXT_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_input_path_dead_air_timing_repair_pitch_contour_objective_next}"
   local model_conditioned_pitch_contour_changed_ratio_repair_objective_next_run_id="${MODEL_CONDITIONED_PITCH_CONTOUR_CHANGED_RATIO_REPAIR_OBJECTIVE_NEXT_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_objective_next}"
-  local outside_soloing_repair_objective_next_run_id="${OUTSIDE_SOLOING_REPAIR_OBJECTIVE_NEXT_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_only_next_decision}"
-  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_mvp_current_evidence_consolidation}"
+  local outside_soloing_repair_objective_next_run_id="${OUTSIDE_SOLOING_REPAIR_OBJECTIVE_NEXT_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_only_next_decision_source_context_refresh}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_mvp_current_evidence_consolidation_source_context_refresh}"
   local contract_report="outputs/stage_b_midi_to_solo_mvp_contract/${contract_run_id}/stage_b_midi_to_solo_mvp_contract.json"
   local context_report="outputs/stage_b_midi_to_solo_context_extraction/${context_run_id}/stage_b_midi_to_solo_context_extraction.json"
   local resource_probe="outputs/stage_b_midi_to_solo_training_resource_probe/${resource_run_id}/stage_b_midi_to_solo_training_resource_probe.json"
@@ -5988,7 +5988,7 @@ run_stage_b_midi_to_solo_mvp_current_evidence_consolidation() {
     --model_conditioned_pitch_contour_changed_ratio_repair_objective_next "$model_conditioned_pitch_contour_changed_ratio_repair_objective_next" \
     --outside_soloing_repair_objective_next "$outside_soloing_repair_objective_next" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_CURRENT_EVIDENCE_CONSOLIDATION_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 898 \
+    --issue_number 982 \
     --expected_boundary stage_b_midi_to_solo_mvp_current_evidence_consolidation \
     --expected_next_boundary stage_b_midi_to_solo_readme_evidence_refresh \
     --min_exported_candidates 3 \

--- a/scripts/consolidate_stage_b_midi_to_solo_mvp_current_evidence.py
+++ b/scripts/consolidate_stage_b_midi_to_solo_mvp_current_evidence.py
@@ -21,7 +21,7 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationError(ValueError):
 
 BOUNDARY = "stage_b_midi_to_solo_mvp_current_evidence_consolidation"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_readme_evidence_refresh"
-SCHEMA_VERSION = "stage_b_midi_to_solo_mvp_current_evidence_consolidation_v1"
+SCHEMA_VERSION = "stage_b_midi_to_solo_mvp_current_evidence_consolidation_v2"
 
 CONTRACT_BOUNDARY = "stage_b_midi_to_solo_mvp_input_contract"
 CONTEXT_BOUNDARY = "stage_b_midi_to_solo_context_extraction_mvp"
@@ -48,6 +48,29 @@ MODEL_CONDITIONED_PITCH_CONTOUR_CHANGED_RATIO_REPAIR_OBJECTIVE_BOUNDARY = (
 OUTSIDE_SOLOING_REPAIR_OBJECTIVE_BOUNDARY = (
     "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_"
     "outside_soloing_repair_objective_only_next_decision"
+)
+BRIDGE_SOURCE_CONTEXT_KEYS = (
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before",
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after",
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_delta",
+    "followup_objective_source_outside_soloing_source_targeted",
+    "followup_objective_source_outside_soloing_source_residual_risk_preserved",
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after",
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_delta",
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before",
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after",
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta",
+    "followup_repair_sweep_source_outside_soloing_source_targeted",
+    "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved",
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after",
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta",
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before",
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after",
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta",
+    "repair_sweep_source_outside_soloing_source_targeted",
+    "repair_sweep_source_outside_soloing_source_residual_risk_preserved",
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after",
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta",
 )
 
 
@@ -79,6 +102,15 @@ def _bool_token(value: Any) -> str:
 
 def _artifact_exists(path: str) -> bool:
     return bool(path and Path(path).exists())
+
+
+def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str, Any]:
+    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+        if key not in container:
+            raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+                f"{label} source-context field required: {key}"
+            )
+    return {key: container[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS}
 
 
 def _duration_range(items: list[dict[str, Any]]) -> dict[str, float]:
@@ -729,6 +761,10 @@ def validate_outside_soloing_repair_objective_next(
         raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
             f"unexpected outside-soloing repair claim: {claimed}"
         )
+    source_context = _source_context_fields(
+        summary,
+        label="outside-soloing repair objective summary",
+    )
     return {
         "boundary": OUTSIDE_SOLOING_REPAIR_OBJECTIVE_BOUNDARY,
         "objective_next_completed": bool(readiness.get("objective_next_completed", False)),
@@ -792,6 +828,7 @@ def validate_outside_soloing_repair_objective_next(
         "non_chord_run_target_supported": bool(
             summary.get("non_chord_run_target_supported", False)
         ),
+        **source_context,
     }
 
 
@@ -935,6 +972,13 @@ def build_current_evidence_consolidation_report(
             ),
             "outside_soloing_repair_objective_path_ready": bool(
                 outside_soloing_repair_objective_path_ready
+            ),
+            "outside_soloing_repair_source_context_preserved": bool(
+                outside_soloing_repair_objective
+            )
+            and all(
+                key in outside_soloing_repair_objective
+                for key in BRIDGE_SOURCE_CONTEXT_KEYS
             ),
             "current_mvp_technical_execution_evidence_supported": technical_path_supported,
             "current_mvp_objective_repair_evidence_supported": selected_scale_objective_path_complete,
@@ -1232,6 +1276,10 @@ def validate_current_evidence_consolidation_report(
                 False,
             )
         ),
+        "outside_soloing_repair_source_context_preserved": bool(
+            readiness.get("outside_soloing_repair_source_context_preserved", False)
+        ),
+        **{key: outside_soloing_repair.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
         "cli_candidate_count": _int(cli_objective.get("candidate_count")),
         "cli_rendered_audio_file_count": _int(cli_objective.get("rendered_audio_file_count")),
         "cli_input_context_bars": _int(cli_objective.get("input_context_bars")),
@@ -1295,6 +1343,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- model-conditioned pitch-contour objective path ready: `{_bool_token(readiness['model_conditioned_pitch_contour_objective_path_ready'])}`",
         f"- model-conditioned pitch-contour changed-ratio repair objective path ready: `{_bool_token(readiness['model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready'])}`",
         f"- outside-soloing repair objective path ready: `{_bool_token(readiness['outside_soloing_repair_objective_path_ready'])}`",
+        f"- outside-soloing repair source context preserved: `{_bool_token(readiness['outside_soloing_repair_source_context_preserved'])}`",
         f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
         f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
         "",
@@ -1394,6 +1443,12 @@ def markdown_report(report: dict[str, Any]) -> str:
                 f"- source outside-soloing repair targeted: `{_bool_token(outside_soloing_repair['source_outside_soloing_repair_targeted'])}`",
                 f"- source outside-soloing residual risk preserved: `{_bool_token(outside_soloing_repair['source_outside_soloing_residual_risk_preserved'])}`",
                 f"- outside-soloing pitch-role risk after / delta: `{outside_soloing_repair['outside_soloing_pitch_role_risk_count_after']}` / `{outside_soloing_repair['outside_soloing_pitch_role_risk_delta']}`",
+                f"- follow-up objective source outside-soloing source pitch-role risk: `{outside_soloing_repair['followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {outside_soloing_repair['followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+                f"- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `{outside_soloing_repair['followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']} / {outside_soloing_repair['followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+                f"- follow-up repair sweep source outside-soloing source pitch-role risk: `{outside_soloing_repair['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {outside_soloing_repair['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+                f"- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `{outside_soloing_repair['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {outside_soloing_repair['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
+                f"- bridge repair sweep source outside-soloing source pitch-role risk: `{outside_soloing_repair['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {outside_soloing_repair['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+                f"- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `{outside_soloing_repair['repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {outside_soloing_repair['repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
                 f"- outside-soloing target supported: `{_bool_token(outside_soloing_repair['outside_soloing_target_supported'])}`",
                 f"- weak landing target supported: `{_bool_token(outside_soloing_repair['weak_landing_target_supported'])}`",
                 f"- final landing chord-tone count after: `{outside_soloing_repair['final_landing_chord_tone_count_after']}`",

--- a/tests/test_stage_b_midi_to_solo_mvp_current_evidence_consolidation.py
+++ b/tests/test_stage_b_midi_to_solo_mvp_current_evidence_consolidation.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from scripts.consolidate_stage_b_midi_to_solo_mvp_current_evidence import (
     BOUNDARY,
+    BRIDGE_SOURCE_CONTEXT_KEYS,
     NEXT_BOUNDARY,
     OBJECTIVE_FINAL_BOUNDARY,
     OBJECTIVE_NEXT_BOUNDARY,
@@ -19,6 +20,31 @@ def touch(path: Path) -> str:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(b"x")
     return str(path)
+
+
+SOURCE_CONTEXT = {
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_objective_source_outside_soloing_source_targeted": False,
+    "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_repair_sweep_source_outside_soloing_source_targeted": False,
+    "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "repair_sweep_source_outside_soloing_source_targeted": False,
+    "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+}
 
 
 def reports(
@@ -331,6 +357,7 @@ def reports(
                     outside_soloing_repair_supported
                 ),
                 "current_evidence_consolidation_ready": outside_soloing_repair_supported,
+                **SOURCE_CONTEXT,
             },
             "readiness": {
                 "objective_next_completed": True,
@@ -374,7 +401,7 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationTest(unittest.TestCase):
                     "outside_soloing_repair_objective"
                 ],
                 output_dir=Path(tmp) / "out",
-                issue_number=812,
+                issue_number=982,
             )
             summary = validate_current_evidence_consolidation_report(
                 report,
@@ -474,6 +501,10 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationTest(unittest.TestCase):
             self.assertTrue(summary["outside_soloing_repair_final_landing_target_supported"])
             self.assertTrue(summary["outside_soloing_repair_non_chord_run_target_supported"])
             self.assertTrue(summary["outside_soloing_repair_objective_path_supported"])
+            self.assertTrue(summary["outside_soloing_repair_source_context_preserved"])
+            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+                self.assertIn(key, report["outside_soloing_repair_objective_path"])
+                self.assertEqual(summary[key], SOURCE_CONTEXT[key])
             self.assertFalse(summary["human_audio_preference_claimed"])
             self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
             self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
@@ -634,6 +665,33 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationTest(unittest.TestCase):
                     ],
                     output_dir=Path(tmp) / "out",
                     issue_number=898,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            data = reports(Path(tmp))
+            del data["outside_soloing_repair_objective"]["objective_summary"][
+                "followup_objective_source_outside_soloing_source_pitch_role_risk_delta"
+            ]
+            with self.assertRaises(StageBMidiToSoloMvpCurrentEvidenceConsolidationError):
+                build_current_evidence_consolidation_report(
+                    contract_report=data["contract"],
+                    context_report=data["context"],
+                    resource_probe=data["resource"],
+                    generation_probe=data["generation"],
+                    audio_render=data["audio"],
+                    objective_next=data["objective"],
+                    cli_objective_next=data["cli_objective"],
+                    model_conditioned_pitch_contour_objective_next=data[
+                        "model_conditioned_pitch_contour_objective"
+                    ],
+                    model_conditioned_pitch_contour_changed_ratio_repair_objective_next=data[
+                        "model_conditioned_pitch_contour_changed_ratio_repair_objective"
+                    ],
+                    outside_soloing_repair_objective_next=data[
+                        "outside_soloing_repair_objective"
+                    ],
+                    output_dir=Path(tmp) / "out",
+                    issue_number=982,
                 )
 
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- MVP current evidence consolidation outside-soloing source-context 보존
- #980 objective evidence를 current evidence report, validation summary, markdown report에 반영
- next boundary `stage_b_midi_to_solo_readme_evidence_refresh` 유지

## Context
- Issue #980 objective next decision 결과: current evidence consolidation ready `true`
- source outside-soloing pitch-role risk: `5 -> 2`
- current repair outside-soloing pitch-role risk after/delta: `0 / 2`
- rendered WAV count: `6`
- changed note total: `2`
- technical WAV validation: `true`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Scope
- current evidence consolidation source-context required field validation 추가
- outside-soloing repair objective path summary/readiness/validation 필드 보존
- #982 harness run/doc/issue 기준 갱신
- README, CURRENT_STATUS, CORE_PLAN, AGENTS handoff 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_current_evidence_consolidation`
- `.venv/bin/python -m py_compile scripts/consolidate_stage_b_midi_to_solo_mvp_current_evidence.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-current-evidence-consolidation`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- objective proxy consolidation 범위
- human/audio preference claim 제외
- MIDI-to-solo musical quality claim 제외
- 다음 README evidence refresh 반영 필요

Closes #982