### PR TITLE
Stage B MIDI-to-solo MVP completion audit source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Primary goal:
 Current handoff scope:
 
 - Latest functional issue completed: Issue #982, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh.
-- Latest audit issue completed: Issue #902, Stage B MIDI-to-solo MVP completion audit source-context refresh.
+- Latest audit issue completed: Issue #986, Stage B MIDI-to-solo MVP completion audit source-context refresh.
 - Latest quality gap decision completed: Issue #904, Stage B MIDI-to-solo quality gap decision source-context refresh.
 - Latest listening review quality gap completed: Issue #906, Stage B MIDI-to-solo listening review quality gap source-context refresh.
 - Latest MVP delivery package completed: Issue #908, Stage B MIDI-to-solo MVP delivery package source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #980, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after README evidence source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo MVP completion audit source-context refresh.
+- Open issue queue after MVP completion audit source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo quality gap decision source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 ## 현재 상태
 
 - latest functional result: `Issue #982`
-- latest MVP completion audit: `Issue #902`
+- latest MVP completion audit: `Issue #986`
 - latest quality gap decision: `Issue #904`
 - latest listening review quality gap: `Issue #906`
 - latest MVP delivery package: `Issue #908`
@@ -218,6 +218,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - MVP completion audit changed-ratio repair objective included: `true`
 - MVP completion audit outside-soloing repair objective included: `true`
 - MVP completion audit outside-soloing source context included: `true`
+- MVP completion audit outside-soloing source context preserved: `true`
 - quality gap decision completed: `true`
 - quality gap decision listening review target selected: `true`
 - quality gap decision outside-soloing repair objective included: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -10017,6 +10017,50 @@ Issue #984는 Issue #982 MVP current evidence consolidation 결과를 README evi
 
 - `Stage B MIDI-to-solo MVP completion audit source-context refresh`
 
+## 9.183 Stage B MIDI-to-solo MVP completion audit source-context refresh
+
+Issue #986은 Issue #982 current evidence와 Issue #984 README evidence refresh를 기준으로 technical model-core MVP completion audit을 갱신하고, outside-soloing source/current context 보존 여부를 audit summary까지 반영한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- next boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- technical model-core MVP completed: `true`
+- input to ranked MIDI completed: `true`
+- input to rendered WAV completed: `true`
+- selected-scale objective repair completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour changed-ratio repair objective completed: `true`
+- outside-soloing repair objective completed: `true`
+- outside-soloing repair source context preserved: `true`
+- outside-soloing repair rendered audio file count: `6`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- current repair outside-soloing pitch-role risk count after / delta: `0 / 2`
+- musical quality MVP completed: `false`
+- human/audio preference completed: `false`
+- product MVP completed: `false`
+
+판단:
+
+- technical model-core MVP completion은 current evidence와 README refresh 기준 완료.
+- source/current outside-soloing context 보존 여부 audit summary에 반영.
+- musical quality MVP, human/audio preference, product MVP claim 제외.
+- 다음 boundary는 quality gap decision.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
+- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_mvp_completion.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo quality gap decision source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -13,7 +13,7 @@
 현재 active issue:
 
 - latest functional result: Issue #982, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
-- latest MVP completion audit: Issue #902, Stage B MIDI-to-solo MVP completion audit source-context refresh
+- latest MVP completion audit: Issue #986, Stage B MIDI-to-solo MVP completion audit source-context refresh
 - latest quality gap decision: Issue #904, Stage B MIDI-to-solo quality gap decision source-context refresh
 - latest listening review quality gap: Issue #906, Stage B MIDI-to-solo listening review quality gap source-context refresh
 - latest MVP delivery package: Issue #908, Stage B MIDI-to-solo MVP delivery package source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #982, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after README evidence source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo MVP completion audit source-context refresh`
+- open issue queue after MVP completion audit source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo quality gap decision source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -917,6 +917,7 @@
 - MVP completion audit source-context refresh 완료
 - technical model-core MVP completed: `true`
 - outside-soloing repair objective completed: `true`
+- outside-soloing repair source context preserved: `true`
 - outside-soloing repair rendered audio file count: `6`
 - outside-soloing source pitch-role risk count: `5 -> 2`
 - outside-soloing source repair targeted: `false`

--- a/docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -9,6 +9,7 @@
 - model-conditioned pitch-contour objective completed: `true`
 - model-conditioned pitch-contour changed-ratio repair objective completed: `true`
 - outside-soloing repair objective completed: `true`
+- outside-soloing repair source context preserved: `true`
 - musical quality MVP completed: `false`
 - human/audio preference completed: `false`
 - product MVP completed: `false`
@@ -46,6 +47,7 @@
 - model-conditioned pitch-contour changed-ratio repair audio review required: `true`
 - model-conditioned pitch-contour changed-ratio repair preference fill allowed: `false`
 - outside-soloing repair objective path ready: `true`
+- outside-soloing repair source context preserved: `true`
 - outside-soloing repair current evidence ready: `true`
 - outside-soloing repair rendered WAV files: `6`
 - outside-soloing repair changed note total: `2`
@@ -54,6 +56,12 @@
 - outside-soloing source repair targeted: `false`
 - outside-soloing source residual risk preserved: `true`
 - outside-soloing pitch-role risk after / delta: `0` / `2`
+- follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- follow-up repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
 - outside-soloing repair objective path supported: `true`
 - outside-soloing repair target supported: `true`
 - outside-soloing repair weak landing target supported: `true`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6002,8 +6002,8 @@ run_stage_b_midi_to_solo_mvp_current_evidence_consolidation() {
 }
 
 run_stage_b_midi_to_solo_mvp_completion_audit() {
-  local current_evidence_run_id="${CURRENT_EVIDENCE_RUN_ID:-harness_stage_b_midi_to_solo_mvp_current_evidence_consolidation}"
-  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_mvp_completion_audit}"
+  local current_evidence_run_id="${CURRENT_EVIDENCE_RUN_ID:-harness_stage_b_midi_to_solo_mvp_current_evidence_consolidation_source_context_refresh}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_mvp_completion_audit_source_context_refresh}"
   local current_evidence="outputs/stage_b_midi_to_solo_mvp_current_evidence_consolidation/${current_evidence_run_id}/stage_b_midi_to_solo_mvp_current_evidence_consolidation.json"
   if [[ ! -f "$current_evidence" ]]; then
     print_header "Stage B MIDI-to-solo MVP current evidence consolidation"
@@ -6015,7 +6015,7 @@ run_stage_b_midi_to_solo_mvp_completion_audit() {
     --current_evidence "$current_evidence" \
     --readme_path README.md \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 902 \
+    --issue_number 986 \
     --expected_boundary stage_b_midi_to_solo_mvp_completion_audit \
     --expected_next_boundary stage_b_midi_to_solo_quality_gap_decision \
     --require_technical_mvp_completion \

--- a/scripts/audit_stage_b_midi_to_solo_mvp_completion.py
+++ b/scripts/audit_stage_b_midi_to_solo_mvp_completion.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
 from scripts.consolidate_stage_b_midi_to_solo_mvp_current_evidence import (  # noqa: E402
+    BRIDGE_SOURCE_CONTEXT_KEYS,
     BOUNDARY as CURRENT_EVIDENCE_BOUNDARY,
 )
 
@@ -24,7 +25,7 @@ class StageBMidiToSoloMvpCompletionAuditError(ValueError):
 
 BOUNDARY = "stage_b_midi_to_solo_mvp_completion_audit"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_quality_gap_decision"
-SCHEMA_VERSION = "stage_b_midi_to_solo_mvp_completion_audit_v1"
+SCHEMA_VERSION = "stage_b_midi_to_solo_mvp_completion_audit_v2"
 
 
 def _dict(value: Any) -> dict[str, Any]:
@@ -51,6 +52,15 @@ def _float(value: Any) -> float:
 
 def _bool_token(value: Any) -> str:
     return "true" if bool(value) else "false"
+
+
+def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str, Any]:
+    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+        if key not in container:
+            raise StageBMidiToSoloMvpCompletionAuditError(
+                f"{label} source-context field required: {key}"
+            )
+    return {key: container[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS}
 
 
 def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
@@ -81,6 +91,7 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
         "model_conditioned_pitch_contour_objective_path_ready",
         "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready",
         "outside_soloing_repair_objective_path_ready",
+        "outside_soloing_repair_source_context_preserved",
         "current_mvp_technical_execution_evidence_supported",
         "current_mvp_objective_repair_evidence_supported",
         "midi_to_solo_mvp_current_evidence_supported",
@@ -297,6 +308,10 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloMvpCompletionAuditError(
             "outside-soloing repair preference fill should remain blocked"
         )
+    source_context = _source_context_fields(
+        outside_soloing_repair,
+        label="outside-soloing repair current evidence",
+    )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloMvpCompletionAuditError("critical user input should not be required")
     return {
@@ -425,6 +440,9 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
         "outside_soloing_repair_objective_path_ready": bool(
             readiness.get("outside_soloing_repair_objective_path_ready", False)
         ),
+        "outside_soloing_repair_source_context_preserved": bool(
+            readiness.get("outside_soloing_repair_source_context_preserved", False)
+        ),
         "outside_soloing_repair_current_evidence_ready": bool(
             outside_soloing_repair.get("current_evidence_consolidation_ready", False)
         ),
@@ -488,6 +506,7 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
         "outside_soloing_repair_preference_fill_allowed": bool(
             outside_soloing_repair.get("preference_fill_allowed", True)
         ),
+        **source_context,
     }
 
 
@@ -583,6 +602,9 @@ def build_mvp_completion_audit_report(
             "model_conditioned_pitch_contour_objective_completed": True,
             "model_conditioned_pitch_contour_changed_ratio_repair_objective_completed": True,
             "outside_soloing_repair_objective_completed": True,
+            "outside_soloing_repair_source_context_preserved": bool(
+                evidence["outside_soloing_repair_source_context_preserved"]
+            ),
             "readme_evidence_boundary_refreshed": True,
             "musical_quality_mvp_completed": False,
             "human_audio_preference_completed": False,
@@ -604,6 +626,9 @@ def build_mvp_completion_audit_report(
             ),
             "outside_soloing_repair_objective_path_ready": bool(
                 evidence["outside_soloing_repair_objective_path_ready"]
+            ),
+            "outside_soloing_repair_source_context_preserved": bool(
+                evidence["outside_soloing_repair_source_context_preserved"]
             ),
             "quality_gap_decision_required": True,
             "human_audio_preference_claimed": False,
@@ -730,6 +755,9 @@ def validate_mvp_completion_audit_report(
         "outside_soloing_repair_objective_completed": bool(
             audit.get("outside_soloing_repair_objective_completed", False)
         ),
+        "outside_soloing_repair_source_context_preserved": bool(
+            audit.get("outside_soloing_repair_source_context_preserved", False)
+        ),
         "musical_quality_mvp_completed": bool(audit.get("musical_quality_mvp_completed", True)),
         "human_audio_preference_completed": bool(audit.get("human_audio_preference_completed", True)),
         "product_mvp_completed": bool(audit.get("product_mvp_completed", True)),
@@ -812,6 +840,9 @@ def validate_mvp_completion_audit_report(
         "outside_soloing_repair_objective_path_ready": bool(
             evidence.get("outside_soloing_repair_objective_path_ready", False)
         ),
+        "outside_soloing_repair_source_context_preserved": bool(
+            evidence.get("outside_soloing_repair_source_context_preserved", False)
+        ),
         "outside_soloing_repair_current_evidence_ready": bool(
             evidence.get("outside_soloing_repair_current_evidence_ready", False)
         ),
@@ -863,6 +894,7 @@ def validate_mvp_completion_audit_report(
         "outside_soloing_repair_preference_fill_allowed": bool(
             evidence.get("outside_soloing_repair_preference_fill_allowed", True)
         ),
+        **{key: evidence.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
         "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
         "midi_to_solo_musical_quality_claimed": bool(
             readiness.get("midi_to_solo_musical_quality_claimed", True)
@@ -889,6 +921,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- model-conditioned pitch-contour objective completed: `{_bool_token(audit['model_conditioned_pitch_contour_objective_completed'])}`",
         f"- model-conditioned pitch-contour changed-ratio repair objective completed: `{_bool_token(audit['model_conditioned_pitch_contour_changed_ratio_repair_objective_completed'])}`",
         f"- outside-soloing repair objective completed: `{_bool_token(audit['outside_soloing_repair_objective_completed'])}`",
+        f"- outside-soloing repair source context preserved: `{_bool_token(audit['outside_soloing_repair_source_context_preserved'])}`",
         f"- musical quality MVP completed: `{_bool_token(audit['musical_quality_mvp_completed'])}`",
         f"- human/audio preference completed: `{_bool_token(audit['human_audio_preference_completed'])}`",
         f"- product MVP completed: `{_bool_token(audit['product_mvp_completed'])}`",
@@ -926,6 +959,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- model-conditioned pitch-contour changed-ratio repair audio review required: `{_bool_token(evidence['model_conditioned_pitch_contour_changed_ratio_repair_audio_review_required'])}`",
         f"- model-conditioned pitch-contour changed-ratio repair preference fill allowed: `{_bool_token(evidence['model_conditioned_pitch_contour_changed_ratio_repair_preference_fill_allowed'])}`",
         f"- outside-soloing repair objective path ready: `{_bool_token(evidence['outside_soloing_repair_objective_path_ready'])}`",
+        f"- outside-soloing repair source context preserved: `{_bool_token(evidence['outside_soloing_repair_source_context_preserved'])}`",
         f"- outside-soloing repair current evidence ready: `{_bool_token(evidence['outside_soloing_repair_current_evidence_ready'])}`",
         f"- outside-soloing repair rendered WAV files: `{evidence['outside_soloing_repair_rendered_audio_file_count']}`",
         f"- outside-soloing repair changed note total: `{evidence['outside_soloing_repair_changed_note_total']}`",
@@ -934,6 +968,12 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- outside-soloing source repair targeted: `{_bool_token(evidence['outside_soloing_repair_source_targeted'])}`",
         f"- outside-soloing source residual risk preserved: `{_bool_token(evidence['outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- outside-soloing pitch-role risk after / delta: `{evidence['outside_soloing_repair_pitch_role_risk_count_after']}` / `{evidence['outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- follow-up objective source outside-soloing source pitch-role risk: `{evidence['followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {evidence['followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `{evidence['followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']} / {evidence['followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- follow-up repair sweep source outside-soloing source pitch-role risk: `{evidence['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {evidence['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `{evidence['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {evidence['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- bridge repair sweep source outside-soloing source pitch-role risk: `{evidence['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {evidence['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `{evidence['repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {evidence['repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- outside-soloing repair objective path supported: `{_bool_token(evidence['outside_soloing_repair_objective_path_supported'])}`",
         f"- outside-soloing repair target supported: `{_bool_token(evidence['outside_soloing_repair_target_supported'])}`",
         f"- outside-soloing repair weak landing target supported: `{_bool_token(evidence['outside_soloing_repair_weak_landing_target_supported'])}`",

--- a/tests/test_stage_b_midi_to_solo_mvp_completion_audit.py
+++ b/tests/test_stage_b_midi_to_solo_mvp_completion_audit.py
@@ -11,8 +11,34 @@ from scripts.audit_stage_b_midi_to_solo_mvp_completion import (
     validate_mvp_completion_audit_report,
 )
 from scripts.consolidate_stage_b_midi_to_solo_mvp_current_evidence import (
+    BRIDGE_SOURCE_CONTEXT_KEYS,
     BOUNDARY as CURRENT_EVIDENCE_BOUNDARY,
 )
+
+
+SOURCE_CONTEXT = {
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_objective_source_outside_soloing_source_targeted": False,
+    "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_repair_sweep_source_outside_soloing_source_targeted": False,
+    "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "repair_sweep_source_outside_soloing_source_targeted": False,
+    "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+}
 
 
 def current_evidence(
@@ -42,6 +68,7 @@ def current_evidence(
             "model_conditioned_pitch_contour_objective_path_ready": pitch_contour_supported,
             "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready": changed_ratio_repair_supported,
             "outside_soloing_repair_objective_path_ready": outside_soloing_repair_supported,
+            "outside_soloing_repair_source_context_preserved": outside_soloing_repair_supported,
             "current_mvp_technical_execution_evidence_supported": True,
             "current_mvp_objective_repair_evidence_supported": True,
             "midi_to_solo_mvp_current_evidence_supported": current_evidence_supported,
@@ -150,6 +177,7 @@ def current_evidence(
             "final_landing_target_supported": True,
             "max_non_chord_tone_run_after": 3,
             "non_chord_run_target_supported": True,
+            **SOURCE_CONTEXT,
         },
         "decision": {
             "critical_user_input_required": False,
@@ -268,6 +296,7 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
         )
         self.assertTrue(summary["outside_soloing_repair_objective_completed"])
         self.assertTrue(summary["outside_soloing_repair_objective_path_ready"])
+        self.assertTrue(summary["outside_soloing_repair_source_context_preserved"])
         self.assertTrue(summary["outside_soloing_repair_current_evidence_ready"])
         self.assertEqual(summary["outside_soloing_repair_rendered_audio_file_count"], 6)
         self.assertEqual(summary["outside_soloing_repair_changed_note_total"], 2)
@@ -297,7 +326,22 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
         self.assertTrue(summary["outside_soloing_repair_final_landing_target_supported"])
         self.assertTrue(summary["outside_soloing_repair_non_chord_run_target_supported"])
         self.assertFalse(summary["outside_soloing_repair_preference_fill_allowed"])
+        for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+            self.assertEqual(summary[key], SOURCE_CONTEXT[key])
         self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
+
+    def test_rejects_missing_outside_soloing_source_context_field(self) -> None:
+        evidence = current_evidence()
+        del evidence["outside_soloing_repair_objective_path"][
+            "followup_objective_source_outside_soloing_source_pitch_role_risk_delta"
+        ]
+        with self.assertRaises(StageBMidiToSoloMvpCompletionAuditError):
+            build_mvp_completion_audit_report(
+                current_evidence=evidence,
+                readme_text=readme_text(),
+                output_dir=Path("outputs/audit"),
+                issue_number=986,
+            )
 
     def test_rejects_missing_readme_evidence_boundary(self) -> None:
         with self.assertRaises(StageBMidiToSoloMvpCompletionAuditError):


### PR DESCRIPTION
## Summary
- MVP completion audit source-context refresh
- #982 current evidence와 #984 README evidence refresh 기준 audit 갱신
- outside-soloing source-context preserved 및 21개 context field를 audit summary/markdown에 보존

## Context
- current MVP evidence supported: `true`
- README evidence refreshed: `true`
- technical model-core MVP completed: `true`
- outside-soloing repair objective completed: `true`
- outside-soloing repair source context preserved: `true`
- source outside-soloing pitch-role risk: `5 -> 2`
- current repair outside-soloing pitch-role risk after/delta: `0 / 2`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Scope
- MVP completion audit current evidence validator source-context 필수 조건 추가
- audit report/readiness/validation summary/markdown source-context 보존
- #986 harness run/doc/issue 기준 갱신
- README, CURRENT_STATUS, CORE_PLAN, AGENTS handoff 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_mvp_completion.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- technical model-core MVP audit 범위
- human/audio preference claim 제외
- MIDI-to-solo musical quality claim 제외
- 다음 quality gap decision 반영 필요

Closes #986

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project audit documentation to reflect latest completion milestones and current verification status.
  * Added source-context preservation tracking to audit evidence records.
  * Refreshed documentation boundaries and recommendations for next audit phases.

* **Testing & Validation**
  * Enhanced audit verification with source-context preservation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->