### PR TITLE
Stage B MIDI-to-solo MVP completion audit source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Primary goal:
 Current handoff scope:
 
 - Latest functional issue completed: Issue #1150, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh.
-- Latest audit issue completed: Issue #1070, Stage B MIDI-to-solo MVP completion audit source-context refresh.
+- Latest audit issue completed: Issue #1154, Stage B MIDI-to-solo MVP completion audit source-context refresh.
 - Latest quality gap decision completed: Issue #1072, Stage B MIDI-to-solo quality gap decision source-context refresh.
 - Latest listening review quality gap completed: Issue #1074, Stage B MIDI-to-solo listening review quality gap source-context refresh.
 - Latest MVP delivery package completed: Issue #1076, Stage B MIDI-to-solo MVP delivery package source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1148, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after Stage B MIDI-to-solo README evidence refresh source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo MVP completion audit source-context refresh.
+- Open issue queue after Stage B MIDI-to-solo MVP completion audit source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo quality gap decision source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 ## 현재 상태
 
-- latest functional result: `Issue #1076`
-- latest MVP completion audit: `Issue #1070`
+- latest functional result: `Issue #1150`
+- latest MVP completion audit: `Issue #1154`
 - latest quality gap decision: `Issue #1072`
 - latest listening review quality gap: `Issue #1074`
 - latest MVP delivery package: `Issue #1076`
@@ -50,9 +50,10 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1150`
 - latest README evidence refresh: `Issue #1152`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after README evidence refresh source-context refresh merge: `0`
-- latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- open issue queue after MVP completion audit source-context refresh merge: `0`
+- latest evidence boundary: `stage_b_midi_to_solo_mvp_completion_audit`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
 - selected quality gap target: `mvp_delivery_package`
@@ -228,6 +229,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - MVP completion audit outside-soloing repair objective included: `true`
 - MVP completion audit outside-soloing source context included: `true`
 - MVP completion audit outside-soloing source context preserved: `true`
+- MVP completion audit outside-soloing schema context preserved: `true`
 - quality gap decision completed: `true`
 - quality gap decision listening review target selected: `true`
 - quality gap decision outside-soloing repair objective included: `true`
@@ -510,10 +512,13 @@ MVP completion audit.
 - technical model-core MVP completed: `true`
 - input to ranked MIDI completed: `true`
 - input to rendered WAV completed: `true`
+- current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - outside-soloing source pitch-role risk count: `5 -> 2`
 - outside-soloing source repair targeted: `false`
 - outside-soloing source residual risk preserved: `true`
 - outside-soloing current repair pitch-role risk count after: `0`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - selected-scale objective repair completed: `true`
 - phrase-bank CLI technical path included: `true`
 - phrase-bank CLI technical path completed: `true`
@@ -1249,6 +1254,7 @@ MVP completion audit.
 
 - latest evidence boundary reflected: `stage_b_midi_to_solo_mvp_completion_audit`
 - source current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - technical model-core MVP completed: `true`
 - input to ranked MIDI completed: `true`
 - input to rendered WAV completed: `true`
@@ -1258,6 +1264,8 @@ MVP completion audit.
 - model-conditioned pitch-contour changed-ratio repair objective completed: `true`
 - outside-soloing repair objective completed: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -393,7 +393,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo controlled scale checkpoint training scale postprocess removal dead-air repair objective-only next decision: objective path support `true`, valid/strict/grammar `9/9/9`, dead-air/collapse `0/0`, avg/max postprocess removal `0.2176/0.2917`, preference/quality claim `false`, next boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - MIDI-to-solo MVP current evidence consolidation: schema `v4`, evidence support `true`, technical path `true`, selected-scale objective path `true`, phrase-bank CLI path `true`, model-conditioned pitch-contour objective path `true`, changed-ratio repair objective path `true`, outside-soloing objective/schema context `true/true`, exported/rendered `3/3`, objective valid/strict/grammar `9/9/9`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_readme_evidence_refresh`
 - MIDI-to-solo README evidence refresh: latest boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`, input-to-WAV technical path `true`, selected-scale objective path `true`, phrase-bank CLI path `true`, model-conditioned pitch-contour objective path `true`, changed-ratio repair objective path `true`, outside-soloing schema-context evidence reflected `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_completion_audit`
-- MIDI-to-solo MVP completion audit refresh: technical model-core MVP `true`, model-conditioned pitch-contour objective `true`, changed-ratio repair objective `true`, max interval/threshold `11/12`, changed-ratio repair ratio/target `0.4348/0.5000`, musical/product MVP `false/false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_gap_decision`
+- MIDI-to-solo MVP completion audit refresh: schema `stage_b_midi_to_solo_mvp_completion_audit_v4`, current evidence schema `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`, technical model-core MVP `true`, model-conditioned pitch-contour objective `true`, changed-ratio repair objective `true`, outside-soloing schema-context preserved `true`, musical/product MVP `false/false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_gap_decision`
 - MIDI-to-solo quality gap decision refresh: selected target `listening_review_quality_gap`, fallback alignment required `false`, changed-ratio repair objective `true`, changed-ratio repair ratio/target `0.4348/0.5000`, changed-ratio repair interval/target `12/12`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_listening_review_quality_gap`
 - MIDI-to-solo listening review quality gap: selected target `mvp_delivery_package`, technical delivery package ready `true`, listening gap open `true`, changed-ratio repair ratio/target `0.4348/0.5000`, interval/target `12/12`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_delivery_package`
 - MIDI-to-solo MVP delivery package: runnable CLI `true`, input ranked MIDI `true`, rendered WAV evidence `true`, CLI/changed-ratio audio candidate count `3/3`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_readme_final_evidence_refresh`
@@ -12144,13 +12144,15 @@ Issue #1152는 Issue #1150 MVP current evidence consolidation 결과를 README e
 
 ## 9.225 Stage B MIDI-to-solo MVP completion audit source-context refresh
 
-Issue #1070은 Issue #1066 current evidence와 Issue #1068 README evidence refresh를 기준으로 technical model-core MVP completion audit을 #1070 boundary로 갱신한 작업이다.
+Issue #1154는 Issue #1150 current evidence와 Issue #1152 README evidence refresh를 기준으로 technical model-core MVP completion audit을 #1154 boundary로 갱신한 작업이다.
 
 결과:
 
 - document: `docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_mvp_completion_audit`
 - next boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- schema version: `stage_b_midi_to_solo_mvp_completion_audit_v4`
+- source schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - technical model-core MVP completed: `true`
 - input to ranked MIDI completed: `true`
 - input to rendered WAV completed: `true`
@@ -12160,6 +12162,8 @@ Issue #1070은 Issue #1066 current evidence와 Issue #1068 README evidence refre
 - model-conditioned pitch-contour changed-ratio repair objective completed: `true`
 - outside-soloing repair objective completed: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`
@@ -12169,7 +12173,8 @@ Issue #1070은 Issue #1066 current evidence와 Issue #1068 README evidence refre
 
 판단:
 
-- #1068 README evidence refresh의 preserved flag 3개가 audit report와 validation summary까지 유지됨.
+- #1152 README evidence refresh의 preserved flag 3개와 schema-context reflected snippet이 audit report와 validation summary까지 유지됨.
+- #1150 current evidence schema v4 입력이 audit 필수 조건으로 검증됨.
 - technical model-core MVP completion은 `true`.
 - listening review input, human/audio preference, MIDI-to-solo musical quality claim 제외.
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -13,7 +13,7 @@
 현재 active issue:
 
 - latest functional result: Issue #1150, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
-- latest MVP completion audit: Issue #1070, Stage B MIDI-to-solo MVP completion audit source-context refresh
+- latest MVP completion audit: Issue #1154, Stage B MIDI-to-solo MVP completion audit source-context refresh
 - latest quality gap decision: Issue #1072, Stage B MIDI-to-solo quality gap decision source-context refresh
 - latest listening review quality gap: Issue #1074, Stage B MIDI-to-solo listening review quality gap source-context refresh
 - latest MVP delivery package: Issue #1076, Stage B MIDI-to-solo MVP delivery package source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1150, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after Stage B MIDI-to-solo README evidence refresh source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo MVP completion audit source-context refresh`
+- open issue queue after Stage B MIDI-to-solo MVP completion audit source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo quality gap decision source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -5373,12 +5373,14 @@ Issue #1152는 Issue #1150 MVP current evidence consolidation 결과를 README e
 
 ## Stage B MIDI-to-Solo MVP Completion Audit Source-Context Refresh Result
 
-Issue #1070은 Issue #1066 current evidence와 Issue #1068 README evidence refresh를 기준으로 technical model-core MVP completion audit을 #1070 boundary로 갱신한 작업이다.
+Issue #1154는 Issue #1150 current evidence와 Issue #1152 README evidence refresh를 기준으로 technical model-core MVP completion audit을 #1154 boundary로 갱신한 작업이다.
 
 변경:
 
-- MVP completion audit schema v3 적용
-- harness issue number #1070 반영
+- MVP completion audit schema v4 적용
+- current evidence schema version 검증 추가
+- outside-soloing repair objective schema version audit summary 반영
+- harness issue number #1154 반영
 - audit report issue number와 schema assertion 추가
 - generated completion audit doc, README, current status, core plan, handoff scope 갱신
 
@@ -5387,6 +5389,8 @@ Issue #1070은 Issue #1066 current evidence와 Issue #1068 README evidence refre
 - document: `docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_mvp_completion_audit`
 - next boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- schema version: `stage_b_midi_to_solo_mvp_completion_audit_v4`
+- source schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - technical model-core MVP completed: `true`
 - input to ranked MIDI completed: `true`
 - input to rendered WAV completed: `true`
@@ -5396,6 +5400,8 @@ Issue #1070은 Issue #1066 current evidence와 Issue #1068 README evidence refre
 - model-conditioned pitch-contour changed-ratio repair objective completed: `true`
 - outside-soloing repair objective completed: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`
@@ -5405,7 +5411,8 @@ Issue #1070은 Issue #1066 current evidence와 Issue #1068 README evidence refre
 
 판단:
 
-- #1068 README evidence refresh의 preserved flag 3개가 audit report와 validation summary까지 유지됨.
+- #1152 README evidence refresh의 preserved flag 3개와 schema-context reflected snippet이 audit report와 validation summary까지 유지됨.
+- #1150 current evidence schema v4 입력이 audit 필수 조건으로 검증됨.
 - technical model-core MVP completion은 `true`.
 - listening review input, human/audio preference, MIDI-to-solo musical quality claim 제외.
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -3,13 +3,16 @@
 ## Summary
 
 - boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- schema version: `stage_b_midi_to_solo_mvp_completion_audit_v4`
 - next boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - technical model-core MVP completed: `true`
 - phrase-bank CLI technical path completed: `true`
 - model-conditioned pitch-contour objective completed: `true`
 - model-conditioned pitch-contour changed-ratio repair objective completed: `true`
 - outside-soloing repair objective completed: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
 - musical quality MVP completed: `false`
 - human/audio preference completed: `false`
 - product MVP completed: `false`
@@ -17,6 +20,7 @@
 ## Evidence
 
 - source boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
+- source schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - generation source: `context_conditioned_fallback`
 - exported / qualified candidates: `3` / `3`
 - rendered WAV files: `3`
@@ -48,6 +52,8 @@
 - model-conditioned pitch-contour changed-ratio repair preference fill allowed: `false`
 - outside-soloing repair objective path ready: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - outside-soloing repair current evidence ready: `true`
 - outside-soloing repair rendered WAV files: `6`
 - outside-soloing repair changed note total: `2`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6015,7 +6015,7 @@ run_stage_b_midi_to_solo_mvp_completion_audit() {
     --current_evidence "$current_evidence" \
     --readme_path README.md \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_COMPLETION_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1070 \
+    --issue_number 1154 \
     --expected_boundary stage_b_midi_to_solo_mvp_completion_audit \
     --expected_next_boundary stage_b_midi_to_solo_quality_gap_decision \
     --require_technical_mvp_completion \

--- a/scripts/audit_stage_b_midi_to_solo_mvp_completion.py
+++ b/scripts/audit_stage_b_midi_to_solo_mvp_completion.py
@@ -19,6 +19,7 @@ from scripts.consolidate_stage_b_midi_to_solo_mvp_current_evidence import (  # n
     BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
     BOUNDARY as CURRENT_EVIDENCE_BOUNDARY,
     OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    SCHEMA_VERSION as CURRENT_EVIDENCE_SCHEMA_VERSION,
     SOURCE_OBJECTIVE_SCHEMA_CONTEXT_KEYS,
 )
 
@@ -29,7 +30,7 @@ class StageBMidiToSoloMvpCompletionAuditError(ValueError):
 
 BOUNDARY = "stage_b_midi_to_solo_mvp_completion_audit"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_quality_gap_decision"
-SCHEMA_VERSION = "stage_b_midi_to_solo_mvp_completion_audit_v3"
+SCHEMA_VERSION = "stage_b_midi_to_solo_mvp_completion_audit_v4"
 
 
 def _dict(value: Any) -> dict[str, Any]:
@@ -75,6 +76,10 @@ def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str
 
 
 def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
+    if str(report.get("schema_version") or "") != CURRENT_EVIDENCE_SCHEMA_VERSION:
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "current evidence schema version mismatch"
+        )
     if str(report.get("boundary") or "") != CURRENT_EVIDENCE_BOUNDARY:
         raise StageBMidiToSoloMvpCompletionAuditError("current evidence boundary required")
     readiness = _dict(report.get("readiness"))
@@ -344,6 +349,7 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloMvpCompletionAuditError("critical user input should not be required")
     return {
         "current_evidence_boundary": CURRENT_EVIDENCE_BOUNDARY,
+        "current_evidence_schema_version": CURRENT_EVIDENCE_SCHEMA_VERSION,
         "current_evidence_supported": True,
         "technical_execution_evidence_supported": True,
         "selected_scale_objective_path_complete": True,
@@ -552,6 +558,9 @@ def validate_current_evidence(report: dict[str, Any]) -> dict[str, Any]:
 def validate_readme_refresh(readme_text: str) -> dict[str, Any]:
     required_snippets = {
         "current_evidence_boundary": f"current evidence boundary: `{CURRENT_EVIDENCE_BOUNDARY}`",
+        "current_evidence_schema_version": (
+            f"current evidence schema version: `{CURRENT_EVIDENCE_SCHEMA_VERSION}`"
+        ),
         "current_evidence_support": "current MVP evidence support: `true`",
         "technical_path": "input MIDI -> context -> ranked MIDI -> WAV technical path: `true`",
         "objective_path": "selected-scale objective repair path complete: `true`",
@@ -637,10 +646,14 @@ def build_mvp_completion_audit_report(
         "issue_number": int(issue_number),
         "boundary": BOUNDARY,
         "source_boundary": CURRENT_EVIDENCE_BOUNDARY,
+        "source_schema_version": evidence["current_evidence_schema_version"],
         "current_evidence": evidence,
         "readme_refresh": readme,
         "completion_audit": {
             "technical_model_core_mvp_completed": technical_model_core_mvp_completed,
+            "current_evidence_schema_version": evidence[
+                "current_evidence_schema_version"
+            ],
             "input_to_ranked_midi_completed": True,
             "input_to_rendered_wav_completed": True,
             "selected_scale_objective_repair_completed": True,
@@ -648,6 +661,9 @@ def build_mvp_completion_audit_report(
             "model_conditioned_pitch_contour_objective_completed": True,
             "model_conditioned_pitch_contour_changed_ratio_repair_objective_completed": True,
             "outside_soloing_repair_objective_completed": True,
+            "outside_soloing_repair_objective_schema_version": evidence[
+                "outside_soloing_repair_objective_schema_version"
+            ],
             "outside_soloing_repair_source_context_preserved": bool(
                 evidence["outside_soloing_repair_source_context_preserved"]
             ),
@@ -737,6 +753,24 @@ def validate_mvp_completion_audit_report(
     decision = _dict(report.get("decision"))
     audit = _dict(report.get("completion_audit"))
     evidence = _dict(report.get("current_evidence"))
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise StageBMidiToSoloMvpCompletionAuditError("completion audit schema version mismatch")
+    if str(report.get("source_schema_version") or "") != CURRENT_EVIDENCE_SCHEMA_VERSION:
+        raise StageBMidiToSoloMvpCompletionAuditError("source schema version mismatch")
+    if str(evidence.get("current_evidence_schema_version") or "") != CURRENT_EVIDENCE_SCHEMA_VERSION:
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "current evidence summary schema version mismatch"
+        )
+    if str(audit.get("current_evidence_schema_version") or "") != CURRENT_EVIDENCE_SCHEMA_VERSION:
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "audit current evidence schema version mismatch"
+        )
+    if str(
+        audit.get("outside_soloing_repair_objective_schema_version") or ""
+    ) != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION:
+        raise StageBMidiToSoloMvpCompletionAuditError(
+            "audit outside-soloing repair objective schema version mismatch"
+        )
     if expected_boundary and boundary != expected_boundary:
         raise StageBMidiToSoloMvpCompletionAuditError(
             f"expected boundary {expected_boundary}, got {boundary}"
@@ -782,7 +816,12 @@ def validate_mvp_completion_audit_report(
         if claimed:
             raise StageBMidiToSoloMvpCompletionAuditError(f"unexpected quality claim: {claimed}")
     return {
+        "schema_version": str(report.get("schema_version") or ""),
         "boundary": boundary,
+        "source_schema_version": str(report.get("source_schema_version") or ""),
+        "current_evidence_schema_version": str(
+            evidence.get("current_evidence_schema_version") or ""
+        ),
         "next_boundary": str(decision.get("next_boundary") or ""),
         "technical_model_core_mvp_completed": bool(
             audit.get("technical_model_core_mvp_completed", False)
@@ -982,13 +1021,16 @@ def markdown_report(report: dict[str, Any]) -> str:
         "## Summary",
         "",
         f"- boundary: `{report['boundary']}`",
+        f"- schema version: `{report['schema_version']}`",
         f"- next boundary: `{decision['next_boundary']}`",
+        f"- current evidence schema version: `{report['source_schema_version']}`",
         f"- technical model-core MVP completed: `{_bool_token(audit['technical_model_core_mvp_completed'])}`",
         f"- phrase-bank CLI technical path completed: `{_bool_token(audit['phrase_bank_cli_technical_path_completed'])}`",
         f"- model-conditioned pitch-contour objective completed: `{_bool_token(audit['model_conditioned_pitch_contour_objective_completed'])}`",
         f"- model-conditioned pitch-contour changed-ratio repair objective completed: `{_bool_token(audit['model_conditioned_pitch_contour_changed_ratio_repair_objective_completed'])}`",
         f"- outside-soloing repair objective completed: `{_bool_token(audit['outside_soloing_repair_objective_completed'])}`",
         f"- outside-soloing repair source context preserved: `{_bool_token(audit['outside_soloing_repair_source_context_preserved'])}`",
+        f"- outside-soloing repair schema context preserved: `{_bool_token(audit['outside_soloing_repair_schema_context_preserved'])}`",
         f"- musical quality MVP completed: `{_bool_token(audit['musical_quality_mvp_completed'])}`",
         f"- human/audio preference completed: `{_bool_token(audit['human_audio_preference_completed'])}`",
         f"- product MVP completed: `{_bool_token(audit['product_mvp_completed'])}`",
@@ -996,6 +1038,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         "## Evidence",
         "",
         f"- source boundary: `{report['source_boundary']}`",
+        f"- source schema version: `{report['source_schema_version']}`",
         f"- generation source: `{evidence['generation_source']}`",
         f"- exported / qualified candidates: `{evidence['exported_candidate_count']}` / `{evidence['exported_qualified_candidate_count']}`",
         f"- rendered WAV files: `{evidence['rendered_audio_file_count']}`",
@@ -1027,6 +1070,8 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- model-conditioned pitch-contour changed-ratio repair preference fill allowed: `{_bool_token(evidence['model_conditioned_pitch_contour_changed_ratio_repair_preference_fill_allowed'])}`",
         f"- outside-soloing repair objective path ready: `{_bool_token(evidence['outside_soloing_repair_objective_path_ready'])}`",
         f"- outside-soloing repair source context preserved: `{_bool_token(evidence['outside_soloing_repair_source_context_preserved'])}`",
+        f"- outside-soloing repair schema context preserved: `{_bool_token(evidence['outside_soloing_repair_schema_context_preserved'])}`",
+        f"- outside-soloing repair objective schema version: `{evidence['outside_soloing_repair_objective_schema_version']}`",
         f"- outside-soloing repair current evidence ready: `{_bool_token(evidence['outside_soloing_repair_current_evidence_ready'])}`",
         f"- outside-soloing repair rendered WAV files: `{evidence['outside_soloing_repair_rendered_audio_file_count']}`",
         f"- outside-soloing repair changed note total: `{evidence['outside_soloing_repair_changed_note_total']}`",
@@ -1079,7 +1124,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=616)
+    parser.add_argument("--issue_number", type=int, default=1154)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--require_technical_mvp_completion", action="store_true")

--- a/tests/test_stage_b_midi_to_solo_mvp_completion_audit.py
+++ b/tests/test_stage_b_midi_to_solo_mvp_completion_audit.py
@@ -15,6 +15,7 @@ from scripts.consolidate_stage_b_midi_to_solo_mvp_current_evidence import (
     BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
     BOUNDARY as CURRENT_EVIDENCE_BOUNDARY,
     OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    SCHEMA_VERSION as CURRENT_EVIDENCE_SCHEMA_VERSION,
     SOURCE_OBJECTIVE_SCHEMA_CONTEXT_KEYS,
 )
 
@@ -109,6 +110,7 @@ def current_evidence(
         and outside_soloing_repair_supported
     )
     return {
+        "schema_version": CURRENT_EVIDENCE_SCHEMA_VERSION,
         "boundary": CURRENT_EVIDENCE_BOUNDARY,
         "readiness": {
             "mvp_current_evidence_consolidated": True,
@@ -250,6 +252,7 @@ def readme_text(*, missing_boundary: bool = False) -> str:
         [
             "- latest evidence boundary: `stage_b_midi_to_solo_mvp_completion_audit`",
             f"- current evidence boundary: `{boundary}`",
+            f"- current evidence schema version: `{CURRENT_EVIDENCE_SCHEMA_VERSION}`",
             "- current MVP evidence support: `true`",
             "- input MIDI -> context -> ranked MIDI -> WAV technical path: `true`",
             "- selected-scale objective repair path complete: `true`",
@@ -285,7 +288,7 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
             current_evidence=current_evidence(),
             readme_text=readme_text(),
             output_dir=Path("outputs/audit"),
-            issue_number=1070,
+            issue_number=1154,
         )
         summary = validate_mvp_completion_audit_report(
             report,
@@ -306,6 +309,15 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
         self.assertFalse(summary["musical_quality_mvp_completed"])
         self.assertFalse(summary["human_audio_preference_completed"])
         self.assertFalse(summary["product_mvp_completed"])
+        self.assertEqual(summary["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(
+            summary["source_schema_version"],
+            CURRENT_EVIDENCE_SCHEMA_VERSION,
+        )
+        self.assertEqual(
+            summary["current_evidence_schema_version"],
+            CURRENT_EVIDENCE_SCHEMA_VERSION,
+        )
         self.assertEqual(summary["generation_source"], "context_conditioned_fallback")
         self.assertEqual(summary["exported_candidate_count"], 3)
         self.assertEqual(summary["rendered_audio_file_count"], 3)
@@ -405,7 +417,23 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
             self.assertEqual(summary[key], SOURCE_CONTEXT[key])
         self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
         self.assertEqual(report["schema_version"], SCHEMA_VERSION)
-        self.assertEqual(report["issue_number"], 1070)
+        self.assertEqual(report["source_schema_version"], CURRENT_EVIDENCE_SCHEMA_VERSION)
+        self.assertEqual(
+            report["completion_audit"]["current_evidence_schema_version"],
+            CURRENT_EVIDENCE_SCHEMA_VERSION,
+        )
+        self.assertEqual(report["issue_number"], 1154)
+
+    def test_rejects_current_evidence_schema_mismatch(self) -> None:
+        evidence = current_evidence()
+        evidence["schema_version"] = "stale_schema"
+        with self.assertRaises(StageBMidiToSoloMvpCompletionAuditError):
+            build_mvp_completion_audit_report(
+                current_evidence=evidence,
+                readme_text=readme_text(),
+                output_dir=Path("outputs/audit"),
+                issue_number=1154,
+            )
 
     def test_rejects_missing_outside_soloing_source_context_field(self) -> None:
         evidence = current_evidence()
@@ -463,6 +491,26 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
                 issue_number=616,
             )
 
+    def test_rejects_completion_audit_schema_mismatch(self) -> None:
+        report = build_mvp_completion_audit_report(
+            current_evidence=current_evidence(),
+            readme_text=readme_text(),
+            output_dir=Path("outputs/audit"),
+            issue_number=1154,
+        )
+        report["schema_version"] = "stale_schema"
+        with self.assertRaises(StageBMidiToSoloMvpCompletionAuditError):
+            validate_mvp_completion_audit_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                require_technical_mvp_completion=True,
+                require_no_quality_claim=True,
+                require_model_conditioned_pitch_contour_objective=True,
+                require_model_conditioned_pitch_contour_changed_ratio_repair_objective=True,
+                require_outside_soloing_repair_objective=True,
+            )
+
     def test_rejects_quality_claim(self) -> None:
         with self.assertRaises(StageBMidiToSoloMvpCompletionAuditError):
             build_mvp_completion_audit_report(
@@ -511,7 +559,7 @@ class StageBMidiToSoloMvpCompletionAuditTest(unittest.TestCase):
     def test_boundary_constants_are_stable(self) -> None:
         self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_mvp_completion_audit")
         self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_quality_gap_decision")
-        self.assertEqual(SCHEMA_VERSION, "stage_b_midi_to_solo_mvp_completion_audit_v3")
+        self.assertEqual(SCHEMA_VERSION, "stage_b_midi_to_solo_mvp_completion_audit_v4")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- MVP completion audit schema v4 적용
- current evidence schema version 필수 검증 추가
- outside-soloing repair objective schema version 및 schema-context preserved summary 반영
- #1154 기준 generated audit doc, README, current status, core plan, handoff scope 갱신

## Context

- #1150 MVP current evidence consolidation 기준 schema `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
- #1152 README evidence refresh 기준 source-context/schema-context reflected snippet 반영
- outside-soloing repair objective schema `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
- technical model-core MVP completion: `true`
- musical quality/product MVP/preference claim: `false`

## Scope

- `scripts/audit_stage_b_midi_to_solo_mvp_completion.py`
  - current evidence schema mismatch 차단
  - audit report/source summary schema version 노출
  - outside-soloing repair objective schema version 검증
- `tests/test_stage_b_midi_to_solo_mvp_completion_audit.py`
  - current evidence schema mismatch 차단 테스트
  - completion audit schema mismatch 차단 테스트
- `scripts/agent_harness.sh`
  - MVP completion audit issue number #1154 반영
- README/status/core plan/generated audit doc 최신 경계 반영

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_completion_audit`
- `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_mvp_completion.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-completion-audit`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- public diff scan for tool-neutral wording

## Risk

- technical model-core MVP completion claim 범위는 local pipeline/objective evidence까지
- musical quality, product MVP, human/audio preference claim 제외 유지
- 다음 검증 경계: quality gap decision source-context refresh

Closes #1154


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tracking references and schema versions across project documentation files to reflect latest audit and completion milestones.
  * Enhanced documentation of MVP completion audit processes and evidence requirements.

* **Tests**
  * Added new validation tests for schema version consistency in audit reports.

* **Chores**
  * Updated internal audit scripts and configuration to enforce schema version consistency across generated reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->