### PR TITLE
Stage B MIDI-to-solo targeted quality repair sweep source context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Current handoff scope:
 - Latest post-MVP quality iteration plan completed: Issue #1082, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh.
 - Latest quality rubric baseline completed: Issue #1084, Stage B MIDI-to-solo quality rubric baseline source-context refresh.
 - Latest candidate failure labeling completed: Issue #1086, Stage B MIDI-to-solo candidate failure labeling source-context refresh.
-- Latest targeted quality repair sweep completed: Issue #1004, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh.
+- Latest targeted quality repair sweep completed: Issue #1088, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh.
 - Latest targeted quality repair audio package completed: Issue #1006, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh.
 - Latest targeted quality repair listening review package completed: Issue #1008, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh.
 - Latest targeted quality repair listening review input guard completed: Issue #1010, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1064, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after candidate failure labeling source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo targeted quality repair sweep source-context refresh.
+- Open issue queue after targeted quality repair sweep source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo targeted quality repair audio package source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest post-MVP quality iteration plan: `Issue #1082`
 - latest quality rubric baseline: `Issue #1084`
 - latest candidate failure labeling: `Issue #1086`
-- latest targeted quality repair sweep: `Issue #1004`
+- latest targeted quality repair sweep: `Issue #1088`
 - latest targeted quality repair audio package: `Issue #1006`
 - latest targeted quality repair listening review package: `Issue #1008`
 - latest targeted quality repair listening review input guard: `Issue #1010`
@@ -50,7 +50,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1066`
 - latest README evidence refresh: `Issue #1068`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after candidate failure labeling source-context refresh merge: `0`
+- open issue queue after targeted quality repair sweep source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -284,6 +284,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - targeted quality repair failure label count: `12 -> 8`
 - targeted quality repair improved candidates: `4 / 6`
 - targeted quality repair technical regression count: `0`
+- targeted quality repair follow-up objective source outside-soloing source context preserved: `true`
+- targeted quality repair follow-up repair sweep source outside-soloing source context preserved: `true`
+- targeted quality repair bridge repair sweep source outside-soloing source context preserved: `true`
 - targeted quality repair audio WAV files: `6`
 - targeted quality repair audio WAV technical validation: `true`
 - targeted quality repair audio duration range: `18.422s - 18.984s`
@@ -360,7 +363,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - final status bridge repair sweep source outside-soloing source context preserved: `true`
 - MVP delivery raw artifact upload required: `false`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -402,7 +402,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo post-MVP quality iteration plan: selected target `quality_rubric_baseline`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, ordered work `4`, taxonomy seed `7`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_rubric_baseline`
 - MIDI-to-solo quality rubric baseline: rubric items `8`, metric groups `30`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, candidate failure labeling ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_candidate_failure_labeling`
 - MIDI-to-solo candidate failure labeling: candidates `6`, failed `6`, failure label types `4`, not-evaluable types `2`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, targeted repair ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_sweep`
-- MIDI-to-solo targeted quality repair sweep: candidates `6`, failure labels `12 -> 8`, improved candidates `4`, technical regression `0`, source risk `5 -> 2`, current repair risk after `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
+- MIDI-to-solo targeted quality repair sweep: candidates `6`, failure labels `12 -> 8`, improved candidates `4`, technical regression `0`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
 - MIDI-to-solo targeted quality repair audio package: rendered WAV `6`, duration `18.422s-18.984s`, source risk `5 -> 2`, current repair risk after `0`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
 - MIDI-to-solo targeted quality repair listening review package: review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after `0`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
 - MIDI-to-solo targeted quality repair listening review input guard: review items `6`, preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
@@ -12442,6 +12442,60 @@ Issue #1086은 Issue #1084 quality rubric baseline 결과를 기준으로 candid
 다음 작업:
 
 - `Stage B MIDI-to-solo targeted quality repair sweep source-context refresh`
+
+## 9.234 Stage B MIDI-to-solo targeted quality repair sweep source-context refresh
+
+Issue #1088은 Issue #1086 candidate failure labeling 결과를 기준으로 targeted quality repair sweep의 source-context validation과 summary에 source-context preserved flag 3개를 보존한 작업이다.
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
+- selected target: `targeted_quality_repair_audio_package`
+- targeted quality repair sweep completed: `true`
+- target supported: `true`
+- candidate count: `6`
+- source total failure label count: `12`
+- repaired total failure label count: `8`
+- failure label delta: `4`
+- improved candidate count: `4`
+- technical regression count: `0`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
+- source outside-soloing source pitch-role risk: `5 -> 2`
+- source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- audio package ready: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- targeted quality repair sweep source validation에 candidate failure labeling preserved flag 3개 포함.
+- preserved flag false 입력은 validation error로 차단.
+- failure label은 `12 -> 8`, improved candidate는 `4 / 6`.
+- technical regression count는 `0`.
+- 다음 검증 대상은 targeted quality repair audio package 유지.
+- musical quality와 human/audio preference claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-sweep`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo targeted quality repair audio package source-context refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -22,7 +22,7 @@
 - latest post-MVP quality iteration plan: Issue #1082, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh
 - latest quality rubric baseline: Issue #1084, Stage B MIDI-to-solo quality rubric baseline source-context refresh
 - latest candidate failure labeling: Issue #1086, Stage B MIDI-to-solo candidate failure labeling source-context refresh
-- latest targeted quality repair sweep: Issue #1004, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh
+- latest targeted quality repair sweep: Issue #1088, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh
 - latest targeted quality repair audio package: Issue #1006, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh
 - latest targeted quality repair listening review package: Issue #1008, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh
 - latest targeted quality repair listening review input guard: Issue #1010, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after candidate failure labeling source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair sweep source-context refresh`
+- open issue queue after targeted quality repair sweep source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair audio package source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -1115,6 +1115,9 @@
 - technical regression count: `0`
 - source outside-soloing repair evidence ready: `true`
 - source outside-soloing repair source context preserved: `true`
+- targeted quality repair follow-up objective source outside-soloing source context preserved: `true`
+- targeted quality repair follow-up repair sweep source outside-soloing source context preserved: `true`
+- targeted quality repair bridge repair sweep source outside-soloing source context preserved: `true`
 - source outside-soloing repair WAV count: `6`
 - source outside-soloing source objective pitch-role risk count: `5`
 - source outside-soloing source pitch-role risk count: `5 -> 2`
@@ -5584,6 +5587,60 @@ Issue #1086은 Issue #1084 quality rubric baseline 결과를 기준으로 candid
 다음:
 
 - `Stage B MIDI-to-solo targeted quality repair sweep source-context refresh`
+
+## 9.234 Stage B MIDI-to-solo targeted quality repair sweep source-context refresh
+
+Issue #1088은 Issue #1086 candidate failure labeling 결과를 기준으로 targeted quality repair sweep의 source-context validation과 summary에 source-context preserved flag 3개를 보존한 작업이다.
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- source boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
+- selected target: `targeted_quality_repair_audio_package`
+- targeted quality repair sweep completed: `true`
+- target supported: `true`
+- candidate count: `6`
+- source total failure label count: `12`
+- repaired total failure label count: `8`
+- failure label delta: `4`
+- improved candidate count: `4`
+- technical regression count: `0`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
+- source outside-soloing source pitch-role risk: `5 -> 2`
+- source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- audio package ready: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- targeted quality repair sweep source validation에 candidate failure labeling preserved flag 3개 포함.
+- preserved flag false 입력은 validation error로 차단.
+- failure label은 `12 -> 8`, improved candidate는 `4 / 6`.
+- technical regression count는 `0`.
+- 다음 검증 대상은 targeted quality repair audio package 유지.
+- musical quality와 human/audio preference claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-sweep`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음:
+
+- `Stage B MIDI-to-solo targeted quality repair audio package source-context refresh`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -14,6 +14,9 @@
 - technical regression count: `0`
 - source outside-soloing repair evidence ready: `true`
 - source outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
 - source outside-soloing source objective pitch-role risk: `5`
 - source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - source outside-soloing source repair targeted: `false`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6212,7 +6212,7 @@ run_stage_b_midi_to_solo_targeted_quality_repair_sweep() {
     --candidate_failure_labeling "$labeling" \
     --rubric_baseline "$rubric" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1004 \
+    --issue_number 1088 \
     --expected_boundary stage_b_midi_to_solo_targeted_quality_repair_sweep \
     --min_candidate_count 6 \
     --require_sweep_completed \

--- a/scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
+++ b/scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
@@ -17,10 +17,10 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
-from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
-    BRIDGE_SOURCE_CONTEXT_KEYS,
-)
 from scripts.label_stage_b_midi_to_solo_candidate_failures import (  # noqa: E402
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+    BRIDGE_SOURCE_CONTEXT_KEYS,
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
     BOUNDARY as LABELING_BOUNDARY,
     REPAIR_NEXT_BOUNDARY as LABELING_NEXT_BOUNDARY,
     REPAIR_TARGET as LABELING_TARGET,
@@ -89,12 +89,19 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
 
 
 def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str, Any]:
-    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+    for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
         if key not in container or container[key] is None:
             raise StageBMidiToSoloTargetedQualityRepairSweepError(
                 f"{label} source-context field required: {key}"
             )
-    return {key: container[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS}
+    missing_preserved = [
+        key for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS if not bool(container.get(key))
+    ]
+    if missing_preserved:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            f"{label} source-context preserved field must be true: {missing_preserved}"
+        )
+    return {key: container[key] for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS}
 
 
 def validate_labeling_source(report: dict[str, Any]) -> dict[str, Any]:
@@ -414,7 +421,7 @@ def build_targeted_quality_repair_sweep_report(
             "repaired_outside_soloing_not_evaluable_count": _int(
                 not_evaluable_counts_after.get("outside_soloing_without_context", 0)
             ),
-            **{key: source_summary[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+            **{key: source_summary[key] for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
             "target_supported": target_supported,
         },
         "selected_next_target": {
@@ -436,6 +443,15 @@ def build_targeted_quality_repair_sweep_report(
             "audio_package_ready": target_supported,
             "source_outside_soloing_repair_source_context_preserved": bool(
                 source_summary["outside_soloing_repair_source_context_preserved"]
+            ),
+            "followup_objective_source_outside_soloing_source_context_preserved": bool(
+                source_summary["followup_objective_source_outside_soloing_source_context_preserved"]
+            ),
+            "followup_repair_sweep_source_outside_soloing_source_context_preserved": bool(
+                source_summary["followup_repair_sweep_source_outside_soloing_source_context_preserved"]
+            ),
+            "repair_sweep_source_outside_soloing_source_context_preserved": bool(
+                source_summary["repair_sweep_source_outside_soloing_source_context_preserved"]
             ),
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
@@ -562,7 +578,7 @@ def validate_targeted_quality_repair_sweep_report(
         ),
         **{
             key: aggregate.get(key)
-            for key in BRIDGE_SOURCE_CONTEXT_KEYS
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
         },
         "audio_package_ready": bool(readiness.get("audio_package_ready", False)),
         "human_audio_preference_claimed": bool(
@@ -597,6 +613,9 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- technical regression count: `{aggregate['technical_regression_count']}`",
         f"- source outside-soloing repair evidence ready: `{_bool_token(aggregate['source_outside_soloing_repair_evidence_ready'])}`",
         f"- source outside-soloing repair source context preserved: `{_bool_token(aggregate['source_outside_soloing_repair_source_context_preserved'])}`",
+        f"- follow-up objective source outside-soloing source context preserved: `{_bool_token(aggregate['followup_objective_source_outside_soloing_source_context_preserved'])}`",
+        f"- follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(aggregate['followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
+        f"- bridge repair sweep source outside-soloing source context preserved: `{_bool_token(aggregate['repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- source outside-soloing source objective pitch-role risk: `{aggregate['source_outside_soloing_repair_source_objective_pitch_role_risk_count']}`",
         f"- source outside-soloing source pitch-role risk before / after / delta: `{aggregate['source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{aggregate['source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{aggregate['source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- source outside-soloing source repair targeted: `{_bool_token(aggregate['source_outside_soloing_repair_source_targeted'])}`",

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pretty_midi
 
-from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_SOURCE_CONTEXT_KEYS
+from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
 from scripts.build_stage_b_midi_to_solo_mvp_delivery_package import BOUNDARY as DELIVERY_BOUNDARY
 from scripts.build_stage_b_midi_to_solo_quality_rubric_baseline import (
     build_quality_rubric_baseline_report,
@@ -22,6 +22,7 @@ from scripts.plan_stage_b_midi_to_solo_post_mvp_quality_iteration import (
 from scripts.run_stage_b_midi_to_solo_targeted_quality_repair_sweep import (
     BOUNDARY,
     NEXT_BOUNDARY,
+    SCHEMA_VERSION,
     StageBMidiToSoloTargetedQualityRepairSweepError,
     build_targeted_quality_repair_sweep_report,
     validate_targeted_quality_repair_sweep_report,
@@ -201,7 +202,7 @@ class StageBMidiToSoloTargetedQualityRepairSweepTest(unittest.TestCase):
                 candidate_failure_labeling=candidate_failure_labeling(root),
                 rubric_baseline=rubric_baseline(root),
                 output_dir=root / "sweep",
-                issue_number=750,
+                issue_number=1088,
             )
             summary = validate_targeted_quality_repair_sweep_report(
                 report,
@@ -212,6 +213,8 @@ class StageBMidiToSoloTargetedQualityRepairSweepTest(unittest.TestCase):
                 require_no_quality_claim=True,
             )
 
+            self.assertEqual(report["schema_version"], SCHEMA_VERSION)
+            self.assertEqual(report["issue_number"], 1088)
             self.assertTrue(summary["targeted_quality_repair_sweep_completed"])
             self.assertTrue(summary["targeted_quality_repair_target_supported"])
             self.assertEqual(summary["candidate_count"], 6)
@@ -236,7 +239,7 @@ class StageBMidiToSoloTargetedQualityRepairSweepTest(unittest.TestCase):
             self.assertEqual(summary["source_outside_soloing_repair_pitch_role_risk_delta"], 2)
             self.assertEqual(summary["source_outside_soloing_not_evaluable_count"], 6)
             self.assertEqual(summary["repaired_outside_soloing_not_evaluable_count"], 6)
-            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[key], SOURCE_CONTEXT[key])
             self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
             self.assertTrue(summary["audio_package_ready"])
@@ -258,7 +261,7 @@ class StageBMidiToSoloTargetedQualityRepairSweepTest(unittest.TestCase):
                     ),
                     rubric_baseline=rubric_baseline(root),
                     output_dir=root / "sweep",
-                    issue_number=750,
+                    issue_number=1088,
                 )
 
     def test_rejects_missing_outside_soloing_labeling_context(self) -> None:
@@ -271,7 +274,7 @@ class StageBMidiToSoloTargetedQualityRepairSweepTest(unittest.TestCase):
                     candidate_failure_labeling=source,
                     rubric_baseline=rubric_baseline(root),
                     output_dir=root / "sweep",
-                    issue_number=750,
+                    issue_number=1088,
                 )
 
     def test_rejects_missing_labeling_source_context_field(self) -> None:
@@ -286,12 +289,28 @@ class StageBMidiToSoloTargetedQualityRepairSweepTest(unittest.TestCase):
                     candidate_failure_labeling=source,
                     rubric_baseline=rubric_baseline(root),
                     output_dir=root / "sweep",
-                    issue_number=1004,
+                    issue_number=1088,
+                )
+
+    def test_rejects_false_labeling_source_context_preserved_field(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = candidate_failure_labeling(root)
+            source["aggregate"][
+                "followup_objective_source_outside_soloing_source_context_preserved"
+            ] = False
+            with self.assertRaises(StageBMidiToSoloTargetedQualityRepairSweepError):
+                build_targeted_quality_repair_sweep_report(
+                    candidate_failure_labeling=source,
+                    rubric_baseline=rubric_baseline(root),
+                    output_dir=root / "sweep",
+                    issue_number=1088,
                 )
 
     def test_constants_are_stable(self) -> None:
         self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_targeted_quality_repair_sweep")
         self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_targeted_quality_repair_audio_package")
+        self.assertEqual(SCHEMA_VERSION, "stage_b_midi_to_solo_targeted_quality_repair_sweep_v3")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary
- targeted quality repair sweep source-context validation 기준 갱신
- preserved flag 3개 aggregate/readiness/validation summary/markdown 전파
- #1088 기준 harness, README, current status, core plan 갱신

Context
- #1086 candidate failure labeling에서 source-context preserved flag 3개 전파 완료
- targeted quality repair sweep validation은 기존 source-context key만 확인
- audio package 이전 단계에서 preserved flag 누락 가능성 존재

Scope
- required source-context key 기준 validation
- preserved flag false 입력 차단 테스트
- failure label `12 -> 8`, improved candidate `4 / 6`, technical regression `0` 기록
- 다음 boundary `stage_b_midi_to_solo_targeted_quality_repair_audio_package` 유지

Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_sweep`
- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-sweep`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

Risk
- musical quality claim 제외
- human/audio preference claim 제외
- outside-soloing not-evaluable `6 / 6` 유지

Follow-up
- Stage B MIDI-to-solo targeted quality repair audio package source-context refresh

Closes #1088