### PR TITLE
Stage B MIDI-to-solo targeted quality repair listening review input guard source context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Current handoff scope:
 - Latest targeted quality repair sweep completed: Issue #1088, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh.
 - Latest targeted quality repair audio package completed: Issue #1090, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh.
 - Latest targeted quality repair listening review package completed: Issue #1092, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh.
-- Latest targeted quality repair listening review input guard completed: Issue #1010, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh.
+- Latest targeted quality repair listening review input guard completed: Issue #1094, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh.
 - Latest targeted quality repair objective-only next decision completed: Issue #1012, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh.
 - Latest targeted quality repair follow-up decision completed: Issue #1014, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh.
 - Latest songlike melody contour repair sweep completed: Issue #1016, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1064, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after targeted quality repair listening review package source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh.
+- Open issue queue after targeted quality repair listening review input guard source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest targeted quality repair sweep: `Issue #1088`
 - latest targeted quality repair audio package: `Issue #1090`
 - latest targeted quality repair listening review package: `Issue #1092`
-- latest targeted quality repair listening review input guard: `Issue #1010`
+- latest targeted quality repair listening review input guard: `Issue #1094`
 - latest targeted quality repair objective-only next decision: `Issue #1012`
 - latest targeted quality repair follow-up decision: `Issue #1014`
 - latest songlike melody contour repair sweep: `Issue #1016`
@@ -50,7 +50,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1066`
 - latest README evidence refresh: `Issue #1068`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after targeted quality repair listening review package source-context refresh merge: `0`
+- open issue queue after targeted quality repair listening review input guard source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -300,6 +300,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - targeted quality repair listening bridge repair sweep source outside-soloing source context preserved: `true`
 - targeted quality repair validated review input: `false`
 - targeted quality repair listening review input guard completed: `true`
+- targeted quality repair input guard follow-up objective source outside-soloing source context preserved: `true`
+- targeted quality repair input guard follow-up repair sweep source outside-soloing source context preserved: `true`
+- targeted quality repair input guard bridge repair sweep source outside-soloing source context preserved: `true`
 - targeted quality repair preference fill allowed: `false`
 - targeted quality repair objective-only next decision completed: `true`
 - targeted quality repair follow-up required: `true`
@@ -369,7 +372,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - final status bridge repair sweep source outside-soloing source context preserved: `true`
 - MVP delivery raw artifact upload required: `false`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -405,7 +405,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo targeted quality repair sweep: candidates `6`, failure labels `12 -> 8`, improved candidates `4`, technical regression `0`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
 - MIDI-to-solo targeted quality repair audio package: rendered WAV `6`, duration `18.422s-18.984s`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
 - MIDI-to-solo targeted quality repair listening review package: review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
-- MIDI-to-solo targeted quality repair listening review input guard: review items `6`, preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
+- MIDI-to-solo targeted quality repair listening review input guard: review items `6`, preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
 - MIDI-to-solo targeted quality repair objective-only next decision: follow-up required `true`, current quality claim ready `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
 - MIDI-to-solo targeted quality repair follow-up decision: selected target `songlike_melody_contour_repair_sweep`, dominant label/count `songlike_melody_not_soloing/5`, objective and repair sweep source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
 - MIDI-to-solo songlike melody contour repair sweep: songlike failure `5 -> 0`, total failure labels `8 -> 4`, source risk `5 -> 2`, current repair risk after/delta `0/2`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
@@ -12604,6 +12604,58 @@ Issue #1092는 Issue #1090 targeted quality repair audio package 결과를 기�
 다음 작업:
 
 - `Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh`
+
+## 9.237 Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh
+
+Issue #1094는 Issue #1092 targeted quality repair listening review package 결과를 기준으로 listening review input guard의 source-context validation과 summary에 source-context preserved flag 3개를 보존한 작업이다.
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_LISTENING_REVIEW_INPUT_GUARD_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- duration range: `18.422s-18.984s`
+- failure label delta: `4`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
+- source outside-soloing source pitch-role risk: `5 -> 2`
+- source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- audio review required: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- input guard source validation에 listening review package preserved flag 3개 포함.
+- preserved flag false 입력은 validation error로 차단.
+- validated review input은 false, preference fill은 false.
+- 다음 검증 대상은 objective-only next decision 유지.
+- human/audio preference와 musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
+- `.venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-listening-review-input-guard`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -25,7 +25,7 @@
 - latest targeted quality repair sweep: Issue #1088, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh
 - latest targeted quality repair audio package: Issue #1090, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh
 - latest targeted quality repair listening review package: Issue #1092, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh
-- latest targeted quality repair listening review input guard: Issue #1010, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh
+- latest targeted quality repair listening review input guard: Issue #1094, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh
 - latest targeted quality repair objective-only next decision: Issue #1012, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh
 - latest targeted quality repair follow-up decision: Issue #1014, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh
 - latest songlike melody contour repair sweep: Issue #1016, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after targeted quality repair listening review package source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh`
+- open issue queue after targeted quality repair listening review input guard source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -1200,6 +1200,9 @@
 - duration range: `18.422s - 18.984s`
 - failure label delta: `4`
 - source outside-soloing repair evidence ready: `true`
+- targeted quality repair input guard follow-up objective source outside-soloing source context preserved: `true`
+- targeted quality repair input guard follow-up repair sweep source outside-soloing source context preserved: `true`
+- targeted quality repair input guard bridge repair sweep source outside-soloing source context preserved: `true`
 - source outside-soloing repair WAV count: `6`
 - source outside-soloing source objective pitch-role risk count: `5`
 - source outside-soloing source pitch-role risk count: `5 -> 2`
@@ -5755,6 +5758,58 @@ Issue #1092는 Issue #1090 targeted quality repair audio package 결과를 기�
 다음:
 
 - `Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh`
+
+## 9.237 Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh
+
+Issue #1094는 Issue #1092 targeted quality repair listening review package 결과를 기준으로 listening review input guard의 source-context validation과 summary에 source-context preserved flag 3개를 보존한 작업이다.
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_LISTENING_REVIEW_INPUT_GUARD_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- duration range: `18.422s-18.984s`
+- failure label delta: `4`
+- source outside-soloing repair evidence ready: `true`
+- source outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
+- source outside-soloing source pitch-role risk: `5 -> 2`
+- source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- audio review required: `true`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- input guard source validation에 listening review package preserved flag 3개 포함.
+- preserved flag false 입력은 validation error로 차단.
+- validated review input은 false, preference fill은 false.
+- 다음 검증 대상은 objective-only next decision 유지.
+- human/audio preference와 musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
+- `.venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-listening-review-input-guard`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음:
+
+- `Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_LISTENING_REVIEW_INPUT_GUARD_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_LISTENING_REVIEW_INPUT_GUARD_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -15,6 +15,9 @@
 - failure label delta: `4`
 - source outside-soloing repair evidence ready: `true`
 - source outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
 - source outside-soloing repair WAV count: `6`
 - source outside-soloing source objective pitch-role risk: `5`
 - source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6276,7 +6276,7 @@ run_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard() 
     --run_id "$guard_run_id" \
     --source_package "$source_package" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_LISTENING_REVIEW_INPUT_GUARD_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1010 \
+    --issue_number 1094 \
     --expected_boundary stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard \
     --expected_next_boundary stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision \
     --require_guard_completed \

--- a/scripts/guard_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input.py
+++ b/scripts/guard_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input.py
@@ -13,10 +13,9 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
-from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
-    BRIDGE_SOURCE_CONTEXT_KEYS,
-)
 from scripts.build_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package import (  # noqa: E402
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
     BOUNDARY as SOURCE_BOUNDARY,
     NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
 )
@@ -31,7 +30,7 @@ FILL_BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_listening_review_f
 OBJECTIVE_NEXT_BOUNDARY = (
     "stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision"
 )
-SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard_v3"
+SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard_v4"
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -81,12 +80,19 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
 
 
 def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str, Any]:
-    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+    for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
         if key not in container or container[key] is None:
             raise StageBMidiToSoloTargetedQualityRepairListeningInputGuardError(
                 f"{label} source-context field required: {key}"
             )
-    return {key: container[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS}
+    missing_preserved = [
+        key for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS if not bool(container.get(key))
+    ]
+    if missing_preserved:
+        raise StageBMidiToSoloTargetedQualityRepairListeningInputGuardError(
+            f"{label} source-context preserved field must be true: {missing_preserved}"
+        )
+    return {key: container[key] for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS}
 
 
 def validate_source_package(report: dict[str, Any]) -> dict[str, Any]:
@@ -423,7 +429,7 @@ def validate_listening_review_input_guard_report(
             source.get("repaired_outside_soloing_not_evaluable_count")
         ),
         "audio_review_required": bool(source.get("audio_review_required", False)),
-        **{key: source.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{key: source.get(key) for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
         "human_audio_preference_claimed": bool(
             readiness.get("human_audio_preference_claimed", True)
         ),
@@ -460,6 +466,9 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- failure label delta: `{source['failure_label_delta']}`",
         f"- source outside-soloing repair evidence ready: `{_bool_token(source['source_outside_soloing_repair_evidence_ready'])}`",
         f"- source outside-soloing repair source context preserved: `{_bool_token(source['source_outside_soloing_repair_source_context_preserved'])}`",
+        f"- follow-up objective source outside-soloing source context preserved: `{_bool_token(source['followup_objective_source_outside_soloing_source_context_preserved'])}`",
+        f"- follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(source['followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
+        f"- bridge repair sweep source outside-soloing source context preserved: `{_bool_token(source['repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- source outside-soloing repair WAV count: `{source['source_outside_soloing_repair_wav_count']}`",
         f"- source outside-soloing source objective pitch-role risk: `{source['source_outside_soloing_repair_source_objective_pitch_role_risk_count']}`",
         f"- source outside-soloing source pitch-role risk before / after / delta: `{source['source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{source['source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{source['source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
@@ -512,7 +521,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=926)
+    parser.add_argument("--issue_number", type=int, default=1094)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--require_guard_completed", action="store_true")

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard.py
@@ -4,7 +4,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_SOURCE_CONTEXT_KEYS
+from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
 from scripts.build_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package import (
     BOUNDARY as SOURCE_BOUNDARY,
     NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
@@ -12,6 +12,7 @@ from scripts.build_stage_b_midi_to_solo_targeted_quality_repair_listening_review
 from scripts.guard_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input import (
     BOUNDARY,
     OBJECTIVE_NEXT_BOUNDARY,
+    SCHEMA_VERSION,
     StageBMidiToSoloTargetedQualityRepairListeningInputGuardError,
     build_listening_review_input_guard_report,
     validate_listening_review_input_guard_report,
@@ -24,6 +25,7 @@ SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
     "followup_objective_source_outside_soloing_source_targeted": False,
     "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_objective_source_outside_soloing_source_context_preserved": True,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
@@ -31,6 +33,7 @@ SOURCE_CONTEXT = {
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
     "followup_repair_sweep_source_outside_soloing_source_targeted": False,
     "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_source_context_preserved": True,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
@@ -38,6 +41,7 @@ SOURCE_CONTEXT = {
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
     "repair_sweep_source_outside_soloing_source_targeted": False,
     "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "repair_sweep_source_outside_soloing_source_context_preserved": True,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
 }
@@ -128,7 +132,7 @@ class StageBMidiToSoloTargetedQualityRepairListeningInputGuardTest(unittest.Test
             report = build_listening_review_input_guard_report(
                 source_package(),
                 output_dir=root / "guard",
-                issue_number=756,
+                issue_number=1094,
             )
             summary = validate_listening_review_input_guard_report(
                 report,
@@ -140,6 +144,8 @@ class StageBMidiToSoloTargetedQualityRepairListeningInputGuardTest(unittest.Test
                 require_no_quality_claim=True,
             )
 
+            self.assertEqual(report["schema_version"], SCHEMA_VERSION)
+            self.assertEqual(report["issue_number"], 1094)
             self.assertTrue(summary["technical_wav_validation"])
             self.assertFalse(summary["validated_review_input_present"])
             self.assertFalse(summary["preference_fill_allowed"])
@@ -148,7 +154,7 @@ class StageBMidiToSoloTargetedQualityRepairListeningInputGuardTest(unittest.Test
             self.assertEqual(summary["failure_label_delta"], 4)
             self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
             self.assertTrue(summary["source_outside_soloing_repair_source_context_preserved"])
-            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[key], SOURCE_CONTEXT[key])
             self.assertEqual(summary["source_outside_soloing_repair_wav_count"], 6)
             self.assertEqual(
@@ -181,7 +187,7 @@ class StageBMidiToSoloTargetedQualityRepairListeningInputGuardTest(unittest.Test
                 build_listening_review_input_guard_report(
                     source_package(quality_claim=True),
                     output_dir=root / "guard",
-                    issue_number=756,
+                    issue_number=1094,
                 )
 
     def test_rejects_missing_outside_soloing_context(self) -> None:
@@ -193,7 +199,7 @@ class StageBMidiToSoloTargetedQualityRepairListeningInputGuardTest(unittest.Test
                 build_listening_review_input_guard_report(
                     source,
                     output_dir=root / "guard",
-                    issue_number=840,
+                    issue_number=1094,
                 )
 
     def test_rejects_source_risk_delta_mismatch(self) -> None:
@@ -205,7 +211,7 @@ class StageBMidiToSoloTargetedQualityRepairListeningInputGuardTest(unittest.Test
                 build_listening_review_input_guard_report(
                     source,
                     output_dir=root / "guard",
-                    issue_number=926,
+                    issue_number=1094,
                 )
 
     def test_rejects_missing_source_context_field(self) -> None:
@@ -219,12 +225,30 @@ class StageBMidiToSoloTargetedQualityRepairListeningInputGuardTest(unittest.Test
                 build_listening_review_input_guard_report(
                     source,
                     output_dir=root / "guard",
-                    issue_number=1010,
+                    issue_number=1094,
+                )
+
+    def test_rejects_false_source_context_preserved_field(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = source_package()
+            source["source_summary"][
+                "followup_objective_source_outside_soloing_source_context_preserved"
+            ] = False
+            with self.assertRaises(StageBMidiToSoloTargetedQualityRepairListeningInputGuardError):
+                build_listening_review_input_guard_report(
+                    source,
+                    output_dir=root / "guard",
+                    issue_number=1094,
                 )
 
     def test_constants_are_stable(self) -> None:
         self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard")
         self.assertEqual(OBJECTIVE_NEXT_BOUNDARY, "stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision")
+        self.assertEqual(
+            SCHEMA_VERSION,
+            "stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard_v4",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary
- targeted quality repair listening review input guard source-context validation 기준 갱신
- preserved flag 3개 guard summary/validation summary/markdown 전파
- #1094 기준 harness, README, current status, core plan 갱신

Context
- #1092 listening review package에서 preserved flag 3개 전파 완료
- input guard는 기존 source-context key만 전달
- objective-only next decision 이전 단계에서 preserved flag 누락 가능성 존재

Scope
- required source-context key 기준 validation
- preserved flag false 입력 차단 테스트
- preference fill `false`, validated review input `false`, next boundary objective-only decision 기록

Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
- `.venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_targeted_quality_repair_listening_review_input.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-listening-review-input-guard`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

Risk
- validated review input claim 제외
- human/audio preference claim 제외
- MIDI-to-solo musical quality claim 제외
- outside-soloing not-evaluable `6 / 6` 유지

Follow-up
- Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh

Closes #1094