### PR TITLE
Stage B MIDI-to-solo targeted quality repair audio package source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Current handoff scope:
 - Latest quality rubric baseline completed: Issue #1000, Stage B MIDI-to-solo quality rubric baseline source-context refresh.
 - Latest candidate failure labeling completed: Issue #1002, Stage B MIDI-to-solo candidate failure labeling source-context refresh.
 - Latest targeted quality repair sweep completed: Issue #1004, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh.
-- Latest targeted quality repair audio package completed: Issue #922, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh.
+- Latest targeted quality repair audio package completed: Issue #1006, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh.
 - Latest targeted quality repair listening review package completed: Issue #924, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh.
 - Latest targeted quality repair listening review input guard completed: Issue #926, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh.
 - Latest targeted quality repair objective-only next decision completed: Issue #928, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh.
@@ -56,7 +56,7 @@ Current handoff scope:
 - Latest documentation issue completed: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
 - Open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo targeted quality repair audio package source-context refresh.
+- Recommended next issue: Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest quality rubric baseline: `Issue #1000`
 - latest candidate failure labeling: `Issue #1002`
 - latest targeted quality repair sweep: `Issue #1004`
-- latest targeted quality repair audio package: `Issue #922`
+- latest targeted quality repair audio package: `Issue #1006`
 - latest targeted quality repair listening review package: `Issue #924`
 - latest targeted quality repair listening review input guard: `Issue #926`
 - latest targeted quality repair objective-only next decision: `Issue #928`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -10499,6 +10499,62 @@ Issue #1004는 Issue #1002 candidate failure labeling의 source/current outside-
 
 - `Stage B MIDI-to-solo targeted quality repair audio package source-context refresh`
 
+## 9.193 Stage B MIDI-to-solo targeted quality repair audio package source-context refresh
+
+Issue #1006은 Issue #1004 targeted quality repair sweep의 source/current outside-soloing context를 targeted quality repair audio package summary까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
+- render attempted: `true`
+- rendered audio file count: `6`
+- technical WAV validation: `true`
+- sample rate: `44100`
+- duration range: `18.422s -> 18.984s`
+- source total failure label count: `12`
+- repaired total failure label count: `8`
+- failure label delta: `4`
+- improved candidate count: `4`
+- technical regression count: `0`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair source context preserved: `true`
+- source outside-soloing repair WAV count: `6`
+- source outside-soloing source objective pitch-role risk count: `5`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing source pitch-role risk delta: `3`
+- source outside-soloing source repair targeted: `false`
+- source outside-soloing source residual risk preserved: `true`
+- source outside-soloing current repair pitch-role risk count after: `0`
+- source outside-soloing current repair pitch-role risk delta: `2`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- audio review required: `true`
+- audio rendered quality claimed: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- targeted repair audio package source validation에 #1004 repair sweep source-context preserved 조건 추가.
+- source-context preserved flag와 21개 context field를 summary와 validation summary에 보존.
+- WAV 6개 렌더 및 technical metadata 검증 완료.
+- audio rendered quality, human/audio preference, MIDI-to-solo musical quality claim 제외.
+- 다음 boundary는 listening review package.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_audio`
+- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_targeted_quality_repair_audio.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-audio-package`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -23,7 +23,7 @@
 - latest quality rubric baseline: Issue #1000, Stage B MIDI-to-solo quality rubric baseline source-context refresh
 - latest candidate failure labeling: Issue #1002, Stage B MIDI-to-solo candidate failure labeling source-context refresh
 - latest targeted quality repair sweep: Issue #1004, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh
-- latest targeted quality repair audio package: Issue #922, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh
+- latest targeted quality repair audio package: Issue #1006, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh
 - latest targeted quality repair listening review package: Issue #924, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh
 - latest targeted quality repair listening review input guard: Issue #926, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh
 - latest targeted quality repair objective-only next decision: Issue #928, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh
@@ -57,7 +57,7 @@
 - latest README evidence refresh: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
 - open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair audio package source-context refresh`
+- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -1103,6 +1103,7 @@
 - improved candidate count: `4`
 - technical regression count: `0`
 - source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair source context preserved: `true`
 - source outside-soloing repair WAV count: `6`
 - source outside-soloing source objective pitch-role risk count: `5`
 - source outside-soloing source pitch-role risk count: `5 -> 2`

--- a/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -13,11 +13,18 @@
 - improved candidate count: `4`
 - technical regression count: `0`
 - source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair source context preserved: `true`
 - source outside-soloing source objective pitch-role risk: `5`
 - source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - source outside-soloing source repair targeted: `false`
 - source outside-soloing source residual risk preserved: `true`
 - source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- follow-up repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
 - source outside-soloing not evaluable count: `6`
 - repaired outside-soloing not evaluable count: `6`
 - audio review required: `true`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6233,7 +6233,7 @@ run_stage_b_midi_to_solo_targeted_quality_repair_audio_package() {
     --run_id "$run_id" \
     --targeted_quality_repair_sweep_report "$repair_sweep_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 922 \
+    --issue_number 1006 \
     --expected_boundary stage_b_midi_to_solo_targeted_quality_repair_audio_package \
     --expected_next_boundary stage_b_midi_to_solo_targeted_quality_repair_listening_review_package \
     --expected_file_count 6 \

--- a/scripts/render_stage_b_midi_to_solo_targeted_quality_repair_audio.py
+++ b/scripts/render_stage_b_midi_to_solo_targeted_quality_repair_audio.py
@@ -16,6 +16,9 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
+    BRIDGE_SOURCE_CONTEXT_KEYS,
+)
 from scripts.render_stage_b_midi_to_solo_candidate_audio import (  # noqa: E402
     resolve_soundfont,
     sha256_file,
@@ -35,7 +38,7 @@ class StageBMidiToSoloTargetedQualityRepairAudioError(ValueError):
 
 BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_audio_package"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_listening_review_package"
-SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_audio_package_v2"
+SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_audio_package_v3"
 CommandRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
 
 QUALITY_CLAIM_KEYS = [
@@ -89,6 +92,15 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
         )
 
 
+def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str, Any]:
+    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+        if key not in container or container[key] is None:
+            raise StageBMidiToSoloTargetedQualityRepairAudioError(
+                f"{label} source-context field required: {key}"
+            )
+    return {key: container[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS}
+
+
 def validate_source_report(
     report: dict[str, Any],
     *,
@@ -130,6 +142,13 @@ def validate_source_report(
         raise StageBMidiToSoloTargetedQualityRepairAudioError(
             "outside-soloing repair evidence readiness required"
         )
+    if not bool(
+        aggregate.get("source_outside_soloing_repair_source_context_preserved", False)
+    ):
+        raise StageBMidiToSoloTargetedQualityRepairAudioError(
+            "outside-soloing repair source context preservation required"
+        )
+    _source_context_fields(aggregate, label="targeted quality repair sweep")
     if _int(aggregate.get("source_outside_soloing_repair_pitch_role_risk_count_after")) != 0:
         raise StageBMidiToSoloTargetedQualityRepairAudioError(
             "outside-soloing residual pitch-role risk should be zero"
@@ -381,6 +400,9 @@ def build_audio_render_report(
             "source_outside_soloing_repair_evidence_ready": bool(
                 aggregate.get("source_outside_soloing_repair_evidence_ready", False)
             ),
+            "source_outside_soloing_repair_source_context_preserved": bool(
+                aggregate.get("source_outside_soloing_repair_source_context_preserved", False)
+            ),
             "source_outside_soloing_repair_wav_count": _int(
                 aggregate.get("source_outside_soloing_repair_wav_count")
             ),
@@ -414,6 +436,7 @@ def build_audio_render_report(
             "repaired_outside_soloing_not_evaluable_count": _int(
                 aggregate.get("repaired_outside_soloing_not_evaluable_count")
             ),
+            **{key: aggregate.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
             "remaining_failure_counts": dict(sorted(failure_counts.items())),
             "audio_review_required": True,
         },
@@ -524,6 +547,9 @@ def validate_audio_render_report(
         "source_outside_soloing_repair_evidence_ready": bool(
             summary.get("source_outside_soloing_repair_evidence_ready", False)
         ),
+        "source_outside_soloing_repair_source_context_preserved": bool(
+            summary.get("source_outside_soloing_repair_source_context_preserved", False)
+        ),
         "source_outside_soloing_repair_wav_count": _int(
             summary.get("source_outside_soloing_repair_wav_count")
         ),
@@ -557,6 +583,10 @@ def validate_audio_render_report(
         "repaired_outside_soloing_not_evaluable_count": _int(
             summary.get("repaired_outside_soloing_not_evaluable_count")
         ),
+        **{
+            key: summary.get(key)
+            for key in BRIDGE_SOURCE_CONTEXT_KEYS
+        },
         "audio_review_required": bool(summary.get("audio_review_required", False)),
         "audio_rendered_quality_claimed": bool(boundary.get("audio_rendered_quality_claimed", True)),
         "human_audio_preference_claimed": bool(boundary.get("human_audio_preference_claimed", True)),
@@ -589,11 +619,18 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- improved candidate count: `{summary['improved_candidate_count']}`",
         f"- technical regression count: `{summary['technical_regression_count']}`",
         f"- source outside-soloing repair evidence ready: `{_bool_token(summary['source_outside_soloing_repair_evidence_ready'])}`",
+        f"- source outside-soloing repair source context preserved: `{_bool_token(summary['source_outside_soloing_repair_source_context_preserved'])}`",
         f"- source outside-soloing source objective pitch-role risk: `{summary['source_outside_soloing_repair_source_objective_pitch_role_risk_count']}`",
         f"- source outside-soloing source pitch-role risk before / after / delta: `{summary['source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{summary['source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{summary['source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- source outside-soloing source repair targeted: `{_bool_token(summary['source_outside_soloing_repair_source_targeted'])}`",
         f"- source outside-soloing source residual risk preserved: `{_bool_token(summary['source_outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- source outside-soloing current repair pitch-role risk after / delta: `{summary['source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{summary['source_outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- follow-up objective source outside-soloing source pitch-role risk: `{summary['followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `{summary['followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']} / {summary['followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- follow-up repair sweep source outside-soloing source pitch-role risk: `{summary['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `{summary['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {summary['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- bridge repair sweep source outside-soloing source pitch-role risk: `{summary['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `{summary['repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {summary['repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- source outside-soloing not evaluable count: `{summary['source_outside_soloing_not_evaluable_count']}`",
         f"- repaired outside-soloing not evaluable count: `{summary['repaired_outside_soloing_not_evaluable_count']}`",
         f"- audio review required: `{_bool_token(summary['audio_review_required'])}`",

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_audio.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_audio.py
@@ -9,6 +9,7 @@ from typing import Sequence
 
 import pretty_midi
 
+from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_SOURCE_CONTEXT_KEYS
 from scripts.render_stage_b_midi_to_solo_targeted_quality_repair_audio import (
     BOUNDARY,
     NEXT_BOUNDARY,
@@ -20,6 +21,31 @@ from scripts.run_stage_b_midi_to_solo_targeted_quality_repair_sweep import (
     BOUNDARY as SOURCE_BOUNDARY,
     NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
 )
+
+
+SOURCE_CONTEXT = {
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_objective_source_outside_soloing_source_targeted": False,
+    "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_repair_sweep_source_outside_soloing_source_targeted": False,
+    "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "repair_sweep_source_outside_soloing_source_targeted": False,
+    "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+}
 
 
 def write_midi(path: Path, pitches: list[int]) -> None:
@@ -91,6 +117,7 @@ def source_report(root: Path, *, quality_claim: bool = False) -> dict:
             "technical_regression_count": 0,
             "repaired_failure_counts": {"songlike_melody_not_soloing": 5},
             "source_outside_soloing_repair_evidence_ready": True,
+            "source_outside_soloing_repair_source_context_preserved": True,
             "source_outside_soloing_repair_wav_count": 6,
             "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
             "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
@@ -102,6 +129,7 @@ def source_report(root: Path, *, quality_claim: bool = False) -> dict:
             "source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "source_outside_soloing_not_evaluable_count": 6,
             "repaired_outside_soloing_not_evaluable_count": 6,
+            **SOURCE_CONTEXT,
             "target_supported": True,
         },
         "selected_next_target": {
@@ -166,6 +194,7 @@ class StageBMidiToSoloTargetedQualityRepairAudioTest(unittest.TestCase):
             self.assertEqual(summary["failure_label_delta"], 7)
             self.assertEqual(summary["technical_regression_count"], 0)
             self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
+            self.assertTrue(summary["source_outside_soloing_repair_source_context_preserved"])
             self.assertEqual(summary["source_outside_soloing_repair_wav_count"], 6)
             self.assertEqual(
                 summary["source_outside_soloing_repair_source_objective_pitch_role_risk_count"], 5
@@ -183,6 +212,8 @@ class StageBMidiToSoloTargetedQualityRepairAudioTest(unittest.TestCase):
             self.assertEqual(summary["source_outside_soloing_repair_pitch_role_risk_delta"], 2)
             self.assertEqual(summary["source_outside_soloing_not_evaluable_count"], 6)
             self.assertEqual(summary["repaired_outside_soloing_not_evaluable_count"], 6)
+            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+                self.assertEqual(summary[key], SOURCE_CONTEXT[key])
             self.assertTrue(summary["audio_review_required"])
             self.assertFalse(summary["human_audio_preference_claimed"])
             self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
@@ -218,6 +249,28 @@ class StageBMidiToSoloTargetedQualityRepairAudioTest(unittest.TestCase):
             soundfont.write_bytes(b"sf2")
             source = source_report(root)
             source["aggregate"]["repaired_outside_soloing_not_evaluable_count"] = 0
+            with self.assertRaises(StageBMidiToSoloTargetedQualityRepairAudioError):
+                build_audio_render_report(
+                    source,
+                    output_dir=root / "audio_package",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(soundfont),
+                    sample_rate=44100,
+                    expected_file_count=6,
+                    runner=fake_runner,
+                )
+
+    def test_rejects_missing_source_context_field(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = root / "fluidsynth"
+            soundfont = root / "soundfont.sf2"
+            renderer.write_text("#!/bin/sh\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            source = source_report(root)
+            source["aggregate"].pop(
+                "followup_objective_source_outside_soloing_source_pitch_role_risk_delta"
+            )
             with self.assertRaises(StageBMidiToSoloTargetedQualityRepairAudioError):
                 build_audio_render_report(
                     source,


### PR DESCRIPTION
## Summary
- targeted quality repair audio package source-context refresh
- #1004 targeted quality repair sweep 기준 audio package 갱신
- outside-soloing source-context preserved 및 21개 context field를 listening review package 전 단계까지 보존

## Context
- source issue: #1004
- rendered audio file count: `6`
- technical WAV validation: `true`
- sample rate: `44100`
- failure labels: `12 -> 8`
- failure label delta: `4`
- technical regression count: `0`
- source outside-soloing repair evidence ready: `true`
- source outside-soloing repair source context preserved: `true`
- source outside-soloing pitch-role risk: `5 -> 2`
- current repair outside-soloing pitch-role risk after/delta: `0 / 2`
- audio rendered quality claim: `false`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Scope
- targeted repair audio package source validator source-context preserved 필수 조건 추가
- 21개 source-context field summary/validation summary/markdown 보존
- #1006 harness run/doc/issue 기준 갱신
- README, CURRENT_STATUS, CORE_PLAN, AGENTS handoff 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_audio`
- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_targeted_quality_repair_audio.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-audio-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- audio package는 WAV 파일 생성 및 기술 메타데이터 검증 범위
- listening preference claim 제외
- MIDI-to-solo musical quality claim 제외
- 다음 listening review package refresh 필요

Closes #1006
