### PR TITLE
Stage B MIDI-to-solo targeted quality repair audio package source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Current handoff scope:
 - Latest quality rubric baseline completed: Issue #1168, Stage B MIDI-to-solo quality rubric baseline source-context refresh.
 - Latest candidate failure labeling completed: Issue #1170, Stage B MIDI-to-solo candidate failure labeling source-context refresh.
 - Latest targeted quality repair sweep completed: Issue #1172, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh.
-- Latest targeted quality repair audio package completed: Issue #1090, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh.
+- Latest targeted quality repair audio package completed: Issue #1174, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh.
 - Latest targeted quality repair listening review package completed: Issue #1092, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh.
 - Latest targeted quality repair listening review input guard completed: Issue #1094, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh.
 - Latest targeted quality repair objective-only next decision completed: Issue #1096, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1148, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after Stage B MIDI-to-solo targeted quality repair sweep source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo targeted quality repair audio package source-context refresh.
+- Open issue queue after Stage B MIDI-to-solo targeted quality repair audio package source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest quality rubric baseline: `Issue #1168`
 - latest candidate failure labeling: `Issue #1170`
 - latest targeted quality repair sweep: `Issue #1172`
-- latest targeted quality repair audio package: `Issue #1090`
+- latest targeted quality repair audio package: `Issue #1174`
 - latest targeted quality repair listening review package: `Issue #1092`
 - latest targeted quality repair listening review input guard: `Issue #1094`
 - latest targeted quality repair objective-only next decision: `Issue #1096`
@@ -50,7 +50,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1150`
 - latest README evidence refresh: `Issue #1152`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after targeted quality repair sweep source-context refresh merge: `0`
+- open issue queue after targeted quality repair audio package source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
@@ -328,9 +328,21 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - targeted quality repair follow-up objective source outside-soloing source context preserved: `true`
 - targeted quality repair follow-up repair sweep source outside-soloing source context preserved: `true`
 - targeted quality repair bridge repair sweep source outside-soloing source context preserved: `true`
+- targeted quality repair audio package schema version: `stage_b_midi_to_solo_targeted_quality_repair_audio_package_v5`
+- targeted quality repair audio source sweep schema version: `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`
+- targeted quality repair audio source candidate failure labeling schema version: `stage_b_midi_to_solo_candidate_failure_labeling_v4`
+- targeted quality repair audio source quality rubric schema version: `stage_b_midi_to_solo_quality_rubric_baseline_v4`
+- targeted quality repair audio source post-MVP plan schema version: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`
+- targeted quality repair audio source final status schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- targeted quality repair audio source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- targeted quality repair audio source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- targeted quality repair audio source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- targeted quality repair audio source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - targeted quality repair audio WAV files: `6`
 - targeted quality repair audio WAV technical validation: `true`
 - targeted quality repair audio duration range: `18.422s - 18.984s`
+- targeted quality repair audio outside-soloing schema context preserved: `true`
+- targeted quality repair audio outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - targeted quality repair audio follow-up objective source outside-soloing source context preserved: `true`
 - targeted quality repair audio follow-up repair sweep source outside-soloing source context preserved: `true`
 - targeted quality repair audio bridge repair sweep source outside-soloing source context preserved: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -403,7 +403,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo quality rubric baseline: schema `stage_b_midi_to_solo_quality_rubric_baseline_v4`, source post-MVP schema `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`, source final status schema `stage_b_midi_to_solo_final_status_audit_v4`, rubric items `8`, metric groups `30`, source risk `5 -> 2`, current repair risk after `0`, outside-soloing schema-context preserved `true`, source-context preserved flags `3/3`, candidate failure labeling ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_candidate_failure_labeling`
 - MIDI-to-solo candidate failure labeling: schema `stage_b_midi_to_solo_candidate_failure_labeling_v4`, source rubric schema `stage_b_midi_to_solo_quality_rubric_baseline_v4`, source post-MVP schema `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`, candidates `6`, failed `6`, failure label types `4`, not-evaluable types `2`, source risk `5 -> 2`, current repair risk after `0`, outside-soloing schema-context preserved `true`, source-context preserved flags `3/3`, targeted repair ready `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_sweep`
 - MIDI-to-solo targeted quality repair sweep: schema `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`, source candidate labeling schema `stage_b_midi_to_solo_candidate_failure_labeling_v4`, source rubric schema `stage_b_midi_to_solo_quality_rubric_baseline_v4`, candidates `6`, failure labels `12 -> 8`, improved candidates `4`, technical regression `0`, source risk `5 -> 2`, current repair risk after `0`, outside-soloing schema-context preserved `true`, source-context preserved flags `3/3`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
-- MIDI-to-solo targeted quality repair audio package: rendered WAV `6`, duration `18.422s-18.984s`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
+- MIDI-to-solo targeted quality repair audio package: schema `stage_b_midi_to_solo_targeted_quality_repair_audio_package_v5`, source sweep schema `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`, rendered WAV `6`, duration `18.422s-18.984s`, source risk `5 -> 2`, current repair risk after `0`, outside-soloing schema-context preserved `true`, source-context preserved flags `3/3`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
 - MIDI-to-solo targeted quality repair listening review package: review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after `0`, source-context preserved flags `3/3`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
 - MIDI-to-solo targeted quality repair listening review input guard: review items `6`, preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
 - MIDI-to-solo targeted quality repair objective-only next decision: follow-up required `true`, current quality claim ready `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
@@ -12670,7 +12670,7 @@ Issue #1172는 Issue #1170 candidate failure labeling v4 결과를 기준으로 
 
 ## 9.235 Stage B MIDI-to-solo targeted quality repair audio package source-context refresh
 
-Issue #1090은 Issue #1088 targeted quality repair sweep 결과를 기준으로 targeted quality repair audio package의 source-context validation과 summary에 source-context preserved flag 3개를 보존한 작업이다.
+Issue #1174는 Issue #1172 targeted quality repair sweep v4 결과를 기준으로 targeted quality repair audio package의 source schema chain, outside-soloing schema context, source-context preserved flag 3개를 보존한 작업이다.
 
 결과:
 
@@ -12678,6 +12678,16 @@ Issue #1090은 Issue #1088 targeted quality repair sweep 결과를 기준으로 
 - boundary: `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
 - source boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
 - next boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
+- schema version: `stage_b_midi_to_solo_targeted_quality_repair_audio_package_v5`
+- source targeted quality repair sweep schema version: `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`
+- source candidate failure labeling schema version: `stage_b_midi_to_solo_candidate_failure_labeling_v4`
+- source quality rubric schema version: `stage_b_midi_to_solo_quality_rubric_baseline_v4`
+- source post-MVP plan schema version: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`
+- source final status schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - targeted quality repair audio package completed: `true`
 - render attempted: `true`
 - rendered audio file count: `6`
@@ -12691,6 +12701,8 @@ Issue #1090은 Issue #1088 targeted quality repair sweep 결과를 기준으로 
 - technical regression count: `0`
 - source outside-soloing repair evidence ready: `true`
 - source outside-soloing repair source context preserved: `true`
+- source outside-soloing repair schema context preserved: `true`
+- source outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`
@@ -12705,8 +12717,8 @@ Issue #1090은 Issue #1088 targeted quality repair sweep 결과를 기준으로 
 
 판단:
 
-- audio package source validation에 targeted repair sweep preserved flag 3개 포함.
-- preserved flag false 입력은 validation error로 차단.
+- audio package source validation에 targeted repair sweep v4와 upstream schema chain 포함.
+- schema version mismatch, schema-context false, preserved flag false 입력은 validation error로 차단.
 - rendered WAV 6개 technical metadata 검증 완료.
 - 청음 preference와 rendered audio quality claim 제외 유지.
 - 다음 검증 대상은 targeted quality repair listening review package 유지.
@@ -12714,7 +12726,8 @@ Issue #1090은 Issue #1088 targeted quality repair sweep 결과를 기준으로 
 검증:
 
 - `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_audio`
-- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_targeted_quality_repair_audio.py`
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
+- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_targeted_quality_repair_audio.py tests/test_stage_b_midi_to_solo_targeted_quality_repair_audio.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-audio-package`
 - `bash scripts/agent_harness.sh quick`

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -23,7 +23,7 @@
 - latest quality rubric baseline: Issue #1168, Stage B MIDI-to-solo quality rubric baseline source-context refresh
 - latest candidate failure labeling: Issue #1170, Stage B MIDI-to-solo candidate failure labeling source-context refresh
 - latest targeted quality repair sweep: Issue #1172, Stage B MIDI-to-solo targeted quality repair sweep source-context refresh
-- latest targeted quality repair audio package: Issue #1090, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh
+- latest targeted quality repair audio package: Issue #1174, Stage B MIDI-to-solo targeted quality repair audio package source-context refresh
 - latest targeted quality repair listening review package: Issue #1092, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh
 - latest targeted quality repair listening review input guard: Issue #1094, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh
 - latest targeted quality repair objective-only next decision: Issue #1096, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1150, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after Stage B MIDI-to-solo post-MVP quality iteration plan source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo quality rubric baseline source-context refresh`
+- open issue queue after Stage B MIDI-to-solo targeted quality repair audio package source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -5975,7 +5975,7 @@ Issue #1172는 Issue #1170 candidate failure labeling v4 결과를 기준으로 
 
 ## 9.235 Stage B MIDI-to-solo targeted quality repair audio package source-context refresh
 
-Issue #1090은 Issue #1088 targeted quality repair sweep 결과를 기준으로 targeted quality repair audio package의 source-context validation과 summary에 source-context preserved flag 3개를 보존한 작업이다.
+Issue #1174는 Issue #1172 targeted quality repair sweep v4 결과를 기준으로 targeted quality repair audio package의 source schema chain, outside-soloing schema context, source-context preserved flag 3개를 보존한 작업이다.
 
 결과:
 
@@ -5983,6 +5983,16 @@ Issue #1090은 Issue #1088 targeted quality repair sweep 결과를 기준으로 
 - boundary: `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
 - source boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
 - next boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
+- schema version: `stage_b_midi_to_solo_targeted_quality_repair_audio_package_v5`
+- source targeted quality repair sweep schema version: `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`
+- source candidate failure labeling schema version: `stage_b_midi_to_solo_candidate_failure_labeling_v4`
+- source quality rubric schema version: `stage_b_midi_to_solo_quality_rubric_baseline_v4`
+- source post-MVP plan schema version: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`
+- source final status schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - targeted quality repair audio package completed: `true`
 - render attempted: `true`
 - rendered audio file count: `6`
@@ -5996,6 +6006,8 @@ Issue #1090은 Issue #1088 targeted quality repair sweep 결과를 기준으로 
 - technical regression count: `0`
 - source outside-soloing repair evidence ready: `true`
 - source outside-soloing repair source context preserved: `true`
+- source outside-soloing repair schema context preserved: `true`
+- source outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`
@@ -6010,8 +6022,8 @@ Issue #1090은 Issue #1088 targeted quality repair sweep 결과를 기준으로 
 
 판단:
 
-- audio package source validation에 targeted repair sweep preserved flag 3개 포함.
-- preserved flag false 입력은 validation error로 차단.
+- audio package source validation에 targeted repair sweep v4와 upstream schema chain 포함.
+- schema version mismatch, schema-context false, preserved flag false 입력은 validation error로 차단.
 - rendered WAV 6개 technical metadata 검증 완료.
 - 청음 preference와 rendered audio quality claim 제외 유지.
 - 다음 검증 대상은 targeted quality repair listening review package 유지.
@@ -6019,7 +6031,8 @@ Issue #1090은 Issue #1088 targeted quality repair sweep 결과를 기준으로 
 검증:
 
 - `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_audio`
-- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_targeted_quality_repair_audio.py`
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
+- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_targeted_quality_repair_audio.py tests/test_stage_b_midi_to_solo_targeted_quality_repair_audio.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-audio-package`
 - `bash scripts/agent_harness.sh quick`

--- a/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -4,6 +4,16 @@
 
 - boundary: `stage_b_midi_to_solo_targeted_quality_repair_audio_package`
 - next boundary: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
+- schema version: `stage_b_midi_to_solo_targeted_quality_repair_audio_package_v5`
+- source targeted quality repair sweep schema version: `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`
+- source candidate failure labeling schema version: `stage_b_midi_to_solo_candidate_failure_labeling_v4`
+- source quality rubric schema version: `stage_b_midi_to_solo_quality_rubric_baseline_v4`
+- source post-MVP plan schema version: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`
+- source final status schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - render attempted: `true`
 - rendered audio file count: `6`
 - technical WAV validation: `true`
@@ -14,6 +24,8 @@
 - technical regression count: `0`
 - source outside-soloing repair evidence ready: `true`
 - source outside-soloing repair source context preserved: `true`
+- source outside-soloing repair schema context preserved: `true`
+- source outside-soloing repair objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6233,7 +6233,7 @@ run_stage_b_midi_to_solo_targeted_quality_repair_audio_package() {
     --run_id "$run_id" \
     --targeted_quality_repair_sweep_report "$repair_sweep_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1090 \
+    --issue_number 1174 \
     --expected_boundary stage_b_midi_to_solo_targeted_quality_repair_audio_package \
     --expected_next_boundary stage_b_midi_to_solo_targeted_quality_repair_listening_review_package \
     --expected_file_count 6 \

--- a/scripts/render_stage_b_midi_to_solo_targeted_quality_repair_audio.py
+++ b/scripts/render_stage_b_midi_to_solo_targeted_quality_repair_audio.py
@@ -25,7 +25,17 @@ from scripts.run_stage_b_midi_to_solo_targeted_quality_repair_sweep import (  # 
     BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
     BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
     BOUNDARY as SOURCE_BOUNDARY,
+    CURRENT_EVIDENCE_SCHEMA_VERSION,
+    DELIVERY_SCHEMA_VERSION,
+    FINAL_STATUS_SCHEMA_VERSION,
+    LABELING_SCHEMA_VERSION,
+    LISTENING_GAP_SCHEMA_VERSION,
     NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    POST_MVP_PLAN_SCHEMA_VERSION,
+    QUALITY_GAP_DECISION_SCHEMA_VERSION,
+    RUBRIC_SCHEMA_VERSION,
+    SCHEMA_VERSION as SOURCE_SCHEMA_VERSION,
     StageBMidiToSoloTargetedQualityRepairSweepError,
     validate_targeted_quality_repair_sweep_report,
 )
@@ -37,8 +47,20 @@ class StageBMidiToSoloTargetedQualityRepairAudioError(ValueError):
 
 BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_audio_package"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_listening_review_package"
-SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_audio_package_v4"
+SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_audio_package_v5"
 CommandRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+EXPECTED_SOURCE_SCHEMA_VERSIONS = {
+    "targeted_quality_repair_sweep": SOURCE_SCHEMA_VERSION,
+    "candidate_failure_labeling": LABELING_SCHEMA_VERSION,
+    "quality_rubric_baseline": RUBRIC_SCHEMA_VERSION,
+    "post_mvp_quality_iteration_plan": POST_MVP_PLAN_SCHEMA_VERSION,
+    "final_status_audit": FINAL_STATUS_SCHEMA_VERSION,
+    "delivery_package": DELIVERY_SCHEMA_VERSION,
+    "listening_review_quality_gap": LISTENING_GAP_SCHEMA_VERSION,
+    "quality_gap_decision": QUALITY_GAP_DECISION_SCHEMA_VERSION,
+    "current_evidence": CURRENT_EVIDENCE_SCHEMA_VERSION,
+}
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -107,11 +129,45 @@ def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str
     return {key: container[key] for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS}
 
 
+def _source_schema_versions_from_summary(summary: dict[str, Any]) -> dict[str, str]:
+    return {
+        "targeted_quality_repair_sweep": str(summary.get("schema_version") or ""),
+        "candidate_failure_labeling": str(
+            summary.get("source_candidate_failure_labeling_schema_version") or ""
+        ),
+        "quality_rubric_baseline": str(
+            summary.get("source_quality_rubric_schema_version") or ""
+        ),
+        "post_mvp_quality_iteration_plan": str(
+            summary.get("source_post_mvp_plan_schema_version") or ""
+        ),
+        "final_status_audit": str(summary.get("source_final_status_schema_version") or ""),
+        "delivery_package": str(summary.get("source_delivery_package_schema_version") or ""),
+        "listening_review_quality_gap": str(
+            summary.get("source_listening_gap_schema_version") or ""
+        ),
+        "quality_gap_decision": str(summary.get("source_quality_gap_schema_version") or ""),
+        "current_evidence": str(summary.get("source_current_evidence_schema_version") or ""),
+    }
+
+
+def _validate_source_schema_versions(
+    source_schema_versions: dict[str, str],
+    *,
+    label: str,
+) -> None:
+    for key, expected in EXPECTED_SOURCE_SCHEMA_VERSIONS.items():
+        if str(source_schema_versions.get(key) or "") != expected:
+            raise StageBMidiToSoloTargetedQualityRepairAudioError(
+                f"{label} source schema version mismatch: {key}"
+            )
+
+
 def validate_source_report(
     report: dict[str, Any],
     *,
     expected_count: int,
-) -> list[dict[str, Any]]:
+) -> dict[str, Any]:
     readiness = _dict(report.get("readiness"))
     decision = _dict(report.get("decision"))
     aggregate = _dict(report.get("aggregate"))
@@ -124,7 +180,7 @@ def validate_source_report(
             "targeted repair sweep must route to audio package"
         )
     try:
-        validate_targeted_quality_repair_sweep_report(
+        source_validation_summary = validate_targeted_quality_repair_sweep_report(
             report,
             expected_boundary=SOURCE_BOUNDARY,
             min_candidate_count=int(expected_count),
@@ -134,6 +190,24 @@ def validate_source_report(
         )
     except StageBMidiToSoloTargetedQualityRepairSweepError as exc:
         raise StageBMidiToSoloTargetedQualityRepairAudioError(str(exc)) from exc
+    source_schema_versions = _source_schema_versions_from_summary(source_validation_summary)
+    _validate_source_schema_versions(source_schema_versions, label="targeted quality repair sweep")
+    if not bool(
+        source_validation_summary.get("source_outside_soloing_repair_schema_context_preserved")
+    ):
+        raise StageBMidiToSoloTargetedQualityRepairAudioError(
+            "outside-soloing repair schema context preservation required"
+        )
+    if (
+        str(
+            source_validation_summary.get("source_outside_soloing_repair_objective_schema_version")
+            or ""
+        )
+        != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+    ):
+        raise StageBMidiToSoloTargetedQualityRepairAudioError(
+            "outside-soloing repair objective schema version mismatch"
+        )
     if not bool(readiness.get("targeted_quality_repair_target_supported", False)):
         raise StageBMidiToSoloTargetedQualityRepairAudioError(
             "targeted quality repair target support required"
@@ -245,7 +319,11 @@ def validate_source_report(
                 ),
             }
         )
-    return compacted
+    return {
+        "candidates": compacted,
+        "source_validation_summary": source_validation_summary,
+        "source_schema_versions": source_schema_versions,
+    }
 
 
 def _safe_name(value: str) -> str:
@@ -349,10 +427,15 @@ def build_audio_render_report(
     soundfont_path: str,
     sample_rate: int,
     expected_file_count: int,
-    issue_number: int = 1090,
+    issue_number: int = 1174,
     runner: CommandRunner = default_runner,
 ) -> dict[str, Any]:
-    candidates = validate_source_report(source_report, expected_count=expected_file_count)
+    source = validate_source_report(source_report, expected_count=expected_file_count)
+    candidates = [_dict(item) for item in _list(source.get("candidates"))]
+    source_validation_summary = _dict(source.get("source_validation_summary"))
+    source_schema_versions = {
+        key: str(value) for key, value in _dict(source.get("source_schema_versions")).items()
+    }
     resolved_renderer = renderer_path or shutil.which("fluidsynth") or ""
     resolved_soundfont = resolve_soundfont(soundfont_path)
     plan = build_render_plan(
@@ -378,6 +461,7 @@ def build_audio_render_report(
         "output_dir": str(output_dir),
         "issue_number": int(issue_number),
         "source_boundary": SOURCE_BOUNDARY,
+        "source_schema_versions": source_schema_versions,
         "source_summary": aggregate,
         "renderer": {
             "name": "fluidsynth",
@@ -403,11 +487,45 @@ def build_audio_render_report(
             "failure_label_delta": _int(aggregate.get("failure_label_delta")),
             "improved_candidate_count": _int(aggregate.get("improved_candidate_count")),
             "technical_regression_count": _int(aggregate.get("technical_regression_count")),
+            "source_targeted_quality_repair_sweep_schema_version": str(
+                source_validation_summary.get("schema_version") or ""
+            ),
+            "source_candidate_failure_labeling_schema_version": str(
+                source_validation_summary.get("source_candidate_failure_labeling_schema_version")
+                or ""
+            ),
+            "source_quality_rubric_schema_version": str(
+                source_validation_summary.get("source_quality_rubric_schema_version") or ""
+            ),
+            "source_post_mvp_plan_schema_version": str(
+                source_validation_summary.get("source_post_mvp_plan_schema_version") or ""
+            ),
+            "source_final_status_schema_version": str(
+                source_validation_summary.get("source_final_status_schema_version") or ""
+            ),
+            "source_delivery_package_schema_version": str(
+                source_validation_summary.get("source_delivery_package_schema_version") or ""
+            ),
+            "source_listening_gap_schema_version": str(
+                source_validation_summary.get("source_listening_gap_schema_version") or ""
+            ),
+            "source_quality_gap_schema_version": str(
+                source_validation_summary.get("source_quality_gap_schema_version") or ""
+            ),
+            "source_current_evidence_schema_version": str(
+                source_validation_summary.get("source_current_evidence_schema_version") or ""
+            ),
             "source_outside_soloing_repair_evidence_ready": bool(
                 aggregate.get("source_outside_soloing_repair_evidence_ready", False)
             ),
             "source_outside_soloing_repair_source_context_preserved": bool(
                 aggregate.get("source_outside_soloing_repair_source_context_preserved", False)
+            ),
+            "source_outside_soloing_repair_schema_context_preserved": bool(
+                aggregate.get("source_outside_soloing_repair_schema_context_preserved", False)
+            ),
+            "source_outside_soloing_repair_objective_schema_version": str(
+                aggregate.get("source_outside_soloing_repair_objective_schema_version") or ""
             ),
             "source_outside_soloing_repair_wav_count": _int(
                 aggregate.get("source_outside_soloing_repair_wav_count")
@@ -452,6 +570,12 @@ def build_audio_render_report(
             "rendered_audio_file_count": int(len(rendered)),
             "technical_wav_validation": True,
             "targeted_quality_repair_audio_package_completed": True,
+            "source_outside_soloing_repair_schema_context_preserved": bool(
+                aggregate.get("source_outside_soloing_repair_schema_context_preserved", False)
+            ),
+            "source_outside_soloing_repair_objective_schema_version": str(
+                aggregate.get("source_outside_soloing_repair_objective_schema_version") or ""
+            ),
             "human_audio_preference_claimed": False,
             "audio_rendered_quality_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
@@ -494,6 +618,15 @@ def validate_audio_render_report(
     boundary = _dict(report.get("audio_render_boundary"))
     decision = _dict(report.get("decision"))
     summary = _dict(report.get("summary"))
+    source_schema_versions = _dict(report.get("source_schema_versions"))
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise StageBMidiToSoloTargetedQualityRepairAudioError(
+            "targeted quality repair audio package schema version mismatch"
+        )
+    _validate_source_schema_versions(
+        {key: str(value) for key, value in source_schema_versions.items()},
+        label="targeted quality repair audio package",
+    )
     if expected_boundary and str(boundary.get("boundary") or "") != expected_boundary:
         raise StageBMidiToSoloTargetedQualityRepairAudioError("unexpected boundary")
     if expected_next_boundary and str(decision.get("next_boundary") or "") != expected_next_boundary:
@@ -523,6 +656,17 @@ def validate_audio_render_report(
         raise StageBMidiToSoloTargetedQualityRepairAudioError(
             "technical regression count should be zero"
         )
+    if not bool(summary.get("source_outside_soloing_repair_schema_context_preserved", False)):
+        raise StageBMidiToSoloTargetedQualityRepairAudioError(
+            "source outside-soloing repair schema context preservation required"
+        )
+    if (
+        str(summary.get("source_outside_soloing_repair_objective_schema_version") or "")
+        != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+    ):
+        raise StageBMidiToSoloTargetedQualityRepairAudioError(
+            "source outside-soloing repair objective schema version mismatch"
+        )
     if bool(decision.get("critical_user_input_required", True)):
         raise StageBMidiToSoloTargetedQualityRepairAudioError(
             "critical user input should not be required"
@@ -533,6 +677,34 @@ def validate_audio_render_report(
         "boundary": str(boundary.get("boundary") or ""),
         "next_boundary": str(decision.get("next_boundary") or ""),
         "render_attempted": bool(boundary.get("render_attempted", False)),
+        "schema_version": str(report.get("schema_version") or ""),
+        "source_targeted_quality_repair_sweep_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_sweep") or ""
+        ),
+        "source_candidate_failure_labeling_schema_version": str(
+            source_schema_versions.get("candidate_failure_labeling") or ""
+        ),
+        "source_quality_rubric_schema_version": str(
+            source_schema_versions.get("quality_rubric_baseline") or ""
+        ),
+        "source_post_mvp_plan_schema_version": str(
+            source_schema_versions.get("post_mvp_quality_iteration_plan") or ""
+        ),
+        "source_final_status_schema_version": str(
+            source_schema_versions.get("final_status_audit") or ""
+        ),
+        "source_delivery_package_schema_version": str(
+            source_schema_versions.get("delivery_package") or ""
+        ),
+        "source_listening_gap_schema_version": str(
+            source_schema_versions.get("listening_review_quality_gap") or ""
+        ),
+        "source_quality_gap_schema_version": str(
+            source_schema_versions.get("quality_gap_decision") or ""
+        ),
+        "source_current_evidence_schema_version": str(
+            source_schema_versions.get("current_evidence") or ""
+        ),
         "rendered_audio_file_count": _int(boundary.get("rendered_audio_file_count")),
         "technical_wav_validation": bool(boundary.get("technical_wav_validation", False)),
         "targeted_quality_repair_audio_package_completed": bool(
@@ -555,6 +727,12 @@ def validate_audio_render_report(
         ),
         "source_outside_soloing_repair_source_context_preserved": bool(
             summary.get("source_outside_soloing_repair_source_context_preserved", False)
+        ),
+        "source_outside_soloing_repair_schema_context_preserved": bool(
+            summary.get("source_outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "source_outside_soloing_repair_objective_schema_version": str(
+            summary.get("source_outside_soloing_repair_objective_schema_version") or ""
         ),
         "source_outside_soloing_repair_wav_count": _int(
             summary.get("source_outside_soloing_repair_wav_count")
@@ -616,6 +794,16 @@ def markdown_report(report: dict[str, Any]) -> str:
         "",
         f"- boundary: `{boundary['boundary']}`",
         f"- next boundary: `{decision['next_boundary']}`",
+        f"- schema version: `{report['schema_version']}`",
+        f"- source targeted quality repair sweep schema version: `{report['source_schema_versions']['targeted_quality_repair_sweep']}`",
+        f"- source candidate failure labeling schema version: `{report['source_schema_versions']['candidate_failure_labeling']}`",
+        f"- source quality rubric schema version: `{report['source_schema_versions']['quality_rubric_baseline']}`",
+        f"- source post-MVP plan schema version: `{report['source_schema_versions']['post_mvp_quality_iteration_plan']}`",
+        f"- source final status schema version: `{report['source_schema_versions']['final_status_audit']}`",
+        f"- source delivery package schema version: `{report['source_schema_versions']['delivery_package']}`",
+        f"- source listening gap schema version: `{report['source_schema_versions']['listening_review_quality_gap']}`",
+        f"- source quality gap schema version: `{report['source_schema_versions']['quality_gap_decision']}`",
+        f"- source current evidence schema version: `{report['source_schema_versions']['current_evidence']}`",
         f"- render attempted: `{_bool_token(boundary['render_attempted'])}`",
         f"- rendered audio file count: `{boundary['rendered_audio_file_count']}`",
         f"- technical WAV validation: `{_bool_token(boundary['technical_wav_validation'])}`",
@@ -626,6 +814,8 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- technical regression count: `{summary['technical_regression_count']}`",
         f"- source outside-soloing repair evidence ready: `{_bool_token(summary['source_outside_soloing_repair_evidence_ready'])}`",
         f"- source outside-soloing repair source context preserved: `{_bool_token(summary['source_outside_soloing_repair_source_context_preserved'])}`",
+        f"- source outside-soloing repair schema context preserved: `{_bool_token(summary['source_outside_soloing_repair_schema_context_preserved'])}`",
+        f"- source outside-soloing repair objective schema version: `{summary['source_outside_soloing_repair_objective_schema_version']}`",
         f"- follow-up objective source outside-soloing source context preserved: `{_bool_token(summary['followup_objective_source_outside_soloing_source_context_preserved'])}`",
         f"- follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(summary['followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- bridge repair sweep source outside-soloing source context preserved: `{_bool_token(summary['repair_sweep_source_outside_soloing_source_context_preserved'])}`",
@@ -677,7 +867,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=1090)
+    parser.add_argument("--issue_number", type=int, default=1174)
     parser.add_argument("--renderer", type=str, default=shutil.which("fluidsynth") or "")
     parser.add_argument("--soundfont", type=str, default="")
     parser.add_argument("--sample_rate", type=int, default=44100)

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_audio.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_audio.py
@@ -213,7 +213,7 @@ class StageBMidiToSoloTargetedQualityRepairAudioTest(unittest.TestCase):
                 soundfont_path=str(soundfont),
                 sample_rate=44100,
                 expected_file_count=6,
-                issue_number=1090,
+                issue_number=1174,
                 runner=fake_runner,
             )
             summary = validate_audio_render_report(
@@ -227,7 +227,80 @@ class StageBMidiToSoloTargetedQualityRepairAudioTest(unittest.TestCase):
             )
 
             self.assertEqual(report["schema_version"], SCHEMA_VERSION)
-            self.assertEqual(report["issue_number"], 1090)
+            self.assertEqual(report["issue_number"], 1174)
+            self.assertEqual(summary["schema_version"], SCHEMA_VERSION)
+            self.assertEqual(
+                report["source_schema_versions"]["targeted_quality_repair_sweep"],
+                SOURCE_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                report["source_schema_versions"]["candidate_failure_labeling"],
+                LABELING_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                report["source_schema_versions"]["quality_rubric_baseline"],
+                RUBRIC_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                report["source_schema_versions"]["post_mvp_quality_iteration_plan"],
+                POST_MVP_PLAN_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                report["source_schema_versions"]["final_status_audit"],
+                FINAL_STATUS_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                report["source_schema_versions"]["delivery_package"],
+                DELIVERY_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                report["source_schema_versions"]["listening_review_quality_gap"],
+                LISTENING_GAP_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                report["source_schema_versions"]["quality_gap_decision"],
+                QUALITY_GAP_DECISION_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                report["source_schema_versions"]["current_evidence"],
+                CURRENT_EVIDENCE_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                summary["source_targeted_quality_repair_sweep_schema_version"],
+                SOURCE_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                summary["source_candidate_failure_labeling_schema_version"],
+                LABELING_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                summary["source_quality_rubric_schema_version"],
+                RUBRIC_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                summary["source_post_mvp_plan_schema_version"],
+                POST_MVP_PLAN_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                summary["source_final_status_schema_version"],
+                FINAL_STATUS_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                summary["source_delivery_package_schema_version"],
+                DELIVERY_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                summary["source_listening_gap_schema_version"],
+                LISTENING_GAP_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                summary["source_quality_gap_schema_version"],
+                QUALITY_GAP_DECISION_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                summary["source_current_evidence_schema_version"],
+                CURRENT_EVIDENCE_SCHEMA_VERSION,
+            )
             self.assertTrue(summary["targeted_quality_repair_audio_package_completed"])
             self.assertEqual(summary["rendered_audio_file_count"], 6)
             self.assertTrue(summary["technical_wav_validation"])
@@ -235,6 +308,11 @@ class StageBMidiToSoloTargetedQualityRepairAudioTest(unittest.TestCase):
             self.assertEqual(summary["technical_regression_count"], 0)
             self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
             self.assertTrue(summary["source_outside_soloing_repair_source_context_preserved"])
+            self.assertTrue(summary["source_outside_soloing_repair_schema_context_preserved"])
+            self.assertEqual(
+                summary["source_outside_soloing_repair_objective_schema_version"],
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+            )
             self.assertEqual(summary["source_outside_soloing_repair_wav_count"], 6)
             self.assertEqual(
                 summary["source_outside_soloing_repair_source_objective_pitch_role_risk_count"], 5
@@ -341,7 +419,47 @@ class StageBMidiToSoloTargetedQualityRepairAudioTest(unittest.TestCase):
                     soundfont_path=str(soundfont),
                     sample_rate=44100,
                     expected_file_count=6,
-                    issue_number=1090,
+                    issue_number=1174,
+                    runner=fake_runner,
+                )
+
+    def test_rejects_source_schema_version_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = root / "fluidsynth"
+            soundfont = root / "soundfont.sf2"
+            renderer.write_text("#!/bin/sh\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            source = source_report(root)
+            source["source_schema_versions"]["candidate_failure_labeling"] = "wrong_schema"
+            with self.assertRaises(StageBMidiToSoloTargetedQualityRepairAudioError):
+                build_audio_render_report(
+                    source,
+                    output_dir=root / "audio_package",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(soundfont),
+                    sample_rate=44100,
+                    expected_file_count=6,
+                    runner=fake_runner,
+                )
+
+    def test_rejects_missing_schema_context_preserved(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = root / "fluidsynth"
+            soundfont = root / "soundfont.sf2"
+            renderer.write_text("#!/bin/sh\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            source = source_report(root)
+            source["aggregate"]["source_outside_soloing_repair_schema_context_preserved"] = False
+            with self.assertRaises(StageBMidiToSoloTargetedQualityRepairAudioError):
+                build_audio_render_report(
+                    source,
+                    output_dir=root / "audio_package",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(soundfont),
+                    sample_rate=44100,
+                    expected_file_count=6,
                     runner=fake_runner,
                 )
 
@@ -350,7 +468,7 @@ class StageBMidiToSoloTargetedQualityRepairAudioTest(unittest.TestCase):
         self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_targeted_quality_repair_listening_review_package")
         self.assertEqual(
             SCHEMA_VERSION,
-            "stage_b_midi_to_solo_targeted_quality_repair_audio_package_v4",
+            "stage_b_midi_to_solo_targeted_quality_repair_audio_package_v5",
         )
 
 


### PR DESCRIPTION
Summary
- targeted quality repair audio package schema v5 적용
- targeted repair sweep v4 및 upstream schema chain 검증/전파
- outside-soloing schema-context flag와 objective schema version 검증/전파
- README, CURRENT_STATUS, CORE_PLAN, AGENTS handoff 갱신

Context
- #1172 targeted quality repair sweep 결과: failure labels `12 -> 8`, improved candidates `4`, technical regression `0`
- audio package 진입 조건: rendered WAV `6`, sample rate `44100`, duration `18.422s-18.984s`
- 제외 claim: audio quality, human preference, MIDI-to-solo musical quality

Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_audio tests.test_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package`
- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_targeted_quality_repair_audio.py scripts/build_stage_b_midi_to_solo_targeted_quality_repair_listening_review_package.py tests/test_stage_b_midi_to_solo_targeted_quality_repair_audio.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-audio-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

Risk
- WAV technical validation 완료, 청음 품질 판단 제외
- 다음 검토 대상: targeted quality repair listening review package source-context refresh

Closes #1174