### PR TITLE
Stage B MIDI-to-solo MVP delivery package source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Current handoff scope:
 - Latest audit issue completed: Issue #1154, Stage B MIDI-to-solo MVP completion audit source-context refresh.
 - Latest quality gap decision completed: Issue #1156, Stage B MIDI-to-solo quality gap decision source-context refresh.
 - Latest listening review quality gap completed: Issue #1158, Stage B MIDI-to-solo listening review quality gap source-context refresh.
-- Latest MVP delivery package completed: Issue #1076, Stage B MIDI-to-solo MVP delivery package source-context refresh.
+- Latest MVP delivery package completed: Issue #1160, Stage B MIDI-to-solo MVP delivery package source-context refresh.
 - Latest README final evidence refresh completed: Issue #1078, Stage B MIDI-to-solo README final evidence refresh source-context refresh.
 - Latest final status audit completed: Issue #1080, Stage B MIDI-to-solo final status audit source-context refresh.
 - Latest post-MVP quality iteration plan completed: Issue #1082, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1148, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after Stage B MIDI-to-solo listening review quality gap source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo MVP delivery package source-context refresh.
+- Open issue queue after Stage B MIDI-to-solo MVP delivery package source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo README final evidence refresh source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP completion audit: `Issue #1154`
 - latest quality gap decision: `Issue #1156`
 - latest listening review quality gap: `Issue #1158`
-- latest MVP delivery package: `Issue #1076`
+- latest MVP delivery package: `Issue #1160`
 - latest README final evidence refresh: `Issue #1078`
 - latest final status audit: `Issue #1080`
 - latest post-MVP quality iteration plan: `Issue #1082`
@@ -50,8 +50,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1150`
 - latest README evidence refresh: `Issue #1152`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after listening review quality gap source-context refresh merge: `0`
-- latest evidence boundary: `stage_b_midi_to_solo_listening_review_quality_gap`
+- open issue queue after MVP delivery package source-context refresh merge: `0`
+- latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - current MVP evidence support: `true`
@@ -618,6 +618,10 @@ Listening review quality gap.
 MVP delivery package.
 
 - boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_readme_final_evidence_refresh`
 - runnable CLI ready: `true`
 - input to ranked MIDI ready: `true`
@@ -625,6 +629,8 @@ MVP delivery package.
 - changed-ratio repair audio evidence ready: `true`
 - outside-soloing repair evidence ready: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -396,7 +396,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo MVP completion audit refresh: schema `stage_b_midi_to_solo_mvp_completion_audit_v4`, current evidence schema `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`, technical model-core MVP `true`, model-conditioned pitch-contour objective `true`, changed-ratio repair objective `true`, outside-soloing schema-context preserved `true`, musical/product MVP `false/false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_gap_decision`
 - MIDI-to-solo quality gap decision refresh: schema `stage_b_midi_to_solo_quality_gap_decision_v4`, source audit schema `stage_b_midi_to_solo_mvp_completion_audit_v4`, current evidence schema `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`, selected target `listening_review_quality_gap`, outside-soloing schema-context preserved `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_listening_review_quality_gap`
 - MIDI-to-solo listening review quality gap: schema `stage_b_midi_to_solo_listening_review_quality_gap_v4`, source quality gap schema `stage_b_midi_to_solo_quality_gap_decision_v4`, current evidence schema `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`, selected target `mvp_delivery_package`, technical delivery package ready `true`, listening gap open `true`, outside-soloing schema-context preserved `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_delivery_package`
-- MIDI-to-solo MVP delivery package: runnable CLI `true`, input ranked MIDI `true`, rendered WAV evidence `true`, CLI/changed-ratio audio candidate count `3/3`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_readme_final_evidence_refresh`
+- MIDI-to-solo MVP delivery package: schema `stage_b_midi_to_solo_mvp_delivery_package_v4`, source listening gap schema `stage_b_midi_to_solo_listening_review_quality_gap_v4`, current evidence schema `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`, runnable CLI `true`, input ranked MIDI `true`, rendered WAV evidence `true`, CLI/changed-ratio audio candidate count `3/3`, outside-soloing schema-context preserved `true`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_readme_final_evidence_refresh`
 - MIDI-to-solo README final evidence refresh: latest evidence boundary `stage_b_midi_to_solo_mvp_delivery_package`, runnable CLI `true`, input ranked MIDI/WAV evidence `true/true`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_final_status_audit`
 - MIDI-to-solo final status audit: technical MVP complete `true`, local review ready `true`, README final evidence reflected `true`, CLI/WAV count `3/3`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
 - MIDI-to-solo post-MVP quality iteration plan: selected target `quality_rubric_baseline`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, ordered work `4`, taxonomy seed `7`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_rubric_baseline`
@@ -12291,12 +12291,16 @@ Issue #1158은 Issue #1156 quality gap decision의 schema/source-context preserv
 
 ## 9.228 Stage B MIDI-to-solo MVP delivery package source-context refresh
 
-Issue #1076은 Issue #1074 listening review quality gap의 source-context preserved flag 3개를 MVP delivery package manifest와 validation summary까지 보존하고, 다음 boundary를 README final evidence refresh로 유지한 작업이다.
+Issue #1160은 Issue #1158 listening review quality gap의 schema/source-context 결과를 MVP delivery package manifest와 validation summary까지 보존하고, 다음 boundary를 README final evidence refresh로 유지한 작업이다.
 
 결과:
 
 - document: `docs/STAGE_B_MIDI_TO_SOLO_MVP_DELIVERY_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_readme_final_evidence_refresh`
 - technical MVP delivery package completed: `true`
 - runnable CLI ready: `true`
@@ -12305,6 +12309,8 @@ Issue #1076은 Issue #1074 listening review quality gap의 source-context preser
 - changed-ratio repair audio evidence ready: `true`
 - outside-soloing repair evidence ready: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -16,7 +16,7 @@
 - latest MVP completion audit: Issue #1154, Stage B MIDI-to-solo MVP completion audit source-context refresh
 - latest quality gap decision: Issue #1156, Stage B MIDI-to-solo quality gap decision source-context refresh
 - latest listening review quality gap: Issue #1158, Stage B MIDI-to-solo listening review quality gap source-context refresh
-- latest MVP delivery package: Issue #1076, Stage B MIDI-to-solo MVP delivery package source-context refresh
+- latest MVP delivery package: Issue #1160, Stage B MIDI-to-solo MVP delivery package source-context refresh
 - latest README final evidence refresh: Issue #1078, Stage B MIDI-to-solo README final evidence refresh source-context refresh
 - latest final status audit: Issue #1080, Stage B MIDI-to-solo final status audit source-context refresh
 - latest post-MVP quality iteration plan: Issue #1082, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1150, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after Stage B MIDI-to-solo listening review quality gap source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo MVP delivery package source-context refresh`
+- open issue queue after Stage B MIDI-to-solo MVP delivery package source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo README final evidence refresh source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -5545,20 +5545,24 @@ Issue #1158은 Issue #1156 quality gap decision의 schema/source-context preserv
 
 ## Stage B MIDI-to-Solo MVP Delivery Package Source-Context Refresh Result
 
-Issue #1076은 Issue #1074 listening review quality gap의 source-context preserved flag 3개를 MVP delivery package manifest와 validation summary까지 보존하고, 다음 boundary를 README final evidence refresh로 유지한 작업이다.
+Issue #1160은 Issue #1158 listening review quality gap의 schema/source-context 결과를 MVP delivery package manifest와 validation summary까지 보존하고, 다음 boundary를 README final evidence refresh로 유지한 작업이다.
 
 변경:
 
-- MVP delivery package schema v3 적용
-- source-context required key를 preserved flag 3개 포함으로 확장
-- false preserved flag 입력 차단 테스트 추가
-- delivery package manifest, generated markdown report, validation summary source-context preserved field 전파
-- harness issue number #1076 반영
+- MVP delivery package schema v4 적용
+- source listening gap schema v4, quality gap decision schema v4, current evidence schema v4 필수 검증
+- outside-soloing schema-context preserved flag와 objective schema version 필수 검증
+- delivery package manifest, generated markdown report, validation summary schema/source-context field 전파
+- harness issue number #1160 반영
 
 결과:
 
 - document: `docs/STAGE_B_MIDI_TO_SOLO_MVP_DELIVERY_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_readme_final_evidence_refresh`
 - technical MVP delivery package completed: `true`
 - runnable CLI ready: `true`
@@ -5567,6 +5571,8 @@ Issue #1076은 Issue #1074 listening review quality gap의 source-context preser
 - changed-ratio repair audio evidence ready: `true`
 - outside-soloing repair evidence ready: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`

--- a/docs/STAGE_B_MIDI_TO_SOLO_MVP_DELIVERY_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_MVP_DELIVERY_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -3,7 +3,11 @@
 ## Summary
 
 - boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
 - next boundary: `stage_b_midi_to_solo_readme_final_evidence_refresh`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - technical MVP delivery package completed: `true`
 - runnable CLI ready: `true`
 - input to ranked MIDI ready: `true`
@@ -11,6 +15,7 @@
 - changed-ratio repair audio evidence ready: `true`
 - outside-soloing repair evidence ready: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
 - listening review quality gap open: `true`
 
 ## Run Command
@@ -27,6 +32,7 @@
 - changed-ratio repair max interval / target: `12` / `12`
 - changed-ratio repair WAV duration range: `18.422s` - `18.978s`
 - outside-soloing repair WAV count: `6`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - outside-soloing repair changed note total: `2`
 - outside-soloing source objective pitch-role risk: `5`
 - outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6093,7 +6093,7 @@ run_stage_b_midi_to_solo_mvp_delivery_package() {
     --cli_mvp_package "$cli_package" \
     --changed_ratio_audio_package "$changed_ratio_audio" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_MVP_DELIVERY_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1076 \
+    --issue_number 1160 \
     --expected_boundary stage_b_midi_to_solo_mvp_delivery_package \
     --expected_next_boundary stage_b_midi_to_solo_readme_final_evidence_refresh \
     --require_delivery_completed \

--- a/scripts/build_stage_b_midi_to_solo_mvp_delivery_package.py
+++ b/scripts/build_stage_b_midi_to_solo_mvp_delivery_package.py
@@ -18,7 +18,11 @@ from scripts.decide_stage_b_midi_to_solo_listening_review_quality_gap import (  
     BRIDGE_SOURCE_CONTEXT_KEYS,
     BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
     BOUNDARY as LISTENING_GAP_BOUNDARY,
+    CURRENT_EVIDENCE_SCHEMA_VERSION,
     NEXT_BOUNDARY as LISTENING_GAP_NEXT_BOUNDARY,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    QUALITY_GAP_DECISION_SCHEMA_VERSION,
+    SCHEMA_VERSION as LISTENING_GAP_SCHEMA_VERSION,
 )
 from scripts.run_stage_b_midi_to_solo_phrase_bank_cli_mvp_package import (  # noqa: E402
     BOUNDARY as CLI_PACKAGE_BOUNDARY,
@@ -31,7 +35,7 @@ class StageBMidiToSoloMvpDeliveryPackageError(ValueError):
 
 BOUNDARY = "stage_b_midi_to_solo_mvp_delivery_package"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_readme_final_evidence_refresh"
-SCHEMA_VERSION = "stage_b_midi_to_solo_mvp_delivery_package_v3"
+SCHEMA_VERSION = "stage_b_midi_to_solo_mvp_delivery_package_v4"
 CHANGED_RATIO_AUDIO_BOUNDARY = (
     "stage_b_midi_to_solo_model_conditioned_pitch_contour_changed_ratio_repair_audio_package"
 )
@@ -112,6 +116,18 @@ def validate_listening_gap(report: dict[str, Any]) -> dict[str, Any]:
     readiness = _dict(report.get("readiness"))
     decision = _dict(report.get("decision"))
     summary = _dict(report.get("quality_gap_summary"))
+    if str(report.get("schema_version") or "") != LISTENING_GAP_SCHEMA_VERSION:
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "listening review quality gap schema version mismatch"
+        )
+    if str(report.get("source_schema_version") or "") != QUALITY_GAP_DECISION_SCHEMA_VERSION:
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "listening review source quality gap schema version mismatch"
+        )
+    if str(report.get("source_current_evidence_schema_version") or "") != CURRENT_EVIDENCE_SCHEMA_VERSION:
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "listening review source current evidence schema version mismatch"
+        )
     if str(report.get("boundary") or "") != LISTENING_GAP_BOUNDARY:
         raise StageBMidiToSoloMvpDeliveryPackageError("listening review quality gap boundary required")
     if str(decision.get("next_boundary") or "") != LISTENING_GAP_NEXT_BOUNDARY:
@@ -132,14 +148,32 @@ def validate_listening_gap(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloMvpDeliveryPackageError(
             "outside-soloing repair source context readiness required"
         )
+    if not bool(readiness.get("outside_soloing_repair_schema_context_preserved", False)):
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "outside-soloing repair schema context readiness required"
+        )
     if not bool(summary.get("outside_soloing_repair_source_context_preserved", False)):
         raise StageBMidiToSoloMvpDeliveryPackageError(
             "outside-soloing repair source context preservation required"
+        )
+    if not bool(summary.get("outside_soloing_repair_schema_context_preserved", False)):
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "outside-soloing repair schema context preservation required"
+        )
+    if str(
+        summary.get("outside_soloing_repair_objective_schema_version") or ""
+    ) != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION:
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "outside-soloing repair objective schema version mismatch"
         )
     source_context = _source_context_fields(
         summary,
         label="listening review quality gap",
     )
+    if str(summary.get("current_evidence_schema_version") or "") != CURRENT_EVIDENCE_SCHEMA_VERSION:
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "listening review summary current evidence schema version mismatch"
+        )
     if _int(summary.get("rendered_audio_file_count")) < 3:
         raise StageBMidiToSoloMvpDeliveryPackageError("changed-ratio repair rendered WAV count below 3")
     if _int(summary.get("max_repaired_interval")) > _int(summary.get("max_interval_threshold")):
@@ -200,11 +234,23 @@ def validate_listening_gap(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloMvpDeliveryPackageError("critical user input should not be required")
     _require_no_quality_claim(readiness, label="listening gap readiness")
     return {
+        "listening_gap_schema_version": LISTENING_GAP_SCHEMA_VERSION,
+        "source_quality_gap_schema_version": QUALITY_GAP_DECISION_SCHEMA_VERSION,
+        "source_current_evidence_schema_version": CURRENT_EVIDENCE_SCHEMA_VERSION,
+        "current_evidence_schema_version": str(
+            summary.get("current_evidence_schema_version") or ""
+        ),
         "technical_model_core_mvp_completed": True,
         "changed_ratio_repair_objective_completed": True,
         "outside_soloing_repair_objective_completed": True,
         "outside_soloing_repair_source_context_preserved": bool(
             summary.get("outside_soloing_repair_source_context_preserved", False)
+        ),
+        "outside_soloing_repair_schema_context_preserved": bool(
+            summary.get("outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "outside_soloing_repair_objective_schema_version": str(
+            summary.get("outside_soloing_repair_objective_schema_version") or ""
         ),
         "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
         "max_repaired_interval": _int(summary.get("max_repaired_interval")),
@@ -375,6 +421,11 @@ def build_delivery_package_report(
         "output_dir": str(output_dir),
         "issue_number": int(issue_number),
         "boundary": BOUNDARY,
+        "source_schema_versions": {
+            "listening_review_quality_gap": listening["listening_gap_schema_version"],
+            "quality_gap_decision": listening["source_quality_gap_schema_version"],
+            "current_evidence": listening["source_current_evidence_schema_version"],
+        },
         "source_boundaries": {
             "listening_review_quality_gap": LISTENING_GAP_BOUNDARY,
             "phrase_bank_cli_mvp_package": CLI_PACKAGE_BOUNDARY,
@@ -390,6 +441,12 @@ def build_delivery_package_report(
             "outside_soloing_repair_source_context_preserved": bool(
                 listening["outside_soloing_repair_source_context_preserved"]
             ),
+            "outside_soloing_repair_schema_context_preserved": bool(
+                listening["outside_soloing_repair_schema_context_preserved"]
+            ),
+            "outside_soloing_repair_objective_schema_version": listening[
+                "outside_soloing_repair_objective_schema_version"
+            ],
             "listening_review_quality_gap_open": bool(
                 listening["listening_review_quality_gap_open"]
             ),
@@ -462,6 +519,9 @@ def build_delivery_package_report(
             "outside_soloing_repair_source_context_preserved": bool(
                 listening["outside_soloing_repair_source_context_preserved"]
             ),
+            "outside_soloing_repair_schema_context_preserved": bool(
+                listening["outside_soloing_repair_schema_context_preserved"]
+            ),
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
             "phrase_bank_musical_quality_claimed": False,
@@ -504,9 +564,30 @@ def validate_delivery_package_report(
     readiness = _dict(report.get("readiness"))
     decision = _dict(report.get("decision"))
     package = _dict(report.get("delivery_package"))
+    source_schema_versions = _dict(report.get("source_schema_versions"))
     artifact_manifest = _dict(report.get("artifact_manifest"))
     cli_candidates = _list(artifact_manifest.get("cli_repaired_midi_candidates"))
     audio_candidates = _list(artifact_manifest.get("changed_ratio_repair_audio_candidates"))
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "MVP delivery package schema version mismatch"
+        )
+    if str(
+        source_schema_versions.get("listening_review_quality_gap") or ""
+    ) != LISTENING_GAP_SCHEMA_VERSION:
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "delivery package source listening gap schema version mismatch"
+        )
+    if str(
+        source_schema_versions.get("quality_gap_decision") or ""
+    ) != QUALITY_GAP_DECISION_SCHEMA_VERSION:
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "delivery package source quality gap schema version mismatch"
+        )
+    if str(source_schema_versions.get("current_evidence") or "") != CURRENT_EVIDENCE_SCHEMA_VERSION:
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "delivery package source current evidence schema version mismatch"
+        )
     if expected_boundary and boundary != expected_boundary:
         raise StageBMidiToSoloMvpDeliveryPackageError(
             f"expected boundary {expected_boundary}, got {boundary}"
@@ -531,9 +612,23 @@ def validate_delivery_package_report(
         raise StageBMidiToSoloMvpDeliveryPackageError(
             "outside-soloing repair source context readiness required"
         )
+    if not bool(readiness.get("outside_soloing_repair_schema_context_preserved", False)):
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "outside-soloing repair schema context readiness required"
+        )
     if not bool(package.get("outside_soloing_repair_source_context_preserved", False)):
         raise StageBMidiToSoloMvpDeliveryPackageError(
             "outside-soloing repair source context preservation required"
+        )
+    if not bool(package.get("outside_soloing_repair_schema_context_preserved", False)):
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "outside-soloing repair schema context preservation required"
+        )
+    if str(
+        package.get("outside_soloing_repair_objective_schema_version") or ""
+    ) != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION:
+        raise StageBMidiToSoloMvpDeliveryPackageError(
+            "outside-soloing repair objective schema version mismatch"
         )
     source_context = _source_context_fields(
         package,
@@ -584,6 +679,16 @@ def validate_delivery_package_report(
     if require_no_quality_claim:
         _require_no_quality_claim(readiness, label="MVP delivery package readiness")
     return {
+        "schema_version": str(report.get("schema_version") or ""),
+        "source_listening_gap_schema_version": str(
+            source_schema_versions.get("listening_review_quality_gap") or ""
+        ),
+        "source_quality_gap_schema_version": str(
+            source_schema_versions.get("quality_gap_decision") or ""
+        ),
+        "source_current_evidence_schema_version": str(
+            source_schema_versions.get("current_evidence") or ""
+        ),
         "boundary": boundary,
         "next_boundary": str(decision.get("next_boundary") or ""),
         "mvp_delivery_package_completed": bool(
@@ -602,6 +707,12 @@ def validate_delivery_package_report(
         ),
         "outside_soloing_repair_source_context_preserved": bool(
             package.get("outside_soloing_repair_source_context_preserved", False)
+        ),
+        "outside_soloing_repair_schema_context_preserved": bool(
+            package.get("outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "outside_soloing_repair_objective_schema_version": str(
+            package.get("outside_soloing_repair_objective_schema_version") or ""
         ),
         "cli_candidate_count": _int(package.get("cli_candidate_count")),
         "changed_ratio_repair_wav_count": _int(package.get("changed_ratio_repair_wav_count")),
@@ -651,7 +762,11 @@ def markdown_report(report: dict[str, Any]) -> str:
         "## Summary",
         "",
         f"- boundary: `{report['boundary']}`",
+        f"- schema version: `{report['schema_version']}`",
         f"- next boundary: `{decision['next_boundary']}`",
+        f"- source listening gap schema version: `{report['source_schema_versions']['listening_review_quality_gap']}`",
+        f"- source quality gap schema version: `{report['source_schema_versions']['quality_gap_decision']}`",
+        f"- source current evidence schema version: `{report['source_schema_versions']['current_evidence']}`",
         f"- technical MVP delivery package completed: `{_bool_token(package['technical_mvp_delivery_package_completed'])}`",
         f"- runnable CLI ready: `{_bool_token(package['runnable_cli_ready'])}`",
         f"- input to ranked MIDI ready: `{_bool_token(package['input_to_ranked_midi_ready'])}`",
@@ -659,6 +774,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- changed-ratio repair audio evidence ready: `{_bool_token(package['changed_ratio_repair_audio_evidence_ready'])}`",
         f"- outside-soloing repair evidence ready: `{_bool_token(package['outside_soloing_repair_evidence_ready'])}`",
         f"- outside-soloing repair source context preserved: `{_bool_token(package['outside_soloing_repair_source_context_preserved'])}`",
+        f"- outside-soloing repair schema context preserved: `{_bool_token(package['outside_soloing_repair_schema_context_preserved'])}`",
         f"- listening review quality gap open: `{_bool_token(package['listening_review_quality_gap_open'])}`",
         "",
         "## Run Command",
@@ -675,6 +791,7 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- changed-ratio repair max interval / target: `{package['changed_ratio_repair_interval_target'][0]}` / `{package['changed_ratio_repair_interval_target'][1]}`",
         f"- changed-ratio repair WAV duration range: `{package['changed_ratio_repair_wav_duration_range'][0]:.3f}s` - `{package['changed_ratio_repair_wav_duration_range'][1]:.3f}s`",
         f"- outside-soloing repair WAV count: `{package['outside_soloing_repair_wav_count']}`",
+        f"- outside-soloing repair objective schema version: `{package['outside_soloing_repair_objective_schema_version']}`",
         f"- outside-soloing repair changed note total: `{package['outside_soloing_repair_changed_note_total']}`",
         f"- outside-soloing source objective pitch-role risk: `{package['outside_soloing_repair_source_objective_pitch_role_risk_count']}`",
         f"- outside-soloing source pitch-role risk before / after / delta: `{package['outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{package['outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{package['outside_soloing_repair_source_pitch_role_risk_delta']}`",
@@ -718,7 +835,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=738)
+    parser.add_argument("--issue_number", type=int, default=1160)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--require_delivery_completed", action="store_true")

--- a/tests/test_stage_b_midi_to_solo_final_status_audit.py
+++ b/tests/test_stage_b_midi_to_solo_final_status_audit.py
@@ -15,7 +15,12 @@ from scripts.audit_stage_b_midi_to_solo_final_status import (
 )
 from scripts.build_stage_b_midi_to_solo_mvp_delivery_package import (
     BOUNDARY as DELIVERY_BOUNDARY,
+    CURRENT_EVIDENCE_SCHEMA_VERSION,
+    LISTENING_GAP_SCHEMA_VERSION,
     NEXT_BOUNDARY as DELIVERY_NEXT_BOUNDARY,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    QUALITY_GAP_DECISION_SCHEMA_VERSION,
+    SCHEMA_VERSION as DELIVERY_SCHEMA_VERSION,
 )
 
 
@@ -54,7 +59,13 @@ def readme_text(*, missing_last: bool = False) -> str:
 
 def delivery_package(*, quality_claim: bool = False, cli_count: int = 3) -> dict:
     return {
+        "schema_version": DELIVERY_SCHEMA_VERSION,
         "boundary": DELIVERY_BOUNDARY,
+        "source_schema_versions": {
+            "listening_review_quality_gap": LISTENING_GAP_SCHEMA_VERSION,
+            "quality_gap_decision": QUALITY_GAP_DECISION_SCHEMA_VERSION,
+            "current_evidence": CURRENT_EVIDENCE_SCHEMA_VERSION,
+        },
         "delivery_package": {
             "runnable_cli_ready": True,
             "input_to_ranked_midi_ready": True,
@@ -62,6 +73,10 @@ def delivery_package(*, quality_claim: bool = False, cli_count: int = 3) -> dict
             "changed_ratio_repair_audio_evidence_ready": True,
             "outside_soloing_repair_evidence_ready": True,
             "outside_soloing_repair_source_context_preserved": True,
+            "outside_soloing_repair_schema_context_preserved": True,
+            "outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "cli_candidate_count": cli_count,
             "changed_ratio_repair_wav_count": 3,
             "outside_soloing_repair_wav_count": 6,
@@ -85,6 +100,7 @@ def delivery_package(*, quality_claim: bool = False, cli_count: int = 3) -> dict
             "mvp_delivery_package_completed": True,
             "raw_artifact_upload_required": False,
             "outside_soloing_repair_source_context_preserved": True,
+            "outside_soloing_repair_schema_context_preserved": True,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
             "phrase_bank_musical_quality_claimed": False,

--- a/tests/test_stage_b_midi_to_solo_mvp_delivery_package.py
+++ b/tests/test_stage_b_midi_to_solo_mvp_delivery_package.py
@@ -15,7 +15,11 @@ from scripts.build_stage_b_midi_to_solo_mvp_delivery_package import (
 from scripts.decide_stage_b_midi_to_solo_listening_review_quality_gap import (
     BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
     BOUNDARY as LISTENING_GAP_BOUNDARY,
+    CURRENT_EVIDENCE_SCHEMA_VERSION,
     NEXT_BOUNDARY as LISTENING_GAP_NEXT_BOUNDARY,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    QUALITY_GAP_DECISION_SCHEMA_VERSION,
+    SCHEMA_VERSION as LISTENING_GAP_SCHEMA_VERSION,
 )
 from scripts.run_stage_b_midi_to_solo_phrase_bank_cli_mvp_package import (
     BOUNDARY as CLI_PACKAGE_BOUNDARY,
@@ -62,12 +66,24 @@ def listening_gap_report(
     outside_soloing_repair_supported: bool = True,
 ) -> dict:
     return {
+        "schema_version": LISTENING_GAP_SCHEMA_VERSION,
         "boundary": LISTENING_GAP_BOUNDARY,
+        "source_schema_versions": {
+            "quality_gap_decision": QUALITY_GAP_DECISION_SCHEMA_VERSION,
+            "current_evidence": CURRENT_EVIDENCE_SCHEMA_VERSION,
+        },
+        "source_schema_version": QUALITY_GAP_DECISION_SCHEMA_VERSION,
+        "source_current_evidence_schema_version": CURRENT_EVIDENCE_SCHEMA_VERSION,
         "quality_gap_summary": {
+            "current_evidence_schema_version": CURRENT_EVIDENCE_SCHEMA_VERSION,
             "technical_model_core_mvp_completed": True,
             "changed_ratio_repair_objective_completed": True,
             "outside_soloing_repair_objective_completed": outside_soloing_repair_supported,
             "outside_soloing_repair_source_context_preserved": outside_soloing_repair_supported,
+            "outside_soloing_repair_schema_context_preserved": outside_soloing_repair_supported,
+            "outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "rendered_audio_file_count": 3,
             "max_repaired_interval": 12,
             "max_interval_threshold": 12,
@@ -94,6 +110,7 @@ def listening_gap_report(
             "listening_review_quality_gap_completed": True,
             "technical_mvp_delivery_package_ready": True,
             "outside_soloing_repair_source_context_preserved": outside_soloing_repair_supported,
+            "outside_soloing_repair_schema_context_preserved": outside_soloing_repair_supported,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
             "broad_trained_model_quality_claimed": False,
@@ -198,7 +215,7 @@ class StageBMidiToSoloMvpDeliveryPackageTest(unittest.TestCase):
                 cli_mvp_package=cli_package_report(tmp_path),
                 changed_ratio_audio_package=changed_ratio_audio_report(tmp_path),
                 output_dir=tmp_path / "delivery",
-                issue_number=1076,
+                issue_number=1160,
             )
             summary = validate_delivery_package_report(
                 report,
@@ -215,6 +232,21 @@ class StageBMidiToSoloMvpDeliveryPackageTest(unittest.TestCase):
         self.assertTrue(summary["changed_ratio_repair_audio_evidence_ready"])
         self.assertTrue(summary["outside_soloing_repair_evidence_ready"])
         self.assertTrue(summary["outside_soloing_repair_source_context_preserved"])
+        self.assertEqual(summary["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(summary["source_listening_gap_schema_version"], LISTENING_GAP_SCHEMA_VERSION)
+        self.assertEqual(
+            summary["source_quality_gap_schema_version"],
+            QUALITY_GAP_DECISION_SCHEMA_VERSION,
+        )
+        self.assertEqual(
+            summary["source_current_evidence_schema_version"],
+            CURRENT_EVIDENCE_SCHEMA_VERSION,
+        )
+        self.assertTrue(summary["outside_soloing_repair_schema_context_preserved"])
+        self.assertEqual(
+            summary["outside_soloing_repair_objective_schema_version"],
+            OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+        )
         self.assertEqual(summary["cli_candidate_count"], 3)
         self.assertEqual(summary["changed_ratio_repair_wav_count"], 3)
         self.assertEqual(summary["outside_soloing_repair_wav_count"], 6)
@@ -247,7 +279,43 @@ class StageBMidiToSoloMvpDeliveryPackageTest(unittest.TestCase):
             "Stage B MIDI-to-solo README final evidence refresh source-context refresh",
         )
         self.assertEqual(report["schema_version"], SCHEMA_VERSION)
-        self.assertEqual(report["issue_number"], 1076)
+        self.assertEqual(
+            report["source_schema_versions"]["listening_review_quality_gap"],
+            LISTENING_GAP_SCHEMA_VERSION,
+        )
+        self.assertEqual(
+            report["source_schema_versions"]["quality_gap_decision"],
+            QUALITY_GAP_DECISION_SCHEMA_VERSION,
+        )
+        self.assertEqual(report["issue_number"], 1160)
+
+    def test_rejects_listening_gap_schema_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            source = listening_gap_report()
+            source["schema_version"] = "stale_schema"
+            with self.assertRaises(StageBMidiToSoloMvpDeliveryPackageError):
+                build_delivery_package_report(
+                    listening_review_quality_gap=source,
+                    cli_mvp_package=cli_package_report(tmp_path),
+                    changed_ratio_audio_package=changed_ratio_audio_report(tmp_path),
+                    output_dir=tmp_path / "delivery",
+                    issue_number=1160,
+                )
+
+    def test_rejects_listening_gap_source_schema_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            source = listening_gap_report()
+            source["source_schema_version"] = "stale_schema"
+            with self.assertRaises(StageBMidiToSoloMvpDeliveryPackageError):
+                build_delivery_package_report(
+                    listening_review_quality_gap=source,
+                    cli_mvp_package=cli_package_report(tmp_path),
+                    changed_ratio_audio_package=changed_ratio_audio_report(tmp_path),
+                    output_dir=tmp_path / "delivery",
+                    issue_number=1160,
+                )
 
     def test_rejects_listening_gap_quality_claim(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -347,6 +415,40 @@ class StageBMidiToSoloMvpDeliveryPackageTest(unittest.TestCase):
                     issue_number=1076,
                 )
 
+    def test_rejects_false_outside_soloing_schema_context_preserved_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            source = listening_gap_report()
+            source["quality_gap_summary"]["outside_soloing_repair_schema_context_preserved"] = False
+            with self.assertRaises(StageBMidiToSoloMvpDeliveryPackageError):
+                build_delivery_package_report(
+                    listening_review_quality_gap=source,
+                    cli_mvp_package=cli_package_report(tmp_path),
+                    changed_ratio_audio_package=changed_ratio_audio_report(tmp_path),
+                    output_dir=tmp_path / "delivery",
+                    issue_number=1160,
+                )
+
+    def test_rejects_delivery_package_schema_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            report = build_delivery_package_report(
+                listening_review_quality_gap=listening_gap_report(),
+                cli_mvp_package=cli_package_report(tmp_path),
+                changed_ratio_audio_package=changed_ratio_audio_report(tmp_path),
+                output_dir=tmp_path / "delivery",
+                issue_number=1160,
+            )
+            report["schema_version"] = "stale_schema"
+            with self.assertRaises(StageBMidiToSoloMvpDeliveryPackageError):
+                validate_delivery_package_report(
+                    report,
+                    expected_boundary=BOUNDARY,
+                    expected_next_boundary=NEXT_BOUNDARY,
+                    require_delivery_completed=True,
+                    require_no_quality_claim=True,
+                )
+
     def test_rejects_targeted_outside_soloing_source_repair(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
@@ -380,7 +482,7 @@ class StageBMidiToSoloMvpDeliveryPackageTest(unittest.TestCase):
     def test_boundary_constants_are_stable(self) -> None:
         self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_mvp_delivery_package")
         self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_readme_final_evidence_refresh")
-        self.assertEqual(SCHEMA_VERSION, "stage_b_midi_to_solo_mvp_delivery_package_v3")
+        self.assertEqual(SCHEMA_VERSION, "stage_b_midi_to_solo_mvp_delivery_package_v4")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- MVP delivery package schema v4 적용
- source listening gap, quality gap decision, current evidence schema version 검증 추가
- outside-soloing schema-context preserved flag와 objective schema version 전파
- README, CURRENT_STATUS, CORE_PLAN, AGENTS 최신 handoff 갱신

## Context

- #1158 listening review quality gap 결과 기준 MVP delivery package 생성 범위
- source schema chain: listening review quality gap v4, quality gap decision v4, current evidence v4
- excluded quality claims: human/audio preference, MIDI-to-solo musical quality, broad trained model quality, Brad style adaptation
- next boundary: README final evidence refresh

## Scope

- delivery package validation contract
- delivery package report/markdown summary
- downstream final status audit fixture schema alignment
- generated source-context refresh document
- handoff/status documentation

## Validation

- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_mvp_delivery_package
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_final_status_audit
- .venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_mvp_delivery_package.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-mvp-delivery-package
- bash scripts/agent_harness.sh quick
- git diff --check

## Risk

- Musical quality/preference 판단 제외
- Raw artifact upload 제외
- Next review boundary: README final evidence refresh

Closes #1160