### PR TITLE
Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm repair objective-only next decision completed: Issue #1120, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair follow-up decision completed: Issue #1122, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-context pitch-role bridge completed: Issue #1124, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh.
-- Latest songlike melody contour phrase/rhythm chord-context pitch-role objective decision completed: Issue #1042, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh.
+- Latest songlike melody contour phrase/rhythm chord-context pitch-role objective decision completed: Issue #1126, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing repair sweep completed: Issue #1044, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing repair audio package completed: Issue #1046, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing repair listening review package completed: Issue #1048, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1064, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh.
+- Open issue queue after songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour phrase/rhythm repair objective-only next decision: `Issue #1120`
 - latest songlike melody contour phrase/rhythm repair follow-up decision: `Issue #1122`
 - latest songlike melody contour phrase/rhythm chord-context pitch-role bridge: `Issue #1124`
-- latest songlike melody contour phrase/rhythm chord-context pitch-role objective decision: `Issue #1042`
+- latest songlike melody contour phrase/rhythm chord-context pitch-role objective decision: `Issue #1126`
 - latest songlike melody contour phrase/rhythm chord-tone landing repair sweep: `Issue #1044`
 - latest songlike melody contour phrase/rhythm chord-tone landing repair audio package: `Issue #1046`
 - latest songlike melody contour phrase/rhythm chord-tone landing repair listening review package: `Issue #1048`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -421,7 +421,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision: follow-up required `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, current quality claim ready `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_followup_decision`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision: selected target `songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`, remaining label/count `rhythmic_monotony/1`, objective/sweep source risk `5 -> 2`, current repair risk after/delta `0/2`, objective/sweep outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge: chord context/pitch-role metrics `6/6`, not evaluable `12 -> 0`, source risk `5 -> 2`, current repair risk after/delta `0/2`, bridge flags `outside_soloing_pitch_role_risk=5`, `weak_chord_tone_landing_risk=6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
-- MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision: primary risk `weak_chord_tone_landing_risk=6`, outside risk `5`, not evaluable `12 -> 0`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
+- MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision: source schema `v4`, primary risk `weak_chord_tone_landing_risk=6`, outside risk `5`, not evaluable `12 -> 0`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep: weak chord-tone landing risk `6 -> 0`, final landing chord-tone `1 -> 6`, changed notes `40`, outside risk `5 -> 2`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package: rendered WAV `6`, duration `18.871s-19.000s`, technical validation `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, audio/preference/quality claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package: review items `6`, validated input `false`, technical WAV validation `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard`
@@ -11416,12 +11416,13 @@ Issue #1124는 Issue #1122 follow-up decision과 Issue #1112 repair sweep의 sou
 
 ## 9.211 Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh
 
-Issue #1042는 Issue #1040 chord-context pitch-role bridge의 source-context preserved flag를 objective decision까지 보존하고, 다음 repair target을 선택한 작업이다.
+Issue #1126은 Issue #1124 chord-context pitch-role bridge v4의 source-context preserved flag를 objective decision까지 보존하고, 다음 repair target을 선택한 작업이다.
 
 결과:
 
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
 - source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- source schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge_v4`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
 - selected target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
 - primary risk label: `weak_chord_tone_landing_risk`
@@ -11442,7 +11443,7 @@ Issue #1042는 Issue #1040 chord-context pitch-role bridge의 source-context pre
 
 판단:
 
-- bridge에서 추가된 preserved flag 3개가 objective summary와 readiness까지 유지됨.
+- bridge schema v4와 preserved flag 3개가 objective summary와 readiness까지 유지됨.
 - weak chord-tone landing risk count `6`이 outside-soloing pitch-role risk count `5`보다 큼.
 - 다음 repair target은 chord-tone landing repair sweep.
 - quality/preference claim 제외 유지.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -41,7 +41,7 @@
 - latest songlike melody contour phrase/rhythm repair objective-only next decision: Issue #1120, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair objective-only next decision source-context refresh
 - latest songlike melody contour phrase/rhythm repair follow-up decision: Issue #1122, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair follow-up decision source-context refresh
 - latest songlike melody contour phrase/rhythm chord-context pitch-role bridge: Issue #1124, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh
-- latest songlike melody contour phrase/rhythm chord-context pitch-role objective decision: Issue #1042, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh
+- latest songlike melody contour phrase/rhythm chord-context pitch-role objective decision: Issue #1126, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing repair sweep: Issue #1044, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing repair audio package: Issue #1046, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing repair listening review package: Issue #1048, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh`
+- open issue queue after songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -4530,21 +4530,22 @@ Issue #1124는 Issue #1122 follow-up decision과 Issue #1112 repair sweep의 sou
 
 ## Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Chord-Context Pitch-Role Objective Decision Source Context Refresh Result
 
-Issue #1042는 Issue #1040 chord-context pitch-role bridge의 source-context preserved flag를 objective decision까지 보존하고, 다음 repair target을 선택한 작업이다.
+Issue #1126은 Issue #1124 chord-context pitch-role bridge v4의 source-context preserved flag를 objective decision까지 보존하고, 다음 repair target을 선택한 작업이다.
 
 변경:
 
-- objective decision schema version `v3`
-- bridge source-context preserved flag 3개 필수 검증
+- objective decision schema version `v4`
+- bridge schema v4와 source-context preserved flag 3개 필수 검증
 - objective summary, readiness, validation summary source-context preserved field 전파
 - generated markdown report source-context preserved field 반영
-- harness issue number를 #1042 기준으로 갱신
+- harness issue number를 #1126 기준으로 갱신
 
 결과:
 
 - document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_CONTEXT_PITCH_ROLE_OBJECTIVE_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
 - source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- source schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge_v4`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
 - selected target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
 - primary risk label: `weak_chord_tone_landing_risk`
@@ -4565,7 +4566,7 @@ Issue #1042는 Issue #1040 chord-context pitch-role bridge의 source-context pre
 
 판단:
 
-- bridge에서 추가된 preserved flag 3개가 objective summary와 readiness까지 유지됨.
+- bridge schema v4와 preserved flag 3개가 objective summary와 readiness까지 유지됨.
 - weak chord-tone landing risk count `6`이 outside-soloing pitch-role risk count `5`보다 큼.
 - 다음 repair target은 chord-tone landing repair sweep.
 - quality/preference claim 제외 유지.

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_CONTEXT_PITCH_ROLE_OBJECTIVE_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_CONTEXT_PITCH_ROLE_OBJECTIVE_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -4,6 +4,7 @@
 
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
 - source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge`
+- source schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge_v4`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
 - selected target: `songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
 - primary risk label: `weak_chord_tone_landing_risk`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6679,7 +6679,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pit
     --run_id "$run_id" \
     --bridge_report "$bridge_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_CONTEXT_PITCH_ROLE_OBJECTIVE_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1042 \
+    --issue_number 1126 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep \
     --expected_target songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep \

--- a/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective.py
+++ b/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective.py
@@ -16,7 +16,9 @@ from scripts.assess_stage_b_generic_base_readiness import read_json, write_json,
 from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge import (  # noqa: E402
     BOUNDARY as BRIDGE_BOUNDARY,
     BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
     NEXT_BOUNDARY as BRIDGE_NEXT_BOUNDARY,
+    SCHEMA_VERSION as BRIDGE_SCHEMA_VERSION,
 )
 
 
@@ -31,7 +33,7 @@ NEXT_BOUNDARY = (
     "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep"
 )
 SELECTED_TARGET = "songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep"
-SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision_v3"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision_v4"
 PRIMARY_RISK_LABEL = "weak_chord_tone_landing_risk"
 SECONDARY_RISK_LABEL = "outside_soloing_pitch_role_risk"
 QUALITY_CLAIM_KEYS = [
@@ -86,6 +88,10 @@ def validate_bridge_source(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
             "chord-context pitch-role bridge boundary required"
         )
+    if str(report.get("schema_version") or "") != BRIDGE_SCHEMA_VERSION:
+        raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+            "bridge schema version must match current bridge report"
+        )
     if str(decision.get("next_boundary") or "") != BRIDGE_NEXT_BOUNDARY:
         raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
             "bridge must route to pitch-role objective decision"
@@ -133,11 +139,7 @@ def validate_bridge_source(report: dict[str, Any]) -> dict[str, Any]:
             raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
                 f"bridge source-context field required: {key}"
             )
-    for key in (
-        "followup_objective_source_outside_soloing_source_context_preserved",
-        "followup_repair_sweep_source_outside_soloing_source_context_preserved",
-        "repair_sweep_source_outside_soloing_source_context_preserved",
-    ):
+    for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS:
         if not bool(readiness.get(key, False)):
             raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
                 f"source outside-soloing context should be preserved: {key}"
@@ -171,6 +173,7 @@ def validate_bridge_source(report: dict[str, Any]) -> dict[str, Any]:
             )
     return {
         "boundary": BRIDGE_BOUNDARY,
+        "schema_version": str(report.get("schema_version") or ""),
         "candidate_count": candidate_count,
         "not_evaluable_before_count": _int(readiness.get("not_evaluable_before_count")),
         "not_evaluable_after_count": _int(readiness.get("not_evaluable_after_count")),
@@ -235,6 +238,7 @@ def build_objective_decision_report(
         "issue_number": int(issue_number),
         "boundary": BOUNDARY,
         "source_boundary": bridge["boundary"],
+        "source_schema_version": bridge["schema_version"],
         "objective_summary": bridge,
         "selected_next_target": {
             "selected_target": selected_target,
@@ -246,6 +250,7 @@ def build_objective_decision_report(
         },
         "readiness": {
             "boundary": BOUNDARY,
+            "source_schema_version": bridge["schema_version"],
             "pitch_role_objective_decision_completed": True,
             "candidate_count": _int(bridge["candidate_count"]),
             "primary_risk_label": primary_label,
@@ -353,9 +358,15 @@ def validate_objective_decision_report(
             raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
                 f"objective source-context field required: {key}"
             )
+    for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS:
+        if not bool(readiness.get(key, False)):
+            raise StageBMidiToSoloPitchRoleObjectiveDecisionError(
+                f"objective source-context preserved field must be true: {key}"
+            )
     return {
         "boundary": boundary,
         "source_boundary": str(report.get("source_boundary") or ""),
+        "source_schema_version": str(readiness.get("source_schema_version") or ""),
         "next_boundary": str(decision.get("next_boundary") or ""),
         "selected_target": str(decision.get("selected_target") or ""),
         "pitch_role_objective_decision_completed": bool(
@@ -414,6 +425,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         "",
         f"- boundary: `{report['boundary']}`",
         f"- source boundary: `{report['source_boundary']}`",
+        f"- source schema version: `{report['source_schema_version']}`",
         f"- next boundary: `{decision['next_boundary']}`",
         f"- selected target: `{decision['selected_target']}`",
         f"- primary risk label: `{selected['primary_risk_label']}`",
@@ -476,7 +488,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=1042)
+    parser.add_argument("--issue_number", type=int, default=1126)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--expected_target", type=str, default="")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision.py
@@ -6,12 +6,15 @@ from pathlib import Path
 
 from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge import (
     BOUNDARY as BRIDGE_BOUNDARY,
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
     NEXT_BOUNDARY as BRIDGE_NEXT_BOUNDARY,
+    SCHEMA_VERSION as BRIDGE_SCHEMA_VERSION,
 )
 from scripts.decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective import (
     BOUNDARY,
     NEXT_BOUNDARY,
     PRIMARY_RISK_LABEL,
+    SCHEMA_VERSION,
     SELECTED_TARGET,
     StageBMidiToSoloPitchRoleObjectiveDecisionError,
     build_objective_decision_report,
@@ -19,8 +22,11 @@ from scripts.decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_c
 )
 
 
-def bridge_report(*, quality_claim: bool = False, weak_count: int = 6, outside_count: int = 5) -> dict:
+def bridge_report(
+    *, quality_claim: bool = False, weak_count: int = 6, outside_count: int = 5
+) -> dict:
     return {
+        "schema_version": BRIDGE_SCHEMA_VERSION,
         "boundary": BRIDGE_BOUNDARY,
         "summary": {
             "candidate_count": 6,
@@ -95,7 +101,7 @@ class StageBMidiToSoloPitchRoleObjectiveDecisionTest(unittest.TestCase):
             report = build_objective_decision_report(
                 bridge_report=bridge_report(),
                 output_dir=Path(tmp) / "decision",
-                issue_number=1042,
+                issue_number=1126,
             )
             summary = validate_objective_decision_report(
                 report,
@@ -106,6 +112,9 @@ class StageBMidiToSoloPitchRoleObjectiveDecisionTest(unittest.TestCase):
                 require_no_quality_claim=True,
             )
 
+            self.assertEqual(report["schema_version"], SCHEMA_VERSION)
+            self.assertEqual(report["source_schema_version"], BRIDGE_SCHEMA_VERSION)
+            self.assertEqual(summary["source_schema_version"], BRIDGE_SCHEMA_VERSION)
             self.assertTrue(summary["pitch_role_objective_decision_completed"])
             self.assertEqual(summary["primary_risk_label"], PRIMARY_RISK_LABEL)
             self.assertEqual(summary["weak_chord_tone_landing_risk_count"], 6)
@@ -195,7 +204,7 @@ class StageBMidiToSoloPitchRoleObjectiveDecisionTest(unittest.TestCase):
                 build_objective_decision_report(
                     bridge_report=bridge_report(quality_claim=True),
                     output_dir=Path(tmp) / "decision",
-                    issue_number=1042,
+                    issue_number=1126,
                 )
 
     def test_routes_outside_soloing_when_it_dominates(self) -> None:
@@ -203,7 +212,7 @@ class StageBMidiToSoloPitchRoleObjectiveDecisionTest(unittest.TestCase):
             report = build_objective_decision_report(
                 bridge_report=bridge_report(weak_count=2, outside_count=5),
                 output_dir=Path(tmp) / "decision",
-                issue_number=1042,
+                issue_number=1126,
             )
             summary = validate_objective_decision_report(
                 report,
@@ -229,7 +238,7 @@ class StageBMidiToSoloPitchRoleObjectiveDecisionTest(unittest.TestCase):
                 build_objective_decision_report(
                     bridge_report=source,
                     output_dir=Path(tmp) / "decision",
-                    issue_number=1042,
+                    issue_number=1126,
                 )
 
     def test_rejects_missing_bridge_source_context_field(self) -> None:
@@ -243,7 +252,7 @@ class StageBMidiToSoloPitchRoleObjectiveDecisionTest(unittest.TestCase):
                 build_objective_decision_report(
                     bridge_report=source,
                     output_dir=Path(tmp) / "decision",
-                    issue_number=1042,
+                    issue_number=1126,
                 )
 
     def test_rejects_source_context_targeted_flag(self) -> None:
@@ -257,7 +266,7 @@ class StageBMidiToSoloPitchRoleObjectiveDecisionTest(unittest.TestCase):
                 build_objective_decision_report(
                     bridge_report=source,
                     output_dir=Path(tmp) / "decision",
-                    issue_number=1042,
+                    issue_number=1126,
                 )
 
     def test_rejects_source_context_preservation_flag(self) -> None:
@@ -271,7 +280,40 @@ class StageBMidiToSoloPitchRoleObjectiveDecisionTest(unittest.TestCase):
                 build_objective_decision_report(
                     bridge_report=source,
                     output_dir=Path(tmp) / "decision",
-                    issue_number=1042,
+                    issue_number=1126,
+                )
+
+    def test_rejects_bridge_schema_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = bridge_report()
+            source["schema_version"] = (
+                "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge_v3"
+            )
+
+            with self.assertRaises(StageBMidiToSoloPitchRoleObjectiveDecisionError):
+                build_objective_decision_report(
+                    bridge_report=source,
+                    output_dir=Path(tmp) / "decision",
+                    issue_number=1126,
+                )
+
+    def test_rejects_report_preserved_flag_false(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            report = build_objective_decision_report(
+                bridge_report=bridge_report(),
+                output_dir=Path(tmp) / "decision",
+                issue_number=1126,
+            )
+            report["readiness"][BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS[0]] = False
+
+            with self.assertRaises(StageBMidiToSoloPitchRoleObjectiveDecisionError):
+                validate_objective_decision_report(
+                    report,
+                    expected_boundary=BOUNDARY,
+                    expected_next_boundary=NEXT_BOUNDARY,
+                    expected_target=SELECTED_TARGET,
+                    require_objective_decision=True,
+                    require_no_quality_claim=True,
                 )
 
     def test_constants_are_stable(self) -> None:
@@ -286,6 +328,10 @@ class StageBMidiToSoloPitchRoleObjectiveDecisionTest(unittest.TestCase):
         self.assertEqual(
             SELECTED_TARGET,
             "songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep",
+        )
+        self.assertEqual(
+            SCHEMA_VERSION,
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision_v4",
         )
 
 


### PR DESCRIPTION
## Summary
- Stage B MIDI-to-solo pitch-role objective decision schema v4 갱신
- bridge schema v4 입력 검증 추가
- source-context preserved flag false 차단
- 다음 repair target: chord-tone landing repair sweep

## Context
- #1124 chord-context pitch-role bridge 완료
- bridge source schema: stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge_v4
- candidate count: 6
- chord context available / pitch-role metrics defined: 6 / 6
- not-evaluable pitch-role count: 12 -> 0
- weak chord-tone landing risk count: 6
- outside-soloing pitch-role risk count: 5
- 선택 기준: largest pitch-role risk count

## Scope
- objective decision schema v4
- bridge schema version match 검증
- preserved source-context flag required true 검증
- objective decision report source schema field 추가
- harness issue number #1126 기준 갱신
- README, AGENTS, CORE_PLAN, CURRENT_STATUS status refresh

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision
- .venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-context-pitch-role-objective-decision
- bash scripts/agent_harness.sh quick
- git diff --check
- public artifact wording scan: no tool-name matches

## Risk
- objective evidence 기준 next repair target 선택 범위
- 청감 선호 및 음악적 품질 판단 미포함
- residual risk: weak_chord_tone_landing_risk=6, outside_soloing_pitch_role_risk=5

## Follow-up
- Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep source-context refresh

Closes #1126