### PR TITLE
Stage B MIDI-to-solo quality gap decision source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Current handoff scope:
 
 - Latest functional issue completed: Issue #982, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh.
 - Latest audit issue completed: Issue #986, Stage B MIDI-to-solo MVP completion audit source-context refresh.
-- Latest quality gap decision completed: Issue #904, Stage B MIDI-to-solo quality gap decision source-context refresh.
+- Latest quality gap decision completed: Issue #988, Stage B MIDI-to-solo quality gap decision source-context refresh.
 - Latest listening review quality gap completed: Issue #906, Stage B MIDI-to-solo listening review quality gap source-context refresh.
 - Latest MVP delivery package completed: Issue #908, Stage B MIDI-to-solo MVP delivery package source-context refresh.
 - Latest README final evidence refresh completed: Issue #910, Stage B MIDI-to-solo README final evidence source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #980, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after MVP completion audit source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo quality gap decision source-context refresh.
+- Open issue queue after quality gap decision source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo listening review quality gap source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 - latest functional result: `Issue #982`
 - latest MVP completion audit: `Issue #986`
-- latest quality gap decision: `Issue #904`
+- latest quality gap decision: `Issue #988`
 - latest listening review quality gap: `Issue #906`
 - latest MVP delivery package: `Issue #908`
 - latest README final evidence refresh: `Issue #910`
@@ -223,6 +223,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - quality gap decision listening review target selected: `true`
 - quality gap decision outside-soloing repair objective included: `true`
 - quality gap decision outside-soloing source context included: `true`
+- quality gap decision outside-soloing source context preserved: `true`
 - pitch-contour changed-ratio review decision completed: `true`
 - pitch-contour changed-ratio repair probe required: `true`
 - pitch-contour changed-ratio repair probe completed: `true`
@@ -460,6 +461,7 @@ Quality gap decision.
 - model-conditioned pitch-contour changed-ratio review required: `true`
 - model-conditioned pitch-contour changed-ratio repair max ratio / target: `0.4348 / 0.5000`
 - model-conditioned pitch-contour changed-ratio repair max interval / target: `12 / 12`
+- outside-soloing repair source context preserved: `true`
 - outside-soloing source pitch-role risk count: `5 -> 2`
 - outside-soloing source repair targeted: `false`
 - outside-soloing source residual risk preserved: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -10061,6 +10061,55 @@ Issue #986은 Issue #982 current evidence와 Issue #984 README evidence refresh�
 
 - `Stage B MIDI-to-solo quality gap decision source-context refresh`
 
+## 9.184 Stage B MIDI-to-solo quality gap decision source-context refresh
+
+Issue #988은 Issue #986 MVP completion audit의 source/current outside-soloing context를 quality gap decision까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- source boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- next boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- selected target: `listening_review_quality_gap`
+- fallback path active: `true`
+- model-conditioned input path alignment required: `false`
+- technical model-core MVP completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour changed-ratio repair objective completed: `true`
+- outside-soloing repair objective completed: `true`
+- outside-soloing repair source context preserved: `true`
+- outside-soloing source objective pitch-role risk count: `5`
+- outside-soloing source pitch-role risk count: `5 -> 2`
+- outside-soloing source pitch-role risk delta: `3`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
+- outside-soloing current repair pitch-role risk count after: `0`
+- outside-soloing current repair pitch-role risk delta: `2`
+- outside-soloing repair target supported: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- quality gap decision 입력 검증에 #986 source-context preserved flag와 21개 context field 필수화.
+- source risk `5 -> 2`와 current repair `2 -> 0` 경계 분리 유지.
+- target은 추가 objective repair가 아니라 listening review quality gap으로 선택.
+- human/audio preference와 MIDI-to-solo musical quality claim 제외.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_gap_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_quality_gap.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-gap-decision`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo listening review quality gap source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -14,7 +14,7 @@
 
 - latest functional result: Issue #982, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest MVP completion audit: Issue #986, Stage B MIDI-to-solo MVP completion audit source-context refresh
-- latest quality gap decision: Issue #904, Stage B MIDI-to-solo quality gap decision source-context refresh
+- latest quality gap decision: Issue #988, Stage B MIDI-to-solo quality gap decision source-context refresh
 - latest listening review quality gap: Issue #906, Stage B MIDI-to-solo listening review quality gap source-context refresh
 - latest MVP delivery package: Issue #908, Stage B MIDI-to-solo MVP delivery package source-context refresh
 - latest README final evidence refresh: Issue #910, Stage B MIDI-to-solo README final evidence source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #982, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after MVP completion audit source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo quality gap decision source-context refresh`
+- open issue queue after quality gap decision source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo listening review quality gap source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -932,6 +932,7 @@
 - selected target: `listening_review_quality_gap`
 - next boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
 - outside-soloing repair objective completed: `true`
+- outside-soloing repair source context preserved: `true`
 - outside-soloing repair target supported: `true`
 - outside-soloing source objective pitch-role risk count: `5`
 - outside-soloing source pitch-role risk count: `5 -> 2`

--- a/docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -16,6 +16,7 @@
 - model-conditioned pitch-contour objective completed: `true`
 - model-conditioned pitch-contour changed-ratio repair objective completed: `true`
 - outside-soloing repair objective completed: `true`
+- outside-soloing repair source context preserved: `true`
 - musical quality MVP completed: `false`
 - generation source: `context_conditioned_fallback`
 - exported candidates: `3`
@@ -45,6 +46,12 @@
 - outside-soloing source repair targeted: `false`
 - outside-soloing source residual risk preserved: `true`
 - outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- follow-up repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
 - outside-soloing repair objective path supported: `true`
 - outside-soloing repair target supported: `true`
 - outside-soloing repair weak landing target supported: `true`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6026,8 +6026,8 @@ run_stage_b_midi_to_solo_mvp_completion_audit() {
 }
 
 run_stage_b_midi_to_solo_quality_gap_decision() {
-  local completion_audit_run_id="${COMPLETION_AUDIT_RUN_ID:-harness_stage_b_midi_to_solo_mvp_completion_audit}"
-  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_quality_gap_decision}"
+  local completion_audit_run_id="${COMPLETION_AUDIT_RUN_ID:-harness_stage_b_midi_to_solo_mvp_completion_audit_source_context_refresh}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_quality_gap_decision_source_context_refresh}"
   local completion_audit="outputs/stage_b_midi_to_solo_mvp_completion_audit/${completion_audit_run_id}/stage_b_midi_to_solo_mvp_completion_audit.json"
   if [[ ! -f "$completion_audit" ]]; then
     print_header "Stage B MIDI-to-solo MVP completion audit"
@@ -6038,7 +6038,7 @@ run_stage_b_midi_to_solo_quality_gap_decision() {
     --run_id "$run_id" \
     --mvp_completion_audit "$completion_audit" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 904 \
+    --issue_number 988 \
     --expected_boundary stage_b_midi_to_solo_quality_gap_decision \
     --expected_next_boundary stage_b_midi_to_solo_listening_review_quality_gap \
     --expected_target listening_review_quality_gap \

--- a/scripts/decide_stage_b_midi_to_solo_quality_gap.py
+++ b/scripts/decide_stage_b_midi_to_solo_quality_gap.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
 from scripts.audit_stage_b_midi_to_solo_mvp_completion import (  # noqa: E402
+    BRIDGE_SOURCE_CONTEXT_KEYS,
     BOUNDARY as MVP_COMPLETION_AUDIT_BOUNDARY,
 )
 
@@ -31,7 +32,7 @@ PITCH_CONTOUR_CHANGED_RATIO_NEXT_BOUNDARY = (
 )
 LISTENING_REVIEW_TARGET = "listening_review_quality_gap"
 LISTENING_REVIEW_NEXT_BOUNDARY = "stage_b_midi_to_solo_listening_review_quality_gap"
-SCHEMA_VERSION = "stage_b_midi_to_solo_quality_gap_decision_v1"
+SCHEMA_VERSION = "stage_b_midi_to_solo_quality_gap_decision_v2"
 
 
 def _dict(value: Any) -> dict[str, Any]:
@@ -54,6 +55,15 @@ def _float(value: Any) -> float:
 
 def _bool_token(value: Any) -> str:
     return "true" if bool(value) else "false"
+
+
+def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str, Any]:
+    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+        if key not in container:
+            raise StageBMidiToSoloQualityGapDecisionError(
+                f"{label} source-context field required: {key}"
+            )
+    return {key: container[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS}
 
 
 def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
@@ -84,6 +94,14 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
     if not bool(audit.get("outside_soloing_repair_objective_completed", False)):
         raise StageBMidiToSoloQualityGapDecisionError(
             "outside-soloing repair objective completion required"
+        )
+    if not bool(readiness.get("outside_soloing_repair_source_context_preserved", False)):
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing repair source context readiness required"
+        )
+    if not bool(audit.get("outside_soloing_repair_source_context_preserved", False)):
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing repair source context audit preservation required"
         )
     if _int(evidence.get("exported_candidate_count")) < 3:
         raise StageBMidiToSoloQualityGapDecisionError("exported candidate count below 3")
@@ -165,6 +183,14 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloQualityGapDecisionError(
             "outside-soloing repair current evidence readiness required"
         )
+    if not bool(evidence.get("outside_soloing_repair_source_context_preserved", False)):
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing repair source context evidence preservation required"
+        )
+    source_context = _source_context_fields(
+        evidence,
+        label="MVP completion audit evidence",
+    )
     if _int(evidence.get("outside_soloing_repair_rendered_audio_file_count")) < 6:
         raise StageBMidiToSoloQualityGapDecisionError(
             "outside-soloing repair rendered WAV count below 6"
@@ -244,6 +270,9 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
         ),
         "outside_soloing_repair_objective_completed": bool(
             audit.get("outside_soloing_repair_objective_completed", False)
+        ),
+        "outside_soloing_repair_source_context_preserved": bool(
+            evidence.get("outside_soloing_repair_source_context_preserved", False)
         ),
         "musical_quality_mvp_completed": False,
         "human_audio_preference_completed": False,
@@ -364,6 +393,7 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
         "outside_soloing_repair_preference_fill_allowed": bool(
             evidence.get("outside_soloing_repair_preference_fill_allowed", True)
         ),
+        **source_context,
     }
 
 
@@ -468,6 +498,9 @@ def build_quality_gap_decision_report(
             "outside_soloing_repair_objective_completed": bool(
                 audit_summary["outside_soloing_repair_objective_completed"]
             ),
+            "outside_soloing_repair_source_context_preserved": bool(
+                audit_summary["outside_soloing_repair_source_context_preserved"]
+            ),
             "musical_quality_mvp_completed": False,
             "human_audio_preference_completed": False,
             "product_mvp_completed": False,
@@ -512,6 +545,7 @@ def build_quality_gap_decision_report(
             "outside_soloing_repair_source_residual_risk_preserved": bool(
                 audit_summary["outside_soloing_repair_source_residual_risk_preserved"]
             ),
+            **{key: audit_summary[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
             "human_review_required_now": False,
         },
         "selected_target": target,
@@ -520,6 +554,9 @@ def build_quality_gap_decision_report(
             "quality_gap_decision_completed": True,
             "selected_target": str(target["selected_target"]),
             "next_boundary_selected": str(target["selected_next_boundary"]),
+            "outside_soloing_repair_source_context_preserved": bool(
+                audit_summary["outside_soloing_repair_source_context_preserved"]
+            ),
             "human_review_required_now": False,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
@@ -583,6 +620,18 @@ def validate_quality_gap_decision_report(
         raise StageBMidiToSoloQualityGapDecisionError(
             "outside-soloing repair objective completion required"
         )
+    if not bool(readiness.get("outside_soloing_repair_source_context_preserved", False)):
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing repair source context readiness required"
+        )
+    if not bool(quality_gap.get("outside_soloing_repair_source_context_preserved", False)):
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing repair source context preservation required"
+        )
+    source_context = _source_context_fields(
+        quality_gap,
+        label="quality gap",
+    )
     if bool(quality_gap.get("musical_quality_mvp_completed", True)):
         raise StageBMidiToSoloQualityGapDecisionError("musical quality should remain incomplete")
     if bool(decision.get("critical_user_input_required", True)):
@@ -657,6 +706,9 @@ def validate_quality_gap_decision_report(
         "outside_soloing_repair_objective_completed": bool(
             quality_gap.get("outside_soloing_repair_objective_completed", False)
         ),
+        "outside_soloing_repair_source_context_preserved": bool(
+            quality_gap.get("outside_soloing_repair_source_context_preserved", False)
+        ),
         "model_conditioned_pitch_contour_objective_path_ready": bool(
             quality_gap.get("model_conditioned_pitch_contour_objective_path_ready", False)
         ),
@@ -693,6 +745,7 @@ def validate_quality_gap_decision_report(
         "outside_soloing_repair_source_residual_risk_preserved": bool(
             quality_gap.get("outside_soloing_repair_source_residual_risk_preserved", False)
         ),
+        **source_context,
         "musical_quality_mvp_completed": bool(quality_gap.get("musical_quality_mvp_completed", True)),
         "cli_candidate_count": _int(_dict(report.get("mvp_completion_summary")).get("cli_candidate_count")),
         "cli_rendered_audio_file_count": _int(
@@ -820,6 +873,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- model-conditioned pitch-contour objective completed: `{_bool_token(summary['model_conditioned_pitch_contour_objective_completed'])}`",
         f"- model-conditioned pitch-contour changed-ratio repair objective completed: `{_bool_token(summary['model_conditioned_pitch_contour_changed_ratio_repair_objective_completed'])}`",
         f"- outside-soloing repair objective completed: `{_bool_token(summary['outside_soloing_repair_objective_completed'])}`",
+        f"- outside-soloing repair source context preserved: `{_bool_token(summary['outside_soloing_repair_source_context_preserved'])}`",
         f"- musical quality MVP completed: `{_bool_token(summary['musical_quality_mvp_completed'])}`",
         f"- generation source: `{summary['generation_source']}`",
         f"- exported candidates: `{summary['exported_candidate_count']}`",
@@ -849,6 +903,12 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- outside-soloing source repair targeted: `{_bool_token(summary['outside_soloing_repair_source_targeted'])}`",
         f"- outside-soloing source residual risk preserved: `{_bool_token(summary['outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- outside-soloing current repair pitch-role risk after / delta: `{summary['outside_soloing_repair_pitch_role_risk_count_after']}` / `{summary['outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- follow-up objective source outside-soloing source pitch-role risk: `{summary['followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `{summary['followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']} / {summary['followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- follow-up repair sweep source outside-soloing source pitch-role risk: `{summary['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `{summary['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {summary['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- bridge repair sweep source outside-soloing source pitch-role risk: `{summary['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `{summary['repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {summary['repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- outside-soloing repair objective path supported: `{_bool_token(summary['outside_soloing_repair_objective_path_supported'])}`",
         f"- outside-soloing repair target supported: `{_bool_token(summary['outside_soloing_repair_target_supported'])}`",
         f"- outside-soloing repair weak landing target supported: `{_bool_token(summary['outside_soloing_repair_weak_landing_target_supported'])}`",

--- a/tests/test_stage_b_midi_to_solo_quality_gap_decision.py
+++ b/tests/test_stage_b_midi_to_solo_quality_gap_decision.py
@@ -4,6 +4,7 @@ import unittest
 from pathlib import Path
 
 from scripts.audit_stage_b_midi_to_solo_mvp_completion import (
+    BRIDGE_SOURCE_CONTEXT_KEYS,
     BOUNDARY as MVP_COMPLETION_BOUNDARY,
 )
 from scripts.decide_stage_b_midi_to_solo_quality_gap import (
@@ -18,6 +19,31 @@ from scripts.decide_stage_b_midi_to_solo_quality_gap import (
     build_quality_gap_decision_report,
     validate_quality_gap_decision_report,
 )
+
+
+SOURCE_CONTEXT = {
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_objective_source_outside_soloing_source_targeted": False,
+    "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_repair_sweep_source_outside_soloing_source_targeted": False,
+    "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "repair_sweep_source_outside_soloing_source_targeted": False,
+    "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+}
 
 
 def mvp_completion_audit(
@@ -37,6 +63,7 @@ def mvp_completion_audit(
             "mvp_completion_audit_completed": True,
             "technical_model_core_mvp_completed": True,
             "quality_gap_decision_required": True,
+            "outside_soloing_repair_source_context_preserved": outside_soloing_repair_supported,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
             "broad_trained_model_quality_claimed": False,
@@ -54,6 +81,7 @@ def mvp_completion_audit(
                 changed_ratio_repair_supported
             ),
             "outside_soloing_repair_objective_completed": outside_soloing_repair_supported,
+            "outside_soloing_repair_source_context_preserved": outside_soloing_repair_supported,
             "readme_evidence_boundary_refreshed": True,
             "musical_quality_mvp_completed": musical_complete,
             "human_audio_preference_completed": False,
@@ -107,6 +135,7 @@ def mvp_completion_audit(
             "model_conditioned_pitch_contour_changed_ratio_repair_preference_fill_allowed": False,
             "outside_soloing_repair_objective_path_ready": outside_soloing_repair_supported,
             "outside_soloing_repair_current_evidence_ready": outside_soloing_repair_supported,
+            "outside_soloing_repair_source_context_preserved": outside_soloing_repair_supported,
             "outside_soloing_repair_rendered_audio_file_count": 6,
             "outside_soloing_repair_changed_note_total": 2,
             "outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
@@ -125,6 +154,7 @@ def mvp_completion_audit(
             "outside_soloing_repair_final_landing_target_supported": True,
             "outside_soloing_repair_non_chord_run_target_supported": True,
             "outside_soloing_repair_preference_fill_allowed": False,
+            **SOURCE_CONTEXT,
         },
         "decision": {
             "next_boundary": "stage_b_midi_to_solo_quality_gap_decision",
@@ -157,6 +187,7 @@ class StageBMidiToSoloQualityGapDecisionTest(unittest.TestCase):
             summary["model_conditioned_pitch_contour_changed_ratio_repair_objective_completed"]
         )
         self.assertTrue(summary["outside_soloing_repair_objective_completed"])
+        self.assertTrue(summary["outside_soloing_repair_source_context_preserved"])
         self.assertTrue(summary["model_conditioned_pitch_contour_objective_path_ready"])
         self.assertTrue(summary["pitch_contour_changed_ratio_review_required"])
         self.assertTrue(summary["pitch_contour_changed_ratio_repair_objective_path_ready"])
@@ -205,6 +236,8 @@ class StageBMidiToSoloQualityGapDecisionTest(unittest.TestCase):
         self.assertTrue(summary["outside_soloing_repair_source_residual_risk_preserved"])
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_count_after"], 0)
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_delta"], 2)
+        for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+            self.assertEqual(summary[key], SOURCE_CONTEXT[key])
         self.assertTrue(summary["outside_soloing_repair_objective_path_supported"])
         self.assertTrue(summary["outside_soloing_repair_weak_landing_target_supported"])
         self.assertTrue(summary["outside_soloing_repair_final_landing_target_supported"])
@@ -353,6 +386,19 @@ class StageBMidiToSoloQualityGapDecisionTest(unittest.TestCase):
                 mvp_completion_audit=source,
                 output_dir=Path("outputs/quality_gap"),
                 issue_number=904,
+            )
+
+    def test_rejects_missing_outside_soloing_source_context_field(self) -> None:
+        source = mvp_completion_audit()
+        source["current_evidence"].pop(
+            "followup_objective_source_outside_soloing_source_pitch_role_risk_delta"
+        )
+
+        with self.assertRaises(StageBMidiToSoloQualityGapDecisionError):
+            build_quality_gap_decision_report(
+                mvp_completion_audit=source,
+                output_dir=Path("outputs/quality_gap"),
+                issue_number=988,
             )
 
     def test_rejects_targeted_outside_soloing_source_repair(self) -> None:


### PR DESCRIPTION
## Summary
- quality gap decision source-context refresh
- #986 MVP completion audit 기준 quality gap decision 갱신
- outside-soloing source-context preserved 및 21개 context field를 decision report/markdown까지 보존

## Context
- technical model-core MVP completed: `true`
- outside-soloing repair objective completed: `true`
- outside-soloing repair source context preserved: `true`
- source outside-soloing pitch-role risk: `5 -> 2`
- current repair outside-soloing pitch-role risk after/delta: `0 / 2`
- selected target: `listening_review_quality_gap`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Scope
- quality gap decision validator source-context preserved 필수 조건 추가
- 21개 source-context field report/readiness/validation summary/markdown 보존
- #988 harness run/doc/issue 기준 갱신
- README, CURRENT_STATUS, CORE_PLAN, AGENTS handoff 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_gap_decision`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_quality_gap.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-gap-decision`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- quality gap decision은 next target 선택과 claim boundary 기록 범위
- human/audio preference claim 제외
- MIDI-to-solo musical quality claim 제외
- 다음 listening review quality gap refresh 필요

Closes #988