### PR TITLE
Stage B MIDI-to-solo quality rubric baseline source context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Current handoff scope:
 - Latest README final evidence refresh completed: Issue #1078, Stage B MIDI-to-solo README final evidence refresh source-context refresh.
 - Latest final status audit completed: Issue #1080, Stage B MIDI-to-solo final status audit source-context refresh.
 - Latest post-MVP quality iteration plan completed: Issue #1082, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh.
-- Latest quality rubric baseline completed: Issue #1000, Stage B MIDI-to-solo quality rubric baseline source-context refresh.
+- Latest quality rubric baseline completed: Issue #1084, Stage B MIDI-to-solo quality rubric baseline source-context refresh.
 - Latest candidate failure labeling completed: Issue #1002, Stage B MIDI-to-solo candidate failure labeling source-context refresh.
 - Latest targeted quality repair sweep completed: Issue #1004, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh.
 - Latest targeted quality repair audio package completed: Issue #1006, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1064, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo quality rubric baseline source-context refresh.
+- Open issue queue after quality rubric baseline source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo candidate failure labeling source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest README final evidence refresh: `Issue #1078`
 - latest final status audit: `Issue #1080`
 - latest post-MVP quality iteration plan: `Issue #1082`
-- latest quality rubric baseline: `Issue #1000`
+- latest quality rubric baseline: `Issue #1084`
 - latest candidate failure labeling: `Issue #1002`
 - latest targeted quality repair sweep: `Issue #1004`
 - latest targeted quality repair audio package: `Issue #1006`
@@ -50,7 +50,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1066`
 - latest README evidence refresh: `Issue #1068`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`
+- open issue queue after quality rubric baseline source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -270,6 +270,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - quality rubric baseline completed: `true`
 - quality rubric item / metric group count: `8 / 30`
 - quality rubric candidate failure labeling ready: `true`
+- quality rubric follow-up objective source outside-soloing source context preserved: `true`
+- quality rubric follow-up repair sweep source outside-soloing source context preserved: `true`
+- quality rubric bridge repair sweep source outside-soloing source context preserved: `true`
 - candidate failure labeling completed: `true`
 - candidate failure failed candidates: `6 / 6`
 - candidate failure label type count: `4`
@@ -354,7 +357,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - final status bridge repair sweep source outside-soloing source context preserved: `true`
 - MVP delivery raw artifact upload required: `false`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
+- next boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -400,7 +400,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo README final evidence refresh: latest evidence boundary `stage_b_midi_to_solo_mvp_delivery_package`, runnable CLI `true`, input ranked MIDI/WAV evidence `true/true`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_final_status_audit`
 - MIDI-to-solo final status audit: technical MVP complete `true`, local review ready `true`, README final evidence reflected `true`, CLI/WAV count `3/3`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
 - MIDI-to-solo post-MVP quality iteration plan: selected target `quality_rubric_baseline`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, ordered work `4`, taxonomy seed `7`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_rubric_baseline`
-- MIDI-to-solo quality rubric baseline: rubric items `8`, metric groups `30`, source risk `5 -> 2`, current repair risk after `0`, candidate failure labeling ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_candidate_failure_labeling`
+- MIDI-to-solo quality rubric baseline: rubric items `8`, metric groups `30`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, candidate failure labeling ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_candidate_failure_labeling`
 - MIDI-to-solo candidate failure labeling: candidates `6`, failed `6`, failure label types `4`, not-evaluable types `2`, source risk `5 -> 2`, current repair risk after `0`, targeted repair ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_sweep`
 - MIDI-to-solo targeted quality repair sweep: candidates `6`, failure labels `12 -> 8`, improved candidates `4`, technical regression `0`, source risk `5 -> 2`, current repair risk after `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
 - MIDI-to-solo targeted quality repair audio package: rendered WAV `6`, duration `18.422s-18.984s`, source risk `5 -> 2`, current repair risk after `0`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
@@ -12346,6 +12346,52 @@ Issue #1082는 Issue #1080 final status audit 결과를 기준으로 post-MVP qu
 다음 작업:
 
 - `Stage B MIDI-to-solo quality rubric baseline source-context refresh`
+
+## 9.232 Stage B MIDI-to-solo quality rubric baseline source-context refresh
+
+Issue #1084는 Issue #1082 post-MVP quality iteration plan 결과를 기준으로 quality rubric baseline의 source-context validation과 summary에 source-context preserved flag 3개를 보존한 작업이다.
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_QUALITY_RUBRIC_BASELINE_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
+- source boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- next boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
+- selected target: `candidate_failure_labeling`
+- quality rubric baseline completed: `true`
+- candidate failure labeling ready: `true`
+- rubric item count: `8`
+- required metric group count: `30`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
+- outside-soloing source pitch-role risk: `5 -> 2`
+- outside-soloing current repair pitch-role risk after / delta: `0 / 2`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- quality rubric baseline source validation에 post-MVP plan preserved flag 3개 포함.
+- preserved flag false 입력은 validation error로 차단.
+- 다음 검증 대상은 candidate failure labeling 유지.
+- musical quality와 human/audio preference claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_rubric_baseline`
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_candidate_failure_labeling`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_quality_rubric_baseline.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-rubric-baseline`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo candidate failure labeling source-context refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -20,7 +20,7 @@
 - latest README final evidence refresh: Issue #1078, Stage B MIDI-to-solo README final evidence refresh source-context refresh
 - latest final status audit: Issue #1080, Stage B MIDI-to-solo final status audit source-context refresh
 - latest post-MVP quality iteration plan: Issue #1082, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh
-- latest quality rubric baseline: Issue #1000, Stage B MIDI-to-solo quality rubric baseline source-context refresh
+- latest quality rubric baseline: Issue #1084, Stage B MIDI-to-solo quality rubric baseline source-context refresh
 - latest candidate failure labeling: Issue #1002, Stage B MIDI-to-solo candidate failure labeling source-context refresh
 - latest targeted quality repair sweep: Issue #1004, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh
 - latest targeted quality repair audio package: Issue #1006, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo quality rubric baseline source-context refresh`
+- open issue queue after quality rubric baseline source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo candidate failure labeling source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -1068,6 +1068,9 @@
 - candidate failure labeling ready: `true`
 - outside-soloing repair evidence ready: `true`
 - outside-soloing repair source context preserved: `true`
+- quality rubric follow-up objective source outside-soloing source context preserved: `true`
+- quality rubric follow-up repair sweep source outside-soloing source context preserved: `true`
+- quality rubric bridge repair sweep source outside-soloing source context preserved: `true`
 - outside-soloing repair WAV count: `6`
 - outside-soloing source objective pitch-role risk count: `5`
 - outside-soloing source pitch-role risk count: `5 -> 2`
@@ -5467,6 +5470,60 @@ Issue #1082는 Issue #1080 final status audit 결과를 기준으로 post-MVP qu
 다음:
 
 - `Stage B MIDI-to-solo quality rubric baseline source-context refresh`
+
+## Stage B MIDI-to-Solo Quality Rubric Baseline Source-Context Refresh Result
+
+Issue #1084는 Issue #1082 post-MVP quality iteration plan 결과를 기준으로 quality rubric baseline의 source-context validation과 summary에 source-context preserved flag 3개를 보존한 작업이다.
+
+변경:
+
+- quality rubric baseline source validation을 required source-context key 기준으로 갱신
+- source-context preserved flag 3개 false 입력 차단
+- source quality context, rubric baseline, generated markdown report, validation summary preserved flag 전파
+- harness issue number #1084 반영
+- candidate failure labeling fixture 입력 계약 갱신
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_QUALITY_RUBRIC_BASELINE_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
+- source boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- next boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
+- selected target: `candidate_failure_labeling`
+- quality rubric baseline completed: `true`
+- candidate failure labeling ready: `true`
+- rubric item count: `8`
+- required metric group count: `30`
+- outside-soloing repair evidence ready: `true`
+- outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
+- outside-soloing source pitch-role risk: `5 -> 2`
+- outside-soloing current repair pitch-role risk after / delta: `0 / 2`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- quality rubric baseline source validation에 post-MVP plan preserved flag 3개 포함.
+- preserved flag false 입력은 validation error로 차단.
+- 다음 검증 대상은 candidate failure labeling 유지.
+- musical quality와 human/audio preference claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_rubric_baseline`
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_candidate_failure_labeling`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_quality_rubric_baseline.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-rubric-baseline`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음:
+
+- `Stage B MIDI-to-solo candidate failure labeling source-context refresh`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_QUALITY_RUBRIC_BASELINE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_QUALITY_RUBRIC_BASELINE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -10,6 +10,9 @@
 - candidate failure labeling ready: `true`
 - outside-soloing repair evidence ready: `true`
 - outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
 - outside-soloing repair WAV count: `6`
 - outside-soloing source objective pitch-role risk: `5`
 - outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6156,7 +6156,7 @@ run_stage_b_midi_to_solo_quality_rubric_baseline() {
     --run_id "$run_id" \
     --post_mvp_quality_plan "$post_mvp_plan" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_QUALITY_RUBRIC_BASELINE_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1000 \
+    --issue_number 1084 \
     --expected_boundary stage_b_midi_to_solo_quality_rubric_baseline \
     --expected_next_boundary stage_b_midi_to_solo_candidate_failure_labeling \
     --expected_target candidate_failure_labeling \

--- a/scripts/build_stage_b_midi_to_solo_quality_rubric_baseline.py
+++ b/scripts/build_stage_b_midi_to_solo_quality_rubric_baseline.py
@@ -13,11 +13,11 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
-from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
-    BRIDGE_SOURCE_CONTEXT_KEYS,
-)
 from scripts.plan_stage_b_midi_to_solo_post_mvp_quality_iteration import (  # noqa: E402
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
     BOUNDARY as POST_MVP_PLAN_BOUNDARY,
+    BRIDGE_SOURCE_CONTEXT_KEYS,
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
     NEXT_BOUNDARY as POST_MVP_PLAN_NEXT_BOUNDARY,
     SELECTED_TARGET as POST_MVP_SELECTED_TARGET,
     StageBMidiToSoloPostMvpQualityIterationPlanError,
@@ -75,12 +75,19 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
 
 
 def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str, Any]:
-    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+    for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
         if key not in container or container[key] is None:
             raise StageBMidiToSoloQualityRubricBaselineError(
                 f"{label} source-context field required: {key}"
             )
-    return {key: container[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS}
+    missing_preserved = [
+        key for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS if not bool(container.get(key))
+    ]
+    if missing_preserved:
+        raise StageBMidiToSoloQualityRubricBaselineError(
+            f"{label} source-context preserved field must be true: {missing_preserved}"
+        )
+    return {key: container[key] for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS}
 
 
 def validate_post_mvp_quality_iteration_plan_source(report: dict[str, Any]) -> dict[str, Any]:
@@ -281,7 +288,7 @@ def build_quality_rubric_baseline_report(
         "outside_soloing_repair_pitch_role_risk_delta": _int(
             source["outside_soloing_repair_pitch_role_risk_delta"]
         ),
-        **{key: source[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{key: source[key] for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
         "outside_soloing_label_scope": "remaining context/listening quality risk after objective pitch-role repair",
     }
     return {
@@ -332,7 +339,7 @@ def build_quality_rubric_baseline_report(
             "outside_soloing_repair_pitch_role_risk_delta": _int(
                 outside_context["outside_soloing_repair_pitch_role_risk_delta"]
             ),
-            **{key: outside_context[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+            **{key: outside_context[key] for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
         },
@@ -350,6 +357,15 @@ def build_quality_rubric_baseline_report(
             "selected_target": SELECTED_TARGET,
             "outside_soloing_repair_source_context_preserved": bool(
                 outside_context["outside_soloing_repair_source_context_preserved"]
+            ),
+            "followup_objective_source_outside_soloing_source_context_preserved": bool(
+                outside_context["followup_objective_source_outside_soloing_source_context_preserved"]
+            ),
+            "followup_repair_sweep_source_outside_soloing_source_context_preserved": bool(
+                outside_context["followup_repair_sweep_source_outside_soloing_source_context_preserved"]
+            ),
+            "repair_sweep_source_outside_soloing_source_context_preserved": bool(
+                outside_context["repair_sweep_source_outside_soloing_source_context_preserved"]
             ),
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
@@ -478,7 +494,7 @@ def validate_quality_rubric_baseline_report(
         ),
         **{
             key: baseline.get(key)
-            for key in BRIDGE_SOURCE_CONTEXT_KEYS
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
         },
         "human_audio_preference_claimed": bool(
             readiness.get("human_audio_preference_claimed", True)
@@ -509,6 +525,9 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- candidate failure labeling ready: `{_bool_token(baseline['candidate_failure_labeling_ready'])}`",
         f"- outside-soloing repair evidence ready: `{_bool_token(source_context['outside_soloing_repair_evidence_ready'])}`",
         f"- outside-soloing repair source context preserved: `{_bool_token(source_context['outside_soloing_repair_source_context_preserved'])}`",
+        f"- follow-up objective source outside-soloing source context preserved: `{_bool_token(source_context['followup_objective_source_outside_soloing_source_context_preserved'])}`",
+        f"- follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(source_context['followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
+        f"- bridge repair sweep source outside-soloing source context preserved: `{_bool_token(source_context['repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- outside-soloing repair WAV count: `{source_context['outside_soloing_repair_wav_count']}`",
         f"- outside-soloing source objective pitch-role risk: `{source_context['outside_soloing_repair_source_objective_pitch_role_risk_count']}`",
         f"- outside-soloing source pitch-role risk before / after / delta: `{source_context['outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{source_context['outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{source_context['outside_soloing_repair_source_pitch_role_risk_delta']}`",

--- a/tests/test_stage_b_midi_to_solo_candidate_failure_labeling.py
+++ b/tests/test_stage_b_midi_to_solo_candidate_failure_labeling.py
@@ -37,6 +37,7 @@ SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_objective_source_outside_soloing_source_context_preserved": True,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
@@ -44,6 +45,7 @@ SOURCE_CONTEXT = {
     "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_context_preserved": True,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
@@ -51,6 +53,7 @@ SOURCE_CONTEXT = {
     "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_context_preserved": True,
 }
 
 

--- a/tests/test_stage_b_midi_to_solo_quality_rubric_baseline.py
+++ b/tests/test_stage_b_midi_to_solo_quality_rubric_baseline.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import unittest
 from pathlib import Path
 
-from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_SOURCE_CONTEXT_KEYS
+from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
 from scripts.build_stage_b_midi_to_solo_quality_rubric_baseline import (
     BOUNDARY,
     NEXT_BOUNDARY,
     SELECTED_TARGET,
+    SCHEMA_VERSION,
     StageBMidiToSoloQualityRubricBaselineError,
     build_quality_rubric_baseline_report,
     validate_quality_rubric_baseline_report,
@@ -120,7 +121,7 @@ class StageBMidiToSoloQualityRubricBaselineTest(unittest.TestCase):
         report = build_quality_rubric_baseline_report(
             post_mvp_quality_plan=post_mvp_quality_plan(),
             output_dir=Path("outputs/quality_rubric"),
-            issue_number=746,
+            issue_number=1084,
         )
         summary = validate_quality_rubric_baseline_report(
             report,
@@ -132,6 +133,8 @@ class StageBMidiToSoloQualityRubricBaselineTest(unittest.TestCase):
             require_no_quality_claim=True,
         )
 
+        self.assertEqual(report["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(report["issue_number"], 1084)
         self.assertTrue(summary["quality_rubric_baseline_completed"])
         self.assertTrue(summary["candidate_failure_labeling_ready"])
         self.assertEqual(summary["selected_target"], SELECTED_TARGET)
@@ -148,7 +151,7 @@ class StageBMidiToSoloQualityRubricBaselineTest(unittest.TestCase):
         self.assertTrue(summary["outside_soloing_repair_source_residual_risk_preserved"])
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_count_after"], 0)
         self.assertEqual(summary["outside_soloing_repair_pitch_role_risk_delta"], 2)
-        for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+        for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
             self.assertEqual(summary[key], SOURCE_CONTEXT[key])
         self.assertFalse(summary["human_audio_preference_claimed"])
         self.assertFalse(summary["midi_to_solo_musical_quality_claimed"])
@@ -164,7 +167,7 @@ class StageBMidiToSoloQualityRubricBaselineTest(unittest.TestCase):
             build_quality_rubric_baseline_report(
                 post_mvp_quality_plan=source,
                 output_dir=Path("outputs/quality_rubric"),
-                issue_number=746,
+                issue_number=1084,
             )
 
     def test_rejects_wrong_selected_target(self) -> None:
@@ -172,7 +175,7 @@ class StageBMidiToSoloQualityRubricBaselineTest(unittest.TestCase):
             build_quality_rubric_baseline_report(
                 post_mvp_quality_plan=post_mvp_quality_plan(selected_target="repair_sweep"),
                 output_dir=Path("outputs/quality_rubric"),
-                issue_number=746,
+                issue_number=1084,
             )
 
     def test_rejects_quality_claim(self) -> None:
@@ -180,7 +183,7 @@ class StageBMidiToSoloQualityRubricBaselineTest(unittest.TestCase):
             build_quality_rubric_baseline_report(
                 post_mvp_quality_plan=post_mvp_quality_plan(quality_claim=True),
                 output_dir=Path("outputs/quality_rubric"),
-                issue_number=746,
+                issue_number=1084,
             )
 
     def test_rejects_incomplete_plan_inputs(self) -> None:
@@ -188,13 +191,13 @@ class StageBMidiToSoloQualityRubricBaselineTest(unittest.TestCase):
             build_quality_rubric_baseline_report(
                 post_mvp_quality_plan=post_mvp_quality_plan(ordered_work_count=3),
                 output_dir=Path("outputs/quality_rubric"),
-                issue_number=746,
+                issue_number=1084,
             )
         with self.assertRaises(StageBMidiToSoloQualityRubricBaselineError):
             build_quality_rubric_baseline_report(
                 post_mvp_quality_plan=post_mvp_quality_plan(taxonomy_count=6),
                 output_dir=Path("outputs/quality_rubric"),
-                issue_number=746,
+                issue_number=1084,
             )
 
     def test_rejects_incomplete_outside_soloing_repair_context(self) -> None:
@@ -202,19 +205,19 @@ class StageBMidiToSoloQualityRubricBaselineTest(unittest.TestCase):
             build_quality_rubric_baseline_report(
                 post_mvp_quality_plan=post_mvp_quality_plan(outside_ready=False),
                 output_dir=Path("outputs/quality_rubric"),
-                issue_number=746,
+                issue_number=1084,
             )
         with self.assertRaises(StageBMidiToSoloQualityRubricBaselineError):
             build_quality_rubric_baseline_report(
                 post_mvp_quality_plan=post_mvp_quality_plan(outside_wav_count=5),
                 output_dir=Path("outputs/quality_rubric"),
-                issue_number=746,
+                issue_number=1084,
             )
         with self.assertRaises(StageBMidiToSoloQualityRubricBaselineError):
             build_quality_rubric_baseline_report(
                 post_mvp_quality_plan=post_mvp_quality_plan(outside_risk_after=1),
                 output_dir=Path("outputs/quality_rubric"),
-                issue_number=746,
+                issue_number=1084,
             )
 
     def test_rejects_missing_outside_soloing_source_context_field(self) -> None:
@@ -226,14 +229,26 @@ class StageBMidiToSoloQualityRubricBaselineTest(unittest.TestCase):
             build_quality_rubric_baseline_report(
                 post_mvp_quality_plan=source,
                 output_dir=Path("outputs/quality_rubric"),
-                issue_number=1000,
+                issue_number=1084,
+            )
+
+    def test_rejects_false_source_context_preserved_field(self) -> None:
+        source = post_mvp_quality_plan()
+        source["post_mvp_status"][
+            "followup_repair_sweep_source_outside_soloing_source_context_preserved"
+        ] = False
+        with self.assertRaises(StageBMidiToSoloQualityRubricBaselineError):
+            build_quality_rubric_baseline_report(
+                post_mvp_quality_plan=source,
+                output_dir=Path("outputs/quality_rubric"),
+                issue_number=1084,
             )
 
     def test_rejects_missing_required_rubric_item(self) -> None:
         report = build_quality_rubric_baseline_report(
             post_mvp_quality_plan=post_mvp_quality_plan(),
             output_dir=Path("outputs/quality_rubric"),
-            issue_number=746,
+            issue_number=1084,
         )
         report["rubric_items"] = [
             item for item in report["rubric_items"] if item["id"] != "weak_chord_tone_landing"
@@ -253,6 +268,7 @@ class StageBMidiToSoloQualityRubricBaselineTest(unittest.TestCase):
         self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_quality_rubric_baseline")
         self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_candidate_failure_labeling")
         self.assertEqual(SELECTED_TARGET, "candidate_failure_labeling")
+        self.assertEqual(SCHEMA_VERSION, "stage_b_midi_to_solo_quality_rubric_baseline_v3")
 
 
 if __name__ == "__main__":

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py
@@ -40,6 +40,7 @@ SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_objective_source_outside_soloing_source_context_preserved": True,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
@@ -47,6 +48,7 @@ SOURCE_CONTEXT = {
     "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_context_preserved": True,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
@@ -54,6 +56,7 @@ SOURCE_CONTEXT = {
     "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_context_preserved": True,
 }
 
 

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
@@ -40,6 +40,7 @@ SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_objective_source_outside_soloing_source_context_preserved": True,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
@@ -47,6 +48,7 @@ SOURCE_CONTEXT = {
     "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_context_preserved": True,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
@@ -54,6 +56,7 @@ SOURCE_CONTEXT = {
     "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_context_preserved": True,
 }
 
 

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
@@ -36,6 +36,7 @@ SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_objective_source_outside_soloing_source_context_preserved": True,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
@@ -43,6 +44,7 @@ SOURCE_CONTEXT = {
     "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "followup_repair_sweep_source_outside_soloing_source_context_preserved": True,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
@@ -50,6 +52,7 @@ SOURCE_CONTEXT = {
     "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
+    "repair_sweep_source_outside_soloing_source_context_preserved": True,
 }
 
 


### PR DESCRIPTION
## Summary

- quality rubric baseline source-context validation 강화
- post-MVP plan preserved flag 3개 source quality context / rubric baseline / validation summary 전파
- candidate failure labeling 다음 boundary 유지

## Context

- #1082 post-MVP quality iteration plan completed: `true`
- selected target: `quality_rubric_baseline`
- follow-up objective / follow-up repair sweep / bridge repair sweep preserved flag: `true` / `true` / `true`
- quality/preference claim: `false`

## Scope

- `scripts/build_stage_b_midi_to_solo_quality_rubric_baseline.py` required source-context key 갱신
- false preserved flag input guard 추가
- quality rubric generated markdown report preserved flag 3개 기록
- downstream candidate failure labeling fixture 입력 계약 보정
- README / current status / core plan / handoff 문서 #1084 기준 갱신

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_rubric_baseline`
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_candidate_failure_labeling`
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_sweep`
- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_quality_rubric_baseline.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-rubric-baseline`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- human/audio preference claim 제외
- MIDI-to-solo musical quality claim 제외
- 다음 검증 대상: candidate failure labeling source-context refresh

Closes #1084