### PR TITLE
Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Current handoff scope:
 - Latest MVP delivery package completed: Issue #1160, Stage B MIDI-to-solo MVP delivery package source-context refresh.
 - Latest README final evidence refresh completed: Issue #1162, Stage B MIDI-to-solo README final evidence refresh source-context refresh.
 - Latest final status audit completed: Issue #1164, Stage B MIDI-to-solo final status audit source-context refresh.
-- Latest post-MVP quality iteration plan completed: Issue #1082, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh.
+- Latest post-MVP quality iteration plan completed: Issue #1166, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh.
 - Latest quality rubric baseline completed: Issue #1084, Stage B MIDI-to-solo quality rubric baseline source-context refresh.
 - Latest candidate failure labeling completed: Issue #1086, Stage B MIDI-to-solo candidate failure labeling source-context refresh.
 - Latest targeted quality repair sweep completed: Issue #1088, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1148, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after Stage B MIDI-to-solo final status audit source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh.
+- Open issue queue after Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo quality rubric baseline source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP delivery package: `Issue #1160`
 - latest README final evidence refresh: `Issue #1162`
 - latest final status audit: `Issue #1164`
-- latest post-MVP quality iteration plan: `Issue #1082`
+- latest post-MVP quality iteration plan: `Issue #1166`
 - latest quality rubric baseline: `Issue #1084`
 - latest candidate failure labeling: `Issue #1086`
 - latest targeted quality repair sweep: `Issue #1088`
@@ -50,7 +50,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1150`
 - latest README evidence refresh: `Issue #1152`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after final status audit source-context refresh merge: `0`
+- open issue queue after post-MVP quality iteration plan source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
@@ -267,8 +267,14 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - outside-soloing pitch-role risk count after: `0`
 - outside-soloing pitch-role risk delta: `2`
 - post-MVP quality iteration plan completed: `true`
+- post-MVP quality iteration plan schema version: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`
+- post-MVP source final status schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- post-MVP source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- post-MVP source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - post-MVP selected target: `quality_rubric_baseline`
 - post-MVP quality rubric required: `true`
+- post-MVP outside-soloing schema context preserved: `true`
+- post-MVP outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - post-MVP follow-up objective source outside-soloing source context preserved: `true`
 - post-MVP follow-up repair sweep source outside-soloing source context preserved: `true`
 - post-MVP bridge repair sweep source outside-soloing source context preserved: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -399,7 +399,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo MVP delivery package: schema `stage_b_midi_to_solo_mvp_delivery_package_v4`, source listening gap schema `stage_b_midi_to_solo_listening_review_quality_gap_v4`, current evidence schema `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`, runnable CLI `true`, input ranked MIDI `true`, rendered WAV evidence `true`, CLI/changed-ratio audio candidate count `3/3`, outside-soloing schema-context preserved `true`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_readme_final_evidence_refresh`
 - MIDI-to-solo README final evidence refresh: latest evidence boundary `stage_b_midi_to_solo_mvp_delivery_package`, delivery schema `stage_b_midi_to_solo_mvp_delivery_package_v4`, source listening gap schema `stage_b_midi_to_solo_listening_review_quality_gap_v4`, current evidence schema `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`, outside-soloing schema-context preserved `true`, runnable CLI `true`, input ranked MIDI/WAV evidence `true/true`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_final_status_audit`
 - MIDI-to-solo final status audit: schema `stage_b_midi_to_solo_final_status_audit_v4`, source delivery schema `stage_b_midi_to_solo_mvp_delivery_package_v4`, source current evidence schema `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`, technical MVP complete `true`, local review ready `true`, README final evidence reflected `true`, outside-soloing schema-context preserved `true`, CLI/WAV count `3/3`, raw artifact upload `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
-- MIDI-to-solo post-MVP quality iteration plan: selected target `quality_rubric_baseline`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, ordered work `4`, taxonomy seed `7`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_rubric_baseline`
+- MIDI-to-solo post-MVP quality iteration plan: schema `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`, source final status schema `stage_b_midi_to_solo_final_status_audit_v4`, source current evidence schema `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`, selected target `quality_rubric_baseline`, source risk `5 -> 2`, current repair risk after `0`, outside-soloing schema-context preserved `true`, ordered work `4`, taxonomy seed `7`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_rubric_baseline`
 - MIDI-to-solo quality rubric baseline: rubric items `8`, metric groups `30`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, candidate failure labeling ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_candidate_failure_labeling`
 - MIDI-to-solo candidate failure labeling: candidates `6`, failed `6`, failure label types `4`, not-evaluable types `2`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, targeted repair ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_sweep`
 - MIDI-to-solo targeted quality repair sweep: candidates `6`, failure labels `12 -> 8`, improved candidates `4`, technical regression `0`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
@@ -12434,13 +12434,19 @@ Issue #1164는 Issue #1162 README final evidence와 Issue #1160 MVP delivery pac
 
 ## 9.231 Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh
 
-Issue #1082는 Issue #1080 final status audit 결과를 기준으로 post-MVP quality iteration plan의 source-context validation과 summary에 source-context preserved flag 3개를 보존한 작업이다.
+Issue #1166은 Issue #1164 final status audit 결과를 기준으로 post-MVP quality iteration plan의 schema/source-context validation과 summary에 final status schema chain을 보존한 작업이다.
 
 결과:
 
 - document: `docs/STAGE_B_MIDI_TO_SOLO_POST_MVP_QUALITY_ITERATION_PLAN_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- schema version: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`
 - source boundary: `stage_b_midi_to_solo_final_status_audit`
+- source final status schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
 - selected target: `quality_rubric_baseline`
 - post-MVP quality iteration plan completed: `true`
@@ -12448,6 +12454,8 @@ Issue #1082는 Issue #1080 final status audit 결과를 기준으로 post-MVP qu
 - local review ready: `true`
 - outside-soloing repair evidence ready: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`
@@ -12460,8 +12468,8 @@ Issue #1082는 Issue #1080 final status audit 결과를 기준으로 post-MVP qu
 
 판단:
 
-- post-MVP plan source validation에 final status audit preserved flag 3개 포함.
-- preserved flag false 입력은 validation error로 차단.
+- post-MVP plan source validation에 final status audit schema/source-context 결과 포함.
+- stale schema와 preserved flag false 입력은 validation error로 차단.
 - 다음 검증 대상은 quality rubric baseline 유지.
 - musical quality와 human/audio preference claim 제외 유지.
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -19,7 +19,7 @@
 - latest MVP delivery package: Issue #1160, Stage B MIDI-to-solo MVP delivery package source-context refresh
 - latest README final evidence refresh: Issue #1162, Stage B MIDI-to-solo README final evidence refresh source-context refresh
 - latest final status audit: Issue #1164, Stage B MIDI-to-solo final status audit source-context refresh
-- latest post-MVP quality iteration plan: Issue #1082, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh
+- latest post-MVP quality iteration plan: Issue #1166, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh
 - latest quality rubric baseline: Issue #1084, Stage B MIDI-to-solo quality rubric baseline source-context refresh
 - latest candidate failure labeling: Issue #1086, Stage B MIDI-to-solo candidate failure labeling source-context refresh
 - latest targeted quality repair sweep: Issue #1088, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1150, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after Stage B MIDI-to-solo final status audit source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh`
+- open issue queue after Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo quality rubric baseline source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -5712,21 +5712,29 @@ Issue #1164는 Issue #1162 README final evidence와 Issue #1160 MVP delivery pac
 
 ## Stage B MIDI-to-Solo Post-MVP Quality Iteration Plan Source-Context Refresh Result
 
-Issue #1082는 Issue #1080 final status audit 결과를 기준으로 post-MVP quality iteration plan의 source-context validation과 summary에 source-context preserved flag 3개를 보존한 작업이다.
+Issue #1166은 Issue #1164 final status audit 결과를 기준으로 post-MVP quality iteration plan의 schema/source-context validation과 summary에 final status schema chain을 보존한 작업이다.
 
 변경:
 
-- post-MVP quality iteration plan source validation을 required source-context key 기준으로 갱신
-- source-context preserved flag 3개 false 입력 차단
-- post-MVP status, generated markdown report, validation summary preserved flag 전파
-- harness issue number #1082 반영
+- post-MVP quality iteration plan schema v4 적용
+- final status audit schema v4와 delivery/source schema chain 필수 검증
+- outside-soloing schema-context preserved flag와 objective schema version 전파
+- post-MVP status, generated markdown report, validation summary schema/source-context field 전파
+- stale schema 입력 차단 테스트 추가
+- harness issue number #1166 반영
 - quality rubric baseline fixture 입력 계약 갱신
 
 결과:
 
 - document: `docs/STAGE_B_MIDI_TO_SOLO_POST_MVP_QUALITY_ITERATION_PLAN_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
+- schema version: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`
 - source boundary: `stage_b_midi_to_solo_final_status_audit`
+- source final status schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
 - selected target: `quality_rubric_baseline`
 - post-MVP quality iteration plan completed: `true`
@@ -5734,6 +5742,8 @@ Issue #1082는 Issue #1080 final status audit 결과를 기준으로 post-MVP qu
 - local review ready: `true`
 - outside-soloing repair evidence ready: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`
@@ -5746,8 +5756,8 @@ Issue #1082는 Issue #1080 final status audit 결과를 기준으로 post-MVP qu
 
 판단:
 
-- post-MVP plan source validation에 final status audit preserved flag 3개 포함.
-- preserved flag false 입력은 validation error로 차단.
+- post-MVP plan source validation에 final status audit schema/source-context 결과 포함.
+- stale schema와 preserved flag false 입력은 validation error로 차단.
 - 다음 검증 대상은 quality rubric baseline 유지.
 - musical quality와 human/audio preference claim 제외 유지.
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_POST_MVP_QUALITY_ITERATION_PLAN_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_POST_MVP_QUALITY_ITERATION_PLAN_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -4,12 +4,20 @@
 
 - boundary: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan`
 - source boundary: `stage_b_midi_to_solo_final_status_audit`
+- schema version: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`
+- source final status schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_quality_rubric_baseline`
 - selected target: `quality_rubric_baseline`
 - technical MVP complete: `true`
 - local review ready: `true`
 - outside-soloing repair evidence ready: `true`
 - outside-soloing repair source context preserved: `true`
+- outside-soloing repair schema context preserved: `true`
+- outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6135,7 +6135,7 @@ run_stage_b_midi_to_solo_post_mvp_quality_iteration_plan() {
     --run_id "$run_id" \
     --final_status_audit "$final_status" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_POST_MVP_QUALITY_ITERATION_PLAN_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1082 \
+    --issue_number 1166 \
     --expected_boundary stage_b_midi_to_solo_post_mvp_quality_iteration_plan \
     --expected_next_boundary stage_b_midi_to_solo_quality_rubric_baseline \
     --expected_target quality_rubric_baseline \

--- a/scripts/plan_stage_b_midi_to_solo_post_mvp_quality_iteration.py
+++ b/scripts/plan_stage_b_midi_to_solo_post_mvp_quality_iteration.py
@@ -18,7 +18,13 @@ from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
     BRIDGE_SOURCE_CONTEXT_KEYS,
     BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
     BOUNDARY as FINAL_STATUS_BOUNDARY,
+    CURRENT_EVIDENCE_SCHEMA_VERSION,
+    DELIVERY_SCHEMA_VERSION,
+    LISTENING_GAP_SCHEMA_VERSION,
     NEXT_BOUNDARY as FINAL_STATUS_NEXT_BOUNDARY,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    QUALITY_GAP_DECISION_SCHEMA_VERSION,
+    SCHEMA_VERSION as FINAL_STATUS_SCHEMA_VERSION,
     StageBMidiToSoloFinalStatusAuditError,
     validate_final_status_audit_report,
 )
@@ -31,7 +37,7 @@ class StageBMidiToSoloPostMvpQualityIterationPlanError(ValueError):
 BOUNDARY = "stage_b_midi_to_solo_post_mvp_quality_iteration_plan"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_quality_rubric_baseline"
 SELECTED_TARGET = "quality_rubric_baseline"
-SCHEMA_VERSION = "stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v3"
+SCHEMA_VERSION = "stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4"
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -134,6 +140,16 @@ def validate_final_status_source(report: dict[str, Any]) -> dict[str, Any]:
         raise StageBMidiToSoloPostMvpQualityIterationPlanError(
             "outside-soloing repair source context preservation required"
         )
+    if not bool(summary.get("outside_soloing_repair_schema_context_preserved", False)):
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            "outside-soloing repair schema context preservation required"
+        )
+    if str(
+        summary.get("outside_soloing_repair_objective_schema_version") or ""
+    ) != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION:
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            "outside-soloing repair objective schema version mismatch"
+        )
     _source_context_fields(summary, label="final status audit")
     if _int(summary.get("outside_soloing_repair_wav_count")) < 6:
         raise StageBMidiToSoloPostMvpQualityIterationPlanError(
@@ -234,8 +250,28 @@ def build_post_mvp_quality_iteration_plan_report(
         "issue_number": int(issue_number),
         "boundary": BOUNDARY,
         "source_boundary": FINAL_STATUS_BOUNDARY,
+        "source_schema_versions": {
+            "final_status_audit": str(source["schema_version"]),
+            "delivery_package": str(source["source_delivery_package_schema_version"]),
+            "listening_review_quality_gap": str(source["source_listening_gap_schema_version"]),
+            "quality_gap_decision": str(source["source_quality_gap_schema_version"]),
+            "current_evidence": str(source["source_current_evidence_schema_version"]),
+        },
         "source_summary": source,
         "post_mvp_status": {
+            "source_final_status_schema_version": str(source["schema_version"]),
+            "source_delivery_package_schema_version": str(
+                source["source_delivery_package_schema_version"]
+            ),
+            "source_listening_gap_schema_version": str(
+                source["source_listening_gap_schema_version"]
+            ),
+            "source_quality_gap_schema_version": str(
+                source["source_quality_gap_schema_version"]
+            ),
+            "source_current_evidence_schema_version": str(
+                source["source_current_evidence_schema_version"]
+            ),
             "technical_mvp_complete": bool(source["technical_mvp_complete"]),
             "local_review_ready": bool(source["technical_mvp_ready_for_local_review"]),
             "readme_final_evidence_reflected": bool(source["readme_final_evidence_reflected"]),
@@ -246,6 +282,12 @@ def build_post_mvp_quality_iteration_plan_report(
             ),
             "outside_soloing_repair_source_context_preserved": bool(
                 source["outside_soloing_repair_source_context_preserved"]
+            ),
+            "outside_soloing_repair_schema_context_preserved": bool(
+                source["outside_soloing_repair_schema_context_preserved"]
+            ),
+            "outside_soloing_repair_objective_schema_version": str(
+                source["outside_soloing_repair_objective_schema_version"]
             ),
             "outside_soloing_repair_wav_count": _int(
                 source["outside_soloing_repair_wav_count"]
@@ -308,6 +350,9 @@ def build_post_mvp_quality_iteration_plan_report(
             "outside_soloing_repair_source_context_preserved": bool(
                 source["outside_soloing_repair_source_context_preserved"]
             ),
+            "outside_soloing_repair_schema_context_preserved": bool(
+                source["outside_soloing_repair_schema_context_preserved"]
+            ),
             "followup_objective_source_outside_soloing_source_context_preserved": bool(
                 source["followup_objective_source_outside_soloing_source_context_preserved"]
             ),
@@ -364,7 +409,34 @@ def validate_post_mvp_quality_iteration_plan_report(
     readiness = _dict(report.get("readiness"))
     selected = _dict(report.get("selected_next_target"))
     post_mvp_status = _dict(report.get("post_mvp_status"))
+    source_schema_versions = _dict(report.get("source_schema_versions"))
     ordered_work = report.get("ordered_work")
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            "post-MVP quality iteration plan schema version mismatch"
+        )
+    if str(source_schema_versions.get("final_status_audit") or "") != FINAL_STATUS_SCHEMA_VERSION:
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            "post-MVP source final status schema version mismatch"
+        )
+    if str(source_schema_versions.get("delivery_package") or "") != DELIVERY_SCHEMA_VERSION:
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            "post-MVP source delivery package schema version mismatch"
+        )
+    if str(
+        source_schema_versions.get("listening_review_quality_gap") or ""
+    ) != LISTENING_GAP_SCHEMA_VERSION:
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            "post-MVP source listening gap schema version mismatch"
+        )
+    if str(source_schema_versions.get("quality_gap_decision") or "") != QUALITY_GAP_DECISION_SCHEMA_VERSION:
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            "post-MVP source quality gap schema version mismatch"
+        )
+    if str(source_schema_versions.get("current_evidence") or "") != CURRENT_EVIDENCE_SCHEMA_VERSION:
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            "post-MVP source current evidence schema version mismatch"
+        )
     if expected_boundary and boundary != expected_boundary:
         raise StageBMidiToSoloPostMvpQualityIterationPlanError(
             f"expected boundary {expected_boundary}, got {boundary}"
@@ -392,7 +464,33 @@ def validate_post_mvp_quality_iteration_plan_report(
     if require_no_quality_claim:
         _require_no_quality_claim(readiness, label="post-MVP quality iteration readiness")
         _require_no_quality_claim(post_mvp_status, label="post-MVP status")
+    if not bool(post_mvp_status.get("outside_soloing_repair_schema_context_preserved", False)):
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            "outside-soloing repair schema context preservation required"
+        )
+    if str(
+        post_mvp_status.get("outside_soloing_repair_objective_schema_version") or ""
+    ) != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION:
+        raise StageBMidiToSoloPostMvpQualityIterationPlanError(
+            "outside-soloing repair objective schema version mismatch"
+        )
     return {
+        "schema_version": str(report.get("schema_version") or ""),
+        "source_final_status_schema_version": str(
+            source_schema_versions.get("final_status_audit") or ""
+        ),
+        "source_delivery_package_schema_version": str(
+            source_schema_versions.get("delivery_package") or ""
+        ),
+        "source_listening_gap_schema_version": str(
+            source_schema_versions.get("listening_review_quality_gap") or ""
+        ),
+        "source_quality_gap_schema_version": str(
+            source_schema_versions.get("quality_gap_decision") or ""
+        ),
+        "source_current_evidence_schema_version": str(
+            source_schema_versions.get("current_evidence") or ""
+        ),
         "boundary": boundary,
         "next_boundary": str(decision.get("next_boundary") or ""),
         "selected_target": str(selected.get("selected_target") or ""),
@@ -407,6 +505,12 @@ def validate_post_mvp_quality_iteration_plan_report(
         ),
         "outside_soloing_repair_source_context_preserved": bool(
             post_mvp_status.get("outside_soloing_repair_source_context_preserved", False)
+        ),
+        "outside_soloing_repair_schema_context_preserved": bool(
+            post_mvp_status.get("outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "outside_soloing_repair_objective_schema_version": str(
+            post_mvp_status.get("outside_soloing_repair_objective_schema_version") or ""
         ),
         "outside_soloing_repair_wav_count": _int(
             post_mvp_status.get("outside_soloing_repair_wav_count")
@@ -479,12 +583,20 @@ def markdown_report(report: dict[str, Any]) -> str:
         "",
         f"- boundary: `{report['boundary']}`",
         f"- source boundary: `{report['source_boundary']}`",
+        f"- schema version: `{report['schema_version']}`",
+        f"- source final status schema version: `{report['source_schema_versions']['final_status_audit']}`",
+        f"- source delivery package schema version: `{report['source_schema_versions']['delivery_package']}`",
+        f"- source listening gap schema version: `{report['source_schema_versions']['listening_review_quality_gap']}`",
+        f"- source quality gap schema version: `{report['source_schema_versions']['quality_gap_decision']}`",
+        f"- source current evidence schema version: `{report['source_schema_versions']['current_evidence']}`",
         f"- next boundary: `{selected['selected_next_boundary']}`",
         f"- selected target: `{selected['selected_target']}`",
         f"- technical MVP complete: `{_bool_token(status['technical_mvp_complete'])}`",
         f"- local review ready: `{_bool_token(status['local_review_ready'])}`",
         f"- outside-soloing repair evidence ready: `{_bool_token(status['outside_soloing_repair_evidence_ready'])}`",
         f"- outside-soloing repair source context preserved: `{_bool_token(status['outside_soloing_repair_source_context_preserved'])}`",
+        f"- outside-soloing repair schema context preserved: `{_bool_token(status['outside_soloing_repair_schema_context_preserved'])}`",
+        f"- outside-soloing repair objective schema version: `{status['outside_soloing_repair_objective_schema_version']}`",
         f"- follow-up objective source outside-soloing source context preserved: `{_bool_token(status['followup_objective_source_outside_soloing_source_context_preserved'])}`",
         f"- follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(status['followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- bridge repair sweep source outside-soloing source context preserved: `{_bool_token(status['repair_sweep_source_outside_soloing_source_context_preserved'])}`",

--- a/tests/test_stage_b_midi_to_solo_candidate_failure_labeling.py
+++ b/tests/test_stage_b_midi_to_solo_candidate_failure_labeling.py
@@ -6,7 +6,15 @@ from pathlib import Path
 
 import pretty_midi
 
-from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
+from scripts.audit_stage_b_midi_to_solo_final_status import (
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+    CURRENT_EVIDENCE_SCHEMA_VERSION,
+    DELIVERY_SCHEMA_VERSION,
+    LISTENING_GAP_SCHEMA_VERSION,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    QUALITY_GAP_DECISION_SCHEMA_VERSION,
+    SCHEMA_VERSION as FINAL_STATUS_SCHEMA_VERSION,
+)
 from scripts.build_stage_b_midi_to_solo_mvp_delivery_package import BOUNDARY as DELIVERY_BOUNDARY
 from scripts.build_stage_b_midi_to_solo_quality_rubric_baseline import (
     BOUNDARY as RUBRIC_BOUNDARY,
@@ -27,6 +35,7 @@ from scripts.plan_stage_b_midi_to_solo_post_mvp_quality_iteration import (
     BOUNDARY as POST_MVP_BOUNDARY,
     NEXT_BOUNDARY as POST_MVP_NEXT_BOUNDARY,
     SELECTED_TARGET as POST_MVP_SELECTED_TARGET,
+    SCHEMA_VERSION as POST_MVP_SCHEMA_VERSION,
 )
 
 
@@ -73,7 +82,15 @@ def write_midi(path: Path, pitches: list[int]) -> None:
 
 def post_mvp_quality_plan() -> dict:
     return {
+        "schema_version": POST_MVP_SCHEMA_VERSION,
         "boundary": POST_MVP_BOUNDARY,
+        "source_schema_versions": {
+            "final_status_audit": FINAL_STATUS_SCHEMA_VERSION,
+            "delivery_package": DELIVERY_SCHEMA_VERSION,
+            "listening_review_quality_gap": LISTENING_GAP_SCHEMA_VERSION,
+            "quality_gap_decision": QUALITY_GAP_DECISION_SCHEMA_VERSION,
+            "current_evidence": CURRENT_EVIDENCE_SCHEMA_VERSION,
+        },
         "selected_next_target": {
             "selected_target": POST_MVP_SELECTED_TARGET,
             "selected_next_boundary": POST_MVP_NEXT_BOUNDARY,
@@ -86,10 +103,19 @@ def post_mvp_quality_plan() -> dict:
         ],
         "quality_failure_taxonomy_seed": [f"failure_{index}" for index in range(7)],
         "post_mvp_status": {
+            "source_final_status_schema_version": FINAL_STATUS_SCHEMA_VERSION,
+            "source_delivery_package_schema_version": DELIVERY_SCHEMA_VERSION,
+            "source_listening_gap_schema_version": LISTENING_GAP_SCHEMA_VERSION,
+            "source_quality_gap_schema_version": QUALITY_GAP_DECISION_SCHEMA_VERSION,
+            "source_current_evidence_schema_version": CURRENT_EVIDENCE_SCHEMA_VERSION,
             "technical_mvp_complete": True,
             "local_review_ready": True,
             "outside_soloing_repair_evidence_ready": True,
             "outside_soloing_repair_source_context_preserved": True,
+            "outside_soloing_repair_schema_context_preserved": True,
+            "outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "outside_soloing_repair_wav_count": 6,
             "outside_soloing_repair_changed_note_total": 2,
             "outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
@@ -111,6 +137,7 @@ def post_mvp_quality_plan() -> dict:
             "targeted_quality_repair_sweep_required": True,
             "audio_review_package_required": True,
             "outside_soloing_repair_source_context_preserved": True,
+            "outside_soloing_repair_schema_context_preserved": True,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
             "audio_rendered_quality_claimed": False,

--- a/tests/test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan.py
+++ b/tests/test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan.py
@@ -150,6 +150,18 @@ class StageBMidiToSoloPostMvpQualityIterationPlanTest(unittest.TestCase):
 
         self.assertEqual(report["schema_version"], SCHEMA_VERSION)
         self.assertEqual(report["issue_number"], 1082)
+        self.assertEqual(summary["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(summary["source_final_status_schema_version"], FINAL_STATUS_SCHEMA_VERSION)
+        self.assertEqual(summary["source_delivery_package_schema_version"], DELIVERY_SCHEMA_VERSION)
+        self.assertEqual(summary["source_listening_gap_schema_version"], LISTENING_GAP_SCHEMA_VERSION)
+        self.assertEqual(
+            summary["source_quality_gap_schema_version"],
+            QUALITY_GAP_DECISION_SCHEMA_VERSION,
+        )
+        self.assertEqual(
+            summary["source_current_evidence_schema_version"],
+            CURRENT_EVIDENCE_SCHEMA_VERSION,
+        )
         self.assertTrue(summary["post_mvp_quality_iteration_plan_completed"])
         self.assertTrue(summary["technical_mvp_complete"])
         self.assertTrue(summary["local_review_ready"])
@@ -157,6 +169,11 @@ class StageBMidiToSoloPostMvpQualityIterationPlanTest(unittest.TestCase):
         self.assertTrue(summary["quality_rubric_required"])
         self.assertTrue(summary["outside_soloing_repair_evidence_ready"])
         self.assertTrue(summary["outside_soloing_repair_source_context_preserved"])
+        self.assertTrue(summary["outside_soloing_repair_schema_context_preserved"])
+        self.assertEqual(
+            summary["outside_soloing_repair_objective_schema_version"],
+            OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+        )
         self.assertEqual(summary["outside_soloing_repair_wav_count"], 6)
         self.assertEqual(summary["outside_soloing_repair_changed_note_total"], 2)
         self.assertEqual(summary["outside_soloing_repair_source_objective_pitch_role_risk_count"], 5)
@@ -180,6 +197,37 @@ class StageBMidiToSoloPostMvpQualityIterationPlanTest(unittest.TestCase):
             summary["next_recommended_issue"],
             "Stage B MIDI-to-solo quality rubric baseline source-context refresh",
         )
+        self.assertEqual(
+            report["source_schema_versions"]["final_status_audit"],
+            FINAL_STATUS_SCHEMA_VERSION,
+        )
+
+    def test_rejects_post_mvp_schema_mismatch(self) -> None:
+        report = build_post_mvp_quality_iteration_plan_report(
+            final_status_audit=final_status_audit(),
+            output_dir=Path("outputs/post_mvp_quality"),
+            issue_number=1166,
+        )
+        report["schema_version"] = "stale_schema"
+        with self.assertRaises(StageBMidiToSoloPostMvpQualityIterationPlanError):
+            validate_post_mvp_quality_iteration_plan_report(
+                report,
+                expected_boundary=BOUNDARY,
+                expected_next_boundary=NEXT_BOUNDARY,
+                expected_target=SELECTED_TARGET,
+                require_quality_rubric=True,
+                require_no_quality_claim=True,
+            )
+
+    def test_rejects_final_status_schema_mismatch(self) -> None:
+        source = final_status_audit()
+        source["schema_version"] = "stale_schema"
+        with self.assertRaises(StageBMidiToSoloPostMvpQualityIterationPlanError):
+            build_post_mvp_quality_iteration_plan_report(
+                final_status_audit=source,
+                output_dir=Path("outputs/post_mvp_quality"),
+                issue_number=1166,
+            )
 
     def test_rejects_wrong_source_boundary(self) -> None:
         source = final_status_audit()
@@ -269,7 +317,7 @@ class StageBMidiToSoloPostMvpQualityIterationPlanTest(unittest.TestCase):
         self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_post_mvp_quality_iteration_plan")
         self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_quality_rubric_baseline")
         self.assertEqual(SELECTED_TARGET, "quality_rubric_baseline")
-        self.assertEqual(SCHEMA_VERSION, "stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v3")
+        self.assertEqual(SCHEMA_VERSION, "stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4")
 
 
 if __name__ == "__main__":

--- a/tests/test_stage_b_midi_to_solo_quality_rubric_baseline.py
+++ b/tests/test_stage_b_midi_to_solo_quality_rubric_baseline.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 import unittest
 from pathlib import Path
 
-from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
+from scripts.audit_stage_b_midi_to_solo_final_status import (
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+    CURRENT_EVIDENCE_SCHEMA_VERSION,
+    DELIVERY_SCHEMA_VERSION,
+    LISTENING_GAP_SCHEMA_VERSION,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    QUALITY_GAP_DECISION_SCHEMA_VERSION,
+    SCHEMA_VERSION as FINAL_STATUS_SCHEMA_VERSION,
+)
 from scripts.build_stage_b_midi_to_solo_quality_rubric_baseline import (
     BOUNDARY,
     NEXT_BOUNDARY,
@@ -17,6 +25,7 @@ from scripts.plan_stage_b_midi_to_solo_post_mvp_quality_iteration import (
     BOUNDARY as POST_MVP_BOUNDARY,
     NEXT_BOUNDARY as POST_MVP_NEXT_BOUNDARY,
     SELECTED_TARGET as POST_MVP_SELECTED_TARGET,
+    SCHEMA_VERSION as POST_MVP_SCHEMA_VERSION,
 )
 
 
@@ -65,13 +74,30 @@ def post_mvp_quality_plan(
         "audio_review_package",
     ][:ordered_work_count]
     return {
+        "schema_version": POST_MVP_SCHEMA_VERSION,
         "boundary": POST_MVP_BOUNDARY,
         "source_boundary": "stage_b_midi_to_solo_final_status_audit",
+        "source_schema_versions": {
+            "final_status_audit": FINAL_STATUS_SCHEMA_VERSION,
+            "delivery_package": DELIVERY_SCHEMA_VERSION,
+            "listening_review_quality_gap": LISTENING_GAP_SCHEMA_VERSION,
+            "quality_gap_decision": QUALITY_GAP_DECISION_SCHEMA_VERSION,
+            "current_evidence": CURRENT_EVIDENCE_SCHEMA_VERSION,
+        },
         "post_mvp_status": {
+            "source_final_status_schema_version": FINAL_STATUS_SCHEMA_VERSION,
+            "source_delivery_package_schema_version": DELIVERY_SCHEMA_VERSION,
+            "source_listening_gap_schema_version": LISTENING_GAP_SCHEMA_VERSION,
+            "source_quality_gap_schema_version": QUALITY_GAP_DECISION_SCHEMA_VERSION,
+            "source_current_evidence_schema_version": CURRENT_EVIDENCE_SCHEMA_VERSION,
             "technical_mvp_complete": True,
             "local_review_ready": True,
             "outside_soloing_repair_evidence_ready": outside_ready,
             "outside_soloing_repair_source_context_preserved": outside_ready,
+            "outside_soloing_repair_schema_context_preserved": outside_ready,
+            "outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "outside_soloing_repair_wav_count": outside_wav_count,
             "outside_soloing_repair_changed_note_total": 2,
             "outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
@@ -99,6 +125,7 @@ def post_mvp_quality_plan(
             "targeted_quality_repair_sweep_required": True,
             "audio_review_package_required": True,
             "outside_soloing_repair_source_context_preserved": outside_ready,
+            "outside_soloing_repair_schema_context_preserved": outside_ready,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
             "audio_rendered_quality_claimed": False,

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py
@@ -7,6 +7,12 @@ from pathlib import Path
 from scripts.audit_stage_b_midi_to_solo_final_status import (
     BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
     BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
+    CURRENT_EVIDENCE_SCHEMA_VERSION,
+    DELIVERY_SCHEMA_VERSION,
+    LISTENING_GAP_SCHEMA_VERSION,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    QUALITY_GAP_DECISION_SCHEMA_VERSION,
+    SCHEMA_VERSION as FINAL_STATUS_SCHEMA_VERSION,
 )
 from scripts.build_stage_b_midi_to_solo_quality_rubric_baseline import (
     build_quality_rubric_baseline_report,
@@ -21,6 +27,7 @@ from scripts.plan_stage_b_midi_to_solo_post_mvp_quality_iteration import (
     BOUNDARY as POST_MVP_BOUNDARY,
     NEXT_BOUNDARY as POST_MVP_NEXT_BOUNDARY,
     SELECTED_TARGET as POST_MVP_SELECTED_TARGET,
+    SCHEMA_VERSION as POST_MVP_SCHEMA_VERSION,
 )
 from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep import (
     BOUNDARY,
@@ -66,7 +73,15 @@ SOURCE_CONTEXT = {
 
 def post_mvp_quality_plan() -> dict:
     return {
+        "schema_version": POST_MVP_SCHEMA_VERSION,
         "boundary": POST_MVP_BOUNDARY,
+        "source_schema_versions": {
+            "final_status_audit": FINAL_STATUS_SCHEMA_VERSION,
+            "delivery_package": DELIVERY_SCHEMA_VERSION,
+            "listening_review_quality_gap": LISTENING_GAP_SCHEMA_VERSION,
+            "quality_gap_decision": QUALITY_GAP_DECISION_SCHEMA_VERSION,
+            "current_evidence": CURRENT_EVIDENCE_SCHEMA_VERSION,
+        },
         "selected_next_target": {
             "selected_target": POST_MVP_SELECTED_TARGET,
             "selected_next_boundary": POST_MVP_NEXT_BOUNDARY,
@@ -79,10 +94,19 @@ def post_mvp_quality_plan() -> dict:
         ],
         "quality_failure_taxonomy_seed": [f"failure_{index}" for index in range(7)],
         "post_mvp_status": {
+            "source_final_status_schema_version": FINAL_STATUS_SCHEMA_VERSION,
+            "source_delivery_package_schema_version": DELIVERY_SCHEMA_VERSION,
+            "source_listening_gap_schema_version": LISTENING_GAP_SCHEMA_VERSION,
+            "source_quality_gap_schema_version": QUALITY_GAP_DECISION_SCHEMA_VERSION,
+            "source_current_evidence_schema_version": CURRENT_EVIDENCE_SCHEMA_VERSION,
             "technical_mvp_complete": True,
             "local_review_ready": True,
             "outside_soloing_repair_evidence_ready": True,
             "outside_soloing_repair_source_context_preserved": True,
+            "outside_soloing_repair_schema_context_preserved": True,
+            "outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "outside_soloing_repair_wav_count": 6,
             "outside_soloing_repair_changed_note_total": 2,
             "outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
@@ -104,6 +128,7 @@ def post_mvp_quality_plan() -> dict:
             "targeted_quality_repair_sweep_required": True,
             "audio_review_package_required": True,
             "outside_soloing_repair_source_context_preserved": True,
+            "outside_soloing_repair_schema_context_preserved": True,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
             "audio_rendered_quality_claimed": False,

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
@@ -4,7 +4,15 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
+from scripts.audit_stage_b_midi_to_solo_final_status import (
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+    CURRENT_EVIDENCE_SCHEMA_VERSION,
+    DELIVERY_SCHEMA_VERSION,
+    LISTENING_GAP_SCHEMA_VERSION,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    QUALITY_GAP_DECISION_SCHEMA_VERSION,
+    SCHEMA_VERSION as FINAL_STATUS_SCHEMA_VERSION,
+)
 from scripts.build_stage_b_midi_to_solo_quality_rubric_baseline import (
     build_quality_rubric_baseline_report,
 )
@@ -17,6 +25,7 @@ from scripts.plan_stage_b_midi_to_solo_post_mvp_quality_iteration import (
     BOUNDARY as POST_MVP_BOUNDARY,
     NEXT_BOUNDARY as POST_MVP_NEXT_BOUNDARY,
     SELECTED_TARGET as POST_MVP_SELECTED_TARGET,
+    SCHEMA_VERSION as POST_MVP_SCHEMA_VERSION,
 )
 from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep import (
     BOUNDARY,
@@ -63,7 +72,15 @@ SOURCE_CONTEXT = {
 
 def post_mvp_quality_plan() -> dict:
     return {
+        "schema_version": POST_MVP_SCHEMA_VERSION,
         "boundary": POST_MVP_BOUNDARY,
+        "source_schema_versions": {
+            "final_status_audit": FINAL_STATUS_SCHEMA_VERSION,
+            "delivery_package": DELIVERY_SCHEMA_VERSION,
+            "listening_review_quality_gap": LISTENING_GAP_SCHEMA_VERSION,
+            "quality_gap_decision": QUALITY_GAP_DECISION_SCHEMA_VERSION,
+            "current_evidence": CURRENT_EVIDENCE_SCHEMA_VERSION,
+        },
         "selected_next_target": {
             "selected_target": POST_MVP_SELECTED_TARGET,
             "selected_next_boundary": POST_MVP_NEXT_BOUNDARY,
@@ -76,10 +93,19 @@ def post_mvp_quality_plan() -> dict:
         ],
         "quality_failure_taxonomy_seed": [f"failure_{index}" for index in range(7)],
         "post_mvp_status": {
+            "source_final_status_schema_version": FINAL_STATUS_SCHEMA_VERSION,
+            "source_delivery_package_schema_version": DELIVERY_SCHEMA_VERSION,
+            "source_listening_gap_schema_version": LISTENING_GAP_SCHEMA_VERSION,
+            "source_quality_gap_schema_version": QUALITY_GAP_DECISION_SCHEMA_VERSION,
+            "source_current_evidence_schema_version": CURRENT_EVIDENCE_SCHEMA_VERSION,
             "technical_mvp_complete": True,
             "local_review_ready": True,
             "outside_soloing_repair_evidence_ready": True,
             "outside_soloing_repair_source_context_preserved": True,
+            "outside_soloing_repair_schema_context_preserved": True,
+            "outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "outside_soloing_repair_wav_count": 6,
             "outside_soloing_repair_changed_note_total": 2,
             "outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
@@ -101,6 +127,7 @@ def post_mvp_quality_plan() -> dict:
             "targeted_quality_repair_sweep_required": True,
             "audio_review_package_required": True,
             "outside_soloing_repair_source_context_preserved": True,
+            "outside_soloing_repair_schema_context_preserved": True,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
             "audio_rendered_quality_claimed": False,

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
@@ -6,7 +6,15 @@ from pathlib import Path
 
 import pretty_midi
 
-from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
+from scripts.audit_stage_b_midi_to_solo_final_status import (
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+    CURRENT_EVIDENCE_SCHEMA_VERSION,
+    DELIVERY_SCHEMA_VERSION,
+    LISTENING_GAP_SCHEMA_VERSION,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    QUALITY_GAP_DECISION_SCHEMA_VERSION,
+    SCHEMA_VERSION as FINAL_STATUS_SCHEMA_VERSION,
+)
 from scripts.build_stage_b_midi_to_solo_mvp_delivery_package import BOUNDARY as DELIVERY_BOUNDARY
 from scripts.build_stage_b_midi_to_solo_quality_rubric_baseline import (
     build_quality_rubric_baseline_report,
@@ -18,6 +26,7 @@ from scripts.plan_stage_b_midi_to_solo_post_mvp_quality_iteration import (
     BOUNDARY as POST_MVP_BOUNDARY,
     NEXT_BOUNDARY as POST_MVP_NEXT_BOUNDARY,
     SELECTED_TARGET as POST_MVP_SELECTED_TARGET,
+    SCHEMA_VERSION as POST_MVP_SCHEMA_VERSION,
 )
 from scripts.run_stage_b_midi_to_solo_targeted_quality_repair_sweep import (
     BOUNDARY,
@@ -72,7 +81,15 @@ def write_midi(path: Path, pitches: list[int]) -> None:
 
 def post_mvp_quality_plan() -> dict:
     return {
+        "schema_version": POST_MVP_SCHEMA_VERSION,
         "boundary": POST_MVP_BOUNDARY,
+        "source_schema_versions": {
+            "final_status_audit": FINAL_STATUS_SCHEMA_VERSION,
+            "delivery_package": DELIVERY_SCHEMA_VERSION,
+            "listening_review_quality_gap": LISTENING_GAP_SCHEMA_VERSION,
+            "quality_gap_decision": QUALITY_GAP_DECISION_SCHEMA_VERSION,
+            "current_evidence": CURRENT_EVIDENCE_SCHEMA_VERSION,
+        },
         "selected_next_target": {
             "selected_target": POST_MVP_SELECTED_TARGET,
             "selected_next_boundary": POST_MVP_NEXT_BOUNDARY,
@@ -85,10 +102,19 @@ def post_mvp_quality_plan() -> dict:
         ],
         "quality_failure_taxonomy_seed": [f"failure_{index}" for index in range(7)],
         "post_mvp_status": {
+            "source_final_status_schema_version": FINAL_STATUS_SCHEMA_VERSION,
+            "source_delivery_package_schema_version": DELIVERY_SCHEMA_VERSION,
+            "source_listening_gap_schema_version": LISTENING_GAP_SCHEMA_VERSION,
+            "source_quality_gap_schema_version": QUALITY_GAP_DECISION_SCHEMA_VERSION,
+            "source_current_evidence_schema_version": CURRENT_EVIDENCE_SCHEMA_VERSION,
             "technical_mvp_complete": True,
             "local_review_ready": True,
             "outside_soloing_repair_evidence_ready": True,
             "outside_soloing_repair_source_context_preserved": True,
+            "outside_soloing_repair_schema_context_preserved": True,
+            "outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "outside_soloing_repair_wav_count": 6,
             "outside_soloing_repair_changed_note_total": 2,
             "outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
@@ -110,6 +136,7 @@ def post_mvp_quality_plan() -> dict:
             "targeted_quality_repair_sweep_required": True,
             "audio_review_package_required": True,
             "outside_soloing_repair_source_context_preserved": True,
+            "outside_soloing_repair_schema_context_preserved": True,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
             "audio_rendered_quality_claimed": False,


### PR DESCRIPTION
## Summary

- post-MVP quality iteration plan schema v4 적용
- final status, delivery package, listening gap, quality gap, current evidence schema version 전파
- outside-soloing schema-context preserved flag와 objective schema version 전파
- quality rubric 및 downstream test fixture 입력 계약 정렬

## Context

- #1164 final status audit source-context refresh 결과 기준
- source boundary: stage_b_midi_to_solo_final_status_audit
- final status schema: stage_b_midi_to_solo_final_status_audit_v4
- selected target: quality_rubric_baseline
- quality/preference claim: false

## Scope

- post-MVP quality iteration plan validation/report/markdown
- post-MVP plan tests
- quality rubric and downstream fixture alignment
- generated post-MVP quality iteration plan document
- README, CURRENT_STATUS, CORE_PLAN, AGENTS handoff

## Validation

- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_post_mvp_quality_iteration_plan
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_quality_rubric_baseline
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_candidate_failure_labeling
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_sweep
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep
- .venv/bin/python -m py_compile scripts/plan_stage_b_midi_to_solo_post_mvp_quality_iteration.py scripts/build_stage_b_midi_to_solo_quality_rubric_baseline.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-post-mvp-quality-iteration-plan
- bash scripts/agent_harness.sh quick
- git diff --check

## Risk

- Musical quality/preference 판단 제외
- Quality rubric baseline은 다음 boundary

Closes #1166