### PR TITLE
Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-context pitch-role objective decision completed: Issue #1126, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing repair sweep completed: Issue #1128, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing repair audio package completed: Issue #1130, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package source-context refresh.
-- Latest songlike melody contour phrase/rhythm chord-tone landing repair listening review package completed: Issue #1048, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package source-context refresh.
+- Latest songlike melody contour phrase/rhythm chord-tone landing repair listening review package completed: Issue #1132, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard completed: Issue #1050, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision completed: Issue #1052, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision completed: Issue #1054, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1064, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after songlike melody contour phrase/rhythm chord-tone landing repair audio package source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package source-context refresh.
+- Open issue queue after songlike melody contour phrase/rhythm chord-tone landing repair listening review package source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour phrase/rhythm chord-context pitch-role objective decision: `Issue #1126`
 - latest songlike melody contour phrase/rhythm chord-tone landing repair sweep: `Issue #1128`
 - latest songlike melody contour phrase/rhythm chord-tone landing repair audio package: `Issue #1130`
-- latest songlike melody contour phrase/rhythm chord-tone landing repair listening review package: `Issue #1048`
+- latest songlike melody contour phrase/rhythm chord-tone landing repair listening review package: `Issue #1132`
 - latest songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard: `Issue #1050`
 - latest songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision: `Issue #1052`
 - latest songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision: `Issue #1054`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -424,7 +424,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision: source schema `v4`, primary risk `weak_chord_tone_landing_risk=6`, outside risk `5`, not evaluable `12 -> 0`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep: source schema `v4`, bridge schema `v4`, weak chord-tone landing risk `6 -> 0`, final landing chord-tone `1 -> 6`, changed notes `40`, outside risk `5 -> 2`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package: source schema `v4`, rendered WAV `6`, duration `18.871s-19.000s`, technical validation `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, audio/preference/quality claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package`
-- MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package: review items `6`, validated input `false`, technical WAV validation `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard`
+- MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package: source schema `v4`, review items `6`, validated input `false`, technical WAV validation `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard: preference fill `false`, validated input `false`, review items `6`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_only_next_decision`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision: follow-up required `true`, selected target `songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup_decision`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup_decision`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision: selected target `songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep`, primary risk `outside_soloing_pitch_role_risk=2`, weak landing resolved `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep`
@@ -11562,11 +11562,12 @@ Issue #1130은 Issue #1128 chord-tone landing repair sweep v4의 source-context 
 
 ## 9.214 Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package source-context refresh
 
-Issue #1048은 Issue #1046 audio package의 source-context preserved flag를 listening review package까지 보존하고, WAV/MIDI review item package 경계를 기록한 작업이다.
+Issue #1132는 Issue #1130 audio package v4의 source-context preserved flag를 listening review package까지 보존하고, WAV/MIDI review item package 경계를 기록한 작업이다.
 
 결과:
 
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package`
+- source schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package_v4`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard`
 - review item count: `6`
 - validated review input: `false`
@@ -11587,7 +11588,7 @@ Issue #1048은 Issue #1046 audio package의 source-context preserved flag를 lis
 
 판단:
 
-- Issue #1046 audio package의 preserved flag 3개가 listening review package source summary와 validation summary까지 유지됨.
+- Issue #1130 audio package v4의 preserved flag 3개가 listening review package source summary와 validation summary까지 유지됨.
 - WAV/MIDI review item `6`개 package 완료.
 - validated listening input은 없음.
 - human/audio preference, MIDI-to-solo musical quality claim 제외.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -44,7 +44,7 @@
 - latest songlike melody contour phrase/rhythm chord-context pitch-role objective decision: Issue #1126, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-context pitch-role objective decision source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing repair sweep: Issue #1128, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing repair audio package: Issue #1130, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package source-context refresh
-- latest songlike melody contour phrase/rhythm chord-tone landing repair listening review package: Issue #1048, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package source-context refresh
+- latest songlike melody contour phrase/rhythm chord-tone landing repair listening review package: Issue #1132, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard: Issue #1050, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision: Issue #1052, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision: Issue #1054, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after songlike melody contour phrase/rhythm chord-tone landing repair audio package source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package source-context refresh`
+- open issue queue after songlike melody contour phrase/rhythm chord-tone landing repair listening review package source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -4702,19 +4702,20 @@ Issue #1130은 Issue #1128 chord-tone landing repair sweep v4의 source-context 
 
 ## Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Chord-Tone Landing Repair Listening Review Package Source Context Refresh Result
 
-Issue #1048은 Issue #1046 audio package의 source-context preserved flag를 listening review package까지 보존하고, WAV/MIDI review item package 경계를 기록한 작업이다.
+Issue #1132는 Issue #1130 audio package v4의 source-context preserved flag를 listening review package까지 보존하고, WAV/MIDI review item package 경계를 기록한 작업이다.
 
 변경:
 
-- listening review package schema version `v2`
-- audio package required source-context key와 preserved flag 3개 필수 검증
+- listening review package schema version `v3`
+- audio package schema v4와 required source-context key, preserved flag 3개 필수 검증
 - source summary, validation summary, markdown report source-context preserved field 전파
-- harness issue number와 generated doc path를 #1048 기준으로 갱신
+- harness issue number와 generated doc path를 #1132 기준으로 갱신
 
 결과:
 
 - document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_LISTENING_REVIEW_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package`
+- source schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package_v4`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard`
 - review item count: `6`
 - validated review input: `false`
@@ -4735,7 +4736,7 @@ Issue #1048은 Issue #1046 audio package의 source-context preserved flag를 lis
 
 판단:
 
-- Issue #1046 audio package의 preserved flag 3개가 listening review package source summary와 validation summary까지 유지됨.
+- Issue #1130 audio package v4의 preserved flag 3개가 listening review package source summary와 validation summary까지 유지됨.
 - WAV/MIDI review item `6`개 package 완료.
 - validated listening input은 없음.
 - human/audio preference, MIDI-to-solo musical quality claim 제외.

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_LISTENING_REVIEW_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_LISTENING_REVIEW_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -3,6 +3,10 @@
 ## Summary
 
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package`
+- source schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package_v4`
+- source repair sweep schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep_v4`
+- source objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision_v4`
+- source bridge schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge_v4`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard`
 - package ready: `true`
 - review item count: `6`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6750,7 +6750,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landin
     --run_id "$review_run_id" \
     --audio_package_report "$audio_package_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_LISTENING_REVIEW_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1048 \
+    --issue_number 1132 \
     --expected_review_item_count 6 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard \

--- a/scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package.py
+++ b/scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package.py
@@ -16,9 +16,11 @@ from scripts.assess_stage_b_generic_base_readiness import read_json, write_json,
 from scripts.render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio import (  # noqa: E402
     BOUNDARY as SOURCE_BOUNDARY,
     NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+    SCHEMA_VERSION as SOURCE_SCHEMA_VERSION,
 )
 from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge import (  # noqa: E402
     BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
 )
 
 
@@ -33,7 +35,7 @@ NEXT_BOUNDARY = (
     "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard"
 )
 SCHEMA_VERSION = (
-    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package_v2"
+    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package_v3"
 )
 
 QUALITY_CLAIM_KEYS = [
@@ -93,11 +95,7 @@ def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str
             raise StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError(
                 f"{label} source-context field required: {key}"
             )
-    for key in (
-        "followup_objective_source_outside_soloing_source_context_preserved",
-        "followup_repair_sweep_source_outside_soloing_source_context_preserved",
-        "repair_sweep_source_outside_soloing_source_context_preserved",
-    ):
+    for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS:
         if not bool(container.get(key, False)):
             raise StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError(
                 f"{label} source context should be preserved: {key}"
@@ -116,6 +114,10 @@ def validate_audio_package_report(
     if str(boundary.get("boundary") or "") != SOURCE_BOUNDARY:
         raise StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError(
             "chord-tone landing repair audio package boundary required"
+        )
+    if str(report.get("schema_version") or "") != SOURCE_SCHEMA_VERSION:
+        raise StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError(
+            "audio package schema version must match current audio package report"
         )
     if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
         raise StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError(
@@ -229,7 +231,16 @@ def build_listening_review_package_report(
         "issue_number": int(issue_number),
         "boundary": BOUNDARY,
         "source_boundary": SOURCE_BOUNDARY,
+        "source_schema_version": SOURCE_SCHEMA_VERSION,
         "source_summary": {
+            "source_schema_version": SOURCE_SCHEMA_VERSION,
+            "source_repair_sweep_schema_version": str(
+                summary.get("source_schema_version") or ""
+            ),
+            "source_objective_schema_version": str(
+                summary.get("source_objective_schema_version") or ""
+            ),
+            "source_bridge_schema_version": str(summary.get("source_bridge_schema_version") or ""),
             "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
             "technical_wav_validation": bool(summary.get("technical_wav_validation", False)),
             "sample_rate": _int(summary.get("sample_rate")),
@@ -376,10 +387,23 @@ def validate_listening_review_package_report(
             raise StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError(
                 f"listening package source-context field required: {key}"
             )
+    for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS:
+        if not bool(source.get(key, False)):
+            raise StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError(
+                f"listening package source-context preserved field must be true: {key}"
+            )
     if require_no_quality_claim:
         _require_no_quality_claim(readiness, label="listening package readiness")
     return {
         "boundary": boundary,
+        "source_schema_version": str(source.get("source_schema_version") or ""),
+        "source_repair_sweep_schema_version": str(
+            source.get("source_repair_sweep_schema_version") or ""
+        ),
+        "source_objective_schema_version": str(
+            source.get("source_objective_schema_version") or ""
+        ),
+        "source_bridge_schema_version": str(source.get("source_bridge_schema_version") or ""),
         "next_boundary": str(decision.get("next_boundary") or ""),
         "listening_review_package_ready": bool(
             readiness.get("listening_review_package_ready", False)
@@ -443,6 +467,10 @@ def markdown_report(report: dict[str, Any]) -> str:
         "## Summary",
         "",
         f"- boundary: `{report['boundary']}`",
+        f"- source schema version: `{report['source_schema_version']}`",
+        f"- source repair sweep schema version: `{source['source_repair_sweep_schema_version']}`",
+        f"- source objective schema version: `{source['source_objective_schema_version']}`",
+        f"- source bridge schema version: `{source['source_bridge_schema_version']}`",
         f"- next boundary: `{decision['next_boundary']}`",
         f"- package ready: `{_bool_token(package['package_ready'])}`",
         f"- review item count: `{package['review_item_count']}`",
@@ -523,7 +551,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=1048)
+    parser.add_argument("--issue_number", type=int, default=1132)
     parser.add_argument("--expected_review_item_count", type=int, default=6)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package.py
@@ -11,13 +11,25 @@ import pretty_midi
 from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package import (
     BOUNDARY,
     NEXT_BOUNDARY,
+    SCHEMA_VERSION,
     StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError,
     build_listening_review_package_report,
     validate_listening_review_package_report,
 )
+from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge import (
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
+    SCHEMA_VERSION as BRIDGE_SCHEMA_VERSION,
+)
+from scripts.decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective import (
+    SCHEMA_VERSION as OBJECTIVE_SCHEMA_VERSION,
+)
 from scripts.render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio import (
     BOUNDARY as SOURCE_BOUNDARY,
     NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+    SCHEMA_VERSION as SOURCE_SCHEMA_VERSION,
+)
+from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep import (
+    SCHEMA_VERSION as REPAIR_SWEEP_SCHEMA_VERSION,
 )
 
 SOURCE_CONTEXT = {
@@ -108,6 +120,8 @@ def audio_package_report(root: Path, *, quality_claim: bool = False) -> dict:
             }
         )
     return {
+        "schema_version": SOURCE_SCHEMA_VERSION,
+        "source_schema_version": REPAIR_SWEEP_SCHEMA_VERSION,
         "audio_render_boundary": {
             "boundary": SOURCE_BOUNDARY,
             "render_attempted": True,
@@ -129,6 +143,9 @@ def audio_package_report(root: Path, *, quality_claim: bool = False) -> dict:
             "critical_user_input_required": False,
         },
         "summary": {
+            "source_schema_version": REPAIR_SWEEP_SCHEMA_VERSION,
+            "source_objective_schema_version": OBJECTIVE_SCHEMA_VERSION,
+            "source_bridge_schema_version": BRIDGE_SCHEMA_VERSION,
             "rendered_audio_file_count": 6,
             "technical_wav_validation": True,
             "sample_rate": 44100,
@@ -161,7 +178,7 @@ class StageBMidiToSoloChordToneLandingRepairListeningReviewPackageTest(unittest.
             report = build_listening_review_package_report(
                 audio_package_report=audio_package_report(root),
                 output_dir=root / "review_package",
-                issue_number=1048,
+                issue_number=1132,
                 expected_count=6,
             )
             summary = validate_listening_review_package_report(
@@ -173,6 +190,18 @@ class StageBMidiToSoloChordToneLandingRepairListeningReviewPackageTest(unittest.
                 require_no_quality_claim=True,
             )
 
+            self.assertEqual(report["schema_version"], SCHEMA_VERSION)
+            self.assertEqual(report["source_schema_version"], SOURCE_SCHEMA_VERSION)
+            self.assertEqual(summary["source_schema_version"], SOURCE_SCHEMA_VERSION)
+            self.assertEqual(
+                summary["source_repair_sweep_schema_version"],
+                REPAIR_SWEEP_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                summary["source_objective_schema_version"],
+                OBJECTIVE_SCHEMA_VERSION,
+            )
+            self.assertEqual(summary["source_bridge_schema_version"], BRIDGE_SCHEMA_VERSION)
             self.assertTrue(summary["listening_review_package_ready"])
             self.assertEqual(summary["review_item_count"], 6)
             self.assertFalse(summary["validated_review_input"])
@@ -235,7 +264,25 @@ class StageBMidiToSoloChordToneLandingRepairListeningReviewPackageTest(unittest.
                 build_listening_review_package_report(
                     audio_package_report=audio_package_report(root, quality_claim=True),
                     output_dir=root / "review_package",
-                    issue_number=1048,
+                    issue_number=1132,
+                    expected_count=6,
+                )
+
+    def test_rejects_audio_package_schema_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = audio_package_report(root)
+            source["schema_version"] = (
+                "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package_v3"
+            )
+
+            with self.assertRaises(
+                StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError
+            ):
+                build_listening_review_package_report(
+                    audio_package_report=source,
+                    output_dir=root / "review_package",
+                    issue_number=1132,
                     expected_count=6,
                 )
 
@@ -251,8 +298,31 @@ class StageBMidiToSoloChordToneLandingRepairListeningReviewPackageTest(unittest.
                 build_listening_review_package_report(
                     audio_package_report=source,
                     output_dir=root / "review_package",
-                    issue_number=1048,
+                    issue_number=1132,
                     expected_count=6,
+                )
+
+    def test_rejects_report_preserved_flag_false(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            report = build_listening_review_package_report(
+                audio_package_report=audio_package_report(root),
+                output_dir=root / "review_package",
+                issue_number=1132,
+                expected_count=6,
+            )
+            report["source_summary"][BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS[0]] = False
+
+            with self.assertRaises(
+                StageBMidiToSoloChordToneLandingRepairListeningReviewPackageError
+            ):
+                validate_listening_review_package_report(
+                    report,
+                    expected_boundary=BOUNDARY,
+                    expected_next_boundary=NEXT_BOUNDARY,
+                    expected_review_item_count=6,
+                    require_package_ready=True,
+                    require_no_quality_claim=True,
                 )
 
     def test_constants_are_stable(self) -> None:
@@ -263,6 +333,10 @@ class StageBMidiToSoloChordToneLandingRepairListeningReviewPackageTest(unittest.
         self.assertEqual(
             NEXT_BOUNDARY,
             "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard",
+        )
+        self.assertEqual(
+            SCHEMA_VERSION,
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package_v3",
         )
 
 


### PR DESCRIPTION
## Summary
- Stage B MIDI-to-solo chord-tone landing repair listening review package schema v3 갱신
- audio package v4 입력 검증 추가
- source-context preserved flag false 차단
- WAV/MIDI review item 6개 package 경계 기록

## Context
- #1130 chord-tone landing repair audio package 완료
- audio package schema: stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package_v4
- review item count: 6
- validated review input: false
- technical WAV validation: true
- rendered audio file count: 6
- duration range: 18.871s-19.000s
- audio review required: true

## Scope
- listening review package schema v3
- audio package schema version match 검증
- preserved source-context flag required true 검증
- source schema lineage summary/report 전파
- harness issue number #1132 기준 갱신
- README, AGENTS, CORE_PLAN, CURRENT_STATUS status refresh

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package
- .venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-repair-listening-review-package
- bash scripts/agent_harness.sh quick
- git diff --check
- public artifact wording scan: no tool-name matches

## Risk
- review package 구성 검증 범위
- human/audio preference, MIDI-to-solo musical quality 판단 미포함
- validated listening input은 후속 input guard 경계

## Follow-up
- Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard source-context refresh

Closes #1132