### PR TITLE
Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Current handoff scope:
 - Latest targeted quality repair listening review input guard completed: Issue #1010, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh.
 - Latest targeted quality repair objective-only next decision completed: Issue #1012, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh.
 - Latest targeted quality repair follow-up decision completed: Issue #1014, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh.
-- Latest songlike melody contour repair sweep completed: Issue #932, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh.
+- Latest songlike melody contour repair sweep completed: Issue #1016, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh.
 - Latest songlike melody contour repair audio package completed: Issue #934, Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh.
 - Latest songlike melody contour repair listening review package completed: Issue #936, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh.
 - Latest songlike melody contour repair listening review input guard completed: Issue #938, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh.
@@ -56,7 +56,7 @@ Current handoff scope:
 - Latest documentation issue completed: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
 - Open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest targeted quality repair listening review input guard: `Issue #1010`
 - latest targeted quality repair objective-only next decision: `Issue #1012`
 - latest targeted quality repair follow-up decision: `Issue #1014`
-- latest songlike melody contour repair sweep: `Issue #932`
+- latest songlike melody contour repair sweep: `Issue #1016`
 - latest songlike melody contour repair audio package: `Issue #934`
 - latest songlike melody contour repair listening review package: `Issue #936`
 - latest songlike melody contour repair listening review input guard: `Issue #938`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -10769,6 +10769,59 @@ Issue #1014는 Issue #1012 objective-only next decision과 Issue #1004 repair sw
 
 - `Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh`
 
+## 9.198 Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh
+
+Issue #1016은 Issue #1014 follow-up decision의 selected target에 따라 songlike melody contour repair sweep을 실행하고 source-context를 sweep aggregate까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- targeted repair sweep boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
+- selected target: `songlike_melody_contour_repair_audio_package`
+- candidate count: `6`
+- source total failure labels: `8`
+- repaired total failure labels: `4`
+- failure label delta: `4`
+- source songlike failure count: `5`
+- repaired songlike failure count: `0`
+- songlike failure delta: `5`
+- improved candidate count: `4`
+- technical regression count: `0`
+- objective source outside-soloing repair source context preserved: `true`
+- source outside-soloing repair source context preserved: `true`
+- objective source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing current repair pitch-role risk count after: `0`
+- source outside-soloing current repair pitch-role risk delta: `2`
+- repaired failure counts: `phrase_shape_missing_tension_release=2`, `rhythmic_monotony=2`
+- repaired not-evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
+- audio package ready: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- songlike melody contour repair sweep source validation에 #1014 follow-up decision source-context preserved 조건 추가.
+- source-context preserved flag와 21개 context field를 aggregate/readiness/validation summary에 보존.
+- songlike failure label은 `5 -> 0`으로 감소.
+- remaining failure labels는 phrase shape/rhythmic monotony 중심으로 남음.
+- human/audio preference와 MIDI-to-solo musical quality claim 제외.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-sweep`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -28,7 +28,7 @@
 - latest targeted quality repair listening review input guard: Issue #1010, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh
 - latest targeted quality repair objective-only next decision: Issue #1012, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh
 - latest targeted quality repair follow-up decision: Issue #1014, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh
-- latest songlike melody contour repair sweep: Issue #932, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh
+- latest songlike melody contour repair sweep: Issue #1016, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh
 - latest songlike melody contour repair audio package: Issue #934, Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh
 - latest songlike melody contour repair listening review package: Issue #936, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh
 - latest songlike melody contour repair listening review input guard: Issue #938, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh
@@ -57,7 +57,7 @@
 - latest README evidence refresh: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
 - open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -3598,6 +3598,64 @@ Issue #1014는 Issue #1012 objective-only next decision과 Issue #1004 repair sw
 다음:
 
 - `Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh`
+
+## Stage B MIDI-to-Solo Songlike Melody Contour Repair Sweep Source Context Refresh Result
+
+Issue #1016은 Issue #1014 follow-up decision의 selected target에 따라 songlike melody contour repair sweep을 실행하고, source-context를 aggregate/readiness/validation summary까지 보존한 작업이다.
+
+변경:
+
+- songlike melody contour repair sweep source-context 검증 추가
+- follow-up objective source-context preserved flag 필수화
+- follow-up repair_sweep source-context preserved flag 필수화
+- bridge source-context 21개 키 누락 시 sweep 실패 처리
+- downstream audio package 입력용 repair_sweep source-context raw key 보존
+- rubric baseline harness run id를 source-context refresh run으로 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
+- selected target: `songlike_melody_contour_repair_audio_package`
+- candidate count: `6`
+- total failure labels: `8 -> 4`
+- failure label delta: `4`
+- songlike failure count: `5 -> 0`
+- songlike failure delta: `5`
+- improved candidate count: `4`
+- technical regression count: `0`
+- objective source outside-soloing source context preserved: `true`
+- source outside-soloing source context preserved: `true`
+- objective source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
+- repaired failure counts: `phrase_shape_missing_tension_release=2`, `rhythmic_monotony=2`
+- repaired not-evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- songlike contour repair sweep 기준 songlike failure label 제거 확인.
+- source-context preserved flag와 21개 context field 보존 확인.
+- outside-soloing 및 weak chord-tone landing은 아직 context/listening 후속 평가 대상.
+- 다음 boundary는 audio package source-context refresh.
+- human/audio preference와 MIDI-to-solo musical quality claim 제외.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-sweep`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음:
+
+- `Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -15,14 +15,24 @@
 - technical regression count: `0`
 - source outside-soloing repair evidence ready: `true`
 - objective source outside-soloing repair WAV count: `6`
+- objective source outside-soloing source context preserved: `true`
 - objective source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - objective source outside-soloing source repair targeted: `false`
 - objective source outside-soloing source residual risk preserved: `true`
 - objective source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- objective follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- objective follow-up objective current repair pitch-role risk after/delta: `0` / `2`
+- objective repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- objective repair sweep current repair pitch-role risk after/delta: `0` / `2`
+- source outside-soloing source context preserved: `true`
 - source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - source outside-soloing source repair targeted: `false`
 - source outside-soloing source residual risk preserved: `true`
 - source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up objective current repair pitch-role risk after/delta: `0` / `2`
+- bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- bridge repair sweep current repair pitch-role risk after/delta: `0` / `2`
 - source outside-soloing not evaluable count: `6`
 - repaired outside-soloing not evaluable count: `6`
 - target supported: `true`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6337,7 +6337,7 @@ run_stage_b_midi_to_solo_targeted_quality_repair_followup_decision() {
 run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep() {
   local followup_run_id="${FOLLOWUP_RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_followup_decision_source_context_refresh}"
   local targeted_sweep_run_id="${TARGETED_SWEEP_RUN_ID:-harness_stage_b_midi_to_solo_targeted_quality_repair_sweep_source_context_refresh}"
-  local rubric_run_id="${RUBRIC_RUN_ID:-harness_stage_b_midi_to_solo_quality_rubric_baseline}"
+  local rubric_run_id="${RUBRIC_RUN_ID:-harness_stage_b_midi_to_solo_quality_rubric_baseline_source_context_refresh}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_source_context_refresh}"
   local followup_report="outputs/stage_b_midi_to_solo_targeted_quality_repair_followup_decision/${followup_run_id}/stage_b_midi_to_solo_targeted_quality_repair_followup_decision.json"
   local targeted_sweep_report="outputs/stage_b_midi_to_solo_targeted_quality_repair_sweep/${targeted_sweep_run_id}/stage_b_midi_to_solo_targeted_quality_repair_sweep.json"
@@ -6361,7 +6361,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep() {
     --targeted_repair_sweep "$targeted_sweep_report" \
     --rubric_baseline "$rubric_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 932 \
+    --issue_number 1016 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_sweep \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package \
     --min_candidate_count 6 \

--- a/scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
+++ b/scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
@@ -16,6 +16,9 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
+    BRIDGE_SOURCE_CONTEXT_KEYS,
+)
 from scripts.decide_stage_b_midi_to_solo_targeted_quality_repair_followup import (  # noqa: E402
     BOUNDARY as FOLLOWUP_BOUNDARY,
     NEXT_BOUNDARY as FOLLOWUP_NEXT_BOUNDARY,
@@ -38,7 +41,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairSweepError(ValueError):
 BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_sweep"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package"
 SELECTED_TARGET = "songlike_melody_contour_repair_audio_package"
-SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v2"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v3"
 SONGLIKE_LABEL = "songlike_melody_not_soloing"
 BAR_SECONDS = 2.0
 
@@ -89,6 +92,23 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
         )
 
 
+def _prefixed_source_context_fields(
+    readiness: dict[str, Any],
+    *,
+    prefix: str,
+    label: str,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+        prefixed_key = f"{prefix}_{key}"
+        if prefixed_key not in readiness or readiness[prefixed_key] is None:
+            raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+                f"{label} source-context field required: {prefixed_key}"
+            )
+        result[prefixed_key] = readiness[prefixed_key]
+    return result
+
+
 def _extract_prefixed_source_context(
     readiness: dict[str, Any],
     *,
@@ -110,6 +130,11 @@ def _extract_prefixed_source_context(
         readiness.get(f"{field_prefix}_source_pitch_role_risk_delta")
     )
     current_risk_delta = _int(readiness.get(f"{field_prefix}_pitch_role_risk_delta"))
+    if not bool(readiness.get(f"{field_prefix}_source_context_preserved", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            f"{label} outside-soloing source context preservation required"
+        )
+    bridge_context = _prefixed_source_context_fields(readiness, prefix=prefix, label=label)
     if minimum_wav_count is not None:
         source_wav_count = _int(readiness.get(f"{field_prefix}_wav_count"))
         if source_wav_count < minimum_wav_count:
@@ -142,6 +167,9 @@ def _extract_prefixed_source_context(
         )
     result = {
         f"{prefix}_source_outside_soloing_repair_source_objective_pitch_role_risk_count": source_objective_risk,
+        f"{prefix}_source_outside_soloing_repair_source_context_preserved": bool(
+            readiness.get(f"{field_prefix}_source_context_preserved", False)
+        ),
         f"{prefix}_source_outside_soloing_repair_source_pitch_role_risk_count_before": source_risk_before,
         f"{prefix}_source_outside_soloing_repair_source_pitch_role_risk_count_after": source_risk_after,
         f"{prefix}_source_outside_soloing_repair_source_pitch_role_risk_delta": source_risk_delta,
@@ -152,6 +180,7 @@ def _extract_prefixed_source_context(
             readiness.get(f"{field_prefix}_source_residual_risk_preserved", False)
         ),
         f"{prefix}_source_outside_soloing_repair_pitch_role_risk_delta": current_risk_delta,
+        **bridge_context,
     }
     if minimum_wav_count is not None:
         result[f"{prefix}_source_outside_soloing_repair_wav_count"] = _int(
@@ -605,6 +634,9 @@ def build_songlike_melody_contour_repair_sweep_report(
             "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
                 followup["objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count"]
             ),
+            "objective_source_outside_soloing_repair_source_context_preserved": bool(
+                followup["objective_source_outside_soloing_repair_source_context_preserved"]
+            ),
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
                 followup["objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"]
             ),
@@ -626,10 +658,14 @@ def build_songlike_melody_contour_repair_sweep_report(
             "objective_source_outside_soloing_repair_pitch_role_risk_delta": _int(
                 followup["objective_source_outside_soloing_repair_pitch_role_risk_delta"]
             ),
+            **{f"objective_{key}": followup[f"objective_{key}"] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
             "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
                 followup[
                     "repair_sweep_source_outside_soloing_repair_source_objective_pitch_role_risk_count"
                 ]
+            ),
+            "source_outside_soloing_repair_source_context_preserved": bool(
+                followup["repair_sweep_source_outside_soloing_repair_source_context_preserved"]
             ),
             "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
                 followup["repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before"]
@@ -652,6 +688,7 @@ def build_songlike_melody_contour_repair_sweep_report(
             "source_outside_soloing_repair_pitch_role_risk_delta": _int(
                 followup["repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta"]
             ),
+            **{key: followup[f"repair_sweep_{key}"] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
             "source_outside_soloing_not_evaluable_count": _int(
                 followup["repair_sweep_repaired_outside_soloing_not_evaluable_count"]
             ),
@@ -690,6 +727,9 @@ def build_songlike_melody_contour_repair_sweep_report(
             "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
                 followup["objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count"]
             ),
+            "objective_source_outside_soloing_repair_source_context_preserved": bool(
+                followup["objective_source_outside_soloing_repair_source_context_preserved"]
+            ),
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
                 followup["objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"]
             ),
@@ -711,10 +751,14 @@ def build_songlike_melody_contour_repair_sweep_report(
             "objective_source_outside_soloing_repair_pitch_role_risk_delta": _int(
                 followup["objective_source_outside_soloing_repair_pitch_role_risk_delta"]
             ),
+            **{f"objective_{key}": followup[f"objective_{key}"] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
             "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
                 followup[
                     "repair_sweep_source_outside_soloing_repair_source_objective_pitch_role_risk_count"
                 ]
+            ),
+            "source_outside_soloing_repair_source_context_preserved": bool(
+                followup["repair_sweep_source_outside_soloing_repair_source_context_preserved"]
             ),
             "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
                 followup["repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before"]
@@ -737,6 +781,7 @@ def build_songlike_melody_contour_repair_sweep_report(
             "source_outside_soloing_repair_pitch_role_risk_delta": _int(
                 followup["repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta"]
             ),
+            **{key: followup[f"repair_sweep_{key}"] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
             "source_outside_soloing_not_evaluable_count": _int(
                 followup["repair_sweep_repaired_outside_soloing_not_evaluable_count"]
             ),
@@ -873,6 +918,9 @@ def validate_songlike_melody_contour_repair_sweep_report(
                 "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count"
             )
         ),
+        "objective_source_outside_soloing_repair_source_context_preserved": bool(
+            aggregate.get("objective_source_outside_soloing_repair_source_context_preserved", False)
+        ),
         "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             aggregate.get("objective_source_outside_soloing_repair_source_pitch_role_risk_count_before")
         ),
@@ -897,8 +945,12 @@ def validate_songlike_melody_contour_repair_sweep_report(
         "objective_source_outside_soloing_repair_pitch_role_risk_delta": _int(
             aggregate.get("objective_source_outside_soloing_repair_pitch_role_risk_delta")
         ),
+        **{f"objective_{key}": aggregate.get(f"objective_{key}") for key in BRIDGE_SOURCE_CONTEXT_KEYS},
         "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
             aggregate.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
+        ),
+        "source_outside_soloing_repair_source_context_preserved": bool(
+            aggregate.get("source_outside_soloing_repair_source_context_preserved", False)
         ),
         "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             aggregate.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
@@ -921,6 +973,7 @@ def validate_songlike_melody_contour_repair_sweep_report(
         "source_outside_soloing_repair_pitch_role_risk_delta": _int(
             aggregate.get("source_outside_soloing_repair_pitch_role_risk_delta")
         ),
+        **{key: aggregate.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
         "source_outside_soloing_not_evaluable_count": _int(
             aggregate.get("source_outside_soloing_not_evaluable_count")
         ),
@@ -968,14 +1021,24 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- technical regression count: `{aggregate['technical_regression_count']}`",
         f"- source outside-soloing repair evidence ready: `{_bool_token(aggregate['source_outside_soloing_repair_evidence_ready'])}`",
         f"- objective source outside-soloing repair WAV count: `{aggregate['objective_source_outside_soloing_repair_wav_count']}`",
+        f"- objective source outside-soloing source context preserved: `{_bool_token(aggregate['objective_source_outside_soloing_repair_source_context_preserved'])}`",
         f"- objective source outside-soloing source pitch-role risk before / after / delta: `{aggregate['objective_source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{aggregate['objective_source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{aggregate['objective_source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- objective source outside-soloing source repair targeted: `{_bool_token(aggregate['objective_source_outside_soloing_repair_source_targeted'])}`",
         f"- objective source outside-soloing source residual risk preserved: `{_bool_token(aggregate['objective_source_outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- objective source outside-soloing current repair pitch-role risk after / delta: `{aggregate['objective_source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{aggregate['objective_source_outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- objective follow-up objective source outside-soloing source pitch-role risk: `{aggregate['objective_followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {aggregate['objective_followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- objective follow-up objective current repair pitch-role risk after/delta: `{aggregate['objective_followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{aggregate['objective_followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- objective repair sweep source outside-soloing source pitch-role risk: `{aggregate['objective_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {aggregate['objective_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- objective repair sweep current repair pitch-role risk after/delta: `{aggregate['objective_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{aggregate['objective_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- source outside-soloing source context preserved: `{_bool_token(aggregate['source_outside_soloing_repair_source_context_preserved'])}`",
         f"- source outside-soloing source pitch-role risk before / after / delta: `{aggregate['source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{aggregate['source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{aggregate['source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- source outside-soloing source repair targeted: `{_bool_token(aggregate['source_outside_soloing_repair_source_targeted'])}`",
         f"- source outside-soloing source residual risk preserved: `{_bool_token(aggregate['source_outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- source outside-soloing current repair pitch-role risk after / delta: `{aggregate['source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{aggregate['source_outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- follow-up objective source outside-soloing source pitch-role risk: `{aggregate['followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {aggregate['followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up objective current repair pitch-role risk after/delta: `{aggregate['followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{aggregate['followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- bridge repair sweep source outside-soloing source pitch-role risk: `{aggregate['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {aggregate['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- bridge repair sweep current repair pitch-role risk after/delta: `{aggregate['repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{aggregate['repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- source outside-soloing not evaluable count: `{aggregate['source_outside_soloing_not_evaluable_count']}`",
         f"- repaired outside-soloing not evaluable count: `{aggregate['repaired_outside_soloing_not_evaluable_count']}`",
         f"- target supported: `{_bool_token(aggregate['target_supported'])}`",

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_SOURCE_CONTEXT_KEYS
 from scripts.build_stage_b_midi_to_solo_quality_rubric_baseline import (
     build_quality_rubric_baseline_report,
 )
@@ -147,6 +148,7 @@ def followup_decision(*, quality_claim: bool = False) -> dict:
             "objective_source_outside_soloing_repair_evidence_ready": True,
             "objective_source_outside_soloing_repair_wav_count": 6,
             "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "objective_source_outside_soloing_repair_source_context_preserved": True,
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
             "objective_source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
@@ -156,8 +158,10 @@ def followup_decision(*, quality_claim: bool = False) -> dict:
             "objective_source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "objective_source_outside_soloing_not_evaluable_count": 6,
             "objective_repaired_outside_soloing_not_evaluable_count": 6,
+            **{f"objective_{key}": value for key, value in SOURCE_CONTEXT.items()},
             "repair_sweep_source_outside_soloing_repair_evidence_ready": True,
             "repair_sweep_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "repair_sweep_source_outside_soloing_repair_source_context_preserved": True,
             "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
             "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
             "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
@@ -167,6 +171,7 @@ def followup_decision(*, quality_claim: bool = False) -> dict:
             "repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "repair_sweep_source_outside_soloing_not_evaluable_count": 6,
             "repair_sweep_repaired_outside_soloing_not_evaluable_count": 6,
+            **{f"repair_sweep_{key}": value for key, value in SOURCE_CONTEXT.items()},
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
             "audio_rendered_quality_claimed": False,
@@ -277,6 +282,9 @@ class StageBMidiToSoloSonglikeMelodyContourRepairSweepTest(unittest.TestCase):
                 ],
                 5,
             )
+            self.assertTrue(summary["objective_source_outside_soloing_repair_source_context_preserved"])
+            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+                self.assertEqual(summary[f"objective_{key}"], SOURCE_CONTEXT[key])
             self.assertEqual(
                 summary[
                     "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"
@@ -306,6 +314,9 @@ class StageBMidiToSoloSonglikeMelodyContourRepairSweepTest(unittest.TestCase):
                 summary["source_outside_soloing_repair_source_objective_pitch_role_risk_count"],
                 5,
             )
+            self.assertTrue(summary["source_outside_soloing_repair_source_context_preserved"])
+            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+                self.assertEqual(summary[key], SOURCE_CONTEXT[key])
             self.assertEqual(
                 summary["source_outside_soloing_repair_source_pitch_role_risk_count_before"], 5
             )
@@ -392,6 +403,21 @@ class StageBMidiToSoloSonglikeMelodyContourRepairSweepTest(unittest.TestCase):
                     rubric_baseline=rubric_baseline(Path(tmp)),
                     output_dir=Path(tmp) / "songlike_repair",
                     issue_number=932,
+                )
+
+    def test_rejects_missing_followup_source_context_field(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = followup_decision()
+            source["readiness"].pop(
+                "repair_sweep_followup_objective_source_outside_soloing_source_pitch_role_risk_delta"
+            )
+            with self.assertRaises(StageBMidiToSoloSonglikeMelodyContourRepairSweepError):
+                build_songlike_melody_contour_repair_sweep_report(
+                    followup_decision=source,
+                    targeted_repair_sweep=targeted_repair_sweep(),
+                    rubric_baseline=rubric_baseline(Path(tmp)),
+                    output_dir=Path(tmp) / "songlike_repair",
+                    issue_number=1016,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary

- songlike melody contour repair sweep source-context 검증 추가
- follow-up objective/repair_sweep source-context preserved flag 필수화
- bridge source-context 21개 키 누락 실패 처리
- sweep aggregate/readiness/validation summary에 source-context 수치 전파
- rubric baseline harness run id를 source-context refresh run으로 갱신
- #1016 상태 문서 갱신

## Context

- #1014 selected target: `songlike_melody_contour_repair_sweep`
- dominant remaining failure label/count: `songlike_melody_not_soloing / 5`
- candidate count: `6`
- source total failure labels: `8`
- repaired total failure labels: `4`
- songlike failure count: `5 -> 0`
- technical regression count: `0`
- source-context preserved: `true`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Scope

- `scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py`
- `tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py`
- `scripts/agent_harness.sh`
- `docs/` status and source-context evidence docs
- `README.md`, `AGENTS.md` handoff fields

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-sweep`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- repair output는 objective failure label 기준 평가
- remaining failure labels: `phrase_shape_missing_tension_release=2`, `rhythmic_monotony=2`
- outside-soloing/chord-tone labels는 아직 context/listening 평가 대상
- human/audio preference와 MIDI-to-solo musical quality claim 제외

Closes #1016