### PR TITLE
Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Current handoff scope:
 - Latest songlike melody contour repair listening review package completed: Issue #1020, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh.
 - Latest songlike melody contour repair listening review input guard completed: Issue #1022, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh.
 - Latest songlike melody contour repair objective-only next decision completed: Issue #1024, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh.
-- Latest songlike melody contour repair follow-up decision completed: Issue #942, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh.
+- Latest songlike melody contour repair follow-up decision completed: Issue #1026, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair sweep completed: Issue #944, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair audio package completed: Issue #946, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair listening review package completed: Issue #948, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh.
@@ -56,7 +56,7 @@ Current handoff scope:
 - Latest documentation issue completed: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
 - Open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour repair listening review package: `Issue #1020`
 - latest songlike melody contour repair listening review input guard: `Issue #1022`
 - latest songlike melody contour repair objective-only next decision: `Issue #1024`
-- latest songlike melody contour repair follow-up decision: `Issue #942`
+- latest songlike melody contour repair follow-up decision: `Issue #1026`
 - latest songlike melody contour phrase/rhythm repair sweep: `Issue #944`
 - latest songlike melody contour phrase/rhythm repair audio package: `Issue #946`
 - latest songlike melody contour phrase/rhythm repair listening review package: `Issue #948`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -11018,6 +11018,51 @@ Issue #1024는 Issue #1022 input guard의 pending input 상태와 source-context
 
 - `Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh`
 
+## 9.203 Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh
+
+Issue #1026은 Issue #1024 objective-only next decision과 songlike melody contour repair sweep의 source/current outside-soloing context를 follow-up decision까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
+- repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- selected target: `songlike_melody_contour_phrase_rhythm_repair_sweep`
+- primary remaining failure labels: `phrase_shape_missing_tension_release`, `rhythmic_monotony`
+- primary remaining failure count: `2`
+- candidate count: `6`
+- failure label delta: `4`
+- technical regression count: `0`
+- objective source outside-soloing repair source context preserved: `true`
+- repair sweep source outside-soloing repair source context preserved: `true`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing current repair pitch-role risk count after: `0`
+- source outside-soloing current repair pitch-role risk delta: `2`
+- objective/sweep outside-soloing not evaluable count: `6/6`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- follow-up decision source validation에 objective와 repair sweep source-context preserved 조건 추가.
+- source-context preserved flag와 21개 context field를 readiness/validation summary에 보존.
+- 잔여 phrase-shape/rhythmic-monotony 동률 기준 다음 repair sweep target 유지.
+- 다음 boundary는 phrase/rhythm repair sweep source-context refresh.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_followup.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-followup-decision`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -33,7 +33,7 @@
 - latest songlike melody contour repair listening review package: Issue #1020, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh
 - latest songlike melody contour repair listening review input guard: Issue #1022, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh
 - latest songlike melody contour repair objective-only next decision: Issue #1024, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh
-- latest songlike melody contour repair follow-up decision: Issue #942, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh
+- latest songlike melody contour repair follow-up decision: Issue #1026, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh
 - latest songlike melody contour phrase/rhythm repair sweep: Issue #944, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh
 - latest songlike melody contour phrase/rhythm repair audio package: Issue #946, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh
 - latest songlike melody contour phrase/rhythm repair listening review package: Issue #948, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh
@@ -57,7 +57,7 @@
 - latest README evidence refresh: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
 - open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -3884,6 +3884,57 @@ Issue #1024는 Issue #1022 input guard의 pending input 상태와 source-context
 다음:
 
 - `Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh`
+
+## Stage B MIDI-to-Solo Songlike Melody Contour Repair Follow-Up Decision Source Context Refresh Result
+
+Issue #1026은 Issue #1024 objective-only next decision과 songlike melody contour repair sweep의 source/current outside-soloing context를 follow-up decision까지 보존한 작업이다.
+
+변경:
+
+- follow-up decision source validation에 source-context preserved flag 필수화
+- bridge source-context 21개 키 누락 시 follow-up decision 실패 처리
+- objective/sweep source-context를 readiness/validation summary까지 전파
+- phrase/rhythm tie target 선택 기준 유지
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
+- repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- selected target: `songlike_melody_contour_phrase_rhythm_repair_sweep`
+- primary remaining failure labels: `phrase_shape_missing_tension_release`, `rhythmic_monotony`
+- primary remaining failure count: `2`
+- candidate count: `6`
+- failure label delta: `4`
+- technical regression count: `0`
+- objective source outside-soloing source context preserved: `true`
+- repair sweep source outside-soloing source context preserved: `true`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- objective/sweep 양쪽 source-context preserved flag와 21개 context field 보존 확인.
+- 잔여 failure label 동률 기준 phrase/rhythm repair sweep 선택 유지.
+- outside-soloing과 weak chord-tone landing은 context 부재로 quality claim 제외 유지.
+- critical user input 없이 다음 repair sweep boundary로 진행 가능.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_followup.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-followup-decision`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -17,6 +17,7 @@
 - technical regression count: `0`
 - objective source outside-soloing repair evidence ready: `true`
 - objective source outside-soloing repair WAV count: `6`
+- objective source outside-soloing source context preserved: `true`
 - objective source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - objective source outside-soloing source repair targeted: `false`
 - objective source outside-soloing source residual risk preserved: `true`
@@ -25,6 +26,7 @@
 - objective source outside-soloing not evaluable count: `6`
 - objective repaired outside-soloing not evaluable count: `6`
 - repair sweep source outside-soloing repair evidence ready: `true`
+- repair sweep source outside-soloing source context preserved: `true`
 - repair sweep source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - repair sweep source outside-soloing source repair targeted: `false`
 - repair sweep source outside-soloing source residual risk preserved: `true`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6476,7 +6476,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision() {
     --objective_next_report "$objective_report" \
     --repair_sweep_report "$sweep_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 942 \
+    --issue_number 1026 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep \
     --expected_target songlike_melody_contour_phrase_rhythm_repair_sweep \

--- a/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_followup.py
+++ b/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_followup.py
@@ -14,6 +14,9 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
+    BRIDGE_SOURCE_CONTEXT_KEYS,
+)
 from scripts.decide_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next import (  # noqa: E402
     BOUNDARY as OBJECTIVE_NEXT_BOUNDARY,
     FOLLOWUP_DECISION_NEXT_BOUNDARY,
@@ -30,7 +33,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError(ValueErro
 BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep"
 SELECTED_TARGET = "songlike_melody_contour_phrase_rhythm_repair_sweep"
-SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision_v2"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision_v3"
 TIE_TARGET_LABELS = (
     "phrase_shape_missing_tension_release",
     "rhythmic_monotony",
@@ -76,8 +79,23 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
         )
 
 
-def _source_context_fields(source: dict[str, Any]) -> dict[str, Any]:
+def _bridge_source_context_fields(source: dict[str, Any], *, label: str) -> dict[str, Any]:
+    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+        if key not in source or source[key] is None:
+            raise StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError(
+                f"{label} source-context field required: {key}"
+            )
+    return {key: source[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS}
+
+
+def _source_context_fields(source: dict[str, Any], *, label: str) -> dict[str, Any]:
     return {
+        "objective_source_outside_soloing_repair_source_context_preserved": bool(
+            source.get(
+                "objective_source_outside_soloing_repair_source_context_preserved",
+                False,
+            )
+        ),
         "objective_source_outside_soloing_repair_wav_count": _int(
             source.get("objective_source_outside_soloing_repair_wav_count")
         ),
@@ -117,6 +135,9 @@ def _source_context_fields(source: dict[str, Any]) -> dict[str, Any]:
         "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
             source.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
         ),
+        "source_outside_soloing_repair_source_context_preserved": bool(
+            source.get("source_outside_soloing_repair_source_context_preserved", False)
+        ),
         "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             source.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
         ),
@@ -138,6 +159,7 @@ def _source_context_fields(source: dict[str, Any]) -> dict[str, Any]:
         "source_outside_soloing_repair_pitch_role_risk_delta": _int(
             source.get("source_outside_soloing_repair_pitch_role_risk_delta")
         ),
+        **_bridge_source_context_fields(source, label=label),
     }
 
 
@@ -168,6 +190,10 @@ def _validate_source_context(source: dict[str, Any], *, base: str, label: str) -
         raise StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError(
             f"{label} source-targeted flag should remain false"
         )
+    if not bool(source.get(f"{base}_source_context_preserved", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError(
+            f"{label} source context preservation required"
+        )
     if not bool(source.get(f"{base}_source_residual_risk_preserved", False)):
         raise StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError(
             f"{label} source residual risk preservation required"
@@ -184,17 +210,26 @@ def _validate_source_context(source: dict[str, Any], *, base: str, label: str) -
 
 def _objective_context_for_followup(source: dict[str, Any]) -> dict[str, Any]:
     return {
-        key: value
-        for key, value in _source_context_fields(source).items()
-        if key.startswith("objective_source_outside_soloing_repair_")
+        **{
+            key: value
+            for key, value in _source_context_fields(source, label="objective follow-up").items()
+            if key.startswith("objective_source_outside_soloing_repair_")
+        },
+        **{f"objective_{key}": source[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
     }
 
 
 def _repair_sweep_context_for_followup(source: dict[str, Any]) -> dict[str, Any]:
     return {
-        f"repair_sweep_{key}": value
-        for key, value in _source_context_fields(source).items()
-        if key.startswith("source_outside_soloing_repair_")
+        **{
+            f"repair_sweep_{key}": value
+            for key, value in _source_context_fields(
+                source,
+                label="repair sweep follow-up",
+            ).items()
+            if key.startswith("source_outside_soloing_repair_")
+        },
+        **{f"repair_sweep_{key}": source[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
     }
 
 
@@ -291,7 +326,7 @@ def validate_objective_next_source(report: dict[str, Any]) -> dict[str, Any]:
         "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
             summary.get("source_outside_soloing_repair_pitch_role_risk_count_after")
         ),
-        **_source_context_fields(summary),
+        **_source_context_fields(summary, label="objective summary"),
         "source_outside_soloing_not_evaluable_count": _int(
             summary.get("source_outside_soloing_not_evaluable_count")
         ),
@@ -419,7 +454,7 @@ def validate_repair_sweep_source(report: dict[str, Any]) -> dict[str, Any]:
         "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
             aggregate.get("source_outside_soloing_repair_pitch_role_risk_count_after")
         ),
-        **_source_context_fields(aggregate),
+        **_source_context_fields(aggregate, label="repair sweep aggregate"),
         "source_outside_soloing_not_evaluable_count": _int(
             aggregate.get("source_outside_soloing_not_evaluable_count")
         ),
@@ -691,6 +726,9 @@ def validate_followup_decision_report(
                 "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count"
             )
         ),
+        "objective_source_outside_soloing_repair_source_context_preserved": bool(
+            targets.get("objective_source_outside_soloing_repair_source_context_preserved", False)
+        ),
         "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             targets.get(
                 "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"
@@ -716,6 +754,7 @@ def validate_followup_decision_report(
         "objective_source_outside_soloing_repair_pitch_role_risk_delta": _int(
             targets.get("objective_source_outside_soloing_repair_pitch_role_risk_delta")
         ),
+        **{f"objective_{key}": targets.get(f"objective_{key}") for key in BRIDGE_SOURCE_CONTEXT_KEYS},
         "repair_sweep_source_outside_soloing_repair_evidence_ready": bool(
             targets.get("repair_sweep_source_outside_soloing_repair_evidence_ready", False)
         ),
@@ -731,6 +770,12 @@ def validate_followup_decision_report(
         "repair_sweep_source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
             targets.get(
                 "repair_sweep_source_outside_soloing_repair_source_objective_pitch_role_risk_count"
+            )
+        ),
+        "repair_sweep_source_outside_soloing_repair_source_context_preserved": bool(
+            targets.get(
+                "repair_sweep_source_outside_soloing_repair_source_context_preserved",
+                False,
             )
         ),
         "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
@@ -758,6 +803,10 @@ def validate_followup_decision_report(
         "repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta": _int(
             targets.get("repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta")
         ),
+        **{
+            f"repair_sweep_{key}": targets.get(f"repair_sweep_{key}")
+            for key in BRIDGE_SOURCE_CONTEXT_KEYS
+        },
         "human_audio_preference_claimed": bool(
             readiness.get("human_audio_preference_claimed", True)
         ),
@@ -796,6 +845,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- technical regression count: `{readiness['technical_regression_count']}`",
         f"- objective source outside-soloing repair evidence ready: `{_bool_token(readiness['objective_source_outside_soloing_repair_evidence_ready'])}`",
         f"- objective source outside-soloing repair WAV count: `{readiness['objective_source_outside_soloing_repair_wav_count']}`",
+        f"- objective source outside-soloing source context preserved: `{_bool_token(readiness['objective_source_outside_soloing_repair_source_context_preserved'])}`",
         f"- objective source outside-soloing source pitch-role risk before / after / delta: `{readiness['objective_source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{readiness['objective_source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{readiness['objective_source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- objective source outside-soloing source repair targeted: `{_bool_token(readiness['objective_source_outside_soloing_repair_source_targeted'])}`",
         f"- objective source outside-soloing source residual risk preserved: `{_bool_token(readiness['objective_source_outside_soloing_repair_source_residual_risk_preserved'])}`",
@@ -804,6 +854,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- objective source outside-soloing not evaluable count: `{readiness['objective_source_outside_soloing_not_evaluable_count']}`",
         f"- objective repaired outside-soloing not evaluable count: `{readiness['objective_repaired_outside_soloing_not_evaluable_count']}`",
         f"- repair sweep source outside-soloing repair evidence ready: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_evidence_ready'])}`",
+        f"- repair sweep source outside-soloing source context preserved: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_source_context_preserved'])}`",
         f"- repair sweep source outside-soloing source pitch-role risk before / after / delta: `{readiness['repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{readiness['repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{readiness['repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- repair sweep source outside-soloing source repair targeted: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_source_targeted'])}`",
         f"- repair sweep source outside-soloing source residual risk preserved: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_source_residual_risk_preserved'])}`",

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_SOURCE_CONTEXT_KEYS
 from scripts.decide_stage_b_midi_to_solo_songlike_melody_contour_repair_followup import (
     BOUNDARY,
     NEXT_BOUNDARY,
@@ -21,6 +22,31 @@ from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep impor
 )
 
 
+SOURCE_CONTEXT = {
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_objective_source_outside_soloing_source_targeted": False,
+    "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_repair_sweep_source_outside_soloing_source_targeted": False,
+    "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "repair_sweep_source_outside_soloing_source_targeted": False,
+    "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+}
+
+
 def objective_next_report(*, quality_claim: bool = False) -> dict:
     return {
         "boundary": OBJECTIVE_NEXT_BOUNDARY,
@@ -33,6 +59,7 @@ def objective_next_report(*, quality_claim: bool = False) -> dict:
             "failure_label_delta": 4,
             "songlike_failure_delta": 5,
             "source_outside_soloing_repair_evidence_ready": True,
+            "objective_source_outside_soloing_repair_source_context_preserved": True,
             "objective_source_outside_soloing_repair_wav_count": 6,
             "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
@@ -43,6 +70,7 @@ def objective_next_report(*, quality_claim: bool = False) -> dict:
             "objective_source_outside_soloing_repair_pitch_role_risk_count_after": 0,
             "objective_source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "source_outside_soloing_repair_source_context_preserved": True,
             "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
             "source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
             "source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
@@ -53,6 +81,7 @@ def objective_next_report(*, quality_claim: bool = False) -> dict:
             "source_outside_soloing_not_evaluable_count": 6,
             "repaired_outside_soloing_not_evaluable_count": 6,
             "current_quality_claim_ready": False,
+            **SOURCE_CONTEXT,
         },
         "readiness": {
             "objective_next_decision_completed": True,
@@ -100,6 +129,7 @@ def repair_sweep_report(*, technical_regression_count: int = 0) -> dict:
                 "rhythmic_monotony": 2,
             },
             "source_outside_soloing_repair_evidence_ready": True,
+            "objective_source_outside_soloing_repair_source_context_preserved": True,
             "objective_source_outside_soloing_repair_wav_count": 6,
             "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
@@ -110,6 +140,7 @@ def repair_sweep_report(*, technical_regression_count: int = 0) -> dict:
             "objective_source_outside_soloing_repair_pitch_role_risk_count_after": 0,
             "objective_source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "source_outside_soloing_repair_source_context_preserved": True,
             "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
             "source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
             "source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
@@ -119,6 +150,7 @@ def repair_sweep_report(*, technical_regression_count: int = 0) -> dict:
             "source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "source_outside_soloing_not_evaluable_count": 6,
             "repaired_outside_soloing_not_evaluable_count": 6,
+            **SOURCE_CONTEXT,
         },
         "readiness": {
             "songlike_melody_contour_repair_sweep_completed": True,
@@ -168,6 +200,11 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
             self.assertEqual(summary["technical_regression_count"], 0)
             self.assertTrue(summary["objective_source_outside_soloing_repair_evidence_ready"])
             self.assertEqual(summary["objective_source_outside_soloing_repair_wav_count"], 6)
+            self.assertTrue(
+                summary["objective_source_outside_soloing_repair_source_context_preserved"]
+            )
+            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+                self.assertEqual(summary[f"objective_{key}"], SOURCE_CONTEXT[key])
             self.assertEqual(
                 summary[
                     "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"
@@ -198,6 +235,11 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
             self.assertEqual(summary["objective_source_outside_soloing_not_evaluable_count"], 6)
             self.assertEqual(summary["objective_repaired_outside_soloing_not_evaluable_count"], 6)
             self.assertTrue(summary["repair_sweep_source_outside_soloing_repair_evidence_ready"])
+            self.assertTrue(
+                summary["repair_sweep_source_outside_soloing_repair_source_context_preserved"]
+            )
+            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+                self.assertEqual(summary[f"repair_sweep_{key}"], SOURCE_CONTEXT[key])
             self.assertEqual(
                 summary[
                     "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before"
@@ -286,6 +328,36 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
                     repair_sweep_report=source,
                     output_dir=Path(tmp) / "followup",
                     issue_number=942,
+                )
+
+    def test_rejects_missing_bridge_source_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = objective_next_report()
+            source["objective_summary"].pop(BRIDGE_SOURCE_CONTEXT_KEYS[0])
+            with self.assertRaises(
+                StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError
+            ):
+                build_followup_decision_report(
+                    objective_next_report=source,
+                    repair_sweep_report=repair_sweep_report(),
+                    output_dir=Path(tmp) / "followup",
+                    issue_number=1026,
+                )
+
+    def test_rejects_source_context_preservation_flag_false(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = objective_next_report()
+            source["objective_summary"][
+                "source_outside_soloing_repair_source_context_preserved"
+            ] = False
+            with self.assertRaises(
+                StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError
+            ):
+                build_followup_decision_report(
+                    objective_next_report=source,
+                    repair_sweep_report=repair_sweep_report(),
+                    output_dir=Path(tmp) / "followup",
+                    issue_number=1026,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary

- Follow-up decision source-context preservation validation
- Objective/sweep source-context preserved flag requirement
- Bridge source-context 21-key propagation to readiness and validation summary
- Handoff and status document update for Issue #1026

## Context

- Previous boundary: Issue #1024 objective-only next decision
- Selected next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
- Primary remaining failure labels: `phrase_shape_missing_tension_release`, `rhythmic_monotony`
- Candidate count: `6`
- Failure label delta: `4`
- Technical regression count: `0`
- Objective/sweep source outside-soloing source risk: `5 -> 2`
- Objective/sweep current repair risk after / delta: `0 / 2`
- Human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Scope

- Follow-up decision script source-context validation 강화
- Missing bridge source-context key failure case 추가
- Source-context preserved flag false failure case 추가
- Harness issue number and generated decision document 갱신
- README, current status, core plan, handoff scope 갱신

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_followup.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-followup-decision`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- Musical quality and human/audio preference unclaimed
- Outside-soloing and weak chord-tone landing still not evaluated without context
- Next validation target: phrase/rhythm repair sweep source-context refresh

Closes #1026
