### PR TITLE
Stage B MIDI-to-solo quality rubric baseline source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Current handoff scope:
 - Latest README final evidence refresh completed: Issue #994, Stage B MIDI-to-solo README final evidence source-context refresh.
 - Latest final status audit completed: Issue #996, Stage B MIDI-to-solo final status audit source-context refresh.
 - Latest post-MVP quality iteration plan completed: Issue #998, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh.
-- Latest quality rubric baseline completed: Issue #916, Stage B MIDI-to-solo quality rubric baseline source-context refresh.
+- Latest quality rubric baseline completed: Issue #1000, Stage B MIDI-to-solo quality rubric baseline source-context refresh.
 - Latest candidate failure labeling completed: Issue #918, Stage B MIDI-to-solo candidate failure labeling source-context refresh.
 - Latest targeted quality repair sweep completed: Issue #920, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh.
 - Latest targeted quality repair audio package completed: Issue #922, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh.
@@ -56,7 +56,7 @@ Current handoff scope:
 - Latest documentation issue completed: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
 - Open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo quality rubric baseline source-context refresh.
+- Recommended next issue: Stage B MIDI-to-solo candidate failure labeling source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest README final evidence refresh: `Issue #994`
 - latest final status audit: `Issue #996`
 - latest post-MVP quality iteration plan: `Issue #998`
-- latest quality rubric baseline: `Issue #916`
+- latest quality rubric baseline: `Issue #1000`
 - latest candidate failure labeling: `Issue #918`
 - latest targeted quality repair sweep: `Issue #920`
 - latest targeted quality repair audio package: `Issue #922`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -10350,6 +10350,52 @@ Issue #998은 Issue #996 final status audit의 source/current outside-soloing co
 
 - `Stage B MIDI-to-solo quality rubric baseline source-context refresh`
 
+## 9.190 Stage B MIDI-to-solo quality rubric baseline source-context refresh
+
+Issue #1000은 Issue #998 post-MVP quality iteration plan의 source/current outside-soloing context를 quality rubric baseline까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
+- source boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- next boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
+- selected target: `candidate_failure_labeling`
+- rubric item count: `8`
+- required metric group count: `30`
+- candidate failure labeling ready: `true`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair source context preserved: `true`
+- outside-soloing repair WAV count: `6`
+- outside-soloing source objective pitch-role risk count: `5`
+- outside-soloing source pitch-role risk count: `5 -> 2`
+- outside-soloing source pitch-role risk delta: `3`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
+- outside-soloing current repair pitch-role risk count after: `0`
+- outside-soloing current repair pitch-role risk delta: `2`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- quality rubric baseline source validation에 #998 post-MVP plan 검증 결과 사용.
+- source-context preserved flag와 21개 context field를 rubric baseline/source quality context/validation summary에 보존.
+- outside-soloing rubric은 residual pitch-role repair 대상이 아니라 context/listening quality risk labeling 대상으로 유지.
+- candidate failure labeling 진입 전 품질/선호 claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_rubric_baseline`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_quality_rubric_baseline.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-rubric-baseline`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo candidate failure labeling source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -20,7 +20,7 @@
 - latest README final evidence refresh: Issue #994, Stage B MIDI-to-solo README final evidence source-context refresh
 - latest final status audit: Issue #996, Stage B MIDI-to-solo final status audit source-context refresh
 - latest post-MVP quality iteration plan: Issue #998, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh
-- latest quality rubric baseline: Issue #916, Stage B MIDI-to-solo quality rubric baseline source-context refresh
+- latest quality rubric baseline: Issue #1000, Stage B MIDI-to-solo quality rubric baseline source-context refresh
 - latest candidate failure labeling: Issue #918, Stage B MIDI-to-solo candidate failure labeling source-context refresh
 - latest targeted quality repair sweep: Issue #920, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh
 - latest targeted quality repair audio package: Issue #922, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh
@@ -57,7 +57,7 @@
 - latest README evidence refresh: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
 - open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo quality rubric baseline source-context refresh`
+- 다음 권장 이슈: `Stage B MIDI-to-solo candidate failure labeling source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -1035,6 +1035,7 @@
 - required metric group count: `30`
 - candidate failure labeling ready: `true`
 - outside-soloing repair evidence ready: `true`
+- outside-soloing repair source context preserved: `true`
 - outside-soloing repair WAV count: `6`
 - outside-soloing source objective pitch-role risk count: `5`
 - outside-soloing source pitch-role risk count: `5 -> 2`

--- a/docs/STAGE_B_MIDI_TO_SOLO_QUALITY_RUBRIC_BASELINE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_QUALITY_RUBRIC_BASELINE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -9,12 +9,19 @@
 - rubric item count: `8`
 - candidate failure labeling ready: `true`
 - outside-soloing repair evidence ready: `true`
+- outside-soloing repair source context preserved: `true`
 - outside-soloing repair WAV count: `6`
 - outside-soloing source objective pitch-role risk: `5`
 - outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - outside-soloing source repair targeted: `false`
 - outside-soloing source residual risk preserved: `true`
 - outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- follow-up repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
 
 ## Rubric Items
 

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6144,7 +6144,7 @@ run_stage_b_midi_to_solo_post_mvp_quality_iteration_plan() {
 }
 
 run_stage_b_midi_to_solo_quality_rubric_baseline() {
-  local post_mvp_plan_run_id="${POST_MVP_PLAN_RUN_ID:-harness_stage_b_midi_to_solo_post_mvp_quality_iteration_plan}"
+  local post_mvp_plan_run_id="${POST_MVP_PLAN_RUN_ID:-harness_stage_b_midi_to_solo_post_mvp_quality_iteration_plan_source_context_refresh}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_quality_rubric_baseline_source_context_refresh}"
   local post_mvp_plan="outputs/stage_b_midi_to_solo_post_mvp_quality_iteration_plan/${post_mvp_plan_run_id}/stage_b_midi_to_solo_post_mvp_quality_iteration_plan.json"
   if [[ ! -f "$post_mvp_plan" ]]; then
@@ -6156,7 +6156,7 @@ run_stage_b_midi_to_solo_quality_rubric_baseline() {
     --run_id "$run_id" \
     --post_mvp_quality_plan "$post_mvp_plan" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_QUALITY_RUBRIC_BASELINE_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 916 \
+    --issue_number 1000 \
     --expected_boundary stage_b_midi_to_solo_quality_rubric_baseline \
     --expected_next_boundary stage_b_midi_to_solo_candidate_failure_labeling \
     --expected_target candidate_failure_labeling \

--- a/scripts/build_stage_b_midi_to_solo_quality_rubric_baseline.py
+++ b/scripts/build_stage_b_midi_to_solo_quality_rubric_baseline.py
@@ -13,6 +13,9 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
+    BRIDGE_SOURCE_CONTEXT_KEYS,
+)
 from scripts.plan_stage_b_midi_to_solo_post_mvp_quality_iteration import (  # noqa: E402
     BOUNDARY as POST_MVP_PLAN_BOUNDARY,
     NEXT_BOUNDARY as POST_MVP_PLAN_NEXT_BOUNDARY,
@@ -29,7 +32,7 @@ class StageBMidiToSoloQualityRubricBaselineError(ValueError):
 BOUNDARY = "stage_b_midi_to_solo_quality_rubric_baseline"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_candidate_failure_labeling"
 SELECTED_TARGET = "candidate_failure_labeling"
-SCHEMA_VERSION = "stage_b_midi_to_solo_quality_rubric_baseline_v2"
+SCHEMA_VERSION = "stage_b_midi_to_solo_quality_rubric_baseline_v3"
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -71,6 +74,15 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
         )
 
 
+def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str, Any]:
+    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+        if key not in container or container[key] is None:
+            raise StageBMidiToSoloQualityRubricBaselineError(
+                f"{label} source-context field required: {key}"
+            )
+    return {key: container[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS}
+
+
 def validate_post_mvp_quality_iteration_plan_source(report: dict[str, Any]) -> dict[str, Any]:
     if str(report.get("boundary") or "") != POST_MVP_PLAN_BOUNDARY:
         raise StageBMidiToSoloQualityRubricBaselineError(
@@ -107,6 +119,11 @@ def validate_post_mvp_quality_iteration_plan_source(report: dict[str, Any]) -> d
         raise StageBMidiToSoloQualityRubricBaselineError(
             "outside-soloing repair evidence readiness required"
         )
+    if not bool(summary.get("outside_soloing_repair_source_context_preserved", False)):
+        raise StageBMidiToSoloQualityRubricBaselineError(
+            "outside-soloing repair source context preservation required"
+        )
+    _source_context_fields(summary, label="post-MVP quality iteration plan")
     if _int(summary.get("outside_soloing_repair_wav_count")) < 6:
         raise StageBMidiToSoloQualityRubricBaselineError(
             "outside-soloing repair WAV count below 6"
@@ -231,6 +248,9 @@ def build_quality_rubric_baseline_report(
         "outside_soloing_repair_evidence_ready": bool(
             source["outside_soloing_repair_evidence_ready"]
         ),
+        "outside_soloing_repair_source_context_preserved": bool(
+            source["outside_soloing_repair_source_context_preserved"]
+        ),
         "outside_soloing_repair_wav_count": _int(
             source["outside_soloing_repair_wav_count"]
         ),
@@ -261,6 +281,7 @@ def build_quality_rubric_baseline_report(
         "outside_soloing_repair_pitch_role_risk_delta": _int(
             source["outside_soloing_repair_pitch_role_risk_delta"]
         ),
+        **{key: source[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
         "outside_soloing_label_scope": "remaining context/listening quality risk after objective pitch-role repair",
     }
     return {
@@ -280,6 +301,9 @@ def build_quality_rubric_baseline_report(
             "candidate_failure_labeling_ready": True,
             "outside_soloing_repair_evidence_ready": bool(
                 outside_context["outside_soloing_repair_evidence_ready"]
+            ),
+            "outside_soloing_repair_source_context_preserved": bool(
+                outside_context["outside_soloing_repair_source_context_preserved"]
             ),
             "outside_soloing_repair_wav_count": _int(
                 outside_context["outside_soloing_repair_wav_count"]
@@ -308,6 +332,7 @@ def build_quality_rubric_baseline_report(
             "outside_soloing_repair_pitch_role_risk_delta": _int(
                 outside_context["outside_soloing_repair_pitch_role_risk_delta"]
             ),
+            **{key: outside_context[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
         },
@@ -323,6 +348,9 @@ def build_quality_rubric_baseline_report(
             "candidate_failure_labeling_ready": True,
             "rubric_item_count": len(rubric_items),
             "selected_target": SELECTED_TARGET,
+            "outside_soloing_repair_source_context_preserved": bool(
+                outside_context["outside_soloing_repair_source_context_preserved"]
+            ),
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
             "audio_rendered_quality_claimed": False,
@@ -418,6 +446,9 @@ def validate_quality_rubric_baseline_report(
         "outside_soloing_repair_evidence_ready": bool(
             baseline.get("outside_soloing_repair_evidence_ready", False)
         ),
+        "outside_soloing_repair_source_context_preserved": bool(
+            baseline.get("outside_soloing_repair_source_context_preserved", False)
+        ),
         "outside_soloing_repair_wav_count": _int(
             baseline.get("outside_soloing_repair_wav_count")
         ),
@@ -445,6 +476,10 @@ def validate_quality_rubric_baseline_report(
         "outside_soloing_repair_pitch_role_risk_delta": _int(
             baseline.get("outside_soloing_repair_pitch_role_risk_delta")
         ),
+        **{
+            key: baseline.get(key)
+            for key in BRIDGE_SOURCE_CONTEXT_KEYS
+        },
         "human_audio_preference_claimed": bool(
             readiness.get("human_audio_preference_claimed", True)
         ),
@@ -473,12 +508,19 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- rubric item count: `{baseline['rubric_item_count']}`",
         f"- candidate failure labeling ready: `{_bool_token(baseline['candidate_failure_labeling_ready'])}`",
         f"- outside-soloing repair evidence ready: `{_bool_token(source_context['outside_soloing_repair_evidence_ready'])}`",
+        f"- outside-soloing repair source context preserved: `{_bool_token(source_context['outside_soloing_repair_source_context_preserved'])}`",
         f"- outside-soloing repair WAV count: `{source_context['outside_soloing_repair_wav_count']}`",
         f"- outside-soloing source objective pitch-role risk: `{source_context['outside_soloing_repair_source_objective_pitch_role_risk_count']}`",
         f"- outside-soloing source pitch-role risk before / after / delta: `{source_context['outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{source_context['outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{source_context['outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- outside-soloing source repair targeted: `{_bool_token(source_context['outside_soloing_repair_source_targeted'])}`",
         f"- outside-soloing source residual risk preserved: `{_bool_token(source_context['outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- outside-soloing current repair pitch-role risk after / delta: `{source_context['outside_soloing_repair_pitch_role_risk_count_after']}` / `{source_context['outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- follow-up objective source outside-soloing source pitch-role risk: `{source_context['followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {source_context['followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `{source_context['followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']} / {source_context['followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- follow-up repair sweep source outside-soloing source pitch-role risk: `{source_context['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {source_context['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `{source_context['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {source_context['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- bridge repair sweep source outside-soloing source pitch-role risk: `{source_context['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {source_context['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `{source_context['repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {source_context['repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         "",
         "## Rubric Items",
         "",

--- a/tests/test_stage_b_midi_to_solo_candidate_failure_labeling.py
+++ b/tests/test_stage_b_midi_to_solo_candidate_failure_labeling.py
@@ -28,6 +28,31 @@ from scripts.plan_stage_b_midi_to_solo_post_mvp_quality_iteration import (
 )
 
 
+SOURCE_CONTEXT = {
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_objective_source_outside_soloing_source_targeted": False,
+    "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_repair_sweep_source_outside_soloing_source_targeted": False,
+    "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "repair_sweep_source_outside_soloing_source_targeted": False,
+    "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+}
+
+
 def write_midi(path: Path, pitches: list[int]) -> None:
     midi = pretty_midi.PrettyMIDI(initial_tempo=120)
     midi.time_signature_changes.append(pretty_midi.TimeSignature(4, 4, 0.0))
@@ -59,6 +84,7 @@ def post_mvp_quality_plan() -> dict:
             "technical_mvp_complete": True,
             "local_review_ready": True,
             "outside_soloing_repair_evidence_ready": True,
+            "outside_soloing_repair_source_context_preserved": True,
             "outside_soloing_repair_wav_count": 6,
             "outside_soloing_repair_changed_note_total": 2,
             "outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
@@ -71,6 +97,7 @@ def post_mvp_quality_plan() -> dict:
             "outside_soloing_repair_pitch_role_risk_delta": 2,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
+            **SOURCE_CONTEXT,
         },
         "readiness": {
             "post_mvp_quality_iteration_plan_completed": True,
@@ -78,6 +105,7 @@ def post_mvp_quality_plan() -> dict:
             "candidate_failure_labeling_required": True,
             "targeted_quality_repair_sweep_required": True,
             "audio_review_package_required": True,
+            "outside_soloing_repair_source_context_preserved": True,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
             "audio_rendered_quality_claimed": False,

--- a/tests/test_stage_b_midi_to_solo_quality_rubric_baseline.py
+++ b/tests/test_stage_b_midi_to_solo_quality_rubric_baseline.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import unittest
 from pathlib import Path
 
+from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_SOURCE_CONTEXT_KEYS
 from scripts.build_stage_b_midi_to_solo_quality_rubric_baseline import (
     BOUNDARY,
     NEXT_BOUNDARY,
@@ -16,6 +17,31 @@ from scripts.plan_stage_b_midi_to_solo_post_mvp_quality_iteration import (
     NEXT_BOUNDARY as POST_MVP_NEXT_BOUNDARY,
     SELECTED_TARGET as POST_MVP_SELECTED_TARGET,
 )
+
+
+SOURCE_CONTEXT = {
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_objective_source_outside_soloing_source_targeted": False,
+    "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_repair_sweep_source_outside_soloing_source_targeted": False,
+    "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "repair_sweep_source_outside_soloing_source_targeted": False,
+    "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+}
 
 
 def post_mvp_quality_plan(
@@ -41,6 +67,7 @@ def post_mvp_quality_plan(
             "technical_mvp_complete": True,
             "local_review_ready": True,
             "outside_soloing_repair_evidence_ready": outside_ready,
+            "outside_soloing_repair_source_context_preserved": outside_ready,
             "outside_soloing_repair_wav_count": outside_wav_count,
             "outside_soloing_repair_changed_note_total": 2,
             "outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
@@ -53,6 +80,7 @@ def post_mvp_quality_plan(
             "outside_soloing_repair_pitch_role_risk_delta": 2,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
+            **SOURCE_CONTEXT,
         },
         "selected_next_target": {
             "selected_target": selected_target,
@@ -66,6 +94,7 @@ def post_mvp_quality_plan(
             "candidate_failure_labeling_required": True,
             "targeted_quality_repair_sweep_required": True,
             "audio_review_package_required": True,
+            "outside_soloing_repair_source_context_preserved": outside_ready,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
             "audio_rendered_quality_claimed": False,
@@ -106,6 +135,7 @@ class StageBMidiToSoloQualityRubricBaselineTest(unittest.TestCase):
         self.assertEqual(summary["rubric_item_count"], 8)
         self.assertGreaterEqual(summary["required_metric_group_count"], 20)
         self.assertTrue(summary["outside_soloing_repair_evidence_ready"])
+        self.assertTrue(summary["outside_soloing_repair_source_context_preserved"])
         self.assertEqual(summary["outside_soloing_repair_wav_count"], 6)
         self.assertEqual(summary["outside_soloing_repair_source_objective_pitch_role_risk_count"], 5)
         self.assertEqual(summary["outside_soloing_repair_source_pitch_role_risk_count_before"], 5)
@@ -115,6 +145,8 @@ class StageBMidiToSoloQualityRubricBaselineTest(unittest.TestCase):
         self.assertTrue(summary["outside_soloing_repair_source_residual_risk_preserved"])
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_count_after"], 0)
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_delta"], 2)
+        for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+            self.assertEqual(summary[key], SOURCE_CONTEXT[key])
         self.assertFalse(summary["human_audio_preference_claimed"])
         self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
         self.assertEqual(
@@ -180,6 +212,18 @@ class StageBMidiToSoloQualityRubricBaselineTest(unittest.TestCase):
                 post_mvp_quality_plan=post_mvp_quality_plan(outside_risk_after=1),
                 output_dir=Path("outputs/quality_rubric"),
                 issue_number=746,
+            )
+
+    def test_rejects_missing_outside_soloing_source_context_field(self) -> None:
+        source = post_mvp_quality_plan()
+        source["post_mvp_status"].pop(
+            "followup_objective_source_outside_soloing_source_pitch_role_risk_delta"
+        )
+        with self.assertRaises(StageBMidiToSoloQualityRubricBaselineError):
+            build_quality_rubric_baseline_report(
+                post_mvp_quality_plan=source,
+                output_dir=Path("outputs/quality_rubric"),
+                issue_number=1000,
             )
 
     def test_rejects_missing_required_rubric_item(self) -> None:

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py
@@ -31,6 +31,31 @@ from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep impor
 )
 
 
+SOURCE_CONTEXT = {
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_objective_source_outside_soloing_source_targeted": False,
+    "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_repair_sweep_source_outside_soloing_source_targeted": False,
+    "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "repair_sweep_source_outside_soloing_source_targeted": False,
+    "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+}
+
+
 def post_mvp_quality_plan() -> dict:
     return {
         "boundary": POST_MVP_BOUNDARY,
@@ -49,6 +74,7 @@ def post_mvp_quality_plan() -> dict:
             "technical_mvp_complete": True,
             "local_review_ready": True,
             "outside_soloing_repair_evidence_ready": True,
+            "outside_soloing_repair_source_context_preserved": True,
             "outside_soloing_repair_wav_count": 6,
             "outside_soloing_repair_changed_note_total": 2,
             "outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
@@ -61,6 +87,7 @@ def post_mvp_quality_plan() -> dict:
             "outside_soloing_repair_pitch_role_risk_delta": 2,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
+            **SOURCE_CONTEXT,
         },
         "readiness": {
             "post_mvp_quality_iteration_plan_completed": True,
@@ -68,6 +95,7 @@ def post_mvp_quality_plan() -> dict:
             "candidate_failure_labeling_required": True,
             "targeted_quality_repair_sweep_required": True,
             "audio_review_package_required": True,
+            "outside_soloing_repair_source_context_preserved": True,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
             "audio_rendered_quality_claimed": False,

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
@@ -31,6 +31,31 @@ from scripts.run_stage_b_midi_to_solo_targeted_quality_repair_sweep import (
 )
 
 
+SOURCE_CONTEXT = {
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_objective_source_outside_soloing_source_targeted": False,
+    "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_repair_sweep_source_outside_soloing_source_targeted": False,
+    "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "repair_sweep_source_outside_soloing_source_targeted": False,
+    "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+}
+
+
 def post_mvp_quality_plan() -> dict:
     return {
         "boundary": POST_MVP_BOUNDARY,
@@ -49,6 +74,7 @@ def post_mvp_quality_plan() -> dict:
             "technical_mvp_complete": True,
             "local_review_ready": True,
             "outside_soloing_repair_evidence_ready": True,
+            "outside_soloing_repair_source_context_preserved": True,
             "outside_soloing_repair_wav_count": 6,
             "outside_soloing_repair_changed_note_total": 2,
             "outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
@@ -61,6 +87,7 @@ def post_mvp_quality_plan() -> dict:
             "outside_soloing_repair_pitch_role_risk_delta": 2,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
+            **SOURCE_CONTEXT,
         },
         "readiness": {
             "post_mvp_quality_iteration_plan_completed": True,
@@ -68,6 +95,7 @@ def post_mvp_quality_plan() -> dict:
             "candidate_failure_labeling_required": True,
             "targeted_quality_repair_sweep_required": True,
             "audio_review_package_required": True,
+            "outside_soloing_repair_source_context_preserved": True,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
             "audio_rendered_quality_claimed": False,

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
@@ -27,6 +27,31 @@ from scripts.run_stage_b_midi_to_solo_targeted_quality_repair_sweep import (
 )
 
 
+SOURCE_CONTEXT = {
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_objective_source_outside_soloing_source_targeted": False,
+    "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_repair_sweep_source_outside_soloing_source_targeted": False,
+    "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "repair_sweep_source_outside_soloing_source_targeted": False,
+    "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+}
+
+
 def write_midi(path: Path, pitches: list[int]) -> None:
     midi = pretty_midi.PrettyMIDI(initial_tempo=120)
     midi.time_signature_changes.append(pretty_midi.TimeSignature(4, 4, 0.0))
@@ -58,6 +83,7 @@ def post_mvp_quality_plan() -> dict:
             "technical_mvp_complete": True,
             "local_review_ready": True,
             "outside_soloing_repair_evidence_ready": True,
+            "outside_soloing_repair_source_context_preserved": True,
             "outside_soloing_repair_wav_count": 6,
             "outside_soloing_repair_changed_note_total": 2,
             "outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
@@ -70,6 +96,7 @@ def post_mvp_quality_plan() -> dict:
             "outside_soloing_repair_pitch_role_risk_delta": 2,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
+            **SOURCE_CONTEXT,
         },
         "readiness": {
             "post_mvp_quality_iteration_plan_completed": True,
@@ -77,6 +104,7 @@ def post_mvp_quality_plan() -> dict:
             "candidate_failure_labeling_required": True,
             "targeted_quality_repair_sweep_required": True,
             "audio_review_package_required": True,
+            "outside_soloing_repair_source_context_preserved": True,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
             "audio_rendered_quality_claimed": False,


### PR DESCRIPTION
## Summary
- quality rubric baseline source-context refresh
- #998 post-MVP quality iteration plan 기준 quality rubric baseline 갱신
- outside-soloing source-context preserved 및 21개 context field를 candidate failure labeling 전 단계까지 보존

## Context
- source issue: #998
- technical MVP complete: `true`
- local review ready: `true`
- selected target: `candidate_failure_labeling`
- rubric item count: `8`
- required metric group count: `30`
- outside-soloing repair evidence ready: `true`
- outside-soloing repair source context preserved: `true`
- source outside-soloing pitch-role risk: `5 -> 2`
- current repair outside-soloing pitch-role risk after/delta: `0 / 2`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Scope
- quality rubric baseline source validator source-context preserved 필수 조건 추가
- 21개 source-context field source quality context/rubric baseline/validation summary/markdown 보존
- downstream test fixtures를 현재 post-MVP plan 계약에 맞춰 갱신
- #1000 harness run/doc/issue 기준 갱신
- README, CURRENT_STATUS, CORE_PLAN, AGENTS handoff 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_rubric_baseline`
- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_quality_rubric_baseline.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-rubric-baseline`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- quality rubric baseline은 MIDI evidence labeling 기준 정의 범위
- human/audio preference claim 제외
- MIDI-to-solo musical quality claim 제외
- 다음 candidate failure labeling refresh 필요

Closes #1000
