### PR TITLE
Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Current handoff scope:
 - Latest targeted quality repair objective-only next decision completed: Issue #1180, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh.
 - Latest targeted quality repair follow-up decision completed: Issue #1182, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh.
 - Latest songlike melody contour repair sweep completed: Issue #1184, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh.
-- Latest songlike melody contour repair audio package completed: Issue #1102, Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh.
+- Latest songlike melody contour repair audio package completed: Issue #1186, Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh.
 - Latest songlike melody contour repair listening review package completed: Issue #1104, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh.
 - Latest songlike melody contour repair listening review input guard completed: Issue #1106, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh.
 - Latest songlike melody contour repair objective-only next decision completed: Issue #1108, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1148, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh.
+- Open issue queue after Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest targeted quality repair objective-only next decision: `Issue #1180`
 - latest targeted quality repair follow-up decision: `Issue #1182`
 - latest songlike melody contour repair sweep: `Issue #1184`
-- latest songlike melody contour repair audio package: `Issue #1102`
+- latest songlike melody contour repair audio package: `Issue #1186`
 - latest songlike melody contour repair listening review package: `Issue #1104`
 - latest songlike melody contour repair listening review input guard: `Issue #1106`
 - latest songlike melody contour repair objective-only next decision: `Issue #1108`
@@ -50,7 +50,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1150`
 - latest README evidence refresh: `Issue #1152`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after songlike melody contour repair sweep source-context refresh merge: `0`
+- open issue queue after songlike melody contour repair audio package source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
@@ -420,14 +420,20 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - songlike contour follow-up repair sweep source outside-soloing source context preserved: `true`
 - songlike contour bridge repair sweep source outside-soloing source context preserved: `true`
 - songlike contour audio package ready: `true`
+- songlike contour audio package schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package_v5`
+- songlike contour audio source sweep schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`
 - songlike contour rendered audio file count: `6`
 - songlike contour audio duration range: `18.849s - 18.992s`
+- songlike contour audio objective source outside-soloing schema context preserved: `true`
+- songlike contour audio objective source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - songlike contour audio objective follow-up objective source outside-soloing source context preserved: `true`
 - songlike contour audio objective follow-up repair sweep source outside-soloing source context preserved: `true`
 - songlike contour audio objective bridge repair sweep source outside-soloing source context preserved: `true`
 - songlike contour audio follow-up objective source outside-soloing source context preserved: `true`
 - songlike contour audio follow-up repair sweep source outside-soloing source context preserved: `true`
 - songlike contour audio bridge repair sweep source outside-soloing source context preserved: `true`
+- songlike contour audio source outside-soloing schema context preserved: `true`
+- songlike contour audio source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - songlike contour source risk: `5 -> 2`
 - songlike contour current risk after / delta: `0 / 2`
 - songlike contour audio technical validation: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -409,7 +409,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo targeted quality repair objective-only next decision: schema `stage_b_midi_to_solo_targeted_quality_repair_objective_next_v5`, source input guard schema `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard_v5`, follow-up required `true`, current quality claim ready `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, outside-soloing schema-context preserved `true`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_targeted_quality_repair_followup_decision`
 - MIDI-to-solo targeted quality repair follow-up decision: schema `stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v5`, source objective next schema `stage_b_midi_to_solo_targeted_quality_repair_objective_next_v5`, source sweep schema `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`, selected target `songlike_melody_contour_repair_sweep`, dominant label/count `songlike_melody_not_soloing/5`, objective and repair sweep source risk `5 -> 2`, current repair risk after/delta `0/2`, source/schema-context preserved flags `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
 - MIDI-to-solo songlike melody contour repair sweep: schema `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`, source follow-up schema `stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v5`, source sweep schema `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`, songlike failure `5 -> 0`, total failure labels `8 -> 4`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/schema-context preserved flags `true`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
-- MIDI-to-solo songlike melody contour repair audio package: rendered WAV `6`, duration `18.849s-18.992s`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
+- MIDI-to-solo songlike melody contour repair audio package: schema `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package_v5`, source sweep schema `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`, rendered WAV `6`, duration `18.849s-18.992s`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/schema-context preserved flags `true`, source/repaired outside-soloing not evaluable `6/6`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
 - MIDI-to-solo songlike melody contour repair listening review package: review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
 - MIDI-to-solo songlike melody contour repair listening review input guard: preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
 - MIDI-to-solo songlike melody contour repair objective-only next decision: follow-up required `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, current quality claim ready `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
@@ -8420,7 +8420,7 @@ Issue #928은 Issue #926 targeted quality repair listening review input guard의
 
 다음 작업:
 
-- `Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh`
+- `Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh`
 
 ## 9.155 Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh
 
@@ -13084,12 +13084,28 @@ Issue #1184는 Issue #1182 targeted quality repair follow-up decision v5의 sele
 
 ## 9.241 Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh
 
-Issue #1102는 Issue #1184 songlike melody contour repair sweep의 MIDI 후보 6개를 WAV로 렌더링하고 source-context preserved flag를 audio summary/validation summary까지 보존한 작업이다.
+Issue #1186은 Issue #1184 songlike melody contour repair sweep v5의 MIDI 후보 6개를 WAV로 렌더링하고 source schema chain, outside-soloing schema context, source-context preserved flag를 audio summary/validation summary까지 보존한 작업이다.
 
 결과:
 
 - document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
+- schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package_v5`
+- source songlike melody contour repair sweep schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`
+- source targeted quality repair follow-up schema version: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v5`
+- source targeted quality repair objective next schema version: `stage_b_midi_to_solo_targeted_quality_repair_objective_next_v5`
+- source targeted quality repair listening review input guard schema version: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard_v5`
+- source targeted quality repair listening review package schema version: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package_v5`
+- source targeted quality repair audio package schema version: `stage_b_midi_to_solo_targeted_quality_repair_audio_package_v5`
+- source targeted quality repair sweep schema version: `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`
+- source candidate failure labeling schema version: `stage_b_midi_to_solo_candidate_failure_labeling_v4`
+- source quality rubric schema version: `stage_b_midi_to_solo_quality_rubric_baseline_v4`
+- source post-MVP plan schema version: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`
+- source final status schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
 - render attempted: `true`
 - rendered audio file count: `6`
@@ -13104,8 +13120,12 @@ Issue #1102는 Issue #1184 songlike melody contour repair sweep의 MIDI 후보 6
 - source outside-soloing repair evidence ready: `true`
 - objective source outside-soloing repair WAV count: `6`
 - objective source outside-soloing source context preserved: `true`
+- objective source outside-soloing schema context preserved: `true`
+- objective source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - objective preserved source-context flags: `3 / 3`
 - source outside-soloing source context preserved: `true`
+- source outside-soloing schema context preserved: `true`
+- source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - source preserved source-context flags: `3 / 3`
 - source outside-soloing source pitch-role risk: `5 -> 2`
 - source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
@@ -13119,16 +13139,16 @@ Issue #1102는 Issue #1184 songlike melody contour repair sweep의 MIDI 후보 6
 
 판단:
 
-- audio package source validation에 #1100 preserved flag 3개 포함.
-- audio summary와 validation summary에 objective/source preserved flag 보존.
-- preserved flag false 입력은 validation error로 차단.
+- audio package source validation에 sweep v5와 upstream schema chain 포함.
+- audio summary와 validation summary에 objective/source schema context 및 preserved flag 보존.
+- schema version mismatch, schema-context false, preserved flag false 입력은 validation error로 차단.
 - WAV 파일 6개 렌더링과 기술 메타데이터 검증 완료.
 - human/audio preference와 audio rendered quality claim 제외 유지.
 
 검증:
 
-- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_audio`
-- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_songlike_melody_contour_repair_audio.py`
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_audio tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
+- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_songlike_melody_contour_repair_audio.py tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_audio.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-audio-package`
 - `bash scripts/agent_harness.sh quick`
@@ -13140,7 +13160,7 @@ Issue #1102는 Issue #1184 songlike melody contour repair sweep의 MIDI 후보 6
 
 ## 9.242 Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh
 
-Issue #1104는 Issue #1102 songlike melody contour repair audio package의 WAV/MIDI 후보 6개를 listening review package로 묶고 source-context preserved flag를 review package source summary/validation summary까지 보존한 작업이다.
+Issue #1104는 Issue #1186 songlike melody contour repair audio package의 WAV/MIDI 후보 6개를 listening review package로 묶고 source-context preserved flag를 review package source summary/validation summary까지 보존한 작업이다.
 
 결과:
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -29,7 +29,7 @@
 - latest targeted quality repair objective-only next decision: Issue #1180, Stage B MIDI-to-solo targeted quality repair objective-only next decision source-context refresh
 - latest targeted quality repair follow-up decision: Issue #1182, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh
 - latest songlike melody contour repair sweep: Issue #1184, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh
-- latest songlike melody contour repair audio package: Issue #1102, Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh
+- latest songlike melody contour repair audio package: Issue #1186, Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh
 - latest songlike melody contour repair listening review package: Issue #1104, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh
 - latest songlike melody contour repair listening review input guard: Issue #1106, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh
 - latest songlike melody contour repair objective-only next decision: Issue #1108, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1150, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh`
+- open issue queue after Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -3619,7 +3619,7 @@ Issue #1012는 Issue #1010 input guard 이후 listening input 없이 objective e
 
 다음:
 
-- `Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh`
+- `Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh`
 
 ## Stage B MIDI-to-Solo Targeted Quality Repair Follow-Up Decision Source Context Refresh Result
 
@@ -6389,12 +6389,28 @@ Issue #1184는 Issue #1182 targeted quality repair follow-up decision v5의 sele
 
 ## 9.241 Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh
 
-Issue #1102는 Issue #1184 songlike melody contour repair sweep의 MIDI 후보 6개를 WAV로 렌더링하고 source-context preserved flag를 audio summary/validation summary까지 보존한 작업이다.
+Issue #1186은 Issue #1184 songlike melody contour repair sweep v5의 MIDI 후보 6개를 WAV로 렌더링하고 source schema chain, outside-soloing schema context, source-context preserved flag를 audio summary/validation summary까지 보존한 작업이다.
 
 결과:
 
 - document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
+- schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package_v5`
+- source songlike melody contour repair sweep schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`
+- source targeted quality repair follow-up schema version: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v5`
+- source targeted quality repair objective next schema version: `stage_b_midi_to_solo_targeted_quality_repair_objective_next_v5`
+- source targeted quality repair listening review input guard schema version: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard_v5`
+- source targeted quality repair listening review package schema version: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package_v5`
+- source targeted quality repair audio package schema version: `stage_b_midi_to_solo_targeted_quality_repair_audio_package_v5`
+- source targeted quality repair sweep schema version: `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`
+- source candidate failure labeling schema version: `stage_b_midi_to_solo_candidate_failure_labeling_v4`
+- source quality rubric schema version: `stage_b_midi_to_solo_quality_rubric_baseline_v4`
+- source post-MVP plan schema version: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`
+- source final status schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
 - render attempted: `true`
 - rendered audio file count: `6`
@@ -6409,8 +6425,12 @@ Issue #1102는 Issue #1184 songlike melody contour repair sweep의 MIDI 후보 6
 - source outside-soloing repair evidence ready: `true`
 - objective source outside-soloing repair WAV count: `6`
 - objective source outside-soloing source context preserved: `true`
+- objective source outside-soloing schema context preserved: `true`
+- objective source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - objective preserved source-context flags: `3 / 3`
 - source outside-soloing source context preserved: `true`
+- source outside-soloing schema context preserved: `true`
+- source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - source preserved source-context flags: `3 / 3`
 - source outside-soloing source pitch-role risk: `5 -> 2`
 - source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
@@ -6424,16 +6444,16 @@ Issue #1102는 Issue #1184 songlike melody contour repair sweep의 MIDI 후보 6
 
 판단:
 
-- audio package source validation에 #1100 preserved flag 3개 포함.
-- audio summary와 validation summary에 objective/source preserved flag 보존.
-- preserved flag false 입력은 validation error로 차단.
+- audio package source validation에 sweep v5와 upstream schema chain 포함.
+- audio summary와 validation summary에 objective/source schema context 및 preserved flag 보존.
+- schema version mismatch, schema-context false, preserved flag false 입력은 validation error로 차단.
 - WAV 파일 6개 렌더링과 기술 메타데이터 검증 완료.
 - human/audio preference와 audio rendered quality claim 제외 유지.
 
 검증:
 
-- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_audio`
-- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_songlike_melody_contour_repair_audio.py`
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_audio tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
+- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_songlike_melody_contour_repair_audio.py tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_audio.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-audio-package`
 - `bash scripts/agent_harness.sh quick`
@@ -6445,7 +6465,7 @@ Issue #1102는 Issue #1184 songlike melody contour repair sweep의 MIDI 후보 6
 
 ## 9.242 Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh
 
-Issue #1104는 Issue #1102 songlike melody contour repair audio package의 WAV/MIDI 후보 6개를 listening review package로 묶고 source-context preserved flag를 review package source summary/validation summary까지 보존한 작업이다.
+Issue #1104는 Issue #1186 songlike melody contour repair audio package의 WAV/MIDI 후보 6개를 listening review package로 묶고 source-context preserved flag를 review package source summary/validation summary까지 보존한 작업이다.
 
 결과:
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -3,6 +3,22 @@
 ## Summary
 
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
+- schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package_v5`
+- source songlike melody contour repair sweep schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`
+- source targeted quality repair follow-up schema version: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v5`
+- source targeted quality repair objective next schema version: `stage_b_midi_to_solo_targeted_quality_repair_objective_next_v5`
+- source targeted quality repair listening review input guard schema version: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard_v5`
+- source targeted quality repair listening review package schema version: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package_v5`
+- source targeted quality repair audio package schema version: `stage_b_midi_to_solo_targeted_quality_repair_audio_package_v5`
+- source targeted quality repair sweep schema version: `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`
+- source candidate failure labeling schema version: `stage_b_midi_to_solo_candidate_failure_labeling_v4`
+- source quality rubric schema version: `stage_b_midi_to_solo_quality_rubric_baseline_v4`
+- source post-MVP plan schema version: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`
+- source final status schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
 - render attempted: `true`
 - rendered audio file count: `6`
@@ -16,6 +32,8 @@
 - source outside-soloing repair evidence ready: `true`
 - objective source outside-soloing repair WAV count: `6`
 - objective source outside-soloing source context preserved: `true`
+- objective source outside-soloing schema context preserved: `true`
+- objective source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - objective source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - objective source outside-soloing source repair targeted: `false`
 - objective source outside-soloing source residual risk preserved: `true`
@@ -28,6 +46,8 @@
 - objective bridge repair sweep source outside-soloing source context preserved: `true`
 - objective repair sweep current repair pitch-role risk after/delta: `0` / `2`
 - source outside-soloing source context preserved: `true`
+- source outside-soloing schema context preserved: `true`
+- source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - source outside-soloing source repair targeted: `false`
 - source outside-soloing source residual risk preserved: `true`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6384,7 +6384,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package() {
     --run_id "$run_id" \
     --songlike_repair_sweep_report "$sweep_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_AUDIO_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1102 \
+    --issue_number 1186 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package \
     --expected_file_count 6 \

--- a/scripts/render_stage_b_midi_to_solo_songlike_melody_contour_repair_audio.py
+++ b/scripts/render_stage_b_midi_to_solo_songlike_melody_contour_repair_audio.py
@@ -27,7 +27,10 @@ from scripts.render_stage_b_midi_to_solo_candidate_audio import (  # noqa: E402
 )
 from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep import (  # noqa: E402
     BOUNDARY as SOURCE_BOUNDARY,
+    EXPECTED_SOURCE_SCHEMA_VERSIONS as SOURCE_SWEEP_SCHEMA_VERSIONS,
     NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    SCHEMA_VERSION as SOURCE_SWEEP_SCHEMA_VERSION,
     StageBMidiToSoloSonglikeMelodyContourRepairSweepError,
     validate_songlike_melody_contour_repair_sweep_report,
 )
@@ -39,8 +42,12 @@ class StageBMidiToSoloSonglikeMelodyContourRepairAudioError(ValueError):
 
 BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package"
-SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package_v4"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package_v5"
 CommandRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+EXPECTED_SOURCE_SCHEMA_VERSIONS = {
+    "songlike_melody_contour_repair_sweep": SOURCE_SWEEP_SCHEMA_VERSION,
+    **SOURCE_SWEEP_SCHEMA_VERSIONS,
+}
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -93,6 +100,20 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
         )
 
 
+def _validate_source_schema_versions(
+    source_schema_versions: dict[str, Any],
+    *,
+    label: str,
+) -> dict[str, str]:
+    normalized = {key: str(value) for key, value in source_schema_versions.items()}
+    for key, expected in EXPECTED_SOURCE_SCHEMA_VERSIONS.items():
+        if str(normalized.get(key) or "") != expected:
+            raise StageBMidiToSoloSonglikeMelodyContourRepairAudioError(
+                f"{label} source schema version mismatch: {key}"
+            )
+    return normalized
+
+
 def _source_context_fields(aggregate: dict[str, Any]) -> dict[str, Any]:
     for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
         objective_key = f"objective_{key}"
@@ -131,6 +152,12 @@ def _source_context_fields(aggregate: dict[str, Any]) -> dict[str, Any]:
         "objective_source_outside_soloing_repair_source_context_preserved": bool(
             aggregate.get("objective_source_outside_soloing_repair_source_context_preserved", False)
         ),
+        "objective_source_outside_soloing_repair_schema_context_preserved": bool(
+            aggregate.get("objective_source_outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "objective_source_outside_soloing_repair_objective_schema_version": str(
+            aggregate.get("objective_source_outside_soloing_repair_objective_schema_version") or ""
+        ),
         "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             aggregate.get(
                 "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"
@@ -166,6 +193,12 @@ def _source_context_fields(aggregate: dict[str, Any]) -> dict[str, Any]:
         ),
         "source_outside_soloing_repair_source_context_preserved": bool(
             aggregate.get("source_outside_soloing_repair_source_context_preserved", False)
+        ),
+        "source_outside_soloing_repair_schema_context_preserved": bool(
+            aggregate.get("source_outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "source_outside_soloing_repair_objective_schema_version": str(
+            aggregate.get("source_outside_soloing_repair_objective_schema_version") or ""
         ),
         "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             aggregate.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
@@ -208,6 +241,17 @@ def _validate_source_context(aggregate: dict[str, Any], *, base: str, label: str
     if not bool(aggregate.get(f"{base}_source_context_preserved", False)):
         raise StageBMidiToSoloSonglikeMelodyContourRepairAudioError(
             f"{label} source context preservation required"
+        )
+    if not bool(aggregate.get(f"{base}_schema_context_preserved", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairAudioError(
+            f"{label} schema context preservation required"
+        )
+    if (
+        str(aggregate.get(f"{base}_objective_schema_version") or "")
+        != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+    ):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairAudioError(
+            f"{label} objective schema version mismatch"
         )
     if objective_risk <= 0 or source_before <= 0:
         raise StageBMidiToSoloSonglikeMelodyContourRepairAudioError(
@@ -260,7 +304,7 @@ def validate_source_report(
             "songlike contour repair sweep must route to audio package"
         )
     try:
-        validate_songlike_melody_contour_repair_sweep_report(
+        source_summary = validate_songlike_melody_contour_repair_sweep_report(
             report,
             expected_boundary=SOURCE_BOUNDARY,
             expected_next_boundary=SOURCE_NEXT_BOUNDARY,
@@ -272,6 +316,13 @@ def validate_source_report(
         )
     except StageBMidiToSoloSonglikeMelodyContourRepairSweepError as exc:
         raise StageBMidiToSoloSonglikeMelodyContourRepairAudioError(str(exc)) from exc
+    _validate_source_schema_versions(
+        {
+            "songlike_melody_contour_repair_sweep": source_summary.get("schema_version"),
+            **_dict(report.get("source_schema_versions")),
+        },
+        label="songlike melody contour repair sweep",
+    )
     if not bool(readiness.get("songlike_melody_contour_repair_target_supported", False)):
         raise StageBMidiToSoloSonglikeMelodyContourRepairAudioError(
             "songlike contour repair support required"
@@ -484,6 +535,13 @@ def build_audio_render_report(
     rendered = execute_render_plan(plan, runner=runner)
     aggregate = _dict(source_report.get("aggregate"))
     source_context = _source_context_fields(aggregate)
+    source_schema_versions = _validate_source_schema_versions(
+        {
+            "songlike_melody_contour_repair_sweep": SOURCE_SWEEP_SCHEMA_VERSION,
+            **_dict(source_report.get("source_schema_versions")),
+        },
+        label="songlike melody contour repair audio package",
+    )
     failure_counts = Counter(
         label for item in rendered for label in _list(item.get("repaired_failure_labels"))
     )
@@ -498,6 +556,7 @@ def build_audio_render_report(
         "output_dir": str(output_dir),
         "issue_number": int(issue_number),
         "source_boundary": SOURCE_BOUNDARY,
+        "source_schema_versions": source_schema_versions,
         "source_summary": aggregate,
         "renderer": {
             "name": "fluidsynth",
@@ -597,6 +656,15 @@ def validate_audio_render_report(
     boundary = _dict(report.get("audio_render_boundary"))
     decision = _dict(report.get("decision"))
     summary = _dict(report.get("summary"))
+    source_schema_versions = _dict(report.get("source_schema_versions"))
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairAudioError(
+            "songlike contour repair audio package schema version mismatch"
+        )
+    _validate_source_schema_versions(
+        source_schema_versions,
+        label="songlike contour repair audio package",
+    )
     if expected_boundary and str(boundary.get("boundary") or "") != expected_boundary:
         raise StageBMidiToSoloSonglikeMelodyContourRepairAudioError(
             "unexpected boundary"
@@ -642,11 +710,81 @@ def validate_audio_render_report(
         raise StageBMidiToSoloSonglikeMelodyContourRepairAudioError(
             "critical user input should not be required"
         )
+    for label, schema_context_key, objective_schema_key in (
+        (
+            "objective",
+            "objective_source_outside_soloing_repair_schema_context_preserved",
+            "objective_source_outside_soloing_repair_objective_schema_version",
+        ),
+        (
+            "source",
+            "source_outside_soloing_repair_schema_context_preserved",
+            "source_outside_soloing_repair_objective_schema_version",
+        ),
+    ):
+        if not bool(summary.get(schema_context_key, False)):
+            raise StageBMidiToSoloSonglikeMelodyContourRepairAudioError(
+                f"{label} outside-soloing schema context preservation required"
+            )
+        if (
+            str(summary.get(objective_schema_key) or "")
+            != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+        ):
+            raise StageBMidiToSoloSonglikeMelodyContourRepairAudioError(
+                f"{label} outside-soloing objective schema version mismatch"
+            )
     if require_no_quality_claim:
         _require_no_quality_claim(boundary, label="audio render boundary")
     return {
         "boundary": str(boundary.get("boundary") or ""),
         "next_boundary": str(decision.get("next_boundary") or ""),
+        "schema_version": str(report.get("schema_version") or ""),
+        "source_songlike_melody_contour_repair_sweep_schema_version": str(
+            source_schema_versions.get("songlike_melody_contour_repair_sweep") or ""
+        ),
+        "source_targeted_quality_repair_followup_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_followup_decision") or ""
+        ),
+        "source_targeted_quality_repair_objective_next_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_objective_next") or ""
+        ),
+        "source_targeted_quality_repair_sweep_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_sweep") or ""
+        ),
+        "source_targeted_quality_repair_listening_review_input_guard_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_listening_review_input_guard")
+            or ""
+        ),
+        "source_targeted_quality_repair_listening_review_package_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_listening_review_package") or ""
+        ),
+        "source_targeted_quality_repair_audio_package_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_audio_package") or ""
+        ),
+        "source_candidate_failure_labeling_schema_version": str(
+            source_schema_versions.get("candidate_failure_labeling") or ""
+        ),
+        "source_quality_rubric_schema_version": str(
+            source_schema_versions.get("quality_rubric_baseline") or ""
+        ),
+        "source_post_mvp_plan_schema_version": str(
+            source_schema_versions.get("post_mvp_quality_iteration_plan") or ""
+        ),
+        "source_final_status_schema_version": str(
+            source_schema_versions.get("final_status_audit") or ""
+        ),
+        "source_delivery_package_schema_version": str(
+            source_schema_versions.get("delivery_package") or ""
+        ),
+        "source_listening_gap_schema_version": str(
+            source_schema_versions.get("listening_review_quality_gap") or ""
+        ),
+        "source_quality_gap_schema_version": str(
+            source_schema_versions.get("quality_gap_decision") or ""
+        ),
+        "source_current_evidence_schema_version": str(
+            source_schema_versions.get("current_evidence") or ""
+        ),
         "render_attempted": bool(boundary.get("render_attempted", False)),
         "rendered_audio_file_count": _int(boundary.get("rendered_audio_file_count")),
         "technical_wav_validation": bool(boundary.get("technical_wav_validation", False)),
@@ -686,6 +824,12 @@ def validate_audio_render_report(
         "objective_source_outside_soloing_repair_source_context_preserved": bool(
             summary.get("objective_source_outside_soloing_repair_source_context_preserved", False)
         ),
+        "objective_source_outside_soloing_repair_schema_context_preserved": bool(
+            summary.get("objective_source_outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "objective_source_outside_soloing_repair_objective_schema_version": str(
+            summary.get("objective_source_outside_soloing_repair_objective_schema_version") or ""
+        ),
         "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             summary.get(
                 "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"
@@ -719,6 +863,12 @@ def validate_audio_render_report(
         ),
         "source_outside_soloing_repair_source_context_preserved": bool(
             summary.get("source_outside_soloing_repair_source_context_preserved", False)
+        ),
+        "source_outside_soloing_repair_schema_context_preserved": bool(
+            summary.get("source_outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "source_outside_soloing_repair_objective_schema_version": str(
+            summary.get("source_outside_soloing_repair_objective_schema_version") or ""
         ),
         "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             summary.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
@@ -783,6 +933,22 @@ def markdown_report(report: dict[str, Any]) -> str:
         "## Summary",
         "",
         f"- boundary: `{boundary['boundary']}`",
+        f"- schema version: `{report['schema_version']}`",
+        f"- source songlike melody contour repair sweep schema version: `{report['source_schema_versions']['songlike_melody_contour_repair_sweep']}`",
+        f"- source targeted quality repair follow-up schema version: `{report['source_schema_versions']['targeted_quality_repair_followup_decision']}`",
+        f"- source targeted quality repair objective next schema version: `{report['source_schema_versions']['targeted_quality_repair_objective_next']}`",
+        f"- source targeted quality repair listening review input guard schema version: `{report['source_schema_versions']['targeted_quality_repair_listening_review_input_guard']}`",
+        f"- source targeted quality repair listening review package schema version: `{report['source_schema_versions']['targeted_quality_repair_listening_review_package']}`",
+        f"- source targeted quality repair audio package schema version: `{report['source_schema_versions']['targeted_quality_repair_audio_package']}`",
+        f"- source targeted quality repair sweep schema version: `{report['source_schema_versions']['targeted_quality_repair_sweep']}`",
+        f"- source candidate failure labeling schema version: `{report['source_schema_versions']['candidate_failure_labeling']}`",
+        f"- source quality rubric schema version: `{report['source_schema_versions']['quality_rubric_baseline']}`",
+        f"- source post-MVP plan schema version: `{report['source_schema_versions']['post_mvp_quality_iteration_plan']}`",
+        f"- source final status schema version: `{report['source_schema_versions']['final_status_audit']}`",
+        f"- source delivery package schema version: `{report['source_schema_versions']['delivery_package']}`",
+        f"- source listening gap schema version: `{report['source_schema_versions']['listening_review_quality_gap']}`",
+        f"- source quality gap schema version: `{report['source_schema_versions']['quality_gap_decision']}`",
+        f"- source current evidence schema version: `{report['source_schema_versions']['current_evidence']}`",
         f"- next boundary: `{decision['next_boundary']}`",
         f"- render attempted: `{_bool_token(boundary['render_attempted'])}`",
         f"- rendered audio file count: `{boundary['rendered_audio_file_count']}`",
@@ -796,6 +962,8 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- source outside-soloing repair evidence ready: `{_bool_token(summary['source_outside_soloing_repair_evidence_ready'])}`",
         f"- objective source outside-soloing repair WAV count: `{summary['objective_source_outside_soloing_repair_wav_count']}`",
         f"- objective source outside-soloing source context preserved: `{_bool_token(summary['objective_source_outside_soloing_repair_source_context_preserved'])}`",
+        f"- objective source outside-soloing schema context preserved: `{_bool_token(summary['objective_source_outside_soloing_repair_schema_context_preserved'])}`",
+        f"- objective source outside-soloing objective schema version: `{summary['objective_source_outside_soloing_repair_objective_schema_version']}`",
         f"- objective source outside-soloing source pitch-role risk before / after / delta: `{summary['objective_source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{summary['objective_source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{summary['objective_source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- objective source outside-soloing source repair targeted: `{_bool_token(summary['objective_source_outside_soloing_repair_source_targeted'])}`",
         f"- objective source outside-soloing source residual risk preserved: `{_bool_token(summary['objective_source_outside_soloing_repair_source_residual_risk_preserved'])}`",
@@ -808,6 +976,8 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- objective bridge repair sweep source outside-soloing source context preserved: `{_bool_token(summary['objective_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- objective repair sweep current repair pitch-role risk after/delta: `{summary['objective_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{summary['objective_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- source outside-soloing source context preserved: `{_bool_token(summary['source_outside_soloing_repair_source_context_preserved'])}`",
+        f"- source outside-soloing schema context preserved: `{_bool_token(summary['source_outside_soloing_repair_schema_context_preserved'])}`",
+        f"- source outside-soloing objective schema version: `{summary['source_outside_soloing_repair_objective_schema_version']}`",
         f"- source outside-soloing source pitch-role risk before / after / delta: `{summary['source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{summary['source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{summary['source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- source outside-soloing source repair targeted: `{_bool_token(summary['source_outside_soloing_repair_source_targeted'])}`",
         f"- source outside-soloing source residual risk preserved: `{_bool_token(summary['source_outside_soloing_repair_source_residual_risk_preserved'])}`",
@@ -860,7 +1030,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=1102)
+    parser.add_argument("--issue_number", type=int, default=1186)
     parser.add_argument("--renderer", type=str, default=shutil.which("fluidsynth") or "")
     parser.add_argument("--soundfont", type=str, default="")
     parser.add_argument("--sample_rate", type=int, default=44100)

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_audio.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_audio.py
@@ -221,7 +221,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairAudioTest(unittest.TestCase):
                 soundfont_path=str(soundfont),
                 sample_rate=44100,
                 expected_file_count=6,
-                issue_number=1102,
+                issue_number=1186,
                 runner=fake_runner,
             )
             summary = validate_audio_render_report(
@@ -235,7 +235,11 @@ class StageBMidiToSoloSonglikeMelodyContourRepairAudioTest(unittest.TestCase):
             )
 
             self.assertEqual(report["schema_version"], SCHEMA_VERSION)
-            self.assertEqual(report["issue_number"], 1102)
+            self.assertEqual(report["issue_number"], 1186)
+            self.assertEqual(
+                summary["source_songlike_melody_contour_repair_sweep_schema_version"],
+                SOURCE_SCHEMA_VERSION,
+            )
             self.assertTrue(
                 summary["songlike_melody_contour_repair_audio_package_completed"]
             )
@@ -252,6 +256,13 @@ class StageBMidiToSoloSonglikeMelodyContourRepairAudioTest(unittest.TestCase):
                 5,
             )
             self.assertTrue(summary["objective_source_outside_soloing_repair_source_context_preserved"])
+            self.assertTrue(
+                summary["objective_source_outside_soloing_repair_schema_context_preserved"]
+            )
+            self.assertEqual(
+                summary["objective_source_outside_soloing_repair_objective_schema_version"],
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+            )
             for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[f"objective_{key}"], SOURCE_CONTEXT[key])
             self.assertEqual(
@@ -284,6 +295,11 @@ class StageBMidiToSoloSonglikeMelodyContourRepairAudioTest(unittest.TestCase):
                 5,
             )
             self.assertTrue(summary["source_outside_soloing_repair_source_context_preserved"])
+            self.assertTrue(summary["source_outside_soloing_repair_schema_context_preserved"])
+            self.assertEqual(
+                summary["source_outside_soloing_repair_objective_schema_version"],
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+            )
             for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[key], SOURCE_CONTEXT[key])
             self.assertEqual(
@@ -324,7 +340,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairAudioTest(unittest.TestCase):
                     soundfont_path=str(soundfont),
                     sample_rate=44100,
                     expected_file_count=6,
-                    issue_number=1102,
+                    issue_number=1186,
                     runner=fake_runner,
                 )
 
@@ -345,7 +361,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairAudioTest(unittest.TestCase):
                     soundfont_path=str(soundfont),
                     sample_rate=44100,
                     expected_file_count=6,
-                    issue_number=1102,
+                    issue_number=1186,
                     runner=fake_runner,
                 )
 
@@ -366,7 +382,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairAudioTest(unittest.TestCase):
                     soundfont_path=str(soundfont),
                     sample_rate=44100,
                     expected_file_count=6,
-                    issue_number=1102,
+                    issue_number=1186,
                     runner=fake_runner,
                 )
 
@@ -389,7 +405,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairAudioTest(unittest.TestCase):
                     soundfont_path=str(soundfont),
                     sample_rate=44100,
                     expected_file_count=6,
-                    issue_number=1102,
+                    issue_number=1186,
                     runner=fake_runner,
                 )
 
@@ -412,7 +428,49 @@ class StageBMidiToSoloSonglikeMelodyContourRepairAudioTest(unittest.TestCase):
                     soundfont_path=str(soundfont),
                     sample_rate=44100,
                     expected_file_count=6,
-                    issue_number=1102,
+                    issue_number=1186,
+                    runner=fake_runner,
+                )
+
+    def test_rejects_source_schema_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = root / "fluidsynth"
+            soundfont = root / "soundfont.sf2"
+            renderer.write_text("#!/bin/sh\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            source = source_report(root)
+            source["source_schema_versions"]["targeted_quality_repair_followup_decision"] = "old"
+            with self.assertRaises(StageBMidiToSoloSonglikeMelodyContourRepairAudioError):
+                build_audio_render_report(
+                    source,
+                    output_dir=root / "audio_package",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(soundfont),
+                    sample_rate=44100,
+                    expected_file_count=6,
+                    issue_number=1186,
+                    runner=fake_runner,
+                )
+
+    def test_rejects_false_schema_context_preserved(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            renderer = root / "fluidsynth"
+            soundfont = root / "soundfont.sf2"
+            renderer.write_text("#!/bin/sh\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            source = source_report(root)
+            source["aggregate"]["source_outside_soloing_repair_schema_context_preserved"] = False
+            with self.assertRaises(StageBMidiToSoloSonglikeMelodyContourRepairAudioError):
+                build_audio_render_report(
+                    source,
+                    output_dir=root / "audio_package",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(soundfont),
+                    sample_rate=44100,
+                    expected_file_count=6,
+                    issue_number=1186,
                     runner=fake_runner,
                 )
 
@@ -421,7 +479,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairAudioTest(unittest.TestCase):
         self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package")
         self.assertEqual(
             SCHEMA_VERSION,
-            "stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package_v4",
+            "stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package_v5",
         )
 
 


### PR DESCRIPTION
## Summary
- songlike melody contour repair audio package schema v5 적용
- Issue #1184 sweep v5 및 upstream source schema chain 검증/전파
- outside-soloing schema context, objective schema version, source-context preserved flag 검증/전파
- README, CURRENT_STATUS, CORE_PLAN, AGENTS handoff 갱신

## Context
- 이전 작업: Issue #1184 songlike melody contour repair sweep v5
- 주요 측정값: songlike failure `5 -> 0`, total failure labels `8 -> 4`, technical regression `0`
- 이번 입력 계약: source sweep schema `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`
- 검토 대상: audio package 진입 시 source schema chain과 outside-soloing schema context 보존 여부

## Scope
- `scripts/render_stage_b_midi_to_solo_songlike_melody_contour_repair_audio.py`
- `tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_audio.py`
- `scripts/agent_harness.sh`
- README / CURRENT_STATUS / CORE_PLAN / AGENTS handoff 문서

## Validation
- `.venv/bin/python -m py_compile scripts/render_stage_b_midi_to_solo_songlike_melody_contour_repair_audio.py tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_audio.py`
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_audio tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-audio-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- musical/audio preference 판단 제외
- WAV 기술 메타데이터 검증 범위: file count, sample rate, duration, non-empty payload
- 다음 검토 대상: listening review package source-context refresh

Closes #1186


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project documentation to reflect schema version v5 for the audio package component with enhanced source schema version tracking and validation.

* **Tests**
  * Updated test assertions and expected metadata to align with schema v5 updates and new issue tracking references.

* **Chores**
  * Updated internal issue tracking references and configuration parameters across scripts and documentation for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->