### PR TITLE
Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Current handoff scope:
 - Latest songlike melody contour repair listening review input guard completed: Issue #1022, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh.
 - Latest songlike melody contour repair objective-only next decision completed: Issue #1024, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh.
 - Latest songlike melody contour repair follow-up decision completed: Issue #1026, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh.
-- Latest songlike melody contour phrase/rhythm repair sweep completed: Issue #944, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh.
+- Latest songlike melody contour phrase/rhythm repair sweep completed: Issue #1028, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair audio package completed: Issue #946, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair listening review package completed: Issue #948, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair listening review input guard completed: Issue #950, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh.
@@ -56,7 +56,7 @@ Current handoff scope:
 - Latest documentation issue completed: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
 - Open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour repair listening review input guard: `Issue #1022`
 - latest songlike melody contour repair objective-only next decision: `Issue #1024`
 - latest songlike melody contour repair follow-up decision: `Issue #1026`
-- latest songlike melody contour phrase/rhythm repair sweep: `Issue #944`
+- latest songlike melody contour phrase/rhythm repair sweep: `Issue #1028`
 - latest songlike melody contour phrase/rhythm repair audio package: `Issue #946`
 - latest songlike melody contour phrase/rhythm repair listening review package: `Issue #948`
 - latest songlike melody contour phrase/rhythm repair listening review input guard: `Issue #950`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -11063,6 +11063,53 @@ Issue #1026은 Issue #1024 objective-only next decision과 songlike melody conto
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh`
 
+## 9.204 Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh
+
+Issue #1028은 Issue #1026 follow-up decision에서 선택된 phrase/rhythm repair sweep에 source/current outside-soloing context를 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
+- source repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
+- selected target: `songlike_melody_contour_phrase_rhythm_repair_audio_package`
+- candidate count: `6`
+- total failure labels: `4 -> 1`
+- failure label delta: `3`
+- phrase/rhythm failure count: `4 -> 1`
+- phrase/rhythm failure delta: `3`
+- improved candidate count: `2`
+- technical regression count: `0`
+- objective source outside-soloing repair source context preserved: `true`
+- source outside-soloing repair source context preserved: `true`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing current repair pitch-role risk count after: `0`
+- source outside-soloing current repair pitch-role risk delta: `2`
+- repaired outside-soloing not evaluable count: `6`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- phrase/rhythm repair sweep validation에 follow-up/source sweep source-context preserved 조건 추가.
+- bridge source-context 21개 키를 aggregate/readiness/validation summary까지 보존.
+- stale quality rubric baseline run_id를 source-context refresh 기준으로 교체.
+- 다음 boundary는 phrase/rhythm repair audio package source-context refresh.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-sweep`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -34,7 +34,7 @@
 - latest songlike melody contour repair listening review input guard: Issue #1022, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh
 - latest songlike melody contour repair objective-only next decision: Issue #1024, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh
 - latest songlike melody contour repair follow-up decision: Issue #1026, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh
-- latest songlike melody contour phrase/rhythm repair sweep: Issue #944, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh
+- latest songlike melody contour phrase/rhythm repair sweep: Issue #1028, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh
 - latest songlike melody contour phrase/rhythm repair audio package: Issue #946, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh
 - latest songlike melody contour phrase/rhythm repair listening review package: Issue #948, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh
 - latest songlike melody contour phrase/rhythm repair listening review input guard: Issue #950, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh
@@ -57,7 +57,7 @@
 - latest README evidence refresh: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
 - open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -3935,6 +3935,60 @@ Issue #1026은 Issue #1024 objective-only next decision과 songlike melody conto
 다음:
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh`
+
+## Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Repair Sweep Source Context Refresh Result
+
+Issue #1028은 Issue #1026 follow-up decision에서 선택된 phrase/rhythm repair sweep에 source/current outside-soloing context를 보존한 작업이다.
+
+변경:
+
+- phrase/rhythm repair sweep input validation에 source-context preserved flag 필수화
+- follow-up decision과 source repair sweep의 bridge source-context 21개 키 일치 검증 추가
+- objective/source context를 aggregate/readiness/validation summary까지 전파
+- stale quality rubric baseline run_id를 source-context refresh 기준으로 교체
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
+- source repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
+- selected target: `songlike_melody_contour_phrase_rhythm_repair_audio_package`
+- candidate count: `6`
+- total failure labels: `4 -> 1`
+- failure label delta: `3`
+- phrase/rhythm failure count: `4 -> 1`
+- phrase/rhythm failure delta: `3`
+- improved candidate count: `2`
+- technical regression count: `0`
+- objective source outside-soloing source context preserved: `true`
+- source outside-soloing source context preserved: `true`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
+- repaired outside-soloing not evaluable count: `6`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- phrase/rhythm repair sweep에서 target label 감소 확인.
+- source-context preserved flag와 21개 context field 보존 확인.
+- outside-soloing과 weak chord-tone landing은 context 부재로 quality claim 제외 유지.
+- 다음 boundary는 audio package source-context refresh.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-sweep`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -14,6 +14,8 @@
 - improved candidate count: `2`
 - technical regression count: `0`
 - source outside-soloing repair evidence ready: `true`
+- objective source outside-soloing source context preserved: `true`
+- source outside-soloing source context preserved: `true`
 - source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - source outside-soloing source repair targeted: `false`
 - source outside-soloing source residual risk preserved: `true`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6488,7 +6488,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision() {
 run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep() {
   local followup_run_id="${FOLLOWUP_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision_source_context_refresh}"
   local source_sweep_run_id="${SOURCE_SWEEP_RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_source_context_refresh}"
-  local rubric_run_id="${RUBRIC_RUN_ID:-harness_stage_b_midi_to_solo_quality_rubric_baseline}"
+  local rubric_run_id="${RUBRIC_RUN_ID:-harness_stage_b_midi_to_solo_quality_rubric_baseline_source_context_refresh}"
   local run_id="${RUN_ID:-harness_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep_source_context_refresh}"
   local followup_report="outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision/${followup_run_id}/stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision.json"
   local source_sweep_report="outputs/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep/${source_sweep_run_id}/stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.json"
@@ -6512,7 +6512,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep() {
     --source_repair_sweep "$source_sweep_report" \
     --rubric_baseline "$rubric_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 944 \
+    --issue_number 1028 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package \
     --min_candidate_count 6 \

--- a/scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py
+++ b/scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py
@@ -16,6 +16,9 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
+    BRIDGE_SOURCE_CONTEXT_KEYS,
+)
 from scripts.decide_stage_b_midi_to_solo_songlike_melody_contour_repair_followup import (  # noqa: E402
     BOUNDARY as FOLLOWUP_BOUNDARY,
     NEXT_BOUNDARY as FOLLOWUP_NEXT_BOUNDARY,
@@ -38,7 +41,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(ValueErr
 BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package"
 SELECTED_TARGET = "songlike_melody_contour_phrase_rhythm_repair_audio_package"
-SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep_v2"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep_v3"
 PHRASE_LABEL = "phrase_shape_missing_tension_release"
 RHYTHM_LABEL = "rhythmic_monotony"
 TARGET_LABELS = (PHRASE_LABEL, RHYTHM_LABEL)
@@ -91,14 +94,36 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
         )
 
 
+def _bridge_source_context_fields(
+    source: dict[str, Any],
+    *,
+    bridge_prefix: str,
+    label: str,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+        source_key = f"{bridge_prefix}_{key}" if bridge_prefix else key
+        if source_key not in source or source[source_key] is None:
+            raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+                f"{label} source-context field required: {source_key}"
+            )
+        result[key] = source[source_key]
+    return result
+
+
 def _source_context_fields(
     source: dict[str, Any],
     *,
     prefix: str = "source_outside_soloing_repair",
+    bridge_prefix: str = "",
+    label: str,
 ) -> dict[str, Any]:
     return {
         "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
             source.get(f"{prefix}_source_objective_pitch_role_risk_count")
+        ),
+        "source_outside_soloing_repair_source_context_preserved": bool(
+            source.get(f"{prefix}_source_context_preserved", False)
         ),
         "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             source.get(f"{prefix}_source_pitch_role_risk_count_before")
@@ -120,6 +145,11 @@ def _source_context_fields(
         ),
         "source_outside_soloing_repair_pitch_role_risk_delta": _int(
             source.get(f"{prefix}_pitch_role_risk_delta")
+        ),
+        **_bridge_source_context_fields(
+            source,
+            bridge_prefix=bridge_prefix,
+            label=label,
         ),
     }
 
@@ -161,6 +191,10 @@ def _validate_source_context(context: dict[str, Any], *, label: str) -> None:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
             f"{label} source-targeted flag should remain false"
         )
+    if not bool(context.get("source_outside_soloing_repair_source_context_preserved", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            f"{label} source context preservation required"
+        )
     if not bool(
         context.get("source_outside_soloing_repair_source_residual_risk_preserved", False)
     ):
@@ -194,6 +228,21 @@ def _require_matching_source_context(
             raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
                 f"{label} mismatch for {key}"
             )
+
+
+def _prefixed_context_for_output(
+    context: dict[str, Any],
+    *,
+    prefix: str,
+) -> dict[str, Any]:
+    return {
+        **{
+            f"{prefix}_{key}": value
+            for key, value in context.items()
+            if key.startswith("source_outside_soloing_repair_")
+        },
+        **{f"{prefix}_{key}": context[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+    }
 
 
 def validate_followup_decision(report: dict[str, Any]) -> dict[str, Any]:
@@ -257,9 +306,21 @@ def validate_followup_decision(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
             "repair sweep repaired outside-soloing not-evaluable boundary required"
         )
+    objective_context = _source_context_fields(
+        readiness,
+        prefix="objective_source_outside_soloing_repair",
+        bridge_prefix="objective",
+        label="follow-up objective source context",
+    )
+    _validate_source_context(
+        objective_context,
+        label="follow-up objective source context",
+    )
     source_context = _source_context_fields(
         readiness,
         prefix="repair_sweep_source_outside_soloing_repair",
+        bridge_prefix="repair_sweep",
+        label="follow-up repair sweep source context",
     )
     _validate_source_context(source_context, label="follow-up repair sweep source context")
     primary_labels = [str(label) for label in _list(selected.get("primary_remaining_failure_labels"))]
@@ -284,6 +345,7 @@ def validate_followup_decision(report: dict[str, Any]) -> dict[str, Any]:
         "remaining_failure_counts": _dict(sweep.get("remaining_failure_counts")),
         "primary_remaining_failure_labels": primary_labels,
         "primary_remaining_failure_count": _int(selected.get("primary_remaining_failure_count")),
+        **_prefixed_context_for_output(objective_context, prefix="objective"),
         "objective_source_outside_soloing_repair_evidence_ready": bool(
             readiness.get("objective_source_outside_soloing_repair_evidence_ready", False)
         ),
@@ -340,7 +402,10 @@ def validate_source_repair_sweep(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
             "source outside-soloing residual pitch-role risk should be zero"
         )
-    source_context = _source_context_fields(aggregate)
+    source_context = _source_context_fields(
+        aggregate,
+        label="source repair sweep context",
+    )
     _validate_source_context(source_context, label="source repair sweep context")
     if _int(aggregate.get("source_outside_soloing_not_evaluable_count")) <= 0:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
@@ -557,11 +622,19 @@ def build_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
         key: value
         for key, value in source.items()
         if key.startswith("source_outside_soloing_repair_")
+        or key in BRIDGE_SOURCE_CONTEXT_KEYS
     }
     followup_context = {
         key: value
         for key, value in followup.items()
         if key.startswith("source_outside_soloing_repair_")
+        or key in BRIDGE_SOURCE_CONTEXT_KEYS
+    }
+    objective_context = {
+        key: value
+        for key, value in followup.items()
+        if key.startswith("objective_source_outside_soloing_repair_")
+        or key in {f"objective_{source_key}" for source_key in BRIDGE_SOURCE_CONTEXT_KEYS}
     }
     _require_matching_source_context(
         followup_context,
@@ -664,6 +737,7 @@ def build_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
             "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
                 followup["repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after"]
             ),
+            **objective_context,
             **source_context,
             "source_outside_soloing_not_evaluable_count": _int(
                 followup["repair_sweep_repaired_outside_soloing_not_evaluable_count"]
@@ -702,6 +776,7 @@ def build_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
             "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
                 followup["repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after"]
             ),
+            **objective_context,
             **source_context,
             "source_outside_soloing_not_evaluable_count": _int(
                 followup["repair_sweep_repaired_outside_soloing_not_evaluable_count"]
@@ -800,6 +875,21 @@ def validate_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
             "outside-soloing residual pitch-role risk should be zero"
         )
+    objective_context = _source_context_fields(
+        aggregate,
+        prefix="objective_source_outside_soloing_repair",
+        bridge_prefix="objective",
+        label="aggregate objective source context",
+    )
+    _validate_source_context(
+        objective_context,
+        label="aggregate objective source context",
+    )
+    source_context = _source_context_fields(
+        aggregate,
+        label="aggregate source context",
+    )
+    _validate_source_context(source_context, label="aggregate source context")
     if _int(aggregate.get("source_outside_soloing_not_evaluable_count")) <= 0:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
             "source outside-soloing not-evaluable boundary required"
@@ -861,6 +951,13 @@ def validate_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
         "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
             aggregate.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
         ),
+        "objective_source_outside_soloing_repair_source_context_preserved": bool(
+            aggregate.get("objective_source_outside_soloing_repair_source_context_preserved", False)
+        ),
+        **{f"objective_{key}": aggregate.get(f"objective_{key}") for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        "source_outside_soloing_repair_source_context_preserved": bool(
+            aggregate.get("source_outside_soloing_repair_source_context_preserved", False)
+        ),
         "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             aggregate.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
         ),
@@ -879,6 +976,7 @@ def validate_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
         "source_outside_soloing_repair_pitch_role_risk_delta": _int(
             aggregate.get("source_outside_soloing_repair_pitch_role_risk_delta")
         ),
+        **{key: aggregate.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
         "source_outside_soloing_not_evaluable_count": _int(
             aggregate.get("source_outside_soloing_not_evaluable_count")
         ),
@@ -924,6 +1022,8 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- improved candidate count: `{aggregate['improved_candidate_count']}`",
         f"- technical regression count: `{aggregate['technical_regression_count']}`",
         f"- source outside-soloing repair evidence ready: `{_bool_token(aggregate['source_outside_soloing_repair_evidence_ready'])}`",
+        f"- objective source outside-soloing source context preserved: `{_bool_token(aggregate['objective_source_outside_soloing_repair_source_context_preserved'])}`",
+        f"- source outside-soloing source context preserved: `{_bool_token(aggregate['source_outside_soloing_repair_source_context_preserved'])}`",
         f"- source outside-soloing source pitch-role risk before / after / delta: `{aggregate['source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{aggregate['source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{aggregate['source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- source outside-soloing source repair targeted: `{_bool_token(aggregate['source_outside_soloing_repair_source_targeted'])}`",
         f"- source outside-soloing source residual risk preserved: `{_bool_token(aggregate['source_outside_soloing_repair_source_residual_risk_preserved'])}`",

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio.py
@@ -22,6 +22,31 @@ from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repa
 )
 
 
+SOURCE_CONTEXT = {
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_objective_source_outside_soloing_source_targeted": False,
+    "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_repair_sweep_source_outside_soloing_source_targeted": False,
+    "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "repair_sweep_source_outside_soloing_source_targeted": False,
+    "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+}
+
+
 def write_midi(path: Path, pitches: list[int]) -> None:
     midi = pretty_midi.PrettyMIDI(initial_tempo=120)
     midi.time_signature_changes.append(pretty_midi.TimeSignature(4, 4, 0.0))
@@ -104,7 +129,18 @@ def source_report(root: Path, *, quality_claim: bool = False) -> dict:
                 "rhythmic_monotony": 1,
             },
             "source_outside_soloing_repair_evidence_ready": True,
+            "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "objective_source_outside_soloing_repair_source_context_preserved": True,
+            "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
+            "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
+            "objective_source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
+            "objective_source_outside_soloing_repair_source_targeted": False,
+            "objective_source_outside_soloing_repair_source_residual_risk_preserved": True,
+            "objective_source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+            "objective_source_outside_soloing_repair_pitch_role_risk_delta": 2,
+            **{f"objective_{key}": value for key, value in SOURCE_CONTEXT.items()},
             "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "source_outside_soloing_repair_source_context_preserved": True,
             "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
             "source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
             "source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
@@ -112,6 +148,7 @@ def source_report(root: Path, *, quality_claim: bool = False) -> dict:
             "source_outside_soloing_repair_source_residual_risk_preserved": True,
             "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
             "source_outside_soloing_repair_pitch_role_risk_delta": 2,
+            **SOURCE_CONTEXT,
             "source_outside_soloing_not_evaluable_count": 6,
             "repaired_outside_soloing_not_evaluable_count": 6,
             "repaired_not_evaluable_counts": {

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_SOURCE_CONTEXT_KEYS
 from scripts.build_stage_b_midi_to_solo_quality_rubric_baseline import (
     build_quality_rubric_baseline_report,
 )
@@ -146,6 +147,7 @@ def followup_decision(*, quality_claim: bool = False) -> dict:
             "objective_source_outside_soloing_repair_evidence_ready": True,
             "objective_source_outside_soloing_repair_wav_count": 6,
             "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "objective_source_outside_soloing_repair_source_context_preserved": True,
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
             "objective_source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
@@ -155,8 +157,10 @@ def followup_decision(*, quality_claim: bool = False) -> dict:
             "objective_source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "objective_source_outside_soloing_not_evaluable_count": 6,
             "objective_repaired_outside_soloing_not_evaluable_count": 6,
+            **{f"objective_{key}": value for key, value in SOURCE_CONTEXT.items()},
             "repair_sweep_source_outside_soloing_repair_evidence_ready": True,
             "repair_sweep_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "repair_sweep_source_outside_soloing_repair_source_context_preserved": True,
             "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
             "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
             "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
@@ -166,6 +170,7 @@ def followup_decision(*, quality_claim: bool = False) -> dict:
             "repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "repair_sweep_source_outside_soloing_not_evaluable_count": 6,
             "repair_sweep_repaired_outside_soloing_not_evaluable_count": 6,
+            **{f"repair_sweep_{key}": value for key, value in SOURCE_CONTEXT.items()},
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
             "audio_rendered_quality_claimed": False,
@@ -224,6 +229,7 @@ def source_repair_sweep(*, technical_regression_count: int = 0) -> dict:
             },
             "source_outside_soloing_repair_evidence_ready": True,
             "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+            "source_outside_soloing_repair_source_context_preserved": True,
             "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
             "source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
             "source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
@@ -233,6 +239,7 @@ def source_repair_sweep(*, technical_regression_count: int = 0) -> dict:
             "source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "source_outside_soloing_not_evaluable_count": 6,
             "repaired_outside_soloing_not_evaluable_count": 6,
+            **SOURCE_CONTEXT,
             "target_supported": True,
         },
         "readiness": {
@@ -290,6 +297,13 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepTest(
             self.assertGreater(summary["phrase_rhythm_failure_delta"], 0)
             self.assertEqual(summary["technical_regression_count"], 0)
             self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
+            self.assertTrue(
+                summary["objective_source_outside_soloing_repair_source_context_preserved"]
+            )
+            self.assertTrue(summary["source_outside_soloing_repair_source_context_preserved"])
+            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+                self.assertEqual(summary[f"objective_{key}"], SOURCE_CONTEXT[key])
+                self.assertEqual(summary[key], SOURCE_CONTEXT[key])
             self.assertEqual(
                 summary[
                     "source_outside_soloing_repair_source_pitch_role_risk_count_before"
@@ -378,6 +392,38 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepTest(
                     rubric_baseline=rubric_baseline(Path(tmp)),
                     output_dir=Path(tmp) / "phrase_rhythm_repair",
                     issue_number=944,
+                )
+
+    def test_rejects_missing_bridge_source_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = source_repair_sweep()
+            source["aggregate"].pop(BRIDGE_SOURCE_CONTEXT_KEYS[0])
+            with self.assertRaises(
+                StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError
+            ):
+                build_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
+                    followup_decision=followup_decision(),
+                    source_repair_sweep=source,
+                    rubric_baseline=rubric_baseline(Path(tmp)),
+                    output_dir=Path(tmp) / "phrase_rhythm_repair",
+                    issue_number=1028,
+                )
+
+    def test_rejects_source_context_preservation_flag_false(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = followup_decision()
+            source["readiness"][
+                "repair_sweep_source_outside_soloing_repair_source_context_preserved"
+            ] = False
+            with self.assertRaises(
+                StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError
+            ):
+                build_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
+                    followup_decision=source,
+                    source_repair_sweep=source_repair_sweep(),
+                    rubric_baseline=rubric_baseline(Path(tmp)),
+                    output_dir=Path(tmp) / "phrase_rhythm_repair",
+                    issue_number=1028,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary

- Phrase/rhythm repair sweep source-context preservation validation
- Follow-up decision and source repair sweep bridge context matching
- Objective/source context propagation to aggregate, readiness, and validation summary
- Handoff and status document update for Issue #1028

## Context

- Previous issue: #1026 follow-up decision source-context refresh
- Selected target: `songlike_melody_contour_phrase_rhythm_repair_sweep`
- Current next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
- Candidate count: `6`
- Total failure labels: `4 -> 1`
- Failure label delta: `3`
- Phrase/rhythm failure count: `4 -> 1`
- Technical regression count: `0`
- Objective/source context preserved: `true`
- Source outside-soloing risk: `5 -> 2`
- Current repair risk after / delta: `0 / 2`
- Human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Scope

- Phrase/rhythm repair sweep input validation 강화
- Source-context preserved flag 필수화
- Bridge source-context 21개 키 누락 및 mismatch failure 추가
- Source-context refresh quality rubric baseline run_id 사용
- Downstream audio test fixture source-context 보정
- README, current status, core plan, handoff scope 갱신

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-sweep`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- Musical quality and human/audio preference unclaimed
- Outside-soloing and weak chord-tone landing remain context-dependent review targets
- Next validation target: phrase/rhythm repair audio package source-context refresh

Closes #1028
