### PR TITLE
Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm repair listening review package completed: Issue #1116, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair listening review input guard completed: Issue #1118, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair objective-only next decision completed: Issue #1120, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh.
-- Latest songlike melody contour phrase/rhythm repair follow-up decision completed: Issue #1038, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh.
+- Latest songlike melody contour phrase/rhythm repair follow-up decision completed: Issue #1122, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-context pitch-role bridge completed: Issue #1040, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-context pitch-role objective decision completed: Issue #1042, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing repair sweep completed: Issue #1044, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1064, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh.
+- Open issue queue after songlike melody contour phrase/rhythm repair follow-up decision source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour phrase/rhythm repair listening review package: `Issue #1116`
 - latest songlike melody contour phrase/rhythm repair listening review input guard: `Issue #1118`
 - latest songlike melody contour phrase/rhythm repair objective-only next decision: `Issue #1120`
-- latest songlike melody contour phrase/rhythm repair follow-up decision: `Issue #1038`
+- latest songlike melody contour phrase/rhythm repair follow-up decision: `Issue #1122`
 - latest songlike melody contour phrase/rhythm chord-context pitch-role bridge: `Issue #1040`
 - latest songlike melody contour phrase/rhythm chord-context pitch-role objective decision: `Issue #1042`
 - latest songlike melody contour phrase/rhythm chord-tone landing repair sweep: `Issue #1044`
@@ -50,7 +50,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1066`
 - latest README evidence refresh: `Issue #1068`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh merge: `0`
+- open issue queue after songlike melody contour phrase/rhythm repair follow-up decision source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -11315,7 +11315,7 @@ Issue #1120은 Issue #1118 input guard의 pending input 상태와 objective/sour
 
 ## 9.209 Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh
 
-Issue #1038은 Issue #1036 objective-only next decision과 Issue #1028 repair sweep의 source-context를 follow-up decision에서 비교 검증한 작업이다.
+Issue #1122는 Issue #1120 objective-only next decision과 Issue #1112 repair sweep의 source-context를 follow-up decision에서 비교 검증한 작업이다.
 
 결과:
 
@@ -11332,6 +11332,12 @@ Issue #1038은 Issue #1036 objective-only next decision과 Issue #1028 repair sw
 - context not-evaluable min count: `6`
 - objective source outside-soloing source context preserved: `true`
 - repair sweep source outside-soloing source context preserved: `true`
+- objective follow-up objective source outside-soloing source context preserved: `true`
+- objective follow-up repair sweep source outside-soloing source context preserved: `true`
+- objective bridge repair sweep source outside-soloing source context preserved: `true`
+- repair sweep follow-up objective source outside-soloing source context preserved: `true`
+- repair sweep follow-up repair sweep source outside-soloing source context preserved: `true`
+- repair sweep bridge repair sweep source outside-soloing source context preserved: `true`
 - source outside-soloing source pitch-role risk count: `5 -> 2`
 - current repair pitch-role risk count after / delta: `0 / 2`
 - technical regression count: `0`
@@ -11340,7 +11346,7 @@ Issue #1038은 Issue #1036 objective-only next decision과 Issue #1028 repair sw
 
 판단:
 
-- objective-only next decision과 repair sweep의 source-context 불일치 없음.
+- objective-only next decision과 repair sweep의 required source-context key 불일치 없음.
 - residual rhythmic monotony는 1개 남았지만, context not-evaluable target 2종이 candidate 6개 전체에서 유지.
 - 후속 repair보다 chord-context pitch-role bridge 진입 조건 우선.
 - quality/preference claim 제외 유지.
@@ -11351,6 +11357,8 @@ Issue #1038은 Issue #1036 objective-only next decision과 Issue #1028 repair sw
 - `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-followup-decision`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
 
 다음 작업:
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -39,7 +39,7 @@
 - latest songlike melody contour phrase/rhythm repair listening review package: Issue #1116, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh
 - latest songlike melody contour phrase/rhythm repair listening review input guard: Issue #1118, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh
 - latest songlike melody contour phrase/rhythm repair objective-only next decision: Issue #1120, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh
-- latest songlike melody contour phrase/rhythm repair follow-up decision: Issue #1038, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh
+- latest songlike melody contour phrase/rhythm repair follow-up decision: Issue #1122, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh
 - latest songlike melody contour phrase/rhythm chord-context pitch-role bridge: Issue #1040, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh
 - latest songlike melody contour phrase/rhythm chord-context pitch-role objective decision: Issue #1042, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing repair sweep: Issue #1044, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh`
+- open issue queue after songlike melody contour phrase/rhythm repair follow-up decision source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -4411,14 +4411,14 @@ Issue #1120은 Issue #1118 input guard의 pending input 상태와 objective/sour
 
 ## Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Repair Follow-Up Decision Source Context Refresh Result
 
-Issue #1038은 Issue #1036 objective-only next decision과 Issue #1028 repair sweep의 source-context를 follow-up decision에서 비교 검증한 작업이다.
+Issue #1122는 Issue #1120 objective-only next decision과 Issue #1112 repair sweep의 source-context를 follow-up decision에서 비교 검증한 작업이다.
 
 변경:
 
-- follow-up decision source validation에 objective/source source-context preserved flag 필수화
-- objective-only next decision과 repair sweep의 bridge source-context 21개 키 consistency 검증 추가
+- follow-up decision source validation에 required source-context key와 preserved flag true 조건 추가
+- objective-only next decision과 repair sweep의 bridge source-context key consistency 검증 추가
 - chord-context pitch-role bridge 선택 결과와 context field를 readiness/validation summary까지 전파
-- harness issue number를 #1038 기준으로 갱신
+- harness issue number를 #1122 기준으로 갱신
 
 결과:
 
@@ -4436,6 +4436,12 @@ Issue #1038은 Issue #1036 objective-only next decision과 Issue #1028 repair sw
 - context not-evaluable min count: `6`
 - objective source outside-soloing source context preserved: `true`
 - repair sweep source outside-soloing source context preserved: `true`
+- objective follow-up objective source outside-soloing source context preserved: `true`
+- objective follow-up repair sweep source outside-soloing source context preserved: `true`
+- objective bridge repair sweep source outside-soloing source context preserved: `true`
+- repair sweep follow-up objective source outside-soloing source context preserved: `true`
+- repair sweep follow-up repair sweep source outside-soloing source context preserved: `true`
+- repair sweep bridge repair sweep source outside-soloing source context preserved: `true`
 - source outside-soloing source pitch-role risk count: `5 -> 2`
 - current repair pitch-role risk count after / delta: `0 / 2`
 - technical regression count: `0`
@@ -4455,6 +4461,8 @@ Issue #1038은 Issue #1036 objective-only next decision과 Issue #1028 repair sw
 - `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-followup-decision`
+- `bash scripts/agent_harness.sh quick`
+- `git diff --check`
 
 다음:
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -23,14 +23,20 @@
 - objective source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - objective source outside-soloing source repair targeted: `false`
 - objective source outside-soloing source residual risk preserved: `true`
+- objective follow-up objective source outside-soloing source context preserved: `true`
 - objective follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- objective follow-up repair sweep source outside-soloing source context preserved: `true`
+- objective bridge repair sweep source outside-soloing source context preserved: `true`
 - objective repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
 - repair sweep source/repaired outside-soloing not evaluable count: `6/6`
 - repair sweep source outside-soloing source context preserved: `true`
 - repair sweep source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - repair sweep source outside-soloing source repair targeted: `false`
 - repair sweep source outside-soloing source residual risk preserved: `true`
+- follow-up objective source outside-soloing source context preserved: `true`
 - follow-up objective source outside-soloing source pitch-role risk: `5 -> 2`
+- follow-up repair sweep source outside-soloing source context preserved: `true`
+- bridge repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
 - objective source outside-soloing repair pitch-role risk count after: `0`
 - objective source outside-soloing current repair pitch-role risk delta: `2`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6627,7 +6627,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_d
     --objective_next_report "$objective_report" \
     --repair_sweep_report "$sweep_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1038 \
+    --issue_number 1122 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge \
     --expected_target songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge \

--- a/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup.py
+++ b/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup.py
@@ -15,7 +15,8 @@ sys.path.insert(0, str(ROOT_DIR))
 
 from scripts.assess_stage_b_generic_base_readiness import read_json, write_json, write_text  # noqa: E402
 from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
-    BRIDGE_SOURCE_CONTEXT_KEYS,
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
 )
 from scripts.decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_next import (  # noqa: E402
     BOUNDARY as OBJECTIVE_NEXT_BOUNDARY,
@@ -35,7 +36,7 @@ NEXT_BOUNDARY = (
     "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge"
 )
 SELECTED_TARGET = "songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge"
-SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision_v3"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision_v4"
 CONTEXT_TARGET_LABELS = (
     "outside_soloing_without_context",
     "weak_chord_tone_landing",
@@ -83,7 +84,7 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
 
 
 def _bridge_source_context_fields(source: dict[str, Any], *, label: str) -> dict[str, Any]:
-    for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+    for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
         objective_key = f"objective_{key}"
         if objective_key not in source or source[objective_key] is None:
             raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
@@ -93,9 +94,23 @@ def _bridge_source_context_fields(source: dict[str, Any], *, label: str) -> dict
             raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
                 f"{label} source-context field required: {key}"
             )
+    missing_preserved = []
+    for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS:
+        objective_key = f"objective_{key}"
+        if not bool(source.get(objective_key)):
+            missing_preserved.append(objective_key)
+        if not bool(source.get(key)):
+            missing_preserved.append(key)
+    if missing_preserved:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError(
+            f"{label} source-context preserved field must be true: {missing_preserved}"
+        )
     return {
-        **{f"objective_{key}": source.get(f"objective_{key}") for key in BRIDGE_SOURCE_CONTEXT_KEYS},
-        **{key: source.get(key) for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{
+            f"objective_{key}": source.get(f"objective_{key}")
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
+        },
+        **{key: source.get(key) for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
     }
 
 
@@ -251,8 +266,8 @@ def _assert_context_consistency(
         "source_outside_soloing_repair_source_residual_risk_preserved",
         "source_outside_soloing_repair_pitch_role_risk_count_after",
         "source_outside_soloing_repair_pitch_role_risk_delta",
-        *BRIDGE_SOURCE_CONTEXT_KEYS,
-        *[f"objective_{key}" for key in BRIDGE_SOURCE_CONTEXT_KEYS],
+        *BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+        *[f"objective_{key}" for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS],
     ]
     mismatched = [
         key
@@ -628,7 +643,10 @@ def build_followup_decision_report(
             "objective_source_outside_soloing_repair_pitch_role_risk_delta": _int(
                 objective["source_outside_soloing_repair_pitch_role_risk_delta"]
             ),
-            **{f"objective_{key}": objective[f"objective_{key}"] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+            **{
+                f"objective_{key}": objective[f"objective_{key}"]
+                for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
+            },
             "objective_source_outside_soloing_not_evaluable_count": _int(
                 objective["source_outside_soloing_not_evaluable_count"]
             ),
@@ -665,7 +683,7 @@ def build_followup_decision_report(
             "repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta": _int(
                 sweep["source_outside_soloing_repair_pitch_role_risk_delta"]
             ),
-            **{f"repair_sweep_{key}": sweep[key] for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+            **{f"repair_sweep_{key}": sweep[key] for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
             "repair_sweep_source_outside_soloing_not_evaluable_count": _int(
                 sweep["source_outside_soloing_not_evaluable_count"]
             ),
@@ -852,7 +870,10 @@ def validate_followup_decision_report(
         "objective_source_outside_soloing_repair_pitch_role_risk_delta": _int(
             readiness.get("objective_source_outside_soloing_repair_pitch_role_risk_delta")
         ),
-        **{f"objective_{key}": readiness.get(f"objective_{key}") for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{
+            f"objective_{key}": readiness.get(f"objective_{key}")
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
+        },
         "objective_source_outside_soloing_not_evaluable_count": _int(
             readiness.get("objective_source_outside_soloing_not_evaluable_count")
         ),
@@ -901,7 +922,10 @@ def validate_followup_decision_report(
         "repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta": _int(
             readiness.get("repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta")
         ),
-        **{f"repair_sweep_{key}": readiness.get(f"repair_sweep_{key}") for key in BRIDGE_SOURCE_CONTEXT_KEYS},
+        **{
+            f"repair_sweep_{key}": readiness.get(f"repair_sweep_{key}")
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
+        },
         "repair_sweep_source_outside_soloing_not_evaluable_count": _int(
             readiness.get("repair_sweep_source_outside_soloing_not_evaluable_count")
         ),
@@ -952,14 +976,20 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- objective source outside-soloing source pitch-role risk before / after / delta: `{readiness['objective_source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{readiness['objective_source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{readiness['objective_source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- objective source outside-soloing source repair targeted: `{_bool_token(readiness['objective_source_outside_soloing_repair_source_targeted'])}`",
         f"- objective source outside-soloing source residual risk preserved: `{_bool_token(readiness['objective_source_outside_soloing_repair_source_residual_risk_preserved'])}`",
+        f"- objective follow-up objective source outside-soloing source context preserved: `{_bool_token(readiness['objective_followup_objective_source_outside_soloing_source_context_preserved'])}`",
         f"- objective follow-up objective source outside-soloing source pitch-role risk: `{readiness['objective_followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {readiness['objective_followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- objective follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(readiness['objective_followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
+        f"- objective bridge repair sweep source outside-soloing source context preserved: `{_bool_token(readiness['objective_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- objective repair sweep source outside-soloing source pitch-role risk: `{readiness['objective_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {readiness['objective_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
         f"- repair sweep source/repaired outside-soloing not evaluable count: `{readiness['repair_sweep_source_outside_soloing_not_evaluable_count']}/{readiness['repair_sweep_repaired_outside_soloing_not_evaluable_count']}`",
         f"- repair sweep source outside-soloing source context preserved: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_source_context_preserved'])}`",
         f"- repair sweep source outside-soloing source pitch-role risk before / after / delta: `{readiness['repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{readiness['repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{readiness['repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- repair sweep source outside-soloing source repair targeted: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_source_targeted'])}`",
         f"- repair sweep source outside-soloing source residual risk preserved: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_source_residual_risk_preserved'])}`",
+        f"- follow-up objective source outside-soloing source context preserved: `{_bool_token(readiness['repair_sweep_followup_objective_source_outside_soloing_source_context_preserved'])}`",
         f"- follow-up objective source outside-soloing source pitch-role risk: `{readiness['repair_sweep_followup_objective_source_outside_soloing_source_pitch_role_risk_count_before']} -> {readiness['repair_sweep_followup_objective_source_outside_soloing_source_pitch_role_risk_count_after']}`",
+        f"- follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(readiness['repair_sweep_followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
+        f"- bridge repair sweep source outside-soloing source context preserved: `{_bool_token(readiness['repair_sweep_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- bridge repair sweep source outside-soloing source pitch-role risk: `{readiness['repair_sweep_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before']} -> {readiness['repair_sweep_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after']}`",
         f"- objective source outside-soloing repair pitch-role risk count after: `{readiness['objective_source_outside_soloing_repair_pitch_role_risk_count_after']}`",
         f"- objective source outside-soloing current repair pitch-role risk delta: `{readiness['objective_source_outside_soloing_repair_pitch_role_risk_delta']}`",
@@ -1025,7 +1055,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=1038)
+    parser.add_argument("--issue_number", type=int, default=1122)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--expected_target", type=str, default="")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision.py
@@ -4,12 +4,16 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_SOURCE_CONTEXT_KEYS
+from scripts.audit_stage_b_midi_to_solo_final_status import (
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
+)
 from scripts.decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup import (
     BOUNDARY,
     CONTEXT_TARGET_LABELS,
     NEXT_BOUNDARY,
     SELECTED_TARGET,
+    SCHEMA_VERSION,
     StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError,
     build_followup_decision_report,
     validate_followup_decision_report,
@@ -24,6 +28,7 @@ from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repa
 
 SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_objective_source_outside_soloing_source_context_preserved": True,
     "followup_objective_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "followup_objective_source_outside_soloing_source_pitch_role_risk_delta": 3,
     "followup_objective_source_outside_soloing_source_targeted": False,
@@ -31,6 +36,7 @@ SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "followup_repair_sweep_source_outside_soloing_source_context_preserved": True,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
     "followup_repair_sweep_source_outside_soloing_source_targeted": False,
@@ -38,6 +44,7 @@ SOURCE_CONTEXT = {
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
+    "repair_sweep_source_outside_soloing_source_context_preserved": True,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
     "repair_sweep_source_outside_soloing_source_targeted": False,
@@ -184,7 +191,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionTes
                 objective_next_report=objective_next_report(),
                 repair_sweep_report=repair_sweep_report(),
                 output_dir=Path(tmp) / "followup",
-                issue_number=1038,
+                issue_number=1122,
             )
             summary = validate_followup_decision_report(
                 report,
@@ -197,6 +204,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionTes
             )
 
             self.assertTrue(summary["followup_decision_completed"])
+            self.assertEqual(report["schema_version"], SCHEMA_VERSION)
             self.assertTrue(summary["chord_context_pitch_role_bridge_selected"])
             self.assertEqual(
                 summary["context_target_labels"],
@@ -221,8 +229,10 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionTes
             self.assertTrue(
                 summary["objective_source_outside_soloing_repair_source_context_preserved"]
             )
-            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[f"objective_{key}"], SOURCE_CONTEXT[key])
+            for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS:
+                self.assertTrue(summary[f"objective_{key}"])
             self.assertEqual(
                 summary[
                     "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after"
@@ -259,8 +269,10 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionTes
             self.assertTrue(
                 summary["repair_sweep_source_outside_soloing_repair_source_context_preserved"]
             )
-            for key in BRIDGE_SOURCE_CONTEXT_KEYS:
+            for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[f"repair_sweep_{key}"], SOURCE_CONTEXT[key])
+            for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS:
+                self.assertTrue(summary[f"repair_sweep_{key}"])
             self.assertEqual(
                 summary[
                     "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after"
@@ -301,7 +313,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionTes
                     objective_next_report=objective_next_report(quality_claim=True),
                     repair_sweep_report=repair_sweep_report(),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1038,
+                    issue_number=1122,
                 )
 
     def test_rejects_technical_regression(self) -> None:
@@ -313,7 +325,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionTes
                     objective_next_report=objective_next_report(),
                     repair_sweep_report=repair_sweep_report(technical_regression_count=1),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1038,
+                    issue_number=1122,
                 )
 
     def test_rejects_missing_objective_outside_soloing_context(self) -> None:
@@ -328,7 +340,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionTes
                     objective_next_report=source,
                     repair_sweep_report=repair_sweep_report(),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1038,
+                    issue_number=1122,
                 )
 
     def test_rejects_missing_repair_sweep_outside_soloing_context(self) -> None:
@@ -343,7 +355,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionTes
                     objective_next_report=objective_next_report(),
                     repair_sweep_report=source,
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1038,
+                    issue_number=1122,
                 )
 
     def test_rejects_repair_sweep_source_context_delta_mismatch(self) -> None:
@@ -358,13 +370,13 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionTes
                     objective_next_report=objective_next_report(),
                     repair_sweep_report=source,
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1038,
+                    issue_number=1122,
                 )
 
     def test_rejects_missing_bridge_source_context_field(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             source = objective_next_report()
-            source["objective_summary"].pop(BRIDGE_SOURCE_CONTEXT_KEYS[0])
+            source["objective_summary"].pop(BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS[0])
 
             with self.assertRaises(
                 StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError
@@ -373,7 +385,37 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionTes
                     objective_next_report=source,
                     repair_sweep_report=repair_sweep_report(),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1038,
+                    issue_number=1122,
+                )
+
+    def test_rejects_source_context_preservation_flag_false(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = objective_next_report()
+            source["objective_summary"][BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS[0]] = False
+
+            with self.assertRaises(
+                StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError
+            ):
+                build_followup_decision_report(
+                    objective_next_report=source,
+                    repair_sweep_report=repair_sweep_report(),
+                    output_dir=Path(tmp) / "followup",
+                    issue_number=1122,
+                )
+
+    def test_rejects_repair_sweep_source_context_preservation_flag_false(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = repair_sweep_report()
+            source["aggregate"][BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS[0]] = False
+
+            with self.assertRaises(
+                StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionError
+            ):
+                build_followup_decision_report(
+                    objective_next_report=objective_next_report(),
+                    repair_sweep_report=source,
+                    output_dir=Path(tmp) / "followup",
+                    issue_number=1122,
                 )
 
     def test_rejects_objective_repair_sweep_context_mismatch(self) -> None:
@@ -388,13 +430,17 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairFollowupDecisionTes
                     objective_next_report=objective_next_report(),
                     repair_sweep_report=source,
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1038,
+                    issue_number=1122,
                 )
 
     def test_constants_are_stable(self) -> None:
         self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision")
         self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge")
         self.assertEqual(SELECTED_TARGET, "songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge")
+        self.assertEqual(
+            SCHEMA_VERSION,
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision_v4",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary
- follow-up decision source validation을 required source-context key와 preserved flag true 조건 기준으로 갱신
- objective-only next decision과 repair sweep source-context consistency 검증 유지
- chord-context pitch-role bridge 선택 결과와 preserved flag를 readiness, validation summary, markdown에 전파

Context
- #1120 objective-only next decision 결과: follow-up decision required
- #1112 repair sweep 결과: candidate count 6, failure label delta 3, phrase/rhythm failure delta 3
- residual rhythmic monotony count: 1
- context not-evaluable min count: 6
- source outside-soloing pitch-role risk: 5 -> 2
- current repair pitch-role risk after / delta: 0 / 2

Scope
- follow-up decision schema v4
- objective/repair sweep false preserved flag 입력 차단 테스트 추가
- harness issue number #1122 갱신
- README, AGENTS, CURRENT_STATUS, CORE_PLAN handoff 갱신

Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision
- .venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-followup-decision
- bash scripts/agent_harness.sh quick
- git diff --check

Risk
- human/audio preference claim 없음
- MIDI-to-solo musical quality claim 없음
- follow-up decision 범위 밖의 repair 품질 판단 제외

Follow-up
- Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh

Closes #1122