### PR TITLE
Stage B MIDI-to-solo songlike melody contour repair follow-up decision source context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Current handoff scope:
 - Latest songlike melody contour repair listening review package completed: Issue #1104, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh.
 - Latest songlike melody contour repair listening review input guard completed: Issue #1106, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh.
 - Latest songlike melody contour repair objective-only next decision completed: Issue #1108, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh.
-- Latest songlike melody contour repair follow-up decision completed: Issue #1026, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh.
+- Latest songlike melody contour repair follow-up decision completed: Issue #1110, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair sweep completed: Issue #1028, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair audio package completed: Issue #1030, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair listening review package completed: Issue #1032, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1064, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after songlike melody contour repair objective-only next decision source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh.
+- Open issue queue after songlike melody contour repair follow-up decision source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour repair listening review package: `Issue #1104`
 - latest songlike melody contour repair listening review input guard: `Issue #1106`
 - latest songlike melody contour repair objective-only next decision: `Issue #1108`
-- latest songlike melody contour repair follow-up decision: `Issue #1026`
+- latest songlike melody contour repair follow-up decision: `Issue #1110`
 - latest songlike melody contour phrase/rhythm repair sweep: `Issue #1028`
 - latest songlike melody contour phrase/rhythm repair audio package: `Issue #1030`
 - latest songlike melody contour phrase/rhythm repair listening review package: `Issue #1032`
@@ -50,7 +50,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1066`
 - latest README evidence refresh: `Issue #1068`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after songlike melody contour repair objective-only next decision source-context refresh merge: `0`
+- open issue queue after songlike melody contour repair follow-up decision source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -365,6 +365,12 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - songlike contour follow-up primary remaining failure labels: `phrase_shape_missing_tension_release`, `rhythmic_monotony`
 - songlike contour follow-up source risk: `5 -> 2`
 - songlike contour follow-up current risk after / delta: `0 / 2`
+- songlike contour follow-up objective follow-up objective source outside-soloing source context preserved: `true`
+- songlike contour follow-up objective follow-up repair sweep source outside-soloing source context preserved: `true`
+- songlike contour follow-up objective bridge repair sweep source outside-soloing source context preserved: `true`
+- songlike contour follow-up repair sweep follow-up objective source outside-soloing source context preserved: `true`
+- songlike contour follow-up repair sweep follow-up repair sweep source outside-soloing source context preserved: `true`
+- songlike contour follow-up repair sweep bridge repair sweep source outside-soloing source context preserved: `true`
 - songlike contour follow-up technical regression count: `0`
 - songlike contour phrase/rhythm repair sweep completed: `true`
 - songlike contour phrase/rhythm failure count: `4 -> 1`
@@ -409,7 +415,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - final status bridge repair sweep source outside-soloing source context preserved: `true`
 - MVP delivery raw artifact upload required: `false`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -413,7 +413,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo songlike melody contour repair listening review package: review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
 - MIDI-to-solo songlike melody contour repair listening review input guard: preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
 - MIDI-to-solo songlike melody contour repair objective-only next decision: follow-up required `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, current quality claim ready `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
-- MIDI-to-solo songlike melody contour repair follow-up decision: selected target `songlike_melody_contour_phrase_rhythm_repair_sweep`, primary labels `phrase_shape_missing_tension_release,rhythmic_monotony`, objective and repair sweep source risk `5 -> 2`, current repair risk after/delta `0/2`, objective/sweep outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- MIDI-to-solo songlike melody contour repair follow-up decision: selected target `songlike_melody_contour_phrase_rhythm_repair_sweep`, primary labels `phrase_shape_missing_tension_release,rhythmic_monotony`, objective and repair sweep source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, objective/sweep outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair sweep: phrase/rhythm failure `4 -> 1`, total failure labels `4 -> 1`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair audio package: rendered WAV `6`, duration `18.871s-19.000s`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package: review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
@@ -13042,6 +13042,63 @@ Issue #1108은 Issue #1106 input guard의 pending input 상태와 source-context
 다음 작업:
 
 - `Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh`
+
+## 9.245 Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh
+
+Issue #1110은 Issue #1108 objective-only next decision과 songlike contour repair sweep의 source-context preserved flag 3개를 follow-up decision targets/readiness까지 보존한 작업이다.
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
+- repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- selected target: `songlike_melody_contour_phrase_rhythm_repair_sweep`
+- follow-up decision completed: `true`
+- phrase/rhythm tie target selected: `true`
+- primary remaining failure labels: `phrase_shape_missing_tension_release`, `rhythmic_monotony`
+- primary remaining failure count: `2`
+- candidate count: `6`
+- source total failure labels: `8`
+- repaired total failure labels: `4`
+- failure label delta: `4`
+- technical regression count: `0`
+- objective source outside-soloing repair evidence ready: `true`
+- objective source outside-soloing source context preserved: `true`
+- objective preserved source-context flags: `3 / 3`
+- repair sweep source outside-soloing repair evidence ready: `true`
+- repair sweep source outside-soloing source context preserved: `true`
+- repair sweep preserved source-context flags: `3 / 3`
+- source outside-soloing source pitch-role risk: `5 -> 2`
+- source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
+- objective source outside-soloing not evaluable count: `6`
+- objective repaired outside-soloing not evaluable count: `6`
+- repair sweep source outside-soloing not evaluable count: `6`
+- repair sweep repaired outside-soloing not evaluable count: `6`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- follow-up decision source validation에 #1108 objective summary와 repair sweep preserved flag 3개 포함.
+- follow-up targets와 readiness에 objective/repair sweep source-context preserved flag 보존.
+- preserved flag false 입력은 validation error로 차단.
+- 남은 primary failure label 2개 기준 phrase/rhythm repair sweep 선택.
+- human/audio preference와 musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_followup.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-followup-decision`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음 작업:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh`
 
 ## 10. 한 문장 요약
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -33,7 +33,7 @@
 - latest songlike melody contour repair listening review package: Issue #1104, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh
 - latest songlike melody contour repair listening review input guard: Issue #1106, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh
 - latest songlike melody contour repair objective-only next decision: Issue #1108, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh
-- latest songlike melody contour repair follow-up decision: Issue #1026, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh
+- latest songlike melody contour repair follow-up decision: Issue #1110, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh
 - latest songlike melody contour phrase/rhythm repair sweep: Issue #1028, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh
 - latest songlike melody contour phrase/rhythm repair audio package: Issue #1030, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh
 - latest songlike melody contour phrase/rhythm repair listening review package: Issue #1032, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after songlike melody contour repair objective-only next decision source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh`
+- open issue queue after songlike melody contour repair follow-up decision source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -4018,6 +4018,63 @@ Issue #1024는 Issue #1022 input guard의 pending input 상태와 source-context
 다음:
 
 - `Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh`
+
+## 9.245 Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh
+
+Issue #1110은 Issue #1108 objective-only next decision과 songlike contour repair sweep의 source-context preserved flag 3개를 follow-up decision targets/readiness까지 보존한 작업이다.
+
+결과:
+
+- document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
+- boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
+- source boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
+- repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
+- selected target: `songlike_melody_contour_phrase_rhythm_repair_sweep`
+- follow-up decision completed: `true`
+- phrase/rhythm tie target selected: `true`
+- primary remaining failure labels: `phrase_shape_missing_tension_release`, `rhythmic_monotony`
+- primary remaining failure count: `2`
+- candidate count: `6`
+- source total failure labels: `8`
+- repaired total failure labels: `4`
+- failure label delta: `4`
+- technical regression count: `0`
+- objective source outside-soloing repair evidence ready: `true`
+- objective source outside-soloing source context preserved: `true`
+- objective preserved source-context flags: `3 / 3`
+- repair sweep source outside-soloing repair evidence ready: `true`
+- repair sweep source outside-soloing source context preserved: `true`
+- repair sweep preserved source-context flags: `3 / 3`
+- source outside-soloing source pitch-role risk: `5 -> 2`
+- source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
+- objective source outside-soloing not evaluable count: `6`
+- objective repaired outside-soloing not evaluable count: `6`
+- repair sweep source outside-soloing not evaluable count: `6`
+- repair sweep repaired outside-soloing not evaluable count: `6`
+- human/audio preference claimed: `false`
+- MIDI-to-solo musical quality claimed: `false`
+
+판단:
+
+- follow-up decision source validation에 #1108 objective summary와 repair sweep preserved flag 3개 포함.
+- follow-up targets와 readiness에 objective/repair sweep source-context preserved flag 보존.
+- preserved flag false 입력은 validation error로 차단.
+- 남은 primary failure label 2개 기준 phrase/rhythm repair sweep 선택.
+- human/audio preference와 musical quality claim 제외 유지.
+
+검증:
+
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_followup.py`
+- `bash -n scripts/agent_harness.sh`
+- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-followup-decision`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
+
+다음:
+
+- `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh`
 
 ## Stage B MIDI-to-Solo Songlike Melody Contour Repair Follow-Up Decision Source Context Refresh Result
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -25,6 +25,9 @@
 - objective source outside-soloing current repair pitch-role risk delta: `2`
 - objective source outside-soloing not evaluable count: `6`
 - objective repaired outside-soloing not evaluable count: `6`
+- objective follow-up objective source outside-soloing source context preserved: `true`
+- objective follow-up repair sweep source outside-soloing source context preserved: `true`
+- objective bridge repair sweep source outside-soloing source context preserved: `true`
 - repair sweep source outside-soloing repair evidence ready: `true`
 - repair sweep source outside-soloing source context preserved: `true`
 - repair sweep source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
@@ -34,6 +37,9 @@
 - repair sweep source outside-soloing current repair pitch-role risk delta: `2`
 - repair sweep source outside-soloing not evaluable count: `6`
 - repair sweep repaired outside-soloing not evaluable count: `6`
+- repair sweep follow-up objective source outside-soloing source context preserved: `true`
+- repair sweep follow-up repair sweep source outside-soloing source context preserved: `true`
+- repair sweep bridge source outside-soloing source context preserved: `true`
 - human/audio preference claimed: `false`
 - MIDI-to-solo musical quality claimed: `false`
 

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6476,7 +6476,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision() {
     --objective_next_report "$objective_report" \
     --repair_sweep_report "$sweep_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1026 \
+    --issue_number 1110 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep \
     --expected_target songlike_melody_contour_phrase_rhythm_repair_sweep \

--- a/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_followup.py
+++ b/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_followup.py
@@ -15,7 +15,8 @@ sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
 from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
-    BRIDGE_SOURCE_CONTEXT_KEYS,
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
 )
 from scripts.decide_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next import (  # noqa: E402
     BOUNDARY as OBJECTIVE_NEXT_BOUNDARY,
@@ -33,7 +34,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError(ValueErro
 BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep"
 SELECTED_TARGET = "songlike_melody_contour_phrase_rhythm_repair_sweep"
-SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision_v3"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision_v4"
 TIE_TARGET_LABELS = (
     "phrase_shape_missing_tension_release",
     "rhythmic_monotony",
@@ -80,12 +81,19 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
 
 
 def _bridge_source_context_fields(source: dict[str, Any], *, label: str) -> dict[str, Any]:
-    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+    for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
         if key not in source or source[key] is None:
             raise StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError(
                 f"{label} source-context field required: {key}"
             )
-    return {key: source[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS}
+    missing_preserved = [
+        key for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS if not bool(source.get(key))
+    ]
+    if missing_preserved:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError(
+            f"{label} source-context preserved field must be true: {missing_preserved}"
+        )
+    return {key: source[key] for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS}
 
 
 def _source_context_fields(source: dict[str, Any], *, label: str) -> dict[str, Any]:
@@ -215,7 +223,7 @@ def _objective_context_for_followup(source: dict[str, Any]) -> dict[str, Any]:
             for key, value in _source_context_fields(source, label="objective follow-up").items()
             if key.startswith("objective_source_outside_soloing_repair_")
         },
-        **{f"objective_{key}": source[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{f"objective_{key}": source[key] for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
     }
 
 
@@ -229,7 +237,10 @@ def _repair_sweep_context_for_followup(source: dict[str, Any]) -> dict[str, Any]
             ).items()
             if key.startswith("source_outside_soloing_repair_")
         },
-        **{f"repair_sweep_{key}": source[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{
+            f"repair_sweep_{key}": source[key]
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
+        },
     }
 
 
@@ -754,7 +765,10 @@ def validate_followup_decision_report(
         "objective_source_outside_soloing_repair_pitch_role_risk_delta": _int(
             targets.get("objective_source_outside_soloing_repair_pitch_role_risk_delta")
         ),
-        **{f"objective_{key}": targets.get(f"objective_{key}") for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{
+            f"objective_{key}": targets.get(f"objective_{key}")
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
+        },
         "repair_sweep_source_outside_soloing_repair_evidence_ready": bool(
             targets.get("repair_sweep_source_outside_soloing_repair_evidence_ready", False)
         ),
@@ -805,7 +819,7 @@ def validate_followup_decision_report(
         ),
         **{
             f"repair_sweep_{key}": targets.get(f"repair_sweep_{key}")
-            for key in BRIDGE_SOURCE_CONTEXT_KEYS
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
         },
         "human_audio_preference_claimed": bool(
             readiness.get("human_audio_preference_claimed", True)
@@ -853,6 +867,9 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- objective source outside-soloing current repair pitch-role risk delta: `{readiness['objective_source_outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- objective source outside-soloing not evaluable count: `{readiness['objective_source_outside_soloing_not_evaluable_count']}`",
         f"- objective repaired outside-soloing not evaluable count: `{readiness['objective_repaired_outside_soloing_not_evaluable_count']}`",
+        f"- objective follow-up objective source outside-soloing source context preserved: `{_bool_token(readiness['objective_followup_objective_source_outside_soloing_source_context_preserved'])}`",
+        f"- objective follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(readiness['objective_followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
+        f"- objective bridge repair sweep source outside-soloing source context preserved: `{_bool_token(readiness['objective_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- repair sweep source outside-soloing repair evidence ready: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_evidence_ready'])}`",
         f"- repair sweep source outside-soloing source context preserved: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_source_context_preserved'])}`",
         f"- repair sweep source outside-soloing source pitch-role risk before / after / delta: `{readiness['repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{readiness['repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{readiness['repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
@@ -862,6 +879,9 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- repair sweep source outside-soloing current repair pitch-role risk delta: `{readiness['repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- repair sweep source outside-soloing not evaluable count: `{readiness['repair_sweep_source_outside_soloing_not_evaluable_count']}`",
         f"- repair sweep repaired outside-soloing not evaluable count: `{readiness['repair_sweep_repaired_outside_soloing_not_evaluable_count']}`",
+        f"- repair sweep follow-up objective source outside-soloing source context preserved: `{_bool_token(readiness['repair_sweep_followup_objective_source_outside_soloing_source_context_preserved'])}`",
+        f"- repair sweep follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(readiness['repair_sweep_followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
+        f"- repair sweep bridge source outside-soloing source context preserved: `{_bool_token(readiness['repair_sweep_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
         f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
         "",
@@ -912,7 +932,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=942)
+    parser.add_argument("--issue_number", type=int, default=1110)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--expected_target", type=str, default="")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision.py
@@ -4,10 +4,11 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_SOURCE_CONTEXT_KEYS
+from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
 from scripts.decide_stage_b_midi_to_solo_songlike_melody_contour_repair_followup import (
     BOUNDARY,
     NEXT_BOUNDARY,
+    SCHEMA_VERSION,
     SELECTED_TARGET,
     TIE_TARGET_LABELS,
     StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError,
@@ -28,6 +29,7 @@ SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
     "followup_objective_source_outside_soloing_source_targeted": False,
     "followup_objective_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_objective_source_outside_soloing_source_context_preserved": True,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
@@ -35,6 +37,7 @@ SOURCE_CONTEXT = {
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
     "followup_repair_sweep_source_outside_soloing_source_targeted": False,
     "followup_repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_source_context_preserved": True,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
@@ -42,6 +45,7 @@ SOURCE_CONTEXT = {
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
     "repair_sweep_source_outside_soloing_source_targeted": False,
     "repair_sweep_source_outside_soloing_source_residual_risk_preserved": True,
+    "repair_sweep_source_outside_soloing_source_context_preserved": True,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
 }
@@ -177,7 +181,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
                 objective_next_report=objective_next_report(),
                 repair_sweep_report=repair_sweep_report(),
                 output_dir=Path(tmp) / "followup",
-                issue_number=856,
+                issue_number=1110,
             )
             summary = validate_followup_decision_report(
                 report,
@@ -189,6 +193,8 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
                 require_no_quality_claim=True,
             )
 
+            self.assertEqual(report["schema_version"], SCHEMA_VERSION)
+            self.assertEqual(report["issue_number"], 1110)
             self.assertTrue(summary["followup_decision_completed"])
             self.assertTrue(summary["phrase_rhythm_tie_target_selected"])
             self.assertEqual(
@@ -203,7 +209,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
             self.assertTrue(
                 summary["objective_source_outside_soloing_repair_source_context_preserved"]
             )
-            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[f"objective_{key}"], SOURCE_CONTEXT[key])
             self.assertEqual(
                 summary[
@@ -238,7 +244,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
             self.assertTrue(
                 summary["repair_sweep_source_outside_soloing_repair_source_context_preserved"]
             )
-            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[f"repair_sweep_{key}"], SOURCE_CONTEXT[key])
             self.assertEqual(
                 summary[
@@ -287,7 +293,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
                     objective_next_report=objective_next_report(quality_claim=True),
                     repair_sweep_report=repair_sweep_report(),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=856,
+                    issue_number=1110,
                 )
 
     def test_rejects_technical_regression(self) -> None:
@@ -299,7 +305,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
                     objective_next_report=objective_next_report(),
                     repair_sweep_report=repair_sweep_report(technical_regression_count=1),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=856,
+                    issue_number=1110,
                 )
 
     def test_rejects_missing_outside_soloing_context(self) -> None:
@@ -313,7 +319,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
                     objective_next_report=objective_next_report(),
                     repair_sweep_report=source,
                     output_dir=Path(tmp) / "followup",
-                    issue_number=856,
+                    issue_number=1110,
                 )
 
     def test_rejects_source_context_delta_mismatch(self) -> None:
@@ -327,13 +333,13 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
                     objective_next_report=objective_next_report(),
                     repair_sweep_report=source,
                     output_dir=Path(tmp) / "followup",
-                    issue_number=942,
+                    issue_number=1110,
                 )
 
     def test_rejects_missing_bridge_source_context(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             source = objective_next_report()
-            source["objective_summary"].pop(BRIDGE_SOURCE_CONTEXT_KEYS[0])
+            source["objective_summary"].pop(BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS[0])
             with self.assertRaises(
                 StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError
             ):
@@ -341,7 +347,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
                     objective_next_report=source,
                     repair_sweep_report=repair_sweep_report(),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1026,
+                    issue_number=1110,
                 )
 
     def test_rejects_source_context_preservation_flag_false(self) -> None:
@@ -357,13 +363,33 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
                     objective_next_report=source,
                     repair_sweep_report=repair_sweep_report(),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1026,
+                    issue_number=1110,
+                )
+
+    def test_rejects_false_bridge_source_context_preserved_field(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = objective_next_report()
+            source["objective_summary"][
+                "followup_objective_source_outside_soloing_source_context_preserved"
+            ] = False
+            with self.assertRaises(
+                StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError
+            ):
+                build_followup_decision_report(
+                    objective_next_report=source,
+                    repair_sweep_report=repair_sweep_report(),
+                    output_dir=Path(tmp) / "followup",
+                    issue_number=1110,
                 )
 
     def test_constants_are_stable(self) -> None:
         self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision")
         self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep")
         self.assertEqual(SELECTED_TARGET, "songlike_melody_contour_phrase_rhythm_repair_sweep")
+        self.assertEqual(
+            SCHEMA_VERSION,
+            "stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision_v4",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary
- songlike melody contour repair follow-up decision source-context validation 기준 갱신
- objective/repair sweep preserved flag 3개 follow-up targets/readiness/markdown 전파
- #1110 기준 harness, README, current status, core plan 갱신

Context
- #1108 objective-only next decision에서 preserved flag 3개 전파 완료
- repair sweep source risk `5 -> 2`, current repair risk after/delta `0/2`
- primary remaining failure labels: `phrase_shape_missing_tension_release`, `rhythmic_monotony`

Scope
- required source-context key 기준 validation
- preserved flag false 입력 차단 테스트
- phrase/rhythm tie target selected `true`, technical regression `0` 기록
- next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep` 기록

Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_followup.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-followup-decision`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

Risk
- human/audio preference claim 제외
- MIDI-to-solo musical quality claim 제외
- phrase/rhythm repair sweep 선택만 포함

Follow-up
- Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh

Closes #1110