### PR TITLE
Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing repair sweep completed: Issue #1128, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing repair audio package completed: Issue #1130, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing repair listening review package completed: Issue #1132, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package source-context refresh.
-- Latest songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard completed: Issue #1050, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard source-context refresh.
+- Latest songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard completed: Issue #1134, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision completed: Issue #1052, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision completed: Issue #1054, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep completed: Issue #1056, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1064, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after songlike melody contour phrase/rhythm chord-tone landing repair listening review package source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard source-context refresh.
+- Open issue queue after songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour phrase/rhythm chord-tone landing repair sweep: `Issue #1128`
 - latest songlike melody contour phrase/rhythm chord-tone landing repair audio package: `Issue #1130`
 - latest songlike melody contour phrase/rhythm chord-tone landing repair listening review package: `Issue #1132`
-- latest songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard: `Issue #1050`
+- latest songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard: `Issue #1134`
 - latest songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision: `Issue #1052`
 - latest songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision: `Issue #1054`
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep: `Issue #1056`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -425,7 +425,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep: source schema `v4`, bridge schema `v4`, weak chord-tone landing risk `6 -> 0`, final landing chord-tone `1 -> 6`, changed notes `40`, outside risk `5 -> 2`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package: source schema `v4`, rendered WAV `6`, duration `18.871s-19.000s`, technical validation `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, audio/preference/quality claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package: source schema `v4`, review items `6`, validated input `false`, technical WAV validation `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard`
-- MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard: preference fill `false`, validated input `false`, review items `6`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_only_next_decision`
+- MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard: source schema `v3`, preference fill `false`, validated input `false`, review items `6`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_only_next_decision`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision: follow-up required `true`, selected target `songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup_decision`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup_decision`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision: selected target `songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep`, primary risk `outside_soloing_pitch_role_risk=2`, weak landing resolved `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep: outside risk `2 -> 0`, changed notes `2`, max non-chord run `4 -> 3`, weak landing after `0`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package`
@@ -11609,12 +11609,13 @@ Issue #1132는 Issue #1130 audio package v4의 source-context preserved flag를 
 
 ## 9.215 Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard source-context refresh
 
-Issue #1050은 Issue #1048 listening review package의 source-context preserved flag를 input guard까지 보존하고, validated input 부재 시 preference fill block을 유지한 작업이다.
+Issue #1134는 Issue #1132 listening review package v3의 source-context preserved flag를 input guard까지 보존하고, validated input 부재 시 preference fill block을 유지한 작업이다.
 
 결과:
 
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard`
 - source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package`
+- source schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package_v3`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_only_next_decision`
 - validated review input present: `false`
 - preference fill allowed: `false`
@@ -11634,7 +11635,7 @@ Issue #1050은 Issue #1048 listening review package의 source-context preserved 
 
 판단:
 
-- Issue #1048 listening review package의 preserved flag 3개가 input guard readiness와 validation summary까지 유지됨.
+- Issue #1132 listening review package v3의 preserved flag 3개가 input guard readiness와 validation summary까지 유지됨.
 - validated review input 부재 상태에서 preference fill blocked 유지.
 - critical user input required는 `false`.
 - human/audio preference, MIDI-to-solo musical quality claim 제외.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -45,7 +45,7 @@
 - latest songlike melody contour phrase/rhythm chord-tone landing repair sweep: Issue #1128, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair sweep source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing repair audio package: Issue #1130, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair audio package source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing repair listening review package: Issue #1132, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review package source-context refresh
-- latest songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard: Issue #1050, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard source-context refresh
+- latest songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard: Issue #1134, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision: Issue #1052, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision: Issue #1054, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep: Issue #1056, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after songlike melody contour phrase/rhythm chord-tone landing repair listening review package source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard source-context refresh`
+- open issue queue after songlike melody contour phrase/rhythm chord-tone landing repair listening review input guard source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -4757,20 +4757,21 @@ Issue #1132는 Issue #1130 audio package v4의 source-context preserved flag를 
 
 ## Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Chord-Tone Landing Repair Listening Review Input Guard Source Context Refresh Result
 
-Issue #1050은 Issue #1048 listening review package의 source-context preserved flag를 input guard까지 보존하고, validated input 부재 시 preference fill block을 유지한 작업이다.
+Issue #1134는 Issue #1132 listening review package v3의 source-context preserved flag를 input guard까지 보존하고, validated input 부재 시 preference fill block을 유지한 작업이다.
 
 변경:
 
-- input guard schema version `v2`
-- listening review package required source-context key와 preserved flag 3개 필수 검증
+- input guard schema version `v3`
+- listening review package schema v3와 required source-context key, preserved flag 3개 필수 검증
 - guard result, readiness, validation summary, markdown report source-context preserved field 전파
-- harness issue number와 generated doc path를 #1050 기준으로 갱신
+- harness issue number와 generated doc path를 #1134 기준으로 갱신
 
 결과:
 
 - document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_LISTENING_REVIEW_INPUT_GUARD_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard`
 - source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package`
+- source schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package_v3`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_only_next_decision`
 - validated review input present: `false`
 - preference fill allowed: `false`
@@ -4790,7 +4791,7 @@ Issue #1050은 Issue #1048 listening review package의 source-context preserved 
 
 판단:
 
-- Issue #1048 listening review package의 preserved flag 3개가 input guard readiness와 validation summary까지 유지됨.
+- Issue #1132 listening review package v3의 preserved flag 3개가 input guard readiness와 validation summary까지 유지됨.
 - validated review input 부재 상태에서 preference fill blocked 유지.
 - critical user input required는 `false`.
 - human/audio preference, MIDI-to-solo musical quality claim 제외.

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_LISTENING_REVIEW_INPUT_GUARD_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_LISTENING_REVIEW_INPUT_GUARD_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -4,6 +4,8 @@
 
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard`
 - source boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package`
+- source schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package_v3`
+- source audio schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package_v4`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_only_next_decision`
 - review item count: `6`
 - required input field count: `4`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6771,7 +6771,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landin
     --run_id "$guard_run_id" \
     --source_package "$source_package" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_REPAIR_LISTENING_REVIEW_INPUT_GUARD_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1050 \
+    --issue_number 1134 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_only_next_decision \
     --require_guard_completed \

--- a/scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input.py
+++ b/scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input.py
@@ -16,9 +16,11 @@ from scripts.assess_stage_b_generic_base_readiness import read_json, write_json,
 from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package import (  # noqa: E402
     BOUNDARY as SOURCE_BOUNDARY,
     NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+    SCHEMA_VERSION as SOURCE_PACKAGE_SCHEMA_VERSION,
 )
 from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge import (  # noqa: E402
     BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
 )
 
 
@@ -36,7 +38,7 @@ OBJECTIVE_NEXT_BOUNDARY = (
     "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_only_next_decision"
 )
 SCHEMA_VERSION = (
-    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard_v2"
+    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard_v3"
 )
 
 QUALITY_CLAIM_KEYS = [
@@ -92,11 +94,7 @@ def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str
             raise StageBMidiToSoloChordToneLandingRepairListeningInputGuardError(
                 f"{label} source-context field required: {key}"
             )
-    for key in (
-        "followup_objective_source_outside_soloing_source_context_preserved",
-        "followup_repair_sweep_source_outside_soloing_source_context_preserved",
-        "repair_sweep_source_outside_soloing_source_context_preserved",
-    ):
+    for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS:
         if not bool(container.get(key, False)):
             raise StageBMidiToSoloChordToneLandingRepairListeningInputGuardError(
                 f"{label} source context should be preserved: {key}"
@@ -114,6 +112,10 @@ def validate_source_package(report: dict[str, Any]) -> dict[str, Any]:
     if boundary != SOURCE_BOUNDARY:
         raise StageBMidiToSoloChordToneLandingRepairListeningInputGuardError(
             "chord-tone landing repair listening review package boundary required"
+        )
+    if str(report.get("schema_version") or "") != SOURCE_PACKAGE_SCHEMA_VERSION:
+        raise StageBMidiToSoloChordToneLandingRepairListeningInputGuardError(
+            "listening review package schema version must match current package report"
         )
     if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
         raise StageBMidiToSoloChordToneLandingRepairListeningInputGuardError(
@@ -166,6 +168,8 @@ def validate_source_package(report: dict[str, Any]) -> dict[str, Any]:
     _require_no_quality_claim(readiness, label="chord-tone landing repair listening package readiness")
     return {
         "boundary": SOURCE_BOUNDARY,
+        "schema_version": str(report.get("schema_version") or ""),
+        "source_schema_version": str(report.get("source_schema_version") or ""),
         "review_item_count": review_item_count,
         "validated_review_input": bool(readiness.get("validated_review_input", False)),
         "human_review_required_now": bool(readiness.get("human_review_required_now", False)),
@@ -233,6 +237,8 @@ def build_listening_review_input_guard_report(
         "issue_number": int(issue_number),
         "boundary": BOUNDARY,
         "source_boundary": source["boundary"],
+        "source_schema_version": source["schema_version"],
+        "source_audio_schema_version": source["source_schema_version"],
         "source_package_summary": source,
         "guard_result": {
             "validated_review_input_present": bool(validated_input),
@@ -332,9 +338,16 @@ def validate_listening_review_input_guard_report(
             raise StageBMidiToSoloChordToneLandingRepairListeningInputGuardError(
                 f"input guard source-context field required: {key}"
             )
+    for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS:
+        if not bool(source.get(key, False)):
+            raise StageBMidiToSoloChordToneLandingRepairListeningInputGuardError(
+                f"input guard source-context preserved field must be true: {key}"
+            )
     return {
         "boundary": boundary,
         "source_boundary": str(report.get("source_boundary") or ""),
+        "source_schema_version": str(report.get("source_schema_version") or ""),
+        "source_audio_schema_version": str(report.get("source_audio_schema_version") or ""),
         "validated_review_input_present": bool(
             guard.get("validated_review_input_present", True)
         ),
@@ -398,6 +411,8 @@ def markdown_report(report: dict[str, Any]) -> str:
         "",
         f"- boundary: `{report['boundary']}`",
         f"- source boundary: `{report['source_boundary']}`",
+        f"- source schema version: `{report['source_schema_version']}`",
+        f"- source audio schema version: `{report['source_audio_schema_version']}`",
         f"- next boundary: `{decision['next_boundary']}`",
         f"- review item count: `{guard['review_item_count']}`",
         f"- required input field count: `{guard['required_input_field_count']}`",
@@ -472,7 +487,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=1050)
+    parser.add_argument("--issue_number", type=int, default=1134)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--require_guard_completed", action="store_true")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input.py
@@ -5,10 +5,18 @@ import unittest
 from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package import (
     BOUNDARY as SOURCE_BOUNDARY,
     NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+    SCHEMA_VERSION as SOURCE_PACKAGE_SCHEMA_VERSION,
+)
+from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge import (
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
+)
+from scripts.render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio import (
+    SCHEMA_VERSION as SOURCE_AUDIO_SCHEMA_VERSION,
 )
 from scripts.guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input import (
     BOUNDARY,
     OBJECTIVE_NEXT_BOUNDARY,
+    SCHEMA_VERSION,
     StageBMidiToSoloChordToneLandingRepairListeningInputGuardError,
     build_listening_review_input_guard_report,
     validate_listening_review_input_guard_report,
@@ -54,7 +62,9 @@ def source_package(*, quality_claim: bool = False, validated_input: bool = False
         for index in range(1, 7)
     ]
     return {
+        "schema_version": SOURCE_PACKAGE_SCHEMA_VERSION,
         "boundary": SOURCE_BOUNDARY,
+        "source_schema_version": SOURCE_AUDIO_SCHEMA_VERSION,
         "source_summary": {
             "technical_wav_validation": True,
             "rendered_audio_file_count": 6,
@@ -113,7 +123,7 @@ class StageBMidiToSoloChordToneLandingRepairListeningInputGuardTest(unittest.Tes
         report = build_listening_review_input_guard_report(
             source_package(),
             output_dir="unused",
-            issue_number=1050,
+            issue_number=1134,
         )
         summary = validate_listening_review_input_guard_report(
             report,
@@ -125,6 +135,11 @@ class StageBMidiToSoloChordToneLandingRepairListeningInputGuardTest(unittest.Tes
             require_no_quality_claim=True,
         )
 
+        self.assertEqual(report["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(report["source_schema_version"], SOURCE_PACKAGE_SCHEMA_VERSION)
+        self.assertEqual(report["source_audio_schema_version"], SOURCE_AUDIO_SCHEMA_VERSION)
+        self.assertEqual(summary["source_schema_version"], SOURCE_PACKAGE_SCHEMA_VERSION)
+        self.assertEqual(summary["source_audio_schema_version"], SOURCE_AUDIO_SCHEMA_VERSION)
         self.assertFalse(summary["validated_review_input_present"])
         self.assertFalse(summary["preference_fill_allowed"])
         self.assertEqual(summary["review_item_count"], 6)
@@ -184,7 +199,20 @@ class StageBMidiToSoloChordToneLandingRepairListeningInputGuardTest(unittest.Tes
             build_listening_review_input_guard_report(
                 source_package(quality_claim=True),
                 output_dir="unused",
-                issue_number=1050,
+                issue_number=1134,
+            )
+
+    def test_rejects_source_package_schema_mismatch(self) -> None:
+        source = source_package()
+        source["schema_version"] = (
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package_v2"
+        )
+
+        with self.assertRaises(StageBMidiToSoloChordToneLandingRepairListeningInputGuardError):
+            build_listening_review_input_guard_report(
+                source,
+                output_dir="unused",
+                issue_number=1134,
             )
 
     def test_rejects_source_context_preservation_flag(self) -> None:
@@ -196,14 +224,35 @@ class StageBMidiToSoloChordToneLandingRepairListeningInputGuardTest(unittest.Tes
             build_listening_review_input_guard_report(
                 source,
                 output_dir="unused",
-                issue_number=1050,
+                issue_number=1134,
+            )
+
+    def test_rejects_report_preserved_flag_false(self) -> None:
+        report = build_listening_review_input_guard_report(
+            source_package(),
+            output_dir="unused",
+            issue_number=1134,
+        )
+        report["guard_result"]["source_summary"][
+            BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS[0]
+        ] = False
+
+        with self.assertRaises(StageBMidiToSoloChordToneLandingRepairListeningInputGuardError):
+            validate_listening_review_input_guard_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=OBJECTIVE_NEXT_BOUNDARY,
+                require_guard_completed=True,
+                require_preference_blocked=True,
+                require_pending_input=True,
+                require_no_quality_claim=True,
             )
 
     def test_routes_to_fill_when_validated_input_exists(self) -> None:
         report = build_listening_review_input_guard_report(
             source_package(validated_input=True),
             output_dir="unused",
-            issue_number=1050,
+            issue_number=1134,
         )
         self.assertTrue(report["guard_result"]["preference_fill_allowed"])
         self.assertTrue(report["guard_result"]["validated_review_input_present"])
@@ -216,6 +265,10 @@ class StageBMidiToSoloChordToneLandingRepairListeningInputGuardTest(unittest.Tes
         self.assertEqual(
             OBJECTIVE_NEXT_BOUNDARY,
             "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_only_next_decision",
+        )
+        self.assertEqual(
+            SCHEMA_VERSION,
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard_v3",
         )
 
 


### PR DESCRIPTION
## Summary

- chord-tone landing repair listening review input guard schema v3 갱신
- listening review package schema v3 입력 검증 추가
- source-context preserved flag false 재유입 차단
- #1134 상태 문서와 harness issue number 갱신

## Context

- #1132 listening review package v3 결과: review item 6개
- validated review input: false
- preference fill allowed: false
- source audio schema: chord-tone landing repair audio package v4
- technical WAV validation: true
- duration range: 18.871s-19.000s
- quality/preference claim: false

## Scope

- input guard source package schema 검증
- guard result source summary preserved flag true 검증
- validation summary와 markdown report source schema field 전파
- README, AGENTS, CORE_PLAN, CURRENT_STATUS_AND_PLAN 상태 갱신

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input`
- `.venv/bin/python -m py_compile scripts/guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-repair-listening-review-input-guard`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- validated listening review input 부재 유지
- preference fill 차단 유지
- musical quality/preference 판단 제외

## Follow-up

- objective-only next decision source-context refresh

Closes #1134