### PR TITLE
Stage B MIDI-to-solo candidate failure labeling source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Current handoff scope:
 - Latest final status audit completed: Issue #996, Stage B MIDI-to-solo final status audit source-context refresh.
 - Latest post-MVP quality iteration plan completed: Issue #998, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh.
 - Latest quality rubric baseline completed: Issue #1000, Stage B MIDI-to-solo quality rubric baseline source-context refresh.
-- Latest candidate failure labeling completed: Issue #918, Stage B MIDI-to-solo candidate failure labeling source-context refresh.
+- Latest candidate failure labeling completed: Issue #1002, Stage B MIDI-to-solo candidate failure labeling source-context refresh.
 - Latest targeted quality repair sweep completed: Issue #920, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh.
 - Latest targeted quality repair audio package completed: Issue #922, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh.
 - Latest targeted quality repair listening review package completed: Issue #924, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh.
@@ -56,7 +56,7 @@ Current handoff scope:
 - Latest documentation issue completed: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
 - Open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo candidate failure labeling source-context refresh.
+- Recommended next issue: Stage B MIDI-to-solo targeted quality repair sweep source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest final status audit: `Issue #996`
 - latest post-MVP quality iteration plan: `Issue #998`
 - latest quality rubric baseline: `Issue #1000`
-- latest candidate failure labeling: `Issue #918`
+- latest candidate failure labeling: `Issue #1002`
 - latest targeted quality repair sweep: `Issue #920`
 - latest targeted quality repair audio package: `Issue #922`
 - latest targeted quality repair listening review package: `Issue #924`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -10396,6 +10396,56 @@ Issue #1000은 Issue #998 post-MVP quality iteration plan의 source/current outs
 
 - `Stage B MIDI-to-solo candidate failure labeling source-context refresh`
 
+## 9.191 Stage B MIDI-to-solo candidate failure labeling source-context refresh
+
+Issue #1002는 Issue #1000 quality rubric baseline의 source/current outside-soloing context를 candidate failure labeling 결과까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
+- source boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- selected target: `targeted_quality_repair_sweep`
+- candidate count: `6`
+- failed candidate count: `6`
+- failure label type count: `4`
+- not evaluable label type count: `2`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair source context preserved: `true`
+- outside-soloing repair WAV count: `6`
+- outside-soloing source objective pitch-role risk count: `5`
+- outside-soloing source pitch-role risk count: `5 -> 2`
+- outside-soloing source pitch-role risk delta: `3`
+- outside-soloing source repair targeted: `false`
+- outside-soloing source residual risk preserved: `true`
+- outside-soloing current repair pitch-role risk count after: `0`
+- outside-soloing current repair pitch-role risk delta: `2`
+- outside-soloing not evaluable count: `6`
+- targeted quality repair sweep ready: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- candidate failure labeling source validation에 #1000 rubric baseline source-context preserved 조건 추가.
+- source-context preserved flag와 21개 context field를 aggregate와 validation summary에 보존.
+- outside-soloing label은 chord-context 부재로 not evaluable 유지.
+- 현재 후보 6개 모두 failure label 보유, 다음 targeted quality repair sweep 진입.
+- human/audio preference와 MIDI-to-solo musical quality claim 제외.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_candidate_failure_labeling`
+- `.venv/bin/python -m py_compile scripts/label_stage_b_midi_to_solo_candidate_failures.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-candidate-failure-labeling`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo targeted quality repair sweep source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -21,7 +21,7 @@
 - latest final status audit: Issue #996, Stage B MIDI-to-solo final status audit source-context refresh
 - latest post-MVP quality iteration plan: Issue #998, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh
 - latest quality rubric baseline: Issue #1000, Stage B MIDI-to-solo quality rubric baseline source-context refresh
-- latest candidate failure labeling: Issue #918, Stage B MIDI-to-solo candidate failure labeling source-context refresh
+- latest candidate failure labeling: Issue #1002, Stage B MIDI-to-solo candidate failure labeling source-context refresh
 - latest targeted quality repair sweep: Issue #920, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh
 - latest targeted quality repair audio package: Issue #922, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh
 - latest targeted quality repair listening review package: Issue #924, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh
@@ -57,7 +57,7 @@
 - latest README evidence refresh: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
 - open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo candidate failure labeling source-context refresh`
+- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair sweep source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -1054,6 +1054,7 @@
 - failure label type count: `4`
 - not evaluable label type count: `2`
 - outside-soloing repair evidence ready: `true`
+- outside-soloing repair source context preserved: `true`
 - outside-soloing repair WAV count: `6`
 - outside-soloing source objective pitch-role risk count: `5`
 - outside-soloing source pitch-role risk count: `5 -> 2`

--- a/docs/STAGE_B_MIDI_TO_SOLO_CANDIDATE_FAILURE_LABELING_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_CANDIDATE_FAILURE_LABELING_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -9,12 +9,19 @@
 - candidate count: `6`
 - failed candidate count: `6`
 - outside-soloing repair evidence ready: `true`
+- outside-soloing repair source context preserved: `true`
 - outside-soloing repair WAV count: `6`
 - outside-soloing source objective pitch-role risk: `5`
 - outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - outside-soloing source repair targeted: `false`
 - outside-soloing source residual risk preserved: `true`
 - outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- follow-up repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
 - outside-soloing not evaluable count: `6`
 - targeted quality repair sweep ready: `true`
 

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6185,7 +6185,7 @@ run_stage_b_midi_to_solo_candidate_failure_labeling() {
     --rubric_baseline "$rubric" \
     --mvp_delivery_package "$delivery" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_CANDIDATE_FAILURE_LABELING_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 918 \
+    --issue_number 1002 \
     --expected_boundary stage_b_midi_to_solo_candidate_failure_labeling \
     --min_candidate_count 6 \
     --require_labeling_completed \

--- a/scripts/label_stage_b_midi_to_solo_candidate_failures.py
+++ b/scripts/label_stage_b_midi_to_solo_candidate_failures.py
@@ -17,6 +17,9 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
+    BRIDGE_SOURCE_CONTEXT_KEYS,
+)
 from scripts.build_stage_b_midi_to_solo_mvp_delivery_package import (  # noqa: E402
     BOUNDARY as DELIVERY_BOUNDARY,
 )
@@ -38,7 +41,7 @@ REPAIR_NEXT_BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_sweep"
 AUDIO_REVIEW_NEXT_BOUNDARY = "stage_b_midi_to_solo_audio_review_package"
 REPAIR_TARGET = "targeted_quality_repair_sweep"
 AUDIO_REVIEW_TARGET = "audio_review_package"
-SCHEMA_VERSION = "stage_b_midi_to_solo_candidate_failure_labeling_v2"
+SCHEMA_VERSION = "stage_b_midi_to_solo_candidate_failure_labeling_v3"
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -87,6 +90,15 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
         )
 
 
+def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str, Any]:
+    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+        if key not in container or container[key] is None:
+            raise StageBMidiToSoloCandidateFailureLabelingError(
+                f"{label} source-context field required: {key}"
+            )
+    return {key: container[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS}
+
+
 def validate_rubric_baseline(report: dict[str, Any]) -> dict[str, Any]:
     if str(report.get("boundary") or "") != RUBRIC_BOUNDARY:
         raise StageBMidiToSoloCandidateFailureLabelingError("rubric baseline boundary required")
@@ -109,6 +121,11 @@ def validate_rubric_baseline(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloCandidateFailureLabelingError(
             "outside-soloing repair evidence readiness required"
         )
+    if not bool(summary.get("outside_soloing_repair_source_context_preserved", False)):
+        raise StageBMidiToSoloCandidateFailureLabelingError(
+            "outside-soloing repair source context preservation required"
+        )
+    _source_context_fields(summary, label="quality rubric baseline")
     if _int(summary.get("outside_soloing_repair_wav_count")) < 6:
         raise StageBMidiToSoloCandidateFailureLabelingError(
             "outside-soloing repair WAV count below 6"
@@ -510,6 +527,9 @@ def build_candidate_failure_labeling_report(
         "outside_soloing_repair_evidence_ready": bool(
             rubric_summary["outside_soloing_repair_evidence_ready"]
         ),
+        "outside_soloing_repair_source_context_preserved": bool(
+            rubric_summary["outside_soloing_repair_source_context_preserved"]
+        ),
         "outside_soloing_repair_wav_count": _int(
             rubric_summary["outside_soloing_repair_wav_count"]
         ),
@@ -540,6 +560,7 @@ def build_candidate_failure_labeling_report(
         "outside_soloing_not_evaluable_count": _int(
             not_evaluable_counts.get("outside_soloing_without_context", 0)
         ),
+        **{key: rubric_summary[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
         "outside_soloing_label_scope": "not_evaluable chord-context gap after objective pitch-role repair",
     }
     failed_candidate_count = sum(1 for item in labeled if _list(item.get("failure_labels")))
@@ -580,6 +601,9 @@ def build_candidate_failure_labeling_report(
             "failed_candidate_count": failed_candidate_count,
             "targeted_quality_repair_sweep_ready": failed_candidate_count > 0,
             "audio_review_package_ready": failed_candidate_count == 0,
+            "outside_soloing_repair_source_context_preserved": bool(
+                outside_context["outside_soloing_repair_source_context_preserved"]
+            ),
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
             "audio_rendered_quality_claimed": False,
@@ -663,6 +687,9 @@ def validate_candidate_failure_labeling_report(
         "outside_soloing_repair_evidence_ready": bool(
             aggregate.get("outside_soloing_repair_evidence_ready", False)
         ),
+        "outside_soloing_repair_source_context_preserved": bool(
+            aggregate.get("outside_soloing_repair_source_context_preserved", False)
+        ),
         "outside_soloing_repair_wav_count": _int(
             aggregate.get("outside_soloing_repair_wav_count")
         ),
@@ -693,6 +720,10 @@ def validate_candidate_failure_labeling_report(
         "outside_soloing_not_evaluable_count": _int(
             aggregate.get("outside_soloing_not_evaluable_count")
         ),
+        **{
+            key: aggregate.get(key)
+            for key in BRIDGE_SOURCE_CONTEXT_KEYS
+        },
         "targeted_quality_repair_sweep_ready": bool(
             readiness.get("targeted_quality_repair_sweep_ready", False)
         ),
@@ -724,12 +755,19 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- candidate count: `{aggregate['candidate_count']}`",
         f"- failed candidate count: `{aggregate['failed_candidate_count']}`",
         f"- outside-soloing repair evidence ready: `{_bool_token(aggregate['outside_soloing_repair_evidence_ready'])}`",
+        f"- outside-soloing repair source context preserved: `{_bool_token(aggregate['outside_soloing_repair_source_context_preserved'])}`",
         f"- outside-soloing repair WAV count: `{aggregate['outside_soloing_repair_wav_count']}`",
         f"- outside-soloing source objective pitch-role risk: `{aggregate['outside_soloing_repair_source_objective_pitch_role_risk_count']}`",
         f"- outside-soloing source pitch-role risk before / after / delta: `{aggregate['outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{aggregate['outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{aggregate['outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- outside-soloing source repair targeted: `{_bool_token(aggregate['outside_soloing_repair_source_targeted'])}`",
         f"- outside-soloing source residual risk preserved: `{_bool_token(aggregate['outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- outside-soloing current repair pitch-role risk after / delta: `{aggregate['outside_soloing_repair_pitch_role_risk_count_after']}` / `{aggregate['outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- follow-up objective source outside-soloing source pitch-role risk: `{aggregate['followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {aggregate['followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `{aggregate['followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']} / {aggregate['followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- follow-up repair sweep source outside-soloing source pitch-role risk: `{aggregate['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {aggregate['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `{aggregate['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {aggregate['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- bridge repair sweep source outside-soloing source pitch-role risk: `{aggregate['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {aggregate['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `{aggregate['repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {aggregate['repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- outside-soloing not evaluable count: `{aggregate['outside_soloing_not_evaluable_count']}`",
         f"- targeted quality repair sweep ready: `{_bool_token(readiness['targeted_quality_repair_sweep_ready'])}`",
         "",

--- a/tests/test_stage_b_midi_to_solo_candidate_failure_labeling.py
+++ b/tests/test_stage_b_midi_to_solo_candidate_failure_labeling.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pretty_midi
 
+from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_SOURCE_CONTEXT_KEYS
 from scripts.build_stage_b_midi_to_solo_mvp_delivery_package import BOUNDARY as DELIVERY_BOUNDARY
 from scripts.build_stage_b_midi_to_solo_quality_rubric_baseline import (
     BOUNDARY as RUBRIC_BOUNDARY,
@@ -211,6 +212,7 @@ class StageBMidiToSoloCandidateFailureLabelingTest(unittest.TestCase):
             self.assertGreater(summary["failure_label_type_count"], 0)
             self.assertGreaterEqual(summary["not_evaluable_label_type_count"], 2)
             self.assertTrue(summary["outside_soloing_repair_evidence_ready"])
+            self.assertTrue(summary["outside_soloing_repair_source_context_preserved"])
             self.assertEqual(summary["outside_soloing_repair_wav_count"], 6)
             self.assertEqual(
                 summary["outside_soloing_repair_source_objective_pitch_role_risk_count"], 5
@@ -222,6 +224,8 @@ class StageBMidiToSoloCandidateFailureLabelingTest(unittest.TestCase):
             self.assertTrue(summary["outside_soloing_repair_source_residual_risk_preserved"])
             self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_count_after"], 0)
             self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_delta"], 2)
+            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+                self.assertEqual(summary[key], SOURCE_CONTEXT[key])
             self.assertEqual(summary["outside_soloing_not_evaluable_count"], 3)
             self.assertEqual(summary["selected_target"], REPAIR_TARGET)
             self.assertEqual(summary["next_boundary"], REPAIR_NEXT_BOUNDARY)
@@ -302,6 +306,24 @@ class StageBMidiToSoloCandidateFailureLabelingTest(unittest.TestCase):
                     mvp_delivery_package=delivery_package(paths),
                     output_dir=root / "labels",
                     issue_number=748,
+                )
+
+    def test_rejects_missing_rubric_source_context_field(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = [root / f"candidate_{index}.mid" for index in range(3)]
+            for path in paths:
+                write_midi(path, [60, 62, 64, 65] * 4)
+            source = rubric_baseline(root)
+            source["rubric_baseline"].pop(
+                "followup_objective_source_outside_soloing_source_pitch_role_risk_delta"
+            )
+            with self.assertRaises(StageBMidiToSoloCandidateFailureLabelingError):
+                build_candidate_failure_labeling_report(
+                    rubric_baseline=source,
+                    mvp_delivery_package=delivery_package(paths),
+                    output_dir=root / "labels",
+                    issue_number=1002,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary
- candidate failure labeling source-context refresh
- #1000 quality rubric baseline 기준 candidate failure labeling 갱신
- outside-soloing source-context preserved 및 21개 context field를 targeted quality repair sweep 전 단계까지 보존

## Context
- source issue: #1000
- candidate count: `6`
- failed candidate count: `6`
- failure label type count: `4`
- not evaluable label type count: `2`
- outside-soloing repair evidence ready: `true`
- outside-soloing repair source context preserved: `true`
- source outside-soloing pitch-role risk: `5 -> 2`
- current repair outside-soloing pitch-role risk after/delta: `0 / 2`
- outside-soloing not evaluable count: `6`
- targeted quality repair sweep ready: `true`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Scope
- candidate failure labeling source validator source-context preserved 필수 조건 추가
- 21개 source-context field aggregate/validation summary/markdown 보존
- #1002 harness run/doc/issue 기준 갱신
- README, CURRENT_STATUS, CORE_PLAN, AGENTS handoff 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_candidate_failure_labeling`
- `.venv/bin/python -m py_compile scripts/label_stage_b_midi_to_solo_candidate_failures.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-candidate-failure-labeling`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- candidate failure labeling은 MIDI evidence 기준 라벨링 범위
- outside-soloing/chord-tone 계열은 chord context 부재 시 not-evaluable 유지
- human/audio preference claim 제외
- MIDI-to-solo musical quality claim 제외
- 다음 targeted quality repair sweep refresh 필요

Closes #1002
