### PR TITLE
Stage B MIDI-to-solo outside-soloing repair audio package source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,14 +49,14 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision completed: Issue #1136, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision completed: Issue #1138, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep completed: Issue #1140, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep source-context refresh.
-- Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package completed: Issue #1058, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package source-context refresh.
+- Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package completed: Issue #1142, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package completed: Issue #1060, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard completed: Issue #1062, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1064, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package source-context refresh.
+- Open issue queue after songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision: `Issue #1136`
 - latest songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision: `Issue #1138`
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep: `Issue #1140`
-- latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package: `Issue #1058`
+- latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package: `Issue #1142`
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package: `Issue #1060`
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard: `Issue #1062`
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision: `Issue #1064`
 - latest MVP current evidence consolidation: `Issue #1066`
 - latest README evidence refresh: `Issue #1068`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep source-context refresh merge: `0`
+- open issue queue after songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -429,7 +429,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision: source schema `v3`, follow-up required `true`, selected target `songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup_decision`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup_decision`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision: source schema `v3`, repair sweep schema `v4`, selected target `songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep`, primary risk `outside_soloing_pitch_role_risk=2`, weak landing resolved `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep: source schema `v3`, chord-tone repair sweep schema `v4`, outside risk `2 -> 0`, changed notes `2`, max non-chord run `4 -> 3`, weak landing after `0`, source risk `5 -> 2`, current repair risk after/delta `0/2`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package`
-- MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package: rendered WAV `6`, duration `18.871s-19.000s`, technical validation `true`, source risk `5 -> 2`, current repair risk `2 -> 0`, source/current context preserved, audio/preference/quality claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package`
+- MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package: source schema `v3`, audio schema `v4`, rendered WAV `6`, duration `18.871s-19.000s`, technical validation `true`, source risk `5 -> 2`, current repair risk `2 -> 0`, source/current context preserved, audio/preference/quality claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package: review items `6`, validated input `false`, technical WAV validation `true`, source risk `5 -> 2`, current repair risk after `0`, source/current context preserved, preference/quality claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_input_guard`
 - MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard: validated input `false`, preference fill `false`, review items `6`, source risk `5 -> 2`, current repair risk after `0`, source/current context preserved, preference/quality claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_only_next_decision`
 - MIDI-to-solo pitch-contour changed-ratio review decision: selected target `lower_pitch_change_ratio_repair_probe`, repair probe required `true`, max interval/threshold `11/12`, changed-ratio review threshold `0.5`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_probe`
@@ -11819,13 +11819,21 @@ Issue #1140은 Issue #1138 follow-up decision v3와 Issue #1128 chord-tone landi
 
 ## 9.219 Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package source-context refresh
 
-Issue #1058은 Issue #1056 outside-soloing repair sweep의 source-context preserved flag를 audio package summary와 validation summary까지 보존하고, rendered WAV technical metadata를 검증한 작업이다.
+Issue #1142는 Issue #1140 outside-soloing repair sweep의 source schema와 source-context preserved flag를 audio package summary, audio render boundary, validation summary까지 보존하고, rendered WAV technical metadata를 검증한 작업이다.
 
 결과:
 
 - document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package`
+- source schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep_v3`
+- source follow-up schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup_decision_v3`
+- source objective input guard schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard_v3`
+- source package schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package_v3`
+- source audio schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package_v4`
+- chord-tone repair sweep schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep_v4`
+- chord-tone repair sweep source schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_only_next_decision_v4`
+- chord-tone repair sweep bridge schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge_v4`
 - rendered audio file count: `6`
 - technical WAV validation: `true`
 - sample rate: `44100`
@@ -11847,7 +11855,7 @@ Issue #1058은 Issue #1056 outside-soloing repair sweep의 source-context preser
 
 판단:
 
-- Issue #1056 sweep의 preserved flag 3개가 audio package summary와 validation summary까지 유지됨.
+- Issue #1140 sweep schema v3와 preserved flag 3개가 audio package summary, audio render boundary, validation summary까지 유지됨.
 - WAV 6개 technical metadata 검증 완료.
 - outside-soloing repair evidence는 audio review package로 전달 가능.
 - audio rendered quality, human/audio preference, MIDI-to-solo musical quality claim 제외.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -49,7 +49,7 @@
 - latest songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision: Issue #1136, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair objective-only next decision source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision: Issue #1138, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing repair follow-up decision source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep: Issue #1140, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair sweep source-context refresh
-- latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package: Issue #1058, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package source-context refresh
+- latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package: Issue #1142, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair audio package source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package: Issue #1060, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard: Issue #1062, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision: Issue #1064, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh
@@ -4998,14 +4998,15 @@ Issue #1140은 Issue #1138 follow-up decision v3와 Issue #1128 chord-tone landi
 
 ## Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Chord-Tone Landing Outside-Soloing Repair Audio Package Source-Context Refresh Result
 
-Issue #1058은 Issue #1056 outside-soloing repair sweep의 source-context preserved flag를 audio package summary와 validation summary까지 보존하고, rendered WAV technical metadata를 검증한 작업이다.
+Issue #1142는 Issue #1140 outside-soloing repair sweep의 source schema와 source-context preserved flag를 audio package summary, audio render boundary, validation summary까지 보존하고, rendered WAV technical metadata를 검증한 작업이다.
 
 변경:
 
-- audio package schema v3 적용
+- audio package schema v4 적용
+- outside-soloing repair sweep schema v3 필수 검증
 - outside-soloing repair sweep required source-context key와 preserved flag 3개 필수 검증
-- summary, audio render boundary, validation summary source-context preserved field 전파
-- harness issue number와 generated doc path를 #1058 기준으로 갱신
+- summary, audio render boundary, validation summary source schema/context field 전파
+- harness issue number와 generated doc path를 #1142 기준으로 갱신
 - next recommended issue를 listening review package source-context refresh로 갱신
 
 결과:
@@ -5013,6 +5014,14 @@ Issue #1058은 Issue #1056 outside-soloing repair sweep의 source-context preser
 - document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package`
+- source schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep_v3`
+- source follow-up schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup_decision_v3`
+- source objective input guard schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard_v3`
+- source package schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package_v3`
+- source audio schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package_v4`
+- chord-tone repair sweep schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep_v4`
+- chord-tone repair sweep source schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_objective_only_next_decision_v4`
+- chord-tone repair sweep bridge schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge_v4`
 - rendered audio file count: `6`
 - technical WAV validation: `true`
 - sample rate: `44100`
@@ -5034,7 +5043,7 @@ Issue #1058은 Issue #1056 outside-soloing repair sweep의 source-context preser
 
 판단:
 
-- Issue #1056 sweep의 preserved flag 3개가 audio package summary와 validation summary까지 유지됨.
+- Issue #1140 sweep schema v3와 preserved flag 3개가 audio package summary, audio render boundary, validation summary까지 유지됨.
 - WAV 6개 technical metadata 검증 완료.
 - outside-soloing repair evidence는 audio review package로 전달 가능.
 - audio rendered quality, human/audio preference, MIDI-to-solo musical quality claim 제외.

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -4,6 +4,14 @@
 
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package`
+- source schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep_v3`
+- source follow-up schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup_decision_v3`
+- source objective input guard schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input_guard_v3`
+- source package schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package_v3`
+- source audio schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio_package_v4`
+- chord-tone repair sweep schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep_v4`
+- chord-tone repair sweep source schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective_decision_v4`
+- chord-tone repair sweep bridge schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge_v4`
 - render attempted: `true`
 - rendered audio file count: `6`
 - technical WAV validation: `true`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6870,7 +6870,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landin
     --run_id "$run_id" \
     --outside_soloing_repair_sweep_report "$sweep_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_CHORD_TONE_LANDING_OUTSIDE_SOLOING_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1058 \
+    --issue_number 1142 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package \
     --expected_file_count 6 \

--- a/scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio.py
+++ b/scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio.py
@@ -22,10 +22,12 @@ from scripts.render_stage_b_midi_to_solo_candidate_audio import (  # noqa: E402
 )
 from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge import (  # noqa: E402
     BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
 )
 from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep import (  # noqa: E402
     BOUNDARY as SOURCE_BOUNDARY,
     NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+    SCHEMA_VERSION as SOURCE_SWEEP_SCHEMA_VERSION,
     StageBMidiToSoloChordToneLandingOutsideSoloingRepairSweepError,
     validate_outside_soloing_repair_sweep_report,
 )
@@ -42,9 +44,19 @@ NEXT_BOUNDARY = (
     "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package"
 )
 SCHEMA_VERSION = (
-    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package_v3"
+    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package_v4"
 )
 CommandRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+SOURCE_SCHEMA_CONTEXT_KEYS = [
+    "source_schema_version",
+    "source_followup_schema_version",
+    "source_objective_input_guard_schema_version",
+    "source_package_schema_version",
+    "source_audio_schema_version",
+    "chord_tone_repair_sweep_schema_version",
+    "chord_tone_repair_sweep_source_schema_version",
+    "chord_tone_repair_sweep_bridge_schema_version",
+]
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -103,16 +115,39 @@ def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str
             raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
                 f"{label} source-context field required: {key}"
             )
-    for key in (
-        "followup_objective_source_outside_soloing_source_context_preserved",
-        "followup_repair_sweep_source_outside_soloing_source_context_preserved",
-        "repair_sweep_source_outside_soloing_source_context_preserved",
-    ):
+    for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS:
         if not bool(container.get(key, False)):
             raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
                 f"{label} source context should be preserved: {key}"
             )
     return {key: container[key] for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS}
+
+
+def _source_schema_context(report: dict[str, Any], *, label: str) -> dict[str, str]:
+    fields = {
+        "source_schema_version": str(report.get("schema_version") or ""),
+        "source_followup_schema_version": str(report.get("source_schema_version") or ""),
+        "source_objective_input_guard_schema_version": str(
+            report.get("source_objective_input_guard_schema_version") or ""
+        ),
+        "source_package_schema_version": str(report.get("source_package_schema_version") or ""),
+        "source_audio_schema_version": str(report.get("source_audio_schema_version") or ""),
+        "chord_tone_repair_sweep_schema_version": str(
+            report.get("chord_tone_repair_sweep_schema_version") or ""
+        ),
+        "chord_tone_repair_sweep_source_schema_version": str(
+            report.get("chord_tone_repair_sweep_source_schema_version") or ""
+        ),
+        "chord_tone_repair_sweep_bridge_schema_version": str(
+            report.get("chord_tone_repair_sweep_bridge_schema_version") or ""
+        ),
+    }
+    missing = [key for key, value in fields.items() if not value]
+    if missing:
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+            f"{label} schema context required: {missing}"
+        )
+    return fields
 
 
 def validate_source_report(
@@ -126,6 +161,11 @@ def validate_source_report(
         raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
             "outside-soloing repair sweep boundary required"
         )
+    if str(report.get("schema_version") or "") != SOURCE_SWEEP_SCHEMA_VERSION:
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+            "outside-soloing repair sweep schema version must match current report"
+        )
+    _source_schema_context(report, label="outside-soloing repair sweep report")
     if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
         raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
             "outside-soloing repair sweep must route to audio package"
@@ -288,10 +328,13 @@ def build_audio_render_report(
     soundfont_path: str,
     sample_rate: int,
     expected_file_count: int,
-    issue_number: int = 1058,
+    issue_number: int = 1142,
     runner: CommandRunner = default_runner,
 ) -> dict[str, Any]:
     candidates = validate_source_report(source_report, expected_count=expected_file_count)
+    source_schema_context = _source_schema_context(
+        source_report, label="outside-soloing repair sweep report"
+    )
     resolved_renderer = renderer_path or shutil.which("fluidsynth") or ""
     resolved_soundfont = resolve_soundfont(soundfont_path)
     plan = build_render_plan(
@@ -315,6 +358,7 @@ def build_audio_render_report(
         "output_dir": str(output_dir),
         "issue_number": int(issue_number),
         "source_boundary": SOURCE_BOUNDARY,
+        **source_schema_context,
         "source_summary": aggregate,
         "renderer": {
             "name": "fluidsynth",
@@ -375,6 +419,7 @@ def build_audio_render_report(
                 aggregate.get("max_non_chord_tone_run_after")
             ),
             "target_supported": bool(aggregate.get("target_supported", False)),
+            **source_schema_context,
             **source_context,
             "audio_review_required": True,
         },
@@ -405,6 +450,7 @@ def build_audio_render_report(
             "outside_soloing_repair_targeted": bool(
                 aggregate.get("outside_soloing_repair_targeted", False)
             ),
+            **source_schema_context,
             **source_context,
             "human_audio_preference_claimed": False,
             "audio_rendered_quality_claimed": False,
@@ -448,6 +494,10 @@ def validate_audio_render_report(
     boundary = _dict(report.get("audio_render_boundary"))
     decision = _dict(report.get("decision"))
     summary = _dict(report.get("summary"))
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+            "audio package schema version must match current report"
+        )
     if expected_boundary and str(boundary.get("boundary") or "") != expected_boundary:
         raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
             "unexpected boundary"
@@ -503,10 +553,32 @@ def validate_audio_render_report(
         raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
             "outside-soloing repair must be targeted before audio package"
         )
+    if str(summary.get("source_schema_version") or "") != SOURCE_SWEEP_SCHEMA_VERSION:
+        raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+            "source schema version must match outside-soloing repair sweep"
+        )
+    for key in SOURCE_SCHEMA_CONTEXT_KEYS:
+        if not str(summary.get(key) or ""):
+            raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+                f"audio package schema-context field required: {key}"
+            )
+        if str(boundary.get(key) or "") != str(summary.get(key) or ""):
+            raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+                f"audio boundary schema-context mismatch: {key}"
+            )
     for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
         if key not in summary:
             raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
                 f"audio package source-context field required: {key}"
+            )
+    for key in BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS:
+        if not bool(summary.get(key, False)):
+            raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+                f"audio package source context should be preserved: {key}"
+            )
+        if not bool(boundary.get(key, False)):
+            raise StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError(
+                f"audio boundary source context should be preserved: {key}"
             )
     if require_no_quality_claim:
         _require_no_quality_claim(boundary, label="audio render boundary")
@@ -567,6 +639,7 @@ def validate_audio_render_report(
         ),
         "target_supported": bool(summary.get("target_supported", False)),
         "audio_review_required": bool(summary.get("audio_review_required", False)),
+        **{key: str(summary.get(key) or "") for key in SOURCE_SCHEMA_CONTEXT_KEYS},
         **{key: summary.get(key) for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS},
         "audio_rendered_quality_claimed": bool(
             boundary.get("audio_rendered_quality_claimed", True)
@@ -596,6 +669,14 @@ def markdown_report(report: dict[str, Any]) -> str:
         "",
         f"- boundary: `{boundary['boundary']}`",
         f"- next boundary: `{decision['next_boundary']}`",
+        f"- source schema version: `{summary['source_schema_version']}`",
+        f"- source follow-up schema version: `{summary['source_followup_schema_version']}`",
+        f"- source objective input guard schema version: `{summary['source_objective_input_guard_schema_version']}`",
+        f"- source package schema version: `{summary['source_package_schema_version']}`",
+        f"- source audio schema version: `{summary['source_audio_schema_version']}`",
+        f"- chord-tone repair sweep schema version: `{summary['chord_tone_repair_sweep_schema_version']}`",
+        f"- chord-tone repair sweep source schema version: `{summary['chord_tone_repair_sweep_source_schema_version']}`",
+        f"- chord-tone repair sweep bridge schema version: `{summary['chord_tone_repair_sweep_bridge_schema_version']}`",
         f"- render attempted: `{_bool_token(boundary['render_attempted'])}`",
         f"- rendered audio file count: `{boundary['rendered_audio_file_count']}`",
         f"- technical WAV validation: `{_bool_token(boundary['technical_wav_validation'])}`",
@@ -661,7 +742,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=1058)
+    parser.add_argument("--issue_number", type=int, default=1142)
     parser.add_argument("--renderer", type=str, default=shutil.which("fluidsynth") or "")
     parser.add_argument("--soundfont", type=str, default="")
     parser.add_argument("--sample_rate", type=int, default=44100)

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio.py
@@ -12,6 +12,7 @@ import pretty_midi
 from scripts.render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio import (
     BOUNDARY,
     NEXT_BOUNDARY,
+    SCHEMA_VERSION as AUDIO_SCHEMA_VERSION,
     StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError,
     build_audio_render_report,
     validate_audio_render_report,
@@ -19,7 +20,30 @@ from scripts.render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_c
 from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep import (
     BOUNDARY as SOURCE_BOUNDARY,
     NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+    SCHEMA_VERSION as SOURCE_SWEEP_SCHEMA_VERSION,
     SELECTED_TARGET as SOURCE_SELECTED_TARGET,
+)
+from scripts.decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_followup import (
+    SCHEMA_VERSION as SOURCE_FOLLOWUP_SCHEMA_VERSION,
+)
+from scripts.decide_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_objective import (
+    SCHEMA_VERSION as CHORD_CONTEXT_OBJECTIVE_SCHEMA_VERSION,
+)
+from scripts.guard_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_input import (
+    SCHEMA_VERSION as SOURCE_INPUT_GUARD_SCHEMA_VERSION,
+)
+from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_listening_review_package import (
+    SCHEMA_VERSION as SOURCE_PACKAGE_SCHEMA_VERSION,
+)
+from scripts.render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_audio import (
+    SCHEMA_VERSION as SOURCE_AUDIO_SCHEMA_VERSION,
+)
+from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_repair_sweep import (
+    SCHEMA_VERSION as CHORD_TONE_REPAIR_SWEEP_SCHEMA_VERSION,
+)
+from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_context_pitch_role_bridge import (
+    BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
+    SCHEMA_VERSION as BRIDGE_SCHEMA_VERSION,
 )
 
 
@@ -110,7 +134,15 @@ def source_report(root: Path, *, quality_claim: bool = False) -> dict:
             }
         )
     return {
+        "schema_version": SOURCE_SWEEP_SCHEMA_VERSION,
         "boundary": SOURCE_BOUNDARY,
+        "source_schema_version": SOURCE_FOLLOWUP_SCHEMA_VERSION,
+        "source_objective_input_guard_schema_version": SOURCE_INPUT_GUARD_SCHEMA_VERSION,
+        "source_package_schema_version": SOURCE_PACKAGE_SCHEMA_VERSION,
+        "source_audio_schema_version": SOURCE_AUDIO_SCHEMA_VERSION,
+        "chord_tone_repair_sweep_schema_version": CHORD_TONE_REPAIR_SWEEP_SCHEMA_VERSION,
+        "chord_tone_repair_sweep_source_schema_version": CHORD_CONTEXT_OBJECTIVE_SCHEMA_VERSION,
+        "chord_tone_repair_sweep_bridge_schema_version": BRIDGE_SCHEMA_VERSION,
         "candidate_repairs": repairs,
         "aggregate": {
             "candidate_count": 6,
@@ -211,6 +243,21 @@ class StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioTest(unittest.Tes
             self.assertTrue(summary["outside_soloing_repair_targeted"])
             self.assertEqual(summary["weak_chord_tone_landing_risk_count_after"], 0)
             self.assertEqual(summary["max_non_chord_tone_run_after"], 3)
+            self.assertEqual(report["schema_version"], AUDIO_SCHEMA_VERSION)
+            self.assertEqual(report["issue_number"], 1142)
+            self.assertEqual(report["source_schema_version"], SOURCE_SWEEP_SCHEMA_VERSION)
+            self.assertEqual(
+                report["source_followup_schema_version"], SOURCE_FOLLOWUP_SCHEMA_VERSION
+            )
+            self.assertEqual(
+                report["source_objective_input_guard_schema_version"],
+                SOURCE_INPUT_GUARD_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                report["chord_tone_repair_sweep_schema_version"],
+                CHORD_TONE_REPAIR_SWEEP_SCHEMA_VERSION,
+            )
+            self.assertEqual(summary["source_schema_version"], SOURCE_SWEEP_SCHEMA_VERSION)
             for key, value in SOURCE_CONTEXT.items():
                 self.assertEqual(report["summary"][key], value)
                 self.assertEqual(report["audio_render_boundary"][key], value)
@@ -231,6 +278,28 @@ class StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioTest(unittest.Tes
             ):
                 build_audio_render_report(
                     source_report(root, quality_claim=True),
+                    output_dir=root / "audio_package",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(soundfont),
+                    sample_rate=44100,
+                    expected_file_count=6,
+                    runner=fake_runner,
+                )
+
+    def test_rejects_source_schema_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = root / "fluidsynth"
+            soundfont = root / "soundfont.sf2"
+            renderer.write_text("#!/bin/sh\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            report = source_report(root)
+            report["schema_version"] = "stale_schema"
+            with self.assertRaises(
+                StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError
+            ):
+                build_audio_render_report(
+                    report,
                     output_dir=root / "audio_package",
                     renderer_path=str(renderer),
                     soundfont_path=str(soundfont),
@@ -263,6 +332,36 @@ class StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioTest(unittest.Tes
                     runner=fake_runner,
                 )
 
+    def test_rejects_audio_summary_source_context_preservation_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = root / "fluidsynth"
+            soundfont = root / "soundfont.sf2"
+            renderer.write_text("#!/bin/sh\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            report = build_audio_render_report(
+                source_report(root),
+                output_dir=root / "audio_package",
+                renderer_path=str(renderer),
+                soundfont_path=str(soundfont),
+                sample_rate=44100,
+                expected_file_count=6,
+                runner=fake_runner,
+            )
+            report["summary"][BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS[0]] = False
+            with self.assertRaises(
+                StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioError
+            ):
+                validate_audio_render_report(
+                    report,
+                    expected_boundary=BOUNDARY,
+                    expected_next_boundary=NEXT_BOUNDARY,
+                    expected_file_count=6,
+                    expected_sample_rate=44100,
+                    require_audio_package_completed=True,
+                    require_no_quality_claim=True,
+                )
+
     def test_constants_are_stable(self) -> None:
         self.assertEqual(
             BOUNDARY,
@@ -271,6 +370,10 @@ class StageBMidiToSoloChordToneLandingOutsideSoloingRepairAudioTest(unittest.Tes
         self.assertEqual(
             NEXT_BOUNDARY,
             "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package",
+        )
+        self.assertEqual(
+            AUDIO_SCHEMA_VERSION,
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package_v4",
         )
 
 


### PR DESCRIPTION
## Summary
- outside-soloing repair audio package schema v4 적용
- #1140 sweep schema v3 검증 추가
- source schema chain 및 source-context preserved flag 전파 보강
- harness issue number, generated doc, handoff/status 문서 #1142 기준 갱신

## Context
- #1140 outside-soloing repair sweep merge 완료
- outside-soloing risk: `2 -> 0`
- changed note total: `2`
- max non-chord-tone run: `4 -> 3`
- audio package 단계의 검토 대상: sweep source schema, follow-up schema, input guard/package/audio schema, chord-tone repair sweep schema 보존

## Scope
- `render_stage_b_*outside_soloing_repair_audio.py` schema/context validation 보강
- audio report summary, audio render boundary, validation summary schema/context field 전파
- unit fixture 및 rejection case 보강
- `agent_harness.sh` issue number #1142 갱신
- README, AGENTS, CORE_PLAN, CURRENT_STATUS 문서 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio`
- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-chord-tone-landing-outside-soloing-repair-audio-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- WAV technical validation 범위
- audio rendered quality, human preference, MIDI-to-solo musical quality claim 제외

## Follow-up
- outside-soloing repair listening review package source-context refresh

Closes #1142