### PR TITLE
Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm repair sweep completed: Issue #1112, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair audio package completed: Issue #1114, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair listening review package completed: Issue #1116, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh.
-- Latest songlike melody contour phrase/rhythm repair listening review input guard completed: Issue #1034, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh.
+- Latest songlike melody contour phrase/rhythm repair listening review input guard completed: Issue #1118, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair objective-only next decision completed: Issue #1036, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair follow-up decision completed: Issue #1038, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-context pitch-role bridge completed: Issue #1040, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1064, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after songlike melody contour phrase/rhythm repair listening review package source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh.
+- Open issue queue after songlike melody contour phrase/rhythm repair listening review input guard source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour phrase/rhythm repair sweep: `Issue #1112`
 - latest songlike melody contour phrase/rhythm repair audio package: `Issue #1114`
 - latest songlike melody contour phrase/rhythm repair listening review package: `Issue #1116`
-- latest songlike melody contour phrase/rhythm repair listening review input guard: `Issue #1034`
+- latest songlike melody contour phrase/rhythm repair listening review input guard: `Issue #1118`
 - latest songlike melody contour phrase/rhythm repair objective-only next decision: `Issue #1036`
 - latest songlike melody contour phrase/rhythm repair follow-up decision: `Issue #1038`
 - latest songlike melody contour phrase/rhythm chord-context pitch-role bridge: `Issue #1040`
@@ -50,7 +50,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1066`
 - latest README evidence refresh: `Issue #1068`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after songlike melody contour phrase/rhythm repair listening review package source-context refresh merge: `0`
+- open issue queue after songlike melody contour phrase/rhythm repair listening review input guard source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -11213,7 +11213,7 @@ Issue #1116은 Issue #1114 phrase/rhythm repair audio package 결과의 WAV/MIDI
 
 ## 9.207 Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh
 
-Issue #1034는 Issue #1032 listening review package의 pending input 상태와 source/current outside-soloing context를 input guard summary까지 보존한 작업이다.
+Issue #1118은 Issue #1116 listening review package의 pending input 상태와 source/current outside-soloing context를 input guard summary까지 보존한 작업이다.
 
 결과:
 
@@ -11230,6 +11230,9 @@ Issue #1034는 Issue #1032 listening review package의 pending input 상태와 s
 - phrase/rhythm failure delta: `3`
 - objective source outside-soloing repair source context preserved: `true`
 - source outside-soloing repair source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
 - source outside-soloing source pitch-role risk count: `5 -> 2`
 - source outside-soloing current repair pitch-role risk count after: `0`
 - source outside-soloing current repair pitch-role risk delta: `2`
@@ -11239,8 +11242,8 @@ Issue #1034는 Issue #1032 listening review package의 pending input 상태와 s
 
 판단:
 
-- input guard source validation에 objective/source source-context preserved 조건 추가.
-- bridge source-context 21개 키를 guard/readiness/validation summary까지 보존.
+- input guard source validation에 required source-context key와 preserved flag true 조건 추가.
+- bridge source-context key를 guard/readiness/validation summary까지 보존.
 - validated review input 부재 상태에서 preference fill 차단 유지.
 - 다음 boundary는 phrase/rhythm repair objective-only next decision source-context refresh.
 
@@ -11250,6 +11253,8 @@ Issue #1034는 Issue #1032 listening review package의 pending input 상태와 s
 - `.venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-listening-review-input-guard`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
 
 다음 작업:
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -37,7 +37,7 @@
 - latest songlike melody contour phrase/rhythm repair sweep: Issue #1112, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh
 - latest songlike melody contour phrase/rhythm repair audio package: Issue #1114, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh
 - latest songlike melody contour phrase/rhythm repair listening review package: Issue #1116, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh
-- latest songlike melody contour phrase/rhythm repair listening review input guard: Issue #1034, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh
+- latest songlike melody contour phrase/rhythm repair listening review input guard: Issue #1118, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh
 - latest songlike melody contour phrase/rhythm repair objective-only next decision: Issue #1036, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh
 - latest songlike melody contour phrase/rhythm repair follow-up decision: Issue #1038, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh
 - latest songlike melody contour phrase/rhythm chord-context pitch-role bridge: Issue #1040, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after songlike melody contour phrase/rhythm repair listening review package source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh`
+- open issue queue after songlike melody contour phrase/rhythm repair listening review input guard source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -4296,14 +4296,14 @@ Issue #1116은 Issue #1114 phrase/rhythm repair audio package 결과의 WAV/MIDI
 
 ## Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Repair Listening Review Input Guard Source Context Refresh Result
 
-Issue #1034는 Issue #1032 listening review package의 pending input 상태와 source/current outside-soloing context를 input guard summary까지 보존한 작업이다.
+Issue #1118은 Issue #1116 listening review package의 pending input 상태와 source/current outside-soloing context를 input guard summary까지 보존한 작업이다.
 
 변경:
 
-- input guard source validation에 objective/source source-context preserved flag 필수화
-- listening review package bridge source-context 21개 키 보존 검증 추가
+- input guard source validation에 required source-context key와 preserved flag true 조건 추가
+- listening review package bridge source-context key 보존 검증 추가
 - pending input, preference fill 차단, source context를 guard/readiness/validation summary까지 전파
-- harness issue number를 #1034 기준으로 갱신
+- harness issue number를 #1118 기준으로 갱신
 
 결과:
 
@@ -4320,6 +4320,9 @@ Issue #1034는 Issue #1032 listening review package의 pending input 상태와 s
 - phrase/rhythm failure delta: `3`
 - objective source outside-soloing source context preserved: `true`
 - source outside-soloing source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
 - source outside-soloing source pitch-role risk count: `5 -> 2`
 - source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
 - source/repaired outside-soloing not evaluable count: `6/6`
@@ -4329,7 +4332,7 @@ Issue #1034는 Issue #1032 listening review package의 pending input 상태와 s
 판단:
 
 - validated review input 부재 상태에서 preference fill 차단 유지.
-- source-context preserved flag와 21개 context field 보존 확인.
+- source-context preserved flag와 required context field 보존 확인.
 - quality/preference claim 제외 유지.
 - critical user input 없이 objective-only next decision boundary로 진행 가능.
 
@@ -4339,6 +4342,8 @@ Issue #1034는 Issue #1032 listening review package의 pending input 상태와 s
 - `.venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-listening-review-input-guard`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
 
 다음:
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_LISTENING_REVIEW_INPUT_GUARD_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_LISTENING_REVIEW_INPUT_GUARD_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -20,6 +20,9 @@
 - objective source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - objective source outside-soloing current repair pitch-role risk after / delta: `0` / `2`
 - source outside-soloing source context preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
 - source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - source outside-soloing source repair targeted: `false`
 - source outside-soloing source residual risk preserved: `true`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6578,7 +6578,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_
     --run_id "$guard_run_id" \
     --source_package "$source_package" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_LISTENING_REVIEW_INPUT_GUARD_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1034 \
+    --issue_number 1118 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision \
     --require_guard_completed \

--- a/scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input.py
+++ b/scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input.py
@@ -14,7 +14,8 @@ sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
 from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
-    BRIDGE_SOURCE_CONTEXT_KEYS,
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
 )
 from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package import (  # noqa: E402
     BOUNDARY as SOURCE_BOUNDARY,
@@ -31,7 +32,7 @@ FILL_BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repa
 OBJECTIVE_NEXT_BOUNDARY = (
     "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision"
 )
-SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard_v3"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard_v4"
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -81,7 +82,7 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
 
 
 def _source_context_fields(source: dict[str, Any]) -> dict[str, Any]:
-    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+    for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
         objective_key = f"objective_{key}"
         if objective_key not in source or source[objective_key] is None:
             raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
@@ -91,6 +92,17 @@ def _source_context_fields(source: dict[str, Any]) -> dict[str, Any]:
             raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
                 f"source-context field required: {key}"
             )
+    missing_preserved = []
+    for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS:
+        objective_key = f"objective_{key}"
+        if not bool(source.get(objective_key)):
+            missing_preserved.append(objective_key)
+        if not bool(source.get(key)):
+            missing_preserved.append(key)
+    if missing_preserved:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError(
+            f"source-context preserved field must be true: {missing_preserved}"
+        )
     return {
         "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": _int(
             source.get(
@@ -157,8 +169,11 @@ def _source_context_fields(source: dict[str, Any]) -> dict[str, Any]:
         "source_outside_soloing_repair_pitch_role_risk_delta": _int(
             source.get("source_outside_soloing_repair_pitch_role_risk_delta")
         ),
-        **{f"objective_{key}": source.get(f"objective_{key}") for key in BRIDGE_SOURCE_CONTEXT_KEYS},
-        **{key: source.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{
+            f"objective_{key}": source.get(f"objective_{key}")
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
+        },
+        **{key: source.get(key) for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
     }
 
 
@@ -525,8 +540,11 @@ def validate_listening_review_input_guard_report(
         "source_outside_soloing_repair_pitch_role_risk_delta": _int(
             source.get("source_outside_soloing_repair_pitch_role_risk_delta")
         ),
-        **{f"objective_{key}": source.get(f"objective_{key}") for key in BRIDGE_SOURCE_CONTEXT_KEYS},
-        **{key: source.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{
+            f"objective_{key}": source.get(f"objective_{key}")
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
+        },
+        **{key: source.get(key) for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
         "source_outside_soloing_not_evaluable_count": _int(
             source.get("source_outside_soloing_not_evaluable_count")
         ),
@@ -576,6 +594,9 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- objective source outside-soloing source pitch-role risk before / after / delta: `{source['objective_source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{source['objective_source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{source['objective_source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- objective source outside-soloing current repair pitch-role risk after / delta: `{source['objective_source_outside_soloing_repair_pitch_role_risk_count_after']}` / `{source['objective_source_outside_soloing_repair_pitch_role_risk_delta']}`",
         f"- source outside-soloing source context preserved: `{_bool_token(source['source_outside_soloing_repair_source_context_preserved'])}`",
+        f"- follow-up objective source outside-soloing source context preserved: `{_bool_token(source['followup_objective_source_outside_soloing_source_context_preserved'])}`",
+        f"- follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(source['followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
+        f"- bridge repair sweep source outside-soloing source context preserved: `{_bool_token(source['repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- source outside-soloing source pitch-role risk before / after / delta: `{source['source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{source['source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{source['source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- source outside-soloing source repair targeted: `{_bool_token(source['source_outside_soloing_repair_source_targeted'])}`",
         f"- source outside-soloing source residual risk preserved: `{_bool_token(source['source_outside_soloing_repair_source_residual_risk_preserved'])}`",
@@ -623,7 +644,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=1034)
+    parser.add_argument("--issue_number", type=int, default=1118)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--require_guard_completed", action="store_true")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard.py
@@ -4,7 +4,10 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_SOURCE_CONTEXT_KEYS
+from scripts.audit_stage_b_midi_to_solo_final_status import (
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
+)
 from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package import (
     BOUNDARY as SOURCE_BOUNDARY,
     NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
@@ -12,6 +15,7 @@ from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_re
 from scripts.guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input import (
     BOUNDARY,
     OBJECTIVE_NEXT_BOUNDARY,
+    SCHEMA_VERSION,
     StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError,
     build_listening_review_input_guard_report,
     validate_listening_review_input_guard_report,
@@ -20,6 +24,7 @@ from scripts.guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_re
 
 SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_objective_source_outside_soloing_source_context_preserved": True,
     "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
     "followup_objective_source_outside_soloing_source_targeted": False,
@@ -27,6 +32,7 @@ SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_repair_sweep_source_outside_soloing_source_context_preserved": True,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
     "followup_repair_sweep_source_outside_soloing_source_targeted": False,
@@ -34,6 +40,7 @@ SOURCE_CONTEXT = {
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "repair_sweep_source_outside_soloing_source_context_preserved": True,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
     "repair_sweep_source_outside_soloing_source_targeted": False,
@@ -157,6 +164,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuard
                 require_no_quality_claim=True,
             )
 
+            self.assertEqual(report["schema_version"], SCHEMA_VERSION)
             self.assertTrue(summary["technical_wav_validation"])
             self.assertFalse(summary["validated_review_input_present"])
             self.assertFalse(summary["preference_fill_allowed"])
@@ -172,7 +180,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuard
                 5,
             )
             self.assertTrue(summary["objective_source_outside_soloing_repair_source_context_preserved"])
-            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[f"objective_{key}"], SOURCE_CONTEXT[key])
             self.assertEqual(
                 summary[
@@ -206,8 +214,11 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuard
                 5,
             )
             self.assertTrue(summary["source_outside_soloing_repair_source_context_preserved"])
-            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[key], SOURCE_CONTEXT[key])
+            for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS:
+                self.assertTrue(summary[f"objective_{key}"])
+                self.assertTrue(summary[key])
             self.assertEqual(
                 summary[
                     "source_outside_soloing_repair_source_pitch_role_risk_count_before"
@@ -286,12 +297,29 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuard
                 build_listening_review_input_guard_report(
                     source,
                     output_dir=root / "guard",
-                    issue_number=1034,
+                    issue_number=1118,
+                )
+
+    def test_rejects_source_context_preservation_flag_false(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = source_package()
+            source["source_summary"][BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS[0]] = False
+
+            with self.assertRaises(StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairListeningInputGuardError):
+                build_listening_review_input_guard_report(
+                    source,
+                    output_dir=root / "guard",
+                    issue_number=1118,
                 )
 
     def test_constants_are_stable(self) -> None:
         self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard")
         self.assertEqual(OBJECTIVE_NEXT_BOUNDARY, "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision")
+        self.assertEqual(
+            SCHEMA_VERSION,
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard_v4",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary
- input guard source validation을 required source-context key와 preserved flag true 조건 기준으로 갱신
- pending review input 상태에서 preference fill 차단 유지
- guard summary, readiness, validation summary, markdown에 preserved flag 전파

Context
- #1116 listening review package 결과: review item count 6, technical WAV validation true
- validated review input present: false
- source outside-soloing pitch-role risk: 5 -> 2
- current repair pitch-role risk after / delta: 0 / 2
- 보존 대상: follow-up objective, follow-up repair sweep, bridge repair sweep source-context preserved flag 3개

Scope
- input guard schema v4
- false preserved flag 입력 차단 테스트 추가
- harness issue number #1118 갱신
- README, AGENTS, CURRENT_STATUS, CORE_PLAN handoff 갱신

Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard
- .venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-listening-review-input-guard
- bash scripts/agent_harness.sh quick
- git diff --check

Risk
- human/audio preference claim 없음
- MIDI-to-solo musical quality claim 없음
- objective-only next decision 전 source-context 누락 차단 범위

Follow-up
- Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh

Closes #1118