### PR TITLE
Stage B MIDI-to-solo final status audit source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Current handoff scope:
 - Latest listening review quality gap completed: Issue #1074, Stage B MIDI-to-solo listening review quality gap source-context refresh.
 - Latest MVP delivery package completed: Issue #1076, Stage B MIDI-to-solo MVP delivery package source-context refresh.
 - Latest README final evidence refresh completed: Issue #1078, Stage B MIDI-to-solo README final evidence refresh source-context refresh.
-- Latest final status audit completed: Issue #996, Stage B MIDI-to-solo final status audit source-context refresh.
+- Latest final status audit completed: Issue #1080, Stage B MIDI-to-solo final status audit source-context refresh.
 - Latest post-MVP quality iteration plan completed: Issue #998, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh.
 - Latest quality rubric baseline completed: Issue #1000, Stage B MIDI-to-solo quality rubric baseline source-context refresh.
 - Latest candidate failure labeling completed: Issue #1002, Stage B MIDI-to-solo candidate failure labeling source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1064, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after README final evidence source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo final status audit source-context refresh.
+- Open issue queue after final status audit source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo post-MVP musical quality iteration plan source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest listening review quality gap: `Issue #1074`
 - latest MVP delivery package: `Issue #1076`
 - latest README final evidence refresh: `Issue #1078`
-- latest final status audit: `Issue #996`
+- latest final status audit: `Issue #1080`
 - latest post-MVP quality iteration plan: `Issue #998`
 - latest quality rubric baseline: `Issue #1000`
 - latest candidate failure labeling: `Issue #1002`
@@ -50,7 +50,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1066`
 - latest README evidence refresh: `Issue #1068`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after README final evidence source-context refresh merge: `0`
+- open issue queue after final status audit source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -343,9 +343,15 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - README final evidence follow-up objective source outside-soloing source context preserved: `true`
 - README final evidence follow-up repair sweep source outside-soloing source context preserved: `true`
 - README final evidence bridge repair sweep source outside-soloing source context preserved: `true`
+- final status audit completed: `true`
+- technical MVP complete: `true`
+- technical MVP ready for local review: `true`
+- final status follow-up objective source outside-soloing source context preserved: `true`
+- final status follow-up repair sweep source outside-soloing source context preserved: `true`
+- final status bridge repair sweep source outside-soloing source context preserved: `true`
 - MVP delivery raw artifact upload required: `false`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_final_status_audit`
+- next boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -12259,6 +12259,47 @@ Issue #1078은 Issue #1076 MVP delivery package의 source-context preserved flag
 
 - `Stage B MIDI-to-solo final status audit source-context refresh`
 
+## 9.230 Stage B MIDI-to-solo final status audit source-context refresh
+
+Issue #1080은 Issue #1078 README final evidence와 Issue #1076 MVP delivery package 결과를 기준으로 final status audit summary와 validation summary에 source-context preserved flag 3개를 보존한 작업이다.
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_FINAL_STATUS_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_final_status_audit`
+- next boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- final status audit completed: `true`
+- technical MVP complete: `true`
+- technical MVP ready for local review: `true`
+- README final evidence reflected: `true`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
+- raw artifact upload required: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- technical MVP complete는 local review 가능한 technical path 기준.
+- final status audit summary에 delivery package preserved flag 3개 보존.
+- musical quality와 human/audio preference claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_final_status_audit`
+- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_final_status.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-final-status-audit`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo post-MVP musical quality iteration plan source-context refresh`
+
 ## 10. 한 문장 요약
 
 이 프로젝트의 현재 핵심은 다음이다.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -18,7 +18,7 @@
 - latest listening review quality gap: Issue #1074, Stage B MIDI-to-solo listening review quality gap source-context refresh
 - latest MVP delivery package: Issue #1076, Stage B MIDI-to-solo MVP delivery package source-context refresh
 - latest README final evidence refresh: Issue #1078, Stage B MIDI-to-solo README final evidence refresh source-context refresh
-- latest final status audit: Issue #996, Stage B MIDI-to-solo final status audit source-context refresh
+- latest final status audit: Issue #1080, Stage B MIDI-to-solo final status audit source-context refresh
 - latest post-MVP quality iteration plan: Issue #998, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh
 - latest quality rubric baseline: Issue #1000, Stage B MIDI-to-solo quality rubric baseline source-context refresh
 - latest candidate failure labeling: Issue #1002, Stage B MIDI-to-solo candidate failure labeling source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after README final evidence source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo final status audit source-context refresh`
+- open issue queue after final status audit source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo post-MVP musical quality iteration plan source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -5361,6 +5361,54 @@ Issue #1078은 Issue #1076 MVP delivery package의 source-context preserved flag
 다음:
 
 - `Stage B MIDI-to-solo final status audit source-context refresh`
+
+## Stage B MIDI-to-Solo Final Status Audit Source-Context Refresh Result
+
+Issue #1080은 Issue #1078 README final evidence와 Issue #1076 MVP delivery package 결과를 기준으로 final status audit summary와 validation summary에 source-context preserved flag 3개를 보존한 작업이다.
+
+변경:
+
+- final status audit schema v3 적용
+- final status summary, generated markdown report, validation summary source-context preserved flag 3개 전파
+- false preserved flag 입력 차단 테스트 추가
+- harness issue number #1080 반영
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_FINAL_STATUS_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_final_status_audit`
+- next boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- final status audit completed: `true`
+- technical MVP complete: `true`
+- technical MVP ready for local review: `true`
+- README final evidence reflected: `true`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
+- raw artifact upload required: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- technical MVP complete는 local review 가능한 technical path 기준.
+- final status audit summary에 delivery package preserved flag 3개 보존.
+- musical quality와 human/audio preference claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_final_status_audit`
+- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_final_status.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-final-status-audit`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음:
+
+- `Stage B MIDI-to-solo post-MVP musical quality iteration plan source-context refresh`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_FINAL_STATUS_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_FINAL_STATUS_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -27,10 +27,13 @@
 - outside-soloing current repair pitch-role risk after / delta: `0` / `2`
 - follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
 - follow-up objective source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
 - follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
 - bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `0 / 2`
+- bridge repair sweep source outside-soloing source context preserved: `true`
 - listening review quality gap open: `true`
 - raw artifact upload required: `false`
 
@@ -43,4 +46,4 @@
 
 ## Next
 
-- `Stage B MIDI-to-solo post-MVP musical quality iteration plan`
+- `Stage B MIDI-to-solo post-MVP musical quality iteration plan source-context refresh`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6114,7 +6114,7 @@ run_stage_b_midi_to_solo_final_status_audit() {
     --delivery_package "$delivery_package" \
     --readme_path README.md \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_FINAL_STATUS_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 996 \
+    --issue_number 1080 \
     --expected_boundary stage_b_midi_to_solo_final_status_audit \
     --expected_next_boundary stage_b_midi_to_solo_post_mvp_quality_iteration_plan \
     --require_technical_mvp_complete \

--- a/scripts/audit_stage_b_midi_to_solo_final_status.py
+++ b/scripts/audit_stage_b_midi_to_solo_final_status.py
@@ -14,7 +14,9 @@ sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
 from scripts.build_stage_b_midi_to_solo_mvp_delivery_package import (  # noqa: E402
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
     BRIDGE_SOURCE_CONTEXT_KEYS,
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
     BOUNDARY as DELIVERY_BOUNDARY,
     StageBMidiToSoloMvpDeliveryPackageError,
     validate_delivery_package_report,
@@ -27,7 +29,7 @@ class StageBMidiToSoloFinalStatusAuditError(ValueError):
 
 BOUNDARY = "stage_b_midi_to_solo_final_status_audit"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_post_mvp_quality_iteration_plan"
-SCHEMA_VERSION = "stage_b_midi_to_solo_final_status_audit_v2"
+SCHEMA_VERSION = "stage_b_midi_to_solo_final_status_audit_v3"
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -89,6 +91,22 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
         raise StageBMidiToSoloFinalStatusAuditError(
             f"unexpected quality claim in {label}: {claimed}"
         )
+
+
+def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str, Any]:
+    for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
+        if key not in container:
+            raise StageBMidiToSoloFinalStatusAuditError(
+                f"{label} source-context field required: {key}"
+            )
+    missing_preserved = [
+        key for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS if not bool(container.get(key))
+    ]
+    if missing_preserved:
+        raise StageBMidiToSoloFinalStatusAuditError(
+            f"{label} source-context preserved field must be true: {missing_preserved}"
+        )
+    return {key: container[key] for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS}
 
 
 def validate_delivery_report(report: dict[str, Any]) -> dict[str, Any]:
@@ -174,7 +192,7 @@ def build_final_status_audit_report(
         "outside_soloing_repair_pitch_role_risk_delta": _int(
             delivery["outside_soloing_repair_pitch_role_risk_delta"]
         ),
-        **{key: delivery[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{key: delivery[key] for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
         "listening_review_quality_gap_open": bool(delivery["listening_review_quality_gap_open"]),
         "raw_artifact_upload_required": bool(delivery["raw_artifact_upload_required"]),
         "human_audio_preference_claimed": bool(delivery["human_audio_preference_claimed"]),
@@ -230,7 +248,7 @@ def build_final_status_audit_report(
             "brad_style_adaptation",
             "production_ready_improviser",
         ],
-        "next_recommended_issue": "Stage B MIDI-to-solo post-MVP musical quality iteration plan",
+        "next_recommended_issue": "Stage B MIDI-to-solo post-MVP musical quality iteration plan source-context refresh",
     }
 
 
@@ -263,6 +281,7 @@ def validate_final_status_audit_report(
         raise StageBMidiToSoloFinalStatusAuditError("critical user input should not be required")
     if require_no_quality_claim:
         _require_no_quality_claim(readiness, label="final status readiness")
+    source_context = _source_context_fields(final_status, label="final status")
     return {
         "boundary": boundary,
         "next_boundary": str(decision.get("next_boundary") or ""),
@@ -316,7 +335,7 @@ def validate_final_status_audit_report(
         "outside_soloing_repair_pitch_role_risk_delta": _int(
             final_status.get("outside_soloing_repair_pitch_role_risk_delta")
         ),
-        **{key: final_status.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **source_context,
         "listening_review_quality_gap_open": bool(
             final_status.get("listening_review_quality_gap_open", False)
         ),
@@ -366,10 +385,13 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- outside-soloing current repair pitch-role risk after / delta: `{final_status['outside_soloing_repair_pitch_role_risk_count_after']}` / `{final_status['outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- follow-up objective source outside-soloing source pitch-role risk: `{final_status['followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {final_status['followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
         f"- follow-up objective source outside-soloing current repair pitch-role risk after/delta: `{final_status['followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']} / {final_status['followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- follow-up objective source outside-soloing source context preserved: `{_bool_token(final_status['followup_objective_source_outside_soloing_source_context_preserved'])}`",
         f"- follow-up repair sweep source outside-soloing source pitch-role risk: `{final_status['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {final_status['followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
         f"- follow-up repair sweep source outside-soloing current repair pitch-role risk after/delta: `{final_status['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {final_status['followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(final_status['followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- bridge repair sweep source outside-soloing source pitch-role risk: `{final_status['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {final_status['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
         f"- bridge repair sweep source outside-soloing current repair pitch-role risk after/delta: `{final_status['repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']} / {final_status['repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- bridge repair sweep source outside-soloing source context preserved: `{_bool_token(final_status['repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- listening review quality gap open: `{_bool_token(final_status['listening_review_quality_gap_open'])}`",
         f"- raw artifact upload required: `{_bool_token(final_status['raw_artifact_upload_required'])}`",
         "",

--- a/tests/test_stage_b_midi_to_solo_final_status_audit.py
+++ b/tests/test_stage_b_midi_to_solo_final_status_audit.py
@@ -4,15 +4,16 @@ import unittest
 from pathlib import Path
 
 from scripts.audit_stage_b_midi_to_solo_final_status import (
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
     BOUNDARY,
     NEXT_BOUNDARY,
     REQUIRED_README_SNIPPETS,
+    SCHEMA_VERSION,
     StageBMidiToSoloFinalStatusAuditError,
     build_final_status_audit_report,
     validate_final_status_audit_report,
 )
 from scripts.build_stage_b_midi_to_solo_mvp_delivery_package import (
-    BRIDGE_SOURCE_CONTEXT_KEYS,
     BOUNDARY as DELIVERY_BOUNDARY,
     NEXT_BOUNDARY as DELIVERY_NEXT_BOUNDARY,
 )
@@ -105,7 +106,7 @@ class StageBMidiToSoloFinalStatusAuditTest(unittest.TestCase):
             delivery_package=delivery_package(),
             readme_text=readme_text(),
             output_dir=Path("outputs/final_status"),
-            issue_number=742,
+            issue_number=1080,
         )
         summary = validate_final_status_audit_report(
             report,
@@ -143,7 +144,7 @@ class StageBMidiToSoloFinalStatusAuditTest(unittest.TestCase):
         self.assertTrue(summary["outside_soloing_repair_source_residual_risk_preserved"])
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_count_after"], 0)
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_delta"], 2)
-        for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+        for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
             self.assertEqual(summary[key], SOURCE_CONTEXT[key])
         self.assertTrue(summary["listening_review_quality_gap_open"])
         self.assertFalse(summary["raw_artifact_upload_required"])
@@ -151,8 +152,10 @@ class StageBMidiToSoloFinalStatusAuditTest(unittest.TestCase):
         self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
         self.assertEqual(
             summary["next_recommended_issue"],
-            "Stage B MIDI-to-solo post-MVP musical quality iteration plan",
+            "Stage B MIDI-to-solo post-MVP musical quality iteration plan source-context refresh",
         )
+        self.assertEqual(report["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(report["issue_number"], 1080)
 
     def test_rejects_missing_readme_snippet(self) -> None:
         with self.assertRaises(StageBMidiToSoloFinalStatusAuditError):
@@ -181,9 +184,24 @@ class StageBMidiToSoloFinalStatusAuditTest(unittest.TestCase):
                 issue_number=742,
             )
 
+    def test_rejects_false_source_context_preserved_flag(self) -> None:
+        source = delivery_package()
+        source["delivery_package"][
+            "repair_sweep_source_outside_soloing_source_context_preserved"
+        ] = False
+
+        with self.assertRaises(StageBMidiToSoloFinalStatusAuditError):
+            build_final_status_audit_report(
+                delivery_package=source,
+                readme_text=readme_text(),
+                output_dir=Path("outputs/final_status"),
+                issue_number=1080,
+            )
+
     def test_boundary_constants_are_stable(self) -> None:
         self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_final_status_audit")
         self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_post_mvp_quality_iteration_plan")
+        self.assertEqual(SCHEMA_VERSION, "stage_b_midi_to_solo_final_status_audit_v3")
 
 
 if __name__ == "__main__":

--- a/tests/test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan.py
+++ b/tests/test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan.py
@@ -26,6 +26,7 @@ SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_objective_source_outside_soloing_source_context_preserved": True,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
@@ -33,6 +34,7 @@ SOURCE_CONTEXT = {
     "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_context_preserved": True,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
@@ -40,6 +42,7 @@ SOURCE_CONTEXT = {
     "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_context_preserved": True,
 }
 
 


### PR DESCRIPTION
Summary
- Final status audit schema v3 적용
- #1078 README final evidence와 #1076 delivery package source-context preserved flag 3개 전파
- post-MVP quality iteration plan next boundary 유지

Context
- #1078 README final evidence refresh 결과: README final evidence source-context reflected `true`
- #1076 MVP delivery package 결과: technical MVP delivery package completed `true`
- outside-soloing repair evidence ready `true`
- follow-up objective, follow-up repair sweep, bridge repair sweep preserved flag `true`
- raw artifact upload, human/audio preference, MIDI-to-solo musical quality claim 제외

Scope
- final status summary, generated markdown report, validation summary preserved flag 3개 전파
- false preserved flag 입력 차단 테스트 추가
- downstream post-MVP fixture 입력 계약 갱신
- harness issue number #1080 반영
- generated final status doc, README, current status, core plan, handoff scope 갱신

Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_final_status_audit`
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_final_status_audit tests.test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_final_status.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-final-status-audit`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

Risk
- listening review input pending
- post-MVP musical quality iteration은 후속 경계
- human/audio preference claim 없음
- MIDI-to-solo musical quality claim 없음

Follow-up
- Stage B MIDI-to-solo post-MVP musical quality iteration plan source-context refresh

Close #1080
