### PR TITLE
Stage B MIDI-to-solo phrase/rhythm objective next source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm repair audio package completed: Issue #1030, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair listening review package completed: Issue #1032, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair listening review input guard completed: Issue #1034, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh.
-- Latest songlike melody contour phrase/rhythm repair objective-only next decision completed: Issue #952, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh.
+- Latest songlike melody contour phrase/rhythm repair objective-only next decision completed: Issue #1036, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair follow-up decision completed: Issue #954, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-context pitch-role bridge completed: Issue #956, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-context pitch-role objective decision completed: Issue #958, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh.
@@ -56,7 +56,7 @@ Current handoff scope:
 - Latest documentation issue completed: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
 - Open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour phrase/rhythm repair audio package: `Issue #1030`
 - latest songlike melody contour phrase/rhythm repair listening review package: `Issue #1032`
 - latest songlike melody contour phrase/rhythm repair listening review input guard: `Issue #1034`
-- latest songlike melody contour phrase/rhythm repair objective-only next decision: `Issue #952`
+- latest songlike melody contour phrase/rhythm repair objective-only next decision: `Issue #1036`
 - latest songlike melody contour phrase/rhythm repair follow-up decision: `Issue #954`
 - latest songlike melody contour phrase/rhythm chord-context pitch-role bridge: `Issue #956`
 - latest songlike melody contour phrase/rhythm chord-context pitch-role objective decision: `Issue #958`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -11242,6 +11242,51 @@ Issue #1034는 Issue #1032 listening review package의 pending input 상태와 s
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh`
 
+## 9.208 Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh
+
+Issue #1036은 Issue #1034 input guard의 pending input 상태와 objective/source outside-soloing context를 objective-only next decision summary까지 보존한 작업이다.
+
+결과:
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- failure label delta: `3`
+- phrase/rhythm failure delta: `3`
+- objective source outside-soloing repair source context preserved: `true`
+- source outside-soloing repair source context preserved: `true`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing current repair pitch-role risk count after / delta: `0 / 2`
+- source/repaired outside-soloing not evaluable count: `6/6`
+- phrase/rhythm follow-up required: `true`
+- current quality claim ready: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- objective-only next decision source validation에 objective/source source-context preserved 조건 추가.
+- bridge source-context 21개 키를 objective summary, readiness, validation summary까지 보존.
+- validated review input 부재 상태에서 human/audio preference와 musical quality claim 제외 유지.
+- 다음 boundary는 phrase/rhythm repair follow-up decision source-context refresh.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-objective-only-next-decision`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -38,7 +38,7 @@
 - latest songlike melody contour phrase/rhythm repair audio package: Issue #1030, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh
 - latest songlike melody contour phrase/rhythm repair listening review package: Issue #1032, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh
 - latest songlike melody contour phrase/rhythm repair listening review input guard: Issue #1034, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh
-- latest songlike melody contour phrase/rhythm repair objective-only next decision: Issue #952, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh
+- latest songlike melody contour phrase/rhythm repair objective-only next decision: Issue #1036, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh
 - latest songlike melody contour phrase/rhythm repair follow-up decision: Issue #954, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh
 - latest songlike melody contour phrase/rhythm chord-context pitch-role bridge: Issue #956, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh
 - latest songlike melody contour phrase/rhythm chord-context pitch-role objective decision: Issue #958, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh
@@ -57,7 +57,7 @@
 - latest README evidence refresh: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
 - open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -4139,6 +4139,58 @@ Issue #1034는 Issue #1032 listening review package의 pending input 상태와 s
 다음:
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh`
+
+## Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Repair Objective-Only Next Decision Source Context Refresh Result
+
+Issue #1036은 Issue #1034 input guard의 pending input 상태와 objective/source outside-soloing context를 objective-only next decision summary까지 보존한 작업이다.
+
+변경:
+
+- objective-only next decision source validation에 objective/source source-context preserved flag 필수화
+- input guard bridge source-context 21개 키 보존 검증 추가
+- follow-up decision 라우팅, quality claim boundary, source context를 objective summary/readiness/validation summary까지 전파
+- harness issue number를 #1036 기준으로 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- phrase/rhythm failure delta: `3`
+- objective source outside-soloing source context preserved: `true`
+- source outside-soloing source context preserved: `true`
+- source outside-soloing source pitch-role risk count: `5 -> 2`
+- source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
+- source/repaired outside-soloing not evaluable count: `6/6`
+- phrase/rhythm follow-up required: `true`
+- current quality claim ready: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- validated review input 부재 상태에서 preference fill 차단 유지.
+- source-context preserved flag와 21개 context field 보존 확인.
+- quality/preference claim 제외 유지.
+- critical user input 없이 follow-up decision boundary로 진행 가능.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-objective-only-next-decision`
+
+다음:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -1,4 +1,4 @@
-# Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Repair Objective-Only Next Decision
+# Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Repair Objective-Only Next Decision Source Context Refresh
 
 ## Summary
 
@@ -17,11 +17,24 @@
 - phrase/rhythm failure count: `4 -> 1`
 - phrase/rhythm failure delta: `3`
 - source outside-soloing repair evidence ready: `true`
+- objective source outside-soloing source context preserved: `true`
+- objective source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
+- objective source outside-soloing source repair targeted: `false`
+- objective source outside-soloing source residual risk preserved: `true`
+- objective source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- objective follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- objective follow-up objective current repair pitch-role risk after/delta: `0` / `2`
+- objective repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- objective repair sweep current repair pitch-role risk after/delta: `0` / `2`
+- source outside-soloing source context preserved: `true`
 - source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - source outside-soloing source repair targeted: `false`
 - source outside-soloing source residual risk preserved: `true`
-- source outside-soloing repair pitch-role risk count after: `0`
-- source outside-soloing current repair pitch-role risk delta: `2`
+- source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
+- follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up objective current repair pitch-role risk after/delta: `0` / `2`
+- bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- bridge repair sweep current repair pitch-role risk after/delta: `0` / `2`
 - source/repaired outside-soloing not evaluable count: `6/6`
 - phrase/rhythm follow-up required: `true`
 - current quality claim ready: `false`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6599,7 +6599,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_
     --run_id "$run_id" \
     --input_guard_report "$input_guard_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 952 \
+    --issue_number 1036 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision \
     --require_objective_decision \

--- a/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next.py
+++ b/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next.py
@@ -13,6 +13,9 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
+from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
+    BRIDGE_SOURCE_CONTEXT_KEYS,
+)
 from scripts.guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input import (  # noqa: E402
     BOUNDARY as SOURCE_BOUNDARY,
     OBJECTIVE_NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
@@ -27,7 +30,7 @@ BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_ob
 FOLLOWUP_DECISION_NEXT_BOUNDARY = (
     "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision"
 )
-SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next_v2"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next_v3"
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -73,9 +76,60 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
 
 
 def _source_context_fields(source: dict[str, Any]) -> dict[str, Any]:
+    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+        objective_key = f"objective_{key}"
+        if objective_key not in source or source[objective_key] is None:
+            raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
+                f"objective source-context field required: {objective_key}"
+            )
+        if key not in source or source[key] is None:
+            raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
+                f"source-context field required: {key}"
+            )
     return {
+        "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+            source.get(
+                "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count"
+            )
+        ),
+        "objective_source_outside_soloing_repair_source_context_preserved": bool(
+            source.get("objective_source_outside_soloing_repair_source_context_preserved", False)
+        ),
+        "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+            source.get(
+                "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"
+            )
+        ),
+        "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+            source.get(
+                "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after"
+            )
+        ),
+        "objective_source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+            source.get(
+                "objective_source_outside_soloing_repair_source_pitch_role_risk_delta"
+            )
+        ),
+        "objective_source_outside_soloing_repair_source_targeted": bool(
+            source.get("objective_source_outside_soloing_repair_source_targeted", True)
+        ),
+        "objective_source_outside_soloing_repair_source_residual_risk_preserved": bool(
+            source.get(
+                "objective_source_outside_soloing_repair_source_residual_risk_preserved",
+                False,
+            )
+        ),
+        "objective_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            source.get("objective_source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "objective_source_outside_soloing_repair_pitch_role_risk_delta": _int(
+            source.get("objective_source_outside_soloing_repair_pitch_role_risk_delta")
+        ),
         "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
             source.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
+        ),
+        "source_outside_soloing_repair_source_context_preserved": bool(
+            source.get("source_outside_soloing_repair_source_context_preserved", False)
         ),
         "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             source.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
@@ -98,22 +152,22 @@ def _source_context_fields(source: dict[str, Any]) -> dict[str, Any]:
         "source_outside_soloing_repair_pitch_role_risk_delta": _int(
             source.get("source_outside_soloing_repair_pitch_role_risk_delta")
         ),
+        **{f"objective_{key}": source.get(f"objective_{key}") for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{key: source.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
     }
 
 
-def _validate_source_context(source: dict[str, Any], *, label: str) -> None:
-    objective_risk = _int(
-        source.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
-    )
-    source_before = _int(
-        source.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
-    )
-    source_after = _int(
-        source.get("source_outside_soloing_repair_source_pitch_role_risk_count_after")
-    )
-    source_delta = _int(source.get("source_outside_soloing_repair_source_pitch_role_risk_delta"))
-    current_after = _int(source.get("source_outside_soloing_repair_pitch_role_risk_count_after"))
-    current_delta = _int(source.get("source_outside_soloing_repair_pitch_role_risk_delta"))
+def _validate_source_context_group(source: dict[str, Any], *, base: str, label: str) -> None:
+    objective_risk = _int(source.get(f"{base}_source_objective_pitch_role_risk_count"))
+    source_before = _int(source.get(f"{base}_source_pitch_role_risk_count_before"))
+    source_after = _int(source.get(f"{base}_source_pitch_role_risk_count_after"))
+    source_delta = _int(source.get(f"{base}_source_pitch_role_risk_delta"))
+    current_after = _int(source.get(f"{base}_pitch_role_risk_count_after"))
+    current_delta = _int(source.get(f"{base}_pitch_role_risk_delta"))
+    if not bool(source.get(f"{base}_source_context_preserved", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
+            f"{label} source context preservation required"
+        )
     if objective_risk <= 0 or source_before <= 0:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
             f"{label} source pitch-role risk context required"
@@ -130,11 +184,11 @@ def _validate_source_context(source: dict[str, Any], *, label: str) -> None:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
             f"{label} positive source pitch-role risk delta required"
         )
-    if bool(source.get("source_outside_soloing_repair_source_targeted", True)):
+    if bool(source.get(f"{base}_source_targeted", True)):
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
             f"{label} source-targeted flag should remain false"
         )
-    if not bool(source.get("source_outside_soloing_repair_source_residual_risk_preserved", False)):
+    if not bool(source.get(f"{base}_source_residual_risk_preserved", False)):
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
             f"{label} source residual risk preservation required"
         )
@@ -146,6 +200,19 @@ def _validate_source_context(source: dict[str, Any], *, label: str) -> None:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError(
             f"{label} positive current repair pitch-role risk delta required"
         )
+
+
+def _validate_source_context(source: dict[str, Any], *, label: str) -> None:
+    _validate_source_context_group(
+        source,
+        base="objective_source_outside_soloing_repair",
+        label=f"objective {label}",
+    )
+    _validate_source_context_group(
+        source,
+        base="source_outside_soloing_repair",
+        label=label,
+    )
 
 
 def validate_input_guard_report(report: dict[str, Any]) -> dict[str, Any]:
@@ -248,6 +315,7 @@ def build_objective_next_report(
     issue_number: int,
 ) -> dict[str, Any]:
     source = validate_input_guard_report(input_guard_report)
+    source_context = _source_context_fields(source)
     followup_required = True
     return {
         "schema_version": SCHEMA_VERSION,
@@ -281,30 +349,7 @@ def build_objective_next_report(
             "source_outside_soloing_repair_evidence_ready": bool(
                 source["source_outside_soloing_repair_evidence_ready"]
             ),
-            "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
-                source["source_outside_soloing_repair_source_objective_pitch_role_risk_count"]
-            ),
-            "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
-                source["source_outside_soloing_repair_source_pitch_role_risk_count_before"]
-            ),
-            "source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
-                source["source_outside_soloing_repair_source_pitch_role_risk_count_after"]
-            ),
-            "source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
-                source["source_outside_soloing_repair_source_pitch_role_risk_delta"]
-            ),
-            "source_outside_soloing_repair_source_targeted": bool(
-                source["source_outside_soloing_repair_source_targeted"]
-            ),
-            "source_outside_soloing_repair_source_residual_risk_preserved": bool(
-                source["source_outside_soloing_repair_source_residual_risk_preserved"]
-            ),
-            "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
-                source["source_outside_soloing_repair_pitch_role_risk_count_after"]
-            ),
-            "source_outside_soloing_repair_pitch_role_risk_delta": _int(
-                source["source_outside_soloing_repair_pitch_role_risk_delta"]
-            ),
+            **source_context,
             "source_outside_soloing_not_evaluable_count": _int(
                 source["source_outside_soloing_not_evaluable_count"]
             ),
@@ -315,6 +360,9 @@ def build_objective_next_report(
             "audio_review_required": bool(source["audio_review_required"]),
             "phrase_rhythm_followup_required": bool(followup_required),
             "current_quality_claim_ready": False,
+            "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+                source["source_outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
         },
         "selected_next_target": {
             "target": "songlike_melody_contour_phrase_rhythm_repair_followup_decision",
@@ -329,6 +377,19 @@ def build_objective_next_report(
             "technical_wav_validation": bool(source["technical_wav_validation"]),
             "phrase_rhythm_followup_required": bool(followup_required),
             "current_quality_claim_ready": False,
+            "source_outside_soloing_repair_evidence_ready": bool(
+                source["source_outside_soloing_repair_evidence_ready"]
+            ),
+            **source_context,
+            "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+                source["source_outside_soloing_repair_pitch_role_risk_count_after"]
+            ),
+            "source_outside_soloing_not_evaluable_count": _int(
+                source["source_outside_soloing_not_evaluable_count"]
+            ),
+            "repaired_outside_soloing_not_evaluable_count": _int(
+                source["repaired_outside_soloing_not_evaluable_count"]
+            ),
             "human_audio_preference_claimed": False,
             "audio_rendered_quality_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
@@ -429,11 +490,50 @@ def validate_objective_next_report(
         "source_outside_soloing_repair_evidence_ready": bool(
             summary.get("source_outside_soloing_repair_evidence_ready", False)
         ),
+        "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
+            summary.get(
+                "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count"
+            )
+        ),
+        "objective_source_outside_soloing_repair_source_context_preserved": bool(
+            summary.get("objective_source_outside_soloing_repair_source_context_preserved", False)
+        ),
+        "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
+            summary.get(
+                "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"
+            )
+        ),
+        "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after": _int(
+            summary.get(
+                "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after"
+            )
+        ),
+        "objective_source_outside_soloing_repair_source_pitch_role_risk_delta": _int(
+            summary.get("objective_source_outside_soloing_repair_source_pitch_role_risk_delta")
+        ),
+        "objective_source_outside_soloing_repair_source_targeted": bool(
+            summary.get("objective_source_outside_soloing_repair_source_targeted", True)
+        ),
+        "objective_source_outside_soloing_repair_source_residual_risk_preserved": bool(
+            summary.get(
+                "objective_source_outside_soloing_repair_source_residual_risk_preserved",
+                False,
+            )
+        ),
+        "objective_source_outside_soloing_repair_pitch_role_risk_count_after": _int(
+            summary.get("objective_source_outside_soloing_repair_pitch_role_risk_count_after")
+        ),
+        "objective_source_outside_soloing_repair_pitch_role_risk_delta": _int(
+            summary.get("objective_source_outside_soloing_repair_pitch_role_risk_delta")
+        ),
         "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
             summary.get("source_outside_soloing_repair_pitch_role_risk_count_after")
         ),
         "source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
             summary.get("source_outside_soloing_repair_source_objective_pitch_role_risk_count")
+        ),
+        "source_outside_soloing_repair_source_context_preserved": bool(
+            summary.get("source_outside_soloing_repair_source_context_preserved", False)
         ),
         "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             summary.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
@@ -453,6 +553,8 @@ def validate_objective_next_report(
         "source_outside_soloing_repair_pitch_role_risk_delta": _int(
             summary.get("source_outside_soloing_repair_pitch_role_risk_delta")
         ),
+        **{f"objective_{key}": summary.get(f"objective_{key}") for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{key: summary.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
         "source_outside_soloing_not_evaluable_count": _int(
             summary.get("source_outside_soloing_not_evaluable_count")
         ),
@@ -482,7 +584,7 @@ def markdown_report(report: dict[str, Any]) -> str:
     summary = report["objective_summary"]
     target = report["selected_next_target"]
     lines = [
-        "# Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Repair Objective-Only Next Decision",
+        "# Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Repair Objective-Only Next Decision Source Context Refresh",
         "",
         "## Summary",
         "",
@@ -501,11 +603,24 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- phrase/rhythm failure count: `{summary['source_phrase_rhythm_failure_count']} -> {summary['repaired_phrase_rhythm_failure_count']}`",
         f"- phrase/rhythm failure delta: `{summary['phrase_rhythm_failure_delta']}`",
         f"- source outside-soloing repair evidence ready: `{_bool_token(summary['source_outside_soloing_repair_evidence_ready'])}`",
+        f"- objective source outside-soloing source context preserved: `{_bool_token(summary['objective_source_outside_soloing_repair_source_context_preserved'])}`",
+        f"- objective source outside-soloing source pitch-role risk before / after / delta: `{summary['objective_source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{summary['objective_source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{summary['objective_source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
+        f"- objective source outside-soloing source repair targeted: `{_bool_token(summary['objective_source_outside_soloing_repair_source_targeted'])}`",
+        f"- objective source outside-soloing source residual risk preserved: `{_bool_token(summary['objective_source_outside_soloing_repair_source_residual_risk_preserved'])}`",
+        f"- objective source outside-soloing current repair pitch-role risk after / delta: `{summary['objective_source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{summary['objective_source_outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- objective follow-up objective source outside-soloing source pitch-role risk: `{summary['objective_followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['objective_followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- objective follow-up objective current repair pitch-role risk after/delta: `{summary['objective_followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{summary['objective_followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- objective repair sweep source outside-soloing source pitch-role risk: `{summary['objective_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['objective_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- objective repair sweep current repair pitch-role risk after/delta: `{summary['objective_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{summary['objective_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- source outside-soloing source context preserved: `{_bool_token(summary['source_outside_soloing_repair_source_context_preserved'])}`",
         f"- source outside-soloing source pitch-role risk before / after / delta: `{summary['source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{summary['source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{summary['source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- source outside-soloing source repair targeted: `{_bool_token(summary['source_outside_soloing_repair_source_targeted'])}`",
         f"- source outside-soloing source residual risk preserved: `{_bool_token(summary['source_outside_soloing_repair_source_residual_risk_preserved'])}`",
-        f"- source outside-soloing repair pitch-role risk count after: `{summary['source_outside_soloing_repair_pitch_role_risk_count_after']}`",
-        f"- source outside-soloing current repair pitch-role risk delta: `{summary['source_outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- source outside-soloing current repair pitch-role risk after / delta: `{summary['source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{summary['source_outside_soloing_repair_pitch_role_risk_delta']}`",
+        f"- follow-up objective source outside-soloing source pitch-role risk: `{summary['followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up objective current repair pitch-role risk after/delta: `{summary['followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{summary['followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- bridge repair sweep source outside-soloing source pitch-role risk: `{summary['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- bridge repair sweep current repair pitch-role risk after/delta: `{summary['repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{summary['repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- source/repaired outside-soloing not evaluable count: `{summary['source_outside_soloing_not_evaluable_count']}/{summary['repaired_outside_soloing_not_evaluable_count']}`",
         f"- phrase/rhythm follow-up required: `{_bool_token(summary['phrase_rhythm_followup_required'])}`",
         f"- current quality claim ready: `{_bool_token(summary['current_quality_claim_ready'])}`",
@@ -549,7 +664,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=952)
+    parser.add_argument("--issue_number", type=int, default=1036)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--require_objective_decision", action="store_true")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_SOURCE_CONTEXT_KEYS
 from scripts.decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next import (
     BOUNDARY,
     FOLLOWUP_DECISION_NEXT_BOUNDARY,
@@ -15,6 +16,31 @@ from scripts.guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_re
     BOUNDARY as SOURCE_BOUNDARY,
     OBJECTIVE_NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
 )
+
+
+SOURCE_CONTEXT = {
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_objective_source_outside_soloing_source_targeted": False,
+    "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_repair_sweep_source_outside_soloing_source_targeted": False,
+    "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
+    "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "repair_sweep_source_outside_soloing_source_targeted": False,
+    "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
+    "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+}
 
 
 def input_guard_report(*, quality_claim: bool = False) -> dict:
@@ -37,7 +63,18 @@ def input_guard_report(*, quality_claim: bool = False) -> dict:
                 "repaired_phrase_rhythm_failure_count": 1,
                 "phrase_rhythm_failure_delta": 3,
                 "source_outside_soloing_repair_evidence_ready": True,
+                "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+                "objective_source_outside_soloing_repair_source_context_preserved": True,
+                "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
+                "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
+                "objective_source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
+                "objective_source_outside_soloing_repair_source_targeted": False,
+                "objective_source_outside_soloing_repair_source_residual_risk_preserved": True,
+                "objective_source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+                "objective_source_outside_soloing_repair_pitch_role_risk_delta": 2,
+                **{f"objective_{key}": value for key, value in SOURCE_CONTEXT.items()},
                 "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+                "source_outside_soloing_repair_source_context_preserved": True,
                 "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
                 "source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
                 "source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
@@ -45,6 +82,7 @@ def input_guard_report(*, quality_claim: bool = False) -> dict:
                 "source_outside_soloing_repair_source_residual_risk_preserved": True,
                 "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
                 "source_outside_soloing_repair_pitch_role_risk_delta": 2,
+                **SOURCE_CONTEXT,
                 "source_outside_soloing_not_evaluable_count": 6,
                 "repaired_outside_soloing_not_evaluable_count": 6,
                 "repaired_not_evaluable_counts": {
@@ -82,7 +120,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextTest(u
             report = build_objective_next_report(
                 input_guard_report=input_guard_report(),
                 output_dir=root / "objective_next",
-                issue_number=952,
+                issue_number=1036,
             )
             summary = validate_objective_next_report(
                 report,
@@ -104,10 +142,47 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextTest(u
             self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
             self.assertEqual(
                 summary[
+                    "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count"
+                ],
+                5,
+            )
+            self.assertTrue(summary["objective_source_outside_soloing_repair_source_context_preserved"])
+            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+                self.assertEqual(summary[f"objective_{key}"], SOURCE_CONTEXT[key])
+            self.assertEqual(
+                summary[
+                    "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"
+                ],
+                5,
+            )
+            self.assertEqual(
+                summary[
+                    "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after"
+                ],
+                2,
+            )
+            self.assertEqual(
+                summary["objective_source_outside_soloing_repair_source_pitch_role_risk_delta"],
+                3,
+            )
+            self.assertFalse(summary["objective_source_outside_soloing_repair_source_targeted"])
+            self.assertTrue(
+                summary["objective_source_outside_soloing_repair_source_residual_risk_preserved"]
+            )
+            self.assertEqual(
+                summary["objective_source_outside_soloing_repair_pitch_role_risk_count_after"],
+                0,
+            )
+            self.assertEqual(summary["objective_source_outside_soloing_repair_pitch_role_risk_delta"], 2)
+            self.assertEqual(
+                summary[
                     "source_outside_soloing_repair_source_objective_pitch_role_risk_count"
                 ],
                 5,
             )
+            self.assertTrue(summary["source_outside_soloing_repair_source_context_preserved"])
+            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+                self.assertEqual(summary[key], SOURCE_CONTEXT[key])
             self.assertEqual(
                 summary[
                     "source_outside_soloing_repair_source_pitch_role_risk_count_before"
@@ -147,7 +222,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextTest(u
                 build_objective_next_report(
                     input_guard_report=input_guard_report(quality_claim=True),
                     output_dir=root / "objective_next",
-                    issue_number=952,
+                    issue_number=1036,
                 )
 
     def test_rejects_missing_outside_soloing_context(self) -> None:
@@ -160,7 +235,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextTest(u
                 build_objective_next_report(
                     input_guard_report=source,
                     output_dir=root / "objective_next",
-                    issue_number=952,
+                    issue_number=1036,
                 )
 
     def test_rejects_source_context_delta_mismatch(self) -> None:
@@ -175,7 +250,22 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextTest(u
                 build_objective_next_report(
                     input_guard_report=source,
                     output_dir=root / "objective_next",
-                    issue_number=952,
+                    issue_number=1036,
+                )
+
+    def test_rejects_missing_source_context_field(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = input_guard_report()
+            source["guard_result"]["source_summary"].pop(
+                "followup_objective_source_outside_soloing_source_pitch_role_risk_delta"
+            )
+
+            with self.assertRaises(StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairObjectiveNextError):
+                build_objective_next_report(
+                    input_guard_report=source,
+                    output_dir=root / "objective_next",
+                    issue_number=1036,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
## Summary
- Stage B MIDI-to-solo phrase/rhythm repair objective-only next decision source-context validation 갱신
- objective/source outside-soloing source-context preserved flag와 bridge key 전파
- pending input 상태에서 follow-up decision 라우팅 및 quality claim boundary 유지

## Context
- #1034 input guard 결과: validated review input false
- preference fill allowed: false
- technical WAV validation: true
- review item count: 6
- source outside-soloing source pitch-role risk: 5 -> 2
- current repair pitch-role risk after / delta: 0 / 2
- source/repaired outside-soloing not evaluable count: 6/6

## Scope
- objective-only next decision 입력 검증에 bridge source-context 필수 조건 추가
- objective/source source-context preserved flag 검증 추가
- validation summary, readiness, markdown report에 context field 보존
- README, AGENTS, CURRENT_STATUS, CORE_PLAN 최신 경계 갱신

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next
- .venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-objective-only-next-decision
- bash scripts/agent_harness.sh quick
- git diff --check

## Risk
- human/audio preference 미검증
- MIDI musical quality claim 제외
- objective evidence 기준 다음 경계 선택만 검증

## Follow-up
- Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh

Closes #1036