### PR TITLE
Stage B MIDI-to-solo targeted quality repair audio package source context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Current handoff scope:
 - Latest quality rubric baseline completed: Issue #1084, Stage B MIDI-to-solo quality rubric baseline source-context refresh.
 - Latest candidate failure labeling completed: Issue #1086, Stage B MIDI-to-solo candidate failure labeling source-context refresh.
 - Latest targeted quality repair sweep completed: Issue #1088, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh.
-- Latest targeted quality repair audio package completed: Issue #1006, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh.
+- Latest targeted quality repair audio package completed: Issue #1090, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh.
 - Latest targeted quality repair listening review package completed: Issue #1008, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh.
 - Latest targeted quality repair listening review input guard completed: Issue #1010, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh.
 - Latest targeted quality repair objective-only next decision completed: Issue #1012, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1064, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after targeted quality repair sweep source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo targeted quality repair audio package source-context refresh.
+- Open issue queue after targeted quality repair audio package source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest quality rubric baseline: `Issue #1084`
 - latest candidate failure labeling: `Issue #1086`
 - latest targeted quality repair sweep: `Issue #1088`
-- latest targeted quality repair audio package: `Issue #1006`
+- latest targeted quality repair audio package: `Issue #1090`
 - latest targeted quality repair listening review package: `Issue #1008`
 - latest targeted quality repair listening review input guard: `Issue #1010`
 - latest targeted quality repair objective-only next decision: `Issue #1012`
@@ -50,7 +50,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1066`
 - latest README evidence refresh: `Issue #1068`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after targeted quality repair sweep source-context refresh merge: `0`
+- open issue queue after targeted quality repair audio package source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -290,6 +290,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - targeted quality repair audio WAV files: `6`
 - targeted quality repair audio WAV technical validation: `true`
 - targeted quality repair audio duration range: `18.422s - 18.984s`
+- targeted quality repair audio follow-up objective source outside-soloing source context preserved: `true`
+- targeted quality repair audio follow-up repair sweep source outside-soloing source context preserved: `true`
+- targeted quality repair audio bridge repair sweep source outside-soloing source context preserved: `true`
 - targeted quality repair listening review package ready: `true`
 - targeted quality repair listening review items: `6`
 - targeted quality repair validated review input: `false`
@@ -363,7 +366,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - final status bridge repair sweep source outside-soloing source context preserved: `true`
 - MVP delivery raw artifact upload required: `false`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -403,7 +403,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo quality rubric baseline: rubric items `8`, metric groups `30`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, candidate failure labeling ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_candidate_failure_labeling`
 - MIDI-to-solo candidate failure labeling: candidates `6`, failed `6`, failure label types `4`, not-evaluable types `2`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, targeted repair ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_sweep`
 - MIDI-to-solo targeted quality repair sweep: candidates `6`, failure labels `12 -> 8`, improved candidates `4`, technical regression `0`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
-- MIDI-to-solo targeted quality repair audio package: rendered WAV `6`, duration `18.422s-18.984s`, source risk `5 -> 2`, current repair risk after `0`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
+- MIDI-to-solo targeted quality repair audio package: rendered WAV `6`, duration `18.422s-18.984s`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
 - MIDI-to-solo targeted quality repair listening review package: review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after `0`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
 - MIDI-to-solo targeted quality repair listening review input guard: review items `6`, preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
 - MIDI-to-solo targeted quality repair objective-only next decision: follow-up required `true`, current quality claim ready `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
@@ -12496,6 +12496,62 @@ Issue #1088은 Issue #1086 candidate failure labeling 결과를 기준으로 tar
 다음 작업:
 
 - `Stage B MIDI-to-solo targeted quality repair audio package source-context refresh`
+
+## 9.235 Stage B MIDI-to-solo targeted quality repair audio package source-context refresh
+
+Issue #1090은 Issue #1088 targeted quality repair sweep 결과를 기준으로 targeted quality repair audio package의 source-context validation과 summary에 source-context preserved flag 3개를 보존한 작업이다.
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
+- targeted quality repair audio package completed: `true`
+- render attempted: `true`
+- rendered audio file count: `6`
+- technical WAV validation: `true`
+- sample rate: `44100`
+- duration range: `18.422s-18.984s`
+- source total failure label count: `12`
+- repaired total failure label count: `8`
+- failure label delta: `4`
+- improved candidate count: `4`
+- technical regression count: `0`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
+- source outside-soloing source pitch-role risk: `5 -> 2`
+- source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- audio review required: `true`
+- human/audio preference claimed: `false`
+- audio rendered quality claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- audio package source validation에 targeted repair sweep preserved flag 3개 포함.
+- preserved flag false 입력은 validation error로 차단.
+- rendered WAV 6개 technical metadata 검증 완료.
+- 청음 preference와 rendered audio quality claim 제외 유지.
+- 다음 검증 대상은 targeted quality repair listening review package 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_audio`
+- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_targeted_quality_repair_audio.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-audio-package`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -23,7 +23,7 @@
 - latest quality rubric baseline: Issue #1084, Stage B MIDI-to-solo quality rubric baseline source-context refresh
 - latest candidate failure labeling: Issue #1086, Stage B MIDI-to-solo candidate failure labeling source-context refresh
 - latest targeted quality repair sweep: Issue #1088, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh
-- latest targeted quality repair audio package: Issue #1006, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh
+- latest targeted quality repair audio package: Issue #1090, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh
 - latest targeted quality repair listening review package: Issue #1008, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh
 - latest targeted quality repair listening review input guard: Issue #1010, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh
 - latest targeted quality repair objective-only next decision: Issue #1012, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after targeted quality repair sweep source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair audio package source-context refresh`
+- open issue queue after targeted quality repair audio package source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -1136,6 +1136,9 @@
 - render attempted: `true`
 - rendered audio file count: `6`
 - technical WAV validation: `true`
+- targeted quality repair audio follow-up objective source outside-soloing source context preserved: `true`
+- targeted quality repair audio follow-up repair sweep source outside-soloing source context preserved: `true`
+- targeted quality repair audio bridge repair sweep source outside-soloing source context preserved: `true`
 - sample rate: `44100`
 - duration range: `18.422s - 18.984s`
 - source total failure label count: `12`
@@ -5641,6 +5644,62 @@ Issue #1088은 Issue #1086 candidate failure labeling 결과를 기준으로 tar
 다음:
 
 - `Stage B MIDI-to-solo targeted quality repair audio package source-context refresh`
+
+## 9.235 Stage B MIDI-to-solo targeted quality repair audio package source-context refresh
+
+Issue #1090은 Issue #1088 targeted quality repair sweep 결과를 기준으로 targeted quality repair audio package의 source-context validation과 summary에 source-context preserved flag 3개를 보존한 작업이다.
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
+- targeted quality repair audio package completed: `true`
+- render attempted: `true`
+- rendered audio file count: `6`
+- technical WAV validation: `true`
+- sample rate: `44100`
+- duration range: `18.422s-18.984s`
+- source total failure label count: `12`
+- repaired total failure label count: `8`
+- failure label delta: `4`
+- improved candidate count: `4`
+- technical regression count: `0`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
+- source outside-soloing source pitch-role risk: `5 -> 2`
+- source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- audio review required: `true`
+- human/audio preference claimed: `false`
+- audio rendered quality claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- audio package source validation에 targeted repair sweep preserved flag 3개 포함.
+- preserved flag false 입력은 validation error로 차단.
+- rendered WAV 6개 technical metadata 검증 완료.
+- 청음 preference와 rendered audio quality claim 제외 유지.
+- 다음 검증 대상은 targeted quality repair listening review package 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_audio`
+- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_targeted_quality_repair_audio.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-audio-package`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음:
+
+- `Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -14,6 +14,9 @@
 - technical regression count: `0`
 - source outside-soloing repair evidence ready: `true`
 - source outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
 - source outside-soloing source objective pitch-role risk: `5`
 - source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - source outside-soloing source repair targeted: `false`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6233,7 +6233,7 @@ run_stage_b_midi_to_solo_targeted_quality_repair_audio_package() {
     --run_id "$run_id" \
     --targeted_quality_repair_sweep_report "$repair_sweep_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1006 \
+    --issue_number 1090 \
     --expected_boundary stage_b_midi_to_solo_targeted_quality_repair_audio_package \
     --expected_next_boundary stage_b_midi_to_solo_targeted_quality_repair_listening_review_package \
     --expected_file_count 6 \

--- a/scripts/render_stage_b_midi_to_solo_targeted_quality_repair_audio.py
+++ b/scripts/render_stage_b_midi_to_solo_targeted_quality_repair_audio.py
@@ -16,15 +16,14 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
-from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
-    BRIDGE_SOURCE_CONTEXT_KEYS,
-)
 from scripts.render_stage_b_midi_to_solo_candidate_audio import (  # noqa: E402
     resolve_soundfont,
     sha256_file,
     wav_meta,
 )
 from scripts.run_stage_b_midi_to_solo_targeted_quality_repair_sweep import (  # noqa: E402
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
     BOUNDARY as SOURCE_BOUNDARY,
     NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
     StageBMidiToSoloTargetedQualityRepairSweepError,
@@ -38,7 +37,7 @@ class StageBMidiToSoloTargetedQualityRepairAudioError(ValueError):
 
 BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_audio_package"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_listening_review_package"
-SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_audio_package_v3"
+SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_audio_package_v4"
 CommandRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
 
 QUALITY_CLAIM_KEYS = [
@@ -93,12 +92,19 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
 
 
 def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str, Any]:
-    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+    for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
         if key not in container or container[key] is None:
             raise StageBMidiToSoloTargetedQualityRepairAudioError(
                 f"{label} source-context field required: {key}"
             )
-    return {key: container[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS}
+    missing_preserved = [
+        key for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS if not bool(container.get(key))
+    ]
+    if missing_preserved:
+        raise StageBMidiToSoloTargetedQualityRepairAudioError(
+            f"{label} source-context preserved field must be true: {missing_preserved}"
+        )
+    return {key: container[key] for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS}
 
 
 def validate_source_report(
@@ -343,7 +349,7 @@ def build_audio_render_report(
     soundfont_path: str,
     sample_rate: int,
     expected_file_count: int,
-    issue_number: int = 752,
+    issue_number: int = 1090,
     runner: CommandRunner = default_runner,
 ) -> dict[str, Any]:
     candidates = validate_source_report(source_report, expected_count=expected_file_count)
@@ -436,7 +442,7 @@ def build_audio_render_report(
             "repaired_outside_soloing_not_evaluable_count": _int(
                 aggregate.get("repaired_outside_soloing_not_evaluable_count")
             ),
-            **{key: aggregate.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+            **{key: aggregate.get(key) for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
             "remaining_failure_counts": dict(sorted(failure_counts.items())),
             "audio_review_required": True,
         },
@@ -585,7 +591,7 @@ def validate_audio_render_report(
         ),
         **{
             key: summary.get(key)
-            for key in BRIDGE_SOURCE_CONTEXT_KEYS
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
         },
         "audio_review_required": bool(summary.get("audio_review_required", False)),
         "audio_rendered_quality_claimed": bool(boundary.get("audio_rendered_quality_claimed", True)),
@@ -620,6 +626,9 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- technical regression count: `{summary['technical_regression_count']}`",
         f"- source outside-soloing repair evidence ready: `{_bool_token(summary['source_outside_soloing_repair_evidence_ready'])}`",
         f"- source outside-soloing repair source context preserved: `{_bool_token(summary['source_outside_soloing_repair_source_context_preserved'])}`",
+        f"- follow-up objective source outside-soloing source context preserved: `{_bool_token(summary['followup_objective_source_outside_soloing_source_context_preserved'])}`",
+        f"- follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(summary['followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
+        f"- bridge repair sweep source outside-soloing source context preserved: `{_bool_token(summary['repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- source outside-soloing source objective pitch-role risk: `{summary['source_outside_soloing_repair_source_objective_pitch_role_risk_count']}`",
         f"- source outside-soloing source pitch-role risk before / after / delta: `{summary['source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{summary['source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{summary['source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- source outside-soloing source repair targeted: `{_bool_token(summary['source_outside_soloing_repair_source_targeted'])}`",
@@ -668,7 +677,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=752)
+    parser.add_argument("--issue_number", type=int, default=1090)
     parser.add_argument("--renderer", type=str, default=shutil.which("fluidsynth") or "")
     parser.add_argument("--soundfont", type=str, default="")
     parser.add_argument("--sample_rate", type=int, default=44100)

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_audio.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_audio.py
@@ -9,10 +9,11 @@ from typing import Sequence
 
 import pretty_midi
 
-from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_SOURCE_CONTEXT_KEYS
+from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
 from scripts.render_stage_b_midi_to_solo_targeted_quality_repair_audio import (
     BOUNDARY,
     NEXT_BOUNDARY,
+    SCHEMA_VERSION,
     StageBMidiToSoloTargetedQualityRepairAudioError,
     build_audio_render_report,
     validate_audio_render_report,
@@ -29,6 +30,7 @@ SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
     "followup_objective_source_outside_soloing_source_targeted": False,
     "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_objective_source_outside_soloing_source_context_preserved": True,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
@@ -36,6 +38,7 @@ SOURCE_CONTEXT = {
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
     "followup_repair_sweep_source_outside_soloing_source_targeted": False,
     "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_source_context_preserved": True,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
@@ -43,6 +46,7 @@ SOURCE_CONTEXT = {
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
     "repair_sweep_source_outside_soloing_source_targeted": False,
     "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "repair_sweep_source_outside_soloing_source_context_preserved": True,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
 }
@@ -176,6 +180,7 @@ class StageBMidiToSoloTargetedQualityRepairAudioTest(unittest.TestCase):
                 soundfont_path=str(soundfont),
                 sample_rate=44100,
                 expected_file_count=6,
+                issue_number=1090,
                 runner=fake_runner,
             )
             summary = validate_audio_render_report(
@@ -188,6 +193,8 @@ class StageBMidiToSoloTargetedQualityRepairAudioTest(unittest.TestCase):
                 require_no_quality_claim=True,
             )
 
+            self.assertEqual(report["schema_version"], SCHEMA_VERSION)
+            self.assertEqual(report["issue_number"], 1090)
             self.assertTrue(summary["targeted_quality_repair_audio_package_completed"])
             self.assertEqual(summary["rendered_audio_file_count"], 6)
             self.assertTrue(summary["technical_wav_validation"])
@@ -212,7 +219,7 @@ class StageBMidiToSoloTargetedQualityRepairAudioTest(unittest.TestCase):
             self.assertEqual(summary["source_outside_soloing_repair_pitch_role_risk_delta"], 2)
             self.assertEqual(summary["source_outside_soloing_not_evaluable_count"], 6)
             self.assertEqual(summary["repaired_outside_soloing_not_evaluable_count"], 6)
-            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[key], SOURCE_CONTEXT[key])
             self.assertTrue(summary["audio_review_required"])
             self.assertFalse(summary["human_audio_preference_claimed"])
@@ -282,9 +289,36 @@ class StageBMidiToSoloTargetedQualityRepairAudioTest(unittest.TestCase):
                     runner=fake_runner,
                 )
 
+    def test_rejects_false_source_context_preserved_field(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = root / "fluidsynth"
+            soundfont = root / "soundfont.sf2"
+            renderer.write_text("#!/bin/sh\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            source = source_report(root)
+            source["aggregate"][
+                "followup_repair_sweep_source_outside_soloing_source_context_preserved"
+            ] = False
+            with self.assertRaises(StageBMidiToSoloTargetedQualityRepairAudioError):
+                build_audio_render_report(
+                    source,
+                    output_dir=root / "audio_package",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(soundfont),
+                    sample_rate=44100,
+                    expected_file_count=6,
+                    issue_number=1090,
+                    runner=fake_runner,
+                )
+
     def test_constants_are_stable(self) -> None:
         self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_targeted_quality_repair_audio_package")
         self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_targeted_quality_repair_listening_review_package")
+        self.assertEqual(
+            SCHEMA_VERSION,
+            "stage_b_midi_to_solo_targeted_quality_repair_audio_package_v4",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary
- targeted quality repair audio package source-context validation 기준 갱신
- preserved flag 3개 summary/validation summary/markdown 전파
- #1090 기준 harness, README, current status, core plan 갱신

Context
- #1088 targeted quality repair sweep에서 preserved flag 3개 전파 완료
- audio package는 기존 source-context key만 전달
- listening review package 이전 단계에서 preserved flag 누락 가능성 존재

Scope
- required source-context key 기준 validation
- preserved flag false 입력 차단 테스트
- rendered WAV `6`, duration `18.422s-18.984s`, technical validation `true` 기록
- 다음 boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package` 유지

Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_audio`
- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_targeted_quality_repair_audio.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-audio-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

Risk
- audio rendered quality claim 제외
- human/audio preference claim 제외
- MIDI-to-solo musical quality claim 제외
- outside-soloing not-evaluable `6 / 6` 유지

Follow-up
- Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh

Closes #1090