### PR TITLE
Stage B MIDI-to-solo listening review quality gap source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Current handoff scope:
 - Latest functional issue completed: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh.
 - Latest audit issue completed: Issue #1070, Stage B MIDI-to-solo MVP completion audit source-context refresh.
 - Latest quality gap decision completed: Issue #1072, Stage B MIDI-to-solo quality gap decision source-context refresh.
-- Latest listening review quality gap completed: Issue #990, Stage B MIDI-to-solo listening review quality gap source-context refresh.
+- Latest listening review quality gap completed: Issue #1074, Stage B MIDI-to-solo listening review quality gap source-context refresh.
 - Latest MVP delivery package completed: Issue #992, Stage B MIDI-to-solo MVP delivery package source-context refresh.
 - Latest README final evidence refresh completed: Issue #994, Stage B MIDI-to-solo README final evidence source-context refresh.
 - Latest final status audit completed: Issue #996, Stage B MIDI-to-solo final status audit source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1064, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after quality gap decision source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo listening review quality gap source-context refresh.
+- Open issue queue after listening review quality gap source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo MVP delivery package source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest functional result: `Issue #1072`
+- latest functional result: `Issue #1074`
 - latest MVP completion audit: `Issue #1070`
 - latest quality gap decision: `Issue #1072`
-- latest listening review quality gap: `Issue #990`
+- latest listening review quality gap: `Issue #1074`
 - latest MVP delivery package: `Issue #992`
 - latest README final evidence refresh: `Issue #994`
 - latest final status audit: `Issue #996`
@@ -49,13 +49,13 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision: `Issue #1064`
 - latest MVP current evidence consolidation: `Issue #1066`
 - latest README evidence refresh: `Issue #1068`
-- latest functional boundary: `stage_b_midi_to_solo_quality_gap_decision`
-- open issue queue after quality gap decision source-context refresh merge: `0`
-- latest evidence boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- latest functional boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- open issue queue after listening review quality gap source-context refresh merge: `0`
+- latest evidence boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
-- selected quality gap target: `listening_review_quality_gap`
+- selected quality gap target: `mvp_delivery_package`
 - model-conditioned input path aligned: `false`
 - model-conditioned candidate source available: `true`
 - model-conditioned audio technical path available: `true`
@@ -497,6 +497,9 @@ Listening review quality gap.
 - changed-ratio repair max ratio / target: `0.4348 / 0.5000`
 - changed-ratio repair max interval / target: `12 / 12`
 - outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
 - outside-soloing source pitch-role risk count: `5 -> 2`
 - outside-soloing source repair targeted: `false`
 - outside-soloing source residual risk preserved: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -12136,6 +12136,48 @@ Issue #1072는 Issue #1070 MVP completion audit의 source-context preserved flag
 
 - `Stage B MIDI-to-solo listening review quality gap source-context refresh`
 
+## 9.227 Stage B MIDI-to-solo listening review quality gap source-context refresh
+
+Issue #1074는 Issue #1072 quality gap decision의 source-context preserved flag 3개를 listening review quality gap summary와 validation summary까지 보존하고, 다음 target을 MVP delivery package로 유지한 작업이다.
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- next boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- selected target: `mvp_delivery_package`
+- listening review quality gap open: `true`
+- technical MVP delivery package ready: `true`
+- technical model-core MVP completed: `true`
+- changed-ratio repair objective completed: `true`
+- outside-soloing repair objective completed: `true`
+- outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
+- human review required now: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- listening review gap은 open 상태.
+- technical delivery package 준비는 quality claim 없이 진행 가능.
+- human/audio preference, MIDI-to-solo musical quality claim 제외.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_listening_review_quality_gap`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-listening-review-quality-gap`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo MVP delivery package source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,10 +12,10 @@
 
 현재 active issue:
 
-- latest functional result: Issue #1072, Stage B MIDI-to-solo quality gap decision source-context refresh
+- latest functional result: Issue #1074, Stage B MIDI-to-solo listening review quality gap source-context refresh
 - latest MVP completion audit: Issue #1070, Stage B MIDI-to-solo MVP completion audit source-context refresh
 - latest quality gap decision: Issue #1072, Stage B MIDI-to-solo quality gap decision source-context refresh
-- latest listening review quality gap: Issue #990, Stage B MIDI-to-solo listening review quality gap source-context refresh
+- latest listening review quality gap: Issue #1074, Stage B MIDI-to-solo listening review quality gap source-context refresh
 - latest MVP delivery package: Issue #992, Stage B MIDI-to-solo MVP delivery package source-context refresh
 - latest README final evidence refresh: Issue #994, Stage B MIDI-to-solo README final evidence source-context refresh
 - latest final status audit: Issue #996, Stage B MIDI-to-solo final status audit source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after quality gap decision source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo listening review quality gap source-context refresh`
+- open issue queue after listening review quality gap source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo MVP delivery package source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -5216,6 +5216,56 @@ Issue #1072는 Issue #1070 MVP completion audit의 source-context preserved flag
 다음:
 
 - `Stage B MIDI-to-solo listening review quality gap source-context refresh`
+
+## Stage B MIDI-to-Solo Listening Review Quality Gap Source-Context Refresh Result
+
+Issue #1074는 Issue #1072 quality gap decision의 source-context preserved flag 3개를 listening review quality gap summary와 validation summary까지 보존하고, 다음 target을 MVP delivery package로 유지한 작업이다.
+
+변경:
+
+- listening review quality gap schema v3 적용
+- source-context required key를 preserved flag 3개 포함으로 확장
+- false preserved flag 입력 차단 테스트 추가
+- quality gap summary, generated markdown report, validation summary source-context preserved field 전파
+- harness issue number #1074 반영
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- next boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- selected target: `mvp_delivery_package`
+- listening review quality gap open: `true`
+- technical MVP delivery package ready: `true`
+- technical model-core MVP completed: `true`
+- changed-ratio repair objective completed: `true`
+- outside-soloing repair objective completed: `true`
+- outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
+- human review required now: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- listening review gap은 open 상태.
+- technical delivery package 준비는 quality claim 없이 진행 가능.
+- human/audio preference, MIDI-to-solo musical quality claim 제외.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_listening_review_quality_gap`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-listening-review-quality-gap`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음:
+
+- `Stage B MIDI-to-solo MVP delivery package source-context refresh`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -32,10 +32,13 @@
 - outside-soloing current repair pitch-role risk after / delta: `0` / `2`
 - follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
 - follow-up objective source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
 - follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
 - bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- bridge repair sweep source outside-soloing source context preserved: `true`
 - outside-soloing repair objective path supported: `true`
 - outside-soloing repair weak landing target supported: `true`
 - outside-soloing repair final landing target supported: `true`
@@ -53,4 +56,4 @@
 
 ## Next
 
-- `Stage B MIDI-to-solo MVP delivery package`
+- `Stage B MIDI-to-solo MVP delivery package source-context refresh`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6058,7 +6058,7 @@ run_stage_b_midi_to_solo_listening_review_quality_gap() {
     --run_id "$run_id" \
     --quality_gap_decision "$quality_gap" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 990 \
+    --issue_number 1074 \
     --expected_boundary stage_b_midi_to_solo_listening_review_quality_gap \
     --expected_next_boundary stage_b_midi_to_solo_mvp_delivery_package \
     --expected_target mvp_delivery_package \

--- a/scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py
+++ b/scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py
@@ -14,7 +14,9 @@ sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
 from scripts.decide_stage_b_midi_to_solo_quality_gap import (  # noqa: E402
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
     BRIDGE_SOURCE_CONTEXT_KEYS,
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
     BOUNDARY as SOURCE_BOUNDARY,
     LISTENING_REVIEW_NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
     LISTENING_REVIEW_TARGET,
@@ -28,7 +30,7 @@ class StageBMidiToSoloListeningReviewQualityGapError(ValueError):
 BOUNDARY = "stage_b_midi_to_solo_listening_review_quality_gap"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_mvp_delivery_package"
 SELECTED_TARGET = "mvp_delivery_package"
-SCHEMA_VERSION = "stage_b_midi_to_solo_listening_review_quality_gap_v2"
+SCHEMA_VERSION = "stage_b_midi_to_solo_listening_review_quality_gap_v3"
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -74,12 +76,19 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
 
 
 def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str, Any]:
-    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+    for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
         if key not in container:
             raise StageBMidiToSoloListeningReviewQualityGapError(
                 f"{label} source-context field required: {key}"
             )
-    return {key: container[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS}
+    missing_preserved = [
+        key for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS if not bool(container.get(key))
+    ]
+    if missing_preserved:
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            f"{label} source-context preserved field must be true: {missing_preserved}"
+        )
+    return {key: container[key] for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS}
 
 
 def validate_quality_gap_decision(report: dict[str, Any]) -> dict[str, Any]:
@@ -367,7 +376,7 @@ def build_listening_review_quality_gap_report(
             "brad_style_adaptation",
             "production_ready_improviser",
         ],
-        "next_recommended_issue": "Stage B MIDI-to-solo MVP delivery package",
+        "next_recommended_issue": "Stage B MIDI-to-solo MVP delivery package source-context refresh",
     }
 
 
@@ -565,10 +574,13 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- outside-soloing current repair pitch-role risk after / delta: `{summary['outside_soloing_repair_pitch_role_risk_count_after']}` / `{summary['outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- follow-up objective source outside-soloing source pitch-role risk: `{summary['followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
         f"- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `{summary['followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']} / {summary['followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- follow-up objective source outside-soloing source context preserved: `{_bool_token(summary['followup_objective_source_outside_soloing_source_context_preserved'])}`",
         f"- follow-up repair sweep source outside-soloing source pitch-role risk: `{summary['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
         f"- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `{summary['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {summary['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(summary['followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- bridge repair sweep source outside-soloing source pitch-role risk: `{summary['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
         f"- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `{summary['repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {summary['repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- bridge repair sweep source outside-soloing source context preserved: `{_bool_token(summary['repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- outside-soloing repair objective path supported: `{_bool_token(summary['outside_soloing_repair_objective_path_supported'])}`",
         f"- outside-soloing repair weak landing target supported: `{_bool_token(summary['outside_soloing_repair_weak_landing_target_supported'])}`",
         f"- outside-soloing repair final landing target supported: `{_bool_token(summary['outside_soloing_repair_final_landing_target_supported'])}`",

--- a/tests/test_stage_b_midi_to_solo_listening_review_quality_gap.py
+++ b/tests/test_stage_b_midi_to_solo_listening_review_quality_gap.py
@@ -7,12 +7,13 @@ from scripts.decide_stage_b_midi_to_solo_listening_review_quality_gap import (
     BOUNDARY,
     NEXT_BOUNDARY,
     SELECTED_TARGET,
+    SCHEMA_VERSION,
     StageBMidiToSoloListeningReviewQualityGapError,
     build_listening_review_quality_gap_report,
     validate_listening_review_quality_gap_report,
 )
 from scripts.decide_stage_b_midi_to_solo_quality_gap import (
-    BRIDGE_SOURCE_CONTEXT_KEYS,
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
     BOUNDARY as QUALITY_GAP_BOUNDARY,
     LISTENING_REVIEW_NEXT_BOUNDARY,
     LISTENING_REVIEW_TARGET,
@@ -27,6 +28,7 @@ SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_objective_source_outside_soloing_source_context_preserved": True,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
@@ -34,6 +36,7 @@ SOURCE_CONTEXT = {
     "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_context_preserved": True,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
@@ -41,6 +44,7 @@ SOURCE_CONTEXT = {
     "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_context_preserved": True,
 }
 
 
@@ -136,7 +140,7 @@ class StageBMidiToSoloListeningReviewQualityGapTest(unittest.TestCase):
         report = build_listening_review_quality_gap_report(
             quality_gap_decision=quality_gap_decision(),
             output_dir=Path("outputs/listening_review_quality_gap"),
-            issue_number=736,
+            issue_number=1074,
         )
         summary = validate_listening_review_quality_gap_report(
             report,
@@ -179,7 +183,7 @@ class StageBMidiToSoloListeningReviewQualityGapTest(unittest.TestCase):
         self.assertTrue(summary["outside_soloing_repair_source_residual_risk_preserved"])
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_count_after"], 0)
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_delta"], 2)
-        for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+        for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
             self.assertEqual(summary[key], SOURCE_CONTEXT[key])
         self.assertTrue(summary["outside_soloing_repair_objective_path_supported"])
         self.assertTrue(summary["outside_soloing_repair_weak_landing_target_supported"])
@@ -193,8 +197,10 @@ class StageBMidiToSoloListeningReviewQualityGapTest(unittest.TestCase):
         self.assertFalse(summary["critical_user_input_required"])
         self.assertEqual(
             summary["next_recommended_issue"],
-            "Stage B MIDI-to-solo MVP delivery package",
+            "Stage B MIDI-to-solo MVP delivery package source-context refresh",
         )
+        self.assertEqual(report["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(report["issue_number"], 1074)
 
     def test_rejects_wrong_selected_target(self) -> None:
         with self.assertRaises(StageBMidiToSoloListeningReviewQualityGapError):
@@ -254,6 +260,19 @@ class StageBMidiToSoloListeningReviewQualityGapTest(unittest.TestCase):
                 issue_number=990,
             )
 
+    def test_rejects_false_outside_soloing_source_context_preserved_flag(self) -> None:
+        source = quality_gap_decision()
+        source["quality_gap"][
+            "repair_sweep_source_outside_soloing_source_context_preserved"
+        ] = False
+
+        with self.assertRaises(StageBMidiToSoloListeningReviewQualityGapError):
+            build_listening_review_quality_gap_report(
+                quality_gap_decision=source,
+                output_dir=Path("outputs/listening_review_quality_gap"),
+                issue_number=1074,
+            )
+
     def test_rejects_targeted_outside_soloing_source_repair(self) -> None:
         source = quality_gap_decision()
         source["quality_gap"]["outside_soloing_repair_source_targeted"] = True
@@ -290,6 +309,10 @@ class StageBMidiToSoloListeningReviewQualityGapTest(unittest.TestCase):
         self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_listening_review_quality_gap")
         self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_mvp_delivery_package")
         self.assertEqual(SELECTED_TARGET, "mvp_delivery_package")
+        self.assertEqual(
+            SCHEMA_VERSION,
+            "stage_b_midi_to_solo_listening_review_quality_gap_v3",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary
- Listening review quality gap schema v3 적용
- #1072 quality gap decision source-context preserved flag 3개 보존
- MVP delivery package next target 유지

Context
- #1072 quality gap decision 결과: selected target `listening_review_quality_gap`
- technical model-core MVP completed `true`
- changed-ratio repair objective completed `true`
- outside-soloing repair objective completed `true`
- outside-soloing source context preserved `true`
- human/audio preference, MIDI-to-solo musical quality claim 제외

Scope
- source-context required key를 preserved flag 포함으로 확장
- quality gap summary, generated markdown report, validation summary preserved flag 전파
- false preserved flag 입력 차단 테스트 추가
- harness issue number #1074 반영
- generated listening review quality gap doc, README, current status, core plan, handoff scope 갱신

Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_listening_review_quality_gap`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-listening-review-quality-gap`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

Risk
- listening review input pending
- human/audio preference claim 없음
- MIDI-to-solo musical quality claim 없음

Follow-up
- Stage B MIDI-to-solo MVP delivery package source-context refresh

Close #1074
