### PR TITLE
Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Current handoff scope:
 - Latest targeted quality repair listening review package completed: Issue #1176, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh.
 - Latest targeted quality repair listening review input guard completed: Issue #1178, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh.
 - Latest targeted quality repair objective-only next decision completed: Issue #1180, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh.
-- Latest targeted quality repair follow-up decision completed: Issue #1098, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh.
+- Latest targeted quality repair follow-up decision completed: Issue #1182, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh.
 - Latest songlike melody contour repair sweep completed: Issue #1100, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh.
 - Latest songlike melody contour repair audio package completed: Issue #1102, Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh.
 - Latest songlike melody contour repair listening review package completed: Issue #1104, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1148, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh.
+- Open issue queue after Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest targeted quality repair listening review package: `Issue #1176`
 - latest targeted quality repair listening review input guard: `Issue #1178`
 - latest targeted quality repair objective-only next decision: `Issue #1180`
-- latest targeted quality repair follow-up decision: `Issue #1098`
+- latest targeted quality repair follow-up decision: `Issue #1182`
 - latest songlike melody contour repair sweep: `Issue #1100`
 - latest songlike melody contour repair audio package: `Issue #1102`
 - latest songlike melody contour repair listening review package: `Issue #1104`
@@ -50,7 +50,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1150`
 - latest README evidence refresh: `Issue #1152`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after targeted quality repair objective-only next decision source-context refresh merge: `0`
+- open issue queue after targeted quality repair follow-up decision source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
@@ -389,9 +389,16 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - targeted quality repair objective next follow-up repair sweep source outside-soloing source context preserved: `true`
 - targeted quality repair objective next bridge repair sweep source outside-soloing source context preserved: `true`
 - targeted quality repair follow-up required: `true`
+- targeted quality repair follow-up schema version: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v5`
+- targeted quality repair follow-up source objective next schema version: `stage_b_midi_to_solo_targeted_quality_repair_objective_next_v5`
+- targeted quality repair follow-up source sweep schema version: `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`
 - targeted quality repair follow-up decision completed: `true`
 - targeted quality repair follow-up objective source outside-soloing source context preserved: `true`
+- targeted quality repair follow-up objective source outside-soloing schema context preserved: `true`
+- targeted quality repair follow-up objective source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - targeted quality repair follow-up repair sweep source outside-soloing source context preserved: `true`
+- targeted quality repair follow-up repair sweep source outside-soloing schema context preserved: `true`
+- targeted quality repair follow-up repair sweep source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - targeted quality repair follow-up bridge repair sweep source outside-soloing source context preserved: `true`
 - targeted quality repair selected next target: `songlike_melody_contour_repair_sweep`
 - targeted quality repair source risk: `5 -> 2`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -407,7 +407,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo targeted quality repair listening review package: schema `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package_v5`, source audio schema `stage_b_midi_to_solo_targeted_quality_repair_audio_package_v5`, review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after `0`, outside-soloing schema-context preserved `true`, source-context preserved flags `3/3`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard`
 - MIDI-to-solo targeted quality repair listening review input guard: schema `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard_v5`, source listening package schema `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package_v5`, review items `6`, preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, outside-soloing schema-context preserved `true`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
 - MIDI-to-solo targeted quality repair objective-only next decision: schema `stage_b_midi_to_solo_targeted_quality_repair_objective_next_v5`, source input guard schema `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard_v5`, follow-up required `true`, current quality claim ready `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, outside-soloing schema-context preserved `true`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
-- MIDI-to-solo targeted quality repair follow-up decision: selected target `songlike_melody_contour_repair_sweep`, dominant label/count `songlike_melody_not_soloing/5`, objective and repair sweep source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- MIDI-to-solo targeted quality repair follow-up decision: schema `stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v5`, source objective next schema `stage_b_midi_to_solo_targeted_quality_repair_objective_next_v5`, source sweep schema `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`, selected target `songlike_melody_contour_repair_sweep`, dominant label/count `songlike_melody_not_soloing/5`, objective and repair sweep source risk `5 -> 2`, current repair risk after/delta `0/2`, source/schema-context preserved flags `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
 - MIDI-to-solo songlike melody contour repair sweep: songlike failure `5 -> 0`, total failure labels `8 -> 4`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
 - MIDI-to-solo songlike melody contour repair audio package: rendered WAV `6`, duration `18.849s-18.992s`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
 - MIDI-to-solo songlike melody contour repair listening review package: review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
@@ -8420,7 +8420,7 @@ Issue #928은 Issue #926 targeted quality repair listening review input guard의
 
 다음 작업:
 
-- `Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh`
+- `Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh`
 
 ## 9.155 Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh
 
@@ -12939,7 +12939,7 @@ Issue #1180은 Issue #1178 targeted quality repair listening review input guard 
 
 ## 9.239 Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh
 
-Issue #1098은 Issue #1096 targeted quality repair objective-only next decision 결과를 기준으로 follow-up decision의 source-context validation과 summary에 source-context preserved flag 3개를 보존한 작업이다.
+Issue #1182는 Issue #1180 targeted quality repair objective-only next decision v5 결과와 targeted quality repair sweep v4 결과를 기준으로 follow-up decision의 source schema chain, outside-soloing schema context, source-context preserved flag 3개를 보존한 작업이다.
 
 결과:
 
@@ -12947,6 +12947,20 @@ Issue #1098은 Issue #1096 targeted quality repair objective-only next decision 
 - boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
 - source boundary: `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
 - repair sweep boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- schema version: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v5`
+- source targeted quality repair objective next schema version: `stage_b_midi_to_solo_targeted_quality_repair_objective_next_v5`
+- source targeted quality repair listening review input guard schema version: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard_v5`
+- source targeted quality repair listening review package schema version: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package_v5`
+- source targeted quality repair audio package schema version: `stage_b_midi_to_solo_targeted_quality_repair_audio_package_v5`
+- source targeted quality repair sweep schema version: `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`
+- source candidate failure labeling schema version: `stage_b_midi_to_solo_candidate_failure_labeling_v4`
+- source quality rubric schema version: `stage_b_midi_to_solo_quality_rubric_baseline_v4`
+- source post-MVP plan schema version: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`
+- source final status schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
 - selected target: `songlike_melody_contour_repair_sweep`
 - dominant remaining failure label/count: `songlike_melody_not_soloing` / `5`
@@ -12958,9 +12972,13 @@ Issue #1098은 Issue #1096 targeted quality repair objective-only next decision 
 - objective source outside-soloing repair evidence ready: `true`
 - objective source outside-soloing repair WAV count: `6`
 - objective source outside-soloing source context preserved: `true`
+- objective source outside-soloing schema context preserved: `true`
+- objective source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - objective preserved source-context flags: `3 / 3`
 - repair sweep source outside-soloing repair evidence ready: `true`
 - repair sweep source outside-soloing source context preserved: `true`
+- repair sweep source outside-soloing schema context preserved: `true`
+- repair sweep source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - repair sweep preserved source-context flags: `3 / 3`
 - objective and repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
 - objective and repair sweep current repair pitch-role risk after / delta: `0 / 2`
@@ -12970,16 +12988,16 @@ Issue #1098은 Issue #1096 targeted quality repair objective-only next decision 
 
 판단:
 
-- follow-up decision source validation에 objective next preserved flag 3개 포함.
-- repair sweep source validation에 targeted repair sweep preserved flag 3개 포함.
-- preserved flag false 입력은 validation error로 차단.
+- follow-up decision source validation에 objective next v5와 upstream schema chain 포함.
+- repair sweep source validation에 targeted repair sweep v4와 source schema chain 포함.
+- schema version mismatch, schema-context false, preserved flag false 입력은 validation error로 차단.
 - dominant remaining failure label 기준 songlike melody contour repair sweep 선택.
 - human/audio preference와 musical quality claim 제외 유지.
 
 검증:
 
 - `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
-- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py tests/test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-followup-decision`
 - `bash scripts/agent_harness.sh quick`
@@ -12991,7 +13009,7 @@ Issue #1098은 Issue #1096 targeted quality repair objective-only next decision 
 
 ## 9.240 Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh
 
-Issue #1100은 Issue #1098 targeted quality repair follow-up decision의 selected target에 따라 songlike melody contour repair sweep을 실행하고 source-context preserved flag를 sweep aggregate/readiness/validation summary까지 보존한 작업이다.
+Issue #1100은 Issue #1182 targeted quality repair follow-up decision의 selected target에 따라 songlike melody contour repair sweep을 실행하고 source-context preserved flag를 sweep aggregate/readiness/validation summary까지 보존한 작업이다.
 
 결과:
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -27,7 +27,7 @@
 - latest targeted quality repair listening review package: Issue #1176, Stage B MIDI-to-solo targeted quality repair listening review package source-context refresh
 - latest targeted quality repair listening review input guard: Issue #1178, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh
 - latest targeted quality repair objective-only next decision: Issue #1180, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh
-- latest targeted quality repair follow-up decision: Issue #1098, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh
+- latest targeted quality repair follow-up decision: Issue #1182, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh
 - latest songlike melody contour repair sweep: Issue #1100, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh
 - latest songlike melody contour repair audio package: Issue #1102, Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh
 - latest songlike melody contour repair listening review package: Issue #1104, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1150, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh`
+- open issue queue after Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -3619,7 +3619,7 @@ Issue #1012는 Issue #1010 input guard 이후 listening input 없이 objective e
 
 다음:
 
-- `Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh`
+- `Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh`
 
 ## Stage B MIDI-to-Solo Targeted Quality Repair Follow-Up Decision Source Context Refresh Result
 
@@ -6244,7 +6244,7 @@ Issue #1180은 Issue #1178 targeted quality repair listening review input guard 
 
 ## 9.239 Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh
 
-Issue #1098은 Issue #1096 targeted quality repair objective-only next decision 결과를 기준으로 follow-up decision의 source-context validation과 summary에 source-context preserved flag 3개를 보존한 작업이다.
+Issue #1182는 Issue #1180 targeted quality repair objective-only next decision v5 결과와 targeted quality repair sweep v4 결과를 기준으로 follow-up decision의 source schema chain, outside-soloing schema context, source-context preserved flag 3개를 보존한 작업이다.
 
 결과:
 
@@ -6252,6 +6252,20 @@ Issue #1098은 Issue #1096 targeted quality repair objective-only next decision 
 - boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
 - source boundary: `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
 - repair sweep boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- schema version: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v5`
+- source targeted quality repair objective next schema version: `stage_b_midi_to_solo_targeted_quality_repair_objective_next_v5`
+- source targeted quality repair listening review input guard schema version: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard_v5`
+- source targeted quality repair listening review package schema version: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package_v5`
+- source targeted quality repair audio package schema version: `stage_b_midi_to_solo_targeted_quality_repair_audio_package_v5`
+- source targeted quality repair sweep schema version: `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`
+- source candidate failure labeling schema version: `stage_b_midi_to_solo_candidate_failure_labeling_v4`
+- source quality rubric schema version: `stage_b_midi_to_solo_quality_rubric_baseline_v4`
+- source post-MVP plan schema version: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`
+- source final status schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
 - selected target: `songlike_melody_contour_repair_sweep`
 - dominant remaining failure label/count: `songlike_melody_not_soloing` / `5`
@@ -6263,9 +6277,13 @@ Issue #1098은 Issue #1096 targeted quality repair objective-only next decision 
 - objective source outside-soloing repair evidence ready: `true`
 - objective source outside-soloing repair WAV count: `6`
 - objective source outside-soloing source context preserved: `true`
+- objective source outside-soloing schema context preserved: `true`
+- objective source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - objective preserved source-context flags: `3 / 3`
 - repair sweep source outside-soloing repair evidence ready: `true`
 - repair sweep source outside-soloing source context preserved: `true`
+- repair sweep source outside-soloing schema context preserved: `true`
+- repair sweep source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - repair sweep preserved source-context flags: `3 / 3`
 - objective and repair sweep source outside-soloing source pitch-role risk: `5 -> 2`
 - objective and repair sweep current repair pitch-role risk after / delta: `0 / 2`
@@ -6275,16 +6293,16 @@ Issue #1098은 Issue #1096 targeted quality repair objective-only next decision 
 
 판단:
 
-- follow-up decision source validation에 objective next preserved flag 3개 포함.
-- repair sweep source validation에 targeted repair sweep preserved flag 3개 포함.
-- preserved flag false 입력은 validation error로 차단.
+- follow-up decision source validation에 objective next v5와 upstream schema chain 포함.
+- repair sweep source validation에 targeted repair sweep v4와 source schema chain 포함.
+- schema version mismatch, schema-context false, preserved flag false 입력은 validation error로 차단.
 - dominant remaining failure label 기준 songlike melody contour repair sweep 선택.
 - human/audio preference와 musical quality claim 제외 유지.
 
 검증:
 
 - `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
-- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py tests/test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-followup-decision`
 - `bash scripts/agent_harness.sh quick`
@@ -6296,7 +6314,7 @@ Issue #1098은 Issue #1096 targeted quality repair objective-only next decision 
 
 ## 9.240 Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh
 
-Issue #1100은 Issue #1098 targeted quality repair follow-up decision의 selected target에 따라 songlike melody contour repair sweep을 실행하고 source-context preserved flag를 sweep aggregate/readiness/validation summary까지 보존한 작업이다.
+Issue #1100은 Issue #1182 targeted quality repair follow-up decision의 selected target에 따라 songlike melody contour repair sweep을 실행하고 source-context preserved flag를 sweep aggregate/readiness/validation summary까지 보존한 작업이다.
 
 결과:
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -3,8 +3,22 @@
 ## Summary
 
 - boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- schema version: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v5`
 - source boundary: `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
 - repair sweep boundary: `stage_b_midi_to_solo_targeted_quality_repair_sweep`
+- source targeted quality repair objective next schema version: `stage_b_midi_to_solo_targeted_quality_repair_objective_next_v5`
+- source targeted quality repair listening review input guard schema version: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard_v5`
+- source targeted quality repair listening review package schema version: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package_v5`
+- source targeted quality repair audio package schema version: `stage_b_midi_to_solo_targeted_quality_repair_audio_package_v5`
+- source targeted quality repair sweep schema version: `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`
+- source candidate failure labeling schema version: `stage_b_midi_to_solo_candidate_failure_labeling_v4`
+- source quality rubric schema version: `stage_b_midi_to_solo_quality_rubric_baseline_v4`
+- source post-MVP plan schema version: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`
+- source final status schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
 - selected target: `songlike_melody_contour_repair_sweep`
 - dominant remaining failure label: `songlike_melody_not_soloing`
@@ -18,6 +32,8 @@
 - objective source outside-soloing repair WAV count: `6`
 - objective source outside-soloing source objective pitch-role risk: `5`
 - objective source outside-soloing source context preserved: `true`
+- objective source outside-soloing schema context preserved: `true`
+- objective source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - objective source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - objective source outside-soloing source repair targeted: `false`
 - objective source outside-soloing source residual risk preserved: `true`
@@ -34,6 +50,8 @@
 - repair sweep source outside-soloing repair evidence ready: `true`
 - repair sweep source outside-soloing source objective pitch-role risk: `5`
 - repair sweep source outside-soloing source context preserved: `true`
+- repair sweep source outside-soloing schema context preserved: `true`
+- repair sweep source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - repair sweep source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - repair sweep source outside-soloing source repair targeted: `false`
 - repair sweep source outside-soloing source residual risk preserved: `true`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6325,7 +6325,7 @@ run_stage_b_midi_to_solo_targeted_quality_repair_followup_decision() {
     --objective_next_report "$objective_report" \
     --repair_sweep_report "$sweep_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_TARGETED_QUALITY_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1098 \
+    --issue_number 1182 \
     --expected_boundary stage_b_midi_to_solo_targeted_quality_repair_followup_decision \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_sweep \
     --expected_target songlike_melody_contour_repair_sweep \

--- a/scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py
+++ b/scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py
@@ -20,10 +20,18 @@ from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
 )
 from scripts.decide_stage_b_midi_to_solo_targeted_quality_repair_objective_next import (  # noqa: E402
     BOUNDARY as OBJECTIVE_NEXT_BOUNDARY,
+    EXPECTED_SOURCE_SCHEMA_VERSIONS as OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS,
     FOLLOWUP_DECISION_NEXT_BOUNDARY,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    SCHEMA_VERSION as OBJECTIVE_NEXT_SCHEMA_VERSION,
+    StageBMidiToSoloTargetedQualityRepairObjectiveNextError,
+    validate_objective_next_report,
 )
 from scripts.run_stage_b_midi_to_solo_targeted_quality_repair_sweep import (  # noqa: E402
     BOUNDARY as REPAIR_SWEEP_BOUNDARY,
+    SCHEMA_VERSION as REPAIR_SWEEP_SCHEMA_VERSION,
+    StageBMidiToSoloTargetedQualityRepairSweepError,
+    validate_targeted_quality_repair_sweep_report,
 )
 
 
@@ -34,8 +42,13 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(ValueError):
 BOUNDARY = "stage_b_midi_to_solo_targeted_quality_repair_followup_decision"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_sweep"
 SELECTED_TARGET = "songlike_melody_contour_repair_sweep"
-SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v4"
+SCHEMA_VERSION = "stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v5"
 DOMINANT_TARGET_LABEL = "songlike_melody_not_soloing"
+EXPECTED_SOURCE_SCHEMA_VERSIONS = {
+    "targeted_quality_repair_objective_next": OBJECTIVE_NEXT_SCHEMA_VERSION,
+    **OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS,
+    "targeted_quality_repair_sweep": REPAIR_SWEEP_SCHEMA_VERSION,
+}
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -93,6 +106,20 @@ def _source_context_fields(container: dict[str, Any], *, label: str) -> dict[str
     return {key: container[key] for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS}
 
 
+def _validate_source_schema_versions(
+    source_schema_versions: dict[str, Any],
+    *,
+    label: str,
+) -> dict[str, str]:
+    normalized = {key: str(value) for key, value in source_schema_versions.items()}
+    for key, expected in EXPECTED_SOURCE_SCHEMA_VERSIONS.items():
+        if str(normalized.get(key) or "") != expected:
+            raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+                f"{label} source schema version mismatch: {key}"
+            )
+    return normalized
+
+
 def _extract_source_context(
     container: dict[str, Any],
     *,
@@ -119,6 +146,19 @@ def _extract_source_context(
     ):
         raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
             f"{label} outside-soloing source context preservation required"
+        )
+    if not bool(
+        container.get("source_outside_soloing_repair_schema_context_preserved", False)
+    ):
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            f"{label} outside-soloing schema context preservation required"
+        )
+    if (
+        str(container.get("source_outside_soloing_repair_objective_schema_version") or "")
+        != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+    ):
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            f"{label} outside-soloing objective schema version mismatch"
         )
     source_context = _source_context_fields(container, label=label)
     if minimum_wav_count is not None:
@@ -158,6 +198,12 @@ def _extract_source_context(
         "source_outside_soloing_repair_source_context_preserved": bool(
             container.get("source_outside_soloing_repair_source_context_preserved", False)
         ),
+        "source_outside_soloing_repair_schema_context_preserved": bool(
+            container.get("source_outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "source_outside_soloing_repair_objective_schema_version": str(
+            container.get("source_outside_soloing_repair_objective_schema_version") or ""
+        ),
         "source_outside_soloing_repair_source_pitch_role_risk_count_before": source_risk_before,
         "source_outside_soloing_repair_source_pitch_role_risk_count_after": source_risk_after,
         "source_outside_soloing_repair_source_pitch_role_risk_delta": source_risk_delta,
@@ -181,6 +227,24 @@ def validate_objective_next_source(report: dict[str, Any]) -> dict[str, Any]:
     readiness = _dict(report.get("readiness"))
     decision = _dict(report.get("decision"))
     summary = _dict(report.get("objective_summary"))
+    try:
+        objective_summary = validate_objective_next_report(
+            report,
+            expected_boundary=OBJECTIVE_NEXT_BOUNDARY,
+            expected_next_boundary=FOLLOWUP_DECISION_NEXT_BOUNDARY,
+            require_objective_decision=True,
+            require_followup_required=True,
+            require_no_quality_claim=True,
+        )
+    except StageBMidiToSoloTargetedQualityRepairObjectiveNextError as exc:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(str(exc)) from exc
+    source_schema_versions = _validate_source_schema_versions(
+        {
+            "targeted_quality_repair_objective_next": objective_summary.get("schema_version"),
+            **_dict(report.get("source_schema_versions")),
+        },
+        label="targeted quality repair objective next",
+    )
     if str(report.get("boundary") or "") != OBJECTIVE_NEXT_BOUNDARY:
         raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
             "targeted quality objective-only next decision boundary required"
@@ -245,6 +309,51 @@ def validate_objective_next_source(report: dict[str, Any]) -> dict[str, Any]:
     _require_no_quality_claim(readiness, label="objective next readiness")
     return {
         "boundary": OBJECTIVE_NEXT_BOUNDARY,
+        "source_schema_versions": source_schema_versions,
+        "schema_version": str(objective_summary.get("schema_version") or ""),
+        "source_targeted_quality_repair_listening_review_input_guard_schema_version": str(
+            objective_summary.get(
+                "source_targeted_quality_repair_listening_review_input_guard_schema_version"
+            )
+            or ""
+        ),
+        "source_targeted_quality_repair_listening_review_package_schema_version": str(
+            objective_summary.get(
+                "source_targeted_quality_repair_listening_review_package_schema_version"
+            )
+            or ""
+        ),
+        "source_targeted_quality_repair_audio_package_schema_version": str(
+            objective_summary.get("source_targeted_quality_repair_audio_package_schema_version")
+            or ""
+        ),
+        "source_targeted_quality_repair_sweep_schema_version": str(
+            objective_summary.get("source_targeted_quality_repair_sweep_schema_version") or ""
+        ),
+        "source_candidate_failure_labeling_schema_version": str(
+            objective_summary.get("source_candidate_failure_labeling_schema_version") or ""
+        ),
+        "source_quality_rubric_schema_version": str(
+            objective_summary.get("source_quality_rubric_schema_version") or ""
+        ),
+        "source_post_mvp_plan_schema_version": str(
+            objective_summary.get("source_post_mvp_plan_schema_version") or ""
+        ),
+        "source_final_status_schema_version": str(
+            objective_summary.get("source_final_status_schema_version") or ""
+        ),
+        "source_delivery_package_schema_version": str(
+            objective_summary.get("source_delivery_package_schema_version") or ""
+        ),
+        "source_listening_gap_schema_version": str(
+            objective_summary.get("source_listening_gap_schema_version") or ""
+        ),
+        "source_quality_gap_schema_version": str(
+            objective_summary.get("source_quality_gap_schema_version") or ""
+        ),
+        "source_current_evidence_schema_version": str(
+            objective_summary.get("source_current_evidence_schema_version") or ""
+        ),
         "review_item_count": _int(summary.get("review_item_count")),
         "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
         "failure_label_delta": _int(summary.get("failure_label_delta")),
@@ -285,6 +394,17 @@ def validate_repair_sweep_source(report: dict[str, Any]) -> dict[str, Any]:
     decision = _dict(report.get("decision"))
     aggregate = _dict(report.get("aggregate"))
     rows = _list(report.get("candidate_repairs"))
+    try:
+        sweep_summary = validate_targeted_quality_repair_sweep_report(
+            report,
+            expected_boundary=REPAIR_SWEEP_BOUNDARY,
+            min_candidate_count=6,
+            require_sweep_completed=True,
+            require_failure_delta=True,
+            require_no_quality_claim=True,
+        )
+    except StageBMidiToSoloTargetedQualityRepairSweepError as exc:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(str(exc)) from exc
     if str(report.get("boundary") or "") != REPAIR_SWEEP_BOUNDARY:
         raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
             "targeted quality repair sweep boundary required"
@@ -351,6 +471,31 @@ def validate_repair_sweep_source(report: dict[str, Any]) -> dict[str, Any]:
         )
     return {
         "boundary": REPAIR_SWEEP_BOUNDARY,
+        "schema_version": str(sweep_summary.get("schema_version") or ""),
+        "source_candidate_failure_labeling_schema_version": str(
+            sweep_summary.get("source_candidate_failure_labeling_schema_version") or ""
+        ),
+        "source_quality_rubric_schema_version": str(
+            sweep_summary.get("source_quality_rubric_schema_version") or ""
+        ),
+        "source_post_mvp_plan_schema_version": str(
+            sweep_summary.get("source_post_mvp_plan_schema_version") or ""
+        ),
+        "source_final_status_schema_version": str(
+            sweep_summary.get("source_final_status_schema_version") or ""
+        ),
+        "source_delivery_package_schema_version": str(
+            sweep_summary.get("source_delivery_package_schema_version") or ""
+        ),
+        "source_listening_gap_schema_version": str(
+            sweep_summary.get("source_listening_gap_schema_version") or ""
+        ),
+        "source_quality_gap_schema_version": str(
+            sweep_summary.get("source_quality_gap_schema_version") or ""
+        ),
+        "source_current_evidence_schema_version": str(
+            sweep_summary.get("source_current_evidence_schema_version") or ""
+        ),
         "candidate_count": _int(aggregate.get("candidate_count")),
         "source_total_failure_label_count": _int(
             aggregate.get("source_total_failure_label_count")
@@ -390,6 +535,14 @@ def build_followup_decision_report(
 ) -> dict[str, Any]:
     objective = validate_objective_next_source(objective_next_report)
     sweep = validate_repair_sweep_source(repair_sweep_report)
+    source_schema_versions = _validate_source_schema_versions(
+        {
+            "targeted_quality_repair_objective_next": objective["schema_version"],
+            **objective["source_schema_versions"],
+            "targeted_quality_repair_sweep": sweep["schema_version"],
+        },
+        label="targeted quality repair follow-up decision",
+    )
     dominant_label = str(sweep["dominant_remaining_failure_label"])
     selected_target = SELECTED_TARGET if dominant_label == DOMINANT_TARGET_LABEL else "targeted_quality_repair_followup_sweep"
     next_boundary = NEXT_BOUNDARY if dominant_label == DOMINANT_TARGET_LABEL else "stage_b_midi_to_solo_targeted_quality_repair_followup_sweep"
@@ -403,6 +556,7 @@ def build_followup_decision_report(
         "boundary": BOUNDARY,
         "source_boundary": objective["boundary"],
         "repair_sweep_boundary": sweep["boundary"],
+        "source_schema_versions": source_schema_versions,
         "objective_summary": objective,
         "repair_sweep_summary": sweep,
         "selected_next_target": {
@@ -454,6 +608,12 @@ def build_followup_decision_report(
             "objective_source_outside_soloing_repair_source_context_preserved": bool(
                 objective["source_outside_soloing_repair_source_context_preserved"]
             ),
+            "objective_source_outside_soloing_repair_schema_context_preserved": bool(
+                objective["source_outside_soloing_repair_schema_context_preserved"]
+            ),
+            "objective_source_outside_soloing_repair_objective_schema_version": str(
+                objective["source_outside_soloing_repair_objective_schema_version"]
+            ),
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
                 objective["source_outside_soloing_repair_source_pitch_role_risk_count_before"]
             ),
@@ -490,6 +650,12 @@ def build_followup_decision_report(
             ),
             "repair_sweep_source_outside_soloing_repair_source_context_preserved": bool(
                 sweep["source_outside_soloing_repair_source_context_preserved"]
+            ),
+            "repair_sweep_source_outside_soloing_repair_schema_context_preserved": bool(
+                sweep["source_outside_soloing_repair_schema_context_preserved"]
+            ),
+            "repair_sweep_source_outside_soloing_repair_objective_schema_version": str(
+                sweep["source_outside_soloing_repair_objective_schema_version"]
             ),
             "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
                 sweep["source_outside_soloing_repair_source_pitch_role_risk_count_before"]
@@ -564,6 +730,15 @@ def validate_followup_decision_report(
     decision = _dict(report.get("decision"))
     selected = _dict(report.get("selected_next_target"))
     sweep = _dict(report.get("repair_sweep_summary"))
+    source_schema_versions = _dict(report.get("source_schema_versions"))
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+            "targeted quality repair follow-up decision schema version mismatch"
+        )
+    _validate_source_schema_versions(
+        source_schema_versions,
+        label="targeted quality repair follow-up decision",
+    )
     if expected_boundary and boundary != expected_boundary:
         raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
             f"expected boundary {expected_boundary}, got {boundary}"
@@ -604,12 +779,75 @@ def validate_followup_decision_report(
         raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
             "critical user input should not be required"
         )
+    for prefix in ("objective", "repair_sweep"):
+        if not bool(
+            readiness.get(
+                f"{prefix}_source_outside_soloing_repair_schema_context_preserved",
+                False,
+            )
+        ):
+            raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+                f"{prefix} source outside-soloing schema context preservation required"
+            )
+        if (
+            str(
+                readiness.get(
+                    f"{prefix}_source_outside_soloing_repair_objective_schema_version"
+                )
+                or ""
+            )
+            != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+        ):
+            raise StageBMidiToSoloTargetedQualityRepairFollowupDecisionError(
+                f"{prefix} source outside-soloing objective schema version mismatch"
+            )
     if require_no_quality_claim:
         _require_no_quality_claim(readiness, label="follow-up readiness")
     return {
         "boundary": boundary,
         "source_boundary": str(report.get("source_boundary") or ""),
         "repair_sweep_boundary": str(report.get("repair_sweep_boundary") or ""),
+        "schema_version": str(report.get("schema_version") or ""),
+        "source_targeted_quality_repair_objective_next_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_objective_next") or ""
+        ),
+        "source_targeted_quality_repair_sweep_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_sweep") or ""
+        ),
+        "source_targeted_quality_repair_listening_review_input_guard_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_listening_review_input_guard")
+            or ""
+        ),
+        "source_targeted_quality_repair_listening_review_package_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_listening_review_package") or ""
+        ),
+        "source_targeted_quality_repair_audio_package_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_audio_package") or ""
+        ),
+        "source_candidate_failure_labeling_schema_version": str(
+            source_schema_versions.get("candidate_failure_labeling") or ""
+        ),
+        "source_quality_rubric_schema_version": str(
+            source_schema_versions.get("quality_rubric_baseline") or ""
+        ),
+        "source_post_mvp_plan_schema_version": str(
+            source_schema_versions.get("post_mvp_quality_iteration_plan") or ""
+        ),
+        "source_final_status_schema_version": str(
+            source_schema_versions.get("final_status_audit") or ""
+        ),
+        "source_delivery_package_schema_version": str(
+            source_schema_versions.get("delivery_package") or ""
+        ),
+        "source_listening_gap_schema_version": str(
+            source_schema_versions.get("listening_review_quality_gap") or ""
+        ),
+        "source_quality_gap_schema_version": str(
+            source_schema_versions.get("quality_gap_decision") or ""
+        ),
+        "source_current_evidence_schema_version": str(
+            source_schema_versions.get("current_evidence") or ""
+        ),
         "next_boundary": str(decision.get("next_boundary") or ""),
         "selected_target": str(selected.get("selected_target") or ""),
         "followup_decision_completed": bool(
@@ -646,6 +884,12 @@ def validate_followup_decision_report(
         ),
         "objective_source_outside_soloing_repair_source_context_preserved": bool(
             readiness.get("objective_source_outside_soloing_repair_source_context_preserved", False)
+        ),
+        "objective_source_outside_soloing_repair_schema_context_preserved": bool(
+            readiness.get("objective_source_outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "objective_source_outside_soloing_repair_objective_schema_version": str(
+            readiness.get("objective_source_outside_soloing_repair_objective_schema_version") or ""
         ),
         "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             readiness.get(
@@ -692,6 +936,16 @@ def validate_followup_decision_report(
         ),
         "repair_sweep_source_outside_soloing_repair_source_context_preserved": bool(
             readiness.get("repair_sweep_source_outside_soloing_repair_source_context_preserved", False)
+        ),
+        "repair_sweep_source_outside_soloing_repair_schema_context_preserved": bool(
+            readiness.get(
+                "repair_sweep_source_outside_soloing_repair_schema_context_preserved",
+                False,
+            )
+        ),
+        "repair_sweep_source_outside_soloing_repair_objective_schema_version": str(
+            readiness.get("repair_sweep_source_outside_soloing_repair_objective_schema_version")
+            or ""
         ),
         "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             readiness.get(
@@ -754,8 +1008,22 @@ def markdown_report(report: dict[str, Any]) -> str:
         "## Summary",
         "",
         f"- boundary: `{report['boundary']}`",
+        f"- schema version: `{report['schema_version']}`",
         f"- source boundary: `{report['source_boundary']}`",
         f"- repair sweep boundary: `{report['repair_sweep_boundary']}`",
+        f"- source targeted quality repair objective next schema version: `{report['source_schema_versions']['targeted_quality_repair_objective_next']}`",
+        f"- source targeted quality repair listening review input guard schema version: `{report['source_schema_versions']['targeted_quality_repair_listening_review_input_guard']}`",
+        f"- source targeted quality repair listening review package schema version: `{report['source_schema_versions']['targeted_quality_repair_listening_review_package']}`",
+        f"- source targeted quality repair audio package schema version: `{report['source_schema_versions']['targeted_quality_repair_audio_package']}`",
+        f"- source targeted quality repair sweep schema version: `{report['source_schema_versions']['targeted_quality_repair_sweep']}`",
+        f"- source candidate failure labeling schema version: `{report['source_schema_versions']['candidate_failure_labeling']}`",
+        f"- source quality rubric schema version: `{report['source_schema_versions']['quality_rubric_baseline']}`",
+        f"- source post-MVP plan schema version: `{report['source_schema_versions']['post_mvp_quality_iteration_plan']}`",
+        f"- source final status schema version: `{report['source_schema_versions']['final_status_audit']}`",
+        f"- source delivery package schema version: `{report['source_schema_versions']['delivery_package']}`",
+        f"- source listening gap schema version: `{report['source_schema_versions']['listening_review_quality_gap']}`",
+        f"- source quality gap schema version: `{report['source_schema_versions']['quality_gap_decision']}`",
+        f"- source current evidence schema version: `{report['source_schema_versions']['current_evidence']}`",
         f"- next boundary: `{decision['next_boundary']}`",
         f"- selected target: `{selected['selected_target']}`",
         f"- dominant remaining failure label: `{selected['dominant_remaining_failure_label']}`",
@@ -769,6 +1037,8 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- objective source outside-soloing repair WAV count: `{readiness['objective_source_outside_soloing_repair_wav_count']}`",
         f"- objective source outside-soloing source objective pitch-role risk: `{readiness['objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count']}`",
         f"- objective source outside-soloing source context preserved: `{_bool_token(readiness['objective_source_outside_soloing_repair_source_context_preserved'])}`",
+        f"- objective source outside-soloing schema context preserved: `{_bool_token(readiness['objective_source_outside_soloing_repair_schema_context_preserved'])}`",
+        f"- objective source outside-soloing objective schema version: `{readiness['objective_source_outside_soloing_repair_objective_schema_version']}`",
         f"- objective source outside-soloing source pitch-role risk before / after / delta: `{readiness['objective_source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{readiness['objective_source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{readiness['objective_source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- objective source outside-soloing source repair targeted: `{_bool_token(readiness['objective_source_outside_soloing_repair_source_targeted'])}`",
         f"- objective source outside-soloing source residual risk preserved: `{_bool_token(readiness['objective_source_outside_soloing_repair_source_residual_risk_preserved'])}`",
@@ -785,6 +1055,8 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- repair sweep source outside-soloing repair evidence ready: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_evidence_ready'])}`",
         f"- repair sweep source outside-soloing source objective pitch-role risk: `{readiness['repair_sweep_source_outside_soloing_repair_source_objective_pitch_role_risk_count']}`",
         f"- repair sweep source outside-soloing source context preserved: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_source_context_preserved'])}`",
+        f"- repair sweep source outside-soloing schema context preserved: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_schema_context_preserved'])}`",
+        f"- repair sweep source outside-soloing objective schema version: `{readiness['repair_sweep_source_outside_soloing_repair_objective_schema_version']}`",
         f"- repair sweep source outside-soloing source pitch-role risk before / after / delta: `{readiness['repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{readiness['repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{readiness['repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- repair sweep source outside-soloing source repair targeted: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_source_targeted'])}`",
         f"- repair sweep source outside-soloing source residual risk preserved: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_source_residual_risk_preserved'])}`",
@@ -848,7 +1120,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=1098)
+    parser.add_argument("--issue_number", type=int, default=1182)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--expected_target", type=str, default="")

--- a/tests/test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision.py
+++ b/tests/test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision.py
@@ -17,11 +17,34 @@ from scripts.decide_stage_b_midi_to_solo_targeted_quality_repair_followup import
 )
 from scripts.decide_stage_b_midi_to_solo_targeted_quality_repair_objective_next import (
     BOUNDARY as OBJECTIVE_NEXT_BOUNDARY,
+    EXPECTED_SOURCE_SCHEMA_VERSIONS as OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    SCHEMA_VERSION as OBJECTIVE_NEXT_SCHEMA_VERSION,
 )
 from scripts.run_stage_b_midi_to_solo_targeted_quality_repair_sweep import (
     BOUNDARY as SWEEP_BOUNDARY,
+    SCHEMA_VERSION as SWEEP_SCHEMA_VERSION,
 )
 
+
+SWEEP_SOURCE_SCHEMA_VERSIONS = {
+    "candidate_failure_labeling": OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+        "candidate_failure_labeling"
+    ],
+    "quality_rubric_baseline": OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+        "quality_rubric_baseline"
+    ],
+    "post_mvp_quality_iteration_plan": OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+        "post_mvp_quality_iteration_plan"
+    ],
+    "final_status_audit": OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS["final_status_audit"],
+    "delivery_package": OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS["delivery_package"],
+    "listening_review_quality_gap": OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+        "listening_review_quality_gap"
+    ],
+    "quality_gap_decision": OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS["quality_gap_decision"],
+    "current_evidence": OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS["current_evidence"],
+}
 
 SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
@@ -53,8 +76,50 @@ SOURCE_CONTEXT = {
 
 def objective_next_report(*, quality_claim: bool = False) -> dict:
     return {
+        "schema_version": OBJECTIVE_NEXT_SCHEMA_VERSION,
         "boundary": OBJECTIVE_NEXT_BOUNDARY,
+        "source_schema_versions": dict(OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS),
         "objective_summary": {
+            "source_targeted_quality_repair_listening_review_input_guard_schema_version": (
+                OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                    "targeted_quality_repair_listening_review_input_guard"
+                ]
+            ),
+            "source_targeted_quality_repair_listening_review_package_schema_version": (
+                OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                    "targeted_quality_repair_listening_review_package"
+                ]
+            ),
+            "source_targeted_quality_repair_audio_package_schema_version": (
+                OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS["targeted_quality_repair_audio_package"]
+            ),
+            "source_targeted_quality_repair_sweep_schema_version": (
+                OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS["targeted_quality_repair_sweep"]
+            ),
+            "source_candidate_failure_labeling_schema_version": (
+                OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS["candidate_failure_labeling"]
+            ),
+            "source_quality_rubric_schema_version": OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                "quality_rubric_baseline"
+            ],
+            "source_post_mvp_plan_schema_version": OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                "post_mvp_quality_iteration_plan"
+            ],
+            "source_final_status_schema_version": OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                "final_status_audit"
+            ],
+            "source_delivery_package_schema_version": OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                "delivery_package"
+            ],
+            "source_listening_gap_schema_version": OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                "listening_review_quality_gap"
+            ],
+            "source_quality_gap_schema_version": OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                "quality_gap_decision"
+            ],
+            "source_current_evidence_schema_version": OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                "current_evidence"
+            ],
             "review_item_count": 6,
             "validated_review_input_present": False,
             "preference_fill_allowed": False,
@@ -63,6 +128,10 @@ def objective_next_report(*, quality_claim: bool = False) -> dict:
             "failure_label_delta": 4,
             "source_outside_soloing_repair_evidence_ready": True,
             "source_outside_soloing_repair_source_context_preserved": True,
+            "source_outside_soloing_repair_schema_context_preserved": True,
+            "source_outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "source_outside_soloing_repair_wav_count": 6,
             "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
             "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
@@ -98,7 +167,9 @@ def objective_next_report(*, quality_claim: bool = False) -> dict:
 
 def repair_sweep_report(*, technical_regression_count: int = 0) -> dict:
     return {
+        "schema_version": SWEEP_SCHEMA_VERSION,
         "boundary": SWEEP_BOUNDARY,
+        "source_schema_versions": dict(SWEEP_SOURCE_SCHEMA_VERSIONS),
         "candidate_repairs": [
             {
                 "repaired_labeling": {
@@ -120,6 +191,10 @@ def repair_sweep_report(*, technical_regression_count: int = 0) -> dict:
             "technical_regression_count": technical_regression_count,
             "source_outside_soloing_repair_evidence_ready": True,
             "source_outside_soloing_repair_source_context_preserved": True,
+            "source_outside_soloing_repair_schema_context_preserved": True,
+            "source_outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
             "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
             "source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
@@ -162,7 +237,7 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
                 objective_next_report=objective_next_report(),
                 repair_sweep_report=repair_sweep_report(),
                 output_dir=Path(tmp) / "followup",
-                issue_number=1098,
+                issue_number=1182,
             )
             summary = validate_followup_decision_report(
                 report,
@@ -175,7 +250,15 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
             )
 
             self.assertEqual(report["schema_version"], SCHEMA_VERSION)
-            self.assertEqual(report["issue_number"], 1098)
+            self.assertEqual(report["issue_number"], 1182)
+            self.assertEqual(
+                summary["source_targeted_quality_repair_objective_next_schema_version"],
+                OBJECTIVE_NEXT_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                summary["source_targeted_quality_repair_sweep_schema_version"],
+                SWEEP_SCHEMA_VERSION,
+            )
             self.assertTrue(summary["followup_decision_completed"])
             self.assertTrue(summary["dominant_songlike_target_selected"])
             self.assertEqual(
@@ -189,6 +272,13 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
             self.assertEqual(summary["objective_source_outside_soloing_repair_wav_count"], 6)
             self.assertTrue(
                 summary["objective_source_outside_soloing_repair_source_context_preserved"]
+            )
+            self.assertTrue(
+                summary["objective_source_outside_soloing_repair_schema_context_preserved"]
+            )
+            self.assertEqual(
+                summary["objective_source_outside_soloing_repair_objective_schema_version"],
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
             )
             for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[f"objective_{key}"], SOURCE_CONTEXT[key])
@@ -228,6 +318,13 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
             self.assertTrue(summary["repair_sweep_source_outside_soloing_repair_evidence_ready"])
             self.assertTrue(
                 summary["repair_sweep_source_outside_soloing_repair_source_context_preserved"]
+            )
+            self.assertTrue(
+                summary["repair_sweep_source_outside_soloing_repair_schema_context_preserved"]
+            )
+            self.assertEqual(
+                summary["repair_sweep_source_outside_soloing_repair_objective_schema_version"],
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
             )
             for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[f"repair_sweep_{key}"], SOURCE_CONTEXT[key])
@@ -285,7 +382,7 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
                     objective_next_report=objective_next_report(quality_claim=True),
                     repair_sweep_report=repair_sweep_report(),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1098,
+                    issue_number=1182,
                 )
 
     def test_rejects_technical_regression(self) -> None:
@@ -297,7 +394,7 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
                     objective_next_report=objective_next_report(),
                     repair_sweep_report=repair_sweep_report(technical_regression_count=1),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1098,
+                    issue_number=1182,
                 )
 
     def test_rejects_missing_objective_outside_soloing_context(self) -> None:
@@ -311,7 +408,7 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
                     objective_next_report=source,
                     repair_sweep_report=repair_sweep_report(),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1098,
+                    issue_number=1182,
                 )
 
     def test_rejects_missing_sweep_outside_soloing_context(self) -> None:
@@ -325,7 +422,7 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
                     objective_next_report=objective_next_report(),
                     repair_sweep_report=source,
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1098,
+                    issue_number=1182,
                 )
 
     def test_rejects_objective_source_risk_delta_mismatch(self) -> None:
@@ -341,7 +438,7 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
                     objective_next_report=source,
                     repair_sweep_report=repair_sweep_report(),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1098,
+                    issue_number=1182,
                 )
 
     def test_rejects_missing_objective_source_context_field(self) -> None:
@@ -357,7 +454,7 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
                     objective_next_report=source,
                     repair_sweep_report=repair_sweep_report(),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1098,
+                    issue_number=1182,
                 )
 
     def test_rejects_missing_repair_sweep_source_context_field(self) -> None:
@@ -373,7 +470,7 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
                     objective_next_report=objective_next_report(),
                     repair_sweep_report=source,
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1098,
+                    issue_number=1182,
                 )
 
     def test_rejects_false_source_context_preserved_field(self) -> None:
@@ -389,7 +486,37 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
                     objective_next_report=source,
                     repair_sweep_report=repair_sweep_report(),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1098,
+                    issue_number=1182,
+                )
+
+    def test_rejects_objective_source_schema_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = objective_next_report()
+            source["source_schema_versions"][
+                "targeted_quality_repair_listening_review_input_guard"
+            ] = "old-schema"
+            with self.assertRaises(
+                StageBMidiToSoloTargetedQualityRepairFollowupDecisionError
+            ):
+                build_followup_decision_report(
+                    objective_next_report=source,
+                    repair_sweep_report=repair_sweep_report(),
+                    output_dir=Path(tmp) / "followup",
+                    issue_number=1182,
+                )
+
+    def test_rejects_false_schema_context_preserved(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = repair_sweep_report()
+            source["aggregate"]["source_outside_soloing_repair_schema_context_preserved"] = False
+            with self.assertRaises(
+                StageBMidiToSoloTargetedQualityRepairFollowupDecisionError
+            ):
+                build_followup_decision_report(
+                    objective_next_report=objective_next_report(),
+                    repair_sweep_report=source,
+                    output_dir=Path(tmp) / "followup",
+                    issue_number=1182,
                 )
 
     def test_constants_are_stable(self) -> None:
@@ -398,7 +525,7 @@ class StageBMidiToSoloTargetedQualityRepairFollowupDecisionTest(unittest.TestCas
         self.assertEqual(SELECTED_TARGET, "songlike_melody_contour_repair_sweep")
         self.assertEqual(
             SCHEMA_VERSION,
-            "stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v4",
+            "stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v5",
         )
 
 


### PR DESCRIPTION
## Summary
- targeted quality repair follow-up decision schema v5 적용
- objective next v5 및 targeted repair sweep v4 schema chain 검증/전파
- outside-soloing schema-context flag와 objective schema version 검증/전파
- README, CURRENT_STATUS, CORE_PLAN, AGENTS handoff 갱신

## Context
- 이전 작업: #1180 targeted quality repair objective-only next decision source-context refresh
- 현재 입력: objective-only next decision v5, targeted repair sweep v4
- 주요 측정값: candidate count `6`, failure label delta `4`, technical regression count `0`
- 잔여 dominant label: `songlike_melody_not_soloing` / `5`
- 제외 기준: human/audio preference claim `false`, MIDI-to-solo musical quality claim `false`
- 이번 검토 대상: follow-up decision에서 source schema chain과 outside-soloing schema context 보존

## Scope
- follow-up decision source schema validation 추가
- objective next/sweep schema version summary 추가
- schema-context false 및 schema mismatch 차단 테스트 추가
- #1182 status 문서와 handoff 문서 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_targeted_quality_repair_followup.py tests/test_stage_b_midi_to_solo_targeted_quality_repair_followup_decision.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-targeted-quality-repair-followup-decision`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- musical quality claim 없음
- listening review input pending 유지
- 다음 검증 대상: songlike melody contour repair sweep source-context refresh

Closes #1182