### PR TITLE
Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Current handoff scope:
 - Latest songlike melody contour repair audio package completed: Issue #1102, Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh.
 - Latest songlike melody contour repair listening review package completed: Issue #1104, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh.
 - Latest songlike melody contour repair listening review input guard completed: Issue #1106, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh.
-- Latest songlike melody contour repair objective-only next decision completed: Issue #1024, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh.
+- Latest songlike melody contour repair objective-only next decision completed: Issue #1108, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh.
 - Latest songlike melody contour repair follow-up decision completed: Issue #1026, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair sweep completed: Issue #1028, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair audio package completed: Issue #1030, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1064, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after songlike melody contour repair listening review input guard source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh.
+- Open issue queue after songlike melody contour repair objective-only next decision source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour repair audio package: `Issue #1102`
 - latest songlike melody contour repair listening review package: `Issue #1104`
 - latest songlike melody contour repair listening review input guard: `Issue #1106`
-- latest songlike melody contour repair objective-only next decision: `Issue #1024`
+- latest songlike melody contour repair objective-only next decision: `Issue #1108`
 - latest songlike melody contour repair follow-up decision: `Issue #1026`
 - latest songlike melody contour phrase/rhythm repair sweep: `Issue #1028`
 - latest songlike melody contour phrase/rhythm repair audio package: `Issue #1030`
@@ -50,7 +50,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1066`
 - latest README evidence refresh: `Issue #1068`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after songlike melody contour repair listening review input guard source-context refresh merge: `0`
+- open issue queue after songlike melody contour repair objective-only next decision source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -353,6 +353,12 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - songlike contour input guard follow-up objective source outside-soloing source context preserved: `true`
 - songlike contour input guard follow-up repair sweep source outside-soloing source context preserved: `true`
 - songlike contour input guard bridge repair sweep source outside-soloing source context preserved: `true`
+- songlike contour objective next objective follow-up objective source outside-soloing source context preserved: `true`
+- songlike contour objective next objective follow-up repair sweep source outside-soloing source context preserved: `true`
+- songlike contour objective next objective bridge repair sweep source outside-soloing source context preserved: `true`
+- songlike contour objective next follow-up objective source outside-soloing source context preserved: `true`
+- songlike contour objective next follow-up repair sweep source outside-soloing source context preserved: `true`
+- songlike contour objective next bridge repair sweep source outside-soloing source context preserved: `true`
 - songlike contour follow-up required: `true`
 - songlike contour follow-up decision completed: `true`
 - songlike contour follow-up selected next target: `songlike_melody_contour_phrase_rhythm_repair_sweep`
@@ -403,7 +409,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - final status bridge repair sweep source outside-soloing source context preserved: `true`
 - MVP delivery raw artifact upload required: `false`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -412,7 +412,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo songlike melody contour repair audio package: rendered WAV `6`, duration `18.849s-18.992s`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
 - MIDI-to-solo songlike melody contour repair listening review package: review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
 - MIDI-to-solo songlike melody contour repair listening review input guard: preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
-- MIDI-to-solo songlike melody contour repair objective-only next decision: follow-up required `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, current quality claim ready `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
+- MIDI-to-solo songlike melody contour repair objective-only next decision: follow-up required `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, current quality claim ready `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
 - MIDI-to-solo songlike melody contour repair follow-up decision: selected target `songlike_melody_contour_phrase_rhythm_repair_sweep`, primary labels `phrase_shape_missing_tension_release,rhythmic_monotony`, objective and repair sweep source risk `5 -> 2`, current repair risk after/delta `0/2`, objective/sweep outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair sweep: phrase/rhythm failure `4 -> 1`, total failure labels `4 -> 1`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair audio package: rendered WAV `6`, duration `18.871s-19.000s`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package`
@@ -12985,6 +12985,63 @@ Issue #1106은 Issue #1104 listening review package의 pending input 상태와 s
 다음 작업:
 
 - `Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh`
+
+## 9.244 Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh
+
+Issue #1108은 Issue #1106 input guard의 pending input 상태와 source-context preserved flag 3개를 objective-only next decision summary까지 보존한 작업이다.
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
+- selected target: `songlike_melody_contour_repair_followup_decision`
+- objective next decision completed: `true`
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- failure label delta: `4`
+- songlike failure delta: `5`
+- source outside-soloing repair evidence ready: `true`
+- objective source outside-soloing repair WAV count: `6`
+- objective source outside-soloing source context preserved: `true`
+- objective preserved source-context flags: `3 / 3`
+- source outside-soloing source context preserved: `true`
+- source preserved source-context flags: `3 / 3`
+- source outside-soloing source pitch-role risk: `5 -> 2`
+- source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- songlike contour follow-up required: `true`
+- current quality claim ready: `false`
+- critical user input required: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- objective-only next decision source validation에 #1106 preserved flag 3개 포함.
+- objective summary와 readiness에 objective/source preserved flag 보존.
+- preserved flag false 입력은 validation error로 차단.
+- review input 부재와 quality claim unavailable 상태에서 follow-up decision boundary 선택.
+- human/audio preference와 musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-objective-only-next-decision`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -32,7 +32,7 @@
 - latest songlike melody contour repair audio package: Issue #1102, Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh
 - latest songlike melody contour repair listening review package: Issue #1104, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh
 - latest songlike melody contour repair listening review input guard: Issue #1106, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh
-- latest songlike melody contour repair objective-only next decision: Issue #1024, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh
+- latest songlike melody contour repair objective-only next decision: Issue #1108, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh
 - latest songlike melody contour repair follow-up decision: Issue #1026, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh
 - latest songlike melody contour phrase/rhythm repair sweep: Issue #1028, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh
 - latest songlike melody contour phrase/rhythm repair audio package: Issue #1030, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after songlike melody contour repair listening review input guard source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh`
+- open issue queue after songlike melody contour repair objective-only next decision source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -3905,6 +3905,63 @@ Issue #1022는 Issue #1020 listening review package의 pending input 상태와 s
 다음:
 
 - `Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh`
+
+## 9.244 Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh
+
+Issue #1108은 Issue #1106 input guard의 pending input 상태와 source-context preserved flag 3개를 objective-only next decision summary까지 보존한 작업이다.
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
+- selected target: `songlike_melody_contour_repair_followup_decision`
+- objective next decision completed: `true`
+- review item count: `6`
+- required input field count: `4`
+- validated review input present: `false`
+- preference fill allowed: `false`
+- technical WAV validation: `true`
+- rendered audio file count: `6`
+- failure label delta: `4`
+- songlike failure delta: `5`
+- source outside-soloing repair evidence ready: `true`
+- objective source outside-soloing repair WAV count: `6`
+- objective source outside-soloing source context preserved: `true`
+- objective preserved source-context flags: `3 / 3`
+- source outside-soloing source context preserved: `true`
+- source preserved source-context flags: `3 / 3`
+- source outside-soloing source pitch-role risk: `5 -> 2`
+- source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
+- source outside-soloing not evaluable count: `6`
+- repaired outside-soloing not evaluable count: `6`
+- songlike contour follow-up required: `true`
+- current quality claim ready: `false`
+- critical user input required: `false`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- objective-only next decision source validation에 #1106 preserved flag 3개 포함.
+- objective summary와 readiness에 objective/source preserved flag 보존.
+- preserved flag false 입력은 validation error로 차단.
+- review input 부재와 quality claim unavailable 상태에서 follow-up decision boundary 선택.
+- human/audio preference와 musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-objective-only-next-decision`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음:
+
+- `Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh`
 
 ## Stage B MIDI-to-Solo Songlike Melody Contour Repair Objective-Only Next Decision Source Context Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -23,8 +23,11 @@
 - objective source outside-soloing source residual risk preserved: `true`
 - objective source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
 - objective follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- objective follow-up objective source outside-soloing source context preserved: `true`
 - objective follow-up objective current repair pitch-role risk after/delta: `0` / `2`
+- objective follow-up repair sweep source outside-soloing source context preserved: `true`
 - objective repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- objective bridge repair sweep source outside-soloing source context preserved: `true`
 - objective repair sweep current repair pitch-role risk after/delta: `0` / `2`
 - source outside-soloing source context preserved: `true`
 - source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
@@ -32,8 +35,11 @@
 - source outside-soloing source residual risk preserved: `true`
 - source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
 - follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up objective source outside-soloing source context preserved: `true`
 - follow-up objective current repair pitch-role risk after/delta: `0` / `2`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
+- bridge repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep current repair pitch-role risk after/delta: `0` / `2`
 - source outside-soloing repair pitch-role risk after: `0`
 - source outside-soloing not evaluable count: `6`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6448,7 +6448,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_deci
     --run_id "$run_id" \
     --input_guard_report "$input_guard_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1024 \
+    --issue_number 1108 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision \
     --require_objective_decision \

--- a/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next.py
+++ b/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next.py
@@ -13,10 +13,9 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
-from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
-    BRIDGE_SOURCE_CONTEXT_KEYS,
-)
 from scripts.guard_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input import (  # noqa: E402
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
     BOUNDARY as SOURCE_BOUNDARY,
     OBJECTIVE_NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
 )
@@ -30,7 +29,7 @@ BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_n
 FOLLOWUP_DECISION_NEXT_BOUNDARY = (
     "stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision"
 )
-SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next_v3"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next_v4"
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -76,7 +75,7 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
 
 
 def _source_context_fields(source: dict[str, Any]) -> dict[str, Any]:
-    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+    for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
         objective_key = f"objective_{key}"
         if objective_key not in source or source[objective_key] is None:
             raise StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextError(
@@ -86,6 +85,19 @@ def _source_context_fields(source: dict[str, Any]) -> dict[str, Any]:
             raise StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextError(
                 f"source-context field required: {key}"
             )
+    missing_preserved = [
+        key for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS if not bool(source.get(key))
+    ]
+    missing_objective_preserved = [
+        f"objective_{key}"
+        for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS
+        if not bool(source.get(f"objective_{key}"))
+    ]
+    if missing_preserved or missing_objective_preserved:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextError(
+            "source-context preserved field must be true: "
+            f"{missing_objective_preserved + missing_preserved}"
+        )
     return {
         "objective_source_outside_soloing_repair_wav_count": _int(
             source.get("objective_source_outside_soloing_repair_wav_count")
@@ -153,8 +165,11 @@ def _source_context_fields(source: dict[str, Any]) -> dict[str, Any]:
         "source_outside_soloing_repair_pitch_role_risk_delta": _int(
             source.get("source_outside_soloing_repair_pitch_role_risk_delta")
         ),
-        **{f"objective_{key}": source.get(f"objective_{key}") for key in BRIDGE_SOURCE_CONTEXT_KEYS},
-        **{key: source.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{
+            f"objective_{key}": source.get(f"objective_{key}")
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
+        },
+        **{key: source.get(key) for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
     }
 
 
@@ -552,8 +567,11 @@ def validate_objective_next_report(
         "source_outside_soloing_repair_pitch_role_risk_count_after": _int(
             summary.get("source_outside_soloing_repair_pitch_role_risk_count_after")
         ),
-        **{f"objective_{key}": summary.get(f"objective_{key}") for key in BRIDGE_SOURCE_CONTEXT_KEYS},
-        **{key: summary.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{
+            f"objective_{key}": summary.get(f"objective_{key}")
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
+        },
+        **{key: summary.get(key) for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
         "source_outside_soloing_not_evaluable_count": _int(
             summary.get("source_outside_soloing_not_evaluable_count")
         ),
@@ -607,8 +625,11 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- objective source outside-soloing source residual risk preserved: `{_bool_token(summary['objective_source_outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- objective source outside-soloing current repair pitch-role risk after / delta: `{summary['objective_source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{summary['objective_source_outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- objective follow-up objective source outside-soloing source pitch-role risk: `{summary['objective_followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['objective_followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- objective follow-up objective source outside-soloing source context preserved: `{_bool_token(summary['objective_followup_objective_source_outside_soloing_source_context_preserved'])}`",
         f"- objective follow-up objective current repair pitch-role risk after/delta: `{summary['objective_followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{summary['objective_followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- objective follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(summary['objective_followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- objective repair sweep source outside-soloing source pitch-role risk: `{summary['objective_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['objective_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- objective bridge repair sweep source outside-soloing source context preserved: `{_bool_token(summary['objective_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- objective repair sweep current repair pitch-role risk after/delta: `{summary['objective_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{summary['objective_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- source outside-soloing source context preserved: `{_bool_token(summary['source_outside_soloing_repair_source_context_preserved'])}`",
         f"- source outside-soloing source pitch-role risk before / after / delta: `{summary['source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{summary['source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{summary['source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
@@ -616,8 +637,11 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- source outside-soloing source residual risk preserved: `{_bool_token(summary['source_outside_soloing_repair_source_residual_risk_preserved'])}`",
         f"- source outside-soloing current repair pitch-role risk after / delta: `{summary['source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{summary['source_outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- follow-up objective source outside-soloing source pitch-role risk: `{summary['followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up objective source outside-soloing source context preserved: `{_bool_token(summary['followup_objective_source_outside_soloing_source_context_preserved'])}`",
         f"- follow-up objective current repair pitch-role risk after/delta: `{summary['followup_objective_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{summary['followup_objective_source_outside_soloing_current_pitch_role_risk_delta']}`",
+        f"- follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(summary['followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- bridge repair sweep source outside-soloing source pitch-role risk: `{summary['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {summary['repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- bridge repair sweep source outside-soloing source context preserved: `{_bool_token(summary['repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- bridge repair sweep current repair pitch-role risk after/delta: `{summary['repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{summary['repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- source outside-soloing repair pitch-role risk after: `{summary['source_outside_soloing_repair_pitch_role_risk_count_after']}`",
         f"- source outside-soloing not evaluable count: `{summary['source_outside_soloing_not_evaluable_count']}`",
@@ -655,7 +679,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=1024)
+    parser.add_argument("--issue_number", type=int, default=1108)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--require_objective_decision", action="store_true")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next.py
@@ -4,10 +4,11 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_SOURCE_CONTEXT_KEYS
+from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
 from scripts.decide_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next import (
     BOUNDARY,
     FOLLOWUP_DECISION_NEXT_BOUNDARY,
+    SCHEMA_VERSION,
     StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextError,
     build_objective_next_report,
     validate_objective_next_report,
@@ -24,6 +25,7 @@ SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
     "followup_objective_source_outside_soloing_source_targeted": False,
     "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_objective_source_outside_soloing_source_context_preserved": True,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
@@ -31,6 +33,7 @@ SOURCE_CONTEXT = {
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
     "followup_repair_sweep_source_outside_soloing_source_targeted": False,
     "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_source_context_preserved": True,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
@@ -38,6 +41,7 @@ SOURCE_CONTEXT = {
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
     "repair_sweep_source_outside_soloing_source_targeted": False,
     "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "repair_sweep_source_outside_soloing_source_context_preserved": True,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
 }
@@ -117,7 +121,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextTest(unittest.Test
             report = build_objective_next_report(
                 input_guard_report=input_guard_report(),
                 output_dir=root / "objective_next",
-                issue_number=940,
+                issue_number=1108,
             )
             summary = validate_objective_next_report(
                 report,
@@ -128,6 +132,8 @@ class StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextTest(unittest.Test
                 require_no_quality_claim=True,
             )
 
+            self.assertEqual(report["schema_version"], SCHEMA_VERSION)
+            self.assertEqual(report["issue_number"], 1108)
             self.assertTrue(summary["objective_next_decision_completed"])
             self.assertFalse(summary["validated_review_input_present"])
             self.assertFalse(summary["preference_fill_allowed"])
@@ -144,7 +150,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextTest(unittest.Test
                 5,
             )
             self.assertTrue(summary["objective_source_outside_soloing_repair_source_context_preserved"])
-            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[f"objective_{key}"], SOURCE_CONTEXT[key])
             self.assertEqual(
                 summary[
@@ -176,7 +182,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextTest(unittest.Test
                 5,
             )
             self.assertTrue(summary["source_outside_soloing_repair_source_context_preserved"])
-            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[key], SOURCE_CONTEXT[key])
             self.assertEqual(
                 summary["source_outside_soloing_repair_source_pitch_role_risk_count_before"],
@@ -205,7 +211,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextTest(unittest.Test
                 build_objective_next_report(
                     input_guard_report=input_guard_report(quality_claim=True),
                     output_dir=root / "objective_next",
-                    issue_number=854,
+                    issue_number=1108,
                 )
 
     def test_rejects_missing_outside_soloing_context(self) -> None:
@@ -217,7 +223,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextTest(unittest.Test
                 build_objective_next_report(
                     input_guard_report=source,
                     output_dir=root / "objective_next",
-                    issue_number=854,
+                    issue_number=1108,
                 )
 
     def test_rejects_source_context_delta_mismatch(self) -> None:
@@ -231,7 +237,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextTest(unittest.Test
                 build_objective_next_report(
                     input_guard_report=source,
                     output_dir=root / "objective_next",
-                    issue_number=940,
+                    issue_number=1108,
                 )
 
     def test_rejects_missing_source_context_field(self) -> None:
@@ -245,12 +251,30 @@ class StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextTest(unittest.Test
                 build_objective_next_report(
                     input_guard_report=source,
                     output_dir=root / "objective_next",
-                    issue_number=1024,
+                    issue_number=1108,
+                )
+
+    def test_rejects_false_source_context_preserved_field(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = input_guard_report()
+            source["guard_result"]["source_summary"][
+                "repair_sweep_source_outside_soloing_source_context_preserved"
+            ] = False
+            with self.assertRaises(StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextError):
+                build_objective_next_report(
+                    input_guard_report=source,
+                    output_dir=root / "objective_next",
+                    issue_number=1108,
                 )
 
     def test_constants_are_stable(self) -> None:
         self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision")
         self.assertEqual(FOLLOWUP_DECISION_NEXT_BOUNDARY, "stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision")
+        self.assertEqual(
+            SCHEMA_VERSION,
+            "stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next_v4",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary
- songlike melody contour repair objective-only next decision source-context validation 기준 갱신
- objective/source preserved flag 3개 objective summary/readiness/markdown 전파
- #1108 기준 harness, README, current status, core plan 갱신

Context
- #1106 input guard에서 preserved flag 3개 전파 완료
- preference fill `false`, validated input `false`, technical WAV validation `true`
- objective-only next decision 이전 단계에서 preserved flag 누락 가능성 존재

Scope
- required source-context key 기준 validation
- preserved flag false 입력 차단 테스트
- follow-up required `true`, current quality claim ready `false`, critical user input `false` 기록
- next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision` 기록

Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-objective-only-next-decision`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

Risk
- human/audio preference claim 제외
- MIDI-to-solo musical quality claim 제외
- follow-up decision 선택만 포함

Follow-up
- Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh

Closes #1108