### PR TITLE
Stage B MIDI-to-solo listening review quality gap source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Current handoff scope:
 - Latest functional issue completed: Issue #1150, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh.
 - Latest audit issue completed: Issue #1154, Stage B MIDI-to-solo MVP completion audit source-context refresh.
 - Latest quality gap decision completed: Issue #1156, Stage B MIDI-to-solo quality gap decision source-context refresh.
-- Latest listening review quality gap completed: Issue #1074, Stage B MIDI-to-solo listening review quality gap source-context refresh.
+- Latest listening review quality gap completed: Issue #1158, Stage B MIDI-to-solo listening review quality gap source-context refresh.
 - Latest MVP delivery package completed: Issue #1076, Stage B MIDI-to-solo MVP delivery package source-context refresh.
 - Latest README final evidence refresh completed: Issue #1078, Stage B MIDI-to-solo README final evidence refresh source-context refresh.
 - Latest final status audit completed: Issue #1080, Stage B MIDI-to-solo final status audit source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1148, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after Stage B MIDI-to-solo quality gap decision source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo listening review quality gap source-context refresh.
+- Open issue queue after Stage B MIDI-to-solo listening review quality gap source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo MVP delivery package source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest functional result: `Issue #1150`
 - latest MVP completion audit: `Issue #1154`
 - latest quality gap decision: `Issue #1156`
-- latest listening review quality gap: `Issue #1074`
+- latest listening review quality gap: `Issue #1158`
 - latest MVP delivery package: `Issue #1076`
 - latest README final evidence refresh: `Issue #1078`
 - latest final status audit: `Issue #1080`
@@ -50,8 +50,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1150`
 - latest README evidence refresh: `Issue #1152`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after quality gap decision source-context refresh merge: `0`
-- latest evidence boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- open issue queue after listening review quality gap source-context refresh merge: `0`
+- latest evidence boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - current MVP evidence support: `true`
@@ -590,6 +590,10 @@ Quality gap decision.
 Listening review quality gap.
 
 - boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source MVP completion audit schema version: `stage_b_midi_to_solo_mvp_completion_audit_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - selected target: `mvp_delivery_package`
 - technical model-core MVP completed: `true`
@@ -597,6 +601,8 @@ Listening review quality gap.
 - changed-ratio repair max ratio / target: `0.4348 / 0.5000`
 - changed-ratio repair max interval / target: `12 / 12`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -395,7 +395,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo README evidence refresh: latest boundary `stage_b_midi_to_solo_mvp_current_evidence_consolidation`, input-to-WAV technical path `true`, selected-scale objective path `true`, phrase-bank CLI path `true`, model-conditioned pitch-contour objective path `true`, changed-ratio repair objective path `true`, outside-soloing schema-context evidence reflected `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_completion_audit`
 - MIDI-to-solo MVP completion audit refresh: schema `stage_b_midi_to_solo_mvp_completion_audit_v4`, current evidence schema `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`, technical model-core MVP `true`, model-conditioned pitch-contour objective `true`, changed-ratio repair objective `true`, outside-soloing schema-context preserved `true`, musical/product MVP `false/false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_gap_decision`
 - MIDI-to-solo quality gap decision refresh: schema `stage_b_midi_to_solo_quality_gap_decision_v4`, source audit schema `stage_b_midi_to_solo_mvp_completion_audit_v4`, current evidence schema `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`, selected target `listening_review_quality_gap`, outside-soloing schema-context preserved `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_listening_review_quality_gap`
-- MIDI-to-solo listening review quality gap: selected target `mvp_delivery_package`, technical delivery package ready `true`, listening gap open `true`, changed-ratio repair ratio/target `0.4348/0.5000`, interval/target `12/12`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_delivery_package`
+- MIDI-to-solo listening review quality gap: schema `stage_b_midi_to_solo_listening_review_quality_gap_v4`, source quality gap schema `stage_b_midi_to_solo_quality_gap_decision_v4`, current evidence schema `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`, selected target `mvp_delivery_package`, technical delivery package ready `true`, listening gap open `true`, outside-soloing schema-context preserved `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_delivery_package`
 - MIDI-to-solo MVP delivery package: runnable CLI `true`, input ranked MIDI `true`, rendered WAV evidence `true`, CLI/changed-ratio audio candidate count `3/3`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_readme_final_evidence_refresh`
 - MIDI-to-solo README final evidence refresh: latest evidence boundary `stage_b_midi_to_solo_mvp_delivery_package`, runnable CLI `true`, input ranked MIDI/WAV evidence `true/true`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_final_status_audit`
 - MIDI-to-solo final status audit: technical MVP complete `true`, local review ready `true`, README final evidence reflected `true`, CLI/WAV count `3/3`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
@@ -12242,13 +12242,17 @@ Issue #1156은 Issue #1154 MVP completion audit의 schema/source-context preserv
 
 ## 9.227 Stage B MIDI-to-solo listening review quality gap source-context refresh
 
-Issue #1074는 Issue #1072 quality gap decision의 source-context preserved flag 3개를 listening review quality gap summary와 validation summary까지 보존하고, 다음 target을 MVP delivery package로 유지한 작업이다.
+Issue #1158은 Issue #1156 quality gap decision의 schema/source-context preserved flag를 listening review quality gap summary와 validation summary까지 보존하고, 다음 target을 MVP delivery package로 유지한 작업이다.
 
 결과:
 
 - document: `docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
 - next boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source MVP completion audit schema version: `stage_b_midi_to_solo_mvp_completion_audit_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - selected target: `mvp_delivery_package`
 - listening review quality gap open: `true`
 - technical MVP delivery package ready: `true`
@@ -12256,6 +12260,8 @@ Issue #1074는 Issue #1072 quality gap decision의 source-context preserved flag
 - changed-ratio repair objective completed: `true`
 - outside-soloing repair objective completed: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`
@@ -12265,6 +12271,7 @@ Issue #1074는 Issue #1072 quality gap decision의 source-context preserved flag
 
 판단:
 
+- #1156 quality gap decision schema v4와 source current evidence schema v4가 listening review gap report까지 보존됨.
 - listening review gap은 open 상태.
 - technical delivery package 준비는 quality claim 없이 진행 가능.
 - human/audio preference, MIDI-to-solo musical quality claim 제외.

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -15,7 +15,7 @@
 - latest functional result: Issue #1150, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest MVP completion audit: Issue #1154, Stage B MIDI-to-solo MVP completion audit source-context refresh
 - latest quality gap decision: Issue #1156, Stage B MIDI-to-solo quality gap decision source-context refresh
-- latest listening review quality gap: Issue #1074, Stage B MIDI-to-solo listening review quality gap source-context refresh
+- latest listening review quality gap: Issue #1158, Stage B MIDI-to-solo listening review quality gap source-context refresh
 - latest MVP delivery package: Issue #1076, Stage B MIDI-to-solo MVP delivery package source-context refresh
 - latest README final evidence refresh: Issue #1078, Stage B MIDI-to-solo README final evidence refresh source-context refresh
 - latest final status audit: Issue #1080, Stage B MIDI-to-solo final status audit source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1150, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after Stage B MIDI-to-solo quality gap decision source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo listening review quality gap source-context refresh`
+- open issue queue after Stage B MIDI-to-solo listening review quality gap source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo MVP delivery package source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -5488,21 +5488,25 @@ Issue #1156은 Issue #1154 MVP completion audit의 schema/source-context preserv
 
 ## Stage B MIDI-to-Solo Listening Review Quality Gap Source-Context Refresh Result
 
-Issue #1074는 Issue #1072 quality gap decision의 source-context preserved flag 3개를 listening review quality gap summary와 validation summary까지 보존하고, 다음 target을 MVP delivery package로 유지한 작업이다.
+Issue #1158은 Issue #1156 quality gap decision의 schema/source-context preserved flag를 listening review quality gap summary와 validation summary까지 보존하고, 다음 target을 MVP delivery package로 유지한 작업이다.
 
 변경:
 
-- listening review quality gap schema v3 적용
-- source-context required key를 preserved flag 3개 포함으로 확장
-- false preserved flag 입력 차단 테스트 추가
-- quality gap summary, generated markdown report, validation summary source-context preserved field 전파
-- harness issue number #1074 반영
+- listening review quality gap schema v4 적용
+- quality gap decision schema v4 입력 검증 추가
+- source MVP completion audit schema v4와 source current evidence schema v4 보존
+- outside-soloing schema-context preserved field와 objective schema version 전파
+- harness issue number #1158 반영
 
 결과:
 
 - document: `docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
 - next boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source MVP completion audit schema version: `stage_b_midi_to_solo_mvp_completion_audit_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - selected target: `mvp_delivery_package`
 - listening review quality gap open: `true`
 - technical MVP delivery package ready: `true`
@@ -5510,6 +5514,8 @@ Issue #1074는 Issue #1072 quality gap decision의 source-context preserved flag
 - changed-ratio repair objective completed: `true`
 - outside-soloing repair objective completed: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`
@@ -5519,6 +5525,7 @@ Issue #1074는 Issue #1072 quality gap decision의 source-context preserved flag
 
 판단:
 
+- #1156 quality gap decision schema v4와 source current evidence schema v4가 listening review gap report까지 보존됨.
 - listening review gap은 open 상태.
 - technical delivery package 준비는 quality claim 없이 진행 가능.
 - human/audio preference, MIDI-to-solo musical quality claim 제외.

--- a/docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -3,7 +3,11 @@
 ## Summary
 
 - boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
 - source boundary: `stage_b_midi_to_solo_quality_gap_decision`
+- source schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source MVP completion audit schema version: `stage_b_midi_to_solo_mvp_completion_audit_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - selected target: `mvp_delivery_package`
 - listening review quality gap open: `true`
@@ -12,12 +16,15 @@
 
 ## Evidence
 
+- current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - technical model-core MVP completed: `true`
 - phrase-bank CLI technical path completed: `true`
 - model-conditioned pitch-contour objective completed: `true`
 - changed-ratio repair objective completed: `true`
 - outside-soloing repair objective completed: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - rendered WAV files: `3`
 - changed-ratio repair max interval / threshold: `12` / `12`
 - changed-ratio repair max ratio / target: `0.4348` / `0.5000`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6058,7 +6058,7 @@ run_stage_b_midi_to_solo_listening_review_quality_gap() {
     --run_id "$run_id" \
     --quality_gap_decision "$quality_gap" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_LISTENING_REVIEW_QUALITY_GAP_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1074 \
+    --issue_number 1158 \
     --expected_boundary stage_b_midi_to_solo_listening_review_quality_gap \
     --expected_next_boundary stage_b_midi_to_solo_mvp_delivery_package \
     --expected_target mvp_delivery_package \

--- a/scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py
+++ b/scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py
@@ -18,8 +18,12 @@ from scripts.decide_stage_b_midi_to_solo_quality_gap import (  # noqa: E402
     BRIDGE_SOURCE_CONTEXT_KEYS,
     BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
     BOUNDARY as SOURCE_BOUNDARY,
+    CURRENT_EVIDENCE_SCHEMA_VERSION,
     LISTENING_REVIEW_NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
     LISTENING_REVIEW_TARGET,
+    MVP_COMPLETION_AUDIT_SCHEMA_VERSION,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    SCHEMA_VERSION as QUALITY_GAP_DECISION_SCHEMA_VERSION,
 )
 
 
@@ -30,7 +34,7 @@ class StageBMidiToSoloListeningReviewQualityGapError(ValueError):
 BOUNDARY = "stage_b_midi_to_solo_listening_review_quality_gap"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_mvp_delivery_package"
 SELECTED_TARGET = "mvp_delivery_package"
-SCHEMA_VERSION = "stage_b_midi_to_solo_listening_review_quality_gap_v3"
+SCHEMA_VERSION = "stage_b_midi_to_solo_listening_review_quality_gap_v4"
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -98,6 +102,18 @@ def validate_quality_gap_decision(report: dict[str, Any]) -> dict[str, Any]:
     selected = _dict(report.get("selected_target"))
     summary = _dict(report.get("mvp_completion_summary"))
 
+    if str(report.get("schema_version") or "") != QUALITY_GAP_DECISION_SCHEMA_VERSION:
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "quality gap decision schema version mismatch"
+        )
+    if str(report.get("source_schema_version") or "") != MVP_COMPLETION_AUDIT_SCHEMA_VERSION:
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "quality gap source audit schema version mismatch"
+        )
+    if str(report.get("source_current_evidence_schema_version") or "") != CURRENT_EVIDENCE_SCHEMA_VERSION:
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "quality gap source current evidence schema version mismatch"
+        )
     if str(report.get("boundary") or "") != SOURCE_BOUNDARY:
         raise StageBMidiToSoloListeningReviewQualityGapError("quality gap decision boundary required")
     if str(decision.get("next_boundary") or "") != SOURCE_NEXT_BOUNDARY:
@@ -141,9 +157,23 @@ def validate_quality_gap_decision(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloListeningReviewQualityGapError(
             "outside-soloing repair source context readiness required"
         )
+    if not bool(readiness.get("outside_soloing_repair_schema_context_preserved", False)):
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing repair schema context readiness required"
+        )
     if not bool(quality_gap.get("outside_soloing_repair_source_context_preserved", False)):
         raise StageBMidiToSoloListeningReviewQualityGapError(
             "outside-soloing repair source context preservation required"
+        )
+    if not bool(quality_gap.get("outside_soloing_repair_schema_context_preserved", False)):
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing repair schema context preservation required"
+        )
+    if str(
+        quality_gap.get("outside_soloing_repair_objective_schema_version") or ""
+    ) != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION:
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing repair objective schema version mismatch"
         )
     source_context = _source_context_fields(
         quality_gap,
@@ -171,6 +201,20 @@ def validate_quality_gap_decision(report: dict[str, Any]) -> dict[str, Any]:
         summary.get("model_conditioned_pitch_contour_changed_ratio_repair_rendered_audio_file_count")
     ) < 3:
         raise StageBMidiToSoloListeningReviewQualityGapError("changed-ratio repair rendered WAV count below 3")
+    if str(summary.get("current_evidence_schema_version") or "") != CURRENT_EVIDENCE_SCHEMA_VERSION:
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "quality gap summary current evidence schema version mismatch"
+        )
+    if not bool(summary.get("outside_soloing_repair_schema_context_preserved", False)):
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "quality gap summary schema context preservation required"
+        )
+    if str(
+        summary.get("outside_soloing_repair_objective_schema_version") or ""
+    ) != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION:
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "quality gap summary outside-soloing objective schema version mismatch"
+        )
     if _int(summary.get("model_conditioned_pitch_contour_changed_ratio_repair_max_interval")) > _int(
         summary.get("model_conditioned_pitch_contour_changed_ratio_repair_max_interval_threshold")
     ):
@@ -237,6 +281,12 @@ def validate_quality_gap_decision(report: dict[str, Any]) -> dict[str, Any]:
     _require_no_quality_claim(readiness, label="quality gap decision readiness")
 
     return {
+        "quality_gap_decision_schema_version": QUALITY_GAP_DECISION_SCHEMA_VERSION,
+        "source_mvp_completion_audit_schema_version": MVP_COMPLETION_AUDIT_SCHEMA_VERSION,
+        "source_current_evidence_schema_version": CURRENT_EVIDENCE_SCHEMA_VERSION,
+        "current_evidence_schema_version": str(
+            summary.get("current_evidence_schema_version") or ""
+        ),
         "boundary": SOURCE_BOUNDARY,
         "technical_model_core_mvp_completed": True,
         "phrase_bank_cli_technical_path_completed": True,
@@ -245,6 +295,12 @@ def validate_quality_gap_decision(report: dict[str, Any]) -> dict[str, Any]:
         "outside_soloing_repair_objective_completed": True,
         "outside_soloing_repair_source_context_preserved": bool(
             quality_gap.get("outside_soloing_repair_source_context_preserved", False)
+        ),
+        "outside_soloing_repair_schema_context_preserved": bool(
+            quality_gap.get("outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "outside_soloing_repair_objective_schema_version": str(
+            quality_gap.get("outside_soloing_repair_objective_schema_version") or ""
         ),
         "fallback_path_active": bool(quality_gap.get("fallback_path_active", False)),
         "model_conditioned_input_path_alignment_required": bool(
@@ -327,6 +383,13 @@ def build_listening_review_quality_gap_report(
         "issue_number": int(issue_number),
         "boundary": BOUNDARY,
         "source_boundary": source["boundary"],
+        "source_schema_version": source["quality_gap_decision_schema_version"],
+        "source_mvp_completion_audit_schema_version": source[
+            "source_mvp_completion_audit_schema_version"
+        ],
+        "source_current_evidence_schema_version": source[
+            "source_current_evidence_schema_version"
+        ],
         "quality_gap_summary": {
             **source,
             "listening_review_quality_gap_open": True,
@@ -350,6 +413,9 @@ def build_listening_review_quality_gap_report(
             "human_review_required_now": False,
             "outside_soloing_repair_source_context_preserved": bool(
                 source["outside_soloing_repair_source_context_preserved"]
+            ),
+            "outside_soloing_repair_schema_context_preserved": bool(
+                source["outside_soloing_repair_schema_context_preserved"]
             ),
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
@@ -394,6 +460,24 @@ def validate_listening_review_quality_gap_report(
     decision = _dict(report.get("decision"))
     selected = _dict(report.get("selected_next_target"))
     summary = _dict(report.get("quality_gap_summary"))
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "listening review quality gap schema version mismatch"
+        )
+    if str(report.get("source_schema_version") or "") != QUALITY_GAP_DECISION_SCHEMA_VERSION:
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "listening review source quality gap schema version mismatch"
+        )
+    if str(
+        report.get("source_mvp_completion_audit_schema_version") or ""
+    ) != MVP_COMPLETION_AUDIT_SCHEMA_VERSION:
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "listening review source MVP completion audit schema version mismatch"
+        )
+    if str(report.get("source_current_evidence_schema_version") or "") != CURRENT_EVIDENCE_SCHEMA_VERSION:
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "listening review source current evidence schema version mismatch"
+        )
     if expected_boundary and boundary != expected_boundary:
         raise StageBMidiToSoloListeningReviewQualityGapError(
             f"expected boundary {expected_boundary}, got {boundary}"
@@ -416,9 +500,23 @@ def validate_listening_review_quality_gap_report(
         raise StageBMidiToSoloListeningReviewQualityGapError(
             "outside-soloing repair source context readiness required"
         )
+    if not bool(readiness.get("outside_soloing_repair_schema_context_preserved", False)):
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing repair schema context readiness required"
+        )
     if not bool(summary.get("outside_soloing_repair_source_context_preserved", False)):
         raise StageBMidiToSoloListeningReviewQualityGapError(
             "outside-soloing repair source context preservation required"
+        )
+    if not bool(summary.get("outside_soloing_repair_schema_context_preserved", False)):
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing repair schema context preservation required"
+        )
+    if str(
+        summary.get("outside_soloing_repair_objective_schema_version") or ""
+    ) != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION:
+        raise StageBMidiToSoloListeningReviewQualityGapError(
+            "outside-soloing repair objective schema version mismatch"
         )
     source_context = _source_context_fields(
         summary,
@@ -457,7 +555,18 @@ def validate_listening_review_quality_gap_report(
             "outside-soloing source residual risk preservation required"
         )
     return {
+        "schema_version": str(report.get("schema_version") or ""),
         "boundary": boundary,
+        "source_schema_version": str(report.get("source_schema_version") or ""),
+        "source_mvp_completion_audit_schema_version": str(
+            report.get("source_mvp_completion_audit_schema_version") or ""
+        ),
+        "source_current_evidence_schema_version": str(
+            report.get("source_current_evidence_schema_version") or ""
+        ),
+        "current_evidence_schema_version": str(
+            summary.get("current_evidence_schema_version") or ""
+        ),
         "next_boundary": str(decision.get("next_boundary") or ""),
         "selected_target": str(selected.get("selected_target") or ""),
         "technical_model_core_mvp_completed": bool(
@@ -471,6 +580,12 @@ def validate_listening_review_quality_gap_report(
         ),
         "outside_soloing_repair_source_context_preserved": bool(
             summary.get("outside_soloing_repair_source_context_preserved", False)
+        ),
+        "outside_soloing_repair_schema_context_preserved": bool(
+            summary.get("outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "outside_soloing_repair_objective_schema_version": str(
+            summary.get("outside_soloing_repair_objective_schema_version") or ""
         ),
         "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
         "max_repaired_interval": _int(summary.get("max_repaired_interval")),
@@ -545,7 +660,11 @@ def markdown_report(report: dict[str, Any]) -> str:
         "## Summary",
         "",
         f"- boundary: `{report['boundary']}`",
+        f"- schema version: `{report['schema_version']}`",
         f"- source boundary: `{report['source_boundary']}`",
+        f"- source schema version: `{report['source_schema_version']}`",
+        f"- source MVP completion audit schema version: `{report['source_mvp_completion_audit_schema_version']}`",
+        f"- source current evidence schema version: `{report['source_current_evidence_schema_version']}`",
         f"- next boundary: `{decision['next_boundary']}`",
         f"- selected target: `{selected['selected_target']}`",
         f"- listening review quality gap open: `{_bool_token(summary['listening_review_quality_gap_open'])}`",
@@ -554,12 +673,15 @@ def markdown_report(report: dict[str, Any]) -> str:
         "",
         "## Evidence",
         "",
+        f"- current evidence schema version: `{summary['current_evidence_schema_version']}`",
         f"- technical model-core MVP completed: `{_bool_token(summary['technical_model_core_mvp_completed'])}`",
         f"- phrase-bank CLI technical path completed: `{_bool_token(summary['phrase_bank_cli_technical_path_completed'])}`",
         f"- model-conditioned pitch-contour objective completed: `{_bool_token(summary['model_conditioned_pitch_contour_objective_completed'])}`",
         f"- changed-ratio repair objective completed: `{_bool_token(summary['changed_ratio_repair_objective_completed'])}`",
         f"- outside-soloing repair objective completed: `{_bool_token(summary['outside_soloing_repair_objective_completed'])}`",
         f"- outside-soloing repair source context preserved: `{_bool_token(summary['outside_soloing_repair_source_context_preserved'])}`",
+        f"- outside-soloing repair schema context preserved: `{_bool_token(summary['outside_soloing_repair_schema_context_preserved'])}`",
+        f"- outside-soloing repair objective schema version: `{summary['outside_soloing_repair_objective_schema_version']}`",
         f"- rendered WAV files: `{summary['rendered_audio_file_count']}`",
         f"- changed-ratio repair max interval / threshold: `{summary['max_repaired_interval']}` / `{summary['max_interval_threshold']}`",
         f"- changed-ratio repair max ratio / target: `{summary['max_repaired_pitch_changed_ratio']:.4f}` / `{summary['target_max_pitch_changed_ratio']:.4f}`",
@@ -613,7 +735,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=736)
+    parser.add_argument("--issue_number", type=int, default=1158)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--expected_target", type=str, default="")

--- a/tests/test_stage_b_midi_to_solo_listening_review_quality_gap.py
+++ b/tests/test_stage_b_midi_to_solo_listening_review_quality_gap.py
@@ -15,8 +15,12 @@ from scripts.decide_stage_b_midi_to_solo_listening_review_quality_gap import (
 from scripts.decide_stage_b_midi_to_solo_quality_gap import (
     BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
     BOUNDARY as QUALITY_GAP_BOUNDARY,
+    CURRENT_EVIDENCE_SCHEMA_VERSION,
     LISTENING_REVIEW_NEXT_BOUNDARY,
     LISTENING_REVIEW_TARGET,
+    MVP_COMPLETION_AUDIT_SCHEMA_VERSION,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    SCHEMA_VERSION as QUALITY_GAP_DECISION_SCHEMA_VERSION,
 )
 
 
@@ -57,7 +61,10 @@ def quality_gap_decision(
     outside_soloing_repair_supported: bool = True,
 ) -> dict:
     return {
+        "schema_version": QUALITY_GAP_DECISION_SCHEMA_VERSION,
         "boundary": QUALITY_GAP_BOUNDARY,
+        "source_schema_version": MVP_COMPLETION_AUDIT_SCHEMA_VERSION,
+        "source_current_evidence_schema_version": CURRENT_EVIDENCE_SCHEMA_VERSION,
         "quality_gap": {
             "technical_model_core_mvp_completed": True,
             "phrase_bank_cli_technical_path_completed": True,
@@ -67,6 +74,10 @@ def quality_gap_decision(
             ),
             "outside_soloing_repair_objective_completed": outside_soloing_repair_supported,
             "outside_soloing_repair_source_context_preserved": outside_soloing_repair_supported,
+            "outside_soloing_repair_schema_context_preserved": outside_soloing_repair_supported,
+            "outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "musical_quality_mvp_completed": False,
             "human_audio_preference_completed": False,
             "product_mvp_completed": False,
@@ -90,6 +101,7 @@ def quality_gap_decision(
             **SOURCE_CONTEXT,
         },
         "mvp_completion_summary": {
+            "current_evidence_schema_version": CURRENT_EVIDENCE_SCHEMA_VERSION,
             "model_conditioned_pitch_contour_changed_ratio_repair_rendered_audio_file_count": 3,
             "model_conditioned_pitch_contour_changed_ratio_repair_max_interval": (
                 12 if changed_ratio_supported else 13
@@ -106,6 +118,10 @@ def quality_gap_decision(
             ),
             "outside_soloing_repair_pitch_role_risk_delta": 2,
             "outside_soloing_repair_objective_path_supported": outside_soloing_repair_supported,
+            "outside_soloing_repair_schema_context_preserved": outside_soloing_repair_supported,
+            "outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "outside_soloing_repair_weak_landing_target_supported": True,
             "outside_soloing_repair_final_landing_target_supported": True,
             "outside_soloing_repair_non_chord_run_target_supported": True,
@@ -121,6 +137,7 @@ def quality_gap_decision(
             "selected_target": selected_target,
             "next_boundary_selected": next_boundary,
             "outside_soloing_repair_source_context_preserved": outside_soloing_repair_supported,
+            "outside_soloing_repair_schema_context_preserved": outside_soloing_repair_supported,
             "human_review_required_now": False,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
@@ -140,7 +157,7 @@ class StageBMidiToSoloListeningReviewQualityGapTest(unittest.TestCase):
         report = build_listening_review_quality_gap_report(
             quality_gap_decision=quality_gap_decision(),
             output_dir=Path("outputs/listening_review_quality_gap"),
-            issue_number=1074,
+            issue_number=1158,
         )
         summary = validate_listening_review_quality_gap_report(
             report,
@@ -153,10 +170,32 @@ class StageBMidiToSoloListeningReviewQualityGapTest(unittest.TestCase):
 
         self.assertEqual(summary["selected_target"], SELECTED_TARGET)
         self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
+        self.assertEqual(summary["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(
+            summary["source_schema_version"],
+            QUALITY_GAP_DECISION_SCHEMA_VERSION,
+        )
+        self.assertEqual(
+            summary["source_mvp_completion_audit_schema_version"],
+            MVP_COMPLETION_AUDIT_SCHEMA_VERSION,
+        )
+        self.assertEqual(
+            summary["source_current_evidence_schema_version"],
+            CURRENT_EVIDENCE_SCHEMA_VERSION,
+        )
+        self.assertEqual(
+            summary["current_evidence_schema_version"],
+            CURRENT_EVIDENCE_SCHEMA_VERSION,
+        )
         self.assertTrue(summary["technical_model_core_mvp_completed"])
         self.assertTrue(summary["changed_ratio_repair_objective_completed"])
         self.assertTrue(summary["outside_soloing_repair_objective_completed"])
         self.assertTrue(summary["outside_soloing_repair_source_context_preserved"])
+        self.assertTrue(summary["outside_soloing_repair_schema_context_preserved"])
+        self.assertEqual(
+            summary["outside_soloing_repair_objective_schema_version"],
+            OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+        )
         self.assertEqual(summary["rendered_audio_file_count"], 3)
         self.assertEqual(summary["max_repaired_interval"], 12)
         self.assertEqual(summary["max_interval_threshold"], 12)
@@ -200,7 +239,36 @@ class StageBMidiToSoloListeningReviewQualityGapTest(unittest.TestCase):
             "Stage B MIDI-to-solo MVP delivery package source-context refresh",
         )
         self.assertEqual(report["schema_version"], SCHEMA_VERSION)
-        self.assertEqual(report["issue_number"], 1074)
+        self.assertEqual(report["source_schema_version"], QUALITY_GAP_DECISION_SCHEMA_VERSION)
+        self.assertEqual(
+            report["source_mvp_completion_audit_schema_version"],
+            MVP_COMPLETION_AUDIT_SCHEMA_VERSION,
+        )
+        self.assertEqual(
+            report["source_current_evidence_schema_version"],
+            CURRENT_EVIDENCE_SCHEMA_VERSION,
+        )
+        self.assertEqual(report["issue_number"], 1158)
+
+    def test_rejects_quality_gap_decision_schema_mismatch(self) -> None:
+        source = quality_gap_decision()
+        source["schema_version"] = "stale_schema"
+        with self.assertRaises(StageBMidiToSoloListeningReviewQualityGapError):
+            build_listening_review_quality_gap_report(
+                quality_gap_decision=source,
+                output_dir=Path("outputs/listening_review_quality_gap"),
+                issue_number=1158,
+            )
+
+    def test_rejects_quality_gap_decision_source_schema_mismatch(self) -> None:
+        source = quality_gap_decision()
+        source["source_schema_version"] = "stale_schema"
+        with self.assertRaises(StageBMidiToSoloListeningReviewQualityGapError):
+            build_listening_review_quality_gap_report(
+                quality_gap_decision=source,
+                output_dir=Path("outputs/listening_review_quality_gap"),
+                issue_number=1158,
+            )
 
     def test_rejects_wrong_selected_target(self) -> None:
         with self.assertRaises(StageBMidiToSoloListeningReviewQualityGapError):
@@ -273,6 +341,34 @@ class StageBMidiToSoloListeningReviewQualityGapTest(unittest.TestCase):
                 issue_number=1074,
             )
 
+    def test_rejects_false_outside_soloing_schema_context_preserved_flag(self) -> None:
+        source = quality_gap_decision()
+        source["quality_gap"]["outside_soloing_repair_schema_context_preserved"] = False
+
+        with self.assertRaises(StageBMidiToSoloListeningReviewQualityGapError):
+            build_listening_review_quality_gap_report(
+                quality_gap_decision=source,
+                output_dir=Path("outputs/listening_review_quality_gap"),
+                issue_number=1158,
+            )
+
+    def test_rejects_listening_review_quality_gap_schema_mismatch(self) -> None:
+        report = build_listening_review_quality_gap_report(
+            quality_gap_decision=quality_gap_decision(),
+            output_dir=Path("outputs/listening_review_quality_gap"),
+            issue_number=1158,
+        )
+        report["schema_version"] = "stale_schema"
+        with self.assertRaises(StageBMidiToSoloListeningReviewQualityGapError):
+            validate_listening_review_quality_gap_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                expected_target=SELECTED_TARGET,
+                require_delivery_package_ready=True,
+                require_no_quality_claim=True,
+            )
+
     def test_rejects_targeted_outside_soloing_source_repair(self) -> None:
         source = quality_gap_decision()
         source["quality_gap"]["outside_soloing_repair_source_targeted"] = True
@@ -311,7 +407,7 @@ class StageBMidiToSoloListeningReviewQualityGapTest(unittest.TestCase):
         self.assertEqual(SELECTED_TARGET, "mvp_delivery_package")
         self.assertEqual(
             SCHEMA_VERSION,
-            "stage_b_midi_to_solo_listening_review_quality_gap_v3",
+            "stage_b_midi_to_solo_listening_review_quality_gap_v4",
         )
 
 


### PR DESCRIPTION
## Summary

- listening review quality gap schema v4 적용
- quality gap decision schema v4 및 source schema chain 입력 검증 추가
- outside-soloing repair schema-context preserved와 objective schema version summary 전파
- #1158 기준 generated listening gap doc, README, current status, core plan, handoff scope 갱신

## Context

- #1156 quality gap decision source-context refresh 완료
- source quality gap schema: `stage_b_midi_to_solo_quality_gap_decision_v4`
- source MVP completion audit schema: `stage_b_midi_to_solo_mvp_completion_audit_v4`
- source current evidence schema: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
- selected target: `mvp_delivery_package`
- listening review quality gap: `open`
- musical quality/preference claim: `false`

## Scope

- `scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py`
  - quality gap decision schema mismatch 차단
  - source MVP/current evidence schema mismatch 차단
  - outside-soloing repair schema-context/objective schema summary 전파
- `tests/test_stage_b_midi_to_solo_listening_review_quality_gap.py`
  - source schema mismatch 차단 테스트
  - listening gap schema mismatch 차단 테스트
  - schema-context preserved false 입력 차단 테스트
- `scripts/agent_harness.sh`
  - listening review quality gap issue number #1158 반영
- README/status/core plan/generated listening gap doc 최신 경계 반영

## Validation

- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_listening_review_quality_gap`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_listening_review_quality_gap.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-listening-review-quality-gap`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- public diff scan for tool-neutral wording

## Risk

- listening review gap은 open 상태 유지
- technical delivery package 준비 가능 여부 판단만 포함
- musical quality/preference claim 제외 유지

Closes #1158
