### PR TITLE
Stage B MIDI-to-solo README evidence source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,10 +53,10 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package completed: Issue #1060, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard completed: Issue #1062, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1064, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
-- Latest documentation issue completed: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh.
+- Latest documentation issue completed: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after MVP current evidence consolidation source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo README evidence refresh source-context refresh.
+- Open issue queue after README evidence refresh source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo MVP completion audit source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard: `Issue #1062`
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision: `Issue #1064`
 - latest MVP current evidence consolidation: `Issue #1066`
-- latest README evidence refresh: `Issue #984`
-- latest functional boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
-- open issue queue after MVP current evidence consolidation source-context refresh merge: `0`
+- latest README evidence refresh: `Issue #1068`
+- latest functional boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
+- open issue queue after README evidence refresh source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -445,6 +445,9 @@ MVP current evidence refresh.
 - model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
 - outside-soloing repair objective path ready: `true`
 - outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
 - outside-soloing repair rendered audio file count: `6`
 - outside-soloing repair changed note total: `2`
 - outside-soloing source objective pitch-role risk count: `5`
@@ -1135,6 +1138,9 @@ README evidence refresh.
 - outside-soloing source pitch-role risk count: `5 -> 2`
 - outside-soloing source residual risk preserved: `true`
 - outside-soloing current repair pitch-role risk count after: `0`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
 - quality/preference claim excluded: `true`
 - next boundary: `stage_b_midi_to_solo_mvp_completion_audit`
 

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -12010,6 +12010,45 @@ Issue #1066은 Issue #1064 outside-soloing repair objective decision의 source-c
 
 - `Stage B MIDI-to-solo README evidence refresh source-context refresh`
 
+## 9.224 Stage B MIDI-to-solo README evidence source-context refresh
+
+Issue #1068은 Issue #1066 MVP current evidence consolidation 결과를 README evidence block과 MVP completion audit README snippet guard에 반영한 문서/검증 정합성 작업이다.
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_README_EVIDENCE_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
+- source boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- latest evidence boundary reflected: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- current MVP evidence supported: `true`
+- outside-soloing repair objective path ready: `true`
+- outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- current repair outside-soloing pitch-role risk count after / delta: `0 / 2`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+
+판단:
+
+- README evidence refresh 완료 조건에 preserved flag 3개 포함.
+- current evidence의 source/current outside-soloing risk 분리 유지.
+- listening review input, human/audio preference, MIDI-to-solo musical quality claim 제외.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
+- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_mvp_completion.py`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo MVP completion audit source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -54,10 +54,10 @@
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard: Issue #1062, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision: Issue #1064, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh
 - latest MVP current evidence consolidation: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
-- latest README evidence refresh: Issue #984, Stage B MIDI-to-solo README evidence source-context refresh
+- latest README evidence refresh: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after MVP current evidence consolidation source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo README evidence refresh source-context refresh`
+- open issue queue after README evidence refresh source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo MVP completion audit source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -5067,6 +5067,53 @@ Issue #1066은 Issue #1064 outside-soloing repair objective decision의 source-c
 다음:
 
 - `Stage B MIDI-to-solo README evidence refresh source-context refresh`
+
+## Stage B MIDI-to-Solo README Evidence Source-Context Refresh Result
+
+Issue #1068은 Issue #1066 MVP current evidence consolidation 결과를 README evidence block과 MVP completion audit README snippet guard에 반영한 문서/검증 정합성 작업이다.
+
+변경:
+
+- README latest evidence refresh를 #1068 기준으로 갱신
+- README current evidence block에 source-context preserved flag 3개 반영
+- MVP completion audit README snippet guard에 preserved flag 3개 필수화
+- false preserved flag 입력 차단 테스트 추가
+- generated evidence doc, current status, core plan, handoff scope 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_README_EVIDENCE_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
+- source boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- latest evidence boundary reflected: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- current MVP evidence supported: `true`
+- outside-soloing repair objective path ready: `true`
+- outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
+- source outside-soloing pitch-role risk count: `5 -> 2`
+- current repair outside-soloing pitch-role risk count after / delta: `0 / 2`
+- human/audio preference claim: `false`
+- MIDI-to-solo musical quality claim: `false`
+
+판단:
+
+- README evidence refresh 완료 조건에 preserved flag 3개 포함.
+- current evidence의 source/current outside-soloing risk 분리 유지.
+- listening review input, human/audio preference, MIDI-to-solo musical quality claim 제외.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
+- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_mvp_completion.py`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음:
+
+- `Stage B MIDI-to-solo MVP completion audit source-context refresh`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -58,10 +58,13 @@
 - outside-soloing pitch-role risk after / delta: `0` / `2`
 - follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
 - follow-up objective source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
 - follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
 - bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- bridge repair sweep source outside-soloing source context preserved: `true`
 - outside-soloing repair objective path supported: `true`
 - outside-soloing repair target supported: `true`
 - outside-soloing repair weak landing target supported: `true`

--- a/docs/STAGE_B_MIDI_TO_SOLO_README_EVIDENCE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_README_EVIDENCE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -21,6 +21,9 @@
 - source outside-soloing residual risk preserved: `true`
 - current repair outside-soloing pitch-role risk count after: `0`
 - current repair outside-soloing pitch-role risk delta: `2`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
 
 ## Claim Boundary
 
@@ -32,11 +35,16 @@
 ## Decision
 
 - README current evidence block에 source/current repair context 분리 기록
+- README evidence block에 source-context preserved flag 3개 반영
+- MVP completion audit README snippet guard에 preserved flag 3개 필수화
 - source repair residual risk boundary 보존
 - current repair objective support만 반영
 - 다음 boundary: `stage_b_midi_to_solo_mvp_completion_audit`
 
 ## Validation
 
-- `git diff --check`
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
+- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_mvp_completion.py`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit`
 - `bash scripts/agent_harness.sh quick`
+- `git diff --check`

--- a/scripts/audit_stage_b_midi_to_solo_mvp_completion.py
+++ b/scripts/audit_stage_b_midi_to_solo_mvp_completion.py
@@ -14,7 +14,9 @@ sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
 from scripts.consolidate_stage_b_midi_to_solo_mvp_current_evidence import (  # noqa: E402
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
     BRIDGE_SOURCE_CONTEXT_KEYS,
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
     BOUNDARY as CURRENT_EVIDENCE_BOUNDARY,
 )
 
@@ -55,12 +57,19 @@ def _bool_token(value: Any) -> str:
 
 
 def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str, Any]:
-    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+    for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
         if key not in container:
             raise StageBMidiToSoloMvpCompletionAuditError(
                 f"{label} source-context field required: {key}"
             )
-    return {key: container[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS}
+    missing_preserved = [
+        key for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS if not bool(container.get(key))
+    ]
+    if missing_preserved:
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            f"{label} source-context preserved field must be true: {missing_preserved}"
+        )
+    return {key: container[key] for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS}
 
 
 def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
@@ -894,7 +903,7 @@ def validate_mvp_completion_audit_report(
         "outside_soloing_repair_preference_fill_allowed": bool(
             evidence.get("outside_soloing_repair_preference_fill_allowed", True)
         ),
-        **{key: evidence.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{key: evidence.get(key) for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
         "human_audio_preference_claimed": bool(readiness.get("human_audio_preference_claimed", True)),
         "midi_to_solo_musical_quality_claimed": bool(
             readiness.get("midi_to_solo_musical_quality_claimed", True)
@@ -970,10 +979,13 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- outside-soloing pitch-role risk after / delta: `{evidence['outside_soloing_repair_pitch_role_risk_count_after']}` / `{evidence['outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- follow-up objective source outside-soloing source pitch-role risk: `{evidence['followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {evidence['followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
         f"- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `{evidence['followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']} / {evidence['followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- follow-up objective source outside-soloing source context preserved: `{_bool_token(evidence['followup_objective_source_outside_soloing_source_context_preserved'])}`",
         f"- follow-up repair sweep source outside-soloing source pitch-role risk: `{evidence['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {evidence['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
         f"- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `{evidence['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {evidence['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(evidence['followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- bridge repair sweep source outside-soloing source pitch-role risk: `{evidence['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {evidence['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
         f"- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `{evidence['repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {evidence['repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- bridge repair sweep source outside-soloing source context preserved: `{_bool_token(evidence['repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- outside-soloing repair objective path supported: `{_bool_token(evidence['outside_soloing_repair_objective_path_supported'])}`",
         f"- outside-soloing repair target supported: `{_bool_token(evidence['outside_soloing_repair_target_supported'])}`",
         f"- outside-soloing repair weak landing target supported: `{_bool_token(evidence['outside_soloing_repair_weak_landing_target_supported'])}`",

--- a/tests/test_stage_b_midi_to_solo_mvp_completion_audit.py
+++ b/tests/test_stage_b_midi_to_solo_mvp_completion_audit.py
@@ -11,7 +11,7 @@ from scripts.audit_stage_b_midi_to_solo_mvp_completion import (
     validate_mvp_completion_audit_report,
 )
 from scripts.consolidate_stage_b_midi_to_solo_mvp_current_evidence import (
-    BRIDGE_SOURCE_CONTEXT_KEYS,
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
     BOUNDARY as CURRENT_EVIDENCE_BOUNDARY,
 )
 
@@ -24,6 +24,7 @@ SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_objective_source_outside_soloing_source_context_preserved": True,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
@@ -31,6 +32,7 @@ SOURCE_CONTEXT = {
     "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_context_preserved": True,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
@@ -38,6 +40,7 @@ SOURCE_CONTEXT = {
     "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_context_preserved": True,
 }
 
 
@@ -205,6 +208,9 @@ def readme_text(*, missing_boundary: bool = False) -> str:
             "- outside-soloing source pitch-role risk count: `5 -> 2`",
             "- outside-soloing source residual risk preserved: `true`",
             "- outside-soloing current repair pitch-role risk count after: `0`",
+            "- follow-up objective source outside-soloing source context preserved: `true`",
+            "- follow-up repair sweep source outside-soloing source context preserved: `true`",
+            "- bridge repair sweep source outside-soloing source context preserved: `true`",
             "- README evidence refreshed: `true`",
             "- human/audio preference claim: `false`",
             "- MIDI-to-solo musical quality claim: `false`",
@@ -326,7 +332,7 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
         self.assertTrue(summary["outside_soloing_repair_final_landing_target_supported"])
         self.assertTrue(summary["outside_soloing_repair_non_chord_run_target_supported"])
         self.assertFalse(summary["outside_soloing_repair_preference_fill_allowed"])
-        for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+        for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
             self.assertEqual(summary[key], SOURCE_CONTEXT[key])
         self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
 
@@ -341,6 +347,19 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
                 readme_text=readme_text(),
                 output_dir=Path("outputs/audit"),
                 issue_number=986,
+            )
+
+    def test_rejects_false_outside_soloing_source_context_preserved_flag(self) -> None:
+        evidence = current_evidence()
+        evidence["outside_soloing_repair_objective_path"][
+            "followup_repair_sweep_source_outside_soloing_source_context_preserved"
+        ] = False
+        with self.assertRaises(StageBMidiToSoloMvpCompletionAuditError):
+            build_mvp_completion_audit_report(
+                current_evidence=evidence,
+                readme_text=readme_text(),
+                output_dir=Path("outputs/audit"),
+                issue_number=1068,
             )
 
     def test_rejects_missing_readme_evidence_boundary(self) -> None:


### PR DESCRIPTION
Summary
- README evidence refresh source-context preserved flag 3개 반영
- MVP completion audit README snippet guard에 preserved flag 필수화
- source/current outside-soloing risk 분리 유지

Context
- #1066 MVP current evidence consolidation 결과: current evidence support `true`
- outside-soloing repair objective path ready `true`
- source outside-soloing pitch-role risk `5 -> 2`
- current outside-soloing repair pitch-role risk after `0`
- current evidence schema v3에서 source-context preserved flag 3개 추가

Scope
- README current evidence block 갱신
- MVP completion audit source-context required key 검증 확장
- README snippet guard preserved flag 3개 추가
- false preserved flag 입력 차단 테스트 추가
- generated evidence doc, current status, core plan, handoff scope 갱신

Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_mvp_completion.py`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

Risk
- listening review input pending
- human/audio preference claim 없음
- MIDI-to-solo musical quality claim 없음

Follow-up
- Stage B MIDI-to-solo MVP completion audit source-context refresh

Close #1068

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project phase tracking and evidence documentation to reflect phase milestone completion.
  * Expanded README evidence sections with additional source-context preservation assertions.
  * Updated validation procedures with enhanced verification commands.

* **Tests**
  * Enhanced audit test fixtures and assertions to validate additional source-context preservation scenarios.
  * Added negative test case for strict validation enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->