### PR TITLE
Stage B MIDI-to-solo post-MVP plan source context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Current handoff scope:
 - Latest MVP delivery package completed: Issue #1076, Stage B MIDI-to-solo MVP delivery package source-context refresh.
 - Latest README final evidence refresh completed: Issue #1078, Stage B MIDI-to-solo README final evidence refresh source-context refresh.
 - Latest final status audit completed: Issue #1080, Stage B MIDI-to-solo final status audit source-context refresh.
-- Latest post-MVP quality iteration plan completed: Issue #998, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh.
+- Latest post-MVP quality iteration plan completed: Issue #1082, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh.
 - Latest quality rubric baseline completed: Issue #1000, Stage B MIDI-to-solo quality rubric baseline source-context refresh.
 - Latest candidate failure labeling completed: Issue #1002, Stage B MIDI-to-solo candidate failure labeling source-context refresh.
 - Latest targeted quality repair sweep completed: Issue #1004, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1064, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after final status audit source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo post-MVP musical quality iteration plan source-context refresh.
+- Open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo quality rubric baseline source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP delivery package: `Issue #1076`
 - latest README final evidence refresh: `Issue #1078`
 - latest final status audit: `Issue #1080`
-- latest post-MVP quality iteration plan: `Issue #998`
+- latest post-MVP quality iteration plan: `Issue #1082`
 - latest quality rubric baseline: `Issue #1000`
 - latest candidate failure labeling: `Issue #1002`
 - latest targeted quality repair sweep: `Issue #1004`
@@ -50,7 +50,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1066`
 - latest README evidence refresh: `Issue #1068`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after final status audit source-context refresh merge: `0`
+- open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -264,6 +264,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - post-MVP quality iteration plan completed: `true`
 - post-MVP selected target: `quality_rubric_baseline`
 - post-MVP quality rubric required: `true`
+- post-MVP follow-up objective source outside-soloing source context preserved: `true`
+- post-MVP follow-up repair sweep source outside-soloing source context preserved: `true`
+- post-MVP bridge repair sweep source outside-soloing source context preserved: `true`
 - quality rubric baseline completed: `true`
 - quality rubric item / metric group count: `8 / 30`
 - quality rubric candidate failure labeling ready: `true`
@@ -351,7 +354,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - final status bridge repair sweep source outside-soloing source context preserved: `true`
 - MVP delivery raw artifact upload required: `false`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- next boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -399,7 +399,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo MVP delivery package: runnable CLI `true`, input ranked MIDI `true`, rendered WAV evidence `true`, CLI/changed-ratio audio candidate count `3/3`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_readme_final_evidence_refresh`
 - MIDI-to-solo README final evidence refresh: latest evidence boundary `stage_b_midi_to_solo_mvp_delivery_package`, runnable CLI `true`, input ranked MIDI/WAV evidence `true/true`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_final_status_audit`
 - MIDI-to-solo final status audit: technical MVP complete `true`, local review ready `true`, README final evidence reflected `true`, CLI/WAV count `3/3`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
-- MIDI-to-solo post-MVP quality iteration plan: selected target `quality_rubric_baseline`, source risk `5 -> 2`, current repair risk after `0`, ordered work `4`, taxonomy seed `7`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_rubric_baseline`
+- MIDI-to-solo post-MVP quality iteration plan: selected target `quality_rubric_baseline`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, ordered work `4`, taxonomy seed `7`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_rubric_baseline`
 - MIDI-to-solo quality rubric baseline: rubric items `8`, metric groups `30`, source risk `5 -> 2`, current repair risk after `0`, candidate failure labeling ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_candidate_failure_labeling`
 - MIDI-to-solo candidate failure labeling: candidates `6`, failed `6`, failure label types `4`, not-evaluable types `2`, source risk `5 -> 2`, current repair risk after `0`, targeted repair ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_sweep`
 - MIDI-to-solo targeted quality repair sweep: candidates `6`, failure labels `12 -> 8`, improved candidates `4`, technical regression `0`, source risk `5 -> 2`, current repair risk after `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
@@ -12299,6 +12299,53 @@ Issue #1080은 Issue #1078 README final evidence와 Issue #1076 MVP delivery pac
 다음 작업:
 
 - `Stage B MIDI-to-solo post-MVP musical quality iteration plan source-context refresh`
+
+## 9.231 Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh
+
+Issue #1082는 Issue #1080 final status audit 결과를 기준으로 post-MVP quality iteration plan의 source-context validation과 summary에 source-context preserved flag 3개를 보존한 작업이다.
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_POST_MVP_QUALITY_ITERATION_PLAN_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- source boundary: `stage_b_midi_to_solo_final_status_audit`
+- next boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
+- selected target: `quality_rubric_baseline`
+- post-MVP quality iteration plan completed: `true`
+- technical MVP complete: `true`
+- local review ready: `true`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
+- outside-soloing source pitch-role risk: `5 -> 2`
+- outside-soloing current repair pitch-role risk after / delta: `0 / 2`
+- ordered work count: `4`
+- quality failure taxonomy seed count: `7`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- post-MVP plan source validation에 final status audit preserved flag 3개 포함.
+- preserved flag false 입력은 validation error로 차단.
+- 다음 검증 대상은 quality rubric baseline 유지.
+- musical quality와 human/audio preference claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_rubric_baseline`
+- `.venv/bin/python -m py_compile scripts/plan_stage_b_midi_to_solo_post_mvp_quality_iteration.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-post-mvp-quality-iteration-plan`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo quality rubric baseline source-context refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -19,7 +19,7 @@
 - latest MVP delivery package: Issue #1076, Stage B MIDI-to-solo MVP delivery package source-context refresh
 - latest README final evidence refresh: Issue #1078, Stage B MIDI-to-solo README final evidence refresh source-context refresh
 - latest final status audit: Issue #1080, Stage B MIDI-to-solo final status audit source-context refresh
-- latest post-MVP quality iteration plan: Issue #998, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh
+- latest post-MVP quality iteration plan: Issue #1082, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh
 - latest quality rubric baseline: Issue #1000, Stage B MIDI-to-solo quality rubric baseline source-context refresh
 - latest candidate failure labeling: Issue #1002, Stage B MIDI-to-solo candidate failure labeling source-context refresh
 - latest targeted quality repair sweep: Issue #1004, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after final status audit source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo post-MVP musical quality iteration plan source-context refresh`
+- open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo quality rubric baseline source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -997,6 +997,9 @@
 - changed-ratio repair audio evidence ready: `true`
 - outside-soloing repair evidence ready: `true`
 - outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
 - outside-soloing repair WAV count: `6`
 - outside-soloing source objective pitch-role risk count: `5`
 - outside-soloing source pitch-role risk count: `5 -> 2`
@@ -5409,6 +5412,61 @@ Issue #1080은 Issue #1078 README final evidence와 Issue #1076 MVP delivery pac
 다음:
 
 - `Stage B MIDI-to-solo post-MVP musical quality iteration plan source-context refresh`
+
+## Stage B MIDI-to-Solo Post-MVP Quality Iteration Plan Source-Context Refresh Result
+
+Issue #1082는 Issue #1080 final status audit 결과를 기준으로 post-MVP quality iteration plan의 source-context validation과 summary에 source-context preserved flag 3개를 보존한 작업이다.
+
+변경:
+
+- post-MVP quality iteration plan source validation을 required source-context key 기준으로 갱신
+- source-context preserved flag 3개 false 입력 차단
+- post-MVP status, generated markdown report, validation summary preserved flag 전파
+- harness issue number #1082 반영
+- quality rubric baseline fixture 입력 계약 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_POST_MVP_QUALITY_ITERATION_PLAN_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- source boundary: `stage_b_midi_to_solo_final_status_audit`
+- next boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
+- selected target: `quality_rubric_baseline`
+- post-MVP quality iteration plan completed: `true`
+- technical MVP complete: `true`
+- local review ready: `true`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
+- outside-soloing source pitch-role risk: `5 -> 2`
+- outside-soloing current repair pitch-role risk after / delta: `0 / 2`
+- ordered work count: `4`
+- quality failure taxonomy seed count: `7`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- post-MVP plan source validation에 final status audit preserved flag 3개 포함.
+- preserved flag false 입력은 validation error로 차단.
+- 다음 검증 대상은 quality rubric baseline 유지.
+- musical quality와 human/audio preference claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_rubric_baseline`
+- `.venv/bin/python -m py_compile scripts/plan_stage_b_midi_to_solo_post_mvp_quality_iteration.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-post-mvp-quality-iteration-plan`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음:
+
+- `Stage B MIDI-to-solo quality rubric baseline source-context refresh`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_POST_MVP_QUALITY_ITERATION_PLAN_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_POST_MVP_QUALITY_ITERATION_PLAN_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -10,6 +10,9 @@
 - local review ready: `true`
 - outside-soloing repair evidence ready: `true`
 - outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
 - outside-soloing repair WAV count: `6`
 - outside-soloing source objective pitch-role risk: `5`
 - outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6135,7 +6135,7 @@ run_stage_b_midi_to_solo_post_mvp_quality_iteration_plan() {
     --run_id "$run_id" \
     --final_status_audit "$final_status" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_POST_MVP_QUALITY_ITERATION_PLAN_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 998 \
+    --issue_number 1082 \
     --expected_boundary stage_b_midi_to_solo_post_mvp_quality_iteration_plan \
     --expected_next_boundary stage_b_midi_to_solo_quality_rubric_baseline \
     --expected_target quality_rubric_baseline \

--- a/scripts/plan_stage_b_midi_to_solo_post_mvp_quality_iteration.py
+++ b/scripts/plan_stage_b_midi_to_solo_post_mvp_quality_iteration.py
@@ -14,7 +14,9 @@ sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
 from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
     BRIDGE_SOURCE_CONTEXT_KEYS,
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
     BOUNDARY as FINAL_STATUS_BOUNDARY,
     NEXT_BOUNDARY as FINAL_STATUS_NEXT_BOUNDARY,
     StageBMidiToSoloFinalStatusAuditError,
@@ -69,12 +71,19 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
 
 
 def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str, Any]:
-    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+    for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
         if key not in container or container[key] is None:
             raise StageBMidiToSoloPostMvpQualityIterationPlanError(
                 f"{label} source-context field required: {key}"
             )
-    return {key: container[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS}
+    missing_preserved = [
+        key for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS if not bool(container.get(key))
+    ]
+    if missing_preserved:
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            f"{label} source-context preserved field must be true: {missing_preserved}"
+        )
+    return {key: container[key] for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS}
 
 
 def validate_final_status_source(report: dict[str, Any]) -> dict[str, Any]:
@@ -268,7 +277,7 @@ def build_post_mvp_quality_iteration_plan_report(
             "outside_soloing_repair_pitch_role_risk_delta": _int(
                 source["outside_soloing_repair_pitch_role_risk_delta"]
             ),
-            **{key: source[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+            **{key: source[key] for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
             "listening_review_quality_gap_open": bool(
                 source["listening_review_quality_gap_open"]
             ),
@@ -298,6 +307,15 @@ def build_post_mvp_quality_iteration_plan_report(
             "technical_mvp_complete": True,
             "outside_soloing_repair_source_context_preserved": bool(
                 source["outside_soloing_repair_source_context_preserved"]
+            ),
+            "followup_objective_source_outside_soloing_source_context_preserved": bool(
+                source["followup_objective_source_outside_soloing_source_context_preserved"]
+            ),
+            "followup_repair_sweep_source_outside_soloing_source_context_preserved": bool(
+                source["followup_repair_sweep_source_outside_soloing_source_context_preserved"]
+            ),
+            "repair_sweep_source_outside_soloing_source_context_preserved": bool(
+                source["repair_sweep_source_outside_soloing_source_context_preserved"]
             ),
             "quality_rubric_required": True,
             "candidate_failure_labeling_required": True,
@@ -422,7 +440,7 @@ def validate_post_mvp_quality_iteration_plan_report(
         ),
         **{
             key: post_mvp_status.get(key)
-            for key in BRIDGE_SOURCE_CONTEXT_KEYS
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
         },
         "candidate_failure_labeling_required": bool(
             readiness.get("candidate_failure_labeling_required", False)
@@ -467,6 +485,9 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- local review ready: `{_bool_token(status['local_review_ready'])}`",
         f"- outside-soloing repair evidence ready: `{_bool_token(status['outside_soloing_repair_evidence_ready'])}`",
         f"- outside-soloing repair source context preserved: `{_bool_token(status['outside_soloing_repair_source_context_preserved'])}`",
+        f"- follow-up objective source outside-soloing source context preserved: `{_bool_token(status['followup_objective_source_outside_soloing_source_context_preserved'])}`",
+        f"- follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(status['followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
+        f"- bridge repair sweep source outside-soloing source context preserved: `{_bool_token(status['repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- outside-soloing repair WAV count: `{status['outside_soloing_repair_wav_count']}`",
         f"- outside-soloing source objective pitch-role risk: `{status['outside_soloing_repair_source_objective_pitch_role_risk_count']}`",
         f"- outside-soloing source pitch-role risk before / after / delta: `{status['outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{status['outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{status['outside_soloing_repair_source_pitch_role_risk_delta']}`",

--- a/tests/test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan.py
+++ b/tests/test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan.py
@@ -4,7 +4,7 @@ import unittest
 from pathlib import Path
 
 from scripts.audit_stage_b_midi_to_solo_final_status import (
-    BRIDGE_SOURCE_CONTEXT_KEYS,
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
     BOUNDARY as FINAL_STATUS_BOUNDARY,
     NEXT_BOUNDARY as FINAL_STATUS_NEXT_BOUNDARY,
 )
@@ -12,6 +12,7 @@ from scripts.plan_stage_b_midi_to_solo_post_mvp_quality_iteration import (
     BOUNDARY,
     NEXT_BOUNDARY,
     SELECTED_TARGET,
+    SCHEMA_VERSION,
     StageBMidiToSoloPostMvpQualityIterationPlanError,
     build_post_mvp_quality_iteration_plan_report,
     validate_post_mvp_quality_iteration_plan_report,
@@ -114,7 +115,7 @@ class StageBMidiToSoloPostMvpQualityIterationPlanTest(unittest.TestCase):
         report = build_post_mvp_quality_iteration_plan_report(
             final_status_audit=final_status_audit(),
             output_dir=Path("outputs/post_mvp_quality"),
-            issue_number=744,
+            issue_number=1082,
         )
         summary = validate_post_mvp_quality_iteration_plan_report(
             report,
@@ -125,6 +126,8 @@ class StageBMidiToSoloPostMvpQualityIterationPlanTest(unittest.TestCase):
             require_no_quality_claim=True,
         )
 
+        self.assertEqual(report["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(report["issue_number"], 1082)
         self.assertTrue(summary["post_mvp_quality_iteration_plan_completed"])
         self.assertTrue(summary["technical_mvp_complete"])
         self.assertTrue(summary["local_review_ready"])
@@ -142,7 +145,7 @@ class StageBMidiToSoloPostMvpQualityIterationPlanTest(unittest.TestCase):
         self.assertTrue(summary["outside_soloing_repair_source_residual_risk_preserved"])
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_count_after"], 0)
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_delta"], 2)
-        for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+        for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
             self.assertEqual(summary[key], SOURCE_CONTEXT[key])
         self.assertTrue(summary["candidate_failure_labeling_required"])
         self.assertTrue(summary["targeted_quality_repair_sweep_required"])
@@ -163,7 +166,7 @@ class StageBMidiToSoloPostMvpQualityIterationPlanTest(unittest.TestCase):
             build_post_mvp_quality_iteration_plan_report(
                 final_status_audit=source,
                 output_dir=Path("outputs/post_mvp_quality"),
-                issue_number=744,
+                issue_number=1082,
             )
 
     def test_rejects_quality_claim(self) -> None:
@@ -171,7 +174,7 @@ class StageBMidiToSoloPostMvpQualityIterationPlanTest(unittest.TestCase):
             build_post_mvp_quality_iteration_plan_report(
                 final_status_audit=final_status_audit(quality_claim=True),
                 output_dir=Path("outputs/post_mvp_quality"),
-                issue_number=744,
+                issue_number=1082,
             )
 
     def test_rejects_closed_listening_gap(self) -> None:
@@ -179,7 +182,7 @@ class StageBMidiToSoloPostMvpQualityIterationPlanTest(unittest.TestCase):
             build_post_mvp_quality_iteration_plan_report(
                 final_status_audit=final_status_audit(listening_gap_open=False),
                 output_dir=Path("outputs/post_mvp_quality"),
-                issue_number=744,
+                issue_number=1082,
             )
 
     def test_rejects_low_candidate_or_wav_count(self) -> None:
@@ -187,13 +190,13 @@ class StageBMidiToSoloPostMvpQualityIterationPlanTest(unittest.TestCase):
             build_post_mvp_quality_iteration_plan_report(
                 final_status_audit=final_status_audit(cli_count=2),
                 output_dir=Path("outputs/post_mvp_quality"),
-                issue_number=744,
+                issue_number=1082,
             )
         with self.assertRaises(StageBMidiToSoloPostMvpQualityIterationPlanError):
             build_post_mvp_quality_iteration_plan_report(
                 final_status_audit=final_status_audit(wav_count=2),
                 output_dir=Path("outputs/post_mvp_quality"),
-                issue_number=744,
+                issue_number=1082,
             )
 
     def test_rejects_incomplete_outside_soloing_repair_evidence(self) -> None:
@@ -201,19 +204,19 @@ class StageBMidiToSoloPostMvpQualityIterationPlanTest(unittest.TestCase):
             build_post_mvp_quality_iteration_plan_report(
                 final_status_audit=final_status_audit(outside_ready=False),
                 output_dir=Path("outputs/post_mvp_quality"),
-                issue_number=744,
+                issue_number=1082,
             )
         with self.assertRaises(StageBMidiToSoloPostMvpQualityIterationPlanError):
             build_post_mvp_quality_iteration_plan_report(
                 final_status_audit=final_status_audit(outside_wav_count=5),
                 output_dir=Path("outputs/post_mvp_quality"),
-                issue_number=744,
+                issue_number=1082,
             )
         with self.assertRaises(StageBMidiToSoloPostMvpQualityIterationPlanError):
             build_post_mvp_quality_iteration_plan_report(
                 final_status_audit=final_status_audit(outside_risk_after=1),
                 output_dir=Path("outputs/post_mvp_quality"),
-                issue_number=744,
+                issue_number=1082,
             )
 
     def test_rejects_missing_outside_soloing_source_context_field(self) -> None:
@@ -225,13 +228,26 @@ class StageBMidiToSoloPostMvpQualityIterationPlanTest(unittest.TestCase):
             build_post_mvp_quality_iteration_plan_report(
                 final_status_audit=source,
                 output_dir=Path("outputs/post_mvp_quality"),
-                issue_number=998,
+                issue_number=1082,
+            )
+
+    def test_rejects_false_source_context_preserved_field(self) -> None:
+        source = final_status_audit()
+        source["final_status"][
+            "repair_sweep_source_outside_soloing_source_context_preserved"
+        ] = False
+        with self.assertRaises(StageBMidiToSoloPostMvpQualityIterationPlanError):
+            build_post_mvp_quality_iteration_plan_report(
+                final_status_audit=source,
+                output_dir=Path("outputs/post_mvp_quality"),
+                issue_number=1082,
             )
 
     def test_boundary_constants_are_stable(self) -> None:
         self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_post_mvp_quality_iteration_plan")
         self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_quality_rubric_baseline")
         self.assertEqual(SELECTED_TARGET, "quality_rubric_baseline")
+        self.assertEqual(SCHEMA_VERSION, "stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v3")
 
 
 if __name__ == "__main__":

--- a/tests/test_stage_b_midi_to_solo_quality_rubric_baseline.py
+++ b/tests/test_stage_b_midi_to_solo_quality_rubric_baseline.py
@@ -27,6 +27,7 @@ SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_objective_source_outside_soloing_source_context_preserved": True,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
@@ -34,6 +35,7 @@ SOURCE_CONTEXT = {
     "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_context_preserved": True,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
@@ -41,6 +43,7 @@ SOURCE_CONTEXT = {
     "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_context_preserved": True,
 }
 
 


### PR DESCRIPTION
## Summary

- post-MVP quality iteration plan source-context validation 강화
- final status audit preserved flag 3개 validation summary / markdown 전파
- quality rubric baseline 다음 boundary 유지

## Context

- #1080 final status audit completed: `true`
- technical MVP complete / local review ready: `true` / `true`
- outside-soloing repair source context preserved: `true`
- follow-up objective / follow-up repair sweep / bridge repair sweep preserved flag: `true` / `true` / `true`
- quality/preference claim: `false`

## Scope

- `scripts/plan_stage_b_midi_to_solo_post_mvp_quality_iteration.py` required source-context key 갱신
- false preserved flag input guard 추가
- post-MVP generated markdown report preserved flag 3개 기록
- quality rubric baseline test fixture 입력 계약 갱신
- README / current status / core plan / handoff 문서 #1082 기준 갱신

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_rubric_baseline`
- `.venv/bin/python -m py_compile scripts/plan_stage_b_midi_to_solo_post_mvp_quality_iteration.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-post-mvp-quality-iteration-plan`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- human/audio preference claim 제외
- MIDI-to-solo musical quality claim 제외
- 다음 검증 대상: quality rubric baseline source-context refresh

Closes #1082

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project roadmap and planning documentation to reflect the latest post-MVP quality iteration phase.
  * Added tracking for source-context preservation across additional validation checkpoints.

* **Chores**
  * Updated internal orchestration and test infrastructure to align with the current project stage progression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->