### PR TITLE
Stage B MIDI-to-solo final status audit source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Current handoff scope:
 - Latest listening review quality gap completed: Issue #990, Stage B MIDI-to-solo listening review quality gap source-context refresh.
 - Latest MVP delivery package completed: Issue #992, Stage B MIDI-to-solo MVP delivery package source-context refresh.
 - Latest README final evidence refresh completed: Issue #994, Stage B MIDI-to-solo README final evidence source-context refresh.
-- Latest final status audit completed: Issue #912, Stage B MIDI-to-solo final status audit source-context refresh.
+- Latest final status audit completed: Issue #996, Stage B MIDI-to-solo final status audit source-context refresh.
 - Latest post-MVP quality iteration plan completed: Issue #914, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh.
 - Latest quality rubric baseline completed: Issue #916, Stage B MIDI-to-solo quality rubric baseline source-context refresh.
 - Latest candidate failure labeling completed: Issue #918, Stage B MIDI-to-solo candidate failure labeling source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #980, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after README final evidence source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo final status audit source-context refresh.
+- Open issue queue after final status audit source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest listening review quality gap: `Issue #990`
 - latest MVP delivery package: `Issue #992`
 - latest README final evidence refresh: `Issue #994`
-- latest final status audit: `Issue #912`
+- latest final status audit: `Issue #996`
 - latest post-MVP quality iteration plan: `Issue #914`
 - latest quality rubric baseline: `Issue #916`
 - latest candidate failure labeling: `Issue #918`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -10251,6 +10251,55 @@ Issue #994는 Issue #992 MVP delivery package의 source-context preserved 결과
 
 - `Stage B MIDI-to-solo final status audit source-context refresh`
 
+## 9.188 Stage B MIDI-to-solo final status audit source-context refresh
+
+Issue #996은 Issue #994 README final evidence와 Issue #992 delivery package 결과를 기준으로 final status audit summary에 source/current outside-soloing context를 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_final_status_audit`
+- source boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- next boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- final status audit completed: `true`
+- technical MVP complete: `true`
+- technical MVP ready for local review: `true`
+- README final evidence reflected: `true`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair source context preserved: `true`
+- outside-soloing repair WAV count: `6`
+- outside-soloing repair changed note total: `2`
+- outside-soloing source objective pitch-role risk count: `5`
+- outside-soloing source pitch-role risk count: `5 -> 2`
+- outside-soloing source pitch-role risk delta: `3`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
+- outside-soloing current repair pitch-role risk count after: `0`
+- outside-soloing current repair pitch-role risk delta: `2`
+- raw artifact upload required: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- delivery package의 source-context preserved flag와 21개 context field를 final status audit summary에 보존.
+- README final evidence reflected 조건에 source-context preserved snippet 포함.
+- technical MVP 완료는 local review 가능한 technical path 기준.
+- human/audio preference와 MIDI-to-solo musical quality claim 제외.
+- 다음 boundary는 post-MVP quality iteration plan.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_final_status_audit`
+- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_final_status.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-final-status-audit`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -18,7 +18,7 @@
 - latest listening review quality gap: Issue #990, Stage B MIDI-to-solo listening review quality gap source-context refresh
 - latest MVP delivery package: Issue #992, Stage B MIDI-to-solo MVP delivery package source-context refresh
 - latest README final evidence refresh: Issue #994, Stage B MIDI-to-solo README final evidence source-context refresh
-- latest final status audit: Issue #912, Stage B MIDI-to-solo final status audit source-context refresh
+- latest final status audit: Issue #996, Stage B MIDI-to-solo final status audit source-context refresh
 - latest post-MVP quality iteration plan: Issue #914, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh
 - latest quality rubric baseline: Issue #916, Stage B MIDI-to-solo quality rubric baseline source-context refresh
 - latest candidate failure labeling: Issue #918, Stage B MIDI-to-solo candidate failure labeling source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #982, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after README final evidence source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo final status audit source-context refresh`
+- open issue queue after final status audit source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -998,6 +998,7 @@
 - technical MVP complete: `true`
 - README final evidence reflected: `true`
 - outside-soloing repair evidence ready: `true`
+- outside-soloing repair source context preserved: `true`
 - outside-soloing repair WAV count: `6`
 - outside-soloing repair changed note total: `2`
 - outside-soloing source objective pitch-role risk count: `5`

--- a/docs/STAGE_B_MIDI_TO_SOLO_FINAL_STATUS_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_FINAL_STATUS_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -15,6 +15,7 @@
 - input to rendered WAV evidence ready: `true`
 - changed-ratio repair audio evidence ready: `true`
 - outside-soloing repair evidence ready: `true`
+- outside-soloing repair source context preserved: `true`
 - CLI candidate count: `3`
 - changed-ratio repair WAV count: `3`
 - outside-soloing repair WAV count: `6`
@@ -24,6 +25,12 @@
 - outside-soloing source repair targeted: `false`
 - outside-soloing source residual risk preserved: `true`
 - outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- follow-up repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
 - listening review quality gap open: `true`
 - raw artifact upload required: `false`
 

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6101,8 +6101,8 @@ run_stage_b_midi_to_solo_mvp_delivery_package() {
 }
 
 run_stage_b_midi_to_solo_final_status_audit() {
-  local delivery_package_run_id="${DELIVERY_PACKAGE_RUN_ID:-harness_stage_b_midi_to_solo_mvp_delivery_package}"
-  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_final_status_audit}"
+  local delivery_package_run_id="${DELIVERY_PACKAGE_RUN_ID:-harness_stage_b_midi_to_solo_mvp_delivery_package_source_context_refresh}"
+  local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_final_status_audit_source_context_refresh}"
   local delivery_package="outputs/stage_b_midi_to_solo_mvp_delivery_package/${delivery_package_run_id}/stage_b_midi_to_solo_mvp_delivery_package.json"
   if [[ ! -f "$delivery_package" ]]; then
     print_header "Stage B MIDI-to-solo MVP delivery package"
@@ -6114,7 +6114,7 @@ run_stage_b_midi_to_solo_final_status_audit() {
     --delivery_package "$delivery_package" \
     --readme_path README.md \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_FINAL_STATUS_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 912 \
+    --issue_number 996 \
     --expected_boundary stage_b_midi_to_solo_final_status_audit \
     --expected_next_boundary stage_b_midi_to_solo_post_mvp_quality_iteration_plan \
     --require_technical_mvp_complete \

--- a/scripts/audit_stage_b_midi_to_solo_final_status.py
+++ b/scripts/audit_stage_b_midi_to_solo_final_status.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
 from scripts.build_stage_b_midi_to_solo_mvp_delivery_package import (  # noqa: E402
+    BRIDGE_SOURCE_CONTEXT_KEYS,
     BOUNDARY as DELIVERY_BOUNDARY,
     StageBMidiToSoloMvpDeliveryPackageError,
     validate_delivery_package_report,
@@ -26,7 +27,7 @@ class StageBMidiToSoloFinalStatusAuditError(ValueError):
 
 BOUNDARY = "stage_b_midi_to_solo_final_status_audit"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_post_mvp_quality_iteration_plan"
-SCHEMA_VERSION = "stage_b_midi_to_solo_final_status_audit_v1"
+SCHEMA_VERSION = "stage_b_midi_to_solo_final_status_audit_v2"
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -135,6 +136,9 @@ def build_final_status_audit_report(
         "outside_soloing_repair_evidence_ready": bool(
             delivery["outside_soloing_repair_evidence_ready"]
         ),
+        "outside_soloing_repair_source_context_preserved": bool(
+            delivery["outside_soloing_repair_source_context_preserved"]
+        ),
         "cli_candidate_count": _int(delivery["cli_candidate_count"]),
         "changed_ratio_repair_wav_count": _int(delivery["changed_ratio_repair_wav_count"]),
         "outside_soloing_repair_wav_count": _int(
@@ -167,6 +171,7 @@ def build_final_status_audit_report(
         "outside_soloing_repair_pitch_role_risk_delta": _int(
             delivery["outside_soloing_repair_pitch_role_risk_delta"]
         ),
+        **{key: delivery[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
         "listening_review_quality_gap_open": bool(delivery["listening_review_quality_gap_open"]),
         "raw_artifact_upload_required": bool(delivery["raw_artifact_upload_required"]),
         "human_audio_preference_claimed": bool(delivery["human_audio_preference_claimed"]),
@@ -193,6 +198,9 @@ def build_final_status_audit_report(
             ),
             "readme_final_evidence_reflected": bool(
                 final_status["readme_final_evidence_reflected"]
+            ),
+            "outside_soloing_repair_source_context_preserved": bool(
+                final_status["outside_soloing_repair_source_context_preserved"]
             ),
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
@@ -272,6 +280,9 @@ def validate_final_status_audit_report(
         "outside_soloing_repair_evidence_ready": bool(
             final_status.get("outside_soloing_repair_evidence_ready", False)
         ),
+        "outside_soloing_repair_source_context_preserved": bool(
+            final_status.get("outside_soloing_repair_source_context_preserved", False)
+        ),
         "outside_soloing_repair_wav_count": _int(
             final_status.get("outside_soloing_repair_wav_count")
         ),
@@ -302,6 +313,7 @@ def validate_final_status_audit_report(
         "outside_soloing_repair_pitch_role_risk_delta": _int(
             final_status.get("outside_soloing_repair_pitch_role_risk_delta")
         ),
+        **{key: final_status.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
         "listening_review_quality_gap_open": bool(
             final_status.get("listening_review_quality_gap_open", False)
         ),
@@ -339,6 +351,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- input to rendered WAV evidence ready: `{_bool_token(final_status['input_to_rendered_wav_evidence_ready'])}`",
         f"- changed-ratio repair audio evidence ready: `{_bool_token(final_status['changed_ratio_repair_audio_evidence_ready'])}`",
         f"- outside-soloing repair evidence ready: `{_bool_token(final_status['outside_soloing_repair_evidence_ready'])}`",
+        f"- outside-soloing repair source context preserved: `{_bool_token(final_status['outside_soloing_repair_source_context_preserved'])}`",
         f"- CLI candidate count: `{final_status['cli_candidate_count']}`",
         f"- changed-ratio repair WAV count: `{final_status['changed_ratio_repair_wav_count']}`",
         f"- outside-soloing repair WAV count: `{final_status['outside_soloing_repair_wav_count']}`",
@@ -348,6 +361,12 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- outside-soloing source repair targeted: `{_bool_token(final_status['outside_soloing_repair_source_targeted'])}`",
         f"- outside-soloing source residual risk preserved: `{_bool_token(final_status['outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- outside-soloing current repair pitch-role risk after / delta: `{final_status['outside_soloing_repair_pitch_role_risk_count_after']}` / `{final_status['outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- follow-up objective source outside-soloing source pitch-role risk: `{final_status['followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {final_status['followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `{final_status['followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']} / {final_status['followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- follow-up repair sweep source outside-soloing source pitch-role risk: `{final_status['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {final_status['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `{final_status['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {final_status['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- bridge repair sweep source outside-soloing source pitch-role risk: `{final_status['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {final_status['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `{final_status['repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {final_status['repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- listening review quality gap open: `{_bool_token(final_status['listening_review_quality_gap_open'])}`",
         f"- raw artifact upload required: `{_bool_token(final_status['raw_artifact_upload_required'])}`",
         "",

--- a/tests/test_stage_b_midi_to_solo_final_status_audit.py
+++ b/tests/test_stage_b_midi_to_solo_final_status_audit.py
@@ -12,6 +12,7 @@ from scripts.audit_stage_b_midi_to_solo_final_status import (
     validate_final_status_audit_report,
 )
 from scripts.build_stage_b_midi_to_solo_mvp_delivery_package import (
+    BRIDGE_SOURCE_CONTEXT_KEYS,
     BOUNDARY as DELIVERY_BOUNDARY,
     NEXT_BOUNDARY as DELIVERY_NEXT_BOUNDARY,
 )
@@ -119,6 +120,7 @@ class StageBMidiToSoloFinalStatusAuditTest(unittest.TestCase):
         self.assertEqual(summary["cli_candidate_count"], 3)
         self.assertEqual(summary["changed_ratio_repair_wav_count"], 3)
         self.assertTrue(summary["outside_soloing_repair_evidence_ready"])
+        self.assertTrue(summary["outside_soloing_repair_source_context_preserved"])
         self.assertEqual(summary["outside_soloing_repair_wav_count"], 6)
         self.assertEqual(summary["outside_soloing_repair_changed_note_total"], 2)
         self.assertEqual(
@@ -138,6 +140,8 @@ class StageBMidiToSoloFinalStatusAuditTest(unittest.TestCase):
         self.assertTrue(summary["outside_soloing_repair_source_residual_risk_preserved"])
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_count_after"], 0)
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_delta"], 2)
+        for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+            self.assertEqual(summary[key], SOURCE_CONTEXT[key])
         self.assertTrue(summary["listening_review_quality_gap_open"])
         self.assertFalse(summary["raw_artifact_upload_required"])
         self.assertFalse(summary["human_audio_preference_claimed"])


### PR DESCRIPTION
## Summary
- final status audit source-context refresh
- #994 README final evidence와 #992 delivery package 기준 final status audit 갱신
- outside-soloing source-context preserved 및 21개 context field를 final status summary까지 보존

## Context
- final status audit completed: `true`
- technical MVP complete: `true`
- technical MVP ready for local review: `true`
- README final evidence reflected: `true`
- outside-soloing repair evidence ready: `true`
- outside-soloing repair source context preserved: `true`
- source outside-soloing pitch-role risk: `5 -> 2`
- current repair outside-soloing pitch-role risk after/delta: `0 / 2`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Scope
- final status audit summary/readiness/validation summary/markdown source-context preserved 반영
- 21개 source-context field final status summary 보존
- #996 harness run/doc/issue 기준 갱신
- README, CURRENT_STATUS, CORE_PLAN, AGENTS handoff 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_final_status_audit`
- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_final_status.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-final-status-audit`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- final status audit은 technical MVP/readme reflection/claim boundary 확인 범위
- human/audio preference claim 제외
- MIDI-to-solo musical quality claim 제외
- 다음 post-MVP quality iteration plan refresh 필요

Closes #996