### PR TITLE
Stage B MIDI-to-solo songlike melody contour repair input guard source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Current handoff scope:
 - Latest songlike melody contour repair sweep completed: Issue #1016, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh.
 - Latest songlike melody contour repair audio package completed: Issue #1018, Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh.
 - Latest songlike melody contour repair listening review package completed: Issue #1020, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh.
-- Latest songlike melody contour repair listening review input guard completed: Issue #938, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh.
+- Latest songlike melody contour repair listening review input guard completed: Issue #1022, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh.
 - Latest songlike melody contour repair objective-only next decision completed: Issue #940, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh.
 - Latest songlike melody contour repair follow-up decision completed: Issue #942, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair sweep completed: Issue #944, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh.
@@ -56,7 +56,7 @@ Current handoff scope:
 - Latest documentation issue completed: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
 - Open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour repair sweep: `Issue #1016`
 - latest songlike melody contour repair audio package: `Issue #1018`
 - latest songlike melody contour repair listening review package: `Issue #1020`
-- latest songlike melody contour repair listening review input guard: `Issue #938`
+- latest songlike melody contour repair listening review input guard: `Issue #1022`
 - latest songlike melody contour repair objective-only next decision: `Issue #940`
 - latest songlike melody contour repair follow-up decision: `Issue #942`
 - latest songlike melody contour phrase/rhythm repair sweep: `Issue #944`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -10921,6 +10921,54 @@ Issue #1020은 Issue #1018 audio package 결과의 WAV/MIDI 후보 6개를 liste
 
 - `Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh`
 
+## 9.201 Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh
+
+Issue #1022는 Issue #1020 listening review package의 pending input 상태와 source-context를 input guard summary까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- review item count: `6`
+- required input field count: `4`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- sample rate: `44100`
+- duration range: `18.849s -> 18.992s`
+- failure label delta: `4`
+- songlike failure delta: `5`
+- objective source outside-soloing repair source context preserved: `true`
+- source outside-soloing repair source context preserved: `true`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing current repair pitch-role risk count after: `0`
+- source outside-soloing current repair pitch-role risk delta: `2`
+- audio review required: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- input guard source validation에 #1020 listening package source-context preserved 조건 추가.
+- source-context preserved flag와 21개 context field를 guard source summary/readiness/validation summary에 보존.
+- validated listening input 부재 상태에서 preference fill 차단 확인.
+- 다음 boundary는 objective-only next decision source-context refresh.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
+- `.venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-listening-review-input-guard`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -31,7 +31,7 @@
 - latest songlike melody contour repair sweep: Issue #1016, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh
 - latest songlike melody contour repair audio package: Issue #1018, Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh
 - latest songlike melody contour repair listening review package: Issue #1020, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh
-- latest songlike melody contour repair listening review input guard: Issue #938, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh
+- latest songlike melody contour repair listening review input guard: Issue #1022, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh
 - latest songlike melody contour repair objective-only next decision: Issue #940, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh
 - latest songlike melody contour repair follow-up decision: Issue #942, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh
 - latest songlike melody contour phrase/rhythm repair sweep: Issue #944, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh
@@ -57,7 +57,7 @@
 - latest README evidence refresh: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
 - open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -3771,6 +3771,63 @@ Issue #1020은 Issue #1018 audio package 결과의 WAV/MIDI 후보 6개를 liste
 다음:
 
 - `Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh`
+
+## Stage B MIDI-to-Solo Songlike Melody Contour Repair Listening Review Input Guard Source Context Refresh Result
+
+Issue #1022는 Issue #1020 listening review package의 pending input 상태와 source-context를 input guard summary까지 보존한 작업이다.
+
+변경:
+
+- listening review input guard source-context 검증 추가
+- listening review package source-context preserved flag 필수화
+- bridge source-context 21개 키 누락 시 input guard 실패 처리
+- guard source summary / readiness / validation summary에 source-context 수치 전파
+- validated review input 부재 상태에서 preference fill 차단 유지
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_LISTENING_REVIEW_INPUT_GUARD_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- review item count: `6`
+- required input field count: `4`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- sample rate: `44100`
+- duration range: `18.849s-18.992s`
+- failure label delta: `4`
+- songlike failure delta: `5`
+- objective source outside-soloing source context preserved: `true`
+- source outside-soloing source context preserved: `true`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
+- source outside-soloing not-evaluable count: `6`
+- repaired outside-soloing not-evaluable count: `6`
+- audio review required: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- pending listening input 상태에서 preference fill 차단 확인.
+- source-context preserved flag와 21개 context field 보존 확인.
+- critical user input 없이 objective-only next decision boundary로 진행 가능.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
+- `.venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-listening-review-input-guard`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음:
+
+- `Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_LISTENING_REVIEW_INPUT_GUARD_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_LISTENING_REVIEW_INPUT_GUARD_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -1,4 +1,4 @@
-# Stage B MIDI-to-Solo Songlike Melody Contour Repair Listening Review Input Guard
+# Stage B MIDI-to-Solo Songlike Melody Contour Repair Listening Review Input Guard Source Context Refresh
 
 ## Summary
 
@@ -17,14 +17,24 @@
 - songlike failure delta: `5`
 - source outside-soloing repair evidence ready: `true`
 - objective source outside-soloing repair WAV count: `6`
+- objective source outside-soloing source context preserved: `true`
 - objective source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - objective source outside-soloing source repair targeted: `false`
 - objective source outside-soloing source residual risk preserved: `true`
 - objective source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- objective follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- objective follow-up objective current repair pitch-role risk after/delta: `0` / `2`
+- objective repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- objective repair sweep current repair pitch-role risk after/delta: `0` / `2`
+- source outside-soloing source context preserved: `true`
 - source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - source outside-soloing source repair targeted: `false`
 - source outside-soloing source residual risk preserved: `true`
 - source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up objective current repair pitch-role risk after/delta: `0` / `2`
+- bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- bridge repair sweep current repair pitch-role risk after/delta: `0` / `2`
 - source outside-soloing repair pitch-role risk after: `0`
 - source outside-soloing not evaluable count: `6`
 - repaired outside-soloing not evaluable count: `6`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6427,7 +6427,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_g
     --run_id "$guard_run_id" \
     --source_package "$source_package" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_LISTENING_REVIEW_INPUT_GUARD_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 938 \
+    --issue_number 1022 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision \
     --require_guard_completed \

--- a/scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input.py
+++ b/scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input.py
@@ -13,6 +13,9 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
+    BRIDGE_SOURCE_CONTEXT_KEYS,
+)
 from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package import (  # noqa: E402
     BOUNDARY as SOURCE_BOUNDARY,
     NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
@@ -28,7 +31,7 @@ FILL_BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_listening_r
 OBJECTIVE_NEXT_BOUNDARY = (
     "stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision"
 )
-SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard_v2"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard_v3"
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -78,6 +81,16 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
 
 
 def _source_context_fields(source: dict[str, Any]) -> dict[str, Any]:
+    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+        objective_key = f"objective_{key}"
+        if objective_key not in source or source[objective_key] is None:
+            raise StageBMidiToSoloSonglikeMelodyContourRepairListeningInputGuardError(
+                f"objective source-context field required: {objective_key}"
+            )
+        if key not in source or source[key] is None:
+            raise StageBMidiToSoloSonglikeMelodyContourRepairListeningInputGuardError(
+                f"source-context field required: {key}"
+            )
     return {
         "objective_source_outside_soloing_repair_wav_count": _int(
             source.get("objective_source_outside_soloing_repair_wav_count")
@@ -86,6 +99,9 @@ def _source_context_fields(source: dict[str, Any]) -> dict[str, Any]:
             source.get(
                 "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count"
             )
+        ),
+        "objective_source_outside_soloing_repair_source_context_preserved": bool(
+            source.get("objective_source_outside_soloing_repair_source_context_preserved", False)
         ),
         "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             source.get(
@@ -118,6 +134,9 @@ def _source_context_fields(source: dict[str, Any]) -> dict[str, Any]:
         "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
             source.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
         ),
+        "source_outside_soloing_repair_source_context_preserved": bool(
+            source.get("source_outside_soloing_repair_source_context_preserved", False)
+        ),
         "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             source.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
         ),
@@ -139,6 +158,8 @@ def _source_context_fields(source: dict[str, Any]) -> dict[str, Any]:
         "source_outside_soloing_repair_pitch_role_risk_delta": _int(
             source.get("source_outside_soloing_repair_pitch_role_risk_delta")
         ),
+        **{f"objective_{key}": source.get(f"objective_{key}") for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{key: source.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
     }
 
 
@@ -149,6 +170,10 @@ def _validate_source_context(source: dict[str, Any], *, base: str, label: str) -
     source_delta = _int(source.get(f"{base}_source_pitch_role_risk_delta"))
     current_after = _int(source.get(f"{base}_pitch_role_risk_count_after"))
     current_delta = _int(source.get(f"{base}_pitch_role_risk_delta"))
+    if not bool(source.get(f"{base}_source_context_preserved", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairListeningInputGuardError(
+            f"{label} source context preservation required"
+        )
     if objective_risk <= 0 or source_before <= 0:
         raise StageBMidiToSoloSonglikeMelodyContourRepairListeningInputGuardError(
             f"{label} source pitch-role risk context required"
@@ -445,6 +470,9 @@ def validate_listening_review_input_guard_report(
                 "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count"
             )
         ),
+        "objective_source_outside_soloing_repair_source_context_preserved": bool(
+            source.get("objective_source_outside_soloing_repair_source_context_preserved", False)
+        ),
         "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             source.get(
                 "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"
@@ -476,6 +504,9 @@ def validate_listening_review_input_guard_report(
         "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
             source.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
         ),
+        "source_outside_soloing_repair_source_context_preserved": bool(
+            source.get("source_outside_soloing_repair_source_context_preserved", False)
+        ),
         "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             source.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
         ),
@@ -497,6 +528,8 @@ def validate_listening_review_input_guard_report(
         "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
             source.get("source_outside_soloing_repair_pitch_role_risk_count_after")
         ),
+        **{f"objective_{key}": source.get(f"objective_{key}") for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{key: source.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
         "source_outside_soloing_not_evaluable_count": _int(
             source.get("source_outside_soloing_not_evaluable_count")
         ),
@@ -523,7 +556,7 @@ def markdown_report(report: dict[str, Any]) -> str:
     source = guard["source_summary"]
     package = report["source_package_summary"]
     lines = [
-        "# Stage B MIDI-to-Solo Songlike Melody Contour Repair Listening Review Input Guard",
+        "# Stage B MIDI-to-Solo Songlike Melody Contour Repair Listening Review Input Guard Source Context Refresh",
         "",
         "## Summary",
         "",
@@ -542,14 +575,24 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- songlike failure delta: `{source['songlike_failure_delta']}`",
         f"- source outside-soloing repair evidence ready: `{_bool_token(source['source_outside_soloing_repair_evidence_ready'])}`",
         f"- objective source outside-soloing repair WAV count: `{source['objective_source_outside_soloing_repair_wav_count']}`",
+        f"- objective source outside-soloing source context preserved: `{_bool_token(source['objective_source_outside_soloing_repair_source_context_preserved'])}`",
         f"- objective source outside-soloing source pitch-role risk before / after / delta: `{source['objective_source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{source['objective_source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{source['objective_source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- objective source outside-soloing source repair targeted: `{_bool_token(source['objective_source_outside_soloing_repair_source_targeted'])}`",
         f"- objective source outside-soloing source residual risk preserved: `{_bool_token(source['objective_source_outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- objective source outside-soloing current repair pitch-role risk after / delta: `{source['objective_source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{source['objective_source_outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- objective follow-up objective source outside-soloing source pitch-role risk: `{source['objective_followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {source['objective_followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- objective follow-up objective current repair pitch-role risk after/delta: `{source['objective_followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{source['objective_followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- objective repair sweep source outside-soloing source pitch-role risk: `{source['objective_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {source['objective_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- objective repair sweep current repair pitch-role risk after/delta: `{source['objective_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{source['objective_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- source outside-soloing source context preserved: `{_bool_token(source['source_outside_soloing_repair_source_context_preserved'])}`",
         f"- source outside-soloing source pitch-role risk before / after / delta: `{source['source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{source['source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{source['source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- source outside-soloing source repair targeted: `{_bool_token(source['source_outside_soloing_repair_source_targeted'])}`",
         f"- source outside-soloing source residual risk preserved: `{_bool_token(source['source_outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- source outside-soloing current repair pitch-role risk after / delta: `{source['source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{source['source_outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- follow-up objective source outside-soloing source pitch-role risk: `{source['followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {source['followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up objective current repair pitch-role risk after/delta: `{source['followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{source['followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- bridge repair sweep source outside-soloing source pitch-role risk: `{source['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {source['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- bridge repair sweep current repair pitch-role risk after/delta: `{source['repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{source['repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- source outside-soloing repair pitch-role risk after: `{source['source_outside_soloing_repair_pitch_role_risk_count_after']}`",
         f"- source outside-soloing not evaluable count: `{source['source_outside_soloing_not_evaluable_count']}`",
         f"- repaired outside-soloing not evaluable count: `{source['repaired_outside_soloing_not_evaluable_count']}`",
@@ -591,7 +634,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=938)
+    parser.add_argument("--issue_number", type=int, default=1022)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--require_guard_completed", action="store_true")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_SOURCE_CONTEXT_KEYS
 from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package import (
     BOUNDARY as SOURCE_BOUNDARY,
     NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
@@ -15,6 +16,31 @@ from scripts.guard_stage_b_midi_to_solo_songlike_melody_contour_repair_listening
     build_listening_review_input_guard_report,
     validate_listening_review_input_guard_report,
 )
+
+
+SOURCE_CONTEXT = {
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_objective_source_outside_soloing_source_targeted": False,
+    "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_repair_sweep_source_outside_soloing_source_targeted": False,
+    "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "repair_sweep_source_outside_soloing_source_targeted": False,
+    "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+}
 
 
 def source_package(*, quality_claim: bool = False, validated_input: bool = False) -> dict:
@@ -51,6 +77,7 @@ def source_package(*, quality_claim: bool = False, validated_input: bool = False
             "source_outside_soloing_repair_evidence_ready": True,
             "objective_source_outside_soloing_repair_wav_count": 6,
             "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "objective_source_outside_soloing_repair_source_context_preserved": True,
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
             "objective_source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
@@ -58,7 +85,9 @@ def source_package(*, quality_claim: bool = False, validated_input: bool = False
             "objective_source_outside_soloing_repair_source_residual_risk_preserved": True,
             "objective_source_outside_soloing_repair_pitch_role_risk_count_after": 0,
             "objective_source_outside_soloing_repair_pitch_role_risk_delta": 2,
+            **{f"objective_{key}": value for key, value in SOURCE_CONTEXT.items()},
             "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "source_outside_soloing_repair_source_context_preserved": True,
             "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
             "source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
             "source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
@@ -66,6 +95,7 @@ def source_package(*, quality_claim: bool = False, validated_input: bool = False
             "source_outside_soloing_repair_source_residual_risk_preserved": True,
             "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
             "source_outside_soloing_repair_pitch_role_risk_delta": 2,
+            **SOURCE_CONTEXT,
             "source_outside_soloing_not_evaluable_count": 6,
             "repaired_outside_soloing_not_evaluable_count": 6,
             "remaining_failure_counts": {
@@ -142,6 +172,9 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningInputGuardTest(unittes
                 ],
                 5,
             )
+            self.assertTrue(summary["objective_source_outside_soloing_repair_source_context_preserved"])
+            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+                self.assertEqual(summary[f"objective_{key}"], SOURCE_CONTEXT[key])
             self.assertEqual(
                 summary[
                     "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"
@@ -171,6 +204,9 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningInputGuardTest(unittes
                 summary["source_outside_soloing_repair_source_objective_pitch_role_risk_count"],
                 5,
             )
+            self.assertTrue(summary["source_outside_soloing_repair_source_context_preserved"])
+            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+                self.assertEqual(summary[key], SOURCE_CONTEXT[key])
             self.assertEqual(
                 summary["source_outside_soloing_repair_source_pitch_role_risk_count_before"],
                 5,
@@ -221,6 +257,22 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningInputGuardTest(unittes
                     source,
                     output_dir=root / "guard",
                     issue_number=938,
+                )
+
+    def test_rejects_missing_source_context_field(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = source_package()
+            source["source_summary"].pop(
+                "followup_objective_source_outside_soloing_source_pitch_role_risk_delta"
+            )
+            with self.assertRaises(
+                StageBMidiToSoloSonglikeMelodyContourRepairListeningInputGuardError
+            ):
+                build_listening_review_input_guard_report(
+                    source,
+                    output_dir=root / "guard",
+                    issue_number=1022,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary
- songlike melody contour repair listening review input guard source-context 검증 추가
- listening review package source-context preserved flag 필수화
- bridge source-context 21개 키 누락 실패 처리
- guard source summary / readiness / validation summary에 source-context 수치 전파
- #1022 상태 문서와 harness issue number 갱신

## Context
- #1020 listening review package completed: `true`
- review item count: `6`
- validated review input present: `false`
- preference fill allowed: `false`
- technical WAV validation: `true`
- failure label delta: `4`
- songlike failure delta: `5`
- source-context preserved: `true`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Scope
- `scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input.py`
- `tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard.py`
- `scripts/agent_harness.sh`
- `docs/` status and source-context evidence docs
- `README.md`, `AGENTS.md` handoff fields

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
- `.venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-listening-review-input-guard`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- input guard는 preference 판단 아님
- validated listening input 부재 상태 유지
- 다음 objective-only decision에서 objective evidence 기준 후속 boundary 분리 필요

Closes #1022