### PR TITLE
Stage B MIDI-to-solo targeted quality repair follow-up decision source context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Current handoff scope:
 - Latest targeted quality repair listening review package completed: Issue #1092, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh.
 - Latest targeted quality repair listening review input guard completed: Issue #1094, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh.
 - Latest targeted quality repair objective-only next decision completed: Issue #1096, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh.
-- Latest targeted quality repair follow-up decision completed: Issue #1014, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh.
+- Latest targeted quality repair follow-up decision completed: Issue #1098, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh.
 - Latest songlike melody contour repair sweep completed: Issue #1016, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh.
 - Latest songlike melody contour repair audio package completed: Issue #1018, Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh.
 - Latest songlike melody contour repair listening review package completed: Issue #1020, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1064, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after targeted quality repair objective-only next decision source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh.
+- Open issue queue after targeted quality repair follow-up decision source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest targeted quality repair listening review package: `Issue #1092`
 - latest targeted quality repair listening review input guard: `Issue #1094`
 - latest targeted quality repair objective-only next decision: `Issue #1096`
-- latest targeted quality repair follow-up decision: `Issue #1014`
+- latest targeted quality repair follow-up decision: `Issue #1098`
 - latest songlike melody contour repair sweep: `Issue #1016`
 - latest songlike melody contour repair audio package: `Issue #1018`
 - latest songlike melody contour repair listening review package: `Issue #1020`
@@ -310,6 +310,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - targeted quality repair objective next bridge repair sweep source outside-soloing source context preserved: `true`
 - targeted quality repair follow-up required: `true`
 - targeted quality repair follow-up decision completed: `true`
+- targeted quality repair follow-up objective source outside-soloing source context preserved: `true`
+- targeted quality repair follow-up repair sweep source outside-soloing source context preserved: `true`
+- targeted quality repair follow-up bridge repair sweep source outside-soloing source context preserved: `true`
 - targeted quality repair selected next target: `songlike_melody_contour_repair_sweep`
 - targeted quality repair source risk: `5 -> 2`
 - targeted quality repair current risk after / delta: `0 / 2`
@@ -375,7 +378,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - final status bridge repair sweep source outside-soloing source context preserved: `true`
 - MVP delivery raw artifact upload required: `false`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -407,7 +407,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo targeted quality repair listening review package: review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
 - MIDI-to-solo targeted quality repair listening review input guard: review items `6`, preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
 - MIDI-to-solo targeted quality repair objective-only next decision: follow-up required `true`, current quality claim ready `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
-- MIDI-to-solo targeted quality repair follow-up decision: selected target `songlike_melody_contour_repair_sweep`, dominant label/count `songlike_melody_not_soloing/5`, objective and repair sweep source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- MIDI-to-solo targeted quality repair follow-up decision: selected target `songlike_melody_contour_repair_sweep`, dominant label/count `songlike_melody_not_soloing/5`, objective and repair sweep source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
 - MIDI-to-solo songlike melody contour repair sweep: songlike failure `5 -> 0`, total failure labels `8 -> 4`, source risk `5 -> 2`, current repair risk after/delta `0/2`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
 - MIDI-to-solo songlike melody contour repair audio package: rendered WAV `6`, duration `18.849s-18.992s`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
 - MIDI-to-solo songlike melody contour repair listening review package: review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
@@ -12710,6 +12710,58 @@ Issue #1096은 Issue #1094 targeted quality repair listening review input guard 
 다음 작업:
 
 - `Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh`
+
+## 9.239 Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh
+
+Issue #1098은 Issue #1096 targeted quality repair objective-only next decision 결과를 기준으로 follow-up decision의 source-context validation과 summary에 source-context preserved flag 3개를 보존한 작업이다.
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
+- repair sweep boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- selected target: `songlike_melody_contour_repair_sweep`
+- dominant remaining failure label/count: `songlike_melody_not_soloing` / `5`
+- candidate count: `6`
+- source total failure labels: `12`
+- repaired total failure labels: `8`
+- failure label delta: `4`
+- technical regression count: `0`
+- objective source outside-soloing repair evidence ready: `true`
+- objective source outside-soloing repair WAV count: `6`
+- objective source outside-soloing source context preserved: `true`
+- objective preserved source-context flags: `3 / 3`
+- repair sweep source outside-soloing repair evidence ready: `true`
+- repair sweep source outside-soloing source context preserved: `true`
+- repair sweep preserved source-context flags: `3 / 3`
+- objective and repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- objective and repair sweep current repair pitch-role risk after / delta: `0 / 2`
+- objective and repair sweep outside-soloing not evaluable count: `6 / 6`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- follow-up decision source validation에 objective next preserved flag 3개 포함.
+- repair sweep source validation에 targeted repair sweep preserved flag 3개 포함.
+- preserved flag false 입력은 validation error로 차단.
+- dominant remaining failure label 기준 songlike melody contour repair sweep 선택.
+- human/audio preference와 musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-followup-decision`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -27,7 +27,7 @@
 - latest targeted quality repair listening review package: Issue #1092, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh
 - latest targeted quality repair listening review input guard: Issue #1094, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh
 - latest targeted quality repair objective-only next decision: Issue #1096, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh
-- latest targeted quality repair follow-up decision: Issue #1014, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh
+- latest targeted quality repair follow-up decision: Issue #1098, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh
 - latest songlike melody contour repair sweep: Issue #1016, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh
 - latest songlike melody contour repair audio package: Issue #1018, Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh
 - latest songlike melody contour repair listening review package: Issue #1020, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after targeted quality repair objective-only next decision source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh`
+- open issue queue after targeted quality repair follow-up decision source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -1261,6 +1261,9 @@
 - objective source outside-soloing source pitch-role risk delta: `3`
 - objective source outside-soloing source repair targeted: `false`
 - objective source outside-soloing source residual risk preserved: `true`
+- objective follow-up objective source outside-soloing source context preserved: `true`
+- objective follow-up repair sweep source outside-soloing source context preserved: `true`
+- objective bridge repair sweep source outside-soloing source context preserved: `true`
 - objective source outside-soloing current repair pitch-role risk count after: `0`
 - objective source outside-soloing current repair pitch-role risk delta: `2`
 - objective source outside-soloing not evaluable count: `6`
@@ -1270,6 +1273,9 @@
 - repair sweep source outside-soloing source pitch-role risk delta: `3`
 - repair sweep source outside-soloing source repair targeted: `false`
 - repair sweep source outside-soloing source residual risk preserved: `true`
+- repair sweep follow-up objective source outside-soloing source context preserved: `true`
+- repair sweep follow-up repair sweep source outside-soloing source context preserved: `true`
+- repair sweep bridge repair sweep source outside-soloing source context preserved: `true`
 - repair sweep source outside-soloing current repair pitch-role risk count after: `0`
 - repair sweep source outside-soloing current repair pitch-role risk delta: `2`
 - repair sweep source outside-soloing not evaluable count: `6`
@@ -5867,6 +5873,58 @@ Issue #1096은 Issue #1094 targeted quality repair listening review input guard 
 다음:
 
 - `Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh`
+
+## 9.239 Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh
+
+Issue #1098은 Issue #1096 targeted quality repair objective-only next decision 결과를 기준으로 follow-up decision의 source-context validation과 summary에 source-context preserved flag 3개를 보존한 작업이다.
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- source boundary: `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
+- repair sweep boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- selected target: `songlike_melody_contour_repair_sweep`
+- dominant remaining failure label/count: `songlike_melody_not_soloing` / `5`
+- candidate count: `6`
+- source total failure labels: `12`
+- repaired total failure labels: `8`
+- failure label delta: `4`
+- technical regression count: `0`
+- objective source outside-soloing repair evidence ready: `true`
+- objective source outside-soloing repair WAV count: `6`
+- objective source outside-soloing source context preserved: `true`
+- objective preserved source-context flags: `3 / 3`
+- repair sweep source outside-soloing repair evidence ready: `true`
+- repair sweep source outside-soloing source context preserved: `true`
+- repair sweep preserved source-context flags: `3 / 3`
+- objective and repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- objective and repair sweep current repair pitch-role risk after / delta: `0 / 2`
+- objective and repair sweep outside-soloing not evaluable count: `6 / 6`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- follow-up decision source validation에 objective next preserved flag 3개 포함.
+- repair sweep source validation에 targeted repair sweep preserved flag 3개 포함.
+- preserved flag false 입력은 validation error로 차단.
+- dominant remaining failure label 기준 songlike melody contour repair sweep 선택.
+- human/audio preference와 musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-followup-decision`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음:
+
+- `Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -23,8 +23,11 @@
 - objective source outside-soloing source residual risk preserved: `true`
 - objective source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
 - objective follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- objective follow-up objective source outside-soloing source context preserved: `true`
 - objective follow-up objective current repair pitch-role risk after/delta: `0` / `2`
 - objective repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- objective follow-up repair sweep source outside-soloing source context preserved: `true`
+- objective bridge repair sweep source outside-soloing source context preserved: `true`
 - objective repair sweep current repair pitch-role risk after/delta: `0` / `2`
 - objective source outside-soloing not evaluable count: `6`
 - objective repaired outside-soloing not evaluable count: `6`
@@ -36,8 +39,11 @@
 - repair sweep source outside-soloing source residual risk preserved: `true`
 - repair sweep source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
 - repair sweep follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- repair sweep follow-up objective source outside-soloing source context preserved: `true`
 - repair sweep follow-up objective current repair pitch-role risk after/delta: `0` / `2`
 - repair sweep bridge source outside-soloing source pitch-role risk: `5 -> 2`
+- repair sweep follow-up repair sweep source outside-soloing source context preserved: `true`
+- repair sweep bridge source outside-soloing source context preserved: `true`
 - repair sweep bridge current repair pitch-role risk after/delta: `0` / `2`
 - repair sweep source outside-soloing not evaluable count: `6`
 - repair sweep repaired outside-soloing not evaluable count: `6`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6325,7 +6325,7 @@ run_stage_b_midi_to_solo_targeted_quality_repair_followup_decision() {
     --objective_next_report "$objective_report" \
     --repair_sweep_report "$sweep_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1014 \
+    --issue_number 1098 \
     --expected_boundary stage_b_midi_to_solo_targeted_quality_repair_followup_decision \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_sweep \
     --expected_target songlike_melody_contour_repair_sweep \

--- a/scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py
+++ b/scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py
@@ -15,7 +15,8 @@ sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
 from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
-    BRIDGE_SOURCE_CONTEXT_KEYS,
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
 )
 from scripts.decide_stage_b_midi_to_solo_targeted_quality_repair_objective_next import (  # noqa: E402
     BOUNDARY as OBJECTIVE_NEXT_BOUNDARY,
@@ -33,7 +34,7 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(ValueError):
 BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_followup_decision"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_sweep"
 SELECTED_TARGET = "songlike_melody_contour_repair_sweep"
-SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v3"
+SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v4"
 DOMINANT_TARGET_LABEL = "songlike_melody_not_soloing"
 
 QUALITY_CLAIM_KEYS = [
@@ -77,12 +78,19 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
 
 
 def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str, Any]:
-    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+    for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
         if key not in container or container[key] is None:
             raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
                 f"{label} source-context field required: {key}"
             )
-    return {key: container[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS}
+    missing_preserved = [
+        key for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS if not bool(container.get(key))
+    ]
+    if missing_preserved:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            f"{label} source-context preserved field must be true: {missing_preserved}"
+        )
+    return {key: container[key] for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS}
 
 
 def _extract_source_context(
@@ -473,7 +481,7 @@ def build_followup_decision_report(
             "objective_repaired_outside_soloing_not_evaluable_count": _int(
                 objective["repaired_outside_soloing_not_evaluable_count"]
             ),
-            **{f"objective_{key}": objective[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+            **{f"objective_{key}": objective[key] for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
             "repair_sweep_source_outside_soloing_repair_evidence_ready": bool(
                 sweep["source_outside_soloing_repair_evidence_ready"]
             ),
@@ -510,7 +518,7 @@ def build_followup_decision_report(
             "repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
                 sweep["repaired_outside_soloing_not_evaluable_count"]
             ),
-            **{f"repair_sweep_{key}": sweep[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+            **{f"repair_sweep_{key}": sweep[key] for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
             "human_audio_preference_claimed": False,
             "audio_rendered_quality_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
@@ -673,7 +681,7 @@ def validate_followup_decision_report(
         "objective_repaired_outside_soloing_not_evaluable_count": _int(
             readiness.get("objective_repaired_outside_soloing_not_evaluable_count")
         ),
-        **{f"objective_{key}": readiness.get(f"objective_{key}") for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{f"objective_{key}": readiness.get(f"objective_{key}") for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
         "repair_sweep_source_outside_soloing_repair_evidence_ready": bool(
             readiness.get("repair_sweep_source_outside_soloing_repair_evidence_ready", False)
         ),
@@ -719,7 +727,7 @@ def validate_followup_decision_report(
         "repair_sweep_repaired_outside_soloing_not_evaluable_count": _int(
             readiness.get("repair_sweep_repaired_outside_soloing_not_evaluable_count")
         ),
-        **{f"repair_sweep_{key}": readiness.get(f"repair_sweep_{key}") for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{f"repair_sweep_{key}": readiness.get(f"repair_sweep_{key}") for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
         "remaining_failure_counts": _dict(sweep.get("remaining_failure_counts")),
         "not_evaluable_counts": _dict(sweep.get("not_evaluable_counts")),
         "human_audio_preference_claimed": bool(
@@ -766,8 +774,11 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- objective source outside-soloing source residual risk preserved: `{_bool_token(readiness['objective_source_outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- objective source outside-soloing current repair pitch-role risk after / delta: `{readiness['objective_source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{readiness['objective_source_outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- objective follow-up objective source outside-soloing source pitch-role risk: `{readiness['objective_followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {readiness['objective_followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- objective follow-up objective source outside-soloing source context preserved: `{_bool_token(readiness['objective_followup_objective_source_outside_soloing_source_context_preserved'])}`",
         f"- objective follow-up objective current repair pitch-role risk after/delta: `{readiness['objective_followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{readiness['objective_followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- objective repair sweep source outside-soloing source pitch-role risk: `{readiness['objective_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {readiness['objective_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- objective follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(readiness['objective_followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
+        f"- objective bridge repair sweep source outside-soloing source context preserved: `{_bool_token(readiness['objective_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- objective repair sweep current repair pitch-role risk after/delta: `{readiness['objective_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{readiness['objective_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- objective source outside-soloing not evaluable count: `{readiness['objective_source_outside_soloing_not_evaluable_count']}`",
         f"- objective repaired outside-soloing not evaluable count: `{readiness['objective_repaired_outside_soloing_not_evaluable_count']}`",
@@ -779,8 +790,11 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- repair sweep source outside-soloing source residual risk preserved: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- repair sweep source outside-soloing current repair pitch-role risk after / delta: `{readiness['repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{readiness['repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- repair sweep follow-up objective source outside-soloing source pitch-role risk: `{readiness['repair_sweep_followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {readiness['repair_sweep_followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- repair sweep follow-up objective source outside-soloing source context preserved: `{_bool_token(readiness['repair_sweep_followup_objective_source_outside_soloing_source_context_preserved'])}`",
         f"- repair sweep follow-up objective current repair pitch-role risk after/delta: `{readiness['repair_sweep_followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{readiness['repair_sweep_followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- repair sweep bridge source outside-soloing source pitch-role risk: `{readiness['repair_sweep_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {readiness['repair_sweep_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- repair sweep follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(readiness['repair_sweep_followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
+        f"- repair sweep bridge source outside-soloing source context preserved: `{_bool_token(readiness['repair_sweep_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- repair sweep bridge current repair pitch-role risk after/delta: `{readiness['repair_sweep_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{readiness['repair_sweep_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- repair sweep source outside-soloing not evaluable count: `{readiness['repair_sweep_source_outside_soloing_not_evaluable_count']}`",
         f"- repair sweep repaired outside-soloing not evaluable count: `{readiness['repair_sweep_repaired_outside_soloing_not_evaluable_count']}`",
@@ -834,7 +848,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=930)
+    parser.add_argument("--issue_number", type=int, default=1098)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--expected_target", type=str, default="")

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision.py
@@ -4,11 +4,12 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_SOURCE_CONTEXT_KEYS
+from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
 from scripts.decide_stage_b_midi_to_solo_targeted_quality_repair_followup import (
     BOUNDARY,
     DOMINANT_TARGET_LABEL,
     NEXT_BOUNDARY,
+    SCHEMA_VERSION,
     SELECTED_TARGET,
     StageBMidiToSoloTargetedQualityRepairFollowupDecisionError,
     build_followup_decision_report,
@@ -28,6 +29,7 @@ SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
     "followup_objective_source_outside_soloing_source_targeted": False,
     "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_objective_source_outside_soloing_source_context_preserved": True,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
@@ -35,6 +37,7 @@ SOURCE_CONTEXT = {
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
     "followup_repair_sweep_source_outside_soloing_source_targeted": False,
     "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_source_context_preserved": True,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
@@ -42,6 +45,7 @@ SOURCE_CONTEXT = {
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
     "repair_sweep_source_outside_soloing_source_targeted": False,
     "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "repair_sweep_source_outside_soloing_source_context_preserved": True,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
 }
@@ -158,7 +162,7 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
                 objective_next_report=objective_next_report(),
                 repair_sweep_report=repair_sweep_report(),
                 output_dir=Path(tmp) / "followup",
-                issue_number=760,
+                issue_number=1098,
             )
             summary = validate_followup_decision_report(
                 report,
@@ -170,6 +174,8 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
                 require_no_quality_claim=True,
             )
 
+            self.assertEqual(report["schema_version"], SCHEMA_VERSION)
+            self.assertEqual(report["issue_number"], 1098)
             self.assertTrue(summary["followup_decision_completed"])
             self.assertTrue(summary["dominant_songlike_target_selected"])
             self.assertEqual(
@@ -184,7 +190,7 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
             self.assertTrue(
                 summary["objective_source_outside_soloing_repair_source_context_preserved"]
             )
-            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[f"objective_{key}"], SOURCE_CONTEXT[key])
             self.assertEqual(
                 summary[
@@ -223,7 +229,7 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
             self.assertTrue(
                 summary["repair_sweep_source_outside_soloing_repair_source_context_preserved"]
             )
-            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[f"repair_sweep_{key}"], SOURCE_CONTEXT[key])
             self.assertEqual(
                 summary[
@@ -279,7 +285,7 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
                     objective_next_report=objective_next_report(quality_claim=True),
                     repair_sweep_report=repair_sweep_report(),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=760,
+                    issue_number=1098,
                 )
 
     def test_rejects_technical_regression(self) -> None:
@@ -291,7 +297,7 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
                     objective_next_report=objective_next_report(),
                     repair_sweep_report=repair_sweep_report(technical_regression_count=1),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=760,
+                    issue_number=1098,
                 )
 
     def test_rejects_missing_objective_outside_soloing_context(self) -> None:
@@ -305,7 +311,7 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
                     objective_next_report=source,
                     repair_sweep_report=repair_sweep_report(),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=844,
+                    issue_number=1098,
                 )
 
     def test_rejects_missing_sweep_outside_soloing_context(self) -> None:
@@ -319,7 +325,7 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
                     objective_next_report=objective_next_report(),
                     repair_sweep_report=source,
                     output_dir=Path(tmp) / "followup",
-                    issue_number=844,
+                    issue_number=1098,
                 )
 
     def test_rejects_objective_source_risk_delta_mismatch(self) -> None:
@@ -335,7 +341,7 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
                     objective_next_report=source,
                     repair_sweep_report=repair_sweep_report(),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=930,
+                    issue_number=1098,
                 )
 
     def test_rejects_missing_objective_source_context_field(self) -> None:
@@ -351,7 +357,7 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
                     objective_next_report=source,
                     repair_sweep_report=repair_sweep_report(),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1014,
+                    issue_number=1098,
                 )
 
     def test_rejects_missing_repair_sweep_source_context_field(self) -> None:
@@ -367,13 +373,33 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
                     objective_next_report=objective_next_report(),
                     repair_sweep_report=source,
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1014,
+                    issue_number=1098,
+                )
+
+    def test_rejects_false_source_context_preserved_field(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = objective_next_report()
+            source["objective_summary"][
+                "followup_repair_sweep_source_outside_soloing_source_context_preserved"
+            ] = False
+            with self.assertRaises(
+                StageBMidiToSoloTargetedQualityRepairFollowupDecisionError
+            ):
+                build_followup_decision_report(
+                    objective_next_report=source,
+                    repair_sweep_report=repair_sweep_report(),
+                    output_dir=Path(tmp) / "followup",
+                    issue_number=1098,
                 )
 
     def test_constants_are_stable(self) -> None:
         self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_targeted_quality_repair_followup_decision")
         self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_songlike_melody_contour_repair_sweep")
         self.assertEqual(SELECTED_TARGET, "songlike_melody_contour_repair_sweep")
+        self.assertEqual(
+            SCHEMA_VERSION,
+            "stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v4",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary
- targeted quality repair follow-up decision source-context validation 기준 갱신
- objective next와 repair sweep preserved flag 3개 readiness/markdown 전파
- #1098 기준 harness, README, current status, core plan 갱신

Context
- #1096 objective-only next decision에서 preserved flag 3개 전파 완료
- follow-up decision은 기존 source-context key 중심 검증
- songlike melody contour repair sweep 이전 단계에서 preserved flag 누락 가능성 존재

Scope
- required source-context key 기준 validation
- preserved flag false 입력 차단 테스트
- selected target `songlike_melody_contour_repair_sweep`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep` 기록

Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-followup-decision`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

Risk
- human/audio preference claim 제외
- MIDI-to-solo musical quality claim 제외
- outside-soloing/chord-tone musical evaluation 미완료

Follow-up
- Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh

Closes #1098