### PR TITLE
Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-context pitch-role bridge completed: Issue #1124, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-context pitch-role objective decision completed: Issue #1126, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing repair sweep completed: Issue #1128, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep source-context refresh.
-- Latest songlike melody contour phrase/rhythm chord-tone landing repair audio package completed: Issue #1046, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package source-context refresh.
+- Latest songlike melody contour phrase/rhythm chord-tone landing repair audio package completed: Issue #1130, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing repair listening review package completed: Issue #1048, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard completed: Issue #1050, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision completed: Issue #1052, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1064, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after songlike melody contour phrase/rhythm chord-tone landing repair sweep source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package source-context refresh.
+- Open issue queue after songlike melody contour phrase/rhythm chord-tone landing repair audio package source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour phrase/rhythm chord-context pitch-role bridge: `Issue #1124`
 - latest songlike melody contour phrase/rhythm chord-context pitch-role objective decision: `Issue #1126`
 - latest songlike melody contour phrase/rhythm chord-tone landing repair sweep: `Issue #1128`
-- latest songlike melody contour phrase/rhythm chord-tone landing repair audio package: `Issue #1046`
+- latest songlike melody contour phrase/rhythm chord-tone landing repair audio package: `Issue #1130`
 - latest songlike melody contour phrase/rhythm chord-tone landing repair listening review package: `Issue #1048`
 - latest songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard: `Issue #1050`
 - latest songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision: `Issue #1052`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -423,7 +423,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge: chord context/pitch-role metrics `6/6`, not evaluable `12 -> 0`, source risk `5 -> 2`, current repair risk after/delta `0/2`, bridge flags `outside_soloing_pitch_role_risk=5`, `weak_chord_tone_landing_risk=6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision: source schema `v4`, primary risk `weak_chord_tone_landing_risk=6`, outside risk `5`, not evaluable `12 -> 0`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep: source schema `v4`, bridge schema `v4`, weak chord-tone landing risk `6 -> 0`, final landing chord-tone `1 -> 6`, changed notes `40`, outside risk `5 -> 2`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package`
-- MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package: rendered WAV `6`, duration `18.871s-19.000s`, technical validation `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, audio/preference/quality claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package`
+- MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package: source schema `v4`, rendered WAV `6`, duration `18.871s-19.000s`, technical validation `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, audio/preference/quality claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package: review items `6`, validated input `false`, technical WAV validation `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard: preference fill `false`, validated input `false`, review items `6`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_only_next_decision`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision: follow-up required `true`, selected target `songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup_decision`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup_decision`
@@ -11513,11 +11513,12 @@ Issue #1128은 Issue #1126 objective decision v4와 Issue #1124 bridge v4의 sou
 
 ## 9.213 Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package source-context refresh
 
-Issue #1046은 Issue #1044 chord-tone landing repair sweep의 source-context preserved flag를 audio package까지 보존하고, rendered WAV technical metadata를 기록한 작업이다.
+Issue #1130은 Issue #1128 chord-tone landing repair sweep v4의 source-context preserved flag를 audio package까지 보존하고, rendered WAV technical metadata를 기록한 작업이다.
 
 결과:
 
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package`
+- source schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep_v4`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package`
 - rendered audio file count: `6`
 - technical WAV validation: `true`
@@ -11539,7 +11540,7 @@ Issue #1046은 Issue #1044 chord-tone landing repair sweep의 source-context pre
 
 판단:
 
-- Issue #1044 repair sweep의 preserved flag 3개가 audio package summary와 validation summary까지 유지됨.
+- Issue #1128 repair sweep v4의 preserved flag 3개가 audio package summary와 validation summary까지 유지됨.
 - repaired MIDI `6`개 모두 WAV 렌더 완료.
 - WAV technical metadata 검증 완료.
 - outside-soloing risk는 repair target이 아니며 residual context preserved 상태 유지.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -43,7 +43,7 @@
 - latest songlike melody contour phrase/rhythm chord-context pitch-role bridge: Issue #1124, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role bridge source-context refresh
 - latest songlike melody contour phrase/rhythm chord-context pitch-role objective decision: Issue #1126, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing repair sweep: Issue #1128, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep source-context refresh
-- latest songlike melody contour phrase/rhythm chord-tone landing repair audio package: Issue #1046, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package source-context refresh
+- latest songlike melody contour phrase/rhythm chord-tone landing repair audio package: Issue #1130, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing repair listening review package: Issue #1048, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard: Issue #1050, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision: Issue #1052, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after songlike melody contour phrase/rhythm chord-tone landing repair sweep source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package source-context refresh`
+- open issue queue after songlike melody contour phrase/rhythm chord-tone landing repair audio package source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -4645,19 +4645,20 @@ Issue #1128은 Issue #1126 objective decision v4와 Issue #1124 bridge v4의 sou
 
 ## Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Chord-Tone Landing Repair Audio Package Source Context Refresh Result
 
-Issue #1046은 Issue #1044 chord-tone landing repair sweep의 source-context preserved flag를 audio package까지 보존하고, rendered WAV technical metadata를 기록한 작업이다.
+Issue #1130은 Issue #1128 chord-tone landing repair sweep v4의 source-context preserved flag를 audio package까지 보존하고, rendered WAV technical metadata를 기록한 작업이다.
 
 변경:
 
-- audio package schema version `v3`
-- repair sweep required source-context key와 preserved flag 3개 필수 검증
+- audio package schema version `v4`
+- repair sweep schema v4와 required source-context key, preserved flag 3개 필수 검증
 - audio package summary, validation summary, markdown report source-context preserved field 전파
-- harness issue number를 #1046 기준으로 갱신
+- harness issue number를 #1130 기준으로 갱신
 
 결과:
 
 - document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package`
+- source schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep_v4`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package`
 - rendered audio file count: `6`
 - technical WAV validation: `true`
@@ -4679,7 +4680,7 @@ Issue #1046은 Issue #1044 chord-tone landing repair sweep의 source-context pre
 
 판단:
 
-- Issue #1044 repair sweep의 preserved flag 3개가 audio package summary와 validation summary까지 유지됨.
+- Issue #1128 repair sweep v4의 preserved flag 3개가 audio package summary와 validation summary까지 유지됨.
 - repaired MIDI `6`개 모두 WAV 렌더 완료.
 - WAV technical metadata 검증 완료.
 - outside-soloing risk는 repair target이 아니며 residual context preserved 상태 유지.

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -3,6 +3,9 @@
 ## Summary
 
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package`
+- source schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep_v4`
+- source objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision_v4`
+- source bridge schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge_v4`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package`
 - render attempted: `true`
 - rendered audio file count: `6`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6728,7 +6728,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landin
     --run_id "$run_id" \
     --chord_tone_landing_repair_sweep_report "$sweep_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1046 \
+    --issue_number 1130 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package \
     --expected_file_count 6 \

--- a/scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio.py
+++ b/scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio.py
@@ -22,10 +22,12 @@ from scripts.render_stage_b_midi_to_solo_candidate_audio import (  # noqa: E402
 )
 from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge import (  # noqa: E402
     BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
 )
 from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep import (  # noqa: E402
     BOUNDARY as SOURCE_BOUNDARY,
     NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+    SCHEMA_VERSION as SOURCE_SCHEMA_VERSION,
     StageBMidiToSoloChordToneLandingRepairSweepError,
     validate_repair_sweep_report,
 )
@@ -42,7 +44,7 @@ NEXT_BOUNDARY = (
     "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package"
 )
 SCHEMA_VERSION = (
-    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package_v3"
+    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package_v4"
 )
 CommandRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
 
@@ -103,11 +105,7 @@ def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str
             raise StageBMidiToSoloChordToneLandingRepairAudioError(
                 f"{label} source-context field required: {key}"
             )
-    for key in (
-        "followup_objective_source_outside_soloing_source_context_preserved",
-        "followup_repair_sweep_source_outside_soloing_source_context_preserved",
-        "repair_sweep_source_outside_soloing_source_context_preserved",
-    ):
+    for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS:
         if not bool(container.get(key, False)):
             raise StageBMidiToSoloChordToneLandingRepairAudioError(
                 f"{label} source context should be preserved: {key}"
@@ -125,6 +123,10 @@ def validate_source_report(
     if str(report.get("boundary") or readiness.get("boundary") or "") != SOURCE_BOUNDARY:
         raise StageBMidiToSoloChordToneLandingRepairAudioError(
             "chord-tone landing repair sweep boundary required"
+        )
+    if str(report.get("schema_version") or "") != SOURCE_SCHEMA_VERSION:
+        raise StageBMidiToSoloChordToneLandingRepairAudioError(
+            "repair sweep schema version must match current repair sweep report"
         )
     if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
         raise StageBMidiToSoloChordToneLandingRepairAudioError(
@@ -335,6 +337,7 @@ def build_audio_render_report(
         "output_dir": str(output_dir),
         "issue_number": int(issue_number),
         "source_boundary": SOURCE_BOUNDARY,
+        "source_schema_version": SOURCE_SCHEMA_VERSION,
         "source_summary": aggregate,
         "renderer": {
             "name": "fluidsynth",
@@ -347,6 +350,9 @@ def build_audio_render_report(
         "rendered_audio_files": rendered,
         "summary": {
             "rendered_audio_file_count": int(len(rendered)),
+            "source_schema_version": SOURCE_SCHEMA_VERSION,
+            "source_objective_schema_version": str(source_report.get("source_schema_version") or ""),
+            "source_bridge_schema_version": str(source_report.get("bridge_schema_version") or ""),
             "technical_wav_validation": True,
             "sample_rate": int(sample_rate),
             "duration_min_seconds": min(durations, default=0.0),
@@ -444,6 +450,14 @@ def validate_audio_render_report(
         raise StageBMidiToSoloChordToneLandingRepairAudioError(
             "unexpected next boundary"
         )
+    if str(report.get("source_schema_version") or "") != SOURCE_SCHEMA_VERSION:
+        raise StageBMidiToSoloChordToneLandingRepairAudioError(
+            "unexpected source schema version"
+        )
+    if str(summary.get("source_schema_version") or "") != SOURCE_SCHEMA_VERSION:
+        raise StageBMidiToSoloChordToneLandingRepairAudioError(
+            "summary source schema version mismatch"
+        )
     files = [_dict(item) for item in _list(report.get("rendered_audio_files"))]
     if len(files) != int(expected_file_count):
         raise StageBMidiToSoloChordToneLandingRepairAudioError(
@@ -493,10 +507,20 @@ def validate_audio_render_report(
             raise StageBMidiToSoloChordToneLandingRepairAudioError(
                 f"audio package source-context field required: {key}"
             )
+    for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS:
+        if not bool(summary.get(key, False)):
+            raise StageBMidiToSoloChordToneLandingRepairAudioError(
+                f"audio package source-context preserved field must be true: {key}"
+            )
     if require_no_quality_claim:
         _require_no_quality_claim(boundary, label="audio render boundary")
     return {
         "boundary": str(boundary.get("boundary") or ""),
+        "source_schema_version": str(summary.get("source_schema_version") or ""),
+        "source_objective_schema_version": str(
+            summary.get("source_objective_schema_version") or ""
+        ),
+        "source_bridge_schema_version": str(summary.get("source_bridge_schema_version") or ""),
         "next_boundary": str(decision.get("next_boundary") or ""),
         "render_attempted": bool(boundary.get("render_attempted", False)),
         "rendered_audio_file_count": _int(boundary.get("rendered_audio_file_count")),
@@ -571,6 +595,9 @@ def markdown_report(report: dict[str, Any]) -> str:
         "## Summary",
         "",
         f"- boundary: `{boundary['boundary']}`",
+        f"- source schema version: `{report['source_schema_version']}`",
+        f"- source objective schema version: `{summary['source_objective_schema_version']}`",
+        f"- source bridge schema version: `{summary['source_bridge_schema_version']}`",
         f"- next boundary: `{decision['next_boundary']}`",
         f"- render attempted: `{_bool_token(boundary['render_attempted'])}`",
         f"- rendered audio file count: `{boundary['rendered_audio_file_count']}`",
@@ -640,7 +667,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=1046)
+    parser.add_argument("--issue_number", type=int, default=1130)
     parser.add_argument("--renderer", type=str, default=shutil.which("fluidsynth") or "")
     parser.add_argument("--soundfont", type=str, default="")
     parser.add_argument("--sample_rate", type=int, default=44100)

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio.py
@@ -12,13 +12,22 @@ import pretty_midi
 from scripts.render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio import (
     BOUNDARY,
     NEXT_BOUNDARY,
+    SCHEMA_VERSION,
     StageBMidiToSoloChordToneLandingRepairAudioError,
     build_audio_render_report,
     validate_audio_render_report,
 )
+from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge import (
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
+    SCHEMA_VERSION as BRIDGE_SCHEMA_VERSION,
+)
+from scripts.decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective import (
+    SCHEMA_VERSION as OBJECTIVE_SCHEMA_VERSION,
+)
 from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep import (
     BOUNDARY as SOURCE_BOUNDARY,
     NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+    SCHEMA_VERSION as SOURCE_SCHEMA_VERSION,
     SELECTED_TARGET as SOURCE_SELECTED_TARGET,
 )
 
@@ -118,10 +127,15 @@ def source_report(root: Path, *, quality_claim: bool = False) -> dict:
             }
         )
     return {
+        "schema_version": SOURCE_SCHEMA_VERSION,
         "boundary": SOURCE_BOUNDARY,
+        "source_schema_version": OBJECTIVE_SCHEMA_VERSION,
+        "bridge_schema_version": BRIDGE_SCHEMA_VERSION,
         "candidate_repairs": repairs,
         "aggregate": {
             "candidate_count": 6,
+            "source_schema_version": OBJECTIVE_SCHEMA_VERSION,
+            "bridge_schema_version": BRIDGE_SCHEMA_VERSION,
             "repaired_midi_count": 6,
             "changed_note_total": 42,
             "objective_outside_soloing_pitch_role_risk_count": 5,
@@ -140,6 +154,8 @@ def source_report(root: Path, *, quality_claim: bool = False) -> dict:
         },
         "readiness": {
             "boundary": SOURCE_BOUNDARY,
+            "source_schema_version": OBJECTIVE_SCHEMA_VERSION,
+            "bridge_schema_version": BRIDGE_SCHEMA_VERSION,
             "chord_tone_landing_repair_sweep_completed": True,
             "candidate_count": 6,
             "repaired_midi_count": 6,
@@ -201,6 +217,14 @@ class StageBMidiToSoloChordToneLandingRepairAudioTest(unittest.TestCase):
                 ]
             )
             self.assertEqual(summary["rendered_audio_file_count"], 6)
+            self.assertEqual(report["schema_version"], SCHEMA_VERSION)
+            self.assertEqual(report["source_schema_version"], SOURCE_SCHEMA_VERSION)
+            self.assertEqual(summary["source_schema_version"], SOURCE_SCHEMA_VERSION)
+            self.assertEqual(
+                summary["source_objective_schema_version"],
+                OBJECTIVE_SCHEMA_VERSION,
+            )
+            self.assertEqual(summary["source_bridge_schema_version"], BRIDGE_SCHEMA_VERSION)
             self.assertTrue(summary["technical_wav_validation"])
             self.assertEqual(summary["weak_chord_tone_landing_risk_delta"], 6)
             self.assertEqual(summary["objective_outside_soloing_pitch_role_risk_count"], 5)
@@ -293,6 +317,58 @@ class StageBMidiToSoloChordToneLandingRepairAudioTest(unittest.TestCase):
                     runner=fake_runner,
                 )
 
+    def test_rejects_source_schema_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = root / "fluidsynth"
+            soundfont = root / "soundfont.sf2"
+            renderer.write_text("#!/bin/sh\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            report = source_report(root)
+            report["schema_version"] = (
+                "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep_v3"
+            )
+
+            with self.assertRaises(StageBMidiToSoloChordToneLandingRepairAudioError):
+                build_audio_render_report(
+                    report,
+                    output_dir=root / "audio_package",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(soundfont),
+                    sample_rate=44100,
+                    expected_file_count=6,
+                    runner=fake_runner,
+                )
+
+    def test_rejects_report_preserved_flag_false(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = root / "fluidsynth"
+            soundfont = root / "soundfont.sf2"
+            renderer.write_text("#!/bin/sh\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            report = build_audio_render_report(
+                source_report(root),
+                output_dir=root / "audio_package",
+                renderer_path=str(renderer),
+                soundfont_path=str(soundfont),
+                sample_rate=44100,
+                expected_file_count=6,
+                runner=fake_runner,
+            )
+            report["summary"][BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS[0]] = False
+
+            with self.assertRaises(StageBMidiToSoloChordToneLandingRepairAudioError):
+                validate_audio_render_report(
+                    report,
+                    expected_boundary=BOUNDARY,
+                    expected_next_boundary=NEXT_BOUNDARY,
+                    expected_file_count=6,
+                    expected_sample_rate=44100,
+                    require_audio_package_completed=True,
+                    require_no_quality_claim=True,
+                )
+
     def test_constants_are_stable(self) -> None:
         self.assertEqual(
             BOUNDARY,
@@ -301,6 +377,10 @@ class StageBMidiToSoloChordToneLandingRepairAudioTest(unittest.TestCase):
         self.assertEqual(
             NEXT_BOUNDARY,
             "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package",
+        )
+        self.assertEqual(
+            SCHEMA_VERSION,
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package_v4",
         )
 
 


### PR DESCRIPTION
## Summary
- Stage B MIDI-to-solo chord-tone landing repair audio package schema v4 갱신
- repair sweep v4 입력 검증 추가
- source-context preserved flag false 차단
- WAV 6개 렌더 기술 검증 기록

## Context
- #1128 chord-tone landing repair sweep 완료
- repair sweep schema: stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep_v4
- rendered audio file count: 6
- sample rate: 44100
- duration range: 18.871s-19.000s
- changed note total: 40
- weak chord-tone landing risk count: 6 -> 0
- outside-soloing pitch-role risk count: 5 -> 2

## Scope
- audio package schema v4
- repair sweep schema version match 검증
- preserved source-context flag required true 검증
- source schema metadata summary/report 전파
- harness issue number #1130 기준 갱신
- README, AGENTS, CORE_PLAN, CURRENT_STATUS status refresh

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio
- .venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-repair-audio-package
- bash scripts/agent_harness.sh quick
- git diff --check
- public artifact wording scan: no tool-name matches

## Risk
- WAV technical validation 범위
- audio rendered quality, human/audio preference, MIDI-to-solo musical quality 판단 미포함
- listening review package에서 검토 항목 경계 필요

## Follow-up
- Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package source-context refresh

Closes #1130