### PR TITLE
Stage B MIDI-to-solo quality gap decision source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Current handoff scope:
 
 - Latest functional issue completed: Issue #1150, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh.
 - Latest audit issue completed: Issue #1154, Stage B MIDI-to-solo MVP completion audit source-context refresh.
-- Latest quality gap decision completed: Issue #1072, Stage B MIDI-to-solo quality gap decision source-context refresh.
+- Latest quality gap decision completed: Issue #1156, Stage B MIDI-to-solo quality gap decision source-context refresh.
 - Latest listening review quality gap completed: Issue #1074, Stage B MIDI-to-solo listening review quality gap source-context refresh.
 - Latest MVP delivery package completed: Issue #1076, Stage B MIDI-to-solo MVP delivery package source-context refresh.
 - Latest README final evidence refresh completed: Issue #1078, Stage B MIDI-to-solo README final evidence refresh source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1148, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after Stage B MIDI-to-solo MVP completion audit source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo quality gap decision source-context refresh.
+- Open issue queue after Stage B MIDI-to-solo quality gap decision source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo listening review quality gap source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 
 - latest functional result: `Issue #1150`
 - latest MVP completion audit: `Issue #1154`
-- latest quality gap decision: `Issue #1072`
+- latest quality gap decision: `Issue #1156`
 - latest listening review quality gap: `Issue #1074`
 - latest MVP delivery package: `Issue #1076`
 - latest README final evidence refresh: `Issue #1078`
@@ -50,13 +50,13 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1150`
 - latest README evidence refresh: `Issue #1152`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after MVP completion audit source-context refresh merge: `0`
-- latest evidence boundary: `stage_b_midi_to_solo_mvp_completion_audit`
+- open issue queue after quality gap decision source-context refresh merge: `0`
+- latest evidence boundary: `stage_b_midi_to_solo_quality_gap_decision`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - current MVP evidence support: `true`
 - technical model-core MVP completed: `true`
-- selected quality gap target: `mvp_delivery_package`
+- selected quality gap target: `listening_review_quality_gap`
 - model-conditioned input path aligned: `false`
 - model-conditioned candidate source available: `true`
 - model-conditioned audio technical path available: `true`
@@ -558,7 +558,10 @@ MVP current evidence refresh.
 Quality gap decision.
 
 - boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
 - next boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- source schema version: `stage_b_midi_to_solo_mvp_completion_audit_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - selected target: `listening_review_quality_gap`
 - fallback path active: `true`
 - model-conditioned input path alignment required: `false`
@@ -570,6 +573,8 @@ Quality gap decision.
 - model-conditioned pitch-contour changed-ratio repair max ratio / target: `0.4348 / 0.5000`
 - model-conditioned pitch-contour changed-ratio repair max interval / target: `12 / 12`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -394,7 +394,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo MVP current evidence consolidation: schema `v4`, evidence support `true`, technical path `true`, selected-scale objective path `true`, phrase-bank CLI path `true`, model-conditioned pitch-contour objective path `true`, changed-ratio repair objective path `true`, outside-soloing objective/schema context `true/true`, exported/rendered `3/3`, objective valid/strict/grammar `9/9/9`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_readme_evidence_refresh`
 - MIDI-to-solo README evidence refresh: latest boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`, input-to-WAV technical path `true`, selected-scale objective path `true`, phrase-bank CLI path `true`, model-conditioned pitch-contour objective path `true`, changed-ratio repair objective path `true`, outside-soloing schema-context evidence reflected `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_completion_audit`
 - MIDI-to-solo MVP completion audit refresh: schema `stage_b_midi_to_solo_mvp_completion_audit_v4`, current evidence schema `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`, technical model-core MVP `true`, model-conditioned pitch-contour objective `true`, changed-ratio repair objective `true`, outside-soloing schema-context preserved `true`, musical/product MVP `false/false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_gap_decision`
-- MIDI-to-solo quality gap decision refresh: selected target `listening_review_quality_gap`, fallback alignment required `false`, changed-ratio repair objective `true`, changed-ratio repair ratio/target `0.4348/0.5000`, changed-ratio repair interval/target `12/12`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_listening_review_quality_gap`
+- MIDI-to-solo quality gap decision refresh: schema `stage_b_midi_to_solo_quality_gap_decision_v4`, source audit schema `stage_b_midi_to_solo_mvp_completion_audit_v4`, current evidence schema `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`, selected target `listening_review_quality_gap`, outside-soloing schema-context preserved `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_listening_review_quality_gap`
 - MIDI-to-solo listening review quality gap: selected target `mvp_delivery_package`, technical delivery package ready `true`, listening gap open `true`, changed-ratio repair ratio/target `0.4348/0.5000`, interval/target `12/12`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_delivery_package`
 - MIDI-to-solo MVP delivery package: runnable CLI `true`, input ranked MIDI `true`, rendered WAV evidence `true`, CLI/changed-ratio audio candidate count `3/3`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_readme_final_evidence_refresh`
 - MIDI-to-solo README final evidence refresh: latest evidence boundary `stage_b_midi_to_solo_mvp_delivery_package`, runnable CLI `true`, input ranked MIDI/WAV evidence `true/true`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_final_status_audit`
@@ -12193,13 +12193,16 @@ Issue #1154는 Issue #1150 current evidence와 Issue #1152 README evidence refre
 
 ## 9.226 Stage B MIDI-to-solo quality gap decision source-context refresh
 
-Issue #1072는 Issue #1070 MVP completion audit의 source-context preserved flag 3개를 quality gap decision summary와 validation summary까지 보존하고, 다음 target을 listening review quality gap으로 유지한 작업이다.
+Issue #1156은 Issue #1154 MVP completion audit의 schema/source-context preserved flag를 quality gap decision summary와 validation summary까지 보존하고, 다음 target을 listening review quality gap으로 유지한 작업이다.
 
 결과:
 
 - document: `docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_quality_gap_decision`
 - next boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source schema version: `stage_b_midi_to_solo_mvp_completion_audit_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - selected target: `listening_review_quality_gap`
 - fallback path active: `true`
 - model-conditioned input path alignment required: `false`
@@ -12208,6 +12211,8 @@ Issue #1072는 Issue #1070 MVP completion audit의 source-context preserved flag
 - model-conditioned pitch-contour changed-ratio repair objective completed: `true`
 - outside-soloing repair objective completed: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`
@@ -12217,6 +12222,7 @@ Issue #1072는 Issue #1070 MVP completion audit의 source-context preserved flag
 
 판단:
 
+- #1154 completion audit schema v4와 source current evidence schema v4가 decision report까지 보존됨.
 - changed-ratio repair와 outside-soloing repair objective path는 현재 target 통과.
 - 다음 gap은 추가 objective repair가 아니라 listening review evidence.
 - human/audio preference, MIDI-to-solo musical quality claim 제외.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -14,7 +14,7 @@
 
 - latest functional result: Issue #1150, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest MVP completion audit: Issue #1154, Stage B MIDI-to-solo MVP completion audit source-context refresh
-- latest quality gap decision: Issue #1072, Stage B MIDI-to-solo quality gap decision source-context refresh
+- latest quality gap decision: Issue #1156, Stage B MIDI-to-solo quality gap decision source-context refresh
 - latest listening review quality gap: Issue #1074, Stage B MIDI-to-solo listening review quality gap source-context refresh
 - latest MVP delivery package: Issue #1076, Stage B MIDI-to-solo MVP delivery package source-context refresh
 - latest README final evidence refresh: Issue #1078, Stage B MIDI-to-solo README final evidence refresh source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1150, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after Stage B MIDI-to-solo MVP completion audit source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo quality gap decision source-context refresh`
+- open issue queue after Stage B MIDI-to-solo quality gap decision source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo listening review quality gap source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -5431,21 +5431,24 @@ Issue #1154는 Issue #1150 current evidence와 Issue #1152 README evidence refre
 
 ## Stage B MIDI-to-Solo Quality Gap Decision Source-Context Refresh Result
 
-Issue #1072는 Issue #1070 MVP completion audit의 source-context preserved flag 3개를 quality gap decision summary와 validation summary까지 보존하고, 다음 target을 listening review quality gap으로 유지한 작업이다.
+Issue #1156은 Issue #1154 MVP completion audit의 schema/source-context preserved flag를 quality gap decision summary와 validation summary까지 보존하고, 다음 target을 listening review quality gap으로 유지한 작업이다.
 
 변경:
 
-- quality gap decision schema v3 적용
-- source-context required key를 preserved flag 3개 포함으로 확장
-- false preserved flag 입력 차단 테스트 추가
-- quality gap summary, generated markdown report, validation summary source-context preserved field 전파
-- harness issue number #1072 반영
+- quality gap decision schema v4 적용
+- MVP completion audit schema v4 입력 검증 추가
+- source current evidence schema v4 보존 검증 추가
+- outside-soloing schema-context preserved field와 objective schema version 전파
+- harness issue number #1156 반영
 
 결과:
 
 - document: `docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_quality_gap_decision`
 - next boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source schema version: `stage_b_midi_to_solo_mvp_completion_audit_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - selected target: `listening_review_quality_gap`
 - fallback path active: `true`
 - model-conditioned input path alignment required: `false`
@@ -5454,6 +5457,8 @@ Issue #1072는 Issue #1070 MVP completion audit의 source-context preserved flag
 - model-conditioned pitch-contour changed-ratio repair objective completed: `true`
 - outside-soloing repair objective completed: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`
@@ -5463,6 +5468,7 @@ Issue #1072는 Issue #1070 MVP completion audit의 source-context preserved flag
 
 판단:
 
+- #1154 completion audit schema v4와 source current evidence schema v4가 decision report까지 보존됨.
 - changed-ratio repair와 outside-soloing repair objective path는 현재 target 통과.
 - 다음 gap은 추가 objective repair가 아니라 listening review evidence.
 - human/audio preference, MIDI-to-solo musical quality claim 제외.

--- a/docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -3,7 +3,10 @@
 ## Summary
 
 - boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
 - next boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- source schema version: `stage_b_midi_to_solo_mvp_completion_audit_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - selected target: `listening_review_quality_gap`
 - fallback path active: `true`
 - pitch-contour changed-ratio review required: `true`
@@ -11,12 +14,15 @@
 
 ## Evidence
 
+- current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - technical model-core MVP completed: `true`
 - phrase-bank CLI technical path completed: `true`
 - model-conditioned pitch-contour objective completed: `true`
 - model-conditioned pitch-contour changed-ratio repair objective completed: `true`
 - outside-soloing repair objective completed: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - musical quality MVP completed: `false`
 - generation source: `context_conditioned_fallback`
 - exported candidates: `3`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6038,7 +6038,7 @@ run_stage_b_midi_to_solo_quality_gap_decision() {
     --run_id "$run_id" \
     --mvp_completion_audit "$completion_audit" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_QUALITY_GAP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1072 \
+    --issue_number 1156 \
     --expected_boundary stage_b_midi_to_solo_quality_gap_decision \
     --expected_next_boundary stage_b_midi_to_solo_listening_review_quality_gap \
     --expected_target listening_review_quality_gap \

--- a/scripts/decide_stage_b_midi_to_solo_quality_gap.py
+++ b/scripts/decide_stage_b_midi_to_solo_quality_gap.py
@@ -18,6 +18,9 @@ from scripts.audit_stage_b_midi_to_solo_mvp_completion import (  # noqa: E402
     BRIDGE_SOURCE_CONTEXT_KEYS,
     BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
     BOUNDARY as MVP_COMPLETION_AUDIT_BOUNDARY,
+    CURRENT_EVIDENCE_SCHEMA_VERSION,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    SCHEMA_VERSION as MVP_COMPLETION_AUDIT_SCHEMA_VERSION,
 )
 
 
@@ -34,7 +37,7 @@ PITCH_CONTOUR_CHANGED_RATIO_NEXT_BOUNDARY = (
 )
 LISTENING_REVIEW_TARGET = "listening_review_quality_gap"
 LISTENING_REVIEW_NEXT_BOUNDARY = "stage_b_midi_to_solo_listening_review_quality_gap"
-SCHEMA_VERSION = "stage_b_midi_to_solo_quality_gap_decision_v3"
+SCHEMA_VERSION = "stage_b_midi_to_solo_quality_gap_decision_v4"
 
 
 def _dict(value: Any) -> dict[str, Any]:
@@ -76,6 +79,14 @@ def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str
 
 
 def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
+    if str(report.get("schema_version") or "") != MVP_COMPLETION_AUDIT_SCHEMA_VERSION:
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "MVP completion audit schema version mismatch"
+        )
+    if str(report.get("source_schema_version") or "") != CURRENT_EVIDENCE_SCHEMA_VERSION:
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "MVP completion audit source schema version mismatch"
+        )
     if str(report.get("boundary") or "") != MVP_COMPLETION_AUDIT_BOUNDARY:
         raise StageBMidiToSoloQualityGapDecisionError("MVP completion audit boundary required")
     readiness = _dict(report.get("readiness"))
@@ -108,9 +119,23 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloQualityGapDecisionError(
             "outside-soloing repair source context readiness required"
         )
+    if not bool(readiness.get("outside_soloing_repair_schema_context_preserved", False)):
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing repair schema context readiness required"
+        )
     if not bool(audit.get("outside_soloing_repair_source_context_preserved", False)):
         raise StageBMidiToSoloQualityGapDecisionError(
             "outside-soloing repair source context audit preservation required"
+        )
+    if not bool(audit.get("outside_soloing_repair_schema_context_preserved", False)):
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing repair schema context audit preservation required"
+        )
+    if str(
+        audit.get("outside_soloing_repair_objective_schema_version") or ""
+    ) != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION:
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing repair objective schema version mismatch"
         )
     if _int(evidence.get("exported_candidate_count")) < 3:
         raise StageBMidiToSoloQualityGapDecisionError("exported candidate count below 3")
@@ -118,6 +143,10 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloQualityGapDecisionError("rendered WAV count below 3")
     if not bool(evidence.get("phrase_bank_cli_technical_path_ready", False)):
         raise StageBMidiToSoloQualityGapDecisionError("phrase-bank CLI technical path readiness required")
+    if str(evidence.get("current_evidence_schema_version") or "") != CURRENT_EVIDENCE_SCHEMA_VERSION:
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "current evidence schema version mismatch"
+        )
     if _int(evidence.get("cli_candidate_count")) < 3:
         raise StageBMidiToSoloQualityGapDecisionError("CLI candidate count below 3")
     if _int(evidence.get("cli_rendered_audio_file_count")) < 3:
@@ -196,6 +225,16 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloQualityGapDecisionError(
             "outside-soloing repair source context evidence preservation required"
         )
+    if not bool(evidence.get("outside_soloing_repair_schema_context_preserved", False)):
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing repair schema context evidence preservation required"
+        )
+    if str(
+        evidence.get("outside_soloing_repair_objective_schema_version") or ""
+    ) != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION:
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing repair evidence objective schema version mismatch"
+        )
     source_context = _source_context_fields(
         evidence,
         label="MVP completion audit evidence",
@@ -271,6 +310,8 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
     if claimed:
         raise StageBMidiToSoloQualityGapDecisionError(f"unexpected quality claim: {claimed}")
     return {
+        "mvp_completion_audit_schema_version": MVP_COMPLETION_AUDIT_SCHEMA_VERSION,
+        "source_current_evidence_schema_version": CURRENT_EVIDENCE_SCHEMA_VERSION,
         "technical_model_core_mvp_completed": True,
         "phrase_bank_cli_technical_path_completed": True,
         "model_conditioned_pitch_contour_objective_completed": True,
@@ -282,6 +323,12 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
         ),
         "outside_soloing_repair_source_context_preserved": bool(
             evidence.get("outside_soloing_repair_source_context_preserved", False)
+        ),
+        "outside_soloing_repair_schema_context_preserved": bool(
+            evidence.get("outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "outside_soloing_repair_objective_schema_version": str(
+            evidence.get("outside_soloing_repair_objective_schema_version") or ""
         ),
         "musical_quality_mvp_completed": False,
         "human_audio_preference_completed": False,
@@ -300,6 +347,9 @@ def validate_mvp_completion_audit(report: dict[str, Any]) -> dict[str, Any]:
         ),
         "phrase_bank_cli_technical_path_ready": bool(
             evidence.get("phrase_bank_cli_technical_path_ready", False)
+        ),
+        "current_evidence_schema_version": str(
+            evidence.get("current_evidence_schema_version") or ""
         ),
         "cli_candidate_count": _int(evidence.get("cli_candidate_count")),
         "cli_rendered_audio_file_count": _int(evidence.get("cli_rendered_audio_file_count")),
@@ -494,6 +544,10 @@ def build_quality_gap_decision_report(
         "issue_number": int(issue_number),
         "boundary": BOUNDARY,
         "source_boundary": MVP_COMPLETION_AUDIT_BOUNDARY,
+        "source_schema_version": audit_summary["mvp_completion_audit_schema_version"],
+        "source_current_evidence_schema_version": audit_summary[
+            "source_current_evidence_schema_version"
+        ],
         "mvp_completion_summary": audit_summary,
         "quality_gap": {
             "technical_model_core_mvp_completed": True,
@@ -509,6 +563,12 @@ def build_quality_gap_decision_report(
             ),
             "outside_soloing_repair_source_context_preserved": bool(
                 audit_summary["outside_soloing_repair_source_context_preserved"]
+            ),
+            "outside_soloing_repair_schema_context_preserved": bool(
+                audit_summary["outside_soloing_repair_schema_context_preserved"]
+            ),
+            "outside_soloing_repair_objective_schema_version": str(
+                audit_summary["outside_soloing_repair_objective_schema_version"]
             ),
             "musical_quality_mvp_completed": False,
             "human_audio_preference_completed": False,
@@ -566,6 +626,9 @@ def build_quality_gap_decision_report(
             "outside_soloing_repair_source_context_preserved": bool(
                 audit_summary["outside_soloing_repair_source_context_preserved"]
             ),
+            "outside_soloing_repair_schema_context_preserved": bool(
+                audit_summary["outside_soloing_repair_schema_context_preserved"]
+            ),
             "human_review_required_now": False,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
@@ -611,6 +674,35 @@ def validate_quality_gap_decision_report(
     readiness = _dict(report.get("readiness"))
     decision = _dict(report.get("decision"))
     quality_gap = _dict(report.get("quality_gap"))
+    summary = _dict(report.get("mvp_completion_summary"))
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "quality gap decision schema version mismatch"
+        )
+    if str(report.get("source_schema_version") or "") != MVP_COMPLETION_AUDIT_SCHEMA_VERSION:
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "quality gap source schema version mismatch"
+        )
+    if str(report.get("source_current_evidence_schema_version") or "") != CURRENT_EVIDENCE_SCHEMA_VERSION:
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "quality gap source current evidence schema version mismatch"
+        )
+    if str(
+        summary.get("mvp_completion_audit_schema_version") or ""
+    ) != MVP_COMPLETION_AUDIT_SCHEMA_VERSION:
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "MVP completion summary schema version mismatch"
+        )
+    if str(
+        summary.get("source_current_evidence_schema_version") or ""
+    ) != CURRENT_EVIDENCE_SCHEMA_VERSION:
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "MVP completion summary source schema version mismatch"
+        )
+    if str(summary.get("current_evidence_schema_version") or "") != CURRENT_EVIDENCE_SCHEMA_VERSION:
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "MVP completion summary current evidence schema version mismatch"
+        )
     if expected_boundary and boundary != expected_boundary:
         raise StageBMidiToSoloQualityGapDecisionError(f"expected boundary {expected_boundary}, got {boundary}")
     if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
@@ -633,9 +725,23 @@ def validate_quality_gap_decision_report(
         raise StageBMidiToSoloQualityGapDecisionError(
             "outside-soloing repair source context readiness required"
         )
+    if not bool(readiness.get("outside_soloing_repair_schema_context_preserved", False)):
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing repair schema context readiness required"
+        )
     if not bool(quality_gap.get("outside_soloing_repair_source_context_preserved", False)):
         raise StageBMidiToSoloQualityGapDecisionError(
             "outside-soloing repair source context preservation required"
+        )
+    if not bool(quality_gap.get("outside_soloing_repair_schema_context_preserved", False)):
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing repair schema context preservation required"
+        )
+    if str(
+        quality_gap.get("outside_soloing_repair_objective_schema_version") or ""
+    ) != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION:
+        raise StageBMidiToSoloQualityGapDecisionError(
+            "outside-soloing repair objective schema version mismatch"
         )
     source_context = _source_context_fields(
         quality_gap,
@@ -689,7 +795,15 @@ def validate_quality_gap_decision_report(
         if claimed:
             raise StageBMidiToSoloQualityGapDecisionError(f"unexpected quality claim: {claimed}")
     return {
+        "schema_version": str(report.get("schema_version") or ""),
         "boundary": boundary,
+        "source_schema_version": str(report.get("source_schema_version") or ""),
+        "source_current_evidence_schema_version": str(
+            report.get("source_current_evidence_schema_version") or ""
+        ),
+        "current_evidence_schema_version": str(
+            summary.get("current_evidence_schema_version") or ""
+        ),
         "next_boundary": str(decision.get("next_boundary") or ""),
         "selected_target": str(readiness.get("selected_target") or ""),
         "fallback_path_active": bool(quality_gap.get("fallback_path_active", False)),
@@ -717,6 +831,12 @@ def validate_quality_gap_decision_report(
         ),
         "outside_soloing_repair_source_context_preserved": bool(
             quality_gap.get("outside_soloing_repair_source_context_preserved", False)
+        ),
+        "outside_soloing_repair_schema_context_preserved": bool(
+            quality_gap.get("outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "outside_soloing_repair_objective_schema_version": str(
+            quality_gap.get("outside_soloing_repair_objective_schema_version") or ""
         ),
         "model_conditioned_pitch_contour_objective_path_ready": bool(
             quality_gap.get("model_conditioned_pitch_contour_objective_path_ready", False)
@@ -869,7 +989,10 @@ def markdown_report(report: dict[str, Any]) -> str:
         "## Summary",
         "",
         f"- boundary: `{report['boundary']}`",
+        f"- schema version: `{report['schema_version']}`",
         f"- next boundary: `{decision['next_boundary']}`",
+        f"- source schema version: `{report['source_schema_version']}`",
+        f"- source current evidence schema version: `{report['source_current_evidence_schema_version']}`",
         f"- selected target: `{selected['selected_target']}`",
         f"- fallback path active: `{_bool_token(quality_gap['fallback_path_active'])}`",
         f"- pitch-contour changed-ratio review required: `{_bool_token(quality_gap['pitch_contour_changed_ratio_review_required'])}`",
@@ -877,12 +1000,15 @@ def markdown_report(report: dict[str, Any]) -> str:
         "",
         "## Evidence",
         "",
+        f"- current evidence schema version: `{summary['current_evidence_schema_version']}`",
         f"- technical model-core MVP completed: `{_bool_token(summary['technical_model_core_mvp_completed'])}`",
         f"- phrase-bank CLI technical path completed: `{_bool_token(summary['phrase_bank_cli_technical_path_completed'])}`",
         f"- model-conditioned pitch-contour objective completed: `{_bool_token(summary['model_conditioned_pitch_contour_objective_completed'])}`",
         f"- model-conditioned pitch-contour changed-ratio repair objective completed: `{_bool_token(summary['model_conditioned_pitch_contour_changed_ratio_repair_objective_completed'])}`",
         f"- outside-soloing repair objective completed: `{_bool_token(summary['outside_soloing_repair_objective_completed'])}`",
         f"- outside-soloing repair source context preserved: `{_bool_token(summary['outside_soloing_repair_source_context_preserved'])}`",
+        f"- outside-soloing repair schema context preserved: `{_bool_token(summary['outside_soloing_repair_schema_context_preserved'])}`",
+        f"- outside-soloing repair objective schema version: `{summary['outside_soloing_repair_objective_schema_version']}`",
         f"- musical quality MVP completed: `{_bool_token(summary['musical_quality_mvp_completed'])}`",
         f"- generation source: `{summary['generation_source']}`",
         f"- exported candidates: `{summary['exported_candidate_count']}`",
@@ -951,7 +1077,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=618)
+    parser.add_argument("--issue_number", type=int, default=1156)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--expected_target", type=str, default="")

--- a/tests/test_stage_b_midi_to_solo_quality_gap_decision.py
+++ b/tests/test_stage_b_midi_to_solo_quality_gap_decision.py
@@ -6,6 +6,9 @@ from pathlib import Path
 from scripts.audit_stage_b_midi_to_solo_mvp_completion import (
     BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
     BOUNDARY as MVP_COMPLETION_BOUNDARY,
+    CURRENT_EVIDENCE_SCHEMA_VERSION,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    SCHEMA_VERSION as MVP_COMPLETION_AUDIT_SCHEMA_VERSION,
 )
 from scripts.decide_stage_b_midi_to_solo_quality_gap import (
     BOUNDARY,
@@ -62,12 +65,15 @@ def mvp_completion_audit(
     outside_soloing_repair_supported: bool = True,
 ) -> dict:
     return {
+        "schema_version": MVP_COMPLETION_AUDIT_SCHEMA_VERSION,
         "boundary": MVP_COMPLETION_BOUNDARY,
+        "source_schema_version": CURRENT_EVIDENCE_SCHEMA_VERSION,
         "readiness": {
             "mvp_completion_audit_completed": True,
             "technical_model_core_mvp_completed": True,
             "quality_gap_decision_required": True,
             "outside_soloing_repair_source_context_preserved": outside_soloing_repair_supported,
+            "outside_soloing_repair_schema_context_preserved": outside_soloing_repair_supported,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
             "broad_trained_model_quality_claimed": False,
@@ -85,7 +91,12 @@ def mvp_completion_audit(
                 changed_ratio_repair_supported
             ),
             "outside_soloing_repair_objective_completed": outside_soloing_repair_supported,
+            "outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "outside_soloing_repair_source_context_preserved": outside_soloing_repair_supported,
+            "outside_soloing_repair_schema_context_preserved": outside_soloing_repair_supported,
+            "current_evidence_schema_version": CURRENT_EVIDENCE_SCHEMA_VERSION,
             "readme_evidence_boundary_refreshed": True,
             "musical_quality_mvp_completed": musical_complete,
             "human_audio_preference_completed": False,
@@ -94,6 +105,7 @@ def mvp_completion_audit(
             "product_mvp_completed": False,
         },
         "current_evidence": {
+            "current_evidence_schema_version": CURRENT_EVIDENCE_SCHEMA_VERSION,
             "generation_source": generation_source,
             "exported_candidate_count": 3,
             "rendered_audio_file_count": 3,
@@ -140,6 +152,10 @@ def mvp_completion_audit(
             "outside_soloing_repair_objective_path_ready": outside_soloing_repair_supported,
             "outside_soloing_repair_current_evidence_ready": outside_soloing_repair_supported,
             "outside_soloing_repair_source_context_preserved": outside_soloing_repair_supported,
+            "outside_soloing_repair_schema_context_preserved": outside_soloing_repair_supported,
+            "outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "outside_soloing_repair_rendered_audio_file_count": 6,
             "outside_soloing_repair_changed_note_total": 2,
             "outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
@@ -172,7 +188,7 @@ class StageBMidiToSoloQualityGapDecisionTest(unittest.TestCase):
         report = build_quality_gap_decision_report(
             mvp_completion_audit=mvp_completion_audit(),
             output_dir=Path("outputs/quality_gap"),
-            issue_number=1072,
+            issue_number=1156,
         )
         summary = validate_quality_gap_decision_report(
             report,
@@ -186,12 +202,30 @@ class StageBMidiToSoloQualityGapDecisionTest(unittest.TestCase):
         self.assertEqual(summary["next_boundary"], LISTENING_REVIEW_NEXT_BOUNDARY)
         self.assertTrue(summary["fallback_path_active"])
         self.assertFalse(summary["model_conditioned_input_path_alignment_required"])
+        self.assertEqual(summary["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(
+            summary["source_schema_version"],
+            MVP_COMPLETION_AUDIT_SCHEMA_VERSION,
+        )
+        self.assertEqual(
+            summary["source_current_evidence_schema_version"],
+            CURRENT_EVIDENCE_SCHEMA_VERSION,
+        )
+        self.assertEqual(
+            summary["current_evidence_schema_version"],
+            CURRENT_EVIDENCE_SCHEMA_VERSION,
+        )
         self.assertTrue(summary["model_conditioned_pitch_contour_objective_completed"])
         self.assertTrue(
             summary["model_conditioned_pitch_contour_changed_ratio_repair_objective_completed"]
         )
         self.assertTrue(summary["outside_soloing_repair_objective_completed"])
         self.assertTrue(summary["outside_soloing_repair_source_context_preserved"])
+        self.assertTrue(summary["outside_soloing_repair_schema_context_preserved"])
+        self.assertEqual(
+            summary["outside_soloing_repair_objective_schema_version"],
+            OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+        )
         self.assertTrue(summary["model_conditioned_pitch_contour_objective_path_ready"])
         self.assertTrue(summary["pitch_contour_changed_ratio_review_required"])
         self.assertTrue(summary["pitch_contour_changed_ratio_repair_objective_path_ready"])
@@ -261,7 +295,32 @@ class StageBMidiToSoloQualityGapDecisionTest(unittest.TestCase):
             "Stage B MIDI-to-solo listening review quality gap source-context refresh",
         )
         self.assertEqual(report["schema_version"], SCHEMA_VERSION)
-        self.assertEqual(report["issue_number"], 1072)
+        self.assertEqual(report["source_schema_version"], MVP_COMPLETION_AUDIT_SCHEMA_VERSION)
+        self.assertEqual(
+            report["source_current_evidence_schema_version"],
+            CURRENT_EVIDENCE_SCHEMA_VERSION,
+        )
+        self.assertEqual(report["issue_number"], 1156)
+
+    def test_rejects_mvp_completion_audit_schema_mismatch(self) -> None:
+        source = mvp_completion_audit()
+        source["schema_version"] = "stale_schema"
+        with self.assertRaises(StageBMidiToSoloQualityGapDecisionError):
+            build_quality_gap_decision_report(
+                mvp_completion_audit=source,
+                output_dir=Path("outputs/quality_gap"),
+                issue_number=1156,
+            )
+
+    def test_rejects_mvp_completion_audit_source_schema_mismatch(self) -> None:
+        source = mvp_completion_audit()
+        source["source_schema_version"] = "stale_schema"
+        with self.assertRaises(StageBMidiToSoloQualityGapDecisionError):
+            build_quality_gap_decision_report(
+                mvp_completion_audit=source,
+                output_dir=Path("outputs/quality_gap"),
+                issue_number=1156,
+            )
 
     def test_selects_pitch_contour_changed_ratio_review_without_repair_path(self) -> None:
         report = build_quality_gap_decision_report(
@@ -420,6 +479,33 @@ class StageBMidiToSoloQualityGapDecisionTest(unittest.TestCase):
                 issue_number=1072,
             )
 
+    def test_rejects_false_outside_soloing_schema_context_preserved_flag(self) -> None:
+        source = mvp_completion_audit()
+        source["current_evidence"]["outside_soloing_repair_schema_context_preserved"] = False
+
+        with self.assertRaises(StageBMidiToSoloQualityGapDecisionError):
+            build_quality_gap_decision_report(
+                mvp_completion_audit=source,
+                output_dir=Path("outputs/quality_gap"),
+                issue_number=1156,
+            )
+
+    def test_rejects_quality_gap_decision_schema_mismatch(self) -> None:
+        report = build_quality_gap_decision_report(
+            mvp_completion_audit=mvp_completion_audit(),
+            output_dir=Path("outputs/quality_gap"),
+            issue_number=1156,
+        )
+        report["schema_version"] = "stale_schema"
+        with self.assertRaises(StageBMidiToSoloQualityGapDecisionError):
+            validate_quality_gap_decision_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=LISTENING_REVIEW_NEXT_BOUNDARY,
+                expected_target=LISTENING_REVIEW_TARGET,
+                require_no_quality_claim=True,
+            )
+
     def test_rejects_targeted_outside_soloing_source_repair(self) -> None:
         source = mvp_completion_audit()
         source["current_evidence"]["outside_soloing_repair_source_targeted"] = True
@@ -464,7 +550,7 @@ class StageBMidiToSoloQualityGapDecisionTest(unittest.TestCase):
             LISTENING_REVIEW_NEXT_BOUNDARY,
             "stage_b_midi_to_solo_listening_review_quality_gap",
         )
-        self.assertEqual(SCHEMA_VERSION, "stage_b_midi_to_solo_quality_gap_decision_v3")
+        self.assertEqual(SCHEMA_VERSION, "stage_b_midi_to_solo_quality_gap_decision_v4")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- quality gap decision schema v4 적용
- MVP completion audit schema v4 및 source current evidence schema v4 입력 검증 추가
- outside-soloing repair schema-context preserved와 objective schema version summary 전파
- #1156 기준 generated decision doc, README, current status, core plan, handoff scope 갱신

## Context

- #1154 MVP completion audit source-context refresh 완료
- source audit schema: `stage_b_midi_to_solo_mvp_completion_audit_v4`
- source current evidence schema: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
- outside-soloing repair schema-context preserved: `true`
- selected target: `listening_review_quality_gap`
- musical quality/preference claim: `false`

## Scope

- `scripts/decide_stage_b_midi_to_solo_quality_gap.py`
  - MVP completion audit schema mismatch 차단
  - source current evidence schema mismatch 차단
  - outside-soloing repair schema-context/objective schema summary 전파
- `tests/test_stage_b_midi_to_solo_quality_gap_decision.py`
  - source schema mismatch 차단 테스트
  - decision schema mismatch 차단 테스트
  - schema-context preserved false 입력 차단 테스트
- `scripts/agent_harness.sh`
  - quality gap decision issue number #1156 반영
- README/status/core plan/generated decision doc 최신 경계 반영

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_gap_decision`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_quality_gap.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-quality-gap-decision`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- public diff scan for tool-neutral wording

## Risk

- decision 범위는 objective evidence 기반 next boundary selection
- listening review input과 human/audio preference claim 제외 유지
- 다음 검증 경계: listening review quality gap source-context refresh

Closes #1156
