### PR TITLE
Stage B MIDI-to-solo targeted quality repair sweep source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Current handoff scope:
 - Latest post-MVP quality iteration plan completed: Issue #1166, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh.
 - Latest quality rubric baseline completed: Issue #1168, Stage B MIDI-to-solo quality rubric baseline source-context refresh.
 - Latest candidate failure labeling completed: Issue #1170, Stage B MIDI-to-solo candidate failure labeling source-context refresh.
-- Latest targeted quality repair sweep completed: Issue #1088, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh.
+- Latest targeted quality repair sweep completed: Issue #1172, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh.
 - Latest targeted quality repair audio package completed: Issue #1090, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh.
 - Latest targeted quality repair listening review package completed: Issue #1092, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh.
 - Latest targeted quality repair listening review input guard completed: Issue #1094, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1148, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after Stage B MIDI-to-solo candidate failure labeling source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo targeted quality repair sweep source-context refresh.
+- Open issue queue after Stage B MIDI-to-solo targeted quality repair sweep source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo targeted quality repair audio package source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest post-MVP quality iteration plan: `Issue #1166`
 - latest quality rubric baseline: `Issue #1168`
 - latest candidate failure labeling: `Issue #1170`
-- latest targeted quality repair sweep: `Issue #1088`
+- latest targeted quality repair sweep: `Issue #1172`
 - latest targeted quality repair audio package: `Issue #1090`
 - latest targeted quality repair listening review package: `Issue #1092`
 - latest targeted quality repair listening review input guard: `Issue #1094`
@@ -50,7 +50,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1150`
 - latest README evidence refresh: `Issue #1152`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after candidate failure labeling source-context refresh merge: `0`
+- open issue queue after targeted quality repair sweep source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
@@ -311,9 +311,20 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - candidate failure follow-up repair sweep source outside-soloing source context preserved: `true`
 - candidate failure bridge repair sweep source outside-soloing source context preserved: `true`
 - targeted quality repair sweep completed: `true`
+- targeted quality repair sweep schema version: `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`
+- targeted quality repair source candidate failure labeling schema version: `stage_b_midi_to_solo_candidate_failure_labeling_v4`
+- targeted quality repair source quality rubric schema version: `stage_b_midi_to_solo_quality_rubric_baseline_v4`
+- targeted quality repair source post-MVP plan schema version: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`
+- targeted quality repair source final status schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- targeted quality repair source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- targeted quality repair source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- targeted quality repair source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- targeted quality repair source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - targeted quality repair failure label count: `12 -> 8`
 - targeted quality repair improved candidates: `4 / 6`
 - targeted quality repair technical regression count: `0`
+- targeted quality repair outside-soloing schema context preserved: `true`
+- targeted quality repair outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - targeted quality repair follow-up objective source outside-soloing source context preserved: `true`
 - targeted quality repair follow-up repair sweep source outside-soloing source context preserved: `true`
 - targeted quality repair bridge repair sweep source outside-soloing source context preserved: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -402,7 +402,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo post-MVP quality iteration plan: schema `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`, source final status schema `stage_b_midi_to_solo_final_status_audit_v4`, source current evidence schema `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`, selected target `quality_rubric_baseline`, source risk `5 -> 2`, current repair risk after `0`, outside-soloing schema-context preserved `true`, ordered work `4`, taxonomy seed `7`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_quality_rubric_baseline`
 - MIDI-to-solo quality rubric baseline: schema `stage_b_midi_to_solo_quality_rubric_baseline_v4`, source post-MVP schema `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`, source final status schema `stage_b_midi_to_solo_final_status_audit_v4`, rubric items `8`, metric groups `30`, source risk `5 -> 2`, current repair risk after `0`, outside-soloing schema-context preserved `true`, source-context preserved flags `3/3`, candidate failure labeling ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_candidate_failure_labeling`
 - MIDI-to-solo candidate failure labeling: schema `stage_b_midi_to_solo_candidate_failure_labeling_v4`, source rubric schema `stage_b_midi_to_solo_quality_rubric_baseline_v4`, source post-MVP schema `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`, candidates `6`, failed `6`, failure label types `4`, not-evaluable types `2`, source risk `5 -> 2`, current repair risk after `0`, outside-soloing schema-context preserved `true`, source-context preserved flags `3/3`, targeted repair ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_sweep`
-- MIDI-to-solo targeted quality repair sweep: candidates `6`, failure labels `12 -> 8`, improved candidates `4`, technical regression `0`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
+- MIDI-to-solo targeted quality repair sweep: schema `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`, source candidate labeling schema `stage_b_midi_to_solo_candidate_failure_labeling_v4`, source rubric schema `stage_b_midi_to_solo_quality_rubric_baseline_v4`, candidates `6`, failure labels `12 -> 8`, improved candidates `4`, technical regression `0`, source risk `5 -> 2`, current repair risk after `0`, outside-soloing schema-context preserved `true`, source-context preserved flags `3/3`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
 - MIDI-to-solo targeted quality repair audio package: rendered WAV `6`, duration `18.422s-18.984s`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
 - MIDI-to-solo targeted quality repair listening review package: review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
 - MIDI-to-solo targeted quality repair listening review input guard: review items `6`, preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
@@ -12604,13 +12604,22 @@ Issue #1170은 Issue #1168 quality rubric baseline v4 결과를 기준으로 can
 
 ## 9.234 Stage B MIDI-to-solo targeted quality repair sweep source-context refresh
 
-Issue #1088은 Issue #1086 candidate failure labeling 결과를 기준으로 targeted quality repair sweep의 source-context validation과 summary에 source-context preserved flag 3개를 보존한 작업이다.
+Issue #1172는 Issue #1170 candidate failure labeling v4 결과를 기준으로 targeted quality repair sweep의 source schema chain과 outside-soloing schema context를 보존한 작업이다.
 
 결과:
 
 - document: `docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
 - source boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
+- schema version: `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`
+- source candidate failure labeling schema version: `stage_b_midi_to_solo_candidate_failure_labeling_v4`
+- source quality rubric schema version: `stage_b_midi_to_solo_quality_rubric_baseline_v4`
+- source post-MVP plan schema version: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`
+- source final status schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
 - selected target: `targeted_quality_repair_audio_package`
 - targeted quality repair sweep completed: `true`
@@ -12623,6 +12632,8 @@ Issue #1088은 Issue #1086 candidate failure labeling 결과를 기준으로 tar
 - technical regression count: `0`
 - source outside-soloing repair evidence ready: `true`
 - source outside-soloing repair source context preserved: `true`
+- source outside-soloing repair schema context preserved: `true`
+- source outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`
@@ -12636,8 +12647,8 @@ Issue #1088은 Issue #1086 candidate failure labeling 결과를 기준으로 tar
 
 판단:
 
-- targeted quality repair sweep source validation에 candidate failure labeling preserved flag 3개 포함.
-- preserved flag false 입력은 validation error로 차단.
+- targeted quality repair sweep source validation에 candidate failure labeling v4와 source schema chain 포함.
+- preserved flag false 입력과 objective schema mismatch 입력은 validation error로 차단.
 - failure label은 `12 -> 8`, improved candidate는 `4 / 6`.
 - technical regression count는 `0`.
 - 다음 검증 대상은 targeted quality repair audio package 유지.
@@ -12646,7 +12657,8 @@ Issue #1088은 Issue #1086 candidate failure labeling 결과를 기준으로 tar
 검증:
 
 - `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_sweep`
-- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py`
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_audio`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py scripts/render_stage_b_midi_to_solo_targeted_quality_repair_audio.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-sweep`
 - `bash scripts/agent_harness.sh quick`

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -22,7 +22,7 @@
 - latest post-MVP quality iteration plan: Issue #1166, Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh
 - latest quality rubric baseline: Issue #1168, Stage B MIDI-to-solo quality rubric baseline source-context refresh
 - latest candidate failure labeling: Issue #1170, Stage B MIDI-to-solo candidate failure labeling source-context refresh
-- latest targeted quality repair sweep: Issue #1088, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh
+- latest targeted quality repair sweep: Issue #1172, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh
 - latest targeted quality repair audio package: Issue #1090, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh
 - latest targeted quality repair listening review package: Issue #1092, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh
 - latest targeted quality repair listening review input guard: Issue #1094, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh
@@ -5909,13 +5909,22 @@ Issue #1170은 Issue #1168 quality rubric baseline v4 결과를 기준으로 can
 
 ## 9.234 Stage B MIDI-to-solo targeted quality repair sweep source-context refresh
 
-Issue #1088은 Issue #1086 candidate failure labeling 결과를 기준으로 targeted quality repair sweep의 source-context validation과 summary에 source-context preserved flag 3개를 보존한 작업이다.
+Issue #1172는 Issue #1170 candidate failure labeling v4 결과를 기준으로 targeted quality repair sweep의 source schema chain과 outside-soloing schema context를 보존한 작업이다.
 
 결과:
 
 - document: `docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
 - source boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
+- schema version: `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`
+- source candidate failure labeling schema version: `stage_b_midi_to_solo_candidate_failure_labeling_v4`
+- source quality rubric schema version: `stage_b_midi_to_solo_quality_rubric_baseline_v4`
+- source post-MVP plan schema version: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`
+- source final status schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
 - selected target: `targeted_quality_repair_audio_package`
 - targeted quality repair sweep completed: `true`
@@ -5928,6 +5937,8 @@ Issue #1088은 Issue #1086 candidate failure labeling 결과를 기준으로 tar
 - technical regression count: `0`
 - source outside-soloing repair evidence ready: `true`
 - source outside-soloing repair source context preserved: `true`
+- source outside-soloing repair schema context preserved: `true`
+- source outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`
@@ -5941,8 +5952,8 @@ Issue #1088은 Issue #1086 candidate failure labeling 결과를 기준으로 tar
 
 판단:
 
-- targeted quality repair sweep source validation에 candidate failure labeling preserved flag 3개 포함.
-- preserved flag false 입력은 validation error로 차단.
+- targeted quality repair sweep source validation에 candidate failure labeling v4와 source schema chain 포함.
+- preserved flag false 입력과 objective schema mismatch 입력은 validation error로 차단.
 - failure label은 `12 -> 8`, improved candidate는 `4 / 6`.
 - technical regression count는 `0`.
 - 다음 검증 대상은 targeted quality repair audio package 유지.
@@ -5951,7 +5962,8 @@ Issue #1088은 Issue #1086 candidate failure labeling 결과를 기준으로 tar
 검증:
 
 - `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_sweep`
-- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py`
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_audio`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py scripts/render_stage_b_midi_to_solo_targeted_quality_repair_audio.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-sweep`
 - `bash scripts/agent_harness.sh quick`

--- a/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -4,6 +4,15 @@
 
 - boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
 - source boundary: `stage_b_midi_to_solo_candidate_failure_labeling`
+- schema version: `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`
+- source candidate failure labeling schema version: `stage_b_midi_to_solo_candidate_failure_labeling_v4`
+- source quality rubric schema version: `stage_b_midi_to_solo_quality_rubric_baseline_v4`
+- source post-MVP plan schema version: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`
+- source final status schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
 - selected target: `targeted_quality_repair_audio_package`
 - candidate count: `6`
@@ -14,6 +23,8 @@
 - technical regression count: `0`
 - source outside-soloing repair evidence ready: `true`
 - source outside-soloing repair source context preserved: `true`
+- source outside-soloing repair schema context preserved: `true`
+- source outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6212,7 +6212,7 @@ run_stage_b_midi_to_solo_targeted_quality_repair_sweep() {
     --candidate_failure_labeling "$labeling" \
     --rubric_baseline "$rubric" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1088 \
+    --issue_number 1172 \
     --expected_boundary stage_b_midi_to_solo_targeted_quality_repair_sweep \
     --min_candidate_count 6 \
     --require_sweep_completed \

--- a/scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
+++ b/scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
@@ -22,8 +22,17 @@ from scripts.label_stage_b_midi_to_solo_candidate_failures import (  # noqa: E40
     BRIDGE_SOURCE_CONTEXT_KEYS,
     BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
     BOUNDARY as LABELING_BOUNDARY,
+    CURRENT_EVIDENCE_SCHEMA_VERSION,
+    DELIVERY_SCHEMA_VERSION,
+    FINAL_STATUS_SCHEMA_VERSION,
+    LISTENING_GAP_SCHEMA_VERSION,
     REPAIR_NEXT_BOUNDARY as LABELING_NEXT_BOUNDARY,
     REPAIR_TARGET as LABELING_TARGET,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    POST_MVP_PLAN_SCHEMA_VERSION,
+    QUALITY_GAP_DECISION_SCHEMA_VERSION,
+    RUBRIC_SCHEMA_VERSION,
+    SCHEMA_VERSION as LABELING_SCHEMA_VERSION,
     StageBMidiToSoloCandidateFailureLabelingError,
     analyze_candidate_midi,
     label_candidate,
@@ -39,7 +48,7 @@ class StageBMidiToSoloTargetedQualityRepairSweepError(ValueError):
 BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_sweep"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_audio_package"
 FOLLOWUP_BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_followup_decision"
-SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_sweep_v3"
+SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_sweep_v4"
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -135,6 +144,52 @@ def validate_labeling_source(report: dict[str, Any]) -> dict[str, Any]:
     if not bool(summary.get("outside_soloing_repair_source_context_preserved", False)):
         raise StageBMidiToSoloTargetedQualityRepairSweepError(
             "outside-soloing repair source context preservation required"
+        )
+    if str(summary.get("schema_version") or "") != LABELING_SCHEMA_VERSION:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "candidate failure labeling schema version mismatch"
+        )
+    if str(summary.get("source_quality_rubric_schema_version") or "") != RUBRIC_SCHEMA_VERSION:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "labeling source quality rubric schema version mismatch"
+        )
+    if str(
+        summary.get("source_post_mvp_plan_schema_version") or ""
+    ) != POST_MVP_PLAN_SCHEMA_VERSION:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "labeling source post-MVP plan schema version mismatch"
+        )
+    if str(
+        summary.get("source_final_status_schema_version") or ""
+    ) != FINAL_STATUS_SCHEMA_VERSION:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "labeling source final status schema version mismatch"
+        )
+    if str(summary.get("source_delivery_package_schema_version") or "") != DELIVERY_SCHEMA_VERSION:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "labeling source delivery package schema version mismatch"
+        )
+    if str(summary.get("source_listening_gap_schema_version") or "") != LISTENING_GAP_SCHEMA_VERSION:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "labeling source listening gap schema version mismatch"
+        )
+    if str(summary.get("source_quality_gap_schema_version") or "") != QUALITY_GAP_DECISION_SCHEMA_VERSION:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "labeling source quality gap schema version mismatch"
+        )
+    if str(summary.get("source_current_evidence_schema_version") or "") != CURRENT_EVIDENCE_SCHEMA_VERSION:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "labeling source current evidence schema version mismatch"
+        )
+    if not bool(summary.get("outside_soloing_repair_schema_context_preserved", False)):
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "outside-soloing repair schema context preservation required"
+        )
+    if str(
+        summary.get("outside_soloing_repair_objective_schema_version") or ""
+    ) != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "outside-soloing repair objective schema version mismatch"
         )
     _source_context_fields(summary, label="candidate failure labeling")
     if _int(summary.get("outside_soloing_repair_wav_count")) < 6:
@@ -373,6 +428,20 @@ def build_targeted_quality_repair_sweep_report(
         "issue_number": int(issue_number),
         "boundary": BOUNDARY,
         "source_boundary": LABELING_BOUNDARY,
+        "source_schema_versions": {
+            "candidate_failure_labeling": str(source_summary["schema_version"]),
+            "quality_rubric_baseline": str(source_summary["source_quality_rubric_schema_version"]),
+            "post_mvp_quality_iteration_plan": str(
+                source_summary["source_post_mvp_plan_schema_version"]
+            ),
+            "final_status_audit": str(source_summary["source_final_status_schema_version"]),
+            "delivery_package": str(source_summary["source_delivery_package_schema_version"]),
+            "listening_review_quality_gap": str(
+                source_summary["source_listening_gap_schema_version"]
+            ),
+            "quality_gap_decision": str(source_summary["source_quality_gap_schema_version"]),
+            "current_evidence": str(source_summary["source_current_evidence_schema_version"]),
+        },
         "candidate_repairs": relabeled,
         "aggregate": {
             "candidate_count": len(relabeled),
@@ -387,6 +456,12 @@ def build_targeted_quality_repair_sweep_report(
             ),
             "source_outside_soloing_repair_source_context_preserved": bool(
                 source_summary["outside_soloing_repair_source_context_preserved"]
+            ),
+            "source_outside_soloing_repair_schema_context_preserved": bool(
+                source_summary["outside_soloing_repair_schema_context_preserved"]
+            ),
+            "source_outside_soloing_repair_objective_schema_version": str(
+                source_summary["outside_soloing_repair_objective_schema_version"]
             ),
             "source_outside_soloing_repair_wav_count": _int(
                 source_summary["outside_soloing_repair_wav_count"]
@@ -444,6 +519,12 @@ def build_targeted_quality_repair_sweep_report(
             "source_outside_soloing_repair_source_context_preserved": bool(
                 source_summary["outside_soloing_repair_source_context_preserved"]
             ),
+            "source_outside_soloing_repair_schema_context_preserved": bool(
+                source_summary["outside_soloing_repair_schema_context_preserved"]
+            ),
+            "source_outside_soloing_repair_objective_schema_version": str(
+                source_summary["outside_soloing_repair_objective_schema_version"]
+            ),
             "followup_objective_source_outside_soloing_source_context_preserved": bool(
                 source_summary["followup_objective_source_outside_soloing_source_context_preserved"]
             ),
@@ -495,7 +576,50 @@ def validate_targeted_quality_repair_sweep_report(
     readiness = _dict(report.get("readiness"))
     decision = _dict(report.get("decision"))
     aggregate = _dict(report.get("aggregate"))
+    source_schema_versions = _dict(report.get("source_schema_versions"))
     repairs = _list(report.get("candidate_repairs"))
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "targeted quality repair sweep schema version mismatch"
+        )
+    if str(
+        source_schema_versions.get("candidate_failure_labeling") or ""
+    ) != LABELING_SCHEMA_VERSION:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "repair sweep source candidate failure labeling schema version mismatch"
+        )
+    if str(source_schema_versions.get("quality_rubric_baseline") or "") != RUBRIC_SCHEMA_VERSION:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "repair sweep source quality rubric schema version mismatch"
+        )
+    if str(
+        source_schema_versions.get("post_mvp_quality_iteration_plan") or ""
+    ) != POST_MVP_PLAN_SCHEMA_VERSION:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "repair sweep source post-MVP plan schema version mismatch"
+        )
+    if str(source_schema_versions.get("final_status_audit") or "") != FINAL_STATUS_SCHEMA_VERSION:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "repair sweep source final status schema version mismatch"
+        )
+    if str(source_schema_versions.get("delivery_package") or "") != DELIVERY_SCHEMA_VERSION:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "repair sweep source delivery package schema version mismatch"
+        )
+    if str(
+        source_schema_versions.get("listening_review_quality_gap") or ""
+    ) != LISTENING_GAP_SCHEMA_VERSION:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "repair sweep source listening gap schema version mismatch"
+        )
+    if str(source_schema_versions.get("quality_gap_decision") or "") != QUALITY_GAP_DECISION_SCHEMA_VERSION:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "repair sweep source quality gap schema version mismatch"
+        )
+    if str(source_schema_versions.get("current_evidence") or "") != CURRENT_EVIDENCE_SCHEMA_VERSION:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "repair sweep source current evidence schema version mismatch"
+        )
     if expected_boundary and boundary != expected_boundary:
         raise StageBMidiToSoloTargetedQualityRepairSweepError(
             f"expected boundary {expected_boundary}, got {boundary}"
@@ -518,7 +642,42 @@ def validate_targeted_quality_repair_sweep_report(
         )
     if require_no_quality_claim:
         _require_no_quality_claim(readiness, label="targeted repair readiness")
+    if not bool(aggregate.get("source_outside_soloing_repair_schema_context_preserved", False)):
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "source outside-soloing repair schema context preservation required"
+        )
+    if str(
+        aggregate.get("source_outside_soloing_repair_objective_schema_version") or ""
+    ) != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION:
+        raise StageBMidiToSoloTargetedQualityRepairSweepError(
+            "source outside-soloing repair objective schema version mismatch"
+        )
     return {
+        "schema_version": str(report.get("schema_version") or ""),
+        "source_candidate_failure_labeling_schema_version": str(
+            source_schema_versions.get("candidate_failure_labeling") or ""
+        ),
+        "source_quality_rubric_schema_version": str(
+            source_schema_versions.get("quality_rubric_baseline") or ""
+        ),
+        "source_post_mvp_plan_schema_version": str(
+            source_schema_versions.get("post_mvp_quality_iteration_plan") or ""
+        ),
+        "source_final_status_schema_version": str(
+            source_schema_versions.get("final_status_audit") or ""
+        ),
+        "source_delivery_package_schema_version": str(
+            source_schema_versions.get("delivery_package") or ""
+        ),
+        "source_listening_gap_schema_version": str(
+            source_schema_versions.get("listening_review_quality_gap") or ""
+        ),
+        "source_quality_gap_schema_version": str(
+            source_schema_versions.get("quality_gap_decision") or ""
+        ),
+        "source_current_evidence_schema_version": str(
+            source_schema_versions.get("current_evidence") or ""
+        ),
         "boundary": boundary,
         "next_boundary": str(decision.get("next_boundary") or ""),
         "targeted_quality_repair_sweep_completed": bool(
@@ -542,6 +701,12 @@ def validate_targeted_quality_repair_sweep_report(
         ),
         "source_outside_soloing_repair_source_context_preserved": bool(
             aggregate.get("source_outside_soloing_repair_source_context_preserved", False)
+        ),
+        "source_outside_soloing_repair_schema_context_preserved": bool(
+            aggregate.get("source_outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "source_outside_soloing_repair_objective_schema_version": str(
+            aggregate.get("source_outside_soloing_repair_objective_schema_version") or ""
         ),
         "source_outside_soloing_repair_wav_count": _int(
             aggregate.get("source_outside_soloing_repair_wav_count")
@@ -603,6 +768,15 @@ def markdown_report(report: dict[str, Any]) -> str:
         "",
         f"- boundary: `{report['boundary']}`",
         f"- source boundary: `{report['source_boundary']}`",
+        f"- schema version: `{report['schema_version']}`",
+        f"- source candidate failure labeling schema version: `{report['source_schema_versions']['candidate_failure_labeling']}`",
+        f"- source quality rubric schema version: `{report['source_schema_versions']['quality_rubric_baseline']}`",
+        f"- source post-MVP plan schema version: `{report['source_schema_versions']['post_mvp_quality_iteration_plan']}`",
+        f"- source final status schema version: `{report['source_schema_versions']['final_status_audit']}`",
+        f"- source delivery package schema version: `{report['source_schema_versions']['delivery_package']}`",
+        f"- source listening gap schema version: `{report['source_schema_versions']['listening_review_quality_gap']}`",
+        f"- source quality gap schema version: `{report['source_schema_versions']['quality_gap_decision']}`",
+        f"- source current evidence schema version: `{report['source_schema_versions']['current_evidence']}`",
         f"- next boundary: `{selected['selected_next_boundary']}`",
         f"- selected target: `{selected['selected_target']}`",
         f"- candidate count: `{aggregate['candidate_count']}`",
@@ -613,6 +787,8 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- technical regression count: `{aggregate['technical_regression_count']}`",
         f"- source outside-soloing repair evidence ready: `{_bool_token(aggregate['source_outside_soloing_repair_evidence_ready'])}`",
         f"- source outside-soloing repair source context preserved: `{_bool_token(aggregate['source_outside_soloing_repair_source_context_preserved'])}`",
+        f"- source outside-soloing repair schema context preserved: `{_bool_token(aggregate['source_outside_soloing_repair_schema_context_preserved'])}`",
+        f"- source outside-soloing repair objective schema version: `{aggregate['source_outside_soloing_repair_objective_schema_version']}`",
         f"- follow-up objective source outside-soloing source context preserved: `{_bool_token(aggregate['followup_objective_source_outside_soloing_source_context_preserved'])}`",
         f"- follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(aggregate['followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- bridge repair sweep source outside-soloing source context preserved: `{_bool_token(aggregate['repair_sweep_source_outside_soloing_source_context_preserved'])}`",
@@ -665,7 +841,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=750)
+    parser.add_argument("--issue_number", type=int, default=1172)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--min_candidate_count", type=int, default=6)
     parser.add_argument("--require_sweep_completed", action="store_true")

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_audio.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_audio.py
@@ -9,7 +9,20 @@ from typing import Sequence
 
 import pretty_midi
 
-from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
+from scripts.audit_stage_b_midi_to_solo_final_status import (
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+    CURRENT_EVIDENCE_SCHEMA_VERSION,
+    DELIVERY_SCHEMA_VERSION,
+    LISTENING_GAP_SCHEMA_VERSION,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    QUALITY_GAP_DECISION_SCHEMA_VERSION,
+    SCHEMA_VERSION as FINAL_STATUS_SCHEMA_VERSION,
+)
+from scripts.label_stage_b_midi_to_solo_candidate_failures import (
+    POST_MVP_PLAN_SCHEMA_VERSION,
+    RUBRIC_SCHEMA_VERSION,
+    SCHEMA_VERSION as LABELING_SCHEMA_VERSION,
+)
 from scripts.render_stage_b_midi_to_solo_targeted_quality_repair_audio import (
     BOUNDARY,
     NEXT_BOUNDARY,
@@ -21,6 +34,7 @@ from scripts.render_stage_b_midi_to_solo_targeted_quality_repair_audio import (
 from scripts.run_stage_b_midi_to_solo_targeted_quality_repair_sweep import (
     BOUNDARY as SOURCE_BOUNDARY,
     NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+    SCHEMA_VERSION as SOURCE_SCHEMA_VERSION,
 )
 
 
@@ -110,7 +124,18 @@ def source_report(root: Path, *, quality_claim: bool = False) -> dict:
             }
         )
     return {
+        "schema_version": SOURCE_SCHEMA_VERSION,
         "boundary": SOURCE_BOUNDARY,
+        "source_schema_versions": {
+            "candidate_failure_labeling": LABELING_SCHEMA_VERSION,
+            "quality_rubric_baseline": RUBRIC_SCHEMA_VERSION,
+            "post_mvp_quality_iteration_plan": POST_MVP_PLAN_SCHEMA_VERSION,
+            "final_status_audit": FINAL_STATUS_SCHEMA_VERSION,
+            "delivery_package": DELIVERY_SCHEMA_VERSION,
+            "listening_review_quality_gap": LISTENING_GAP_SCHEMA_VERSION,
+            "quality_gap_decision": QUALITY_GAP_DECISION_SCHEMA_VERSION,
+            "current_evidence": CURRENT_EVIDENCE_SCHEMA_VERSION,
+        },
         "candidate_repairs": repairs,
         "aggregate": {
             "candidate_count": 6,
@@ -122,6 +147,10 @@ def source_report(root: Path, *, quality_claim: bool = False) -> dict:
             "repaired_failure_counts": {"songlike_melody_not_soloing": 5},
             "source_outside_soloing_repair_evidence_ready": True,
             "source_outside_soloing_repair_source_context_preserved": True,
+            "source_outside_soloing_repair_schema_context_preserved": True,
+            "source_outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "source_outside_soloing_repair_wav_count": 6,
             "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
             "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
@@ -148,6 +177,10 @@ def source_report(root: Path, *, quality_claim: bool = False) -> dict:
             "failure_label_delta": 7,
             "technical_regression_count": 0,
             "audio_package_ready": True,
+            "source_outside_soloing_repair_schema_context_preserved": True,
+            "source_outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
             "audio_rendered_quality_claimed": False,

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
@@ -18,9 +18,11 @@ from scripts.audit_stage_b_midi_to_solo_final_status import (
 from scripts.build_stage_b_midi_to_solo_mvp_delivery_package import BOUNDARY as DELIVERY_BOUNDARY
 from scripts.build_stage_b_midi_to_solo_quality_rubric_baseline import (
     build_quality_rubric_baseline_report,
+    SCHEMA_VERSION as RUBRIC_SCHEMA_VERSION,
 )
 from scripts.label_stage_b_midi_to_solo_candidate_failures import (
     build_candidate_failure_labeling_report,
+    SCHEMA_VERSION as LABELING_SCHEMA_VERSION,
 )
 from scripts.plan_stage_b_midi_to_solo_post_mvp_quality_iteration import (
     BOUNDARY as POST_MVP_BOUNDARY,
@@ -157,7 +159,7 @@ def rubric_baseline(root: Path) -> dict:
     return build_quality_rubric_baseline_report(
         post_mvp_quality_plan=post_mvp_quality_plan(),
         output_dir=root / "rubric",
-        issue_number=746,
+        issue_number=1168,
     )
 
 
@@ -214,7 +216,7 @@ def candidate_failure_labeling(root: Path, *, quality_claim: bool = False) -> di
         rubric_baseline=rubric_baseline(root),
         mvp_delivery_package=delivery_package(paths),
         output_dir=root / "labels",
-        issue_number=748,
+        issue_number=1170,
     )
     if quality_claim:
         report["readiness"]["midi_to_solo_musical_quality_claimed"] = True
@@ -229,7 +231,7 @@ class StageBMidiToSoloTargetedQualityRepairSweepTest(unittest.TestCase):
                 candidate_failure_labeling=candidate_failure_labeling(root),
                 rubric_baseline=rubric_baseline(root),
                 output_dir=root / "sweep",
-                issue_number=1088,
+                issue_number=1172,
             )
             summary = validate_targeted_quality_repair_sweep_report(
                 report,
@@ -241,7 +243,19 @@ class StageBMidiToSoloTargetedQualityRepairSweepTest(unittest.TestCase):
             )
 
             self.assertEqual(report["schema_version"], SCHEMA_VERSION)
-            self.assertEqual(report["issue_number"], 1088)
+            self.assertEqual(report["issue_number"], 1172)
+            self.assertEqual(summary["schema_version"], SCHEMA_VERSION)
+            self.assertEqual(
+                summary["source_candidate_failure_labeling_schema_version"],
+                LABELING_SCHEMA_VERSION,
+            )
+            self.assertEqual(summary["source_quality_rubric_schema_version"], RUBRIC_SCHEMA_VERSION)
+            self.assertEqual(summary["source_post_mvp_plan_schema_version"], POST_MVP_SCHEMA_VERSION)
+            self.assertEqual(summary["source_final_status_schema_version"], FINAL_STATUS_SCHEMA_VERSION)
+            self.assertEqual(summary["source_delivery_package_schema_version"], DELIVERY_SCHEMA_VERSION)
+            self.assertEqual(summary["source_listening_gap_schema_version"], LISTENING_GAP_SCHEMA_VERSION)
+            self.assertEqual(summary["source_quality_gap_schema_version"], QUALITY_GAP_DECISION_SCHEMA_VERSION)
+            self.assertEqual(summary["source_current_evidence_schema_version"], CURRENT_EVIDENCE_SCHEMA_VERSION)
             self.assertTrue(summary["targeted_quality_repair_sweep_completed"])
             self.assertTrue(summary["targeted_quality_repair_target_supported"])
             self.assertEqual(summary["candidate_count"], 6)
@@ -249,6 +263,11 @@ class StageBMidiToSoloTargetedQualityRepairSweepTest(unittest.TestCase):
             self.assertEqual(summary["technical_regression_count"], 0)
             self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
             self.assertTrue(summary["source_outside_soloing_repair_source_context_preserved"])
+            self.assertTrue(summary["source_outside_soloing_repair_schema_context_preserved"])
+            self.assertEqual(
+                summary["source_outside_soloing_repair_objective_schema_version"],
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+            )
             self.assertEqual(summary["source_outside_soloing_repair_wav_count"], 6)
             self.assertEqual(
                 summary["source_outside_soloing_repair_source_objective_pitch_role_risk_count"], 5
@@ -288,7 +307,33 @@ class StageBMidiToSoloTargetedQualityRepairSweepTest(unittest.TestCase):
                     ),
                     rubric_baseline=rubric_baseline(root),
                     output_dir=root / "sweep",
-                    issue_number=1088,
+                    issue_number=1172,
+                )
+
+    def test_rejects_labeling_source_schema_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = candidate_failure_labeling(root)
+            source["source_schema_versions"]["quality_rubric_baseline"] = "wrong_schema"
+            with self.assertRaises(StageBMidiToSoloTargetedQualityRepairSweepError):
+                build_targeted_quality_repair_sweep_report(
+                    candidate_failure_labeling=source,
+                    rubric_baseline=rubric_baseline(root),
+                    output_dir=root / "sweep",
+                    issue_number=1172,
+                )
+
+    def test_rejects_missing_labeling_schema_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = candidate_failure_labeling(root)
+            source["aggregate"]["outside_soloing_repair_schema_context_preserved"] = False
+            with self.assertRaises(StageBMidiToSoloTargetedQualityRepairSweepError):
+                build_targeted_quality_repair_sweep_report(
+                    candidate_failure_labeling=source,
+                    rubric_baseline=rubric_baseline(root),
+                    output_dir=root / "sweep",
+                    issue_number=1172,
                 )
 
     def test_rejects_missing_outside_soloing_labeling_context(self) -> None:
@@ -301,7 +346,7 @@ class StageBMidiToSoloTargetedQualityRepairSweepTest(unittest.TestCase):
                     candidate_failure_labeling=source,
                     rubric_baseline=rubric_baseline(root),
                     output_dir=root / "sweep",
-                    issue_number=1088,
+                    issue_number=1172,
                 )
 
     def test_rejects_missing_labeling_source_context_field(self) -> None:
@@ -316,7 +361,7 @@ class StageBMidiToSoloTargetedQualityRepairSweepTest(unittest.TestCase):
                     candidate_failure_labeling=source,
                     rubric_baseline=rubric_baseline(root),
                     output_dir=root / "sweep",
-                    issue_number=1088,
+                    issue_number=1172,
                 )
 
     def test_rejects_false_labeling_source_context_preserved_field(self) -> None:
@@ -331,13 +376,13 @@ class StageBMidiToSoloTargetedQualityRepairSweepTest(unittest.TestCase):
                     candidate_failure_labeling=source,
                     rubric_baseline=rubric_baseline(root),
                     output_dir=root / "sweep",
-                    issue_number=1088,
+                    issue_number=1172,
                 )
 
     def test_constants_are_stable(self) -> None:
         self.assertEqual(BOUNDARY, "stage_b_midi_to_solo_targeted_quality_repair_sweep")
         self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_targeted_quality_repair_audio_package")
-        self.assertEqual(SCHEMA_VERSION, "stage_b_midi_to_solo_targeted_quality_repair_sweep_v3")
+        self.assertEqual(SCHEMA_VERSION, "stage_b_midi_to_solo_targeted_quality_repair_sweep_v4")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- targeted quality repair sweep schema v4 적용
- candidate failure labeling, quality rubric, post-MVP plan, final status, delivery package, listening gap, quality gap, current evidence schema version 검증 및 전파
- outside-soloing schema-context flag와 objective schema version 검증 및 전파
- downstream audio fixture 입력 계약 정렬
- README, CURRENT_STATUS, CORE_PLAN, AGENTS 최신 handoff 갱신

## Context
- Issue #1170 candidate failure labeling v4 결과의 targeted quality repair sweep 입력 계약 보존 필요
- audio package 진입 전 source schema chain과 outside-soloing schema context 추적 필요
- musical quality, human/audio preference claim 제외 유지

## Scope
- scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
- tests/test_stage_b_midi_to_solo_targeted_quality_repair_sweep.py
- tests/test_stage_b_midi_to_solo_targeted_quality_repair_audio.py
- scripts/agent_harness.sh
- README.md, AGENTS.md, docs/CURRENT_STATUS_AND_PLAN.md, docs/CORE_PLAN.md
- docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md

## Validation
- .venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_sweep tests.test_stage_b_midi_to_solo_targeted_quality_repair_audio
- .venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_targeted_quality_repair_sweep.py scripts/render_stage_b_midi_to_solo_targeted_quality_repair_audio.py
- bash -n scripts/agent_harness.sh
- bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-sweep
- bash scripts/agent_harness.sh quick
- git diff --check

## Risk
- objective repair sweep contract 갱신 범위
- musical quality, human/audio preference claim 없음
- raw artifact upload 없음

Closes #1172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated process tracking and quality assurance documentation.

* **Chores**
  * Enhanced internal validation logic and schema versioning for quality repair workflows.
  * Updated references and configuration across supporting tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->