### PR TITLE
Stage B MIDI-to-solo MVP current evidence source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Primary goal:
 
 Current handoff scope:
 
-- Latest functional issue completed: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh.
+- Latest functional issue completed: Issue #1150, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh.
 - Latest audit issue completed: Issue #1070, Stage B MIDI-to-solo MVP completion audit source-context refresh.
 - Latest quality gap decision completed: Issue #1072, Stage B MIDI-to-solo quality gap decision source-context refresh.
 - Latest listening review quality gap completed: Issue #1074, Stage B MIDI-to-solo listening review quality gap source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1148, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh.
+- Open issue queue after Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo README evidence refresh source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package: `Issue #1144`
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard: `Issue #1146`
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision: `Issue #1148`
-- latest MVP current evidence consolidation: `Issue #1066`
+- latest MVP current evidence consolidation: `Issue #1150`
 - latest README evidence refresh: `Issue #1068`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh merge: `0`
+- open issue queue after MVP current evidence consolidation source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -391,7 +391,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo controlled scale checkpoint training scale postprocess removal dead-air repair audio review package: candidate/rendered `3/3`, sample rate `44100`, duration `6.866s-6.869s`, technical validation `true`, preference claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_training_scale_postprocess_removal_dead_air_repair_listening_review`
 - MIDI-to-solo controlled scale checkpoint training scale postprocess removal dead-air repair listening review: review template `true`, pending status/candidate/field `4/3/9`, preference fill `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_training_scale_postprocess_removal_dead_air_repair_objective_only_next_decision`
 - MIDI-to-solo controlled scale checkpoint training scale postprocess removal dead-air repair objective-only next decision: objective path support `true`, valid/strict/grammar `9/9/9`, dead-air/collapse `0/0`, avg/max postprocess removal `0.2176/0.2917`, preference/quality claim `false`, next boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
-- MIDI-to-solo MVP current evidence consolidation: evidence support `true`, technical path `true`, selected-scale objective path `true`, phrase-bank CLI path `true`, model-conditioned pitch-contour objective path `true`, changed-ratio repair objective path `true`, exported/rendered `3/3`, objective valid/strict/grammar `9/9/9`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_readme_evidence_refresh`
+- MIDI-to-solo MVP current evidence consolidation: schema `v4`, evidence support `true`, technical path `true`, selected-scale objective path `true`, phrase-bank CLI path `true`, model-conditioned pitch-contour objective path `true`, changed-ratio repair objective path `true`, outside-soloing objective/schema context `true/true`, exported/rendered `3/3`, objective valid/strict/grammar `9/9/9`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_readme_evidence_refresh`
 - MIDI-to-solo README evidence refresh: latest boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`, input-to-WAV technical path `true`, selected-scale objective path `true`, phrase-bank CLI path `true`, model-conditioned pitch-contour objective path `true`, changed-ratio repair objective path `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_completion_audit`
 - MIDI-to-solo MVP completion audit refresh: technical model-core MVP `true`, model-conditioned pitch-contour objective `true`, changed-ratio repair objective `true`, max interval/threshold `11/12`, changed-ratio repair ratio/target `0.4348/0.5000`, musical/product MVP `false/false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_gap_decision`
 - MIDI-to-solo quality gap decision refresh: selected target `listening_review_quality_gap`, fallback alignment required `false`, changed-ratio repair objective `true`, changed-ratio repair ratio/target `0.4348/0.5000`, changed-ratio repair interval/target `12/12`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_listening_review_quality_gap`
@@ -12053,7 +12053,7 @@ Issue #1148은 Issue #1146 input guard v4의 source schema chain을 objective-on
 
 ## 9.223 Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 
-Issue #1066은 Issue #1064 outside-soloing repair objective decision의 source-context preserved flag를 MVP current evidence consolidation까지 보존하고, current evidence support를 재검증한 작업이다.
+Issue #1150은 Issue #1148 outside-soloing repair objective decision v4의 source schema chain을 MVP current evidence consolidation까지 보존하고, current evidence support를 재검증한 작업이다.
 
 결과:
 
@@ -12068,6 +12068,8 @@ Issue #1066은 Issue #1064 outside-soloing repair objective decision의 source-c
 - model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
 - outside-soloing repair objective path ready: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - outside-soloing repair rendered audio file count: `6`
 - outside-soloing repair changed note total: `2`
 - source outside-soloing pitch-role risk count: `5 -> 2`
@@ -12083,7 +12085,7 @@ Issue #1066은 Issue #1064 outside-soloing repair objective decision의 source-c
 
 판단:
 
-- Issue #1064 objective decision의 preserved flag 3개가 current evidence outside-soloing repair objective path와 validation summary까지 유지됨.
+- Issue #1148 objective decision v4의 source schema chain과 preserved context가 current evidence outside-soloing repair objective path와 validation summary까지 유지됨.
 - selected-scale objective path, phrase-bank CLI technical path, model-conditioned pitch-contour path, changed-ratio repair path, outside-soloing repair path 모두 current evidence support에 포함.
 - human/audio preference, MIDI-to-solo musical quality, broad trained model quality claim 제외.
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -12,7 +12,7 @@
 
 현재 active issue:
 
-- latest functional result: Issue #1076, Stage B MIDI-to-solo MVP delivery package source-context refresh
+- latest functional result: Issue #1150, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest MVP completion audit: Issue #1070, Stage B MIDI-to-solo MVP completion audit source-context refresh
 - latest quality gap decision: Issue #1072, Stage B MIDI-to-solo quality gap decision source-context refresh
 - latest listening review quality gap: Issue #1074, Stage B MIDI-to-solo listening review quality gap source-context refresh
@@ -53,11 +53,11 @@
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package: Issue #1144, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard: Issue #1146, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision: Issue #1148, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh
-- latest MVP current evidence consolidation: Issue #1066, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
+- latest MVP current evidence consolidation: Issue #1150, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh`
+- open issue queue after Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo README evidence refresh source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -5266,14 +5266,14 @@ Issue #1148은 Issue #1146 input guard v4의 source schema chain을 objective-on
 
 ## Stage B MIDI-to-Solo MVP Current Evidence Consolidation Source-Context Refresh Result
 
-Issue #1066은 Issue #1064 outside-soloing repair objective decision의 source-context preserved flag를 MVP current evidence consolidation까지 보존하고, current evidence support를 재검증한 작업이다.
+Issue #1150은 Issue #1148 outside-soloing repair objective decision v4의 source schema chain을 MVP current evidence consolidation까지 보존하고, current evidence support를 재검증한 작업이다.
 
 변경:
 
-- current evidence consolidation schema v3 적용
-- outside-soloing repair objective required source-context key와 preserved flag 3개 필수 검증
-- outside-soloing repair objective path, readiness, validation summary source-context preserved field 전파
-- harness issue number를 #1066 기준으로 갱신
+- current evidence consolidation schema v4 적용
+- outside-soloing repair objective schema v4와 source schema-context key 필수 검증
+- outside-soloing repair objective path, readiness, validation summary schema/context field 전파
+- harness issue number를 #1150 기준으로 갱신
 - next recommended issue를 README evidence refresh source-context refresh로 갱신
 
 결과:
@@ -5289,6 +5289,8 @@ Issue #1066은 Issue #1064 outside-soloing repair objective decision의 source-c
 - model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
 - outside-soloing repair objective path ready: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - outside-soloing repair rendered audio file count: `6`
 - outside-soloing repair changed note total: `2`
 - source outside-soloing pitch-role risk count: `5 -> 2`
@@ -5304,7 +5306,7 @@ Issue #1066은 Issue #1064 outside-soloing repair objective decision의 source-c
 
 판단:
 
-- Issue #1064 objective decision의 preserved flag 3개가 current evidence outside-soloing repair objective path와 validation summary까지 유지됨.
+- Issue #1148 objective decision v4의 source schema chain과 preserved context가 current evidence outside-soloing repair objective path와 validation summary까지 유지됨.
 - selected-scale objective path, phrase-bank CLI technical path, model-conditioned pitch-contour path, changed-ratio repair path, outside-soloing repair path 모두 current evidence support에 포함.
 - human/audio preference, MIDI-to-solo musical quality, broad trained model quality claim 제외.
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MVP_CURRENT_EVIDENCE_CONSOLIDATION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MVP_CURRENT_EVIDENCE_CONSOLIDATION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -12,6 +12,7 @@
 - model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
 - outside-soloing repair objective path ready: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
 - human/audio preference claimed: `false`
 - MIDI-to-solo musical quality claimed: `false`
 
@@ -88,6 +89,11 @@
 ## Outside-Soloing Repair Objective Path
 
 - current evidence consolidation ready: `true`
+- objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
+- source schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_input_guard_v4`
+- source listening package schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_listening_review_package_v4`
+- source audio package schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_audio_package_v4`
+- source repair sweep schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_sweep_v3`
 - objective path supported: `true`
 - rendered WAV files: `6`
 - technical WAV validation: `true`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -5988,7 +5988,7 @@ run_stage_b_midi_to_solo_mvp_current_evidence_consolidation() {
     --model_conditioned_pitch_contour_changed_ratio_repair_objective_next "$model_conditioned_pitch_contour_changed_ratio_repair_objective_next" \
     --outside_soloing_repair_objective_next "$outside_soloing_repair_objective_next" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_CURRENT_EVIDENCE_CONSOLIDATION_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1066 \
+    --issue_number 1150 \
     --expected_boundary stage_b_midi_to_solo_mvp_current_evidence_consolidation \
     --expected_next_boundary stage_b_midi_to_solo_readme_evidence_refresh \
     --min_exported_candidates 3 \

--- a/scripts/consolidate_stage_b_midi_to_solo_mvp_current_evidence.py
+++ b/scripts/consolidate_stage_b_midi_to_solo_mvp_current_evidence.py
@@ -21,7 +21,7 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationError(ValueError):
 
 BOUNDARY = "stage_b_midi_to_solo_mvp_current_evidence_consolidation"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_readme_evidence_refresh"
-SCHEMA_VERSION = "stage_b_midi_to_solo_mvp_current_evidence_consolidation_v3"
+SCHEMA_VERSION = "stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4"
 
 CONTRACT_BOUNDARY = "stage_b_midi_to_solo_mvp_input_contract"
 CONTEXT_BOUNDARY = "stage_b_midi_to_solo_context_extraction_mvp"
@@ -48,6 +48,23 @@ MODEL_CONDITIONED_PITCH_CONTOUR_CHANGED_RATIO_REPAIR_OBJECTIVE_BOUNDARY = (
 OUTSIDE_SOLOING_REPAIR_OBJECTIVE_BOUNDARY = (
     "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_"
     "outside_soloing_repair_objective_only_next_decision"
+)
+OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION = (
+    "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_"
+    "outside_soloing_repair_objective_next_v4"
+)
+SOURCE_OBJECTIVE_SCHEMA_CONTEXT_KEYS = (
+    "source_schema_version",
+    "source_listening_package_schema_version",
+    "source_audio_package_schema_version",
+    "source_repair_sweep_schema_version",
+    "source_followup_schema_version",
+    "source_objective_input_guard_schema_version",
+    "source_package_schema_version",
+    "source_audio_schema_version",
+    "chord_tone_repair_sweep_schema_version",
+    "chord_tone_repair_sweep_source_schema_version",
+    "chord_tone_repair_sweep_bridge_schema_version",
 )
 BRIDGE_SOURCE_CONTEXT_KEYS = (
     "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before",
@@ -127,6 +144,35 @@ def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str
             f"{label} source-context preserved field must be true: {missing_preserved}"
         )
     return {key: container[key] for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS}
+
+
+def _outside_soloing_schema_context(
+    report: dict[str, Any],
+    summary: dict[str, Any],
+    readiness: dict[str, Any],
+    *,
+    label: str,
+) -> dict[str, str]:
+    if str(report.get("schema_version") or "") != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION:
+        raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+            "outside-soloing repair objective schema version must match current report"
+        )
+    context = {
+        "outside_soloing_repair_objective_schema_version": (
+            OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+        )
+    }
+    for key in SOURCE_OBJECTIVE_SCHEMA_CONTEXT_KEYS:
+        if not str(summary.get(key) or ""):
+            raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+                f"{label} schema-context field required: {key}"
+            )
+        if str(readiness.get(key) or "") != str(summary.get(key) or ""):
+            raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+                f"{label} readiness schema-context mismatch: {key}"
+            )
+        context[key] = str(summary.get(key) or "")
+    return context
 
 
 def _duration_range(items: list[dict[str, Any]]) -> dict[str, float]:
@@ -781,8 +827,15 @@ def validate_outside_soloing_repair_objective_next(
         summary,
         label="outside-soloing repair objective summary",
     )
+    schema_context = _outside_soloing_schema_context(
+        report,
+        summary,
+        readiness,
+        label="outside-soloing repair objective summary",
+    )
     return {
         "boundary": OUTSIDE_SOLOING_REPAIR_OBJECTIVE_BOUNDARY,
+        **schema_context,
         "objective_next_completed": bool(readiness.get("objective_next_completed", False)),
         "objective_next_decision_completed": bool(
             readiness.get("objective_next_decision_completed", False)
@@ -996,6 +1049,17 @@ def build_current_evidence_consolidation_report(
                 key in outside_soloing_repair_objective
                 for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
             ),
+            "outside_soloing_repair_schema_context_preserved": bool(
+                outside_soloing_repair_objective
+            )
+            and outside_soloing_repair_objective.get(
+                "outside_soloing_repair_objective_schema_version"
+            )
+            == OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            and all(
+                key in outside_soloing_repair_objective
+                for key in SOURCE_OBJECTIVE_SCHEMA_CONTEXT_KEYS
+            ),
             "current_mvp_technical_execution_evidence_supported": technical_path_supported,
             "current_mvp_objective_repair_evidence_supported": selected_scale_objective_path_complete,
             "midi_to_solo_mvp_current_evidence_supported": current_evidence_supported,
@@ -1146,6 +1210,27 @@ def validate_current_evidence_consolidation_report(
         raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
             "outside-soloing repair preference fill should remain blocked"
         )
+    if outside_soloing_repair:
+        if str(
+            outside_soloing_repair.get("outside_soloing_repair_objective_schema_version")
+            or ""
+        ) != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION:
+            raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+                "outside-soloing repair objective schema version mismatch"
+            )
+        missing_schema_context = [
+            key
+            for key in SOURCE_OBJECTIVE_SCHEMA_CONTEXT_KEYS
+            if not str(outside_soloing_repair.get(key) or "")
+        ]
+        if missing_schema_context:
+            raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+                f"outside-soloing repair schema-context missing: {missing_schema_context}"
+            )
+        if not bool(readiness.get("outside_soloing_repair_schema_context_preserved", False)):
+            raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError(
+                "outside-soloing repair schema-context preservation required"
+            )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloMvpCurrentEvidenceConsolidationError("critical user input should not be required")
     for item in _list(generation.get("midi_paths")) + _list(audio.get("wav_paths")):
@@ -1295,6 +1380,17 @@ def validate_current_evidence_consolidation_report(
         "outside_soloing_repair_source_context_preserved": bool(
             readiness.get("outside_soloing_repair_source_context_preserved", False)
         ),
+        "outside_soloing_repair_schema_context_preserved": bool(
+            readiness.get("outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "outside_soloing_repair_objective_schema_version": str(
+            outside_soloing_repair.get("outside_soloing_repair_objective_schema_version")
+            or ""
+        ),
+        **{
+            f"outside_soloing_repair_{key}": outside_soloing_repair.get(key)
+            for key in SOURCE_OBJECTIVE_SCHEMA_CONTEXT_KEYS
+        },
         **{
             key: outside_soloing_repair.get(key)
             for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
@@ -1363,6 +1459,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- model-conditioned pitch-contour changed-ratio repair objective path ready: `{_bool_token(readiness['model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready'])}`",
         f"- outside-soloing repair objective path ready: `{_bool_token(readiness['outside_soloing_repair_objective_path_ready'])}`",
         f"- outside-soloing repair source context preserved: `{_bool_token(readiness['outside_soloing_repair_source_context_preserved'])}`",
+        f"- outside-soloing repair schema context preserved: `{_bool_token(readiness['outside_soloing_repair_schema_context_preserved'])}`",
         f"- human/audio preference claimed: `{_bool_token(readiness['human_audio_preference_claimed'])}`",
         f"- MIDI-to-solo musical quality claimed: `{_bool_token(readiness['midi_to_solo_musical_quality_claimed'])}`",
         "",
@@ -1453,6 +1550,11 @@ def markdown_report(report: dict[str, Any]) -> str:
                 "## Outside-Soloing Repair Objective Path",
                 "",
                 f"- current evidence consolidation ready: `{_bool_token(outside_soloing_repair['current_evidence_consolidation_ready'])}`",
+                f"- objective schema version: `{outside_soloing_repair['outside_soloing_repair_objective_schema_version']}`",
+                f"- source schema version: `{outside_soloing_repair['source_schema_version']}`",
+                f"- source listening package schema version: `{outside_soloing_repair['source_listening_package_schema_version']}`",
+                f"- source audio package schema version: `{outside_soloing_repair['source_audio_package_schema_version']}`",
+                f"- source repair sweep schema version: `{outside_soloing_repair['source_repair_sweep_schema_version']}`",
                 f"- objective path supported: `{_bool_token(outside_soloing_repair['outside_soloing_repair_objective_path_supported'])}`",
                 f"- rendered WAV files: `{outside_soloing_repair['rendered_audio_file_count']}`",
                 f"- technical WAV validation: `{_bool_token(outside_soloing_repair['technical_wav_validation'])}`",
@@ -1516,7 +1618,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=1066)
+    parser.add_argument("--issue_number", type=int, default=1150)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--require_current_evidence_support", action="store_true")

--- a/tests/test_stage_b_midi_to_solo_mvp_current_evidence_consolidation.py
+++ b/tests/test_stage_b_midi_to_solo_mvp_current_evidence_consolidation.py
@@ -10,6 +10,9 @@ from scripts.consolidate_stage_b_midi_to_solo_mvp_current_evidence import (
     NEXT_BOUNDARY,
     OBJECTIVE_FINAL_BOUNDARY,
     OBJECTIVE_NEXT_BOUNDARY,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    SCHEMA_VERSION,
+    SOURCE_OBJECTIVE_SCHEMA_CONTEXT_KEYS,
     StageBMidiToSoloMvpCurrentEvidenceConsolidationError,
     build_current_evidence_consolidation_report,
     validate_current_evidence_consolidation_report,
@@ -47,6 +50,54 @@ SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_source_context_preserved": True,
     "followup_repair_sweep_source_outside_soloing_source_context_preserved": True,
     "repair_sweep_source_outside_soloing_source_context_preserved": True,
+}
+
+
+SOURCE_SCHEMA_CONTEXT = {
+    "source_schema_version": (
+        "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_"
+        "outside_soloing_repair_listening_review_input_guard_v4"
+    ),
+    "source_listening_package_schema_version": (
+        "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_"
+        "outside_soloing_repair_listening_review_package_v4"
+    ),
+    "source_audio_package_schema_version": (
+        "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_"
+        "outside_soloing_repair_audio_package_v4"
+    ),
+    "source_repair_sweep_schema_version": (
+        "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_"
+        "outside_soloing_repair_sweep_v3"
+    ),
+    "source_followup_schema_version": (
+        "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_"
+        "repair_followup_decision_v3"
+    ),
+    "source_objective_input_guard_schema_version": (
+        "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_"
+        "repair_listening_review_input_guard_v3"
+    ),
+    "source_package_schema_version": (
+        "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_"
+        "repair_listening_review_package_v3"
+    ),
+    "source_audio_schema_version": (
+        "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_"
+        "repair_audio_package_v4"
+    ),
+    "chord_tone_repair_sweep_schema_version": (
+        "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_"
+        "repair_sweep_v4"
+    ),
+    "chord_tone_repair_sweep_source_schema_version": (
+        "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_"
+        "chord_context_pitch_role_objective_decision_v4"
+    ),
+    "chord_tone_repair_sweep_bridge_schema_version": (
+        "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_"
+        "chord_context_pitch_role_bridge_v4"
+    ),
 }
 
 
@@ -328,11 +379,13 @@ def reports(
             },
         },
         "outside_soloing_repair_objective": {
+            "schema_version": OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
             "boundary": (
                 "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_"
                 "chord_tone_landing_outside_soloing_repair_objective_only_next_decision"
             ),
             "objective_summary": {
+                **SOURCE_SCHEMA_CONTEXT,
                 "review_item_count": 6,
                 "validated_review_input_present": False,
                 "preference_fill_allowed": False,
@@ -363,6 +416,7 @@ def reports(
                 **SOURCE_CONTEXT,
             },
             "readiness": {
+                **SOURCE_SCHEMA_CONTEXT,
                 "objective_next_completed": True,
                 "objective_next_decision_completed": True,
                 "human_audio_preference_claimed": False,
@@ -404,7 +458,7 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationTest(unittest.TestCase):
                     "outside_soloing_repair_objective"
                 ],
                 output_dir=Path(tmp) / "out",
-                issue_number=1066,
+                issue_number=1150,
             )
             summary = validate_current_evidence_consolidation_report(
                 report,
@@ -505,6 +559,17 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationTest(unittest.TestCase):
             self.assertTrue(summary["outside_soloing_repair_non_chord_run_target_supported"])
             self.assertTrue(summary["outside_soloing_repair_objective_path_supported"])
             self.assertTrue(summary["outside_soloing_repair_source_context_preserved"])
+            self.assertTrue(summary["outside_soloing_repair_schema_context_preserved"])
+            self.assertEqual(
+                summary["outside_soloing_repair_objective_schema_version"],
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+            )
+            for key in SOURCE_OBJECTIVE_SCHEMA_CONTEXT_KEYS:
+                self.assertIn(key, report["outside_soloing_repair_objective_path"])
+                self.assertEqual(
+                    summary[f"outside_soloing_repair_{key}"],
+                    SOURCE_SCHEMA_CONTEXT[key],
+                )
             for key in BRIDGE_SOURCE_CONTEXT_KEYS:
                 self.assertIn(key, report["outside_soloing_repair_objective_path"])
                 self.assertEqual(summary[key], SOURCE_CONTEXT[key])
@@ -654,6 +719,58 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationTest(unittest.TestCase):
     def test_rejects_missing_outside_soloing_source_context(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             data = reports(Path(tmp))
+            data["outside_soloing_repair_objective"]["schema_version"] = "legacy_schema"
+            with self.assertRaises(StageBMidiToSoloMvpCurrentEvidenceConsolidationError):
+                build_current_evidence_consolidation_report(
+                    contract_report=data["contract"],
+                    context_report=data["context"],
+                    resource_probe=data["resource"],
+                    generation_probe=data["generation"],
+                    audio_render=data["audio"],
+                    objective_next=data["objective"],
+                    cli_objective_next=data["cli_objective"],
+                    model_conditioned_pitch_contour_objective_next=data[
+                        "model_conditioned_pitch_contour_objective"
+                    ],
+                    model_conditioned_pitch_contour_changed_ratio_repair_objective_next=data[
+                        "model_conditioned_pitch_contour_changed_ratio_repair_objective"
+                    ],
+                    outside_soloing_repair_objective_next=data[
+                        "outside_soloing_repair_objective"
+                    ],
+                    output_dir=Path(tmp) / "out",
+                    issue_number=1150,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            data = reports(Path(tmp))
+            data["outside_soloing_repair_objective"]["readiness"][
+                "source_schema_version"
+            ] = "mismatched_schema"
+            with self.assertRaises(StageBMidiToSoloMvpCurrentEvidenceConsolidationError):
+                build_current_evidence_consolidation_report(
+                    contract_report=data["contract"],
+                    context_report=data["context"],
+                    resource_probe=data["resource"],
+                    generation_probe=data["generation"],
+                    audio_render=data["audio"],
+                    objective_next=data["objective"],
+                    cli_objective_next=data["cli_objective"],
+                    model_conditioned_pitch_contour_objective_next=data[
+                        "model_conditioned_pitch_contour_objective"
+                    ],
+                    model_conditioned_pitch_contour_changed_ratio_repair_objective_next=data[
+                        "model_conditioned_pitch_contour_changed_ratio_repair_objective"
+                    ],
+                    outside_soloing_repair_objective_next=data[
+                        "outside_soloing_repair_objective"
+                    ],
+                    output_dir=Path(tmp) / "out",
+                    issue_number=1150,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            data = reports(Path(tmp))
             data["outside_soloing_repair_objective"]["objective_summary"][
                 "source_outside_soloing_residual_risk_preserved"
             ] = False
@@ -763,6 +880,7 @@ class StageBMidiToSoloMvpCurrentEvidenceConsolidationTest(unittest.TestCase):
     def test_boundary_constants_are_stable(self) -> None:
         self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_mvp_current_evidence_consolidation")
         self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_readme_evidence_refresh")
+        self.assertEqual(SCHEMA_VERSION, "stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- MVP current evidence consolidation schema v4 적용
- #1148 outside-soloing repair objective decision schema chain 보존
- current evidence report, validation summary, markdown 산출물 schema/context field 전파

## Context
- #1148 objective decision: outside-soloing repair objective path supported `true`
- current repair risk after: `0`
- source risk: `5 -> 2`
- objective schema: `outside_soloing_repair_objective_next_v4`
- source schema context preserved: `true`
- listening review input: `false`
- MIDI-to-solo musical quality claim: `false`

## Scope
- current evidence consolidation schema `v4`
- outside-soloing repair objective schema/context validation
- readiness, validation summary, generated markdown schema-context field 추가
- #1150 기준 harness issue number, README, CORE_PLAN, CURRENT_STATUS, AGENTS 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_current_evidence_consolidation`
- `.venv/bin/python -m py_compile scripts/consolidate_stage_b_midi_to_solo_mvp_current_evidence.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-current-evidence-consolidation`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- current evidence consolidation은 objective evidence 범위
- listening review 완료 claim 제외
- MIDI-to-solo musical quality claim 제외

## Follow-up
- Stage B MIDI-to-solo README evidence refresh source-context refresh

Closes #1150