### PR TITLE
Stage B MIDI-to-solo MVP completion audit source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Primary goal:
 Current handoff scope:
 
 - Latest functional issue completed: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh.
-- Latest audit issue completed: Issue #986, Stage B MIDI-to-solo MVP completion audit source-context refresh.
+- Latest audit issue completed: Issue #1070, Stage B MIDI-to-solo MVP completion audit source-context refresh.
 - Latest quality gap decision completed: Issue #988, Stage B MIDI-to-solo quality gap decision source-context refresh.
 - Latest listening review quality gap completed: Issue #990, Stage B MIDI-to-solo listening review quality gap source-context refresh.
 - Latest MVP delivery package completed: Issue #992, Stage B MIDI-to-solo MVP delivery package source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1064, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after README evidence refresh source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo MVP completion audit source-context refresh.
+- Open issue queue after MVP completion audit source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo quality gap decision source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest functional result: `Issue #1066`
-- latest MVP completion audit: `Issue #986`
+- latest functional result: `Issue #1070`
+- latest MVP completion audit: `Issue #1070`
 - latest quality gap decision: `Issue #988`
 - latest listening review quality gap: `Issue #990`
 - latest MVP delivery package: `Issue #992`
@@ -49,9 +49,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision: `Issue #1064`
 - latest MVP current evidence consolidation: `Issue #1066`
 - latest README evidence refresh: `Issue #1068`
-- latest functional boundary: `stage_b_midi_to_solo_readme_evidence_refresh`
-- open issue queue after README evidence refresh source-context refresh merge: `0`
-- latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- latest functional boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- open issue queue after MVP completion audit source-context refresh merge: `0`
+- latest evidence boundary: `stage_b_midi_to_solo_mvp_completion_audit`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
@@ -1154,6 +1154,12 @@ MVP completion audit.
 - selected-scale objective repair completed: `true`
 - phrase-bank CLI technical path completed: `true`
 - model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour changed-ratio repair objective completed: `true`
+- outside-soloing repair objective completed: `true`
+- outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
 - model-conditioned pitch-contour max interval / threshold: `11 / 12`
 - model-conditioned pitch-contour changed-ratio review required: `true`
 - musical quality MVP completed: `false`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -12049,6 +12049,50 @@ Issue #1068은 Issue #1066 MVP current evidence consolidation 결과를 README e
 
 - `Stage B MIDI-to-solo MVP completion audit source-context refresh`
 
+## 9.225 Stage B MIDI-to-solo MVP completion audit source-context refresh
+
+Issue #1070은 Issue #1066 current evidence와 Issue #1068 README evidence refresh를 기준으로 technical model-core MVP completion audit을 #1070 boundary로 갱신한 작업이다.
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- next boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- technical model-core MVP completed: `true`
+- input to ranked MIDI completed: `true`
+- input to rendered WAV completed: `true`
+- selected-scale objective repair completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour changed-ratio repair objective completed: `true`
+- outside-soloing repair objective completed: `true`
+- outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
+- musical quality MVP completed: `false`
+- human/audio preference completed: `false`
+- product MVP completed: `false`
+
+판단:
+
+- #1068 README evidence refresh의 preserved flag 3개가 audit report와 validation summary까지 유지됨.
+- technical model-core MVP completion은 `true`.
+- listening review input, human/audio preference, MIDI-to-solo musical quality claim 제외.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
+- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_mvp_completion.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo quality gap decision source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,8 +12,8 @@
 
 현재 active issue:
 
-- latest functional result: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
-- latest MVP completion audit: Issue #986, Stage B MIDI-to-solo MVP completion audit source-context refresh
+- latest functional result: Issue #1070, Stage B MIDI-to-solo MVP completion audit source-context refresh
+- latest MVP completion audit: Issue #1070, Stage B MIDI-to-solo MVP completion audit source-context refresh
 - latest quality gap decision: Issue #988, Stage B MIDI-to-solo quality gap decision source-context refresh
 - latest listening review quality gap: Issue #990, Stage B MIDI-to-solo listening review quality gap source-context refresh
 - latest MVP delivery package: Issue #992, Stage B MIDI-to-solo MVP delivery package source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after README evidence refresh source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo MVP completion audit source-context refresh`
+- open issue queue after MVP completion audit source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo quality gap decision source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -5114,6 +5114,57 @@ Issue #1068은 Issue #1066 MVP current evidence consolidation 결과를 README e
 다음:
 
 - `Stage B MIDI-to-solo MVP completion audit source-context refresh`
+
+## Stage B MIDI-to-Solo MVP Completion Audit Source-Context Refresh Result
+
+Issue #1070은 Issue #1066 current evidence와 Issue #1068 README evidence refresh를 기준으로 technical model-core MVP completion audit을 #1070 boundary로 갱신한 작업이다.
+
+변경:
+
+- MVP completion audit schema v3 적용
+- harness issue number #1070 반영
+- audit report issue number와 schema assertion 추가
+- generated completion audit doc, README, current status, core plan, handoff scope 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- next boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- technical model-core MVP completed: `true`
+- input to ranked MIDI completed: `true`
+- input to rendered WAV completed: `true`
+- selected-scale objective repair completed: `true`
+- phrase-bank CLI technical path completed: `true`
+- model-conditioned pitch-contour objective completed: `true`
+- model-conditioned pitch-contour changed-ratio repair objective completed: `true`
+- outside-soloing repair objective completed: `true`
+- outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
+- musical quality MVP completed: `false`
+- human/audio preference completed: `false`
+- product MVP completed: `false`
+
+판단:
+
+- #1068 README evidence refresh의 preserved flag 3개가 audit report와 validation summary까지 유지됨.
+- technical model-core MVP completion은 `true`.
+- listening review input, human/audio preference, MIDI-to-solo musical quality claim 제외.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
+- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_mvp_completion.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음:
+
+- `Stage B MIDI-to-solo quality gap decision source-context refresh`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -90,4 +90,4 @@
 
 ## Next
 
-- `Stage B MIDI-to-solo quality gap decision`
+- `Stage B MIDI-to-solo quality gap decision source-context refresh`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6015,7 +6015,7 @@ run_stage_b_midi_to_solo_mvp_completion_audit() {
     --current_evidence "$current_evidence" \
     --readme_path README.md \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 986 \
+    --issue_number 1070 \
     --expected_boundary stage_b_midi_to_solo_mvp_completion_audit \
     --expected_next_boundary stage_b_midi_to_solo_quality_gap_decision \
     --require_technical_mvp_completion \

--- a/scripts/audit_stage_b_midi_to_solo_mvp_completion.py
+++ b/scripts/audit_stage_b_midi_to_solo_mvp_completion.py
@@ -27,7 +27,7 @@ class StageBMidiToSoloMvpCompletionAuditError(ValueError):
 
 BOUNDARY = "stage_b_midi_to_solo_mvp_completion_audit"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_quality_gap_decision"
-SCHEMA_VERSION = "stage_b_midi_to_solo_mvp_completion_audit_v2"
+SCHEMA_VERSION = "stage_b_midi_to_solo_mvp_completion_audit_v3"
 
 
 def _dict(value: Any) -> dict[str, Any]:
@@ -674,7 +674,7 @@ def build_mvp_completion_audit_report(
             "brad_style_adaptation",
             "production_ready_improviser",
         ],
-        "next_recommended_issue": "Stage B MIDI-to-solo quality gap decision",
+        "next_recommended_issue": "Stage B MIDI-to-solo quality gap decision source-context refresh",
     }
 
 

--- a/tests/test_stage_b_midi_to_solo_mvp_completion_audit.py
+++ b/tests/test_stage_b_midi_to_solo_mvp_completion_audit.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from scripts.audit_stage_b_midi_to_solo_mvp_completion import (
     BOUNDARY,
     NEXT_BOUNDARY,
+    SCHEMA_VERSION,
     StageBMidiToSoloMvpCompletionAuditError,
     build_mvp_completion_audit_report,
     validate_mvp_completion_audit_report,
@@ -226,7 +227,7 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
             current_evidence=current_evidence(),
             readme_text=readme_text(),
             output_dir=Path("outputs/audit"),
-            issue_number=616,
+            issue_number=1070,
         )
         summary = validate_mvp_completion_audit_report(
             report,
@@ -335,6 +336,8 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
         for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
             self.assertEqual(summary[key], SOURCE_CONTEXT[key])
         self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
+        self.assertEqual(report["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(report["issue_number"], 1070)
 
     def test_rejects_missing_outside_soloing_source_context_field(self) -> None:
         evidence = current_evidence()
@@ -346,7 +349,7 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
                 current_evidence=evidence,
                 readme_text=readme_text(),
                 output_dir=Path("outputs/audit"),
-                issue_number=986,
+                issue_number=1070,
             )
 
     def test_rejects_false_outside_soloing_source_context_preserved_flag(self) -> None:
@@ -359,7 +362,7 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
                 current_evidence=evidence,
                 readme_text=readme_text(),
                 output_dir=Path("outputs/audit"),
-                issue_number=1068,
+                issue_number=1070,
             )
 
     def test_rejects_missing_readme_evidence_boundary(self) -> None:
@@ -419,6 +422,7 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
     def test_boundary_constants_are_stable(self) -> None:
         self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_mvp_completion_audit")
         self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_quality_gap_decision")
+        self.assertEqual(SCHEMA_VERSION, "stage_b_midi_to_solo_mvp_completion_audit_v3")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary
- MVP completion audit schema v3 적용
- #1070 audit boundary 기준 harness/report 갱신
- quality gap decision source-context refresh로 next boundary 정리

Context
- #1066 current evidence consolidation 결과: current evidence support `true`
- #1068 README evidence refresh 결과: preserved flag 3개 README snippet guard 반영
- technical model-core MVP completed `true`
- outside-soloing repair source-context preserved `true`
- musical quality, human/audio preference, broad model claim 제외

Scope
- MVP completion audit schema version 갱신
- harness issue number #1070 반영
- audit report schema/issue number assertion 추가
- generated audit doc, README, current status, core plan, handoff scope 갱신

Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_mvp_completion.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

Risk
- listening review input pending
- human/audio preference claim 없음
- MIDI-to-solo musical quality claim 없음

Follow-up
- Stage B MIDI-to-solo quality gap decision source-context refresh

Close #1070