### PR TITLE
Stage B MIDI-to-solo README final evidence source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Current handoff scope:
 - Latest quality gap decision completed: Issue #988, Stage B MIDI-to-solo quality gap decision source-context refresh.
 - Latest listening review quality gap completed: Issue #990, Stage B MIDI-to-solo listening review quality gap source-context refresh.
 - Latest MVP delivery package completed: Issue #992, Stage B MIDI-to-solo MVP delivery package source-context refresh.
-- Latest README final evidence refresh completed: Issue #910, Stage B MIDI-to-solo README final evidence source-context refresh.
+- Latest README final evidence refresh completed: Issue #994, Stage B MIDI-to-solo README final evidence source-context refresh.
 - Latest final status audit completed: Issue #912, Stage B MIDI-to-solo final status audit source-context refresh.
 - Latest post-MVP quality iteration plan completed: Issue #914, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh.
 - Latest quality rubric baseline completed: Issue #916, Stage B MIDI-to-solo quality rubric baseline source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #980, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after MVP delivery package source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo README final evidence source-context refresh.
+- Open issue queue after README final evidence source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo final status audit source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest quality gap decision: `Issue #988`
 - latest listening review quality gap: `Issue #990`
 - latest MVP delivery package: `Issue #992`
-- latest README final evidence refresh: `Issue #910`
+- latest README final evidence refresh: `Issue #994`
 - latest final status audit: `Issue #912`
 - latest post-MVP quality iteration plan: `Issue #914`
 - latest quality rubric baseline: `Issue #916`
@@ -332,6 +332,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - MVP delivery changed-ratio repair WAV files: `3`
 - MVP delivery outside-soloing repair WAV files: `6`
 - README final evidence source-context reflected: `true`
+- README final evidence outside-soloing source context preserved: `true`
 - MVP delivery raw artifact upload required: `false`
 - model-conditioned input path quality alignment decision completed: `true`
 - next boundary: `stage_b_midi_to_solo_readme_final_evidence_refresh`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -10211,6 +10211,46 @@ Issue #992는 Issue #990 listening review quality gap의 source/current outside-
 
 - `Stage B MIDI-to-solo README final evidence source-context refresh`
 
+## 9.187 Stage B MIDI-to-solo README final evidence source-context refresh
+
+Issue #994는 Issue #992 MVP delivery package의 source-context preserved 결과를 README final evidence와 final status audit README snippet 계약에 반영한 작업이다.
+
+결과:
+
+- source boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- next boundary: `stage_b_midi_to_solo_final_status_audit`
+- latest evidence boundary reflected: `stage_b_midi_to_solo_mvp_delivery_package`
+- README final evidence source-context reflected: `true`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair source context preserved: `true`
+- outside-soloing repair WAV count: `6`
+- outside-soloing source pitch-role risk count: `5 -> 2`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
+- outside-soloing current repair pitch-role risk count after: `0`
+- outside-soloing current repair pitch-role risk delta: `2`
+- raw artifact upload required: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- README final evidence block에 #992 delivery package source-context preserved 결과 반영.
+- final status audit README snippet 계약에 source-context preserved 항목 추가.
+- raw artifact upload, human/audio preference, MIDI-to-solo musical quality claim 제외 유지.
+- 다음 boundary는 final status audit.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_final_status_audit`
+- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_final_status.py`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo final status audit source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -17,7 +17,7 @@
 - latest quality gap decision: Issue #988, Stage B MIDI-to-solo quality gap decision source-context refresh
 - latest listening review quality gap: Issue #990, Stage B MIDI-to-solo listening review quality gap source-context refresh
 - latest MVP delivery package: Issue #992, Stage B MIDI-to-solo MVP delivery package source-context refresh
-- latest README final evidence refresh: Issue #910, Stage B MIDI-to-solo README final evidence source-context refresh
+- latest README final evidence refresh: Issue #994, Stage B MIDI-to-solo README final evidence source-context refresh
 - latest final status audit: Issue #912, Stage B MIDI-to-solo final status audit source-context refresh
 - latest post-MVP quality iteration plan: Issue #914, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh
 - latest quality rubric baseline: Issue #916, Stage B MIDI-to-solo quality rubric baseline source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #982, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after MVP delivery package source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo README final evidence source-context refresh`
+- open issue queue after README final evidence source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo final status audit source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -983,6 +983,7 @@
 - README final evidence source-context refresh 완료
 - latest evidence boundary reflected: `stage_b_midi_to_solo_mvp_delivery_package`
 - outside-soloing repair evidence ready: `true`
+- outside-soloing repair source context preserved: `true`
 - outside-soloing repair WAV count: `6`
 - outside-soloing source pitch-role risk count: `5 -> 2`
 - outside-soloing source repair targeted: `false`

--- a/docs/STAGE_B_MIDI_TO_SOLO_README_FINAL_EVIDENCE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_README_FINAL_EVIDENCE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -15,6 +15,7 @@
 - input to rendered WAV evidence ready: `true`
 - changed-ratio repair audio evidence ready: `true`
 - outside-soloing repair evidence ready: `true`
+- outside-soloing repair source context preserved: `true`
 - outside-soloing repair WAV count: `6`
 - outside-soloing source pitch-role risk count: `5 -> 2`
 - outside-soloing source repair targeted: `false`

--- a/scripts/audit_stage_b_midi_to_solo_final_status.py
+++ b/scripts/audit_stage_b_midi_to_solo_final_status.py
@@ -49,6 +49,7 @@ REQUIRED_README_SNIPPETS = [
     "- input to rendered WAV evidence ready: `true`",
     "- changed-ratio repair audio evidence ready: `true`",
     "- outside-soloing repair evidence ready: `true`",
+    "- outside-soloing repair source context preserved: `true`",
     "- outside-soloing repair WAV count: `6`",
     "- outside-soloing source pitch-role risk count: `5 -> 2`",
     "- outside-soloing source repair targeted: `false`",


### PR DESCRIPTION
## Summary
- README final evidence source-context refresh
- #992 MVP delivery package 기준 README final evidence 갱신
- final status audit README snippet 계약에 source-context preserved 항목 추가

## Context
- latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
- MVP delivery package completed: `true`
- outside-soloing repair evidence ready: `true`
- outside-soloing repair source context preserved: `true`
- source outside-soloing pitch-role risk: `5 -> 2`
- current repair outside-soloing pitch-role risk after/delta: `0 / 2`
- raw artifact upload required: `false`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Scope
- README final evidence source-context preserved 항목 추가
- final status audit required README snippet 갱신
- #994 handoff 문서 기준 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_final_status_audit`
- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_final_status.py`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- 문서/README snippet 계약 범위
- delivery package schema 변경 제외
- human/audio preference claim 제외
- MIDI-to-solo musical quality claim 제외
- 다음 final status audit refresh 필요

Closes #994