### PR TITLE
Stage B MIDI-to-solo targeted quality repair objective next source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Current handoff scope:
 - Latest targeted quality repair audio package completed: Issue #1006, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh.
 - Latest targeted quality repair listening review package completed: Issue #1008, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh.
 - Latest targeted quality repair listening review input guard completed: Issue #1010, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh.
-- Latest targeted quality repair objective-only next decision completed: Issue #928, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh.
+- Latest targeted quality repair objective-only next decision completed: Issue #1012, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh.
 - Latest targeted quality repair follow-up decision completed: Issue #930, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh.
 - Latest songlike melody contour repair sweep completed: Issue #932, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh.
 - Latest songlike melody contour repair audio package completed: Issue #934, Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh.
@@ -56,7 +56,7 @@ Current handoff scope:
 - Latest documentation issue completed: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
 - Open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh.
+- Recommended next issue: Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest targeted quality repair audio package: `Issue #1006`
 - latest targeted quality repair listening review package: `Issue #1008`
 - latest targeted quality repair listening review input guard: `Issue #1010`
-- latest targeted quality repair objective-only next decision: `Issue #928`
+- latest targeted quality repair objective-only next decision: `Issue #1012`
 - latest targeted quality repair follow-up decision: `Issue #930`
 - latest songlike melody contour repair sweep: `Issue #932`
 - latest songlike melody contour repair audio package: `Issue #934`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -10663,6 +10663,61 @@ Issue #1010은 Issue #1008 targeted quality repair listening review package의 s
 
 - `Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh`
 
+## 9.196 Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh
+
+Issue #1012는 Issue #1010 targeted quality repair listening review input guard의 source/current outside-soloing context를 objective-only next decision summary까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- selected target: `targeted_quality_repair_followup_decision`
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- failure label delta: `4`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair source context preserved: `true`
+- source outside-soloing repair WAV count: `6`
+- source outside-soloing source objective pitch-role risk count: `5`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing source pitch-role risk delta: `3`
+- source outside-soloing source repair targeted: `false`
+- source outside-soloing source residual risk preserved: `true`
+- source outside-soloing current repair pitch-role risk count after: `0`
+- source outside-soloing current repair pitch-role risk delta: `2`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- targeted quality follow-up required: `true`
+- current quality claim ready: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- objective-only next decision source validation에 #1010 input guard source-context preserved 조건 추가.
+- source-context preserved flag와 21개 context field를 objective summary, readiness, validation summary에 보존.
+- listening input pending과 preference fill blocked 상태 유지.
+- human/audio preference와 MIDI-to-solo musical quality claim 제외.
+- 다음 boundary는 targeted quality repair follow-up decision source-context refresh.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_objective_next`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_objective_next.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-objective-only-next-decision`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -26,7 +26,7 @@
 - latest targeted quality repair audio package: Issue #1006, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh
 - latest targeted quality repair listening review package: Issue #1008, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh
 - latest targeted quality repair listening review input guard: Issue #1010, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh
-- latest targeted quality repair objective-only next decision: Issue #928, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh
+- latest targeted quality repair objective-only next decision: Issue #1012, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh
 - latest targeted quality repair follow-up decision: Issue #930, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh
 - latest songlike melody contour repair sweep: Issue #932, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh
 - latest songlike melody contour repair audio package: Issue #934, Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh
@@ -57,7 +57,7 @@
 - latest README evidence refresh: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
 - open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh`
+- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -3483,21 +3483,22 @@ Issue #1010은 Issue #1008 listening review package의 validated review input �
 
 - `Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh`
 
-## Stage B MIDI-to-Solo Targeted Quality Repair Objective-Only Next Decision Result
+## Stage B MIDI-to-Solo Targeted Quality Repair Objective-Only Next Decision Source Context Refresh Result
 
-Issue #758은 Issue #756 input guard 이후 listening input 없이 objective evidence만으로 다음 boundary를 선택한 작업이다.
+Issue #1012는 Issue #1010 input guard 이후 listening input 없이 objective evidence만으로 다음 boundary를 선택하면서 source/current outside-soloing context를 objective decision summary까지 보존한 작업이다.
 
 변경:
 
-- targeted quality repair objective-only next decision script 추가
-- input guard report 입력 검증 연결
+- targeted quality repair objective-only next decision source-context 검증 추가
+- input guard source-context preserved flag 필수화
+- bridge source-context 21개 키 누락 시 objective decision 실패 처리
+- objective summary, readiness, validation summary, markdown report에 source-context 수치 전파
 - preference fill blocked 상태 유지
-- quality claim 불가 상태에서 follow-up repair decision 라우팅
-- 전용 harness mode와 unit test 추가
+- quality claim 불가 상태에서 follow-up repair decision 라우팅 유지
 
 결과:
 
-- document: `docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-09.md`
+- document: `docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
 - source boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
 - next boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
@@ -3509,6 +3510,13 @@ Issue #758은 Issue #756 input guard 이후 listening input 없이 objective evi
 - technical WAV validation: `true`
 - rendered audio file count: `6`
 - failure label delta: `4`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair source context preserved: `true`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
+- follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
 - targeted quality follow-up required: `true`
 - current quality claim ready: `false`
 - human/audio preference claimed: `false`
@@ -3518,8 +3526,9 @@ Issue #758은 Issue #756 input guard 이후 listening input 없이 objective evi
 
 - listening input 부재 상태에서 quality claim 불가.
 - preference fill blocked 상태 유지.
+- source-context preserved flag와 21개 context field 보존 확인.
 - repair 결과가 quality claim으로 승격되지 않았으므로 follow-up decision 필요.
-- 다음 boundary는 targeted quality repair follow-up decision.
+- 다음 boundary는 targeted quality repair follow-up decision source-context refresh.
 
 검증:
 
@@ -3527,10 +3536,12 @@ Issue #758은 Issue #756 input guard 이후 listening input 없이 objective evi
 - `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_objective_next.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-objective-only-next-decision`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
 
 다음:
 
-- `Stage B MIDI-to-solo targeted quality repair follow-up decision`
+- `Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -14,12 +14,19 @@
 - rendered audio file count: `6`
 - failure label delta: `4`
 - source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair source context preserved: `true`
 - source outside-soloing repair WAV count: `6`
 - source outside-soloing source objective pitch-role risk: `5`
 - source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - source outside-soloing source repair targeted: `false`
 - source outside-soloing source residual risk preserved: `true`
 - source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `0` / `2`
+- follow-up repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `0` / `2`
+- bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `0` / `2`
 - source outside-soloing not evaluable count: `6`
 - repaired outside-soloing not evaluable count: `6`
 - targeted quality follow-up required: `true`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6297,7 +6297,7 @@ run_stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision() 
     --run_id "$run_id" \
     --input_guard_report "$input_guard_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 928 \
+    --issue_number 1012 \
     --expected_boundary stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision \
     --expected_next_boundary stage_b_midi_to_solo_targeted_quality_repair_followup_decision \
     --require_objective_decision \

--- a/scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_objective_next.py
+++ b/scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_objective_next.py
@@ -13,6 +13,9 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
+    BRIDGE_SOURCE_CONTEXT_KEYS,
+)
 from scripts.guard_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input import (  # noqa: E402
     BOUNDARY as SOURCE_BOUNDARY,
     OBJECTIVE_NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
@@ -27,7 +30,7 @@ BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_dec
 FOLLOWUP_DECISION_NEXT_BOUNDARY = (
     "stage_b_midi_to_solo_targeted_quality_repair_followup_decision"
 )
-SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_objective_next_v2"
+SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_objective_next_v3"
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -72,6 +75,15 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
         )
 
 
+def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str, Any]:
+    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+        if key not in container or container[key] is None:
+            raise StageBMidiToSoloTargetedQualityRepairObjectiveNextError(
+                f"{label} source-context field required: {key}"
+            )
+    return {key: container[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS}
+
+
 def validate_input_guard_report(report: dict[str, Any]) -> dict[str, Any]:
     readiness = _dict(report.get("readiness"))
     decision = _dict(report.get("decision"))
@@ -109,6 +121,13 @@ def validate_input_guard_report(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloTargetedQualityRepairObjectiveNextError(
             "outside-soloing repair evidence readiness required"
         )
+    if not bool(
+        source.get("source_outside_soloing_repair_source_context_preserved", False)
+    ):
+        raise StageBMidiToSoloTargetedQualityRepairObjectiveNextError(
+            "outside-soloing repair source context preservation required"
+        )
+    source_context = _source_context_fields(source, label="input guard")
     source_wav_count = _int(source.get("source_outside_soloing_repair_wav_count"))
     if source_wav_count < _int(guard.get("review_item_count")):
         raise StageBMidiToSoloTargetedQualityRepairObjectiveNextError(
@@ -186,6 +205,9 @@ def validate_input_guard_report(report: dict[str, Any]) -> dict[str, Any]:
         "source_outside_soloing_repair_evidence_ready": bool(
             source.get("source_outside_soloing_repair_evidence_ready", False)
         ),
+        "source_outside_soloing_repair_source_context_preserved": bool(
+            source.get("source_outside_soloing_repair_source_context_preserved", False)
+        ),
         "source_outside_soloing_repair_wav_count": source_wav_count,
         "source_outside_soloing_repair_source_objective_pitch_role_risk_count": source_objective_risk,
         "source_outside_soloing_repair_source_pitch_role_risk_count_before": source_risk_before,
@@ -210,6 +232,7 @@ def validate_input_guard_report(report: dict[str, Any]) -> dict[str, Any]:
             source.get("repaired_outside_soloing_not_evaluable_count")
         ),
         "audio_review_required": bool(source.get("audio_review_required", False)),
+        **source_context,
     }
 
 
@@ -246,6 +269,9 @@ def build_objective_next_report(
             "source_outside_soloing_repair_evidence_ready": bool(
                 source["source_outside_soloing_repair_evidence_ready"]
             ),
+            "source_outside_soloing_repair_source_context_preserved": bool(
+                source["source_outside_soloing_repair_source_context_preserved"]
+            ),
             "source_outside_soloing_repair_wav_count": _int(
                 source["source_outside_soloing_repair_wav_count"]
             ),
@@ -280,6 +306,7 @@ def build_objective_next_report(
                 source["repaired_outside_soloing_not_evaluable_count"]
             ),
             "audio_review_required": bool(source["audio_review_required"]),
+            **{key: source[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
             "targeted_quality_followup_required": bool(followup_required),
             "current_quality_claim_ready": False,
         },
@@ -296,6 +323,9 @@ def build_objective_next_report(
             "technical_wav_validation": bool(source["technical_wav_validation"]),
             "source_outside_soloing_repair_evidence_ready": bool(
                 source["source_outside_soloing_repair_evidence_ready"]
+            ),
+            "source_outside_soloing_repair_source_context_preserved": bool(
+                source["source_outside_soloing_repair_source_context_preserved"]
             ),
             "source_outside_soloing_repair_wav_count": _int(
                 source["source_outside_soloing_repair_wav_count"]
@@ -330,6 +360,7 @@ def build_objective_next_report(
             "repaired_outside_soloing_not_evaluable_count": _int(
                 source["repaired_outside_soloing_not_evaluable_count"]
             ),
+            **{key: source[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
             "targeted_quality_followup_required": bool(followup_required),
             "current_quality_claim_ready": False,
             "human_audio_preference_claimed": False,
@@ -428,6 +459,9 @@ def validate_objective_next_report(
         "source_outside_soloing_repair_evidence_ready": bool(
             summary.get("source_outside_soloing_repair_evidence_ready", False)
         ),
+        "source_outside_soloing_repair_source_context_preserved": bool(
+            summary.get("source_outside_soloing_repair_source_context_preserved", False)
+        ),
         "source_outside_soloing_repair_wav_count": _int(
             summary.get("source_outside_soloing_repair_wav_count")
         ),
@@ -462,6 +496,7 @@ def validate_objective_next_report(
             summary.get("repaired_outside_soloing_not_evaluable_count")
         ),
         "audio_review_required": bool(summary.get("audio_review_required", False)),
+        **{key: summary.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
         "targeted_quality_followup_required": bool(
             summary.get("targeted_quality_followup_required", False)
         ),
@@ -499,12 +534,19 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- rendered audio file count: `{summary['rendered_audio_file_count']}`",
         f"- failure label delta: `{summary['failure_label_delta']}`",
         f"- source outside-soloing repair evidence ready: `{_bool_token(summary['source_outside_soloing_repair_evidence_ready'])}`",
+        f"- source outside-soloing repair source context preserved: `{_bool_token(summary['source_outside_soloing_repair_source_context_preserved'])}`",
         f"- source outside-soloing repair WAV count: `{summary['source_outside_soloing_repair_wav_count']}`",
         f"- source outside-soloing source objective pitch-role risk: `{summary['source_outside_soloing_repair_source_objective_pitch_role_risk_count']}`",
         f"- source outside-soloing source pitch-role risk before / after / delta: `{summary['source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{summary['source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{summary['source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- source outside-soloing source repair targeted: `{_bool_token(summary['source_outside_soloing_repair_source_targeted'])}`",
         f"- source outside-soloing source residual risk preserved: `{_bool_token(summary['source_outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- source outside-soloing current repair pitch-role risk after / delta: `{summary['source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{summary['source_outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- follow-up objective source outside-soloing source pitch-role risk: `{summary['followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `{summary['followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{summary['followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- follow-up repair sweep source outside-soloing source pitch-role risk: `{summary['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `{summary['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{summary['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- bridge repair sweep source outside-soloing source pitch-role risk: `{summary['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `{summary['repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{summary['repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- source outside-soloing not evaluable count: `{summary['source_outside_soloing_not_evaluable_count']}`",
         f"- repaired outside-soloing not evaluable count: `{summary['repaired_outside_soloing_not_evaluable_count']}`",
         f"- targeted quality follow-up required: `{_bool_token(summary['targeted_quality_followup_required'])}`",

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_objective_next.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_objective_next.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_SOURCE_CONTEXT_KEYS
 from scripts.decide_stage_b_midi_to_solo_targeted_quality_repair_objective_next import (
     BOUNDARY,
     FOLLOWUP_DECISION_NEXT_BOUNDARY,
@@ -15,6 +16,31 @@ from scripts.guard_stage_b_midi_to_solo_targeted_quality_repair_listening_review
     BOUNDARY as SOURCE_BOUNDARY,
     OBJECTIVE_NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
 )
+
+
+SOURCE_CONTEXT = {
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_objective_source_outside_soloing_source_targeted": False,
+    "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_repair_sweep_source_outside_soloing_source_targeted": False,
+    "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "repair_sweep_source_outside_soloing_source_targeted": False,
+    "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+}
 
 
 def input_guard_report(*, quality_claim: bool = False) -> dict:
@@ -34,6 +60,7 @@ def input_guard_report(*, quality_claim: bool = False) -> dict:
                 "duration_max_seconds": 18.984,
                 "failure_label_delta": 4,
                 "source_outside_soloing_repair_evidence_ready": True,
+                "source_outside_soloing_repair_source_context_preserved": True,
                 "source_outside_soloing_repair_wav_count": 6,
                 "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
                 "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
@@ -46,6 +73,7 @@ def input_guard_report(*, quality_claim: bool = False) -> dict:
                 "source_outside_soloing_not_evaluable_count": 6,
                 "repaired_outside_soloing_not_evaluable_count": 6,
                 "audio_review_required": True,
+                **SOURCE_CONTEXT,
             },
         },
         "readiness": {
@@ -94,6 +122,9 @@ class StageBMidiToSoloTargetedQualityRepairObjectiveNextTest(unittest.TestCase):
             self.assertEqual(summary["rendered_audio_file_count"], 6)
             self.assertEqual(summary["failure_label_delta"], 4)
             self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
+            self.assertTrue(summary["source_outside_soloing_repair_source_context_preserved"])
+            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+                self.assertEqual(summary[key], SOURCE_CONTEXT[key])
             self.assertEqual(summary["source_outside_soloing_repair_wav_count"], 6)
             self.assertEqual(
                 summary["source_outside_soloing_repair_source_objective_pitch_role_risk_count"], 5
@@ -156,6 +187,20 @@ class StageBMidiToSoloTargetedQualityRepairObjectiveNextTest(unittest.TestCase):
                     input_guard_report=source,
                     output_dir=root / "objective_next",
                     issue_number=928,
+                )
+
+    def test_rejects_missing_source_context_field(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = input_guard_report()
+            source["guard_result"]["source_summary"].pop(
+                "followup_objective_source_outside_soloing_source_pitch_role_risk_delta"
+            )
+            with self.assertRaises(StageBMidiToSoloTargetedQualityRepairObjectiveNextError):
+                build_objective_next_report(
+                    input_guard_report=source,
+                    output_dir=root / "objective_next",
+                    issue_number=1012,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary

- targeted quality repair objective-only next decision source-context 검증 추가
- input guard source-context preserved flag 필수화
- bridge source-context 21개 키 누락 실패 처리
- objective summary, readiness, validation summary, markdown report에 source-context 수치 전파
- #1012 상태 문서와 harness issue number 갱신

## Context

- #1010 input guard completed: `true`
- review item count: `6`
- validated review input present: `false`
- preference fill allowed: `false`
- technical WAV validation: `true`
- source-context preserved: `true`
- source outside-soloing source pitch-role risk: `5 -> 2`
- source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
- targeted quality follow-up required: `true`
- current quality claim ready: `false`

## Scope

- `scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_objective_next.py`
- `tests/test_stage_b_midi_to_solo_targeted_quality_repair_objective_next.py`
- `scripts/agent_harness.sh`
- `docs/` status and source-context evidence docs
- `README.md`, `AGENTS.md` handoff fields

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_objective_next`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_objective_next.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-objective-only-next-decision`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- listening review input pending 상태 유지
- follow-up decision 필요 상태 유지
- objective evidence만으로 human/audio preference 또는 MIDI-to-solo musical quality claim 제외

Closes #1012