### PR TITLE
Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Current handoff scope:
 - Latest targeted quality repair listening review input guard completed: Issue #1178, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh.
 - Latest targeted quality repair objective-only next decision completed: Issue #1180, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh.
 - Latest targeted quality repair follow-up decision completed: Issue #1182, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh.
-- Latest songlike melody contour repair sweep completed: Issue #1100, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh.
+- Latest songlike melody contour repair sweep completed: Issue #1184, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh.
 - Latest songlike melody contour repair audio package completed: Issue #1102, Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh.
 - Latest songlike melody contour repair listening review package completed: Issue #1104, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh.
 - Latest songlike melody contour repair listening review input guard completed: Issue #1106, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1148, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh.
+- Open issue queue after Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest targeted quality repair listening review input guard: `Issue #1178`
 - latest targeted quality repair objective-only next decision: `Issue #1180`
 - latest targeted quality repair follow-up decision: `Issue #1182`
-- latest songlike melody contour repair sweep: `Issue #1100`
+- latest songlike melody contour repair sweep: `Issue #1184`
 - latest songlike melody contour repair audio package: `Issue #1102`
 - latest songlike melody contour repair listening review package: `Issue #1104`
 - latest songlike melody contour repair listening review input guard: `Issue #1106`
@@ -50,7 +50,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1150`
 - latest README evidence refresh: `Issue #1152`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after targeted quality repair follow-up decision source-context refresh merge: `0`
+- open issue queue after songlike melody contour repair sweep source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
@@ -403,12 +403,19 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - targeted quality repair selected next target: `songlike_melody_contour_repair_sweep`
 - targeted quality repair source risk: `5 -> 2`
 - targeted quality repair current risk after / delta: `0 / 2`
+- songlike melody contour repair sweep schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`
+- songlike contour source follow-up schema version: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v5`
+- songlike contour source targeted repair sweep schema version: `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`
 - songlike melody contour repair sweep completed: `true`
 - songlike failure count: `5 -> 0`
 - songlike contour total failure labels: `8 -> 4`
+- songlike contour objective source outside-soloing schema context preserved: `true`
+- songlike contour objective source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - songlike contour objective follow-up objective source outside-soloing source context preserved: `true`
 - songlike contour objective follow-up repair sweep source outside-soloing source context preserved: `true`
 - songlike contour objective bridge repair sweep source outside-soloing source context preserved: `true`
+- songlike contour source outside-soloing schema context preserved: `true`
+- songlike contour source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - songlike contour follow-up objective source outside-soloing source context preserved: `true`
 - songlike contour follow-up repair sweep source outside-soloing source context preserved: `true`
 - songlike contour bridge repair sweep source outside-soloing source context preserved: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -408,7 +408,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo targeted quality repair listening review input guard: schema `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard_v5`, source listening package schema `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package_v5`, review items `6`, preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, outside-soloing schema-context preserved `true`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_objective_only_next_decision`
 - MIDI-to-solo targeted quality repair objective-only next decision: schema `stage_b_midi_to_solo_targeted_quality_repair_objective_next_v5`, source input guard schema `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard_v5`, follow-up required `true`, current quality claim ready `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, outside-soloing schema-context preserved `true`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
 - MIDI-to-solo targeted quality repair follow-up decision: schema `stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v5`, source objective next schema `stage_b_midi_to_solo_targeted_quality_repair_objective_next_v5`, source sweep schema `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`, selected target `songlike_melody_contour_repair_sweep`, dominant label/count `songlike_melody_not_soloing/5`, objective and repair sweep source risk `5 -> 2`, current repair risk after/delta `0/2`, source/schema-context preserved flags `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
-- MIDI-to-solo songlike melody contour repair sweep: songlike failure `5 -> 0`, total failure labels `8 -> 4`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
+- MIDI-to-solo songlike melody contour repair sweep: schema `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`, source follow-up schema `stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v5`, source sweep schema `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`, songlike failure `5 -> 0`, total failure labels `8 -> 4`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/schema-context preserved flags `true`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
 - MIDI-to-solo songlike melody contour repair audio package: rendered WAV `6`, duration `18.849s-18.992s`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
 - MIDI-to-solo songlike melody contour repair listening review package: review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
 - MIDI-to-solo songlike melody contour repair listening review input guard: preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
@@ -8420,7 +8420,7 @@ Issue #928은 Issue #926 targeted quality repair listening review input guard의
 
 다음 작업:
 
-- `Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh`
+- `Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh`
 
 ## 9.155 Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh
 
@@ -13009,13 +13009,28 @@ Issue #1182는 Issue #1180 targeted quality repair objective-only next decision 
 
 ## 9.240 Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh
 
-Issue #1100은 Issue #1182 targeted quality repair follow-up decision의 selected target에 따라 songlike melody contour repair sweep을 실행하고 source-context preserved flag를 sweep aggregate/readiness/validation summary까지 보존한 작업이다.
+Issue #1184는 Issue #1182 targeted quality repair follow-up decision v5의 selected target에 따라 songlike melody contour repair sweep을 실행하고 source schema chain, outside-soloing schema context, source-context preserved flag를 sweep aggregate/readiness/validation summary까지 보존한 작업이다.
 
 결과:
 
 - document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
 - source boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`
+- source targeted quality repair follow-up schema version: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v5`
+- source targeted quality repair objective next schema version: `stage_b_midi_to_solo_targeted_quality_repair_objective_next_v5`
+- source targeted quality repair listening review input guard schema version: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard_v5`
+- source targeted quality repair listening review package schema version: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package_v5`
+- source targeted quality repair audio package schema version: `stage_b_midi_to_solo_targeted_quality_repair_audio_package_v5`
+- source targeted quality repair sweep schema version: `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`
+- source candidate failure labeling schema version: `stage_b_midi_to_solo_candidate_failure_labeling_v4`
+- source quality rubric schema version: `stage_b_midi_to_solo_quality_rubric_baseline_v4`
+- source post-MVP plan schema version: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`
+- source final status schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
 - selected target: `songlike_melody_contour_repair_audio_package`
 - candidate count: `6`
@@ -13028,8 +13043,12 @@ Issue #1100은 Issue #1182 targeted quality repair follow-up decision의 selecte
 - source outside-soloing repair evidence ready: `true`
 - objective source outside-soloing repair WAV count: `6`
 - objective source outside-soloing source context preserved: `true`
+- objective source outside-soloing schema context preserved: `true`
+- objective source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - objective preserved source-context flags: `3 / 3`
 - source outside-soloing source context preserved: `true`
+- source outside-soloing schema context preserved: `true`
+- source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - source preserved source-context flags: `3 / 3`
 - source outside-soloing source pitch-role risk: `5 -> 2`
 - source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
@@ -13043,9 +13062,9 @@ Issue #1100은 Issue #1182 targeted quality repair follow-up decision의 selecte
 
 판단:
 
-- songlike contour repair sweep source validation에 #1098 preserved flag 3개 포함.
-- sweep aggregate와 readiness에 objective/source preserved flag 보존.
-- preserved flag false 입력은 validation error로 차단.
+- songlike contour repair sweep source validation에 follow-up v5와 upstream schema chain 포함.
+- sweep aggregate와 readiness에 objective/source schema context 및 preserved flag 보존.
+- schema version mismatch, schema-context false, preserved flag false 입력은 validation error로 차단.
 - songlike failure label은 `5 -> 0`으로 감소, technical regression은 `0`.
 - outside-soloing과 weak chord-tone landing은 not-evaluable 경계 유지.
 - human/audio preference와 musical quality claim 제외 유지.
@@ -13053,7 +13072,7 @@ Issue #1100은 Issue #1182 targeted quality repair follow-up decision의 selecte
 검증:
 
 - `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
-- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-sweep`
 - `bash scripts/agent_harness.sh quick`
@@ -13065,7 +13084,7 @@ Issue #1100은 Issue #1182 targeted quality repair follow-up decision의 selecte
 
 ## 9.241 Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh
 
-Issue #1102는 Issue #1100 songlike melody contour repair sweep의 MIDI 후보 6개를 WAV로 렌더링하고 source-context preserved flag를 audio summary/validation summary까지 보존한 작업이다.
+Issue #1102는 Issue #1184 songlike melody contour repair sweep의 MIDI 후보 6개를 WAV로 렌더링하고 source-context preserved flag를 audio summary/validation summary까지 보존한 작업이다.
 
 결과:
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -28,7 +28,7 @@
 - latest targeted quality repair listening review input guard: Issue #1178, Stage B MIDI-to-solo targeted quality repair listening review input guard source-context refresh
 - latest targeted quality repair objective-only next decision: Issue #1180, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh
 - latest targeted quality repair follow-up decision: Issue #1182, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh
-- latest songlike melody contour repair sweep: Issue #1100, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh
+- latest songlike melody contour repair sweep: Issue #1184, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh
 - latest songlike melody contour repair audio package: Issue #1102, Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh
 - latest songlike melody contour repair listening review package: Issue #1104, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh
 - latest songlike melody contour repair listening review input guard: Issue #1106, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1150, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh`
+- open issue queue after Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -3619,7 +3619,7 @@ Issue #1012는 Issue #1010 input guard 이후 listening input 없이 objective e
 
 다음:
 
-- `Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh`
+- `Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh`
 
 ## Stage B MIDI-to-Solo Targeted Quality Repair Follow-Up Decision Source Context Refresh Result
 
@@ -6314,13 +6314,28 @@ Issue #1182는 Issue #1180 targeted quality repair objective-only next decision 
 
 ## 9.240 Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh
 
-Issue #1100은 Issue #1182 targeted quality repair follow-up decision의 selected target에 따라 songlike melody contour repair sweep을 실행하고 source-context preserved flag를 sweep aggregate/readiness/validation summary까지 보존한 작업이다.
+Issue #1184는 Issue #1182 targeted quality repair follow-up decision v5의 selected target에 따라 songlike melody contour repair sweep을 실행하고 source schema chain, outside-soloing schema context, source-context preserved flag를 sweep aggregate/readiness/validation summary까지 보존한 작업이다.
 
 결과:
 
 - document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
 - source boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`
+- source targeted quality repair follow-up schema version: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v5`
+- source targeted quality repair objective next schema version: `stage_b_midi_to_solo_targeted_quality_repair_objective_next_v5`
+- source targeted quality repair listening review input guard schema version: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard_v5`
+- source targeted quality repair listening review package schema version: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package_v5`
+- source targeted quality repair audio package schema version: `stage_b_midi_to_solo_targeted_quality_repair_audio_package_v5`
+- source targeted quality repair sweep schema version: `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`
+- source candidate failure labeling schema version: `stage_b_midi_to_solo_candidate_failure_labeling_v4`
+- source quality rubric schema version: `stage_b_midi_to_solo_quality_rubric_baseline_v4`
+- source post-MVP plan schema version: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`
+- source final status schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
 - selected target: `songlike_melody_contour_repair_audio_package`
 - candidate count: `6`
@@ -6333,8 +6348,12 @@ Issue #1100은 Issue #1182 targeted quality repair follow-up decision의 selecte
 - source outside-soloing repair evidence ready: `true`
 - objective source outside-soloing repair WAV count: `6`
 - objective source outside-soloing source context preserved: `true`
+- objective source outside-soloing schema context preserved: `true`
+- objective source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - objective preserved source-context flags: `3 / 3`
 - source outside-soloing source context preserved: `true`
+- source outside-soloing schema context preserved: `true`
+- source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - source preserved source-context flags: `3 / 3`
 - source outside-soloing source pitch-role risk: `5 -> 2`
 - source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
@@ -6348,9 +6367,9 @@ Issue #1100은 Issue #1182 targeted quality repair follow-up decision의 selecte
 
 판단:
 
-- songlike contour repair sweep source validation에 #1098 preserved flag 3개 포함.
-- sweep aggregate와 readiness에 objective/source preserved flag 보존.
-- preserved flag false 입력은 validation error로 차단.
+- songlike contour repair sweep source validation에 follow-up v5와 upstream schema chain 포함.
+- sweep aggregate와 readiness에 objective/source schema context 및 preserved flag 보존.
+- schema version mismatch, schema-context false, preserved flag false 입력은 validation error로 차단.
 - songlike failure label은 `5 -> 0`으로 감소, technical regression은 `0`.
 - outside-soloing과 weak chord-tone landing은 not-evaluable 경계 유지.
 - human/audio preference와 musical quality claim 제외 유지.
@@ -6358,7 +6377,7 @@ Issue #1100은 Issue #1182 targeted quality repair follow-up decision의 selecte
 검증:
 
 - `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
-- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-sweep`
 - `bash scripts/agent_harness.sh quick`
@@ -6370,7 +6389,7 @@ Issue #1100은 Issue #1182 targeted quality repair follow-up decision의 selecte
 
 ## 9.241 Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh
 
-Issue #1102는 Issue #1100 songlike melody contour repair sweep의 MIDI 후보 6개를 WAV로 렌더링하고 source-context preserved flag를 audio summary/validation summary까지 보존한 작업이다.
+Issue #1102는 Issue #1184 songlike melody contour repair sweep의 MIDI 후보 6개를 WAV로 렌더링하고 source-context preserved flag를 audio summary/validation summary까지 보존한 작업이다.
 
 결과:
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -3,7 +3,22 @@
 ## Summary
 
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`
 - source boundary: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
+- source targeted quality repair follow-up schema version: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v5`
+- source targeted quality repair objective next schema version: `stage_b_midi_to_solo_targeted_quality_repair_objective_next_v5`
+- source targeted quality repair listening review input guard schema version: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard_v5`
+- source targeted quality repair listening review package schema version: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package_v5`
+- source targeted quality repair audio package schema version: `stage_b_midi_to_solo_targeted_quality_repair_audio_package_v5`
+- source targeted quality repair sweep schema version: `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`
+- source candidate failure labeling schema version: `stage_b_midi_to_solo_candidate_failure_labeling_v4`
+- source quality rubric schema version: `stage_b_midi_to_solo_quality_rubric_baseline_v4`
+- source post-MVP plan schema version: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`
+- source final status schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
 - selected target: `songlike_melody_contour_repair_audio_package`
 - candidate count: `6`
@@ -16,6 +31,8 @@
 - source outside-soloing repair evidence ready: `true`
 - objective source outside-soloing repair WAV count: `6`
 - objective source outside-soloing source context preserved: `true`
+- objective source outside-soloing schema context preserved: `true`
+- objective source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - objective source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - objective source outside-soloing source repair targeted: `false`
 - objective source outside-soloing source residual risk preserved: `true`
@@ -28,6 +45,8 @@
 - objective bridge repair sweep source outside-soloing source context preserved: `true`
 - objective repair sweep current repair pitch-role risk after/delta: `0` / `2`
 - source outside-soloing source context preserved: `true`
+- source outside-soloing schema context preserved: `true`
+- source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - source outside-soloing source repair targeted: `false`
 - source outside-soloing source residual risk preserved: `true`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6361,7 +6361,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep() {
     --targeted_repair_sweep "$targeted_sweep_report" \
     --rubric_baseline "$rubric_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1100 \
+    --issue_number 1184 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_sweep \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package \
     --min_candidate_count 6 \

--- a/scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
+++ b/scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
@@ -22,8 +22,13 @@ from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
 )
 from scripts.decide_stage_b_midi_to_solo_targeted_quality_repair_followup import (  # noqa: E402
     BOUNDARY as FOLLOWUP_BOUNDARY,
+    EXPECTED_SOURCE_SCHEMA_VERSIONS as FOLLOWUP_SOURCE_SCHEMA_VERSIONS,
     NEXT_BOUNDARY as FOLLOWUP_NEXT_BOUNDARY,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
     SELECTED_TARGET as FOLLOWUP_SELECTED_TARGET,
+    SCHEMA_VERSION as FOLLOWUP_SCHEMA_VERSION,
+    StageBMidiToSoloTargetedQualityRepairFollowupDecisionError,
+    validate_followup_decision_report,
 )
 from scripts.label_stage_b_midi_to_solo_candidate_failures import (  # noqa: E402
     analyze_candidate_midi,
@@ -32,6 +37,9 @@ from scripts.label_stage_b_midi_to_solo_candidate_failures import (  # noqa: E40
 )
 from scripts.run_stage_b_midi_to_solo_targeted_quality_repair_sweep import (  # noqa: E402
     BOUNDARY as TARGETED_REPAIR_SWEEP_BOUNDARY,
+    SCHEMA_VERSION as TARGETED_REPAIR_SWEEP_SCHEMA_VERSION,
+    StageBMidiToSoloTargetedQualityRepairSweepError,
+    validate_targeted_quality_repair_sweep_report,
 )
 
 
@@ -42,9 +50,14 @@ class StageBMidiToSoloSonglikeMelodyContourRepairSweepError(ValueError):
 BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_sweep"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package"
 SELECTED_TARGET = "songlike_melody_contour_repair_audio_package"
-SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v4"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5"
 SONGLIKE_LABEL = "songlike_melody_not_soloing"
 BAR_SECONDS = 2.0
+EXPECTED_SOURCE_SCHEMA_VERSIONS = {
+    "targeted_quality_repair_followup_decision": FOLLOWUP_SCHEMA_VERSION,
+    **FOLLOWUP_SOURCE_SCHEMA_VERSIONS,
+    "targeted_quality_repair_sweep": TARGETED_REPAIR_SWEEP_SCHEMA_VERSION,
+}
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -119,6 +132,20 @@ def _prefixed_source_context_fields(
     return result
 
 
+def _validate_source_schema_versions(
+    source_schema_versions: dict[str, Any],
+    *,
+    label: str,
+) -> dict[str, str]:
+    normalized = {key: str(value) for key, value in source_schema_versions.items()}
+    for key, expected in EXPECTED_SOURCE_SCHEMA_VERSIONS.items():
+        if str(normalized.get(key) or "") != expected:
+            raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+                f"{label} source schema version mismatch: {key}"
+            )
+    return normalized
+
+
 def _extract_prefixed_source_context(
     readiness: dict[str, Any],
     *,
@@ -143,6 +170,17 @@ def _extract_prefixed_source_context(
     if not bool(readiness.get(f"{field_prefix}_source_context_preserved", False)):
         raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
             f"{label} outside-soloing source context preservation required"
+        )
+    if not bool(readiness.get(f"{field_prefix}_schema_context_preserved", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            f"{label} outside-soloing schema context preservation required"
+        )
+    if (
+        str(readiness.get(f"{field_prefix}_objective_schema_version") or "")
+        != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+    ):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            f"{label} outside-soloing objective schema version mismatch"
         )
     bridge_context = _prefixed_source_context_fields(readiness, prefix=prefix, label=label)
     if minimum_wav_count is not None:
@@ -180,6 +218,12 @@ def _extract_prefixed_source_context(
         f"{prefix}_source_outside_soloing_repair_source_context_preserved": bool(
             readiness.get(f"{field_prefix}_source_context_preserved", False)
         ),
+        f"{prefix}_source_outside_soloing_repair_schema_context_preserved": bool(
+            readiness.get(f"{field_prefix}_schema_context_preserved", False)
+        ),
+        f"{prefix}_source_outside_soloing_repair_objective_schema_version": str(
+            readiness.get(f"{field_prefix}_objective_schema_version") or ""
+        ),
         f"{prefix}_source_outside_soloing_repair_source_pitch_role_risk_count_before": source_risk_before,
         f"{prefix}_source_outside_soloing_repair_source_pitch_role_risk_count_after": source_risk_after,
         f"{prefix}_source_outside_soloing_repair_source_pitch_role_risk_delta": source_risk_delta,
@@ -204,6 +248,27 @@ def validate_followup_decision(report: dict[str, Any]) -> dict[str, Any]:
     decision = _dict(report.get("decision"))
     selected = _dict(report.get("selected_next_target"))
     sweep = _dict(report.get("repair_sweep_summary"))
+    try:
+        followup_summary = validate_followup_decision_report(
+            report,
+            expected_boundary=FOLLOWUP_BOUNDARY,
+            expected_next_boundary=FOLLOWUP_NEXT_BOUNDARY,
+            expected_target=FOLLOWUP_SELECTED_TARGET,
+            require_followup_decision=True,
+            require_dominant_songlike_target=True,
+            require_no_quality_claim=True,
+        )
+    except StageBMidiToSoloTargetedQualityRepairFollowupDecisionError as exc:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(str(exc)) from exc
+    source_schema_versions = _validate_source_schema_versions(
+        {
+            "targeted_quality_repair_followup_decision": followup_summary.get(
+                "schema_version"
+            ),
+            **_dict(report.get("source_schema_versions")),
+        },
+        label="targeted quality repair follow-up decision",
+    )
     if str(report.get("boundary") or "") != FOLLOWUP_BOUNDARY:
         raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
             "targeted quality follow-up decision boundary required"
@@ -277,6 +342,55 @@ def validate_followup_decision(report: dict[str, Any]) -> dict[str, Any]:
         )
     _require_no_quality_claim(readiness, label="follow-up readiness")
     return {
+        "schema_version": str(followup_summary.get("schema_version") or ""),
+        "source_schema_versions": source_schema_versions,
+        "source_targeted_quality_repair_objective_next_schema_version": str(
+            followup_summary.get("source_targeted_quality_repair_objective_next_schema_version")
+            or ""
+        ),
+        "source_targeted_quality_repair_sweep_schema_version": str(
+            followup_summary.get("source_targeted_quality_repair_sweep_schema_version") or ""
+        ),
+        "source_targeted_quality_repair_listening_review_input_guard_schema_version": str(
+            followup_summary.get(
+                "source_targeted_quality_repair_listening_review_input_guard_schema_version"
+            )
+            or ""
+        ),
+        "source_targeted_quality_repair_listening_review_package_schema_version": str(
+            followup_summary.get(
+                "source_targeted_quality_repair_listening_review_package_schema_version"
+            )
+            or ""
+        ),
+        "source_targeted_quality_repair_audio_package_schema_version": str(
+            followup_summary.get("source_targeted_quality_repair_audio_package_schema_version")
+            or ""
+        ),
+        "source_candidate_failure_labeling_schema_version": str(
+            followup_summary.get("source_candidate_failure_labeling_schema_version") or ""
+        ),
+        "source_quality_rubric_schema_version": str(
+            followup_summary.get("source_quality_rubric_schema_version") or ""
+        ),
+        "source_post_mvp_plan_schema_version": str(
+            followup_summary.get("source_post_mvp_plan_schema_version") or ""
+        ),
+        "source_final_status_schema_version": str(
+            followup_summary.get("source_final_status_schema_version") or ""
+        ),
+        "source_delivery_package_schema_version": str(
+            followup_summary.get("source_delivery_package_schema_version") or ""
+        ),
+        "source_listening_gap_schema_version": str(
+            followup_summary.get("source_listening_gap_schema_version") or ""
+        ),
+        "source_quality_gap_schema_version": str(
+            followup_summary.get("source_quality_gap_schema_version") or ""
+        ),
+        "source_current_evidence_schema_version": str(
+            followup_summary.get("source_current_evidence_schema_version") or ""
+        ),
         "candidate_count": _int(readiness.get("candidate_count")),
         "source_total_failure_label_count": _int(
             readiness.get("source_total_failure_label_count")
@@ -318,10 +432,21 @@ def validate_followup_decision(report: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def validate_targeted_repair_sweep(report: dict[str, Any]) -> list[dict[str, Any]]:
+def validate_targeted_repair_sweep(report: dict[str, Any]) -> dict[str, Any]:
     readiness = _dict(report.get("readiness"))
     aggregate = _dict(report.get("aggregate"))
     rows = [_dict(item) for item in _list(report.get("candidate_repairs"))]
+    try:
+        sweep_summary = validate_targeted_quality_repair_sweep_report(
+            report,
+            expected_boundary=TARGETED_REPAIR_SWEEP_BOUNDARY,
+            min_candidate_count=6,
+            require_sweep_completed=True,
+            require_failure_delta=True,
+            require_no_quality_claim=True,
+        )
+    except StageBMidiToSoloTargetedQualityRepairSweepError as exc:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(str(exc)) from exc
     if str(report.get("boundary") or "") != TARGETED_REPAIR_SWEEP_BOUNDARY:
         raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
             "targeted quality repair sweep source required"
@@ -355,7 +480,11 @@ def validate_targeted_repair_sweep(report: dict[str, Any]) -> list[dict[str, Any
             "source repair row count below 6"
         )
     _require_no_quality_claim(readiness, label="targeted repair readiness")
-    return rows
+    return {
+        "schema_version": str(sweep_summary.get("schema_version") or ""),
+        "source_schema_versions": _dict(report.get("source_schema_versions")),
+        "rows": rows,
+    }
 
 
 def density_patterns() -> list[list[int]]:
@@ -549,7 +678,8 @@ def build_songlike_melody_contour_repair_sweep_report(
     issue_number: int,
 ) -> dict[str, Any]:
     followup = validate_followup_decision(followup_decision)
-    source_rows = validate_targeted_repair_sweep(targeted_repair_sweep)
+    targeted_sweep = validate_targeted_repair_sweep(targeted_repair_sweep)
+    source_rows = [_dict(item) for item in _list(targeted_sweep.get("rows"))]
     rubric_summary = validate_rubric_baseline(rubric_baseline)
     rubric_items = [_dict(item) for item in _list(rubric_summary.get("rubric_items"))]
     if len(source_rows) < followup["candidate_count"]:
@@ -614,6 +744,14 @@ def build_songlike_melody_contour_repair_sweep_report(
         and repaired_songlike_count < source_songlike_count
         and technical_regression_count == 0
     )
+    source_schema_versions = _validate_source_schema_versions(
+        {
+            "targeted_quality_repair_followup_decision": followup["schema_version"],
+            **followup["source_schema_versions"],
+            "targeted_quality_repair_sweep": targeted_sweep["schema_version"],
+        },
+        label="songlike melody contour repair sweep",
+    )
     return {
         "schema_version": SCHEMA_VERSION,
         "created_at": datetime.now(timezone.utc)
@@ -624,6 +762,7 @@ def build_songlike_melody_contour_repair_sweep_report(
         "boundary": BOUNDARY,
         "source_boundary": FOLLOWUP_BOUNDARY,
         "targeted_repair_sweep_boundary": TARGETED_REPAIR_SWEEP_BOUNDARY,
+        "source_schema_versions": source_schema_versions,
         "candidate_repairs": relabeled,
         "aggregate": {
             "candidate_count": len(relabeled),
@@ -646,6 +785,12 @@ def build_songlike_melody_contour_repair_sweep_report(
             ),
             "objective_source_outside_soloing_repair_source_context_preserved": bool(
                 followup["objective_source_outside_soloing_repair_source_context_preserved"]
+            ),
+            "objective_source_outside_soloing_repair_schema_context_preserved": bool(
+                followup["objective_source_outside_soloing_repair_schema_context_preserved"]
+            ),
+            "objective_source_outside_soloing_repair_objective_schema_version": str(
+                followup["objective_source_outside_soloing_repair_objective_schema_version"]
             ),
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
                 followup["objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"]
@@ -679,6 +824,12 @@ def build_songlike_melody_contour_repair_sweep_report(
             ),
             "source_outside_soloing_repair_source_context_preserved": bool(
                 followup["repair_sweep_source_outside_soloing_repair_source_context_preserved"]
+            ),
+            "source_outside_soloing_repair_schema_context_preserved": bool(
+                followup["repair_sweep_source_outside_soloing_repair_schema_context_preserved"]
+            ),
+            "source_outside_soloing_repair_objective_schema_version": str(
+                followup["repair_sweep_source_outside_soloing_repair_objective_schema_version"]
             ),
             "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
                 followup["repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before"]
@@ -746,6 +897,12 @@ def build_songlike_melody_contour_repair_sweep_report(
             "objective_source_outside_soloing_repair_source_context_preserved": bool(
                 followup["objective_source_outside_soloing_repair_source_context_preserved"]
             ),
+            "objective_source_outside_soloing_repair_schema_context_preserved": bool(
+                followup["objective_source_outside_soloing_repair_schema_context_preserved"]
+            ),
+            "objective_source_outside_soloing_repair_objective_schema_version": str(
+                followup["objective_source_outside_soloing_repair_objective_schema_version"]
+            ),
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
                 followup["objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"]
             ),
@@ -778,6 +935,12 @@ def build_songlike_melody_contour_repair_sweep_report(
             ),
             "source_outside_soloing_repair_source_context_preserved": bool(
                 followup["repair_sweep_source_outside_soloing_repair_source_context_preserved"]
+            ),
+            "source_outside_soloing_repair_schema_context_preserved": bool(
+                followup["repair_sweep_source_outside_soloing_repair_schema_context_preserved"]
+            ),
+            "source_outside_soloing_repair_objective_schema_version": str(
+                followup["repair_sweep_source_outside_soloing_repair_objective_schema_version"]
             ),
             "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
                 followup["repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before"]
@@ -860,6 +1023,15 @@ def validate_songlike_melody_contour_repair_sweep_report(
     decision = _dict(report.get("decision"))
     aggregate = _dict(report.get("aggregate"))
     repairs = _list(report.get("candidate_repairs"))
+    source_schema_versions = _dict(report.get("source_schema_versions"))
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+            "songlike melody contour repair sweep schema version mismatch"
+        )
+    _validate_source_schema_versions(
+        source_schema_versions,
+        label="songlike melody contour repair sweep",
+    )
     if expected_boundary and boundary != expected_boundary:
         raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
             f"expected boundary {expected_boundary}, got {boundary}"
@@ -894,6 +1066,29 @@ def validate_songlike_melody_contour_repair_sweep_report(
         raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
             "critical user input should not be required"
         )
+    for label, schema_context_key, objective_schema_key in (
+        (
+            "objective",
+            "objective_source_outside_soloing_repair_schema_context_preserved",
+            "objective_source_outside_soloing_repair_objective_schema_version",
+        ),
+        (
+            "source",
+            "source_outside_soloing_repair_schema_context_preserved",
+            "source_outside_soloing_repair_objective_schema_version",
+        ),
+    ):
+        if not bool(aggregate.get(schema_context_key, False)):
+            raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+                f"{label} outside-soloing schema context preservation required"
+            )
+        if (
+            str(aggregate.get(objective_schema_key) or "")
+            != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+        ):
+            raise StageBMidiToSoloSonglikeMelodyContourRepairSweepError(
+                f"{label} outside-soloing objective schema version mismatch"
+            )
     if require_no_quality_claim:
         _require_no_quality_claim(readiness, label="songlike contour repair readiness")
     return {
@@ -901,6 +1096,50 @@ def validate_songlike_melody_contour_repair_sweep_report(
         "source_boundary": str(report.get("source_boundary") or ""),
         "targeted_repair_sweep_boundary": str(
             report.get("targeted_repair_sweep_boundary") or ""
+        ),
+        "schema_version": str(report.get("schema_version") or ""),
+        "source_targeted_quality_repair_followup_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_followup_decision") or ""
+        ),
+        "source_targeted_quality_repair_objective_next_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_objective_next") or ""
+        ),
+        "source_targeted_quality_repair_sweep_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_sweep") or ""
+        ),
+        "source_targeted_quality_repair_listening_review_input_guard_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_listening_review_input_guard")
+            or ""
+        ),
+        "source_targeted_quality_repair_listening_review_package_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_listening_review_package") or ""
+        ),
+        "source_targeted_quality_repair_audio_package_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_audio_package") or ""
+        ),
+        "source_candidate_failure_labeling_schema_version": str(
+            source_schema_versions.get("candidate_failure_labeling") or ""
+        ),
+        "source_quality_rubric_schema_version": str(
+            source_schema_versions.get("quality_rubric_baseline") or ""
+        ),
+        "source_post_mvp_plan_schema_version": str(
+            source_schema_versions.get("post_mvp_quality_iteration_plan") or ""
+        ),
+        "source_final_status_schema_version": str(
+            source_schema_versions.get("final_status_audit") or ""
+        ),
+        "source_delivery_package_schema_version": str(
+            source_schema_versions.get("delivery_package") or ""
+        ),
+        "source_listening_gap_schema_version": str(
+            source_schema_versions.get("listening_review_quality_gap") or ""
+        ),
+        "source_quality_gap_schema_version": str(
+            source_schema_versions.get("quality_gap_decision") or ""
+        ),
+        "source_current_evidence_schema_version": str(
+            source_schema_versions.get("current_evidence") or ""
         ),
         "next_boundary": str(decision.get("next_boundary") or ""),
         "selected_target": str(
@@ -943,6 +1182,12 @@ def validate_songlike_melody_contour_repair_sweep_report(
         "objective_source_outside_soloing_repair_source_context_preserved": bool(
             aggregate.get("objective_source_outside_soloing_repair_source_context_preserved", False)
         ),
+        "objective_source_outside_soloing_repair_schema_context_preserved": bool(
+            aggregate.get("objective_source_outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "objective_source_outside_soloing_repair_objective_schema_version": str(
+            aggregate.get("objective_source_outside_soloing_repair_objective_schema_version") or ""
+        ),
         "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             aggregate.get("objective_source_outside_soloing_repair_source_pitch_role_risk_count_before")
         ),
@@ -976,6 +1221,12 @@ def validate_songlike_melody_contour_repair_sweep_report(
         ),
         "source_outside_soloing_repair_source_context_preserved": bool(
             aggregate.get("source_outside_soloing_repair_source_context_preserved", False)
+        ),
+        "source_outside_soloing_repair_schema_context_preserved": bool(
+            aggregate.get("source_outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "source_outside_soloing_repair_objective_schema_version": str(
+            aggregate.get("source_outside_soloing_repair_objective_schema_version") or ""
         ),
         "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             aggregate.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
@@ -1034,7 +1285,22 @@ def markdown_report(report: dict[str, Any]) -> str:
         "## Summary",
         "",
         f"- boundary: `{report['boundary']}`",
+        f"- schema version: `{report['schema_version']}`",
         f"- source boundary: `{report['source_boundary']}`",
+        f"- source targeted quality repair follow-up schema version: `{report['source_schema_versions']['targeted_quality_repair_followup_decision']}`",
+        f"- source targeted quality repair objective next schema version: `{report['source_schema_versions']['targeted_quality_repair_objective_next']}`",
+        f"- source targeted quality repair listening review input guard schema version: `{report['source_schema_versions']['targeted_quality_repair_listening_review_input_guard']}`",
+        f"- source targeted quality repair listening review package schema version: `{report['source_schema_versions']['targeted_quality_repair_listening_review_package']}`",
+        f"- source targeted quality repair audio package schema version: `{report['source_schema_versions']['targeted_quality_repair_audio_package']}`",
+        f"- source targeted quality repair sweep schema version: `{report['source_schema_versions']['targeted_quality_repair_sweep']}`",
+        f"- source candidate failure labeling schema version: `{report['source_schema_versions']['candidate_failure_labeling']}`",
+        f"- source quality rubric schema version: `{report['source_schema_versions']['quality_rubric_baseline']}`",
+        f"- source post-MVP plan schema version: `{report['source_schema_versions']['post_mvp_quality_iteration_plan']}`",
+        f"- source final status schema version: `{report['source_schema_versions']['final_status_audit']}`",
+        f"- source delivery package schema version: `{report['source_schema_versions']['delivery_package']}`",
+        f"- source listening gap schema version: `{report['source_schema_versions']['listening_review_quality_gap']}`",
+        f"- source quality gap schema version: `{report['source_schema_versions']['quality_gap_decision']}`",
+        f"- source current evidence schema version: `{report['source_schema_versions']['current_evidence']}`",
         f"- next boundary: `{decision['next_boundary']}`",
         f"- selected target: `{selected['selected_target']}`",
         f"- candidate count: `{aggregate['candidate_count']}`",
@@ -1047,6 +1313,8 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- source outside-soloing repair evidence ready: `{_bool_token(aggregate['source_outside_soloing_repair_evidence_ready'])}`",
         f"- objective source outside-soloing repair WAV count: `{aggregate['objective_source_outside_soloing_repair_wav_count']}`",
         f"- objective source outside-soloing source context preserved: `{_bool_token(aggregate['objective_source_outside_soloing_repair_source_context_preserved'])}`",
+        f"- objective source outside-soloing schema context preserved: `{_bool_token(aggregate['objective_source_outside_soloing_repair_schema_context_preserved'])}`",
+        f"- objective source outside-soloing objective schema version: `{aggregate['objective_source_outside_soloing_repair_objective_schema_version']}`",
         f"- objective source outside-soloing source pitch-role risk before / after / delta: `{aggregate['objective_source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{aggregate['objective_source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{aggregate['objective_source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- objective source outside-soloing source repair targeted: `{_bool_token(aggregate['objective_source_outside_soloing_repair_source_targeted'])}`",
         f"- objective source outside-soloing source residual risk preserved: `{_bool_token(aggregate['objective_source_outside_soloing_repair_source_residual_risk_preserved'])}`",
@@ -1059,6 +1327,8 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- objective bridge repair sweep source outside-soloing source context preserved: `{_bool_token(aggregate['objective_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- objective repair sweep current repair pitch-role risk after/delta: `{aggregate['objective_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{aggregate['objective_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- source outside-soloing source context preserved: `{_bool_token(aggregate['source_outside_soloing_repair_source_context_preserved'])}`",
+        f"- source outside-soloing schema context preserved: `{_bool_token(aggregate['source_outside_soloing_repair_schema_context_preserved'])}`",
+        f"- source outside-soloing objective schema version: `{aggregate['source_outside_soloing_repair_objective_schema_version']}`",
         f"- source outside-soloing source pitch-role risk before / after / delta: `{aggregate['source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{aggregate['source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{aggregate['source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- source outside-soloing source repair targeted: `{_bool_token(aggregate['source_outside_soloing_repair_source_targeted'])}`",
         f"- source outside-soloing source residual risk preserved: `{_bool_token(aggregate['source_outside_soloing_repair_source_residual_risk_preserved'])}`",
@@ -1127,7 +1397,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=1100)
+    parser.add_argument("--issue_number", type=int, default=1184)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--min_candidate_count", type=int, default=6)

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_audio.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_audio.py
@@ -9,7 +9,10 @@ from typing import Sequence
 
 import pretty_midi
 
-from scripts.audit_stage_b_midi_to_solo_final_status import BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
+from scripts.audit_stage_b_midi_to_solo_final_status import (
+    BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+)
 from scripts.render_stage_b_midi_to_solo_songlike_melody_contour_repair_audio import (
     BOUNDARY,
     NEXT_BOUNDARY,
@@ -20,7 +23,9 @@ from scripts.render_stage_b_midi_to_solo_songlike_melody_contour_repair_audio im
 )
 from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep import (
     BOUNDARY as SOURCE_BOUNDARY,
+    EXPECTED_SOURCE_SCHEMA_VERSIONS as SOURCE_SCHEMA_VERSIONS,
     NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+    SCHEMA_VERSION as SOURCE_SCHEMA_VERSION,
 )
 
 
@@ -115,7 +120,9 @@ def source_report(root: Path, *, quality_claim: bool = False) -> dict:
             }
         )
     return {
+        "schema_version": SOURCE_SCHEMA_VERSION,
         "boundary": SOURCE_BOUNDARY,
+        "source_schema_versions": dict(SOURCE_SCHEMA_VERSIONS),
         "candidate_repairs": repairs,
         "aggregate": {
             "candidate_count": 6,
@@ -131,6 +138,10 @@ def source_report(root: Path, *, quality_claim: bool = False) -> dict:
             "objective_source_outside_soloing_repair_wav_count": 6,
             "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
             "objective_source_outside_soloing_repair_source_context_preserved": True,
+            "objective_source_outside_soloing_repair_schema_context_preserved": True,
+            "objective_source_outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
             "objective_source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
@@ -141,6 +152,10 @@ def source_report(root: Path, *, quality_claim: bool = False) -> dict:
             **{f"objective_{key}": value for key, value in SOURCE_CONTEXT.items()},
             "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
             "source_outside_soloing_repair_source_context_preserved": True,
+            "source_outside_soloing_repair_schema_context_preserved": True,
+            "source_outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
             "source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
             "source_outside_soloing_repair_source_pitch_role_risk_delta": 3,

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py
@@ -18,8 +18,10 @@ from scripts.build_stage_b_midi_to_solo_quality_rubric_baseline import (
 )
 from scripts.decide_stage_b_midi_to_solo_targeted_quality_repair_followup import (
     BOUNDARY as FOLLOWUP_BOUNDARY,
+    EXPECTED_SOURCE_SCHEMA_VERSIONS as FOLLOWUP_SOURCE_SCHEMA_VERSIONS,
     NEXT_BOUNDARY as FOLLOWUP_NEXT_BOUNDARY,
     SELECTED_TARGET as FOLLOWUP_SELECTED_TARGET,
+    SCHEMA_VERSION as FOLLOWUP_SCHEMA_VERSION,
 )
 from scripts.plan_stage_b_midi_to_solo_post_mvp_quality_iteration import (
     BOUNDARY as POST_MVP_BOUNDARY,
@@ -39,8 +41,28 @@ from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep impor
 )
 from scripts.run_stage_b_midi_to_solo_targeted_quality_repair_sweep import (
     BOUNDARY as TARGETED_REPAIR_SWEEP_BOUNDARY,
+    SCHEMA_VERSION as TARGETED_REPAIR_SWEEP_SCHEMA_VERSION,
 )
 
+
+TARGETED_REPAIR_SWEEP_SOURCE_SCHEMA_VERSIONS = {
+    "candidate_failure_labeling": FOLLOWUP_SOURCE_SCHEMA_VERSIONS[
+        "candidate_failure_labeling"
+    ],
+    "quality_rubric_baseline": FOLLOWUP_SOURCE_SCHEMA_VERSIONS[
+        "quality_rubric_baseline"
+    ],
+    "post_mvp_quality_iteration_plan": FOLLOWUP_SOURCE_SCHEMA_VERSIONS[
+        "post_mvp_quality_iteration_plan"
+    ],
+    "final_status_audit": FOLLOWUP_SOURCE_SCHEMA_VERSIONS["final_status_audit"],
+    "delivery_package": FOLLOWUP_SOURCE_SCHEMA_VERSIONS["delivery_package"],
+    "listening_review_quality_gap": FOLLOWUP_SOURCE_SCHEMA_VERSIONS[
+        "listening_review_quality_gap"
+    ],
+    "quality_gap_decision": FOLLOWUP_SOURCE_SCHEMA_VERSIONS["quality_gap_decision"],
+    "current_evidence": FOLLOWUP_SOURCE_SCHEMA_VERSIONS["current_evidence"],
+}
 
 SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_source_pitch_role_risk_count_before": 5,
@@ -154,7 +176,9 @@ def rubric_baseline(root: Path) -> dict:
 
 def followup_decision(*, quality_claim: bool = False) -> dict:
     return {
+        "schema_version": FOLLOWUP_SCHEMA_VERSION,
         "boundary": FOLLOWUP_BOUNDARY,
+        "source_schema_versions": dict(FOLLOWUP_SOURCE_SCHEMA_VERSIONS),
         "repair_sweep_summary": {
             "remaining_failure_counts": {
                 "dead_air_or_density_gap": 1,
@@ -180,6 +204,10 @@ def followup_decision(*, quality_claim: bool = False) -> dict:
             "objective_source_outside_soloing_repair_wav_count": 6,
             "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
             "objective_source_outside_soloing_repair_source_context_preserved": True,
+            "objective_source_outside_soloing_repair_schema_context_preserved": True,
+            "objective_source_outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
             "objective_source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
@@ -193,6 +221,10 @@ def followup_decision(*, quality_claim: bool = False) -> dict:
             "repair_sweep_source_outside_soloing_repair_evidence_ready": True,
             "repair_sweep_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
             "repair_sweep_source_outside_soloing_repair_source_context_preserved": True,
+            "repair_sweep_source_outside_soloing_repair_schema_context_preserved": True,
+            "repair_sweep_source_outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
             "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
             "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
@@ -229,7 +261,9 @@ def targeted_repair_sweep(*, technical_regression_count: int = 0) -> dict:
         ["dead_air_or_density_gap", "phrase_shape_missing_tension_release", SONGLIKE_LABEL],
     ]
     return {
+        "schema_version": TARGETED_REPAIR_SWEEP_SCHEMA_VERSION,
         "boundary": TARGETED_REPAIR_SWEEP_BOUNDARY,
+        "source_schema_versions": dict(TARGETED_REPAIR_SWEEP_SOURCE_SCHEMA_VERSIONS),
         "candidate_repairs": [
             {
                 "source": "test",
@@ -253,6 +287,10 @@ def targeted_repair_sweep(*, technical_regression_count: int = 0) -> dict:
             "improved_candidate_count": 4,
             "technical_regression_count": technical_regression_count,
             "source_outside_soloing_repair_evidence_ready": True,
+            "source_outside_soloing_repair_schema_context_preserved": True,
+            "source_outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "source_outside_soloing_repair_pitch_role_risk_count_after": 0,
             "source_outside_soloing_not_evaluable_count": 6,
             "repaired_outside_soloing_not_evaluable_count": 6,
@@ -264,6 +302,7 @@ def targeted_repair_sweep(*, technical_regression_count: int = 0) -> dict:
         },
         "readiness": {
             "targeted_quality_repair_sweep_completed": True,
+            "targeted_quality_repair_target_supported": True,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
             "audio_rendered_quality_claimed": False,
@@ -272,6 +311,9 @@ def targeted_repair_sweep(*, technical_regression_count: int = 0) -> dict:
             "broad_trained_model_quality_claimed": False,
             "brad_style_adaptation_claimed": False,
             "production_ready_claimed": False,
+        },
+        "decision": {
+            "critical_user_input_required": False,
         },
     }
 
@@ -285,7 +327,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairSweepTest(unittest.TestCase):
                 targeted_repair_sweep=targeted_repair_sweep(),
                 rubric_baseline=rubric_baseline(root),
                 output_dir=root / "songlike_repair",
-                issue_number=1100,
+                issue_number=1184,
             )
             summary = validate_songlike_melody_contour_repair_sweep_report(
                 report,
@@ -299,7 +341,15 @@ class StageBMidiToSoloSonglikeMelodyContourRepairSweepTest(unittest.TestCase):
             )
 
             self.assertEqual(report["schema_version"], SCHEMA_VERSION)
-            self.assertEqual(report["issue_number"], 1100)
+            self.assertEqual(report["issue_number"], 1184)
+            self.assertEqual(
+                summary["source_targeted_quality_repair_followup_schema_version"],
+                FOLLOWUP_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                summary["source_targeted_quality_repair_sweep_schema_version"],
+                TARGETED_REPAIR_SWEEP_SCHEMA_VERSION,
+            )
             self.assertTrue(summary["songlike_melody_contour_repair_sweep_completed"])
             self.assertTrue(summary["songlike_melody_contour_repair_target_supported"])
             self.assertEqual(summary["candidate_count"], 6)
@@ -316,6 +366,13 @@ class StageBMidiToSoloSonglikeMelodyContourRepairSweepTest(unittest.TestCase):
                 5,
             )
             self.assertTrue(summary["objective_source_outside_soloing_repair_source_context_preserved"])
+            self.assertTrue(
+                summary["objective_source_outside_soloing_repair_schema_context_preserved"]
+            )
+            self.assertEqual(
+                summary["objective_source_outside_soloing_repair_objective_schema_version"],
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+            )
             for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[f"objective_{key}"], SOURCE_CONTEXT[key])
             self.assertEqual(
@@ -348,6 +405,11 @@ class StageBMidiToSoloSonglikeMelodyContourRepairSweepTest(unittest.TestCase):
                 5,
             )
             self.assertTrue(summary["source_outside_soloing_repair_source_context_preserved"])
+            self.assertTrue(summary["source_outside_soloing_repair_schema_context_preserved"])
+            self.assertEqual(
+                summary["source_outside_soloing_repair_objective_schema_version"],
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+            )
             for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[key], SOURCE_CONTEXT[key])
             self.assertEqual(
@@ -383,7 +445,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairSweepTest(unittest.TestCase):
                     targeted_repair_sweep=targeted_repair_sweep(),
                     rubric_baseline=rubric_baseline(Path(tmp)),
                     output_dir=Path(tmp) / "songlike_repair",
-                    issue_number=1100,
+                    issue_number=1184,
                 )
 
     def test_rejects_source_technical_regression(self) -> None:
@@ -394,7 +456,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairSweepTest(unittest.TestCase):
                     targeted_repair_sweep=targeted_repair_sweep(technical_regression_count=1),
                     rubric_baseline=rubric_baseline(Path(tmp)),
                     output_dir=Path(tmp) / "songlike_repair",
-                    issue_number=1100,
+                    issue_number=1184,
                 )
 
     def test_rejects_missing_followup_outside_soloing_context(self) -> None:
@@ -407,7 +469,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairSweepTest(unittest.TestCase):
                     targeted_repair_sweep=targeted_repair_sweep(),
                     rubric_baseline=rubric_baseline(Path(tmp)),
                     output_dir=Path(tmp) / "songlike_repair",
-                    issue_number=1100,
+                    issue_number=1184,
                 )
 
     def test_rejects_missing_targeted_sweep_outside_soloing_context(self) -> None:
@@ -420,7 +482,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairSweepTest(unittest.TestCase):
                     targeted_repair_sweep=source,
                     rubric_baseline=rubric_baseline(Path(tmp)),
                     output_dir=Path(tmp) / "songlike_repair",
-                    issue_number=1100,
+                    issue_number=1184,
                 )
 
     def test_rejects_followup_source_risk_delta_mismatch(self) -> None:
@@ -435,7 +497,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairSweepTest(unittest.TestCase):
                     targeted_repair_sweep=targeted_repair_sweep(),
                     rubric_baseline=rubric_baseline(Path(tmp)),
                     output_dir=Path(tmp) / "songlike_repair",
-                    issue_number=1100,
+                    issue_number=1184,
                 )
 
     def test_rejects_missing_followup_source_context_field(self) -> None:
@@ -450,7 +512,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairSweepTest(unittest.TestCase):
                     targeted_repair_sweep=targeted_repair_sweep(),
                     rubric_baseline=rubric_baseline(Path(tmp)),
                     output_dir=Path(tmp) / "songlike_repair",
-                    issue_number=1100,
+                    issue_number=1184,
                 )
 
     def test_rejects_false_followup_source_context_preserved_field(self) -> None:
@@ -465,7 +527,35 @@ class StageBMidiToSoloSonglikeMelodyContourRepairSweepTest(unittest.TestCase):
                     targeted_repair_sweep=targeted_repair_sweep(),
                     rubric_baseline=rubric_baseline(Path(tmp)),
                     output_dir=Path(tmp) / "songlike_repair",
-                    issue_number=1100,
+                    issue_number=1184,
+                )
+
+    def test_rejects_followup_source_schema_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = followup_decision()
+            source["source_schema_versions"]["targeted_quality_repair_objective_next"] = "old"
+            with self.assertRaises(StageBMidiToSoloSonglikeMelodyContourRepairSweepError):
+                build_songlike_melody_contour_repair_sweep_report(
+                    followup_decision=source,
+                    targeted_repair_sweep=targeted_repair_sweep(),
+                    rubric_baseline=rubric_baseline(Path(tmp)),
+                    output_dir=Path(tmp) / "songlike_repair",
+                    issue_number=1184,
+                )
+
+    def test_rejects_false_schema_context_preserved(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = followup_decision()
+            source["readiness"][
+                "repair_sweep_source_outside_soloing_repair_schema_context_preserved"
+            ] = False
+            with self.assertRaises(StageBMidiToSoloSonglikeMelodyContourRepairSweepError):
+                build_songlike_melody_contour_repair_sweep_report(
+                    followup_decision=source,
+                    targeted_repair_sweep=targeted_repair_sweep(),
+                    rubric_baseline=rubric_baseline(Path(tmp)),
+                    output_dir=Path(tmp) / "songlike_repair",
+                    issue_number=1184,
                 )
 
     def test_constants_are_stable(self) -> None:
@@ -474,7 +564,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairSweepTest(unittest.TestCase):
         self.assertEqual(SELECTED_TARGET, "songlike_melody_contour_repair_audio_package")
         self.assertEqual(
             SCHEMA_VERSION,
-            "stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v4",
+            "stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5",
         )
 
 


### PR DESCRIPTION
## Summary
- songlike melody contour repair sweep schema v5 적용
- follow-up v5 및 targeted repair sweep v4 schema chain 검증/전파
- outside-soloing schema-context flag와 objective schema version 검증/전파
- audio package 연동 fixture를 sweep v5 source 계약에 맞춰 갱신
- README, CURRENT_STATUS, CORE_PLAN, AGENTS handoff 갱신

## Context
- 이전 작업: #1182 targeted quality repair follow-up decision source-context refresh
- 현재 입력: follow-up decision v5, targeted repair sweep v4
- 주요 측정값: songlike failure `5 -> 0`, total failure labels `8 -> 4`, technical regression count `0`
- outside-soloing boundary: source risk `5 -> 2`, current repair risk `0 / 2`, not evaluable count `6 / 6`
- 제외 기준: human/audio preference claim `false`, MIDI-to-solo musical quality claim `false`
- 이번 검토 대상: songlike contour repair sweep에서 source schema chain과 outside-soloing schema context 보존

## Scope
- songlike contour repair sweep source schema validation 추가
- follow-up/sweep schema version summary 추가
- schema-context false 및 schema mismatch 차단 테스트 추가
- #1184 status 문서와 handoff 문서 갱신

## Validation
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_audio`
- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep.py tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_audio.py`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-sweep`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- musical quality claim 없음
- outside-soloing과 weak chord-tone landing은 not-evaluable 경계 유지
- 다음 검증 대상: songlike melody contour repair audio package source-context refresh

Closes #1184