### PR TITLE
Stage B MIDI-to-solo MVP delivery package source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Current handoff scope:
 - Latest audit issue completed: Issue #986, Stage B MIDI-to-solo MVP completion audit source-context refresh.
 - Latest quality gap decision completed: Issue #988, Stage B MIDI-to-solo quality gap decision source-context refresh.
 - Latest listening review quality gap completed: Issue #990, Stage B MIDI-to-solo listening review quality gap source-context refresh.
-- Latest MVP delivery package completed: Issue #908, Stage B MIDI-to-solo MVP delivery package source-context refresh.
+- Latest MVP delivery package completed: Issue #992, Stage B MIDI-to-solo MVP delivery package source-context refresh.
 - Latest README final evidence refresh completed: Issue #910, Stage B MIDI-to-solo README final evidence source-context refresh.
 - Latest final status audit completed: Issue #912, Stage B MIDI-to-solo final status audit source-context refresh.
 - Latest post-MVP quality iteration plan completed: Issue #914, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #980, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after listening review quality gap source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo MVP delivery package source-context refresh.
+- Open issue queue after MVP delivery package source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo README final evidence source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP completion audit: `Issue #986`
 - latest quality gap decision: `Issue #988`
 - latest listening review quality gap: `Issue #990`
-- latest MVP delivery package: `Issue #908`
+- latest MVP delivery package: `Issue #992`
 - latest README final evidence refresh: `Issue #910`
 - latest final status audit: `Issue #912`
 - latest post-MVP quality iteration plan: `Issue #914`
@@ -327,6 +327,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - input to rendered WAV evidence ready: `true`
 - changed-ratio repair audio evidence ready: `true`
 - outside-soloing repair evidence ready: `true`
+- MVP delivery outside-soloing source context preserved: `true`
 - MVP delivery CLI candidates: `3`
 - MVP delivery changed-ratio repair WAV files: `3`
 - MVP delivery outside-soloing repair WAV files: `6`
@@ -500,6 +501,7 @@ MVP delivery package.
 - input to rendered WAV evidence ready: `true`
 - changed-ratio repair audio evidence ready: `true`
 - outside-soloing repair evidence ready: `true`
+- outside-soloing repair source context preserved: `true`
 - CLI candidate count: `3`
 - changed-ratio repair WAV count: `3`
 - outside-soloing repair WAV count: `6`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -10160,6 +10160,57 @@ Issue #990은 Issue #988 quality gap decision의 source/current outside-soloing 
 
 - `Stage B MIDI-to-solo MVP delivery package source-context refresh`
 
+## 9.186 Stage B MIDI-to-solo MVP delivery package source-context refresh
+
+Issue #992는 Issue #990 listening review quality gap의 source/current outside-soloing context를 MVP delivery package manifest까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- next boundary: `stage_b_midi_to_solo_readme_final_evidence_refresh`
+- technical MVP delivery package completed: `true`
+- runnable CLI ready: `true`
+- input to ranked MIDI ready: `true`
+- input to rendered WAV evidence ready: `true`
+- changed-ratio repair audio evidence ready: `true`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair source context preserved: `true`
+- CLI candidate count: `3`
+- changed-ratio repair WAV count: `3`
+- outside-soloing repair WAV count: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing source objective pitch-role risk count: `5`
+- outside-soloing source pitch-role risk count: `5 -> 2`
+- outside-soloing source pitch-role risk delta: `3`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
+- outside-soloing current repair pitch-role risk count after: `0`
+- outside-soloing current repair pitch-role risk delta: `2`
+- raw artifact upload required: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- #990 listening review quality gap의 source-context preserved flag와 21개 context field를 delivery manifest에 보존.
+- delivery package는 local artifact path manifest 범위.
+- raw MIDI/WAV artifact upload 제외.
+- human/audio preference와 MIDI-to-solo musical quality claim 제외.
+- 다음 boundary는 README final evidence refresh.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_delivery_package`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_mvp_delivery_package.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-delivery-package`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo README final evidence source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -16,7 +16,7 @@
 - latest MVP completion audit: Issue #986, Stage B MIDI-to-solo MVP completion audit source-context refresh
 - latest quality gap decision: Issue #988, Stage B MIDI-to-solo quality gap decision source-context refresh
 - latest listening review quality gap: Issue #990, Stage B MIDI-to-solo listening review quality gap source-context refresh
-- latest MVP delivery package: Issue #908, Stage B MIDI-to-solo MVP delivery package source-context refresh
+- latest MVP delivery package: Issue #992, Stage B MIDI-to-solo MVP delivery package source-context refresh
 - latest README final evidence refresh: Issue #910, Stage B MIDI-to-solo README final evidence source-context refresh
 - latest final status audit: Issue #912, Stage B MIDI-to-solo final status audit source-context refresh
 - latest post-MVP quality iteration plan: Issue #914, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #982, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after listening review quality gap source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo MVP delivery package source-context refresh`
+- open issue queue after MVP delivery package source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo README final evidence source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -967,6 +967,7 @@
 - input to rendered WAV evidence ready: `true`
 - changed-ratio repair audio evidence ready: `true`
 - outside-soloing repair evidence ready: `true`
+- outside-soloing repair source context preserved: `true`
 - outside-soloing repair WAV count: `6`
 - outside-soloing source objective pitch-role risk count: `5`
 - outside-soloing source pitch-role risk count: `5 -> 2`

--- a/docs/STAGE_B_MIDI_TO_SOLO_MVP_DELIVERY_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MVP_DELIVERY_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -10,6 +10,7 @@
 - input to rendered WAV evidence ready: `true`
 - changed-ratio repair audio evidence ready: `true`
 - outside-soloing repair evidence ready: `true`
+- outside-soloing repair source context preserved: `true`
 - listening review quality gap open: `true`
 
 ## Run Command
@@ -32,6 +33,12 @@
 - outside-soloing source repair targeted: `false`
 - outside-soloing source residual risk preserved: `true`
 - outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- follow-up repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
 
 ## Claim Boundary
 

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6067,10 +6067,10 @@ run_stage_b_midi_to_solo_listening_review_quality_gap() {
 }
 
 run_stage_b_midi_to_solo_mvp_delivery_package() {
-  local listening_gap_run_id="${LISTENING_GAP_RUN_ID:-harness_stage_b_midi_to_solo_listening_review_quality_gap}"
+  local listening_gap_run_id="${LISTENING_GAP_RUN_ID:-harness_stage_b_midi_to_solo_listening_review_quality_gap_source_context_refresh}"
   local cli_package_run_id="${CLI_PACKAGE_RUN_ID:-harness_stage_b_midi_to_solo_phrase_bank_cli_mvp_package}"
   local changed_ratio_audio_run_id="${CHANGED_RATIO_AUDIO_RUN_ID:-harness_stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package}"
-  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_mvp_delivery_package}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_mvp_delivery_package_source_context_refresh}"
   local listening_gap="outputs/stage_b_midi_to_solo_listening_review_quality_gap/${listening_gap_run_id}/stage_b_midi_to_solo_listening_review_quality_gap.json"
   local cli_package="outputs/stage_b_midi_to_solo_phrase_bank_cli_mvp_package/${cli_package_run_id}/stage_b_midi_to_solo_phrase_bank_cli_mvp_package.json"
   local changed_ratio_audio="outputs/stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package/${changed_ratio_audio_run_id}/stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package.json"
@@ -6093,7 +6093,7 @@ run_stage_b_midi_to_solo_mvp_delivery_package() {
     --cli_mvp_package "$cli_package" \
     --changed_ratio_audio_package "$changed_ratio_audio" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_DELIVERY_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 908 \
+    --issue_number 992 \
     --expected_boundary stage_b_midi_to_solo_mvp_delivery_package \
     --expected_next_boundary stage_b_midi_to_solo_readme_final_evidence_refresh \
     --require_delivery_completed \

--- a/scripts/build_stage_b_midi_to_solo_mvp_delivery_package.py
+++ b/scripts/build_stage_b_midi_to_solo_mvp_delivery_package.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
 from scripts.decide_stage_b_midi_to_solo_listening_review_quality_gap import (  # noqa: E402
+    BRIDGE_SOURCE_CONTEXT_KEYS,
     BOUNDARY as LISTENING_GAP_BOUNDARY,
     NEXT_BOUNDARY as LISTENING_GAP_NEXT_BOUNDARY,
 )
@@ -28,7 +29,7 @@ class StageBMidiToSoloMvpDeliveryPackageError(ValueError):
 
 BOUNDARY = "stage_b_midi_to_solo_mvp_delivery_package"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_readme_final_evidence_refresh"
-SCHEMA_VERSION = "stage_b_midi_to_solo_mvp_delivery_package_v1"
+SCHEMA_VERSION = "stage_b_midi_to_solo_mvp_delivery_package_v2"
 CHANGED_RATIO_AUDIO_BOUNDARY = (
     "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package"
 )
@@ -89,6 +90,15 @@ def _require_existing_file(path: str, *, label: str) -> str:
     return path
 
 
+def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str, Any]:
+    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+        if key not in container:
+            raise StageBMidiToSoloMvpDeliveryPackageError(
+                f"{label} source-context field required: {key}"
+            )
+    return {key: container[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS}
+
+
 def validate_listening_gap(report: dict[str, Any]) -> dict[str, Any]:
     readiness = _dict(report.get("readiness"))
     decision = _dict(report.get("decision"))
@@ -109,6 +119,18 @@ def validate_listening_gap(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloMvpDeliveryPackageError(
             "outside-soloing repair objective completion required"
         )
+    if not bool(readiness.get("outside_soloing_repair_source_context_preserved", False)):
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "outside-soloing repair source context readiness required"
+        )
+    if not bool(summary.get("outside_soloing_repair_source_context_preserved", False)):
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "outside-soloing repair source context preservation required"
+        )
+    source_context = _source_context_fields(
+        summary,
+        label="listening review quality gap",
+    )
     if _int(summary.get("rendered_audio_file_count")) < 3:
         raise StageBMidiToSoloMvpDeliveryPackageError("changed-ratio repair rendered WAV count below 3")
     if _int(summary.get("max_repaired_interval")) > _int(summary.get("max_interval_threshold")):
@@ -172,6 +194,9 @@ def validate_listening_gap(report: dict[str, Any]) -> dict[str, Any]:
         "technical_model_core_mvp_completed": True,
         "changed_ratio_repair_objective_completed": True,
         "outside_soloing_repair_objective_completed": True,
+        "outside_soloing_repair_source_context_preserved": bool(
+            summary.get("outside_soloing_repair_source_context_preserved", False)
+        ),
         "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
         "max_repaired_interval": _int(summary.get("max_repaired_interval")),
         "max_interval_threshold": _int(summary.get("max_interval_threshold")),
@@ -208,6 +233,7 @@ def validate_listening_gap(report: dict[str, Any]) -> dict[str, Any]:
         "outside_soloing_repair_pitch_role_risk_delta": _int(
             summary.get("outside_soloing_repair_pitch_role_risk_delta")
         ),
+        **source_context,
     }
 
 
@@ -352,6 +378,9 @@ def build_delivery_package_report(
             "input_to_rendered_wav_evidence_ready": True,
             "changed_ratio_repair_audio_evidence_ready": True,
             "outside_soloing_repair_evidence_ready": True,
+            "outside_soloing_repair_source_context_preserved": bool(
+                listening["outside_soloing_repair_source_context_preserved"]
+            ),
             "listening_review_quality_gap_open": bool(
                 listening["listening_review_quality_gap_open"]
             ),
@@ -408,6 +437,7 @@ def build_delivery_package_report(
             "outside_soloing_repair_pitch_role_risk_delta": listening[
                 "outside_soloing_repair_pitch_role_risk_delta"
             ],
+            **{key: listening[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
         },
         "artifact_manifest": {
             "cli_repaired_midi_candidates": cli["candidate_manifest"],
@@ -420,6 +450,9 @@ def build_delivery_package_report(
             "runnable_cli_ready": True,
             "local_artifact_paths_recorded": True,
             "raw_artifact_upload_required": False,
+            "outside_soloing_repair_source_context_preserved": bool(
+                listening["outside_soloing_repair_source_context_preserved"]
+            ),
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
             "phrase_bank_musical_quality_claimed": False,
@@ -485,6 +518,18 @@ def validate_delivery_package_report(
         raise StageBMidiToSoloMvpDeliveryPackageError(
             "outside-soloing repair evidence readiness required"
         )
+    if not bool(readiness.get("outside_soloing_repair_source_context_preserved", False)):
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "outside-soloing repair source context readiness required"
+        )
+    if not bool(package.get("outside_soloing_repair_source_context_preserved", False)):
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "outside-soloing repair source context preservation required"
+        )
+    source_context = _source_context_fields(
+        package,
+        label="MVP delivery package",
+    )
     if _int(package.get("outside_soloing_repair_wav_count")) < 6:
         raise StageBMidiToSoloMvpDeliveryPackageError(
             "outside-soloing repair WAV count below 6"
@@ -546,6 +591,9 @@ def validate_delivery_package_report(
         "outside_soloing_repair_evidence_ready": bool(
             package.get("outside_soloing_repair_evidence_ready", False)
         ),
+        "outside_soloing_repair_source_context_preserved": bool(
+            package.get("outside_soloing_repair_source_context_preserved", False)
+        ),
         "cli_candidate_count": _int(package.get("cli_candidate_count")),
         "changed_ratio_repair_wav_count": _int(package.get("changed_ratio_repair_wav_count")),
         "outside_soloing_repair_wav_count": _int(
@@ -570,6 +618,7 @@ def validate_delivery_package_report(
         "outside_soloing_repair_pitch_role_risk_delta": _int(
             package.get("outside_soloing_repair_pitch_role_risk_delta")
         ),
+        **source_context,
         "listening_review_quality_gap_open": bool(
             package.get("listening_review_quality_gap_open", False)
         ),
@@ -600,6 +649,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- input to rendered WAV evidence ready: `{_bool_token(package['input_to_rendered_wav_evidence_ready'])}`",
         f"- changed-ratio repair audio evidence ready: `{_bool_token(package['changed_ratio_repair_audio_evidence_ready'])}`",
         f"- outside-soloing repair evidence ready: `{_bool_token(package['outside_soloing_repair_evidence_ready'])}`",
+        f"- outside-soloing repair source context preserved: `{_bool_token(package['outside_soloing_repair_source_context_preserved'])}`",
         f"- listening review quality gap open: `{_bool_token(package['listening_review_quality_gap_open'])}`",
         "",
         "## Run Command",
@@ -622,6 +672,12 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- outside-soloing source repair targeted: `{_bool_token(package['outside_soloing_repair_source_targeted'])}`",
         f"- outside-soloing source residual risk preserved: `{_bool_token(package['outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- outside-soloing current repair pitch-role risk after / delta: `{package['outside_soloing_repair_pitch_role_risk_count_after']}` / `{package['outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- follow-up objective source outside-soloing source pitch-role risk: `{package['followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {package['followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `{package['followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']} / {package['followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- follow-up repair sweep source outside-soloing source pitch-role risk: `{package['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {package['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `{package['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {package['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- bridge repair sweep source outside-soloing source pitch-role risk: `{package['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {package['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `{package['repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {package['repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         "",
         "## Claim Boundary",
         "",

--- a/tests/test_stage_b_midi_to_solo_final_status_audit.py
+++ b/tests/test_stage_b_midi_to_solo_final_status_audit.py
@@ -17,6 +17,31 @@ from scripts.build_stage_b_midi_to_solo_mvp_delivery_package import (
 )
 
 
+SOURCE_CONTEXT = {
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_objective_source_outside_soloing_source_targeted": False,
+    "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_repair_sweep_source_outside_soloing_source_targeted": False,
+    "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "repair_sweep_source_outside_soloing_source_targeted": False,
+    "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+}
+
+
 def readme_text(*, missing_last: bool = False) -> str:
     snippets = REQUIRED_README_SNIPPETS[:-1] if missing_last else REQUIRED_README_SNIPPETS
     return "\n".join(snippets) + "\n"
@@ -31,6 +56,7 @@ def delivery_package(*, quality_claim: bool = False, cli_count: int = 3) -> dict
             "input_to_rendered_wav_evidence_ready": True,
             "changed_ratio_repair_audio_evidence_ready": True,
             "outside_soloing_repair_evidence_ready": True,
+            "outside_soloing_repair_source_context_preserved": True,
             "cli_candidate_count": cli_count,
             "changed_ratio_repair_wav_count": 3,
             "outside_soloing_repair_wav_count": 6,
@@ -44,6 +70,7 @@ def delivery_package(*, quality_claim: bool = False, cli_count: int = 3) -> dict
             "outside_soloing_repair_pitch_role_risk_count_after": 0,
             "outside_soloing_repair_pitch_role_risk_delta": 2,
             "listening_review_quality_gap_open": True,
+            **SOURCE_CONTEXT,
         },
         "artifact_manifest": {
             "cli_repaired_midi_candidates": [{} for _ in range(cli_count)],
@@ -52,6 +79,7 @@ def delivery_package(*, quality_claim: bool = False, cli_count: int = 3) -> dict
         "readiness": {
             "mvp_delivery_package_completed": True,
             "raw_artifact_upload_required": False,
+            "outside_soloing_repair_source_context_preserved": True,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
             "phrase_bank_musical_quality_claimed": False,

--- a/tests/test_stage_b_midi_to_solo_mvp_delivery_package.py
+++ b/tests/test_stage_b_midi_to_solo_mvp_delivery_package.py
@@ -12,6 +12,7 @@ from scripts.build_stage_b_midi_to_solo_mvp_delivery_package import (
     validate_delivery_package_report,
 )
 from scripts.decide_stage_b_midi_to_solo_listening_review_quality_gap import (
+    BRIDGE_SOURCE_CONTEXT_KEYS,
     BOUNDARY as LISTENING_GAP_BOUNDARY,
     NEXT_BOUNDARY as LISTENING_GAP_NEXT_BOUNDARY,
 )
@@ -26,6 +27,31 @@ def touch(path: Path) -> str:
     return str(path)
 
 
+SOURCE_CONTEXT = {
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_objective_source_outside_soloing_source_targeted": False,
+    "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_repair_sweep_source_outside_soloing_source_targeted": False,
+    "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "repair_sweep_source_outside_soloing_source_targeted": False,
+    "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+}
+
+
 def listening_gap_report(
     *,
     quality_claim: bool = False,
@@ -37,6 +63,7 @@ def listening_gap_report(
             "technical_model_core_mvp_completed": True,
             "changed_ratio_repair_objective_completed": True,
             "outside_soloing_repair_objective_completed": outside_soloing_repair_supported,
+            "outside_soloing_repair_source_context_preserved": outside_soloing_repair_supported,
             "rendered_audio_file_count": 3,
             "max_repaired_interval": 12,
             "max_interval_threshold": 12,
@@ -57,10 +84,12 @@ def listening_gap_report(
                 0 if outside_soloing_repair_supported else 1
             ),
             "outside_soloing_repair_pitch_role_risk_delta": 2,
+            **SOURCE_CONTEXT,
         },
         "readiness": {
             "listening_review_quality_gap_completed": True,
             "technical_mvp_delivery_package_ready": True,
+            "outside_soloing_repair_source_context_preserved": outside_soloing_repair_supported,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
             "broad_trained_model_quality_claimed": False,
@@ -181,6 +210,7 @@ class StageBMidiToSoloMvpDeliveryPackageTest(unittest.TestCase):
         self.assertTrue(summary["input_to_rendered_wav_evidence_ready"])
         self.assertTrue(summary["changed_ratio_repair_audio_evidence_ready"])
         self.assertTrue(summary["outside_soloing_repair_evidence_ready"])
+        self.assertTrue(summary["outside_soloing_repair_source_context_preserved"])
         self.assertEqual(summary["cli_candidate_count"], 3)
         self.assertEqual(summary["changed_ratio_repair_wav_count"], 3)
         self.assertEqual(summary["outside_soloing_repair_wav_count"], 6)
@@ -202,6 +232,8 @@ class StageBMidiToSoloMvpDeliveryPackageTest(unittest.TestCase):
         self.assertTrue(summary["outside_soloing_repair_source_residual_risk_preserved"])
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_count_after"], 0)
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_delta"], 2)
+        for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+            self.assertEqual(summary[key], SOURCE_CONTEXT[key])
         self.assertTrue(summary["listening_review_quality_gap_open"])
         self.assertFalse(summary["raw_artifact_upload_required"])
         self.assertFalse(summary["human_audio_preference_claimed"])
@@ -275,6 +307,22 @@ class StageBMidiToSoloMvpDeliveryPackageTest(unittest.TestCase):
                     changed_ratio_audio_package=changed_ratio_audio_report(tmp_path),
                     output_dir=tmp_path / "delivery",
                     issue_number=908,
+                )
+
+    def test_rejects_missing_outside_soloing_source_context_field(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            source = listening_gap_report()
+            source["quality_gap_summary"].pop(
+                "followup_objective_source_outside_soloing_source_pitch_role_risk_delta"
+            )
+            with self.assertRaises(StageBMidiToSoloMvpDeliveryPackageError):
+                build_delivery_package_report(
+                    listening_review_quality_gap=source,
+                    cli_mvp_package=cli_package_report(tmp_path),
+                    changed_ratio_audio_package=changed_ratio_audio_report(tmp_path),
+                    output_dir=tmp_path / "delivery",
+                    issue_number=992,
                 )
 
     def test_rejects_targeted_outside_soloing_source_repair(self) -> None:


### PR DESCRIPTION
## Summary
- MVP delivery package source-context refresh
- #990 listening review quality gap 기준 delivery manifest 갱신
- outside-soloing source-context preserved 및 21개 context field를 delivery package까지 보존

## Context
- technical MVP delivery package completed: `true`
- runnable CLI ready: `true`
- input to ranked MIDI ready: `true`
- input to rendered WAV evidence ready: `true`
- outside-soloing repair evidence ready: `true`
- outside-soloing repair source context preserved: `true`
- source outside-soloing pitch-role risk: `5 -> 2`
- current repair outside-soloing pitch-role risk after/delta: `0 / 2`
- raw artifact upload required: `false`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Scope
- delivery package validator source-context preserved 필수 조건 추가
- 21개 source-context field delivery package/readiness/validation summary/markdown 보존
- downstream final status fixture schema v2 호환 갱신
- #992 harness run/doc/issue 기준 갱신
- README, CURRENT_STATUS, CORE_PLAN, AGENTS handoff 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_delivery_package`
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_final_status_audit`
- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_mvp_delivery_package.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-delivery-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- delivery package는 local artifact path manifest와 claim boundary 기록 범위
- raw artifact upload 제외
- human/audio preference claim 제외
- MIDI-to-solo musical quality claim 제외
- 다음 README final evidence refresh 필요

Closes #992