### PR TITLE
Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Current handoff scope:
 - Latest targeted quality repair follow-up decision completed: Issue #1014, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh.
 - Latest songlike melody contour repair sweep completed: Issue #1016, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh.
 - Latest songlike melody contour repair audio package completed: Issue #1018, Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh.
-- Latest songlike melody contour repair listening review package completed: Issue #936, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh.
+- Latest songlike melody contour repair listening review package completed: Issue #1020, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh.
 - Latest songlike melody contour repair listening review input guard completed: Issue #938, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh.
 - Latest songlike melody contour repair objective-only next decision completed: Issue #940, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh.
 - Latest songlike melody contour repair follow-up decision completed: Issue #942, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh.
@@ -56,7 +56,7 @@ Current handoff scope:
 - Latest documentation issue completed: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
 - Open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest targeted quality repair follow-up decision: `Issue #1014`
 - latest songlike melody contour repair sweep: `Issue #1016`
 - latest songlike melody contour repair audio package: `Issue #1018`
-- latest songlike melody contour repair listening review package: `Issue #936`
+- latest songlike melody contour repair listening review package: `Issue #1020`
 - latest songlike melody contour repair listening review input guard: `Issue #938`
 - latest songlike melody contour repair objective-only next decision: `Issue #940`
 - latest songlike melody contour repair follow-up decision: `Issue #942`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -10873,6 +10873,54 @@ Issue #1018은 Issue #1016 songlike melody contour repair sweep의 MIDI 후보 6
 
 - `Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh`
 
+## 9.200 Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh
+
+Issue #1020은 Issue #1018 audio package 결과의 WAV/MIDI 후보 6개를 listening review package로 묶고 source-context를 review package summary까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
+- listening review package ready: `true`
+- review item count: `6`
+- validated review input: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- sample rate: `44100`
+- duration range: `18.849s -> 18.992s`
+- failure label delta: `4`
+- songlike failure delta: `5`
+- objective source outside-soloing repair source context preserved: `true`
+- source outside-soloing repair source context preserved: `true`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing current repair pitch-role risk count after: `0`
+- source outside-soloing current repair pitch-role risk delta: `2`
+- audio review required: `true`
+- human review required now: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- listening review package source validation에 #1018 audio package source-context preserved 조건 추가.
+- source-context preserved flag와 21개 context field를 source summary/validation summary에 보존.
+- WAV/MIDI 6개 review item package 준비 완료.
+- validated listening input은 아직 없으므로 preference fill 차단 대상.
+- 다음 boundary는 listening review input guard source-context refresh.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-listening-review-package`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -30,7 +30,7 @@
 - latest targeted quality repair follow-up decision: Issue #1014, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh
 - latest songlike melody contour repair sweep: Issue #1016, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh
 - latest songlike melody contour repair audio package: Issue #1018, Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh
-- latest songlike melody contour repair listening review package: Issue #936, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh
+- latest songlike melody contour repair listening review package: Issue #1020, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh
 - latest songlike melody contour repair listening review input guard: Issue #938, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh
 - latest songlike melody contour repair objective-only next decision: Issue #940, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh
 - latest songlike melody contour repair follow-up decision: Issue #942, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh
@@ -57,7 +57,7 @@
 - latest README evidence refresh: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
 - open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -3714,6 +3714,63 @@ Issue #1018은 Issue #1016 songlike melody contour repair sweep의 MIDI 후보 6
 다음:
 
 - `Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh`
+
+## Stage B MIDI-to-Solo Songlike Melody Contour Repair Listening Review Package Source Context Refresh Result
+
+Issue #1020은 Issue #1018 audio package 결과의 WAV/MIDI 후보 6개를 listening review package로 묶고, audio package source-context를 review package summary까지 보존한 작업이다.
+
+변경:
+
+- songlike melody contour repair listening review package source-context 검증 추가
+- audio package source-context preserved flag 필수화
+- bridge source-context 21개 키 누락 시 listening review package 실패 처리
+- source summary / validation summary / markdown report에 source-context 수치 전파
+- validated review input pending 상태 유지
+- human/audio preference와 MIDI-to-solo musical quality claim 제외 유지
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_LISTENING_REVIEW_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
+- listening review package ready: `true`
+- review item count: `6`
+- validated review input: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- sample rate: `44100`
+- duration range: `18.849s-18.992s`
+- failure label delta: `4`
+- songlike failure delta: `5`
+- objective source outside-soloing source context preserved: `true`
+- source outside-soloing source context preserved: `true`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
+- repaired not-evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
+- audio review required: `true`
+- human review required now: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- WAV/MIDI 6개 review item package 준비 완료.
+- source-context preserved flag와 21개 context field 보존 확인.
+- validated listening input은 아직 없으므로 preference fill 차단 대상.
+- 다음 boundary는 listening review input guard source-context refresh.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-listening-review-package`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음:
+
+- `Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_LISTENING_REVIEW_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_LISTENING_REVIEW_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -1,4 +1,4 @@
-# Stage B MIDI-to-Solo Songlike Melody Contour Repair Listening Review Package
+# Stage B MIDI-to-Solo Songlike Melody Contour Repair Listening Review Package Source Context Refresh
 
 ## Summary
 
@@ -15,14 +15,24 @@
 - songlike failure delta: `5`
 - source outside-soloing repair evidence ready: `true`
 - objective source outside-soloing repair WAV count: `6`
+- objective source outside-soloing source context preserved: `true`
 - objective source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - objective source outside-soloing source repair targeted: `false`
 - objective source outside-soloing source residual risk preserved: `true`
 - objective source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- objective follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- objective follow-up objective current repair pitch-role risk after/delta: `0` / `2`
+- objective repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- objective repair sweep current repair pitch-role risk after/delta: `0` / `2`
+- source outside-soloing source context preserved: `true`
 - source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - source outside-soloing source repair targeted: `false`
 - source outside-soloing source residual risk preserved: `true`
 - source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up objective current repair pitch-role risk after/delta: `0` / `2`
+- bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- bridge repair sweep current repair pitch-role risk after/delta: `0` / `2`
 - source outside-soloing repair pitch-role risk after: `0`
 - source outside-soloing not evaluable count: `6`
 - repaired outside-soloing not evaluable count: `6`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6406,7 +6406,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package
     --run_id "$review_run_id" \
     --audio_package_report "$audio_package_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_LISTENING_REVIEW_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 936 \
+    --issue_number 1020 \
     --expected_review_item_count 6 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard \

--- a/scripts/build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py
+++ b/scripts/build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py
@@ -13,6 +13,9 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
+    BRIDGE_SOURCE_CONTEXT_KEYS,
+)
 from scripts.render_stage_b_midi_to_solo_songlike_melody_contour_repair_audio import (  # noqa: E402
     BOUNDARY as SOURCE_BOUNDARY,
     NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
@@ -25,7 +28,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(Val
 
 BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard"
-SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package_v2"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package_v3"
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -79,6 +82,16 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
 
 
 def _source_context_fields(summary: dict[str, Any]) -> dict[str, Any]:
+    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+        objective_key = f"objective_{key}"
+        if objective_key not in summary or summary[objective_key] is None:
+            raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
+                f"objective source-context field required: {objective_key}"
+            )
+        if key not in summary or summary[key] is None:
+            raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
+                f"source-context field required: {key}"
+            )
     return {
         "objective_source_outside_soloing_repair_wav_count": _int(
             summary.get("objective_source_outside_soloing_repair_wav_count")
@@ -87,6 +100,9 @@ def _source_context_fields(summary: dict[str, Any]) -> dict[str, Any]:
             summary.get(
                 "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count"
             )
+        ),
+        "objective_source_outside_soloing_repair_source_context_preserved": bool(
+            summary.get("objective_source_outside_soloing_repair_source_context_preserved", False)
         ),
         "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             summary.get(
@@ -121,6 +137,9 @@ def _source_context_fields(summary: dict[str, Any]) -> dict[str, Any]:
         "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
             summary.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
         ),
+        "source_outside_soloing_repair_source_context_preserved": bool(
+            summary.get("source_outside_soloing_repair_source_context_preserved", False)
+        ),
         "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             summary.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
         ),
@@ -142,6 +161,8 @@ def _source_context_fields(summary: dict[str, Any]) -> dict[str, Any]:
         "source_outside_soloing_repair_pitch_role_risk_delta": _int(
             summary.get("source_outside_soloing_repair_pitch_role_risk_delta")
         ),
+        **{f"objective_{key}": summary.get(f"objective_{key}") for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{key: summary.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
     }
 
 
@@ -152,6 +173,10 @@ def _validate_source_context(summary: dict[str, Any], *, base: str, label: str) 
     source_delta = _int(summary.get(f"{base}_source_pitch_role_risk_delta"))
     current_after = _int(summary.get(f"{base}_pitch_role_risk_count_after"))
     current_delta = _int(summary.get(f"{base}_pitch_role_risk_delta"))
+    if not bool(summary.get(f"{base}_source_context_preserved", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
+            f"{label} source context preservation required"
+        )
     if objective_risk <= 0 or source_before <= 0:
         raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
             f"{label} source pitch-role risk context required"
@@ -468,6 +493,9 @@ def validate_listening_review_package_report(
                 "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count"
             )
         ),
+        "objective_source_outside_soloing_repair_source_context_preserved": bool(
+            source.get("objective_source_outside_soloing_repair_source_context_preserved", False)
+        ),
         "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             source.get(
                 "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"
@@ -499,6 +527,9 @@ def validate_listening_review_package_report(
         "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
             source.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
         ),
+        "source_outside_soloing_repair_source_context_preserved": bool(
+            source.get("source_outside_soloing_repair_source_context_preserved", False)
+        ),
         "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             source.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
         ),
@@ -520,6 +551,8 @@ def validate_listening_review_package_report(
         "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
             source.get("source_outside_soloing_repair_pitch_role_risk_count_after")
         ),
+        **{f"objective_{key}": source.get(f"objective_{key}") for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{key: source.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
         "source_outside_soloing_not_evaluable_count": _int(
             source.get("source_outside_soloing_not_evaluable_count")
         ),
@@ -547,7 +580,7 @@ def markdown_report(report: dict[str, Any]) -> str:
     package = report["review_package"]
     source = report["source_summary"]
     lines = [
-        "# Stage B MIDI-to-Solo Songlike Melody Contour Repair Listening Review Package",
+        "# Stage B MIDI-to-Solo Songlike Melody Contour Repair Listening Review Package Source Context Refresh",
         "",
         "## Summary",
         "",
@@ -564,14 +597,24 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- songlike failure delta: `{source['songlike_failure_delta']}`",
         f"- source outside-soloing repair evidence ready: `{_bool_token(source['source_outside_soloing_repair_evidence_ready'])}`",
         f"- objective source outside-soloing repair WAV count: `{source['objective_source_outside_soloing_repair_wav_count']}`",
+        f"- objective source outside-soloing source context preserved: `{_bool_token(source['objective_source_outside_soloing_repair_source_context_preserved'])}`",
         f"- objective source outside-soloing source pitch-role risk before / after / delta: `{source['objective_source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{source['objective_source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{source['objective_source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- objective source outside-soloing source repair targeted: `{_bool_token(source['objective_source_outside_soloing_repair_source_targeted'])}`",
         f"- objective source outside-soloing source residual risk preserved: `{_bool_token(source['objective_source_outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- objective source outside-soloing current repair pitch-role risk after / delta: `{source['objective_source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{source['objective_source_outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- objective follow-up objective source outside-soloing source pitch-role risk: `{source['objective_followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {source['objective_followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- objective follow-up objective current repair pitch-role risk after/delta: `{source['objective_followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{source['objective_followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- objective repair sweep source outside-soloing source pitch-role risk: `{source['objective_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {source['objective_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- objective repair sweep current repair pitch-role risk after/delta: `{source['objective_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{source['objective_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- source outside-soloing source context preserved: `{_bool_token(source['source_outside_soloing_repair_source_context_preserved'])}`",
         f"- source outside-soloing source pitch-role risk before / after / delta: `{source['source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{source['source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{source['source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- source outside-soloing source repair targeted: `{_bool_token(source['source_outside_soloing_repair_source_targeted'])}`",
         f"- source outside-soloing source residual risk preserved: `{_bool_token(source['source_outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- source outside-soloing current repair pitch-role risk after / delta: `{source['source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{source['source_outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- follow-up objective source outside-soloing source pitch-role risk: `{source['followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {source['followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up objective current repair pitch-role risk after/delta: `{source['followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{source['followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- bridge repair sweep source outside-soloing source pitch-role risk: `{source['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {source['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- bridge repair sweep current repair pitch-role risk after/delta: `{source['repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{source['repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- source outside-soloing repair pitch-role risk after: `{source['source_outside_soloing_repair_pitch_role_risk_count_after']}`",
         f"- source outside-soloing not evaluable count: `{source['source_outside_soloing_not_evaluable_count']}`",
         f"- repaired outside-soloing not evaluable count: `{source['repaired_outside_soloing_not_evaluable_count']}`",
@@ -622,7 +665,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=936)
+    parser.add_argument("--issue_number", type=int, default=1020)
     parser.add_argument("--expected_review_item_count", type=int, default=6)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pretty_midi
 
+from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_SOURCE_CONTEXT_KEYS
 from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package import (
     BOUNDARY,
     NEXT_BOUNDARY,
@@ -19,6 +20,31 @@ from scripts.render_stage_b_midi_to_solo_songlike_melody_contour_repair_audio im
     BOUNDARY as SOURCE_BOUNDARY,
     NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
 )
+
+
+SOURCE_CONTEXT = {
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_objective_source_outside_soloing_source_targeted": False,
+    "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_repair_sweep_source_outside_soloing_source_targeted": False,
+    "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "repair_sweep_source_outside_soloing_source_targeted": False,
+    "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+}
 
 
 def write_midi(path: Path) -> None:
@@ -118,6 +144,7 @@ def audio_package_report(root: Path, *, quality_claim: bool = False) -> dict:
             "source_outside_soloing_repair_evidence_ready": True,
             "objective_source_outside_soloing_repair_wav_count": 6,
             "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "objective_source_outside_soloing_repair_source_context_preserved": True,
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
             "objective_source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
@@ -125,7 +152,9 @@ def audio_package_report(root: Path, *, quality_claim: bool = False) -> dict:
             "objective_source_outside_soloing_repair_source_residual_risk_preserved": True,
             "objective_source_outside_soloing_repair_pitch_role_risk_count_after": 0,
             "objective_source_outside_soloing_repair_pitch_role_risk_delta": 2,
+            **{f"objective_{key}": value for key, value in SOURCE_CONTEXT.items()},
             "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "source_outside_soloing_repair_source_context_preserved": True,
             "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
             "source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
             "source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
@@ -133,6 +162,7 @@ def audio_package_report(root: Path, *, quality_claim: bool = False) -> dict:
             "source_outside_soloing_repair_source_residual_risk_preserved": True,
             "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
             "source_outside_soloing_repair_pitch_role_risk_delta": 2,
+            **SOURCE_CONTEXT,
             "source_outside_soloing_not_evaluable_count": 6,
             "repaired_outside_soloing_not_evaluable_count": 6,
             "repaired_not_evaluable_counts": {
@@ -182,6 +212,9 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageTest(unit
                 ],
                 5,
             )
+            self.assertTrue(summary["objective_source_outside_soloing_repair_source_context_preserved"])
+            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+                self.assertEqual(summary[f"objective_{key}"], SOURCE_CONTEXT[key])
             self.assertEqual(
                 summary[
                     "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"
@@ -211,6 +244,9 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageTest(unit
                 summary["source_outside_soloing_repair_source_objective_pitch_role_risk_count"],
                 5,
             )
+            self.assertTrue(summary["source_outside_soloing_repair_source_context_preserved"])
+            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+                self.assertEqual(summary[key], SOURCE_CONTEXT[key])
             self.assertEqual(
                 summary["source_outside_soloing_repair_source_pitch_role_risk_count_before"],
                 5,
@@ -273,6 +309,23 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageTest(unit
                     audio_package_report=source,
                     output_dir=root / "review_package",
                     issue_number=936,
+                    expected_count=6,
+                )
+
+    def test_rejects_missing_source_context_field(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = audio_package_report(root)
+            source["summary"].pop(
+                "followup_objective_source_outside_soloing_source_pitch_role_risk_delta"
+            )
+            with self.assertRaises(
+                StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError
+            ):
+                build_listening_review_package_report(
+                    audio_package_report=source,
+                    output_dir=root / "review_package",
+                    issue_number=1020,
                     expected_count=6,
                 )
 


### PR DESCRIPTION
## Summary
- songlike melody contour repair listening review package source-context 검증 추가
- audio package source-context preserved flag 필수화
- bridge source-context 21개 키 누락 실패 처리
- source summary / validation summary / markdown report에 source-context 수치 전파
- #1020 상태 문서와 harness issue number 갱신

## Context
- #1018 audio package completed: `true`
- review item count: `6`
- technical WAV validation: `true`
- rendered audio file count: `6`
- duration range: `18.849s-18.992s`
- failure label delta: `4`
- songlike failure delta: `5`
- source-context preserved: `true`
- validated review input: `false`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Scope
- `scripts/build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py`
- `tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py`
- `scripts/agent_harness.sh`
- `docs/` status and source-context evidence docs
- `README.md`, `AGENTS.md` handoff fields

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-listening-review-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- listening review package는 review input package이며 preference claim 아님
- validated listening input 부재 상태 유지
- 다음 input guard에서 preference fill 차단 조건 별도 검증 필요

Closes #1020