### PR TITLE
Stage B MIDI-to-solo songlike melody contour repair listening review package source context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Current handoff scope:
 - Latest targeted quality repair follow-up decision completed: Issue #1098, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh.
 - Latest songlike melody contour repair sweep completed: Issue #1100, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh.
 - Latest songlike melody contour repair audio package completed: Issue #1102, Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh.
-- Latest songlike melody contour repair listening review package completed: Issue #1020, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh.
+- Latest songlike melody contour repair listening review package completed: Issue #1104, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh.
 - Latest songlike melody contour repair listening review input guard completed: Issue #1022, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh.
 - Latest songlike melody contour repair objective-only next decision completed: Issue #1024, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh.
 - Latest songlike melody contour repair follow-up decision completed: Issue #1026, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1064, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after songlike melody contour repair audio package source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh.
+- Open issue queue after songlike melody contour repair listening review package source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest targeted quality repair follow-up decision: `Issue #1098`
 - latest songlike melody contour repair sweep: `Issue #1100`
 - latest songlike melody contour repair audio package: `Issue #1102`
-- latest songlike melody contour repair listening review package: `Issue #1020`
+- latest songlike melody contour repair listening review package: `Issue #1104`
 - latest songlike melody contour repair listening review input guard: `Issue #1022`
 - latest songlike melody contour repair objective-only next decision: `Issue #1024`
 - latest songlike melody contour repair follow-up decision: `Issue #1026`
@@ -338,6 +338,13 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - songlike contour current risk after / delta: `0 / 2`
 - songlike contour audio technical validation: `true`
 - songlike contour listening review item count: `6`
+- songlike contour listening review validated input: `false`
+- songlike contour listening review objective follow-up objective source outside-soloing source context preserved: `true`
+- songlike contour listening review objective follow-up repair sweep source outside-soloing source context preserved: `true`
+- songlike contour listening review objective bridge repair sweep source outside-soloing source context preserved: `true`
+- songlike contour listening review follow-up objective source outside-soloing source context preserved: `true`
+- songlike contour listening review follow-up repair sweep source outside-soloing source context preserved: `true`
+- songlike contour listening review bridge repair sweep source outside-soloing source context preserved: `true`
 - songlike contour validated review input: `false`
 - songlike contour preference fill allowed: `false`
 - songlike contour follow-up required: `true`
@@ -390,7 +397,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - final status bridge repair sweep source outside-soloing source context preserved: `true`
 - MVP delivery raw artifact upload required: `false`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -410,7 +410,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo targeted quality repair follow-up decision: selected target `songlike_melody_contour_repair_sweep`, dominant label/count `songlike_melody_not_soloing/5`, objective and repair sweep source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
 - MIDI-to-solo songlike melody contour repair sweep: songlike failure `5 -> 0`, total failure labels `8 -> 4`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
 - MIDI-to-solo songlike melody contour repair audio package: rendered WAV `6`, duration `18.849s-18.992s`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
-- MIDI-to-solo songlike melody contour repair listening review package: review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
+- MIDI-to-solo songlike melody contour repair listening review package: review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
 - MIDI-to-solo songlike melody contour repair listening review input guard: preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
 - MIDI-to-solo songlike melody contour repair objective-only next decision: follow-up required `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, current quality claim ready `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
 - MIDI-to-solo songlike melody contour repair follow-up decision: selected target `songlike_melody_contour_phrase_rhythm_repair_sweep`, primary labels `phrase_shape_missing_tension_release,rhythmic_monotony`, objective and repair sweep source risk `5 -> 2`, current repair risk after/delta `0/2`, objective/sweep outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
@@ -12874,6 +12874,61 @@ Issue #1102는 Issue #1100 songlike melody contour repair sweep의 MIDI 후보 6
 다음 작업:
 
 - `Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh`
+
+## 9.242 Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh
+
+Issue #1104는 Issue #1102 songlike melody contour repair audio package의 WAV/MIDI 후보 6개를 listening review package로 묶고 source-context preserved flag를 review package source summary/validation summary까지 보존한 작업이다.
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_LISTENING_REVIEW_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
+- package ready: `true`
+- review item count: `6`
+- validated review input: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- WAV sample rate: `44100`
+- WAV duration range: `18.849s-18.992s`
+- failure label delta: `4`
+- songlike failure count: `5 -> 0`
+- songlike failure delta: `5`
+- source outside-soloing repair evidence ready: `true`
+- objective source outside-soloing repair WAV count: `6`
+- objective source outside-soloing source context preserved: `true`
+- objective preserved source-context flags: `3 / 3`
+- source outside-soloing source context preserved: `true`
+- source preserved source-context flags: `3 / 3`
+- source outside-soloing source pitch-role risk: `5 -> 2`
+- source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- repaired not evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
+- human review required now: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- listening review package source validation에 #1102 preserved flag 3개 포함.
+- review package source summary와 validation summary에 objective/source preserved flag 보존.
+- preserved flag false 입력은 validation error로 차단.
+- review item 6개 생성, review input은 pending 상태 유지.
+- human/audio preference와 musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-listening-review-package`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -30,7 +30,7 @@
 - latest targeted quality repair follow-up decision: Issue #1098, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh
 - latest songlike melody contour repair sweep: Issue #1100, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh
 - latest songlike melody contour repair audio package: Issue #1102, Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh
-- latest songlike melody contour repair listening review package: Issue #1020, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh
+- latest songlike melody contour repair listening review package: Issue #1104, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh
 - latest songlike melody contour repair listening review input guard: Issue #1022, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh
 - latest songlike melody contour repair objective-only next decision: Issue #1024, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh
 - latest songlike melody contour repair follow-up decision: Issue #1026, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after songlike melody contour repair audio package source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh`
+- open issue queue after songlike melody contour repair listening review package source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -1360,6 +1360,12 @@
 - failure label delta: `4`
 - songlike failure count: `5 -> 0`
 - songlike failure delta: `5`
+- objective follow-up objective source outside-soloing source context preserved: `true`
+- objective follow-up repair sweep source outside-soloing source context preserved: `true`
+- objective bridge repair sweep source outside-soloing source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
 - source outside-soloing repair pitch-role risk count after: `0`
 - source outside-soloing not evaluable count: `6`
 - repaired outside-soloing not evaluable count: `6`
@@ -6049,6 +6055,61 @@ Issue #1102는 Issue #1100 songlike melody contour repair sweep의 MIDI 후보 6
 다음:
 
 - `Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh`
+
+## 9.242 Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh
+
+Issue #1104는 Issue #1102 songlike melody contour repair audio package의 WAV/MIDI 후보 6개를 listening review package로 묶고 source-context preserved flag를 review package source summary/validation summary까지 보존한 작업이다.
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_LISTENING_REVIEW_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
+- package ready: `true`
+- review item count: `6`
+- validated review input: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- WAV sample rate: `44100`
+- WAV duration range: `18.849s-18.992s`
+- failure label delta: `4`
+- songlike failure count: `5 -> 0`
+- songlike failure delta: `5`
+- source outside-soloing repair evidence ready: `true`
+- objective source outside-soloing repair WAV count: `6`
+- objective source outside-soloing source context preserved: `true`
+- objective preserved source-context flags: `3 / 3`
+- source outside-soloing source context preserved: `true`
+- source preserved source-context flags: `3 / 3`
+- source outside-soloing source pitch-role risk: `5 -> 2`
+- source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- repaired not evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
+- human review required now: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- listening review package source validation에 #1102 preserved flag 3개 포함.
+- review package source summary와 validation summary에 objective/source preserved flag 보존.
+- preserved flag false 입력은 validation error로 차단.
+- review item 6개 생성, review input은 pending 상태 유지.
+- human/audio preference와 musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-listening-review-package`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음:
+
+- `Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh`
 
 ## Stage B MIDI-to-Solo README Evidence Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_LISTENING_REVIEW_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_LISTENING_REVIEW_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -21,8 +21,11 @@
 - objective source outside-soloing source residual risk preserved: `true`
 - objective source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
 - objective follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- objective follow-up objective source outside-soloing source context preserved: `true`
 - objective follow-up objective current repair pitch-role risk after/delta: `0` / `2`
 - objective repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- objective follow-up repair sweep source outside-soloing source context preserved: `true`
+- objective bridge repair sweep source outside-soloing source context preserved: `true`
 - objective repair sweep current repair pitch-role risk after/delta: `0` / `2`
 - source outside-soloing source context preserved: `true`
 - source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
@@ -30,8 +33,11 @@
 - source outside-soloing source residual risk preserved: `true`
 - source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
 - follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up objective source outside-soloing source context preserved: `true`
 - follow-up objective current repair pitch-role risk after/delta: `0` / `2`
 - bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep current repair pitch-role risk after/delta: `0` / `2`
 - source outside-soloing repair pitch-role risk after: `0`
 - source outside-soloing not evaluable count: `6`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6406,7 +6406,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package
     --run_id "$review_run_id" \
     --audio_package_report "$audio_package_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_LISTENING_REVIEW_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1020 \
+    --issue_number 1104 \
     --expected_review_item_count 6 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard \

--- a/scripts/build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py
+++ b/scripts/build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py
@@ -14,7 +14,8 @@ sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
 from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
-    BRIDGE_SOURCE_CONTEXT_KEYS,
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
 )
 from scripts.render_stage_b_midi_to_solo_songlike_melody_contour_repair_audio import (  # noqa: E402
     BOUNDARY as SOURCE_BOUNDARY,
@@ -28,7 +29,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(Val
 
 BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard"
-SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package_v3"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package_v4"
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -82,7 +83,7 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
 
 
 def _source_context_fields(summary: dict[str, Any]) -> dict[str, Any]:
-    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+    for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
         objective_key = f"objective_{key}"
         if objective_key not in summary or summary[objective_key] is None:
             raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
@@ -92,6 +93,19 @@ def _source_context_fields(summary: dict[str, Any]) -> dict[str, Any]:
             raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
                 f"source-context field required: {key}"
             )
+    missing_preserved = [
+        key for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS if not bool(summary.get(key))
+    ]
+    missing_objective_preserved = [
+        f"objective_{key}"
+        for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS
+        if not bool(summary.get(f"objective_{key}"))
+    ]
+    if missing_preserved or missing_objective_preserved:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
+            "source-context preserved field must be true: "
+            f"{missing_objective_preserved + missing_preserved}"
+        )
     return {
         "objective_source_outside_soloing_repair_wav_count": _int(
             summary.get("objective_source_outside_soloing_repair_wav_count")
@@ -161,8 +175,11 @@ def _source_context_fields(summary: dict[str, Any]) -> dict[str, Any]:
         "source_outside_soloing_repair_pitch_role_risk_delta": _int(
             summary.get("source_outside_soloing_repair_pitch_role_risk_delta")
         ),
-        **{f"objective_{key}": summary.get(f"objective_{key}") for key in BRIDGE_SOURCE_CONTEXT_KEYS},
-        **{key: summary.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{
+            f"objective_{key}": summary.get(f"objective_{key}")
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
+        },
+        **{key: summary.get(key) for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
     }
 
 
@@ -551,8 +568,11 @@ def validate_listening_review_package_report(
         "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
             source.get("source_outside_soloing_repair_pitch_role_risk_count_after")
         ),
-        **{f"objective_{key}": source.get(f"objective_{key}") for key in BRIDGE_SOURCE_CONTEXT_KEYS},
-        **{key: source.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{
+            f"objective_{key}": source.get(f"objective_{key}")
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
+        },
+        **{key: source.get(key) for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
         "source_outside_soloing_not_evaluable_count": _int(
             source.get("source_outside_soloing_not_evaluable_count")
         ),
@@ -603,8 +623,11 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- objective source outside-soloing source residual risk preserved: `{_bool_token(source['objective_source_outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- objective source outside-soloing current repair pitch-role risk after / delta: `{source['objective_source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{source['objective_source_outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- objective follow-up objective source outside-soloing source pitch-role risk: `{source['objective_followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {source['objective_followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- objective follow-up objective source outside-soloing source context preserved: `{_bool_token(source['objective_followup_objective_source_outside_soloing_source_context_preserved'])}`",
         f"- objective follow-up objective current repair pitch-role risk after/delta: `{source['objective_followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{source['objective_followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- objective repair sweep source outside-soloing source pitch-role risk: `{source['objective_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {source['objective_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- objective follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(source['objective_followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
+        f"- objective bridge repair sweep source outside-soloing source context preserved: `{_bool_token(source['objective_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- objective repair sweep current repair pitch-role risk after/delta: `{source['objective_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{source['objective_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- source outside-soloing source context preserved: `{_bool_token(source['source_outside_soloing_repair_source_context_preserved'])}`",
         f"- source outside-soloing source pitch-role risk before / after / delta: `{source['source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{source['source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{source['source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
@@ -612,8 +635,11 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- source outside-soloing source residual risk preserved: `{_bool_token(source['source_outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- source outside-soloing current repair pitch-role risk after / delta: `{source['source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{source['source_outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- follow-up objective source outside-soloing source pitch-role risk: `{source['followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {source['followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up objective source outside-soloing source context preserved: `{_bool_token(source['followup_objective_source_outside_soloing_source_context_preserved'])}`",
         f"- follow-up objective current repair pitch-role risk after/delta: `{source['followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{source['followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- bridge repair sweep source outside-soloing source pitch-role risk: `{source['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {source['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(source['followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
+        f"- bridge repair sweep source outside-soloing source context preserved: `{_bool_token(source['repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- bridge repair sweep current repair pitch-role risk after/delta: `{source['repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{source['repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- source outside-soloing repair pitch-role risk after: `{source['source_outside_soloing_repair_pitch_role_risk_count_after']}`",
         f"- source outside-soloing not evaluable count: `{source['source_outside_soloing_not_evaluable_count']}`",
@@ -665,7 +691,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=1020)
+    parser.add_argument("--issue_number", type=int, default=1104)
     parser.add_argument("--expected_review_item_count", type=int, default=6)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py
@@ -8,10 +8,11 @@ from pathlib import Path
 
 import pretty_midi
 
-from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_SOURCE_CONTEXT_KEYS
+from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
 from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package import (
     BOUNDARY,
     NEXT_BOUNDARY,
+    SCHEMA_VERSION,
     StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError,
     build_listening_review_package_report,
     validate_listening_review_package_report,
@@ -28,6 +29,7 @@ SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
     "followup_objective_source_outside_soloing_source_targeted": False,
     "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_objective_source_outside_soloing_source_context_preserved": True,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
@@ -35,6 +37,7 @@ SOURCE_CONTEXT = {
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
     "followup_repair_sweep_source_outside_soloing_source_targeted": False,
     "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_source_context_preserved": True,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
@@ -42,6 +45,7 @@ SOURCE_CONTEXT = {
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
     "repair_sweep_source_outside_soloing_source_targeted": False,
     "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "repair_sweep_source_outside_soloing_source_context_preserved": True,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
 }
@@ -186,7 +190,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageTest(unit
             report = build_listening_review_package_report(
                 audio_package_report=audio_package_report(root),
                 output_dir=root / "review_package",
-                issue_number=936,
+                issue_number=1104,
                 expected_count=6,
             )
             summary = validate_listening_review_package_report(
@@ -198,6 +202,8 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageTest(unit
                 require_no_quality_claim=True,
             )
 
+            self.assertEqual(report["schema_version"], SCHEMA_VERSION)
+            self.assertEqual(report["issue_number"], 1104)
             self.assertTrue(summary["listening_review_package_ready"])
             self.assertEqual(summary["review_item_count"], 6)
             self.assertFalse(summary["validated_review_input"])
@@ -213,7 +219,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageTest(unit
                 5,
             )
             self.assertTrue(summary["objective_source_outside_soloing_repair_source_context_preserved"])
-            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[f"objective_{key}"], SOURCE_CONTEXT[key])
             self.assertEqual(
                 summary[
@@ -245,7 +251,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageTest(unit
                 5,
             )
             self.assertTrue(summary["source_outside_soloing_repair_source_context_preserved"])
-            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[key], SOURCE_CONTEXT[key])
             self.assertEqual(
                 summary["source_outside_soloing_repair_source_pitch_role_risk_count_before"],
@@ -278,7 +284,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageTest(unit
                 build_listening_review_package_report(
                     audio_package_report=audio_package_report(root, quality_claim=True),
                     output_dir=root / "review_package",
-                    issue_number=766,
+                    issue_number=1104,
                     expected_count=6,
                 )
 
@@ -293,7 +299,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageTest(unit
                 build_listening_review_package_report(
                     audio_package_report=source,
                     output_dir=root / "review_package",
-                    issue_number=850,
+                    issue_number=1104,
                     expected_count=6,
                 )
 
@@ -308,7 +314,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageTest(unit
                 build_listening_review_package_report(
                     audio_package_report=source,
                     output_dir=root / "review_package",
-                    issue_number=936,
+                    issue_number=1104,
                     expected_count=6,
                 )
 
@@ -325,13 +331,34 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageTest(unit
                 build_listening_review_package_report(
                     audio_package_report=source,
                     output_dir=root / "review_package",
-                    issue_number=1020,
+                    issue_number=1104,
+                    expected_count=6,
+                )
+
+    def test_rejects_false_source_context_preserved_field(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = audio_package_report(root)
+            source["summary"][
+                "followup_repair_sweep_source_outside_soloing_source_context_preserved"
+            ] = False
+            with self.assertRaises(
+                StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError
+            ):
+                build_listening_review_package_report(
+                    audio_package_report=source,
+                    output_dir=root / "review_package",
+                    issue_number=1104,
                     expected_count=6,
                 )
 
     def test_constants_are_stable(self) -> None:
         self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package")
         self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard")
+        self.assertEqual(
+            SCHEMA_VERSION,
+            "stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package_v4",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary
- songlike melody contour repair listening review package source-context validation 기준 갱신
- objective/source preserved flag 3개 source summary/validation summary/markdown 전파
- #1104 기준 harness, README, current status, core plan 갱신

Context
- #1102 audio package에서 preserved flag 3개 전파 완료
- listening review package는 기존 source-context key 중심 검증
- input guard 이전 단계에서 preserved flag 누락 가능성 존재

Scope
- required source-context key 기준 validation
- preserved flag false 입력 차단 테스트
- review item `6`, validated input `false`, technical WAV validation `true` 기록
- next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard` 기록

Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-listening-review-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

Risk
- human/audio preference claim 제외
- audio rendered quality claim 제외
- MIDI-to-solo musical quality claim 제외

Follow-up
- Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh

Closes #1104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated issue references and status tracking for songlike melody contour repair workflows.
  * Added validation status and evidence flags for source-context preservation across multiple repair phases.
  * Refreshed package metadata and boundary markers.

* **Tests**
  * Expanded validation test coverage for source-context preservation requirements.

* **Chores**
  * Bumped schema version for enhanced validation enforcement.
  * Updated issue tracking references and default parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->