### PR TITLE
Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ Current handoff scope:
 - Latest songlike melody contour repair objective-only next decision completed: Issue #1108, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh.
 - Latest songlike melody contour repair follow-up decision completed: Issue #1110, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair sweep completed: Issue #1112, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh.
-- Latest songlike melody contour phrase/rhythm repair audio package completed: Issue #1030, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh.
+- Latest songlike melody contour phrase/rhythm repair audio package completed: Issue #1114, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair listening review package completed: Issue #1032, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair listening review input guard completed: Issue #1034, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair objective-only next decision completed: Issue #1036, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1064, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after songlike melody contour phrase/rhythm repair sweep source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh.
+- Open issue queue after songlike melody contour phrase/rhythm repair audio package source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour repair objective-only next decision: `Issue #1108`
 - latest songlike melody contour repair follow-up decision: `Issue #1110`
 - latest songlike melody contour phrase/rhythm repair sweep: `Issue #1112`
-- latest songlike melody contour phrase/rhythm repair audio package: `Issue #1030`
+- latest songlike melody contour phrase/rhythm repair audio package: `Issue #1114`
 - latest songlike melody contour phrase/rhythm repair listening review package: `Issue #1032`
 - latest songlike melody contour phrase/rhythm repair listening review input guard: `Issue #1034`
 - latest songlike melody contour phrase/rhythm repair objective-only next decision: `Issue #1036`
@@ -50,7 +50,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1066`
 - latest README evidence refresh: `Issue #1068`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after songlike melody contour phrase/rhythm repair sweep source-context refresh merge: `0`
+- open issue queue after songlike melody contour phrase/rhythm repair audio package source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -417,9 +417,13 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - songlike contour phrase/rhythm failure count: `4 -> 1`
 - songlike contour phrase/rhythm source-context preserved flags: `3/3`
 - songlike contour phrase/rhythm technical regression count: `0`
+- songlike contour phrase/rhythm audio package completed: `true`
+- songlike contour phrase/rhythm rendered WAV count: `6`
+- songlike contour phrase/rhythm audio source-context preserved flags: `3/3`
+- songlike contour phrase/rhythm audio rendered quality claim: `false`
 - MVP delivery raw artifact upload required: `false`
 - model-conditioned input path quality alignment decision completed: `true`
-- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
+- next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package`
 - validated review input: `false`
 - input MIDI -> context -> ranked MIDI -> WAV technical path: `true`
 - selected-scale objective repair path complete: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -415,7 +415,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo songlike melody contour repair objective-only next decision: follow-up required `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, current quality claim ready `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
 - MIDI-to-solo songlike melody contour repair follow-up decision: selected target `songlike_melody_contour_phrase_rhythm_repair_sweep`, primary labels `phrase_shape_missing_tension_release,rhythmic_monotony`, objective and repair sweep source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, objective/sweep outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair sweep: phrase/rhythm failure `4 -> 1`, total failure labels `4 -> 1`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
-- MIDI-to-solo songlike melody contour phrase/rhythm repair audio package: rendered WAV `6`, duration `18.871s-19.000s`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package`
+- MIDI-to-solo songlike melody contour phrase/rhythm repair audio package: rendered WAV `6`, duration `18.871s-19.000s`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package: review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard: preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision: follow-up required `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, current quality claim ready `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
@@ -5019,6 +5019,8 @@ Issue #776은 Issue #774 phrase/rhythm repair sweep MIDI 후보 6개를 WAV로 �
 - `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-audio-package`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
 
 다음 작업:
 
@@ -11115,7 +11117,7 @@ Issue #1112는 Issue #1110 follow-up decision에서 선택된 phrase/rhythm repa
 
 ## 9.205 Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh
 
-Issue #1030은 Issue #1028 phrase/rhythm repair sweep MIDI 후보 6개를 WAV로 렌더링하고 source/current outside-soloing context를 audio package까지 보존한 작업이다.
+Issue #1114는 Issue #1112 phrase/rhythm repair sweep MIDI 후보 6개를 WAV로 렌더링하고 source/current outside-soloing context를 audio package까지 보존한 작업이다.
 
 결과:
 
@@ -11133,6 +11135,9 @@ Issue #1030은 Issue #1028 phrase/rhythm repair sweep MIDI 후보 6개를 WAV로
 - technical regression count: `0`
 - objective source outside-soloing repair source context preserved: `true`
 - source outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
 - source outside-soloing source pitch-role risk count: `5 -> 2`
 - source outside-soloing current repair pitch-role risk count after: `0`
 - source outside-soloing current repair pitch-role risk delta: `2`
@@ -11142,8 +11147,8 @@ Issue #1030은 Issue #1028 phrase/rhythm repair sweep MIDI 후보 6개를 WAV로
 
 판단:
 
-- audio package source validation에 objective/source source-context preserved 조건 추가.
-- bridge source-context 21개 키를 audio package summary와 validation summary까지 보존.
+- audio package source validation에 objective/source source-context preserved 조건 유지.
+- required source-context key와 preserved flag true 조건을 audio package summary와 validation summary까지 보존.
 - WAV 6개 렌더링 및 sample-rate/duration/file metadata 기술 검증 완료.
 - 다음 boundary는 phrase/rhythm repair listening review package source-context refresh.
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -35,7 +35,7 @@
 - latest songlike melody contour repair objective-only next decision: Issue #1108, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh
 - latest songlike melody contour repair follow-up decision: Issue #1110, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh
 - latest songlike melody contour phrase/rhythm repair sweep: Issue #1112, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh
-- latest songlike melody contour phrase/rhythm repair audio package: Issue #1030, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh
+- latest songlike melody contour phrase/rhythm repair audio package: Issue #1114, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh
 - latest songlike melody contour phrase/rhythm repair listening review package: Issue #1032, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh
 - latest songlike melody contour phrase/rhythm repair listening review input guard: Issue #1034, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh
 - latest songlike melody contour phrase/rhythm repair objective-only next decision: Issue #1036, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after songlike melody contour phrase/rhythm repair sweep source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh`
+- open issue queue after songlike melody contour phrase/rhythm repair audio package source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -4186,14 +4186,14 @@ Issue #1112는 Issue #1110 follow-up decision에서 선택된 phrase/rhythm repa
 
 ## Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Repair Audio Package Source Context Refresh Result
 
-Issue #1030은 Issue #1028 phrase/rhythm repair sweep MIDI 후보 6개를 WAV로 렌더링하고 source/current outside-soloing context를 audio package까지 보존한 작업이다.
+Issue #1114는 Issue #1112 phrase/rhythm repair sweep MIDI 후보 6개를 WAV로 렌더링하고 source/current outside-soloing context를 audio package까지 보존한 작업이다.
 
 변경:
 
 - audio package source validation에 objective/source source-context preserved flag 필수화
-- follow-up/source repair sweep bridge source-context 21개 키 보존 검증 추가
+- follow-up/source repair sweep required source-context key 보존 검증 추가
 - objective/source context를 audio package summary와 validation summary까지 전파
-- harness issue number를 #1030 기준으로 갱신
+- harness issue number를 #1114 기준으로 갱신
 
 결과:
 
@@ -4211,6 +4211,9 @@ Issue #1030은 Issue #1028 phrase/rhythm repair sweep MIDI 후보 6개를 WAV로
 - technical regression count: `0`
 - objective source outside-soloing source context preserved: `true`
 - source outside-soloing source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
 - source outside-soloing source pitch-role risk count: `5 -> 2`
 - source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
 - repaired outside-soloing not evaluable count: `6`
@@ -4220,7 +4223,7 @@ Issue #1030은 Issue #1028 phrase/rhythm repair sweep MIDI 후보 6개를 WAV로
 판단:
 
 - phrase/rhythm repair MIDI 후보 6개 WAV 렌더링과 기술 메타데이터 검증 완료.
-- source-context preserved flag와 21개 context field 보존 확인.
+- source-context preserved flag `3/3` 보존 확인.
 - outside-soloing과 weak chord-tone landing은 context 부재로 quality claim 제외 유지.
 - 다음 boundary는 listening review package source-context refresh.
 
@@ -4230,6 +4233,8 @@ Issue #1030은 Issue #1028 phrase/rhythm repair sweep MIDI 후보 6개를 WAV로
 - `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-audio-package`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
 
 다음:
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -18,6 +18,9 @@
 - objective source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - objective source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
 - source outside-soloing source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
 - source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - source outside-soloing source repair targeted: `false`
 - source outside-soloing source residual risk preserved: `true`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6535,7 +6535,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_pack
     --run_id "$run_id" \
     --phrase_rhythm_repair_sweep_report "$sweep_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1030 \
+    --issue_number 1114 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package \
     --expected_file_count 6 \

--- a/scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio.py
+++ b/scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio.py
@@ -17,7 +17,8 @@ sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
 from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
-    BRIDGE_SOURCE_CONTEXT_KEYS,
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
 )
 from scripts.render_stage_b_midi_to_solo_candidate_audio import (  # noqa: E402
     resolve_soundfont,
@@ -38,7 +39,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(ValueErr
 
 BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package"
-SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package_v3"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package_v4"
 CommandRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
 
 QUALITY_CLAIM_KEYS = [
@@ -93,7 +94,7 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
 
 
 def _source_context_fields(source: dict[str, Any]) -> dict[str, Any]:
-    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+    for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
         objective_key = f"objective_{key}"
         if objective_key not in source or source[objective_key] is None:
             raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
@@ -103,6 +104,17 @@ def _source_context_fields(source: dict[str, Any]) -> dict[str, Any]:
             raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
                 f"source-context field required: {key}"
             )
+    missing_preserved = []
+    for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS:
+        objective_key = f"objective_{key}"
+        if not bool(source.get(objective_key)):
+            missing_preserved.append(objective_key)
+        if not bool(source.get(key)):
+            missing_preserved.append(key)
+    if missing_preserved:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError(
+            f"source-context preserved field must be true: {missing_preserved}"
+        )
     return {
         "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
             source.get(
@@ -169,8 +181,11 @@ def _source_context_fields(source: dict[str, Any]) -> dict[str, Any]:
         "source_outside_soloing_repair_pitch_role_risk_delta": _int(
             source.get("source_outside_soloing_repair_pitch_role_risk_delta")
         ),
-        **{f"objective_{key}": source.get(f"objective_{key}") for key in BRIDGE_SOURCE_CONTEXT_KEYS},
-        **{key: source.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{
+            f"objective_{key}": source.get(f"objective_{key}")
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
+        },
+        **{key: source.get(key) for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
     }
 
 
@@ -437,8 +452,8 @@ def build_audio_render_report(
         for key, value in source.items()
         if key.startswith("objective_source_outside_soloing_repair_")
         or key.startswith("source_outside_soloing_repair_")
-        or key in BRIDGE_SOURCE_CONTEXT_KEYS
-        or key in {f"objective_{source_key}" for source_key in BRIDGE_SOURCE_CONTEXT_KEYS}
+        or key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
+        or key in {f"objective_{source_key}" for source_key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS}
     }
     resolved_renderer = renderer_path or shutil.which("fluidsynth") or ""
     resolved_soundfont = resolve_soundfont(soundfont_path)
@@ -705,8 +720,11 @@ def validate_audio_render_report(
         "source_outside_soloing_repair_pitch_role_risk_delta": _int(
             summary.get("source_outside_soloing_repair_pitch_role_risk_delta")
         ),
-        **{f"objective_{key}": summary.get(f"objective_{key}") for key in BRIDGE_SOURCE_CONTEXT_KEYS},
-        **{key: summary.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{
+            f"objective_{key}": summary.get(f"objective_{key}")
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
+        },
+        **{key: summary.get(key) for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
         "source_outside_soloing_not_evaluable_count": _int(
             summary.get("source_outside_soloing_not_evaluable_count")
         ),
@@ -759,6 +777,9 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- objective source outside-soloing source pitch-role risk before / after / delta: `{summary['objective_source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{summary['objective_source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{summary['objective_source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- objective source outside-soloing current repair pitch-role risk after / delta: `{summary['objective_source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{summary['objective_source_outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- source outside-soloing source context preserved: `{_bool_token(summary['source_outside_soloing_repair_source_context_preserved'])}`",
+        f"- follow-up objective source outside-soloing source context preserved: `{_bool_token(summary['followup_objective_source_outside_soloing_source_context_preserved'])}`",
+        f"- follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(summary['followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
+        f"- bridge repair sweep source outside-soloing source context preserved: `{_bool_token(summary['repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- source outside-soloing source pitch-role risk before / after / delta: `{summary['source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{summary['source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{summary['source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- source outside-soloing source repair targeted: `{_bool_token(summary['source_outside_soloing_repair_source_targeted'])}`",
         f"- source outside-soloing source residual risk preserved: `{_bool_token(summary['source_outside_soloing_repair_source_residual_risk_preserved'])}`",

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio.py
@@ -9,10 +9,14 @@ from typing import Sequence
 
 import pretty_midi
 
-from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_SOURCE_CONTEXT_KEYS
+from scripts.audit_stage_b_midi_to_solo_final_status import (
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
+)
 from scripts.render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio import (
     BOUNDARY,
     NEXT_BOUNDARY,
+    SCHEMA_VERSION,
     StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError,
     build_audio_render_report,
     validate_audio_render_report,
@@ -233,7 +237,8 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioTest(unittest.
                 5,
             )
             self.assertTrue(summary["objective_source_outside_soloing_repair_source_context_preserved"])
-            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+            self.assertEqual(report["schema_version"], SCHEMA_VERSION)
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[f"objective_{key}"], SOURCE_CONTEXT[key])
             self.assertEqual(
                 summary[
@@ -265,8 +270,11 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioTest(unittest.
                 5,
             )
             self.assertTrue(summary["source_outside_soloing_repair_source_context_preserved"])
-            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[key], SOURCE_CONTEXT[key])
+            for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS:
+                self.assertTrue(summary[f"objective_{key}"])
+                self.assertTrue(summary[key])
             self.assertEqual(
                 summary[
                     "source_outside_soloing_repair_source_pitch_role_risk_count_before"
@@ -379,9 +387,33 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioTest(unittest.
                     runner=fake_runner,
                 )
 
+    def test_rejects_source_context_preservation_flag_false(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = root / "fluidsynth"
+            soundfont = root / "soundfont.sf2"
+            renderer.write_text("#!/bin/sh\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            source = source_report(root)
+            source["aggregate"][BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS[0]] = False
+            with self.assertRaises(StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairAudioError):
+                build_audio_render_report(
+                    source,
+                    output_dir=root / "audio_package",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(soundfont),
+                    sample_rate=44100,
+                    expected_file_count=6,
+                    runner=fake_runner,
+                )
+
     def test_constants_are_stable(self) -> None:
         self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package")
         self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package")
+        self.assertEqual(
+            SCHEMA_VERSION,
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package_v4",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary
- phrase/rhythm repair audio package source-context validation 갱신
- required source-context key와 preserved flag 3개 summary/validation/markdown 보존
- preserved flag false 입력 차단 테스트 추가
- #1114 기준 harness/status 문서 갱신

Context
- #1112 phrase/rhythm repair sweep 기준 phrase/rhythm failure `4 -> 1`
- rendered WAV `6`, duration `18.871s-19.000s`
- source risk `5 -> 2`, current repair risk after/delta `0/2`
- source-context preserved flag `3/3` 유지 필요

Scope
- `BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS` 기준 audio package 검증 전환
- `BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS` false 입력 차단
- audio package markdown에 preserved flag 3개 명시
- README, CURRENT_STATUS, CORE_PLAN, AGENTS handoff 갱신

Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio`
- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-audio-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

Risk
- listening preference claim 없음
- audio rendered quality claim 없음
- MIDI-to-solo musical quality claim 없음

Follow-up
- Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh

Closes #1114