### PR TITLE
Stage B MIDI-to-solo outside-soloing repair sweep source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,15 +48,15 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard completed: Issue #1050, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision completed: Issue #1052, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision completed: Issue #1054, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision source-context refresh.
-- Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep completed: Issue #972, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep source-context refresh.
+- Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep completed: Issue #1056, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package completed: Issue #974, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package completed: Issue #976, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard completed: Issue #978, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #980, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after chord-tone landing repair follow-up decision source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep source-context refresh.
+- Open issue queue after chord-tone landing outside-soloing repair sweep source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard: `Issue #1050`
 - latest songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision: `Issue #1052`
 - latest songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision: `Issue #1054`
-- latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep: `Issue #972`
+- latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep: `Issue #1056`
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package: `Issue #974`
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package: `Issue #976`
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard: `Issue #978`
@@ -50,7 +50,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #982`
 - latest README evidence refresh: `Issue #984`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
-- open issue queue after chord-tone landing repair follow-up decision source-context refresh merge: `0`
+- open issue queue after chord-tone landing outside-soloing repair sweep source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -11709,6 +11709,56 @@ Issue #1054는 Issue #1052 objective-only next decision과 Issue #1044 repair sw
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep source-context refresh`
 
+## 9.218 Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep source-context refresh
+
+Issue #1056은 Issue #1054 follow-up decision과 Issue #1044 chord-tone landing repair sweep의 source-context preserved flag를 outside-soloing repair sweep에서 대조하고, residual outside-soloing pitch-role risk를 objective MIDI evidence 기준으로 수리한 작업이다.
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup_decision`
+- chord-tone repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package`
+- selected target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package`
+- candidate count: `6`
+- repaired MIDI count: `6`
+- changed note total: `2`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- outside-soloing pitch-role risk count: `2 -> 0`
+- outside-soloing pitch-role risk delta: `2`
+- outside-soloing repair targeted: `true`
+- weak chord-tone landing risk count after: `0`
+- final landing chord-tone count after: `6`
+- max non-chord-tone run: `4 -> 3`
+- target supported: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- Issue #1054 follow-up decision과 Issue #1044 repair sweep의 preserved flag 3개 불일치 없음.
+- residual outside-soloing pitch-role risk는 `2 -> 0`으로 감소.
+- weak chord-tone landing risk after `0` 유지.
+- final landing chord-tone count after `6` 유지.
+- human/audio preference, MIDI-to-solo musical quality claim 제외.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-outside-soloing-repair-sweep`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -48,7 +48,7 @@
 - latest songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard: Issue #1050, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision: Issue #1052, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision: Issue #1054, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision source-context refresh
-- latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep: Issue #972, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep source-context refresh
+- latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep: Issue #1056, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package: Issue #974, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package: Issue #976, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard: Issue #978, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #982, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after chord-tone landing repair follow-up decision source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep source-context refresh`
+- open issue queue after chord-tone landing outside-soloing repair sweep source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -4689,6 +4689,64 @@ Issue #1054는 Issue #1052 objective-only next decision과 Issue #1044 repair sw
 다음:
 
 - `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep source-context refresh`
+
+## Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Chord-Tone Landing Outside-Soloing Repair Sweep Source-Context Refresh Result
+
+Issue #1056은 Issue #1054 follow-up decision과 Issue #1044 chord-tone landing repair sweep의 source-context preserved flag를 outside-soloing repair sweep에서 대조하고, residual outside-soloing pitch-role risk를 objective MIDI evidence 기준으로 수리한 작업이다.
+
+변경:
+
+- outside-soloing repair sweep schema v2 적용
+- follow-up decision과 chord-tone repair sweep의 required source-context key 비교
+- preserved flag 3개 필수 검증 추가
+- sweep aggregate, readiness, validation summary, markdown report source-context preserved field 전파
+- next recommended issue를 outside-soloing repair audio package source-context refresh로 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup_decision`
+- chord-tone repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package`
+- selected target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package`
+- candidate count: `6`
+- repaired MIDI count: `6`
+- changed note total: `2`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- outside-soloing pitch-role risk count: `2 -> 0`
+- outside-soloing pitch-role risk delta: `2`
+- outside-soloing repair targeted: `true`
+- weak chord-tone landing risk count after: `0`
+- final landing chord-tone count after: `6`
+- max non-chord-tone run: `4 -> 3`
+- target supported: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- Issue #1054 follow-up decision과 Issue #1044 repair sweep의 preserved flag 3개 불일치 없음.
+- residual outside-soloing pitch-role risk는 `2 -> 0`으로 감소.
+- weak chord-tone landing risk after `0` 유지.
+- final landing chord-tone count after `6` 유지.
+- human/audio preference, MIDI-to-solo musical quality claim 제외.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-outside-soloing-repair-sweep`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package source-context refresh`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -1,0 +1,69 @@
+# Stage B MIDI-to-Solo Chord-Tone Landing Outside-Soloing Repair Sweep
+
+## Summary
+
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup_decision`
+- chord-tone repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package`
+- selected target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package`
+- repair policy: `break_four_note_non_chord_tone_run_with_nearest_chord_tone`
+- candidate count: `6`
+- repaired MIDI count: `6`
+- changed note total: `2`
+- source objective outside-soloing pitch-role risk count: `5`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- source outside-soloing pitch-role risk delta: `3`
+- source outside-soloing repair targeted: `false`
+- source outside-soloing residual risk preserved: `true`
+- outside-soloing pitch-role risk count: `2 -> 0`
+- outside-soloing pitch-role risk delta: `2`
+- outside-soloing repair targeted: `true`
+- follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up objective source outside-soloing source pitch-role risk delta: `3`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up objective source outside-soloing source targeted: `false`
+- follow-up objective source outside-soloing source residual risk preserved: `true`
+- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- follow-up repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up repair sweep source outside-soloing source pitch-role risk delta: `3`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source targeted: `false`
+- follow-up repair sweep source outside-soloing source residual risk preserved: `true`
+- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- bridge repair sweep source outside-soloing source pitch-role risk delta: `3`
+- bridge repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source targeted: `false`
+- bridge repair sweep source outside-soloing source residual risk preserved: `true`
+- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- weak chord-tone landing risk count after: `0`
+- final landing chord-tone count after: `6`
+- max non-chord-tone run: `4 -> 3`
+- target supported: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+## Candidate Summary
+
+- rank `1`: changed `0`, max non-chord run `3` -> `3`, flags `none` -> `none`
+- rank `2`: changed `0`, max non-chord run `2` -> `2`, flags `none` -> `none`
+- rank `3`: changed `1`, max non-chord run `4` -> `3`, flags `outside_soloing_pitch_role_risk` -> `none`
+- rank `4`: changed `0`, max non-chord run `3` -> `3`, flags `none` -> `none`
+- rank `5`: changed `1`, max non-chord run `4` -> `3`, flags `outside_soloing_pitch_role_risk` -> `none`
+- rank `6`: changed `0`, max non-chord run `2` -> `2`, flags `none` -> `none`
+
+## Decision
+
+- reason: `outside-soloing repair sweep completed without quality claim`
+- auto progress allowed: `true`
+- critical user input required: `false`
+- next recommended issue: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package source-context refresh`
+
+## Claim Boundary
+
+- `human_audio_preference`
+- `midi_to_solo_musical_quality`
+- `audio_rendered_quality`
+- `broad_trained_model_quality`
+- `brad_style_adaptation`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6848,8 +6848,8 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landin
     --run_id "$run_id" \
     --followup_report "$followup_report" \
     --chord_tone_repair_sweep_report "$sweep_report" \
-    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_SWEEP_2026-06-11.md \
-    --issue_number 972 \
+    --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
+    --issue_number 1056 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package \
     --require_repair_completed \

--- a/scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep.py
+++ b/scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep.py
@@ -16,7 +16,7 @@ sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
 from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge import (  # noqa: E402
-    BRIDGE_SOURCE_CONTEXT_KEYS,
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
     bridge_candidate,
     parse_chords,
 )
@@ -48,7 +48,7 @@ SELECTED_TARGET = (
     "songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package"
 )
 SCHEMA_VERSION = (
-    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep_v1"
+    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep_v2"
 )
 OUTSIDE_RISK_FLAG = "outside_soloing_pitch_role_risk"
 WEAK_LANDING_FLAG = "weak_chord_tone_landing_risk"
@@ -101,12 +101,21 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
 
 
 def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str, Any]:
-    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+    for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
         if key not in container:
             raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairSweepError(
                 f"{label} source-context field required: {key}"
             )
-    return {key: container[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS}
+    for key in (
+        "followup_objective_source_outside_soloing_source_context_preserved",
+        "followup_repair_sweep_source_outside_soloing_source_context_preserved",
+        "repair_sweep_source_outside_soloing_source_context_preserved",
+    ):
+        if not bool(container.get(key, False)):
+            raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairSweepError(
+                f"{label} source context should be preserved: {key}"
+            )
+    return {key: container[key] for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS}
 
 
 def _absolute_path(path: str | Path) -> Path:
@@ -463,7 +472,7 @@ def build_outside_soloing_repair_sweep_report(
         raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairSweepError(
             "follow-up and chord-tone sweep outside-soloing source flags must match"
         )
-    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+    for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
         if followup.get(key) != source.get(key):
             raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairSweepError(
                 f"follow-up and chord-tone sweep source-context field mismatch: {key}"
@@ -552,7 +561,7 @@ def build_outside_soloing_repair_sweep_report(
             "source_primary_remaining_risk_count": int(
                 followup["primary_remaining_risk_count"]
             ),
-            **{key: followup.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+            **{key: followup.get(key) for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
         },
         "readiness": {
             "boundary": BOUNDARY,
@@ -581,7 +590,7 @@ def build_outside_soloing_repair_sweep_report(
             "outside_soloing_repair_targeted": True,
             "outside_soloing_pitch_role_risk_delta": int(outside_before - outside_after),
             "weak_chord_tone_landing_risk_count_after": int(weak_after),
-            **{key: followup.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+            **{key: followup.get(key) for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
             "human_audio_preference_claimed": False,
             "audio_rendered_quality_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
@@ -607,9 +616,9 @@ def build_outside_soloing_repair_sweep_report(
             "brad_style_adaptation",
         ],
         "next_recommended_issue": (
-            "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package"
+            "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package source-context refresh"
             if target_supported
-            else "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision"
+            else "Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision source-context refresh"
         ),
     }
 
@@ -681,7 +690,7 @@ def validate_outside_soloing_repair_sweep_report(
         )
     if require_no_quality_claim:
         _require_no_quality_claim(readiness, label="outside-soloing repair readiness")
-    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+    for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
         if key not in aggregate:
             raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairSweepError(
                 f"outside-soloing repair aggregate source-context field required: {key}"
@@ -743,7 +752,7 @@ def validate_outside_soloing_repair_sweep_report(
             aggregate.get("max_non_chord_tone_run_after")
         ),
         "target_supported": bool(aggregate.get("target_supported", False)),
-        **{key: aggregate.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{key: aggregate.get(key) for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
         "human_audio_preference_claimed": bool(
             readiness.get("human_audio_preference_claimed", True)
         ),
@@ -786,16 +795,19 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- outside-soloing repair targeted: `{_bool_token(aggregate['outside_soloing_repair_targeted'])}`",
         f"- follow-up objective source outside-soloing source pitch-role risk: `{aggregate['followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {aggregate['followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
         f"- follow-up objective source outside-soloing source pitch-role risk delta: `{aggregate['followup_objective_source_outside_soloing_source_pitch_role_risk_delta']}`",
+        f"- follow-up objective source outside-soloing source context preserved: `{_bool_token(aggregate['followup_objective_source_outside_soloing_source_context_preserved'])}`",
         f"- follow-up objective source outside-soloing source targeted: `{_bool_token(aggregate['followup_objective_source_outside_soloing_source_targeted'])}`",
         f"- follow-up objective source outside-soloing source residual risk preserved: `{_bool_token(aggregate['followup_objective_source_outside_soloing_source_residual_risk_preserved'])}`",
         f"- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `{aggregate['followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']} / {aggregate['followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- follow-up repair sweep source outside-soloing source pitch-role risk: `{aggregate['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {aggregate['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
         f"- follow-up repair sweep source outside-soloing source pitch-role risk delta: `{aggregate['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta']}`",
+        f"- follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(aggregate['followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- follow-up repair sweep source outside-soloing source targeted: `{_bool_token(aggregate['followup_repair_sweep_source_outside_soloing_source_targeted'])}`",
         f"- follow-up repair sweep source outside-soloing source residual risk preserved: `{_bool_token(aggregate['followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved'])}`",
         f"- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `{aggregate['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {aggregate['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- bridge repair sweep source outside-soloing source pitch-role risk: `{aggregate['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {aggregate['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
         f"- bridge repair sweep source outside-soloing source pitch-role risk delta: `{aggregate['repair_sweep_source_outside_soloing_source_pitch_role_risk_delta']}`",
+        f"- bridge repair sweep source outside-soloing source context preserved: `{_bool_token(aggregate['repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- bridge repair sweep source outside-soloing source targeted: `{_bool_token(aggregate['repair_sweep_source_outside_soloing_source_targeted'])}`",
         f"- bridge repair sweep source outside-soloing source residual risk preserved: `{_bool_token(aggregate['repair_sweep_source_outside_soloing_source_residual_risk_preserved'])}`",
         f"- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `{aggregate['repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {aggregate['repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
@@ -859,7 +871,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=972)
+    parser.add_argument("--issue_number", type=int, default=1056)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--require_repair_completed", action="store_true")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio.py
@@ -27,6 +27,7 @@ SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_objective_source_outside_soloing_source_context_preserved": True,
     "followup_objective_source_outside_soloing_source_targeted": False,
     "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
@@ -34,6 +35,7 @@ SOURCE_CONTEXT = {
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_repair_sweep_source_outside_soloing_source_context_preserved": True,
     "followup_repair_sweep_source_outside_soloing_source_targeted": False,
     "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
@@ -41,11 +43,16 @@ SOURCE_CONTEXT = {
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "repair_sweep_source_outside_soloing_source_context_preserved": True,
     "repair_sweep_source_outside_soloing_source_targeted": False,
     "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
 }
+
+AUDIO_PROPAGATED_SOURCE_CONTEXT_KEYS = tuple(
+    key for key in SOURCE_CONTEXT if not key.endswith("_context_preserved")
+)
 
 
 def write_midi(path: Path) -> None:
@@ -209,7 +216,8 @@ class StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioTest(unittest.Tes
             self.assertTrue(summary["outside_soloing_repair_targeted"])
             self.assertEqual(summary["weak_chord_tone_landing_risk_count_after"], 0)
             self.assertEqual(summary["max_non_chord_tone_run_after"], 3)
-            for key, value in SOURCE_CONTEXT.items():
+            for key in AUDIO_PROPAGATED_SOURCE_CONTEXT_KEYS:
+                value = SOURCE_CONTEXT[key]
                 self.assertEqual(report["summary"][key], value)
                 self.assertEqual(report["audio_render_boundary"][key], value)
                 self.assertEqual(summary[key], value)

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep.py
@@ -31,6 +31,7 @@ SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_objective_source_outside_soloing_source_context_preserved": True,
     "followup_objective_source_outside_soloing_source_targeted": False,
     "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
@@ -38,6 +39,7 @@ SOURCE_CONTEXT = {
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "followup_repair_sweep_source_outside_soloing_source_context_preserved": True,
     "followup_repair_sweep_source_outside_soloing_source_targeted": False,
     "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
@@ -45,6 +47,7 @@ SOURCE_CONTEXT = {
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
+    "repair_sweep_source_outside_soloing_source_context_preserved": True,
     "repair_sweep_source_outside_soloing_source_targeted": False,
     "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
@@ -200,7 +203,7 @@ class StageBMidiToSoloChordToneLandingOutsideSoloingRepairSweepTest(unittest.Tes
                 followup_report=followup_report(),
                 chord_tone_repair_sweep_report=chord_tone_repair_sweep_report(midi_paths),
                 output_dir=root / "outside_repair",
-                issue_number=886,
+                issue_number=1056,
             )
             summary = validate_outside_soloing_repair_sweep_report(
                 report,
@@ -241,17 +244,30 @@ class StageBMidiToSoloChordToneLandingOutsideSoloingRepairSweepTest(unittest.Tes
                 ],
                 0,
             )
+            self.assertTrue(
+                summary[
+                    "followup_objective_source_outside_soloing_source_context_preserved"
+                ]
+            )
             self.assertEqual(
                 summary[
                     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta"
                 ],
                 3,
             )
+            self.assertTrue(
+                summary[
+                    "followup_repair_sweep_source_outside_soloing_source_context_preserved"
+                ]
+            )
             self.assertEqual(
                 summary[
                     "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta"
                 ],
                 2,
+            )
+            self.assertTrue(
+                summary["repair_sweep_source_outside_soloing_source_context_preserved"]
             )
             self.assertGreater(summary["outside_soloing_pitch_role_risk_delta"], 0)
             self.assertEqual(summary["outside_soloing_pitch_role_risk_count_after"], 0)
@@ -281,7 +297,30 @@ class StageBMidiToSoloChordToneLandingOutsideSoloingRepairSweepTest(unittest.Tes
                     followup_report=followup_report(quality_claim=True),
                     chord_tone_repair_sweep_report=chord_tone_repair_sweep_report(midi_paths),
                     output_dir=root / "outside_repair",
-                    issue_number=886,
+                    issue_number=1056,
+                )
+
+    def test_rejects_source_context_preservation_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            midi_paths = []
+            for index in range(6):
+                midi_path = root / f"candidate_{index}.mid"
+                write_outside_run_midi(midi_path)
+                midi_paths.append(midi_path)
+
+            report = followup_report()
+            report["readiness"][
+                "followup_repair_sweep_source_outside_soloing_source_context_preserved"
+            ] = False
+            with self.assertRaises(
+                StageBMidiToSoloChordToneLandingOutsideSoloingRepairSweepError
+            ):
+                build_outside_soloing_repair_sweep_report(
+                    followup_report=report,
+                    chord_tone_repair_sweep_report=chord_tone_repair_sweep_report(midi_paths),
+                    output_dir=root / "outside_repair",
+                    issue_number=1056,
                 )
 
     def test_constants_are_stable(self) -> None:


### PR DESCRIPTION
Summary
- Stage B chord-tone landing outside-soloing repair sweep source-context refresh
- Follow-up decision과 chord-tone repair sweep preserved flag 비교 검증
- residual outside-soloing pitch-role risk repair 결과 기록

Context
- Issue #1054 follow-up decision 결과: outside-soloing repair sweep 선택
- source outside-soloing pitch-role risk: 5 -> 2
- current outside-soloing pitch-role risk: 2 -> 0
- changed note total: 2
- max non-chord-tone run: 4 -> 3
- quality/preference claim: false

Scope
- outside-soloing repair sweep schema v2 적용
- required source-context key와 preserved flag 3개 필수 검증 추가
- sweep aggregate/readiness/markdown output preserved field 전파
- next recommended issue: outside-soloing repair audio package source-context refresh

Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep
- .venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-outside-soloing-repair-sweep
- bash scripts/agent_harness.sh quick
- git diff --check

Risk
- human/audio preference claim 제외
- MIDI-to-solo musical quality claim 제외
- audio package preserved flag propagation은 다음 작업 범위

Follow-up
- Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package source-context refresh

Close #1056