### PR TITLE
Stage B MIDI-to-solo targeted quality repair sweep source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Current handoff scope:
 - Latest post-MVP quality iteration plan completed: Issue #998, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh.
 - Latest quality rubric baseline completed: Issue #1000, Stage B MIDI-to-solo quality rubric baseline source-context refresh.
 - Latest candidate failure labeling completed: Issue #1002, Stage B MIDI-to-solo candidate failure labeling source-context refresh.
-- Latest targeted quality repair sweep completed: Issue #920, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh.
+- Latest targeted quality repair sweep completed: Issue #1004, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh.
 - Latest targeted quality repair audio package completed: Issue #922, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh.
 - Latest targeted quality repair listening review package completed: Issue #924, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh.
 - Latest targeted quality repair listening review input guard completed: Issue #926, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh.
@@ -56,7 +56,7 @@ Current handoff scope:
 - Latest documentation issue completed: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
 - Open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo targeted quality repair sweep source-context refresh.
+- Recommended next issue: Stage B MIDI-to-solo targeted quality repair audio package source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest post-MVP quality iteration plan: `Issue #998`
 - latest quality rubric baseline: `Issue #1000`
 - latest candidate failure labeling: `Issue #1002`
-- latest targeted quality repair sweep: `Issue #920`
+- latest targeted quality repair sweep: `Issue #1004`
 - latest targeted quality repair audio package: `Issue #922`
 - latest targeted quality repair listening review package: `Issue #924`
 - latest targeted quality repair listening review input guard: `Issue #926`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -10446,6 +10446,59 @@ Issue #1002는 Issue #1000 quality rubric baseline의 source/current outside-sol
 
 - `Stage B MIDI-to-solo targeted quality repair sweep source-context refresh`
 
+## 9.192 Stage B MIDI-to-solo targeted quality repair sweep source-context refresh
+
+Issue #1004는 Issue #1002 candidate failure labeling의 source/current outside-soloing context를 targeted quality repair sweep 결과까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
+- selected target: `targeted_quality_repair_audio_package`
+- candidate count: `6`
+- source total failure label count: `12`
+- repaired total failure label count: `8`
+- failure label delta: `4`
+- improved candidate count: `4`
+- technical regression count: `0`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair source context preserved: `true`
+- source outside-soloing repair WAV count: `6`
+- source outside-soloing source objective pitch-role risk count: `5`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing source pitch-role risk delta: `3`
+- source outside-soloing source repair targeted: `false`
+- source outside-soloing source residual risk preserved: `true`
+- source outside-soloing current repair pitch-role risk count after: `0`
+- source outside-soloing current repair pitch-role risk delta: `2`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- audio package ready: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- targeted repair sweep source validation에 #1002 labeling source-context preserved 조건 추가.
+- source-context preserved flag와 21개 context field를 aggregate와 validation summary에 보존.
+- repair sweep 결과 objective failure label delta `4`, technical regression `0`.
+- outside-soloing/chord-tone 계열은 chord context 부재로 not evaluable 유지.
+- human/audio preference와 MIDI-to-solo musical quality claim 제외.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-sweep`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo targeted quality repair audio package source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -22,7 +22,7 @@
 - latest post-MVP quality iteration plan: Issue #998, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh
 - latest quality rubric baseline: Issue #1000, Stage B MIDI-to-solo quality rubric baseline source-context refresh
 - latest candidate failure labeling: Issue #1002, Stage B MIDI-to-solo candidate failure labeling source-context refresh
-- latest targeted quality repair sweep: Issue #920, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh
+- latest targeted quality repair sweep: Issue #1004, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh
 - latest targeted quality repair audio package: Issue #922, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh
 - latest targeted quality repair listening review package: Issue #924, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh
 - latest targeted quality repair listening review input guard: Issue #926, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh
@@ -57,7 +57,7 @@
 - latest README evidence refresh: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
 - open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair sweep source-context refresh`
+- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair audio package source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -1076,6 +1076,7 @@
 - improved candidate count: `4`
 - technical regression count: `0`
 - source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair source context preserved: `true`
 - source outside-soloing repair WAV count: `6`
 - source outside-soloing source objective pitch-role risk count: `5`
 - source outside-soloing source pitch-role risk count: `5 -> 2`

--- a/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -13,11 +13,18 @@
 - improved candidate count: `4`
 - technical regression count: `0`
 - source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair source context preserved: `true`
 - source outside-soloing source objective pitch-role risk: `5`
 - source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - source outside-soloing source repair targeted: `false`
 - source outside-soloing source residual risk preserved: `true`
 - source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- follow-up repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
 - source outside-soloing not evaluable count: `6`
 - repaired outside-soloing not evaluable count: `6`
 - target supported: `true`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6212,7 +6212,7 @@ run_stage_b_midi_to_solo_targeted_quality_repair_sweep() {
     --candidate_failure_labeling "$labeling" \
     --rubric_baseline "$rubric" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 920 \
+    --issue_number 1004 \
     --expected_boundary stage_b_midi_to_solo_targeted_quality_repair_sweep \
     --min_candidate_count 6 \
     --require_sweep_completed \

--- a/scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
+++ b/scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
@@ -17,6 +17,9 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
+    BRIDGE_SOURCE_CONTEXT_KEYS,
+)
 from scripts.label_stage_b_midi_to_solo_candidate_failures import (  # noqa: E402
     BOUNDARY as LABELING_BOUNDARY,
     REPAIR_NEXT_BOUNDARY as LABELING_NEXT_BOUNDARY,
@@ -36,7 +39,7 @@ class StageBMidiToSoloTargetedQualityRepairSweepError(ValueError):
 BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_sweep"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_audio_package"
 FOLLOWUP_BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_followup_decision"
-SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_sweep_v2"
+SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_sweep_v3"
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -85,6 +88,15 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
         )
 
 
+def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str, Any]:
+    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+        if key not in container or container[key] is None:
+            raise StageBMidiToSoloTargetedQualityRepairSweepError(
+                f"{label} source-context field required: {key}"
+            )
+    return {key: container[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS}
+
+
 def validate_labeling_source(report: dict[str, Any]) -> dict[str, Any]:
     if str(report.get("boundary") or "") != LABELING_BOUNDARY:
         raise StageBMidiToSoloTargetedQualityRepairSweepError(
@@ -113,6 +125,11 @@ def validate_labeling_source(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloTargetedQualityRepairSweepError(
             "outside-soloing repair evidence readiness required"
         )
+    if not bool(summary.get("outside_soloing_repair_source_context_preserved", False)):
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "outside-soloing repair source context preservation required"
+        )
+    _source_context_fields(summary, label="candidate failure labeling")
     if _int(summary.get("outside_soloing_repair_wav_count")) < 6:
         raise StageBMidiToSoloTargetedQualityRepairSweepError(
             "outside-soloing repair WAV count below 6"
@@ -361,6 +378,9 @@ def build_targeted_quality_repair_sweep_report(
             "source_outside_soloing_repair_evidence_ready": bool(
                 source_summary["outside_soloing_repair_evidence_ready"]
             ),
+            "source_outside_soloing_repair_source_context_preserved": bool(
+                source_summary["outside_soloing_repair_source_context_preserved"]
+            ),
             "source_outside_soloing_repair_wav_count": _int(
                 source_summary["outside_soloing_repair_wav_count"]
             ),
@@ -394,6 +414,7 @@ def build_targeted_quality_repair_sweep_report(
             "repaired_outside_soloing_not_evaluable_count": _int(
                 not_evaluable_counts_after.get("outside_soloing_without_context", 0)
             ),
+            **{key: source_summary[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
             "target_supported": target_supported,
         },
         "selected_next_target": {
@@ -413,6 +434,9 @@ def build_targeted_quality_repair_sweep_report(
             "failure_label_delta": total_before - total_after,
             "technical_regression_count": technical_regression_count,
             "audio_package_ready": target_supported,
+            "source_outside_soloing_repair_source_context_preserved": bool(
+                source_summary["outside_soloing_repair_source_context_preserved"]
+            ),
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
             "audio_rendered_quality_claimed": False,
@@ -500,6 +524,9 @@ def validate_targeted_quality_repair_sweep_report(
         "source_outside_soloing_repair_evidence_ready": bool(
             aggregate.get("source_outside_soloing_repair_evidence_ready", False)
         ),
+        "source_outside_soloing_repair_source_context_preserved": bool(
+            aggregate.get("source_outside_soloing_repair_source_context_preserved", False)
+        ),
         "source_outside_soloing_repair_wav_count": _int(
             aggregate.get("source_outside_soloing_repair_wav_count")
         ),
@@ -533,6 +560,10 @@ def validate_targeted_quality_repair_sweep_report(
         "repaired_outside_soloing_not_evaluable_count": _int(
             aggregate.get("repaired_outside_soloing_not_evaluable_count")
         ),
+        **{
+            key: aggregate.get(key)
+            for key in BRIDGE_SOURCE_CONTEXT_KEYS
+        },
         "audio_package_ready": bool(readiness.get("audio_package_ready", False)),
         "human_audio_preference_claimed": bool(
             readiness.get("human_audio_preference_claimed", True)
@@ -565,11 +596,18 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- improved candidate count: `{aggregate['improved_candidate_count']}`",
         f"- technical regression count: `{aggregate['technical_regression_count']}`",
         f"- source outside-soloing repair evidence ready: `{_bool_token(aggregate['source_outside_soloing_repair_evidence_ready'])}`",
+        f"- source outside-soloing repair source context preserved: `{_bool_token(aggregate['source_outside_soloing_repair_source_context_preserved'])}`",
         f"- source outside-soloing source objective pitch-role risk: `{aggregate['source_outside_soloing_repair_source_objective_pitch_role_risk_count']}`",
         f"- source outside-soloing source pitch-role risk before / after / delta: `{aggregate['source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{aggregate['source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{aggregate['source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- source outside-soloing source repair targeted: `{_bool_token(aggregate['source_outside_soloing_repair_source_targeted'])}`",
         f"- source outside-soloing source residual risk preserved: `{_bool_token(aggregate['source_outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- source outside-soloing current repair pitch-role risk after / delta: `{aggregate['source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{aggregate['source_outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- follow-up objective source outside-soloing source pitch-role risk: `{aggregate['followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {aggregate['followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `{aggregate['followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']} / {aggregate['followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- follow-up repair sweep source outside-soloing source pitch-role risk: `{aggregate['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {aggregate['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `{aggregate['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {aggregate['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- bridge repair sweep source outside-soloing source pitch-role risk: `{aggregate['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {aggregate['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `{aggregate['repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {aggregate['repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- source outside-soloing not evaluable count: `{aggregate['source_outside_soloing_not_evaluable_count']}`",
         f"- repaired outside-soloing not evaluable count: `{aggregate['repaired_outside_soloing_not_evaluable_count']}`",
         f"- target supported: `{_bool_token(aggregate['target_supported'])}`",

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pretty_midi
 
+from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_SOURCE_CONTEXT_KEYS
 from scripts.build_stage_b_midi_to_solo_mvp_delivery_package import BOUNDARY as DELIVERY_BOUNDARY
 from scripts.build_stage_b_midi_to_solo_quality_rubric_baseline import (
     build_quality_rubric_baseline_report,
@@ -214,6 +215,7 @@ class StageBMidiToSoloTargetedQualityRepairSweepTest(unittest.TestCase):
             self.assertGreater(summary["failure_label_delta"], 0)
             self.assertEqual(summary["technical_regression_count"], 0)
             self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
+            self.assertTrue(summary["source_outside_soloing_repair_source_context_preserved"])
             self.assertEqual(summary["source_outside_soloing_repair_wav_count"], 6)
             self.assertEqual(
                 summary["source_outside_soloing_repair_source_objective_pitch_role_risk_count"], 5
@@ -231,6 +233,8 @@ class StageBMidiToSoloTargetedQualityRepairSweepTest(unittest.TestCase):
             self.assertEqual(summary["source_outside_soloing_repair_pitch_role_risk_delta"], 2)
             self.assertEqual(summary["source_outside_soloing_not_evaluable_count"], 6)
             self.assertEqual(summary["repaired_outside_soloing_not_evaluable_count"], 6)
+            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+                self.assertEqual(summary[key], SOURCE_CONTEXT[key])
             self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
             self.assertTrue(summary["audio_package_ready"])
             self.assertFalse(summary["human_audio_preference_claimed"])
@@ -265,6 +269,21 @@ class StageBMidiToSoloTargetedQualityRepairSweepTest(unittest.TestCase):
                     rubric_baseline=rubric_baseline(root),
                     output_dir=root / "sweep",
                     issue_number=750,
+                )
+
+    def test_rejects_missing_labeling_source_context_field(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = candidate_failure_labeling(root)
+            source["aggregate"].pop(
+                "followup_objective_source_outside_soloing_source_pitch_role_risk_delta"
+            )
+            with self.assertRaises(StageBMidiToSoloTargetedQualityRepairSweepError):
+                build_targeted_quality_repair_sweep_report(
+                    candidate_failure_labeling=source,
+                    rubric_baseline=rubric_baseline(root),
+                    output_dir=root / "sweep",
+                    issue_number=1004,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary
- targeted quality repair sweep source-context refresh
- #1002 candidate failure labeling 기준 targeted repair sweep 갱신
- outside-soloing source-context preserved 및 21개 context field를 targeted repair audio package 전 단계까지 보존

## Context
- source issue: #1002
- candidate count: `6`
- source total failure label count: `12`
- repaired total failure label count: `8`
- failure label delta: `4`
- improved candidate count: `4`
- technical regression count: `0`
- source outside-soloing repair evidence ready: `true`
- source outside-soloing repair source context preserved: `true`
- source outside-soloing pitch-role risk: `5 -> 2`
- current repair outside-soloing pitch-role risk after/delta: `0 / 2`
- source outside-soloing not evaluable count: `6`
- repaired outside-soloing not evaluable count: `6`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Scope
- targeted repair sweep source validator source-context preserved 필수 조건 추가
- 21개 source-context field aggregate/validation summary/markdown 보존
- #1004 harness run/doc/issue 기준 갱신
- README, CURRENT_STATUS, CORE_PLAN, AGENTS handoff 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_sweep`
- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-sweep`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- targeted repair sweep는 MIDI evidence objective label 감소 검증 범위
- outside-soloing/chord-tone 계열은 chord context 부재 시 not-evaluable 유지
- human/audio preference claim 제외
- MIDI-to-solo musical quality claim 제외
- 다음 targeted quality repair audio package refresh 필요

Closes #1004
