### PR TITLE
Stage B MIDI-to-solo final status audit source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Current handoff scope:
 - Latest listening review quality gap completed: Issue #1158, Stage B MIDI-to-solo listening review quality gap source-context refresh.
 - Latest MVP delivery package completed: Issue #1160, Stage B MIDI-to-solo MVP delivery package source-context refresh.
 - Latest README final evidence refresh completed: Issue #1162, Stage B MIDI-to-solo README final evidence refresh source-context refresh.
-- Latest final status audit completed: Issue #1080, Stage B MIDI-to-solo final status audit source-context refresh.
+- Latest final status audit completed: Issue #1164, Stage B MIDI-to-solo final status audit source-context refresh.
 - Latest post-MVP quality iteration plan completed: Issue #1082, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh.
 - Latest quality rubric baseline completed: Issue #1084, Stage B MIDI-to-solo quality rubric baseline source-context refresh.
 - Latest candidate failure labeling completed: Issue #1086, Stage B MIDI-to-solo candidate failure labeling source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1148, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after Stage B MIDI-to-solo README final evidence refresh source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo final status audit source-context refresh.
+- Open issue queue after Stage B MIDI-to-solo final status audit source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest listening review quality gap: `Issue #1158`
 - latest MVP delivery package: `Issue #1160`
 - latest README final evidence refresh: `Issue #1162`
-- latest final status audit: `Issue #1080`
+- latest final status audit: `Issue #1164`
 - latest post-MVP quality iteration plan: `Issue #1082`
 - latest quality rubric baseline: `Issue #1084`
 - latest candidate failure labeling: `Issue #1086`
@@ -50,7 +50,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1150`
 - latest README evidence refresh: `Issue #1152`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after README final evidence source-context refresh merge: `0`
+- open issue queue after final status audit source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
@@ -420,8 +420,15 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - README final evidence follow-up repair sweep source outside-soloing source context preserved: `true`
 - README final evidence bridge repair sweep source outside-soloing source context preserved: `true`
 - final status audit completed: `true`
+- final status audit schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- final status source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- final status source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- final status source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- final status source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - technical MVP complete: `true`
 - technical MVP ready for local review: `true`
+- final status outside-soloing schema context preserved: `true`
+- final status outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - final status follow-up objective source outside-soloing source context preserved: `true`
 - final status follow-up repair sweep source outside-soloing source context preserved: `true`
 - final status bridge repair sweep source outside-soloing source context preserved: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -398,7 +398,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo listening review quality gap: schema `stage_b_midi_to_solo_listening_review_quality_gap_v4`, source quality gap schema `stage_b_midi_to_solo_quality_gap_decision_v4`, current evidence schema `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`, selected target `mvp_delivery_package`, technical delivery package ready `true`, listening gap open `true`, outside-soloing schema-context preserved `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_mvp_delivery_package`
 - MIDI-to-solo MVP delivery package: schema `stage_b_midi_to_solo_mvp_delivery_package_v4`, source listening gap schema `stage_b_midi_to_solo_listening_review_quality_gap_v4`, current evidence schema `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`, runnable CLI `true`, input ranked MIDI `true`, rendered WAV evidence `true`, CLI/changed-ratio audio candidate count `3/3`, outside-soloing schema-context preserved `true`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_readme_final_evidence_refresh`
 - MIDI-to-solo README final evidence refresh: latest evidence boundary `stage_b_midi_to_solo_mvp_delivery_package`, delivery schema `stage_b_midi_to_solo_mvp_delivery_package_v4`, source listening gap schema `stage_b_midi_to_solo_listening_review_quality_gap_v4`, current evidence schema `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`, outside-soloing schema-context preserved `true`, runnable CLI `true`, input ranked MIDI/WAV evidence `true/true`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_final_status_audit`
-- MIDI-to-solo final status audit: technical MVP complete `true`, local review ready `true`, README final evidence reflected `true`, CLI/WAV count `3/3`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- MIDI-to-solo final status audit: schema `stage_b_midi_to_solo_final_status_audit_v4`, source delivery schema `stage_b_midi_to_solo_mvp_delivery_package_v4`, source current evidence schema `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`, technical MVP complete `true`, local review ready `true`, README final evidence reflected `true`, outside-soloing schema-context preserved `true`, CLI/WAV count `3/3`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
 - MIDI-to-solo post-MVP quality iteration plan: selected target `quality_rubric_baseline`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, ordered work `4`, taxonomy seed `7`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_rubric_baseline`
 - MIDI-to-solo quality rubric baseline: rubric items `8`, metric groups `30`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, candidate failure labeling ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_candidate_failure_labeling`
 - MIDI-to-solo candidate failure labeling: candidates `6`, failed `6`, failure label types `4`, not-evaluable types `2`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, targeted repair ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_sweep`
@@ -4339,6 +4339,7 @@ Issue #742는 Issue #740 README final evidence refresh와 Issue #738 MVP deliver
 검증:
 
 - `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_final_status_audit`
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
 - `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_final_status.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-final-status-audit`
@@ -12385,12 +12386,17 @@ Issue #1162는 Issue #1160 MVP delivery package의 schema/source-context 결과�
 
 ## 9.230 Stage B MIDI-to-solo final status audit source-context refresh
 
-Issue #1080은 Issue #1078 README final evidence와 Issue #1076 MVP delivery package 결과를 기준으로 final status audit summary와 validation summary에 source-context preserved flag 3개를 보존한 작업이다.
+Issue #1164는 Issue #1162 README final evidence와 Issue #1160 MVP delivery package 결과를 기준으로 final status audit summary와 validation summary에 schema/source-context 결과를 보존한 작업이다.
 
 결과:
 
 - document: `docs/STAGE_B_MIDI_TO_SOLO_FINAL_STATUS_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_final_status_audit`
+- schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
 - final status audit completed: `true`
 - technical MVP complete: `true`
@@ -12398,6 +12404,8 @@ Issue #1080은 Issue #1078 README final evidence와 Issue #1076 MVP delivery pac
 - README final evidence reflected: `true`
 - outside-soloing repair evidence ready: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`
@@ -12408,7 +12416,7 @@ Issue #1080은 Issue #1078 README final evidence와 Issue #1076 MVP delivery pac
 판단:
 
 - technical MVP complete는 local review 가능한 technical path 기준.
-- final status audit summary에 delivery package preserved flag 3개 보존.
+- final status audit summary에 delivery package schema/source-context 결과 보존.
 - musical quality와 human/audio preference claim 제외 유지.
 
 검증:

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -18,7 +18,7 @@
 - latest listening review quality gap: Issue #1158, Stage B MIDI-to-solo listening review quality gap source-context refresh
 - latest MVP delivery package: Issue #1160, Stage B MIDI-to-solo MVP delivery package source-context refresh
 - latest README final evidence refresh: Issue #1162, Stage B MIDI-to-solo README final evidence refresh source-context refresh
-- latest final status audit: Issue #1080, Stage B MIDI-to-solo final status audit source-context refresh
+- latest final status audit: Issue #1164, Stage B MIDI-to-solo final status audit source-context refresh
 - latest post-MVP quality iteration plan: Issue #1082, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh
 - latest quality rubric baseline: Issue #1084, Stage B MIDI-to-solo quality rubric baseline source-context refresh
 - latest candidate failure labeling: Issue #1086, Stage B MIDI-to-solo candidate failure labeling source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1150, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after Stage B MIDI-to-solo README final evidence refresh source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo final status audit source-context refresh`
+- open issue queue after Stage B MIDI-to-solo final status audit source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -3213,6 +3213,7 @@ Issue #742는 Issue #740 README final evidence refresh와 Issue #738 MVP deliver
 검증:
 
 - `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_final_status_audit`
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
 - `.venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_final_status.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-final-status-audit`
@@ -5654,19 +5655,26 @@ Issue #1162는 Issue #1160 MVP delivery package의 schema/source-context 결과�
 
 ## Stage B MIDI-to-Solo Final Status Audit Source-Context Refresh Result
 
-Issue #1080은 Issue #1078 README final evidence와 Issue #1076 MVP delivery package 결과를 기준으로 final status audit summary와 validation summary에 source-context preserved flag 3개를 보존한 작업이다.
+Issue #1164는 Issue #1162 README final evidence와 Issue #1160 MVP delivery package 결과를 기준으로 final status audit summary와 validation summary에 schema/source-context 결과를 보존한 작업이다.
 
 변경:
 
-- final status audit schema v3 적용
-- final status summary, generated markdown report, validation summary source-context preserved flag 3개 전파
-- false preserved flag 입력 차단 테스트 추가
-- harness issue number #1080 반영
+- final status audit schema v4 적용
+- final status summary, generated markdown report, validation summary에 delivery/source schema version 전파
+- outside-soloing schema-context preserved flag와 objective schema version 전파
+- stale schema, false schema-context flag 입력 차단 테스트 추가
+- post-MVP quality iteration fixture의 final status v4 입력 계약 정렬
+- harness issue number #1164 반영
 
 결과:
 
 - document: `docs/STAGE_B_MIDI_TO_SOLO_FINAL_STATUS_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_final_status_audit`
+- schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
 - final status audit completed: `true`
 - technical MVP complete: `true`
@@ -5674,6 +5682,8 @@ Issue #1080은 Issue #1078 README final evidence와 Issue #1076 MVP delivery pac
 - README final evidence reflected: `true`
 - outside-soloing repair evidence ready: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`
@@ -5684,7 +5694,7 @@ Issue #1080은 Issue #1078 README final evidence와 Issue #1076 MVP delivery pac
 판단:
 
 - technical MVP complete는 local review 가능한 technical path 기준.
-- final status audit summary에 delivery package preserved flag 3개 보존.
+- final status audit summary에 delivery package schema/source-context 결과 보존.
 - musical quality와 human/audio preference claim 제외 유지.
 
 검증:

--- a/docs/STAGE_B_MIDI_TO_SOLO_FINAL_STATUS_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_FINAL_STATUS_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -4,6 +4,11 @@
 
 - boundary: `stage_b_midi_to_solo_final_status_audit`
 - source boundary: `stage_b_midi_to_solo_mvp_delivery_package`
+- schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
 - technical MVP complete: `true`
 - technical MVP ready for local review: `true`
@@ -16,6 +21,8 @@
 - changed-ratio repair audio evidence ready: `true`
 - outside-soloing repair evidence ready: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - CLI candidate count: `3`
 - changed-ratio repair WAV count: `3`
 - outside-soloing repair WAV count: `6`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6114,7 +6114,7 @@ run_stage_b_midi_to_solo_final_status_audit() {
     --delivery_package "$delivery_package" \
     --readme_path README.md \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_FINAL_STATUS_AUDIT_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1080 \
+    --issue_number 1164 \
     --expected_boundary stage_b_midi_to_solo_final_status_audit \
     --expected_next_boundary stage_b_midi_to_solo_post_mvp_quality_iteration_plan \
     --require_technical_mvp_complete \

--- a/scripts/audit_stage_b_midi_to_solo_final_status.py
+++ b/scripts/audit_stage_b_midi_to_solo_final_status.py
@@ -18,6 +18,11 @@ from scripts.build_stage_b_midi_to_solo_mvp_delivery_package import (  # noqa: E
     BRIDGE_SOURCE_CONTEXT_KEYS,
     BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
     BOUNDARY as DELIVERY_BOUNDARY,
+    CURRENT_EVIDENCE_SCHEMA_VERSION,
+    LISTENING_GAP_SCHEMA_VERSION,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    QUALITY_GAP_DECISION_SCHEMA_VERSION,
+    SCHEMA_VERSION as DELIVERY_SCHEMA_VERSION,
     StageBMidiToSoloMvpDeliveryPackageError,
     validate_delivery_package_report,
 )
@@ -29,7 +34,7 @@ class StageBMidiToSoloFinalStatusAuditError(ValueError):
 
 BOUNDARY = "stage_b_midi_to_solo_final_status_audit"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_post_mvp_quality_iteration_plan"
-SCHEMA_VERSION = "stage_b_midi_to_solo_final_status_audit_v3"
+SCHEMA_VERSION = "stage_b_midi_to_solo_final_status_audit_v4"
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -156,6 +161,16 @@ def build_final_status_audit_report(
         "technical_mvp_complete": bool(delivery["mvp_delivery_package_completed"]),
         "technical_mvp_ready_for_local_review": bool(delivery["runnable_cli_ready"]),
         "readme_final_evidence_reflected": bool(readme["readme_final_evidence_reflected"]),
+        "delivery_package_schema_version": str(delivery["schema_version"]),
+        "delivery_source_listening_gap_schema_version": str(
+            delivery["source_listening_gap_schema_version"]
+        ),
+        "delivery_source_quality_gap_schema_version": str(
+            delivery["source_quality_gap_schema_version"]
+        ),
+        "delivery_source_current_evidence_schema_version": str(
+            delivery["source_current_evidence_schema_version"]
+        ),
         "input_to_ranked_midi_ready": bool(delivery["input_to_ranked_midi_ready"]),
         "input_to_rendered_wav_evidence_ready": bool(delivery["input_to_rendered_wav_evidence_ready"]),
         "changed_ratio_repair_audio_evidence_ready": bool(
@@ -166,6 +181,12 @@ def build_final_status_audit_report(
         ),
         "outside_soloing_repair_source_context_preserved": bool(
             delivery["outside_soloing_repair_source_context_preserved"]
+        ),
+        "outside_soloing_repair_schema_context_preserved": bool(
+            delivery["outside_soloing_repair_schema_context_preserved"]
+        ),
+        "outside_soloing_repair_objective_schema_version": str(
+            delivery["outside_soloing_repair_objective_schema_version"]
         ),
         "cli_candidate_count": _int(delivery["cli_candidate_count"]),
         "changed_ratio_repair_wav_count": _int(delivery["changed_ratio_repair_wav_count"]),
@@ -215,6 +236,14 @@ def build_final_status_audit_report(
         "issue_number": int(issue_number),
         "boundary": BOUNDARY,
         "source_boundary": DELIVERY_BOUNDARY,
+        "source_schema_versions": {
+            "delivery_package": final_status["delivery_package_schema_version"],
+            "listening_review_quality_gap": final_status[
+                "delivery_source_listening_gap_schema_version"
+            ],
+            "quality_gap_decision": final_status["delivery_source_quality_gap_schema_version"],
+            "current_evidence": final_status["delivery_source_current_evidence_schema_version"],
+        },
         "final_status": final_status,
         "readme_audit": readme,
         "readiness": {
@@ -229,6 +258,9 @@ def build_final_status_audit_report(
             ),
             "outside_soloing_repair_source_context_preserved": bool(
                 final_status["outside_soloing_repair_source_context_preserved"]
+            ),
+            "outside_soloing_repair_schema_context_preserved": bool(
+                final_status["outside_soloing_repair_schema_context_preserved"]
             ),
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
@@ -272,6 +304,27 @@ def validate_final_status_audit_report(
     readiness = _dict(report.get("readiness"))
     decision = _dict(report.get("decision"))
     final_status = _dict(report.get("final_status"))
+    source_schema_versions = _dict(report.get("source_schema_versions"))
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise StageBMidiToSoloFinalStatusAuditError("final status audit schema version mismatch")
+    if str(source_schema_versions.get("delivery_package") or "") != DELIVERY_SCHEMA_VERSION:
+        raise StageBMidiToSoloFinalStatusAuditError(
+            "final status source delivery package schema version mismatch"
+        )
+    if str(
+        source_schema_versions.get("listening_review_quality_gap") or ""
+    ) != LISTENING_GAP_SCHEMA_VERSION:
+        raise StageBMidiToSoloFinalStatusAuditError(
+            "final status source listening gap schema version mismatch"
+        )
+    if str(source_schema_versions.get("quality_gap_decision") or "") != QUALITY_GAP_DECISION_SCHEMA_VERSION:
+        raise StageBMidiToSoloFinalStatusAuditError(
+            "final status source quality gap schema version mismatch"
+        )
+    if str(source_schema_versions.get("current_evidence") or "") != CURRENT_EVIDENCE_SCHEMA_VERSION:
+        raise StageBMidiToSoloFinalStatusAuditError(
+            "final status source current evidence schema version mismatch"
+        )
     if expected_boundary and boundary != expected_boundary:
         raise StageBMidiToSoloFinalStatusAuditError(
             f"expected boundary {expected_boundary}, got {boundary}"
@@ -288,8 +341,31 @@ def validate_final_status_audit_report(
         raise StageBMidiToSoloFinalStatusAuditError("critical user input should not be required")
     if require_no_quality_claim:
         _require_no_quality_claim(readiness, label="final status readiness")
+    if not bool(final_status.get("outside_soloing_repair_schema_context_preserved", False)):
+        raise StageBMidiToSoloFinalStatusAuditError(
+            "outside-soloing repair schema context preservation required"
+        )
+    if str(
+        final_status.get("outside_soloing_repair_objective_schema_version") or ""
+    ) != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION:
+        raise StageBMidiToSoloFinalStatusAuditError(
+            "outside-soloing repair objective schema version mismatch"
+        )
     source_context = _source_context_fields(final_status, label="final status")
     return {
+        "schema_version": str(report.get("schema_version") or ""),
+        "source_delivery_package_schema_version": str(
+            source_schema_versions.get("delivery_package") or ""
+        ),
+        "source_listening_gap_schema_version": str(
+            source_schema_versions.get("listening_review_quality_gap") or ""
+        ),
+        "source_quality_gap_schema_version": str(
+            source_schema_versions.get("quality_gap_decision") or ""
+        ),
+        "source_current_evidence_schema_version": str(
+            source_schema_versions.get("current_evidence") or ""
+        ),
         "boundary": boundary,
         "next_boundary": str(decision.get("next_boundary") or ""),
         "final_status_audit_completed": bool(
@@ -311,6 +387,12 @@ def validate_final_status_audit_report(
         ),
         "outside_soloing_repair_source_context_preserved": bool(
             final_status.get("outside_soloing_repair_source_context_preserved", False)
+        ),
+        "outside_soloing_repair_schema_context_preserved": bool(
+            final_status.get("outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "outside_soloing_repair_objective_schema_version": str(
+            final_status.get("outside_soloing_repair_objective_schema_version") or ""
         ),
         "outside_soloing_repair_wav_count": _int(
             final_status.get("outside_soloing_repair_wav_count")
@@ -369,6 +451,11 @@ def markdown_report(report: dict[str, Any]) -> str:
         "",
         f"- boundary: `{report['boundary']}`",
         f"- source boundary: `{report['source_boundary']}`",
+        f"- schema version: `{report['schema_version']}`",
+        f"- source delivery package schema version: `{report['source_schema_versions']['delivery_package']}`",
+        f"- source listening gap schema version: `{report['source_schema_versions']['listening_review_quality_gap']}`",
+        f"- source quality gap schema version: `{report['source_schema_versions']['quality_gap_decision']}`",
+        f"- source current evidence schema version: `{report['source_schema_versions']['current_evidence']}`",
         f"- next boundary: `{decision['next_boundary']}`",
         f"- technical MVP complete: `{_bool_token(final_status['technical_mvp_complete'])}`",
         f"- technical MVP ready for local review: `{_bool_token(final_status['technical_mvp_ready_for_local_review'])}`",
@@ -381,6 +468,8 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- changed-ratio repair audio evidence ready: `{_bool_token(final_status['changed_ratio_repair_audio_evidence_ready'])}`",
         f"- outside-soloing repair evidence ready: `{_bool_token(final_status['outside_soloing_repair_evidence_ready'])}`",
         f"- outside-soloing repair source context preserved: `{_bool_token(final_status['outside_soloing_repair_source_context_preserved'])}`",
+        f"- outside-soloing repair schema context preserved: `{_bool_token(final_status['outside_soloing_repair_schema_context_preserved'])}`",
+        f"- outside-soloing repair objective schema version: `{final_status['outside_soloing_repair_objective_schema_version']}`",
         f"- CLI candidate count: `{final_status['cli_candidate_count']}`",
         f"- changed-ratio repair WAV count: `{final_status['changed_ratio_repair_wav_count']}`",
         f"- outside-soloing repair WAV count: `{final_status['outside_soloing_repair_wav_count']}`",

--- a/tests/test_stage_b_midi_to_solo_final_status_audit.py
+++ b/tests/test_stage_b_midi_to_solo_final_status_audit.py
@@ -134,6 +134,17 @@ class StageBMidiToSoloFinalStatusAuditTest(unittest.TestCase):
         )
 
         self.assertTrue(summary["final_status_audit_completed"])
+        self.assertEqual(summary["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(summary["source_delivery_package_schema_version"], DELIVERY_SCHEMA_VERSION)
+        self.assertEqual(summary["source_listening_gap_schema_version"], LISTENING_GAP_SCHEMA_VERSION)
+        self.assertEqual(
+            summary["source_quality_gap_schema_version"],
+            QUALITY_GAP_DECISION_SCHEMA_VERSION,
+        )
+        self.assertEqual(
+            summary["source_current_evidence_schema_version"],
+            CURRENT_EVIDENCE_SCHEMA_VERSION,
+        )
         self.assertTrue(summary["technical_mvp_complete"])
         self.assertTrue(summary["technical_mvp_ready_for_local_review"])
         self.assertTrue(summary["readme_final_evidence_reflected"])
@@ -141,6 +152,11 @@ class StageBMidiToSoloFinalStatusAuditTest(unittest.TestCase):
         self.assertEqual(summary["changed_ratio_repair_wav_count"], 3)
         self.assertTrue(summary["outside_soloing_repair_evidence_ready"])
         self.assertTrue(summary["outside_soloing_repair_source_context_preserved"])
+        self.assertTrue(summary["outside_soloing_repair_schema_context_preserved"])
+        self.assertEqual(
+            summary["outside_soloing_repair_objective_schema_version"],
+            OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+        )
         self.assertEqual(summary["outside_soloing_repair_wav_count"], 6)
         self.assertEqual(summary["outside_soloing_repair_changed_note_total"], 2)
         self.assertEqual(
@@ -172,6 +188,47 @@ class StageBMidiToSoloFinalStatusAuditTest(unittest.TestCase):
         )
         self.assertEqual(report["schema_version"], SCHEMA_VERSION)
         self.assertEqual(report["issue_number"], 1080)
+        self.assertEqual(report["source_schema_versions"]["delivery_package"], DELIVERY_SCHEMA_VERSION)
+
+    def test_rejects_final_status_schema_mismatch(self) -> None:
+        report = build_final_status_audit_report(
+            delivery_package=delivery_package(),
+            readme_text=readme_text(),
+            output_dir=Path("outputs/final_status"),
+            issue_number=1164,
+        )
+        report["schema_version"] = "stale_schema"
+        with self.assertRaises(StageBMidiToSoloFinalStatusAuditError):
+            validate_final_status_audit_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                require_technical_mvp_complete=True,
+                require_readme_reflected=True,
+                require_no_quality_claim=True,
+            )
+
+    def test_rejects_delivery_source_schema_mismatch(self) -> None:
+        source = delivery_package()
+        source["source_schema_versions"]["current_evidence"] = "stale_schema"
+        with self.assertRaises(StageBMidiToSoloFinalStatusAuditError):
+            build_final_status_audit_report(
+                delivery_package=source,
+                readme_text=readme_text(),
+                output_dir=Path("outputs/final_status"),
+                issue_number=1164,
+            )
+
+    def test_rejects_false_schema_context_preserved_flag(self) -> None:
+        source = delivery_package()
+        source["delivery_package"]["outside_soloing_repair_schema_context_preserved"] = False
+        with self.assertRaises(StageBMidiToSoloFinalStatusAuditError):
+            build_final_status_audit_report(
+                delivery_package=source,
+                readme_text=readme_text(),
+                output_dir=Path("outputs/final_status"),
+                issue_number=1164,
+            )
 
     def test_rejects_missing_readme_snippet(self) -> None:
         with self.assertRaises(StageBMidiToSoloFinalStatusAuditError):
@@ -217,7 +274,7 @@ class StageBMidiToSoloFinalStatusAuditTest(unittest.TestCase):
     def test_boundary_constants_are_stable(self) -> None:
         self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_final_status_audit")
         self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_post_mvp_quality_iteration_plan")
-        self.assertEqual(SCHEMA_VERSION, "stage_b_midi_to_solo_final_status_audit_v3")
+        self.assertEqual(SCHEMA_VERSION, "stage_b_midi_to_solo_final_status_audit_v4")
 
 
 if __name__ == "__main__":

--- a/tests/test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan.py
+++ b/tests/test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan.py
@@ -6,7 +6,13 @@ from pathlib import Path
 from scripts.audit_stage_b_midi_to_solo_final_status import (
     BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
     BOUNDARY as FINAL_STATUS_BOUNDARY,
+    CURRENT_EVIDENCE_SCHEMA_VERSION,
+    DELIVERY_SCHEMA_VERSION,
+    LISTENING_GAP_SCHEMA_VERSION,
     NEXT_BOUNDARY as FINAL_STATUS_NEXT_BOUNDARY,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    QUALITY_GAP_DECISION_SCHEMA_VERSION,
+    SCHEMA_VERSION as FINAL_STATUS_SCHEMA_VERSION,
 )
 from scripts.plan_stage_b_midi_to_solo_post_mvp_quality_iteration import (
     BOUNDARY,
@@ -58,12 +64,23 @@ def final_status_audit(
     outside_risk_after: int = 0,
 ) -> dict:
     return {
+        "schema_version": FINAL_STATUS_SCHEMA_VERSION,
         "boundary": FINAL_STATUS_BOUNDARY,
         "source_boundary": "stage_b_midi_to_solo_mvp_delivery_package",
+        "source_schema_versions": {
+            "delivery_package": DELIVERY_SCHEMA_VERSION,
+            "listening_review_quality_gap": LISTENING_GAP_SCHEMA_VERSION,
+            "quality_gap_decision": QUALITY_GAP_DECISION_SCHEMA_VERSION,
+            "current_evidence": CURRENT_EVIDENCE_SCHEMA_VERSION,
+        },
         "final_status": {
             "technical_mvp_complete": True,
             "technical_mvp_ready_for_local_review": True,
             "readme_final_evidence_reflected": True,
+            "delivery_package_schema_version": DELIVERY_SCHEMA_VERSION,
+            "delivery_source_listening_gap_schema_version": LISTENING_GAP_SCHEMA_VERSION,
+            "delivery_source_quality_gap_schema_version": QUALITY_GAP_DECISION_SCHEMA_VERSION,
+            "delivery_source_current_evidence_schema_version": CURRENT_EVIDENCE_SCHEMA_VERSION,
             "input_to_ranked_midi_ready": True,
             "input_to_rendered_wav_evidence_ready": True,
             "changed_ratio_repair_audio_evidence_ready": True,
@@ -71,6 +88,10 @@ def final_status_audit(
             "changed_ratio_repair_wav_count": wav_count,
             "outside_soloing_repair_evidence_ready": outside_ready,
             "outside_soloing_repair_source_context_preserved": outside_ready,
+            "outside_soloing_repair_schema_context_preserved": outside_ready,
+            "outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "outside_soloing_repair_wav_count": outside_wav_count,
             "outside_soloing_repair_changed_note_total": 2,
             "outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
@@ -93,6 +114,7 @@ def final_status_audit(
             "technical_mvp_ready_for_local_review": True,
             "readme_final_evidence_reflected": True,
             "outside_soloing_repair_source_context_preserved": outside_ready,
+            "outside_soloing_repair_schema_context_preserved": outside_ready,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
             "audio_rendered_quality_claimed": False,


### PR DESCRIPTION
## Summary

- final status audit schema v4 적용
- delivery package, listening gap, quality gap, current evidence schema version 전파
- outside-soloing schema-context preserved flag와 objective schema version 전파
- post-MVP quality iteration fixture의 final status v4 입력 계약 정렬

## Context

- #1162 README final evidence source-context refresh 결과 기준
- source boundary: stage_b_midi_to_solo_mvp_delivery_package
- delivery schema: stage_b_midi_to_solo_mvp_delivery_package_v4
- README final evidence reflected: true
- quality/preference claim: false

## Scope

- final status audit validation/report/markdown
- final status audit tests
- post-MVP quality iteration source fixture
- generated final status audit document
- README, CURRENT_STATUS, CORE_PLAN, AGENTS handoff

## Validation

- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_final_status_audit
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan
- .venv/bin/python -m py_compile scripts/audit_stage_b_midi_to_solo_final_status.py scripts/plan_stage_b_midi_to_solo_post_mvp_quality_iteration.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-final-status-audit
- bash scripts/agent_harness.sh quick
- git diff --check

## Risk

- Musical quality/preference 판단 제외
- Raw artifact upload 제외
- post-MVP quality iteration은 다음 boundary

Closes #1164