### PR TITLE
Stage B MIDI-to-solo README evidence source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,10 +53,10 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package completed: Issue #976, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard completed: Issue #978, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #980, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
-- Latest documentation issue completed: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh.
+- Latest documentation issue completed: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after MVP current evidence consolidation source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo README evidence source-context refresh.
+- Open issue queue after README evidence source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo MVP completion audit source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard: `Issue #978`
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision: `Issue #980`
 - latest MVP current evidence consolidation: `Issue #982`
-- latest README evidence refresh: `Issue #900`
+- latest README evidence refresh: `Issue #984`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
-- open issue queue after MVP current evidence consolidation source-context refresh merge: `0`
+- open issue queue after README evidence source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -432,6 +432,7 @@ MVP current evidence refresh.
 - model-conditioned pitch-contour objective path ready: `true`
 - model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
 - outside-soloing repair objective path ready: `true`
+- outside-soloing repair source context preserved: `true`
 - outside-soloing repair rendered audio file count: `6`
 - outside-soloing repair changed note total: `2`
 - outside-soloing source objective pitch-role risk count: `5`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -9980,6 +9980,43 @@ Issue #982는 Issue #980 outside-soloing repair objective-only next decision 결
 
 - `Stage B MIDI-to-solo README evidence source-context refresh`
 
+## 9.182 Stage B MIDI-to-solo README evidence source-context refresh
+
+Issue #984는 Issue #982 MVP current evidence consolidation 결과를 README evidence block과 상태 문서에 반영한 문서 정합성 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
+- source boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- latest evidence boundary reflected: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- current MVP evidence supported: `true`
+- outside-soloing repair objective path ready: `true`
+- outside-soloing repair source context preserved: `true`
+- outside-soloing repair rendered audio file count: `6`
+- outside-soloing repair changed note total: `2`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- source outside-soloing repair targeted: `false`
+- source outside-soloing residual risk preserved: `true`
+- current repair outside-soloing pitch-role risk count after / delta: `0 / 2`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+
+판단:
+
+- README current evidence block에 #982 source-context preserved 결과 반영.
+- source risk boundary와 current repair objective result 분리 유지.
+- 품질/선호 claim 제외.
+- 다음 boundary는 MVP completion audit.
+
+검증:
+
+- `git diff --check`
+- `bash scripts/agent_harness.sh quick`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo MVP completion audit source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -54,10 +54,10 @@
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard: Issue #978, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision: Issue #980, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh
 - latest MVP current evidence consolidation: Issue #982, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
-- latest README evidence refresh: Issue #900, Stage B MIDI-to-solo README evidence source-context refresh
+- latest README evidence refresh: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after MVP current evidence consolidation source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo README evidence source-context refresh`
+- open issue queue after README evidence source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo MVP completion audit source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -887,6 +887,7 @@
 - model-conditioned pitch-contour objective path ready: `true`
 - model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
 - outside-soloing repair objective path ready: `true`
+- outside-soloing repair source context preserved: `true`
 - outside-soloing repair rendered audio file count: `6`
 - outside-soloing repair changed note total: `2`
 - source objective outside-soloing pitch-role risk count: `5`
@@ -904,6 +905,7 @@
 - latest evidence boundary reflected: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence supported: `true`
 - outside-soloing repair objective path ready: `true`
+- outside-soloing repair source context preserved: `true`
 - outside-soloing repair rendered audio file count: `6`
 - outside-soloing source pitch-role risk count: `5 -> 2`
 - outside-soloing source residual risk preserved: `true`

--- a/docs/STAGE_B_MIDI_TO_SOLO_README_EVIDENCE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_README_EVIDENCE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -11,6 +11,7 @@
 
 - current MVP evidence supported: `true`
 - outside-soloing repair objective path ready: `true`
+- outside-soloing repair source context preserved: `true`
 - outside-soloing repair rendered audio file count: `6`
 - outside-soloing repair changed note total: `2`
 - source objective outside-soloing pitch-role risk count: `5`


### PR DESCRIPTION
## Summary
- README evidence source-context refresh
- #982 current evidence consolidation 결과를 README evidence block과 상태 문서에 반영
- next boundary `stage_b_midi_to_solo_mvp_completion_audit` 기록

## Context
- current MVP evidence supported: `true`
- outside-soloing repair objective path ready: `true`
- outside-soloing repair source context preserved: `true`
- outside-soloing repair rendered audio file count: `6`
- source outside-soloing pitch-role risk: `5 -> 2`
- current repair outside-soloing pitch-role risk after/delta: `0 / 2`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Scope
- README latest evidence issue 및 source-context preserved 항목 갱신
- README evidence source-context refresh 문서 갱신
- CURRENT_STATUS, CORE_PLAN, AGENTS handoff 갱신

## Validation
- `git diff --check`
- `bash scripts/agent_harness.sh quick`

## Risk
- 문서 정합성 범위
- 모델 품질/선호 claim 제외
- 다음 MVP completion audit 반영 필요

Closes #984