### PR TITLE
Stage B MIDI-to-solo listening review quality gap source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Current handoff scope:
 - Latest functional issue completed: Issue #982, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh.
 - Latest audit issue completed: Issue #986, Stage B MIDI-to-solo MVP completion audit source-context refresh.
 - Latest quality gap decision completed: Issue #988, Stage B MIDI-to-solo quality gap decision source-context refresh.
-- Latest listening review quality gap completed: Issue #906, Stage B MIDI-to-solo listening review quality gap source-context refresh.
+- Latest listening review quality gap completed: Issue #990, Stage B MIDI-to-solo listening review quality gap source-context refresh.
 - Latest MVP delivery package completed: Issue #908, Stage B MIDI-to-solo MVP delivery package source-context refresh.
 - Latest README final evidence refresh completed: Issue #910, Stage B MIDI-to-solo README final evidence source-context refresh.
 - Latest final status audit completed: Issue #912, Stage B MIDI-to-solo final status audit source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #980, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after quality gap decision source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo listening review quality gap source-context refresh.
+- Open issue queue after listening review quality gap source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo MVP delivery package source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest functional result: `Issue #982`
 - latest MVP completion audit: `Issue #986`
 - latest quality gap decision: `Issue #988`
-- latest listening review quality gap: `Issue #906`
+- latest listening review quality gap: `Issue #990`
 - latest MVP delivery package: `Issue #908`
 - latest README final evidence refresh: `Issue #910`
 - latest final status audit: `Issue #912`
@@ -320,6 +320,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - listening review quality gap open: `true`
 - listening review quality gap outside-soloing repair objective included: `true`
 - listening review quality gap outside-soloing source context included: `true`
+- listening review quality gap outside-soloing source context preserved: `true`
 - MVP delivery package completed: `true`
 - runnable CLI ready: `true`
 - input to ranked MIDI ready: `true`
@@ -480,6 +481,7 @@ Listening review quality gap.
 - changed-ratio repair objective completed: `true`
 - changed-ratio repair max ratio / target: `0.4348 / 0.5000`
 - changed-ratio repair max interval / target: `12 / 12`
+- outside-soloing repair source context preserved: `true`
 - outside-soloing source pitch-role risk count: `5 -> 2`
 - outside-soloing source repair targeted: `false`
 - outside-soloing source residual risk preserved: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -10110,6 +10110,56 @@ Issue #988은 Issue #986 MVP completion audit의 source/current outside-soloing 
 
 - `Stage B MIDI-to-solo listening review quality gap source-context refresh`
 
+## 9.185 Stage B MIDI-to-solo listening review quality gap source-context refresh
+
+Issue #990은 Issue #988 quality gap decision의 source/current outside-soloing context를 listening review quality gap boundary까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- source boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- next boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- selected target: `mvp_delivery_package`
+- listening review quality gap open: `true`
+- technical MVP delivery package ready: `true`
+- technical model-core MVP completed: `true`
+- changed-ratio repair objective completed: `true`
+- changed-ratio repair max interval / threshold: `12 / 12`
+- changed-ratio repair max ratio / target: `0.4348 / 0.5000`
+- outside-soloing repair objective completed: `true`
+- outside-soloing repair source context preserved: `true`
+- outside-soloing repair rendered audio file count: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing source objective pitch-role risk count: `5`
+- outside-soloing source pitch-role risk count: `5 -> 2`
+- outside-soloing source pitch-role risk delta: `3`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
+- outside-soloing current repair pitch-role risk count after: `0`
+- outside-soloing current repair pitch-role risk delta: `2`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- #988 quality gap decision의 source-context preserved flag와 21개 context field를 listening review quality gap summary에 보존.
+- listening review quality gap은 open 상태 유지.
+- technical delivery package 준비는 가능하지만 human/audio preference와 MIDI-to-solo musical quality claim 제외.
+- 다음 boundary는 MVP delivery package.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_listening_review_quality_gap`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-listening-review-quality-gap`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo MVP delivery package source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -15,7 +15,7 @@
 - latest functional result: Issue #982, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest MVP completion audit: Issue #986, Stage B MIDI-to-solo MVP completion audit source-context refresh
 - latest quality gap decision: Issue #988, Stage B MIDI-to-solo quality gap decision source-context refresh
-- latest listening review quality gap: Issue #906, Stage B MIDI-to-solo listening review quality gap source-context refresh
+- latest listening review quality gap: Issue #990, Stage B MIDI-to-solo listening review quality gap source-context refresh
 - latest MVP delivery package: Issue #908, Stage B MIDI-to-solo MVP delivery package source-context refresh
 - latest README final evidence refresh: Issue #910, Stage B MIDI-to-solo README final evidence source-context refresh
 - latest final status audit: Issue #912, Stage B MIDI-to-solo final status audit source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #982, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after quality gap decision source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo listening review quality gap source-context refresh`
+- open issue queue after listening review quality gap source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo MVP delivery package source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -948,6 +948,7 @@
 - selected target: `mvp_delivery_package`
 - technical MVP delivery package ready: `true`
 - outside-soloing repair objective completed: `true`
+- outside-soloing repair source context preserved: `true`
 - outside-soloing repair rendered audio file count: `6`
 - outside-soloing source objective pitch-role risk count: `5`
 - outside-soloing source pitch-role risk count: `5 -> 2`

--- a/docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -17,6 +17,7 @@
 - model-conditioned pitch-contour objective completed: `true`
 - changed-ratio repair objective completed: `true`
 - outside-soloing repair objective completed: `true`
+- outside-soloing repair source context preserved: `true`
 - rendered WAV files: `3`
 - changed-ratio repair max interval / threshold: `12` / `12`
 - changed-ratio repair max ratio / target: `0.4348` / `0.5000`
@@ -29,6 +30,12 @@
 - outside-soloing source repair targeted: `false`
 - outside-soloing source residual risk preserved: `true`
 - outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- follow-up repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
 - outside-soloing repair objective path supported: `true`
 - outside-soloing repair weak landing target supported: `true`
 - outside-soloing repair final landing target supported: `true`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6046,8 +6046,8 @@ run_stage_b_midi_to_solo_quality_gap_decision() {
 }
 
 run_stage_b_midi_to_solo_listening_review_quality_gap() {
-  local quality_gap_run_id="${QUALITY_GAP_RUN_ID:-harness_stage_b_midi_to_solo_quality_gap_decision}"
-  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_listening_review_quality_gap}"
+  local quality_gap_run_id="${QUALITY_GAP_RUN_ID:-harness_stage_b_midi_to_solo_quality_gap_decision_source_context_refresh}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_listening_review_quality_gap_source_context_refresh}"
   local quality_gap="outputs/stage_b_midi_to_solo_quality_gap_decision/${quality_gap_run_id}/stage_b_midi_to_solo_quality_gap_decision.json"
   if [[ ! -f "$quality_gap" ]]; then
     print_header "Stage B MIDI-to-solo quality gap decision"
@@ -6058,7 +6058,7 @@ run_stage_b_midi_to_solo_listening_review_quality_gap() {
     --run_id "$run_id" \
     --quality_gap_decision "$quality_gap" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 906 \
+    --issue_number 990 \
     --expected_boundary stage_b_midi_to_solo_listening_review_quality_gap \
     --expected_next_boundary stage_b_midi_to_solo_mvp_delivery_package \
     --expected_target mvp_delivery_package \

--- a/scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py
+++ b/scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
 from scripts.decide_stage_b_midi_to_solo_quality_gap import (  # noqa: E402
+    BRIDGE_SOURCE_CONTEXT_KEYS,
     BOUNDARY as SOURCE_BOUNDARY,
     LISTENING_REVIEW_NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
     LISTENING_REVIEW_TARGET,
@@ -27,7 +28,7 @@ class StageBMidiToSoloListeningReviewQualityGapError(ValueError):
 BOUNDARY = "stage_b_midi_to_solo_listening_review_quality_gap"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_mvp_delivery_package"
 SELECTED_TARGET = "mvp_delivery_package"
-SCHEMA_VERSION = "stage_b_midi_to_solo_listening_review_quality_gap_v1"
+SCHEMA_VERSION = "stage_b_midi_to_solo_listening_review_quality_gap_v2"
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -70,6 +71,15 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
         raise StageBMidiToSoloListeningReviewQualityGapError(
             f"unexpected quality claim in {label}: {claimed}"
         )
+
+
+def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str, Any]:
+    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+        if key not in container:
+            raise StageBMidiToSoloListeningReviewQualityGapError(
+                f"{label} source-context field required: {key}"
+            )
+    return {key: container[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS}
 
 
 def validate_quality_gap_decision(report: dict[str, Any]) -> dict[str, Any]:
@@ -118,6 +128,18 @@ def validate_quality_gap_decision(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloListeningReviewQualityGapError(
             "outside-soloing repair objective completion required"
         )
+    if not bool(readiness.get("outside_soloing_repair_source_context_preserved", False)):
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing repair source context readiness required"
+        )
+    if not bool(quality_gap.get("outside_soloing_repair_source_context_preserved", False)):
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing repair source context preservation required"
+        )
+    source_context = _source_context_fields(
+        quality_gap,
+        label="quality gap decision",
+    )
     if not bool(quality_gap.get("outside_soloing_repair_objective_path_ready", False)):
         raise StageBMidiToSoloListeningReviewQualityGapError(
             "outside-soloing repair objective path readiness required"
@@ -212,6 +234,9 @@ def validate_quality_gap_decision(report: dict[str, Any]) -> dict[str, Any]:
         "model_conditioned_pitch_contour_objective_completed": True,
         "changed_ratio_repair_objective_completed": True,
         "outside_soloing_repair_objective_completed": True,
+        "outside_soloing_repair_source_context_preserved": bool(
+            quality_gap.get("outside_soloing_repair_source_context_preserved", False)
+        ),
         "fallback_path_active": bool(quality_gap.get("fallback_path_active", False)),
         "model_conditioned_input_path_alignment_required": bool(
             quality_gap.get("model_conditioned_input_path_alignment_required", False)
@@ -271,6 +296,7 @@ def validate_quality_gap_decision(report: dict[str, Any]) -> dict[str, Any]:
         "outside_soloing_repair_non_chord_run_target_supported": bool(
             summary.get("outside_soloing_repair_non_chord_run_target_supported", False)
         ),
+        **source_context,
         "human_review_required_now": bool(quality_gap.get("human_review_required_now", False)),
         "musical_quality_mvp_completed": False,
         "human_audio_preference_completed": False,
@@ -313,6 +339,9 @@ def build_listening_review_quality_gap_report(
             "technical_mvp_delivery_package_ready": True,
             "listening_review_quality_gap_open": True,
             "human_review_required_now": False,
+            "outside_soloing_repair_source_context_preserved": bool(
+                source["outside_soloing_repair_source_context_preserved"]
+            ),
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
             "audio_rendered_quality_claimed": False,
@@ -374,6 +403,18 @@ def validate_listening_review_quality_gap_report(
         raise StageBMidiToSoloListeningReviewQualityGapError("critical user input should not be required")
     if require_no_quality_claim:
         _require_no_quality_claim(readiness, label="listening review quality gap readiness")
+    if not bool(readiness.get("outside_soloing_repair_source_context_preserved", False)):
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing repair source context readiness required"
+        )
+    if not bool(summary.get("outside_soloing_repair_source_context_preserved", False)):
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing repair source context preservation required"
+        )
+    source_context = _source_context_fields(
+        summary,
+        label="listening review quality gap",
+    )
     source_objective_risk = _int(
         summary.get("outside_soloing_repair_source_objective_pitch_role_risk_count")
     )
@@ -418,6 +459,9 @@ def validate_listening_review_quality_gap_report(
         ),
         "outside_soloing_repair_objective_completed": bool(
             summary.get("outside_soloing_repair_objective_completed", False)
+        ),
+        "outside_soloing_repair_source_context_preserved": bool(
+            summary.get("outside_soloing_repair_source_context_preserved", False)
         ),
         "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
         "max_repaired_interval": _int(summary.get("max_repaired_interval")),
@@ -464,6 +508,7 @@ def validate_listening_review_quality_gap_report(
         "outside_soloing_repair_non_chord_run_target_supported": bool(
             summary.get("outside_soloing_repair_non_chord_run_target_supported", False)
         ),
+        **source_context,
         "listening_review_quality_gap_open": bool(
             summary.get("listening_review_quality_gap_open", False)
         ),
@@ -505,6 +550,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- model-conditioned pitch-contour objective completed: `{_bool_token(summary['model_conditioned_pitch_contour_objective_completed'])}`",
         f"- changed-ratio repair objective completed: `{_bool_token(summary['changed_ratio_repair_objective_completed'])}`",
         f"- outside-soloing repair objective completed: `{_bool_token(summary['outside_soloing_repair_objective_completed'])}`",
+        f"- outside-soloing repair source context preserved: `{_bool_token(summary['outside_soloing_repair_source_context_preserved'])}`",
         f"- rendered WAV files: `{summary['rendered_audio_file_count']}`",
         f"- changed-ratio repair max interval / threshold: `{summary['max_repaired_interval']}` / `{summary['max_interval_threshold']}`",
         f"- changed-ratio repair max ratio / target: `{summary['max_repaired_pitch_changed_ratio']:.4f}` / `{summary['target_max_pitch_changed_ratio']:.4f}`",
@@ -517,6 +563,12 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- outside-soloing source repair targeted: `{_bool_token(summary['outside_soloing_repair_source_targeted'])}`",
         f"- outside-soloing source residual risk preserved: `{_bool_token(summary['outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- outside-soloing current repair pitch-role risk after / delta: `{summary['outside_soloing_repair_pitch_role_risk_count_after']}` / `{summary['outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- follow-up objective source outside-soloing source pitch-role risk: `{summary['followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `{summary['followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']} / {summary['followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- follow-up repair sweep source outside-soloing source pitch-role risk: `{summary['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `{summary['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {summary['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- bridge repair sweep source outside-soloing source pitch-role risk: `{summary['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `{summary['repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {summary['repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- outside-soloing repair objective path supported: `{_bool_token(summary['outside_soloing_repair_objective_path_supported'])}`",
         f"- outside-soloing repair weak landing target supported: `{_bool_token(summary['outside_soloing_repair_weak_landing_target_supported'])}`",
         f"- outside-soloing repair final landing target supported: `{_bool_token(summary['outside_soloing_repair_final_landing_target_supported'])}`",

--- a/tests/test_stage_b_midi_to_solo_listening_review_quality_gap.py
+++ b/tests/test_stage_b_midi_to_solo_listening_review_quality_gap.py
@@ -12,10 +12,36 @@ from scripts.decide_stage_b_midi_to_solo_listening_review_quality_gap import (
     validate_listening_review_quality_gap_report,
 )
 from scripts.decide_stage_b_midi_to_solo_quality_gap import (
+    BRIDGE_SOURCE_CONTEXT_KEYS,
     BOUNDARY as QUALITY_GAP_BOUNDARY,
     LISTENING_REVIEW_NEXT_BOUNDARY,
     LISTENING_REVIEW_TARGET,
 )
+
+
+SOURCE_CONTEXT = {
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_objective_source_outside_soloing_source_targeted": False,
+    "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_repair_sweep_source_outside_soloing_source_targeted": False,
+    "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "repair_sweep_source_outside_soloing_source_targeted": False,
+    "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+}
 
 
 def quality_gap_decision(
@@ -36,6 +62,7 @@ def quality_gap_decision(
                 changed_ratio_supported
             ),
             "outside_soloing_repair_objective_completed": outside_soloing_repair_supported,
+            "outside_soloing_repair_source_context_preserved": outside_soloing_repair_supported,
             "musical_quality_mvp_completed": False,
             "human_audio_preference_completed": False,
             "product_mvp_completed": False,
@@ -56,6 +83,7 @@ def quality_gap_decision(
             "outside_soloing_repair_source_targeted": False,
             "outside_soloing_repair_source_residual_risk_preserved": True,
             "human_review_required_now": False,
+            **SOURCE_CONTEXT,
         },
         "mvp_completion_summary": {
             "model_conditioned_pitch_contour_changed_ratio_repair_rendered_audio_file_count": 3,
@@ -88,6 +116,7 @@ def quality_gap_decision(
             "quality_gap_decision_completed": True,
             "selected_target": selected_target,
             "next_boundary_selected": next_boundary,
+            "outside_soloing_repair_source_context_preserved": outside_soloing_repair_supported,
             "human_review_required_now": False,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
@@ -123,6 +152,7 @@ class StageBMidiToSoloListeningReviewQualityGapTest(unittest.TestCase):
         self.assertTrue(summary["technical_model_core_mvp_completed"])
         self.assertTrue(summary["changed_ratio_repair_objective_completed"])
         self.assertTrue(summary["outside_soloing_repair_objective_completed"])
+        self.assertTrue(summary["outside_soloing_repair_source_context_preserved"])
         self.assertEqual(summary["rendered_audio_file_count"], 3)
         self.assertEqual(summary["max_repaired_interval"], 12)
         self.assertEqual(summary["max_interval_threshold"], 12)
@@ -149,6 +179,8 @@ class StageBMidiToSoloListeningReviewQualityGapTest(unittest.TestCase):
         self.assertTrue(summary["outside_soloing_repair_source_residual_risk_preserved"])
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_count_after"], 0)
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_delta"], 2)
+        for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+            self.assertEqual(summary[key], SOURCE_CONTEXT[key])
         self.assertTrue(summary["outside_soloing_repair_objective_path_supported"])
         self.assertTrue(summary["outside_soloing_repair_weak_landing_target_supported"])
         self.assertTrue(summary["outside_soloing_repair_final_landing_target_supported"])
@@ -207,6 +239,19 @@ class StageBMidiToSoloListeningReviewQualityGapTest(unittest.TestCase):
                 quality_gap_decision=source,
                 output_dir=Path("outputs/listening_review_quality_gap"),
                 issue_number=906,
+            )
+
+    def test_rejects_missing_outside_soloing_source_context_field(self) -> None:
+        source = quality_gap_decision()
+        source["quality_gap"].pop(
+            "followup_objective_source_outside_soloing_source_pitch_role_risk_delta"
+        )
+
+        with self.assertRaises(StageBMidiToSoloListeningReviewQualityGapError):
+            build_listening_review_quality_gap_report(
+                quality_gap_decision=source,
+                output_dir=Path("outputs/listening_review_quality_gap"),
+                issue_number=990,
             )
 
     def test_rejects_targeted_outside_soloing_source_repair(self) -> None:


### PR DESCRIPTION
## Summary
- listening review quality gap source-context refresh
- #988 quality gap decision 기준 listening review quality gap 갱신
- outside-soloing source-context preserved 및 21개 context field를 delivery package 전 단계까지 보존

## Context
- selected target: `mvp_delivery_package`
- technical MVP delivery package ready: `true`
- outside-soloing repair objective completed: `true`
- outside-soloing repair source context preserved: `true`
- source outside-soloing pitch-role risk: `5 -> 2`
- current repair outside-soloing pitch-role risk after/delta: `0 / 2`
- listening review quality gap open: `true`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Scope
- listening review quality gap validator source-context preserved 필수 조건 추가
- 21개 source-context field report/readiness/validation summary/markdown 보존
- #990 harness run/doc/issue 기준 갱신
- README, CURRENT_STATUS, CORE_PLAN, AGENTS handoff 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_listening_review_quality_gap`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-listening-review-quality-gap`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- listening review quality gap은 delivery package 준비 가능 여부와 claim boundary 기록 범위
- human/audio preference claim 제외
- MIDI-to-solo musical quality claim 제외
- 다음 MVP delivery package refresh 필요

Closes #990