### PR TITLE
Stage B MIDI-to-solo README evidence source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,10 +53,10 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package completed: Issue #1144, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review package source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard completed: Issue #1146, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard source-context refresh.
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1148, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
-- Latest documentation issue completed: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh.
+- Latest documentation issue completed: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo README evidence refresh source-context refresh.
+- Open issue queue after Stage B MIDI-to-solo README evidence refresh source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo MVP completion audit source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard: `Issue #1146`
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision: `Issue #1148`
 - latest MVP current evidence consolidation: `Issue #1150`
-- latest README evidence refresh: `Issue #1068`
+- latest README evidence refresh: `Issue #1152`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after MVP current evidence consolidation source-context refresh merge: `0`
+- open issue queue after README evidence refresh source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current MVP evidence support: `true`
@@ -135,6 +135,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - phrase/rhythm chord-tone landing outside-soloing repair objective path supported: `true`
 - phrase/rhythm chord-tone landing outside-soloing repair current evidence consolidation ready: `true`
 - phrase/rhythm chord-tone landing outside-soloing repair source context preserved: `true`
+- phrase/rhythm chord-tone landing outside-soloing repair schema context preserved: `true`
+- phrase/rhythm chord-tone landing outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - phrase/rhythm repair rendered WAV count: `6`
 - phrase/rhythm repair technical WAV validation: `true`
 - phrase/rhythm repair source context preserved: `true`
@@ -253,6 +255,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - current evidence changed-ratio repair objective path included: `true`
 - outside-soloing repair objective path included in current evidence: `true`
 - outside-soloing repair source context preserved in current evidence: `true`
+- outside-soloing repair schema context preserved in current evidence: `true`
 - outside-soloing repair WAV files: `6`
 - outside-soloing repair changed note total: `2`
 - outside-soloing source pitch-role risk: `5 -> 2`
@@ -530,6 +533,8 @@ MVP current evidence refresh.
 - model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
 - outside-soloing repair objective path ready: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`
@@ -1229,6 +1234,8 @@ README evidence refresh.
 - model-conditioned pitch-contour changed-ratio repair objective path ready: `true`
 - model-conditioned pitch-contour changed-ratio repair max ratio / target: `0.4348 / 0.5000`
 - outside-soloing source-context evidence reflected: `true`
+- outside-soloing schema-context evidence reflected: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - outside-soloing source pitch-role risk count: `5 -> 2`
 - outside-soloing source residual risk preserved: `true`
 - outside-soloing current repair pitch-role risk count after: `0`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -392,7 +392,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo controlled scale checkpoint training scale postprocess removal dead-air repair listening review: review template `true`, pending status/candidate/field `4/3/9`, preference fill `false`, quality claim `false`, next boundary `stage_b_midi_to_solo_controlled_scale_checkpoint_training_scale_postprocess_removal_dead_air_repair_objective_only_next_decision`
 - MIDI-to-solo controlled scale checkpoint training scale postprocess removal dead-air repair objective-only next decision: objective path support `true`, valid/strict/grammar `9/9/9`, dead-air/collapse `0/0`, avg/max postprocess removal `0.2176/0.2917`, preference/quality claim `false`, next boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - MIDI-to-solo MVP current evidence consolidation: schema `v4`, evidence support `true`, technical path `true`, selected-scale objective path `true`, phrase-bank CLI path `true`, model-conditioned pitch-contour objective path `true`, changed-ratio repair objective path `true`, outside-soloing objective/schema context `true/true`, exported/rendered `3/3`, objective valid/strict/grammar `9/9/9`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_readme_evidence_refresh`
-- MIDI-to-solo README evidence refresh: latest boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`, input-to-WAV technical path `true`, selected-scale objective path `true`, phrase-bank CLI path `true`, model-conditioned pitch-contour objective path `true`, changed-ratio repair objective path `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_completion_audit`
+- MIDI-to-solo README evidence refresh: latest boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`, input-to-WAV technical path `true`, selected-scale objective path `true`, phrase-bank CLI path `true`, model-conditioned pitch-contour objective path `true`, changed-ratio repair objective path `true`, outside-soloing schema-context evidence reflected `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_completion_audit`
 - MIDI-to-solo MVP completion audit refresh: technical model-core MVP `true`, model-conditioned pitch-contour objective `true`, changed-ratio repair objective `true`, max interval/threshold `11/12`, changed-ratio repair ratio/target `0.4348/0.5000`, musical/product MVP `false/false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_gap_decision`
 - MIDI-to-solo quality gap decision refresh: selected target `listening_review_quality_gap`, fallback alignment required `false`, changed-ratio repair objective `true`, changed-ratio repair ratio/target `0.4348/0.5000`, changed-ratio repair interval/target `12/12`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_listening_review_quality_gap`
 - MIDI-to-solo listening review quality gap: selected target `mvp_delivery_package`, technical delivery package ready `true`, listening gap open `true`, changed-ratio repair ratio/target `0.4348/0.5000`, interval/target `12/12`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_delivery_package`
@@ -12104,7 +12104,7 @@ Issue #1150은 Issue #1148 outside-soloing repair objective decision v4의 sourc
 
 ## 9.224 Stage B MIDI-to-solo README evidence source-context refresh
 
-Issue #1068은 Issue #1066 MVP current evidence consolidation 결과를 README evidence block과 MVP completion audit README snippet guard에 반영한 문서/검증 정합성 작업이다.
+Issue #1152는 Issue #1150 MVP current evidence consolidation 결과를 README evidence block과 MVP completion audit README snippet guard에 반영한 문서/검증 정합성 작업이다.
 
 결과:
 
@@ -12115,6 +12115,8 @@ Issue #1068은 Issue #1066 MVP current evidence consolidation 결과를 README e
 - current MVP evidence supported: `true`
 - outside-soloing repair objective path ready: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`
@@ -12125,7 +12127,7 @@ Issue #1068은 Issue #1066 MVP current evidence consolidation 결과를 README e
 
 판단:
 
-- README evidence refresh 완료 조건에 preserved flag 3개 포함.
+- README evidence refresh 완료 조건에 schema-context reflected snippet과 preserved flag 3개 포함.
 - current evidence의 source/current outside-soloing risk 분리 유지.
 - listening review input, human/audio preference, MIDI-to-solo musical quality claim 제외.
 
@@ -12133,7 +12135,6 @@ Issue #1068은 Issue #1066 MVP current evidence consolidation 결과를 README e
 
 - `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
 - `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_mvp_completion.py`
-- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit`
 - `bash scripts/agent_harness.sh quick`
 - `git diff --check`
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -54,10 +54,10 @@
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard: Issue #1146, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair listening review input guard source-context refresh
 - latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision: Issue #1148, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh
 - latest MVP current evidence consolidation: Issue #1150, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
-- latest README evidence refresh: Issue #1068, Stage B MIDI-to-solo README evidence source-context refresh
+- latest README evidence refresh: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo README evidence refresh source-context refresh`
+- open issue queue after Stage B MIDI-to-solo README evidence refresh source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo MVP completion audit source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -5325,14 +5325,14 @@ Issue #1150은 Issue #1148 outside-soloing repair objective decision v4의 sourc
 
 ## Stage B MIDI-to-Solo README Evidence Source-Context Refresh Result
 
-Issue #1068은 Issue #1066 MVP current evidence consolidation 결과를 README evidence block과 MVP completion audit README snippet guard에 반영한 문서/검증 정합성 작업이다.
+Issue #1152는 Issue #1150 MVP current evidence consolidation 결과를 README evidence block과 MVP completion audit README snippet guard에 반영한 문서/검증 정합성 작업이다.
 
 변경:
 
-- README latest evidence refresh를 #1068 기준으로 갱신
-- README current evidence block에 source-context preserved flag 3개 반영
-- MVP completion audit README snippet guard에 preserved flag 3개 필수화
-- false preserved flag 입력 차단 테스트 추가
+- README latest evidence refresh를 #1152 기준으로 갱신
+- README current evidence block에 source-context preserved flag와 schema-context reflected field 반영
+- MVP completion audit README snippet guard에 schema-context reflected snippet 필수화
+- false preserved flag와 schema-context 누락 입력 차단 테스트 추가
 - generated evidence doc, current status, core plan, handoff scope 갱신
 
 결과:
@@ -5344,6 +5344,8 @@ Issue #1068은 Issue #1066 MVP current evidence consolidation 결과를 README e
 - current MVP evidence supported: `true`
 - outside-soloing repair objective path ready: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`
@@ -5354,7 +5356,7 @@ Issue #1068은 Issue #1066 MVP current evidence consolidation 결과를 README e
 
 판단:
 
-- README evidence refresh 완료 조건에 preserved flag 3개 포함.
+- README evidence refresh 완료 조건에 schema-context reflected snippet과 preserved flag 3개 포함.
 - current evidence의 source/current outside-soloing risk 분리 유지.
 - listening review input, human/audio preference, MIDI-to-solo musical quality claim 제외.
 
@@ -5362,7 +5364,6 @@ Issue #1068은 Issue #1066 MVP current evidence consolidation 결과를 README e
 
 - `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
 - `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_mvp_completion.py`
-- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit`
 - `bash scripts/agent_harness.sh quick`
 - `git diff --check`
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_README_EVIDENCE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_README_EVIDENCE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -12,6 +12,8 @@
 - current MVP evidence supported: `true`
 - outside-soloing repair objective path ready: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - outside-soloing repair rendered audio file count: `6`
 - outside-soloing repair changed note total: `2`
 - source objective outside-soloing pitch-role risk count: `5`
@@ -35,8 +37,8 @@
 ## Decision
 
 - README current evidence block에 source/current repair context 분리 기록
-- README evidence block에 source-context preserved flag 3개 반영
-- MVP completion audit README snippet guard에 preserved flag 3개 필수화
+- README evidence block에 source-context preserved flag와 schema-context reflected field 반영
+- MVP completion audit README snippet guard에 schema-context reflected snippet 필수화
 - source repair residual risk boundary 보존
 - current repair objective support만 반영
 - 다음 boundary: `stage_b_midi_to_solo_mvp_completion_audit`
@@ -45,6 +47,5 @@
 
 - `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
 - `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_mvp_completion.py`
-- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit`
 - `bash scripts/agent_harness.sh quick`
 - `git diff --check`

--- a/scripts/audit_stage_b_midi_to_solo_mvp_completion.py
+++ b/scripts/audit_stage_b_midi_to_solo_mvp_completion.py
@@ -18,6 +18,8 @@ from scripts.consolidate_stage_b_midi_to_solo_mvp_current_evidence import (  # n
     BRIDGE_SOURCE_CONTEXT_KEYS,
     BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
     BOUNDARY as CURRENT_EVIDENCE_BOUNDARY,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    SOURCE_OBJECTIVE_SCHEMA_CONTEXT_KEYS,
 )
 
 
@@ -101,6 +103,7 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
         "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready",
         "outside_soloing_repair_objective_path_ready",
         "outside_soloing_repair_source_context_preserved",
+        "outside_soloing_repair_schema_context_preserved",
         "current_mvp_technical_execution_evidence_supported",
         "current_mvp_objective_repair_evidence_supported",
         "midi_to_solo_mvp_current_evidence_supported",
@@ -321,6 +324,22 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
         outside_soloing_repair,
         label="outside-soloing repair current evidence",
     )
+    if str(
+        outside_soloing_repair.get("outside_soloing_repair_objective_schema_version")
+        or ""
+    ) != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION:
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "outside-soloing repair objective schema version mismatch"
+        )
+    missing_schema_context = [
+        key
+        for key in SOURCE_OBJECTIVE_SCHEMA_CONTEXT_KEYS
+        if not str(outside_soloing_repair.get(key) or "")
+    ]
+    if missing_schema_context:
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            f"outside-soloing repair schema-context missing: {missing_schema_context}"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloMvpCompletionAuditError("critical user input should not be required")
     return {
@@ -452,6 +471,17 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
         "outside_soloing_repair_source_context_preserved": bool(
             readiness.get("outside_soloing_repair_source_context_preserved", False)
         ),
+        "outside_soloing_repair_schema_context_preserved": bool(
+            readiness.get("outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "outside_soloing_repair_objective_schema_version": str(
+            outside_soloing_repair.get("outside_soloing_repair_objective_schema_version")
+            or ""
+        ),
+        **{
+            f"outside_soloing_repair_{key}": outside_soloing_repair.get(key)
+            for key in SOURCE_OBJECTIVE_SCHEMA_CONTEXT_KEYS
+        },
         "outside_soloing_repair_current_evidence_ready": bool(
             outside_soloing_repair.get("current_evidence_consolidation_ready", False)
         ),
@@ -547,6 +577,13 @@ def validate_readme_refresh(readme_text: str) -> dict[str, Any]:
         "outside_soloing_source_context_reflected": (
             "outside-soloing source-context evidence reflected: `true`"
         ),
+        "outside_soloing_schema_context_reflected": (
+            "outside-soloing schema-context evidence reflected: `true`"
+        ),
+        "outside_soloing_objective_schema": (
+            "outside-soloing repair objective schema version: "
+            f"`{OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION}`"
+        ),
         "outside_soloing_source_risk": (
             "outside-soloing source pitch-role risk count: `5 -> 2`"
         ),
@@ -614,6 +651,9 @@ def build_mvp_completion_audit_report(
             "outside_soloing_repair_source_context_preserved": bool(
                 evidence["outside_soloing_repair_source_context_preserved"]
             ),
+            "outside_soloing_repair_schema_context_preserved": bool(
+                evidence["outside_soloing_repair_schema_context_preserved"]
+            ),
             "readme_evidence_boundary_refreshed": True,
             "musical_quality_mvp_completed": False,
             "human_audio_preference_completed": False,
@@ -638,6 +678,9 @@ def build_mvp_completion_audit_report(
             ),
             "outside_soloing_repair_source_context_preserved": bool(
                 evidence["outside_soloing_repair_source_context_preserved"]
+            ),
+            "outside_soloing_repair_schema_context_preserved": bool(
+                evidence["outside_soloing_repair_schema_context_preserved"]
             ),
             "quality_gap_decision_required": True,
             "human_audio_preference_claimed": False,
@@ -767,6 +810,9 @@ def validate_mvp_completion_audit_report(
         "outside_soloing_repair_source_context_preserved": bool(
             audit.get("outside_soloing_repair_source_context_preserved", False)
         ),
+        "outside_soloing_repair_schema_context_preserved": bool(
+            audit.get("outside_soloing_repair_schema_context_preserved", False)
+        ),
         "musical_quality_mvp_completed": bool(audit.get("musical_quality_mvp_completed", True)),
         "human_audio_preference_completed": bool(audit.get("human_audio_preference_completed", True)),
         "product_mvp_completed": bool(audit.get("product_mvp_completed", True)),
@@ -852,6 +898,18 @@ def validate_mvp_completion_audit_report(
         "outside_soloing_repair_source_context_preserved": bool(
             evidence.get("outside_soloing_repair_source_context_preserved", False)
         ),
+        "outside_soloing_repair_schema_context_preserved": bool(
+            evidence.get("outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "outside_soloing_repair_objective_schema_version": str(
+            evidence.get("outside_soloing_repair_objective_schema_version") or ""
+        ),
+        **{
+            f"outside_soloing_repair_{key}": evidence.get(
+                f"outside_soloing_repair_{key}"
+            )
+            for key in SOURCE_OBJECTIVE_SCHEMA_CONTEXT_KEYS
+        },
         "outside_soloing_repair_current_evidence_ready": bool(
             evidence.get("outside_soloing_repair_current_evidence_ready", False)
         ),

--- a/tests/test_stage_b_midi_to_solo_mvp_completion_audit.py
+++ b/tests/test_stage_b_midi_to_solo_mvp_completion_audit.py
@@ -14,6 +14,8 @@ from scripts.audit_stage_b_midi_to_solo_mvp_completion import (
 from scripts.consolidate_stage_b_midi_to_solo_mvp_current_evidence import (
     BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
     BOUNDARY as CURRENT_EVIDENCE_BOUNDARY,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    SOURCE_OBJECTIVE_SCHEMA_CONTEXT_KEYS,
 )
 
 
@@ -45,6 +47,54 @@ SOURCE_CONTEXT = {
 }
 
 
+SOURCE_SCHEMA_CONTEXT = {
+    "source_schema_version": (
+        "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_"
+        "outside_soloing_repair_listening_review_input_guard_v4"
+    ),
+    "source_listening_package_schema_version": (
+        "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_"
+        "outside_soloing_repair_listening_review_package_v4"
+    ),
+    "source_audio_package_schema_version": (
+        "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_"
+        "outside_soloing_repair_audio_package_v4"
+    ),
+    "source_repair_sweep_schema_version": (
+        "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_"
+        "outside_soloing_repair_sweep_v3"
+    ),
+    "source_followup_schema_version": (
+        "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_"
+        "repair_followup_decision_v3"
+    ),
+    "source_objective_input_guard_schema_version": (
+        "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_"
+        "repair_listening_review_input_guard_v3"
+    ),
+    "source_package_schema_version": (
+        "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_"
+        "repair_listening_review_package_v3"
+    ),
+    "source_audio_schema_version": (
+        "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_"
+        "repair_audio_package_v4"
+    ),
+    "chord_tone_repair_sweep_schema_version": (
+        "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_"
+        "repair_sweep_v4"
+    ),
+    "chord_tone_repair_sweep_source_schema_version": (
+        "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_"
+        "chord_context_pitch_role_objective_decision_v4"
+    ),
+    "chord_tone_repair_sweep_bridge_schema_version": (
+        "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_"
+        "chord_context_pitch_role_bridge_v4"
+    ),
+}
+
+
 def current_evidence(
     *,
     quality_claim: bool = False,
@@ -73,6 +123,7 @@ def current_evidence(
             "model_conditioned_pitch_contour_changed_ratio_repair_objective_path_ready": changed_ratio_repair_supported,
             "outside_soloing_repair_objective_path_ready": outside_soloing_repair_supported,
             "outside_soloing_repair_source_context_preserved": outside_soloing_repair_supported,
+            "outside_soloing_repair_schema_context_preserved": outside_soloing_repair_supported,
             "current_mvp_technical_execution_evidence_supported": True,
             "current_mvp_objective_repair_evidence_supported": True,
             "midi_to_solo_mvp_current_evidence_supported": current_evidence_supported,
@@ -154,6 +205,10 @@ def current_evidence(
                 "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_"
                 "chord_tone_landing_outside_soloing_repair_objective_only_next_decision"
             ),
+            "outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
+            **SOURCE_SCHEMA_CONTEXT,
             "objective_next_completed": True,
             "objective_next_decision_completed": True,
             "current_evidence_consolidation_ready": outside_soloing_repair_supported,
@@ -206,6 +261,9 @@ def readme_text(*, missing_boundary: bool = False) -> str:
             "- outside-soloing repair objective path included in current evidence: `true`",
             "- current evidence outside-soloing repair objective path included: `true`",
             "- outside-soloing source-context evidence reflected: `true`",
+            "- outside-soloing schema-context evidence reflected: `true`",
+            "- outside-soloing repair objective schema version: "
+            f"`{OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION}`",
             "- outside-soloing source pitch-role risk count: `5 -> 2`",
             "- outside-soloing source residual risk preserved: `true`",
             "- outside-soloing current repair pitch-role risk count after: `0`",
@@ -304,6 +362,16 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
         self.assertTrue(summary["outside_soloing_repair_objective_completed"])
         self.assertTrue(summary["outside_soloing_repair_objective_path_ready"])
         self.assertTrue(summary["outside_soloing_repair_source_context_preserved"])
+        self.assertTrue(summary["outside_soloing_repair_schema_context_preserved"])
+        self.assertEqual(
+            summary["outside_soloing_repair_objective_schema_version"],
+            OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+        )
+        for key in SOURCE_OBJECTIVE_SCHEMA_CONTEXT_KEYS:
+            self.assertEqual(
+                summary[f"outside_soloing_repair_{key}"],
+                SOURCE_SCHEMA_CONTEXT[key],
+            )
         self.assertTrue(summary["outside_soloing_repair_current_evidence_ready"])
         self.assertEqual(summary["outside_soloing_repair_rendered_audio_file_count"], 6)
         self.assertEqual(summary["outside_soloing_repair_changed_note_total"], 2)
@@ -363,6 +431,27 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
                 readme_text=readme_text(),
                 output_dir=Path("outputs/audit"),
                 issue_number=1070,
+            )
+
+    def test_rejects_missing_outside_soloing_schema_context(self) -> None:
+        evidence = current_evidence()
+        evidence["readiness"]["outside_soloing_repair_schema_context_preserved"] = False
+        with self.assertRaises(StageBMidiToSoloMvpCompletionAuditError):
+            build_mvp_completion_audit_report(
+                current_evidence=evidence,
+                readme_text=readme_text(),
+                output_dir=Path("outputs/audit"),
+                issue_number=1152,
+            )
+
+        evidence = current_evidence()
+        del evidence["outside_soloing_repair_objective_path"]["source_schema_version"]
+        with self.assertRaises(StageBMidiToSoloMvpCompletionAuditError):
+            build_mvp_completion_audit_report(
+                current_evidence=evidence,
+                readme_text=readme_text(),
+                output_dir=Path("outputs/audit"),
+                issue_number=1152,
             )
 
     def test_rejects_missing_readme_evidence_boundary(self) -> None:


### PR DESCRIPTION
## Summary
- README evidence block #1150 current evidence 기준 갱신
- outside-soloing schema-context reflected 항목 추가
- MVP completion audit README snippet guard에 schema-context 조건 추가

## Context
- #1150 current evidence schema: `v4`
- current MVP evidence supported: `true`
- outside-soloing repair objective/schema context preserved: `true/true`
- outside-soloing repair objective schema: `outside_soloing_repair_objective_next_v4`
- MIDI-to-solo musical quality claim: `false`

## Scope
- README current evidence block schema-context field 반영
- README evidence source-context generated doc 갱신
- MVP completion audit README snippet guard 확장
- AGENTS, CORE_PLAN, CURRENT_STATUS handoff 상태 #1152 기준 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_mvp_completion.py`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- README evidence refresh는 technical/current evidence 반영 범위
- listening review 완료 claim 제외
- MIDI-to-solo musical quality claim 제외

## Follow-up
- Stage B MIDI-to-solo MVP completion audit source-context refresh

Closes #1152