### PR TITLE
Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Current handoff scope:
 - Latest targeted quality repair follow-up decision completed: Issue #1182, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh.
 - Latest songlike melody contour repair sweep completed: Issue #1184, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh.
 - Latest songlike melody contour repair audio package completed: Issue #1186, Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh.
-- Latest songlike melody contour repair listening review package completed: Issue #1104, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh.
+- Latest songlike melody contour repair listening review package completed: Issue #1188, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh.
 - Latest songlike melody contour repair listening review input guard completed: Issue #1106, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh.
 - Latest songlike melody contour repair objective-only next decision completed: Issue #1108, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh.
 - Latest songlike melody contour repair follow-up decision completed: Issue #1110, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1148, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh.
+- Open issue queue after Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest targeted quality repair follow-up decision: `Issue #1182`
 - latest songlike melody contour repair sweep: `Issue #1184`
 - latest songlike melody contour repair audio package: `Issue #1186`
-- latest songlike melody contour repair listening review package: `Issue #1104`
+- latest songlike melody contour repair listening review package: `Issue #1188`
 - latest songlike melody contour repair listening review input guard: `Issue #1106`
 - latest songlike melody contour repair objective-only next decision: `Issue #1108`
 - latest songlike melody contour repair follow-up decision: `Issue #1110`
@@ -50,7 +50,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1150`
 - latest README evidence refresh: `Issue #1152`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after songlike melody contour repair audio package source-context refresh merge: `0`
+- open issue queue after songlike melody contour repair listening review package source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
@@ -438,7 +438,14 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - songlike contour current risk after / delta: `0 / 2`
 - songlike contour audio technical validation: `true`
 - songlike contour listening review item count: `6`
+- songlike contour listening review package schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package_v5`
+- songlike contour listening review source audio package schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package_v5`
+- songlike contour listening review source sweep schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`
 - songlike contour listening review validated input: `false`
+- songlike contour listening review objective source outside-soloing schema context preserved: `true`
+- songlike contour listening review objective source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
+- songlike contour listening review source outside-soloing schema context preserved: `true`
+- songlike contour listening review source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - songlike contour listening review objective follow-up objective source outside-soloing source context preserved: `true`
 - songlike contour listening review objective follow-up repair sweep source outside-soloing source context preserved: `true`
 - songlike contour listening review objective bridge repair sweep source outside-soloing source context preserved: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -410,7 +410,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo targeted quality repair follow-up decision: schema `stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v5`, source objective next schema `stage_b_midi_to_solo_targeted_quality_repair_objective_next_v5`, source sweep schema `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`, selected target `songlike_melody_contour_repair_sweep`, dominant label/count `songlike_melody_not_soloing/5`, objective and repair sweep source risk `5 -> 2`, current repair risk after/delta `0/2`, source/schema-context preserved flags `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
 - MIDI-to-solo songlike melody contour repair sweep: schema `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`, source follow-up schema `stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v5`, source sweep schema `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`, songlike failure `5 -> 0`, total failure labels `8 -> 4`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/schema-context preserved flags `true`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package`
 - MIDI-to-solo songlike melody contour repair audio package: schema `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package_v5`, source sweep schema `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`, rendered WAV `6`, duration `18.849s-18.992s`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/schema-context preserved flags `true`, source/repaired outside-soloing not evaluable `6/6`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
-- MIDI-to-solo songlike melody contour repair listening review package: review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
+- MIDI-to-solo songlike melody contour repair listening review package: schema `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package_v5`, source audio schema `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package_v5`, review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/schema-context preserved flags `true`, source/repaired outside-soloing not evaluable `6/6`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
 - MIDI-to-solo songlike melody contour repair listening review input guard: preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
 - MIDI-to-solo songlike melody contour repair objective-only next decision: follow-up required `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, current quality claim ready `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
 - MIDI-to-solo songlike melody contour repair follow-up decision: selected target `songlike_melody_contour_phrase_rhythm_repair_sweep`, primary labels `phrase_shape_missing_tension_release,rhythmic_monotony`, objective and repair sweep source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, objective/sweep outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
@@ -13160,12 +13160,29 @@ Issue #1186은 Issue #1184 songlike melody contour repair sweep v5의 MIDI 후�
 
 ## 9.242 Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh
 
-Issue #1104는 Issue #1186 songlike melody contour repair audio package의 WAV/MIDI 후보 6개를 listening review package로 묶고 source-context preserved flag를 review package source summary/validation summary까지 보존한 작업이다.
+Issue #1188은 Issue #1186 songlike melody contour repair audio package v5의 WAV/MIDI 후보 6개를 listening review package로 묶고 source schema chain, outside-soloing schema context, source-context preserved flag를 review package source summary/validation summary까지 보존한 작업이다.
 
 결과:
 
 - document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_LISTENING_REVIEW_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
+- schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package_v5`
+- source audio package schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package_v5`
+- source songlike melody contour repair sweep schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`
+- source targeted quality repair follow-up schema version: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v5`
+- source targeted quality repair objective next schema version: `stage_b_midi_to_solo_targeted_quality_repair_objective_next_v5`
+- source targeted quality repair listening review input guard schema version: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard_v5`
+- source targeted quality repair listening review package schema version: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package_v5`
+- source targeted quality repair audio package schema version: `stage_b_midi_to_solo_targeted_quality_repair_audio_package_v5`
+- source targeted quality repair sweep schema version: `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`
+- source candidate failure labeling schema version: `stage_b_midi_to_solo_candidate_failure_labeling_v4`
+- source quality rubric schema version: `stage_b_midi_to_solo_quality_rubric_baseline_v4`
+- source post-MVP plan schema version: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`
+- source final status schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
 - package ready: `true`
 - review item count: `6`
@@ -13180,8 +13197,12 @@ Issue #1104는 Issue #1186 songlike melody contour repair audio package의 WAV/M
 - source outside-soloing repair evidence ready: `true`
 - objective source outside-soloing repair WAV count: `6`
 - objective source outside-soloing source context preserved: `true`
+- objective source outside-soloing schema context preserved: `true`
+- objective source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - objective preserved source-context flags: `3 / 3`
 - source outside-soloing source context preserved: `true`
+- source outside-soloing schema context preserved: `true`
+- source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - source preserved source-context flags: `3 / 3`
 - source outside-soloing source pitch-role risk: `5 -> 2`
 - source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
@@ -13194,16 +13215,16 @@ Issue #1104는 Issue #1186 songlike melody contour repair audio package의 WAV/M
 
 판단:
 
-- listening review package source validation에 #1102 preserved flag 3개 포함.
-- review package source summary와 validation summary에 objective/source preserved flag 보존.
-- preserved flag false 입력은 validation error로 차단.
+- listening review package source validation에 audio package v5와 upstream schema chain 포함.
+- review package source summary와 validation summary에 objective/source schema context 및 preserved flag 보존.
+- schema version mismatch, schema-context false, preserved flag false 입력은 validation error로 차단.
 - review item 6개 생성, review input은 pending 상태 유지.
 - human/audio preference와 musical quality claim 제외 유지.
 
 검증:
 
 - `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
-- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-listening-review-package`
 - `bash scripts/agent_harness.sh quick`
@@ -13215,7 +13236,7 @@ Issue #1104는 Issue #1186 songlike melody contour repair audio package의 WAV/M
 
 ## 9.243 Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh
 
-Issue #1106은 Issue #1104 listening review package의 pending input 상태와 source-context preserved flag 3개를 input guard summary까지 보존한 작업이다.
+Issue #1106은 Issue #1188 listening review package의 pending input 상태와 source-context preserved flag 3개를 input guard summary까지 보존한 작업이다.
 
 결과:
 

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -30,7 +30,7 @@
 - latest targeted quality repair follow-up decision: Issue #1182, Stage B MIDI-to-solo targeted quality repair follow-up decision source-context refresh
 - latest songlike melody contour repair sweep: Issue #1184, Stage B MIDI-to-solo songlike melody contour repair sweep source-context refresh
 - latest songlike melody contour repair audio package: Issue #1186, Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh
-- latest songlike melody contour repair listening review package: Issue #1104, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh
+- latest songlike melody contour repair listening review package: Issue #1188, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh
 - latest songlike melody contour repair listening review input guard: Issue #1106, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh
 - latest songlike melody contour repair objective-only next decision: Issue #1108, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh
 - latest songlike melody contour repair follow-up decision: Issue #1110, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1150, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after Stage B MIDI-to-solo songlike melody contour repair audio package source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh`
+- open issue queue after Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -6465,12 +6465,29 @@ Issue #1186은 Issue #1184 songlike melody contour repair sweep v5의 MIDI 후�
 
 ## 9.242 Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh
 
-Issue #1104는 Issue #1186 songlike melody contour repair audio package의 WAV/MIDI 후보 6개를 listening review package로 묶고 source-context preserved flag를 review package source summary/validation summary까지 보존한 작업이다.
+Issue #1188은 Issue #1186 songlike melody contour repair audio package v5의 WAV/MIDI 후보 6개를 listening review package로 묶고 source schema chain, outside-soloing schema context, source-context preserved flag를 review package source summary/validation summary까지 보존한 작업이다.
 
 결과:
 
 - document: `docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_LISTENING_REVIEW_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md`
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
+- schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package_v5`
+- source audio package schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package_v5`
+- source songlike melody contour repair sweep schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`
+- source targeted quality repair follow-up schema version: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v5`
+- source targeted quality repair objective next schema version: `stage_b_midi_to_solo_targeted_quality_repair_objective_next_v5`
+- source targeted quality repair listening review input guard schema version: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard_v5`
+- source targeted quality repair listening review package schema version: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package_v5`
+- source targeted quality repair audio package schema version: `stage_b_midi_to_solo_targeted_quality_repair_audio_package_v5`
+- source targeted quality repair sweep schema version: `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`
+- source candidate failure labeling schema version: `stage_b_midi_to_solo_candidate_failure_labeling_v4`
+- source quality rubric schema version: `stage_b_midi_to_solo_quality_rubric_baseline_v4`
+- source post-MVP plan schema version: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`
+- source final status schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
 - package ready: `true`
 - review item count: `6`
@@ -6485,8 +6502,12 @@ Issue #1104는 Issue #1186 songlike melody contour repair audio package의 WAV/M
 - source outside-soloing repair evidence ready: `true`
 - objective source outside-soloing repair WAV count: `6`
 - objective source outside-soloing source context preserved: `true`
+- objective source outside-soloing schema context preserved: `true`
+- objective source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - objective preserved source-context flags: `3 / 3`
 - source outside-soloing source context preserved: `true`
+- source outside-soloing schema context preserved: `true`
+- source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - source preserved source-context flags: `3 / 3`
 - source outside-soloing source pitch-role risk: `5 -> 2`
 - source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
@@ -6499,16 +6520,16 @@ Issue #1104는 Issue #1186 songlike melody contour repair audio package의 WAV/M
 
 판단:
 
-- listening review package source validation에 #1102 preserved flag 3개 포함.
-- review package source summary와 validation summary에 objective/source preserved flag 보존.
-- preserved flag false 입력은 validation error로 차단.
+- listening review package source validation에 audio package v5와 upstream schema chain 포함.
+- review package source summary와 validation summary에 objective/source schema context 및 preserved flag 보존.
+- schema version mismatch, schema-context false, preserved flag false 입력은 validation error로 차단.
 - review item 6개 생성, review input은 pending 상태 유지.
 - human/audio preference와 musical quality claim 제외 유지.
 
 검증:
 
 - `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
-- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py`
+- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-listening-review-package`
 - `bash scripts/agent_harness.sh quick`
@@ -6520,7 +6541,7 @@ Issue #1104는 Issue #1186 songlike melody contour repair audio package의 WAV/M
 
 ## 9.243 Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh
 
-Issue #1106은 Issue #1104 listening review package의 pending input 상태와 source-context preserved flag 3개를 input guard summary까지 보존한 작업이다.
+Issue #1106은 Issue #1188 listening review package의 pending input 상태와 source-context preserved flag 3개를 input guard summary까지 보존한 작업이다.
 
 결과:
 

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_LISTENING_REVIEW_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_LISTENING_REVIEW_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -3,6 +3,23 @@
 ## Summary
 
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package`
+- schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package_v5`
+- source audio package schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package_v5`
+- source sweep schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`
+- source targeted quality repair follow-up schema version: `stage_b_midi_to_solo_targeted_quality_repair_followup_decision_v5`
+- source targeted quality repair objective next schema version: `stage_b_midi_to_solo_targeted_quality_repair_objective_next_v5`
+- source targeted quality repair sweep schema version: `stage_b_midi_to_solo_targeted_quality_repair_sweep_v4`
+- source targeted quality repair listening review input guard schema version: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_input_guard_v5`
+- source targeted quality repair listening review package schema version: `stage_b_midi_to_solo_targeted_quality_repair_listening_review_package_v5`
+- source targeted quality repair audio package schema version: `stage_b_midi_to_solo_targeted_quality_repair_audio_package_v5`
+- source candidate failure labeling schema version: `stage_b_midi_to_solo_candidate_failure_labeling_v4`
+- source quality rubric schema version: `stage_b_midi_to_solo_quality_rubric_baseline_v4`
+- source post-MVP plan schema version: `stage_b_midi_to_solo_post_mvp_quality_iteration_plan_v4`
+- source final status schema version: `stage_b_midi_to_solo_final_status_audit_v4`
+- source delivery package schema version: `stage_b_midi_to_solo_mvp_delivery_package_v4`
+- source listening gap schema version: `stage_b_midi_to_solo_listening_review_quality_gap_v4`
+- source quality gap schema version: `stage_b_midi_to_solo_quality_gap_decision_v4`
+- source current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
 - package ready: `true`
 - review item count: `6`
@@ -16,6 +33,8 @@
 - source outside-soloing repair evidence ready: `true`
 - objective source outside-soloing repair WAV count: `6`
 - objective source outside-soloing source context preserved: `true`
+- objective source outside-soloing schema context preserved: `true`
+- objective source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - objective source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - objective source outside-soloing source repair targeted: `false`
 - objective source outside-soloing source residual risk preserved: `true`
@@ -28,6 +47,8 @@
 - objective bridge repair sweep source outside-soloing source context preserved: `true`
 - objective repair sweep current repair pitch-role risk after/delta: `0` / `2`
 - source outside-soloing source context preserved: `true`
+- source outside-soloing schema context preserved: `true`
+- source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - source outside-soloing source repair targeted: `false`
 - source outside-soloing source residual risk preserved: `true`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6406,7 +6406,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package
     --run_id "$review_run_id" \
     --audio_package_report "$audio_package_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_LISTENING_REVIEW_PACKAGE_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1104 \
+    --issue_number 1188 \
     --expected_review_item_count 6 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard \

--- a/scripts/build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py
+++ b/scripts/build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py
@@ -19,7 +19,12 @@ from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
 )
 from scripts.render_stage_b_midi_to_solo_songlike_melody_contour_repair_audio import (  # noqa: E402
     BOUNDARY as SOURCE_BOUNDARY,
+    EXPECTED_SOURCE_SCHEMA_VERSIONS,
     NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    SCHEMA_VERSION as SOURCE_AUDIO_SCHEMA_VERSION,
+    StageBMidiToSoloSonglikeMelodyContourRepairAudioError,
+    validate_audio_render_report,
 )
 
 
@@ -29,7 +34,12 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(Val
 
 BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard"
-SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package_v4"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package_v5"
+
+EXPECTED_AUDIO_SOURCE_SCHEMA_VERSIONS = {
+    "songlike_melody_contour_repair_audio_package": SOURCE_AUDIO_SCHEMA_VERSION,
+    **EXPECTED_SOURCE_SCHEMA_VERSIONS,
+}
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -82,6 +92,20 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
         )
 
 
+def _validate_source_schema_versions(
+    source_schema_versions: dict[str, Any],
+    *,
+    label: str,
+) -> dict[str, str]:
+    normalized = {key: str(value) for key, value in source_schema_versions.items()}
+    for key, expected in EXPECTED_AUDIO_SOURCE_SCHEMA_VERSIONS.items():
+        if str(normalized.get(key) or "") != expected:
+            raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
+                f"{label} source schema version mismatch: {key}"
+            )
+    return normalized
+
+
 def _source_context_fields(summary: dict[str, Any]) -> dict[str, Any]:
     for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
         objective_key = f"objective_{key}"
@@ -118,6 +142,12 @@ def _source_context_fields(summary: dict[str, Any]) -> dict[str, Any]:
         "objective_source_outside_soloing_repair_source_context_preserved": bool(
             summary.get("objective_source_outside_soloing_repair_source_context_preserved", False)
         ),
+        "objective_source_outside_soloing_repair_schema_context_preserved": bool(
+            summary.get("objective_source_outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "objective_source_outside_soloing_repair_objective_schema_version": str(
+            summary.get("objective_source_outside_soloing_repair_objective_schema_version") or ""
+        ),
         "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             summary.get(
                 "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before"
@@ -153,6 +183,12 @@ def _source_context_fields(summary: dict[str, Any]) -> dict[str, Any]:
         ),
         "source_outside_soloing_repair_source_context_preserved": bool(
             summary.get("source_outside_soloing_repair_source_context_preserved", False)
+        ),
+        "source_outside_soloing_repair_schema_context_preserved": bool(
+            summary.get("source_outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "source_outside_soloing_repair_objective_schema_version": str(
+            summary.get("source_outside_soloing_repair_objective_schema_version") or ""
         ),
         "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             summary.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
@@ -194,6 +230,17 @@ def _validate_source_context(summary: dict[str, Any], *, base: str, label: str) 
         raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
             f"{label} source context preservation required"
         )
+    if not bool(summary.get(f"{base}_schema_context_preserved", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
+            f"{label} schema context preservation required"
+        )
+    if (
+        str(summary.get(f"{base}_objective_schema_version") or "")
+        != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+    ):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
+            f"{label} objective schema version mismatch"
+        )
     if objective_risk <= 0 or source_before <= 0:
         raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
             f"{label} source pitch-role risk context required"
@@ -232,10 +279,33 @@ def validate_audio_package_report(
     report: dict[str, Any],
     *,
     expected_count: int,
-) -> list[dict[str, Any]]:
+) -> dict[str, Any]:
     boundary = _dict(report.get("audio_render_boundary"))
     decision = _dict(report.get("decision"))
     summary = _dict(report.get("summary"))
+    try:
+        audio_validation_summary = validate_audio_render_report(
+            report,
+            expected_boundary=SOURCE_BOUNDARY,
+            expected_next_boundary=SOURCE_NEXT_BOUNDARY,
+            expected_file_count=int(expected_count),
+            expected_sample_rate=_int(summary.get("sample_rate")) or 44100,
+            require_audio_package_completed=True,
+            require_no_quality_claim=True,
+        )
+    except StageBMidiToSoloSonglikeMelodyContourRepairAudioError as exc:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
+            str(exc)
+        ) from exc
+    source_schema_versions = _validate_source_schema_versions(
+        {
+            "songlike_melody_contour_repair_audio_package": audio_validation_summary.get(
+                "schema_version"
+            ),
+            **_dict(report.get("source_schema_versions")),
+        },
+        label="songlike melody contour repair audio package",
+    )
     if str(boundary.get("boundary") or "") != SOURCE_BOUNDARY:
         raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
             "songlike melody contour repair audio package boundary required"
@@ -334,7 +404,11 @@ def validate_audio_package_report(
                 "review_status": "pending",
             }
         )
-    return review_items
+    return {
+        "review_items": review_items,
+        "audio_validation_summary": audio_validation_summary,
+        "source_schema_versions": source_schema_versions,
+    }
 
 
 def build_listening_review_package_report(
@@ -344,10 +418,15 @@ def build_listening_review_package_report(
     issue_number: int,
     expected_count: int,
 ) -> dict[str, Any]:
-    review_items = validate_audio_package_report(
+    source = validate_audio_package_report(
         audio_package_report,
         expected_count=int(expected_count),
     )
+    review_items = [_dict(item) for item in _list(source.get("review_items"))]
+    audio_validation_summary = _dict(source.get("audio_validation_summary"))
+    source_schema_versions = {
+        key: str(value) for key, value in _dict(source.get("source_schema_versions")).items()
+    }
     summary = _dict(audio_package_report.get("summary"))
     source_context = _source_context_fields(summary)
     return {
@@ -359,7 +438,76 @@ def build_listening_review_package_report(
         "issue_number": int(issue_number),
         "boundary": BOUNDARY,
         "source_boundary": SOURCE_BOUNDARY,
+        "source_schema_versions": source_schema_versions,
         "source_summary": {
+            "source_songlike_melody_contour_repair_audio_package_schema_version": str(
+                audio_validation_summary.get("schema_version") or ""
+            ),
+            "source_songlike_melody_contour_repair_sweep_schema_version": str(
+                audio_validation_summary.get(
+                    "source_songlike_melody_contour_repair_sweep_schema_version"
+                )
+                or ""
+            ),
+            "source_targeted_quality_repair_followup_schema_version": str(
+                audio_validation_summary.get(
+                    "source_targeted_quality_repair_followup_schema_version"
+                )
+                or ""
+            ),
+            "source_targeted_quality_repair_objective_next_schema_version": str(
+                audio_validation_summary.get(
+                    "source_targeted_quality_repair_objective_next_schema_version"
+                )
+                or ""
+            ),
+            "source_targeted_quality_repair_sweep_schema_version": str(
+                audio_validation_summary.get("source_targeted_quality_repair_sweep_schema_version")
+                or ""
+            ),
+            "source_targeted_quality_repair_listening_review_input_guard_schema_version": str(
+                audio_validation_summary.get(
+                    "source_targeted_quality_repair_listening_review_input_guard_schema_version"
+                )
+                or ""
+            ),
+            "source_targeted_quality_repair_listening_review_package_schema_version": str(
+                audio_validation_summary.get(
+                    "source_targeted_quality_repair_listening_review_package_schema_version"
+                )
+                or ""
+            ),
+            "source_targeted_quality_repair_audio_package_schema_version": str(
+                audio_validation_summary.get(
+                    "source_targeted_quality_repair_audio_package_schema_version"
+                )
+                or ""
+            ),
+            "source_candidate_failure_labeling_schema_version": str(
+                audio_validation_summary.get("source_candidate_failure_labeling_schema_version")
+                or ""
+            ),
+            "source_quality_rubric_schema_version": str(
+                audio_validation_summary.get("source_quality_rubric_schema_version") or ""
+            ),
+            "source_post_mvp_plan_schema_version": str(
+                audio_validation_summary.get("source_post_mvp_plan_schema_version") or ""
+            ),
+            "source_final_status_schema_version": str(
+                audio_validation_summary.get("source_final_status_schema_version") or ""
+            ),
+            "source_delivery_package_schema_version": str(
+                audio_validation_summary.get("source_delivery_package_schema_version") or ""
+            ),
+            "source_listening_gap_schema_version": str(
+                audio_validation_summary.get("source_listening_gap_schema_version") or ""
+            ),
+            "source_quality_gap_schema_version": str(
+                audio_validation_summary.get("source_quality_gap_schema_version") or ""
+            ),
+            "source_current_evidence_schema_version": str(
+                audio_validation_summary.get("source_current_evidence_schema_version") or ""
+            ),
             "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
             "technical_wav_validation": bool(summary.get("technical_wav_validation", False)),
             "sample_rate": _int(summary.get("sample_rate")),
@@ -419,6 +567,18 @@ def build_listening_review_package_report(
             "review_item_count": int(len(review_items)),
             "validated_review_input": False,
             "human_review_required_now": False,
+            "objective_source_outside_soloing_repair_schema_context_preserved": bool(
+                summary.get("objective_source_outside_soloing_repair_schema_context_preserved", False)
+            ),
+            "objective_source_outside_soloing_repair_objective_schema_version": str(
+                summary.get("objective_source_outside_soloing_repair_objective_schema_version") or ""
+            ),
+            "source_outside_soloing_repair_schema_context_preserved": bool(
+                summary.get("source_outside_soloing_repair_schema_context_preserved", False)
+            ),
+            "source_outside_soloing_repair_objective_schema_version": str(
+                summary.get("source_outside_soloing_repair_objective_schema_version") or ""
+            ),
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": False,
             "audio_rendered_quality_claimed": False,
@@ -460,6 +620,15 @@ def validate_listening_review_package_report(
     readiness = _dict(report.get("readiness"))
     decision = _dict(report.get("decision"))
     source = _dict(report.get("source_summary"))
+    source_schema_versions = _dict(report.get("source_schema_versions"))
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
+            "songlike melody contour repair listening review package schema version mismatch"
+        )
+    _validate_source_schema_versions(
+        source_schema_versions,
+        label="songlike melody contour repair listening review package",
+    )
     if expected_boundary and boundary != expected_boundary:
         raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
             f"expected boundary {expected_boundary}, got {boundary}"
@@ -484,11 +653,84 @@ def validate_listening_review_package_report(
         raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
             "critical user input should not be required"
         )
+    for label, schema_context_key, objective_schema_key in (
+        (
+            "objective",
+            "objective_source_outside_soloing_repair_schema_context_preserved",
+            "objective_source_outside_soloing_repair_objective_schema_version",
+        ),
+        (
+            "source",
+            "source_outside_soloing_repair_schema_context_preserved",
+            "source_outside_soloing_repair_objective_schema_version",
+        ),
+    ):
+        if not bool(source.get(schema_context_key, False)):
+            raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
+                f"{label} outside-soloing schema context preservation required"
+            )
+        if (
+            str(source.get(objective_schema_key) or "")
+            != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+        ):
+            raise StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError(
+                f"{label} outside-soloing objective schema version mismatch"
+            )
     if require_no_quality_claim:
         _require_no_quality_claim(readiness, label="listening package readiness")
     return {
         "boundary": boundary,
         "next_boundary": str(decision.get("next_boundary") or ""),
+        "schema_version": str(report.get("schema_version") or ""),
+        "source_songlike_melody_contour_repair_audio_package_schema_version": str(
+            source_schema_versions.get("songlike_melody_contour_repair_audio_package") or ""
+        ),
+        "source_songlike_melody_contour_repair_sweep_schema_version": str(
+            source_schema_versions.get("songlike_melody_contour_repair_sweep") or ""
+        ),
+        "source_targeted_quality_repair_followup_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_followup_decision") or ""
+        ),
+        "source_targeted_quality_repair_objective_next_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_objective_next") or ""
+        ),
+        "source_targeted_quality_repair_sweep_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_sweep") or ""
+        ),
+        "source_targeted_quality_repair_listening_review_input_guard_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_listening_review_input_guard")
+            or ""
+        ),
+        "source_targeted_quality_repair_listening_review_package_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_listening_review_package") or ""
+        ),
+        "source_targeted_quality_repair_audio_package_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_audio_package") or ""
+        ),
+        "source_candidate_failure_labeling_schema_version": str(
+            source_schema_versions.get("candidate_failure_labeling") or ""
+        ),
+        "source_quality_rubric_schema_version": str(
+            source_schema_versions.get("quality_rubric_baseline") or ""
+        ),
+        "source_post_mvp_plan_schema_version": str(
+            source_schema_versions.get("post_mvp_quality_iteration_plan") or ""
+        ),
+        "source_final_status_schema_version": str(
+            source_schema_versions.get("final_status_audit") or ""
+        ),
+        "source_delivery_package_schema_version": str(
+            source_schema_versions.get("delivery_package") or ""
+        ),
+        "source_listening_gap_schema_version": str(
+            source_schema_versions.get("listening_review_quality_gap") or ""
+        ),
+        "source_quality_gap_schema_version": str(
+            source_schema_versions.get("quality_gap_decision") or ""
+        ),
+        "source_current_evidence_schema_version": str(
+            source_schema_versions.get("current_evidence") or ""
+        ),
         "listening_review_package_ready": bool(readiness.get("listening_review_package_ready", False)),
         "review_item_count": _int(readiness.get("review_item_count")),
         "validated_review_input": bool(readiness.get("validated_review_input", True)),
@@ -512,6 +754,12 @@ def validate_listening_review_package_report(
         ),
         "objective_source_outside_soloing_repair_source_context_preserved": bool(
             source.get("objective_source_outside_soloing_repair_source_context_preserved", False)
+        ),
+        "objective_source_outside_soloing_repair_schema_context_preserved": bool(
+            source.get("objective_source_outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "objective_source_outside_soloing_repair_objective_schema_version": str(
+            source.get("objective_source_outside_soloing_repair_objective_schema_version") or ""
         ),
         "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             source.get(
@@ -546,6 +794,12 @@ def validate_listening_review_package_report(
         ),
         "source_outside_soloing_repair_source_context_preserved": bool(
             source.get("source_outside_soloing_repair_source_context_preserved", False)
+        ),
+        "source_outside_soloing_repair_schema_context_preserved": bool(
+            source.get("source_outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "source_outside_soloing_repair_objective_schema_version": str(
+            source.get("source_outside_soloing_repair_objective_schema_version") or ""
         ),
         "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             source.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
@@ -605,6 +859,23 @@ def markdown_report(report: dict[str, Any]) -> str:
         "## Summary",
         "",
         f"- boundary: `{report['boundary']}`",
+        f"- schema version: `{report['schema_version']}`",
+        f"- source audio package schema version: `{report['source_schema_versions']['songlike_melody_contour_repair_audio_package']}`",
+        f"- source sweep schema version: `{report['source_schema_versions']['songlike_melody_contour_repair_sweep']}`",
+        f"- source targeted quality repair follow-up schema version: `{report['source_schema_versions']['targeted_quality_repair_followup_decision']}`",
+        f"- source targeted quality repair objective next schema version: `{report['source_schema_versions']['targeted_quality_repair_objective_next']}`",
+        f"- source targeted quality repair sweep schema version: `{report['source_schema_versions']['targeted_quality_repair_sweep']}`",
+        f"- source targeted quality repair listening review input guard schema version: `{report['source_schema_versions']['targeted_quality_repair_listening_review_input_guard']}`",
+        f"- source targeted quality repair listening review package schema version: `{report['source_schema_versions']['targeted_quality_repair_listening_review_package']}`",
+        f"- source targeted quality repair audio package schema version: `{report['source_schema_versions']['targeted_quality_repair_audio_package']}`",
+        f"- source candidate failure labeling schema version: `{report['source_schema_versions']['candidate_failure_labeling']}`",
+        f"- source quality rubric schema version: `{report['source_schema_versions']['quality_rubric_baseline']}`",
+        f"- source post-MVP plan schema version: `{report['source_schema_versions']['post_mvp_quality_iteration_plan']}`",
+        f"- source final status schema version: `{report['source_schema_versions']['final_status_audit']}`",
+        f"- source delivery package schema version: `{report['source_schema_versions']['delivery_package']}`",
+        f"- source listening gap schema version: `{report['source_schema_versions']['listening_review_quality_gap']}`",
+        f"- source quality gap schema version: `{report['source_schema_versions']['quality_gap_decision']}`",
+        f"- source current evidence schema version: `{report['source_schema_versions']['current_evidence']}`",
         f"- next boundary: `{decision['next_boundary']}`",
         f"- package ready: `{_bool_token(package['package_ready'])}`",
         f"- review item count: `{package['review_item_count']}`",
@@ -618,6 +889,8 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- source outside-soloing repair evidence ready: `{_bool_token(source['source_outside_soloing_repair_evidence_ready'])}`",
         f"- objective source outside-soloing repair WAV count: `{source['objective_source_outside_soloing_repair_wav_count']}`",
         f"- objective source outside-soloing source context preserved: `{_bool_token(source['objective_source_outside_soloing_repair_source_context_preserved'])}`",
+        f"- objective source outside-soloing schema context preserved: `{_bool_token(source['objective_source_outside_soloing_repair_schema_context_preserved'])}`",
+        f"- objective source outside-soloing objective schema version: `{source['objective_source_outside_soloing_repair_objective_schema_version']}`",
         f"- objective source outside-soloing source pitch-role risk before / after / delta: `{source['objective_source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{source['objective_source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{source['objective_source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- objective source outside-soloing source repair targeted: `{_bool_token(source['objective_source_outside_soloing_repair_source_targeted'])}`",
         f"- objective source outside-soloing source residual risk preserved: `{_bool_token(source['objective_source_outside_soloing_repair_source_residual_risk_preserved'])}`",
@@ -630,6 +903,8 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- objective bridge repair sweep source outside-soloing source context preserved: `{_bool_token(source['objective_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- objective repair sweep current repair pitch-role risk after/delta: `{source['objective_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after']}` / `{source['objective_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta']}`",
         f"- source outside-soloing source context preserved: `{_bool_token(source['source_outside_soloing_repair_source_context_preserved'])}`",
+        f"- source outside-soloing schema context preserved: `{_bool_token(source['source_outside_soloing_repair_schema_context_preserved'])}`",
+        f"- source outside-soloing objective schema version: `{source['source_outside_soloing_repair_objective_schema_version']}`",
         f"- source outside-soloing source pitch-role risk before / after / delta: `{source['source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{source['source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{source['source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- source outside-soloing source repair targeted: `{_bool_token(source['source_outside_soloing_repair_source_targeted'])}`",
         f"- source outside-soloing source residual risk preserved: `{_bool_token(source['source_outside_soloing_repair_source_residual_risk_preserved'])}`",
@@ -691,7 +966,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=1104)
+    parser.add_argument("--issue_number", type=int, default=1188)
     parser.add_argument("--expected_review_item_count", type=int, default=6)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py
@@ -19,7 +19,10 @@ from scripts.build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening
 )
 from scripts.render_stage_b_midi_to_solo_songlike_melody_contour_repair_audio import (
     BOUNDARY as SOURCE_BOUNDARY,
+    EXPECTED_SOURCE_SCHEMA_VERSIONS,
     NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    SCHEMA_VERSION as SOURCE_AUDIO_SCHEMA_VERSION,
 )
 
 
@@ -112,6 +115,8 @@ def audio_package_report(root: Path, *, quality_claim: bool = False) -> dict:
             }
         )
     return {
+        "schema_version": SOURCE_AUDIO_SCHEMA_VERSION,
+        "source_schema_versions": dict(EXPECTED_SOURCE_SCHEMA_VERSIONS),
         "audio_render_boundary": {
             "boundary": SOURCE_BOUNDARY,
             "render_attempted": True,
@@ -149,6 +154,10 @@ def audio_package_report(root: Path, *, quality_claim: bool = False) -> dict:
             "objective_source_outside_soloing_repair_wav_count": 6,
             "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
             "objective_source_outside_soloing_repair_source_context_preserved": True,
+            "objective_source_outside_soloing_repair_schema_context_preserved": True,
+            "objective_source_outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
             "objective_source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
@@ -159,6 +168,10 @@ def audio_package_report(root: Path, *, quality_claim: bool = False) -> dict:
             **{f"objective_{key}": value for key, value in SOURCE_CONTEXT.items()},
             "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
             "source_outside_soloing_repair_source_context_preserved": True,
+            "source_outside_soloing_repair_schema_context_preserved": True,
+            "source_outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
             "source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
             "source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
@@ -190,7 +203,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageTest(unit
             report = build_listening_review_package_report(
                 audio_package_report=audio_package_report(root),
                 output_dir=root / "review_package",
-                issue_number=1104,
+                issue_number=1188,
                 expected_count=6,
             )
             summary = validate_listening_review_package_report(
@@ -203,7 +216,18 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageTest(unit
             )
 
             self.assertEqual(report["schema_version"], SCHEMA_VERSION)
-            self.assertEqual(report["issue_number"], 1104)
+            self.assertEqual(report["issue_number"], 1188)
+            self.assertEqual(summary["schema_version"], SCHEMA_VERSION)
+            self.assertEqual(
+                report["source_schema_versions"]["songlike_melody_contour_repair_audio_package"],
+                SOURCE_AUDIO_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                summary["source_songlike_melody_contour_repair_audio_package_schema_version"],
+                SOURCE_AUDIO_SCHEMA_VERSION,
+            )
+            for key, expected in EXPECTED_SOURCE_SCHEMA_VERSIONS.items():
+                self.assertEqual(report["source_schema_versions"][key], expected)
             self.assertTrue(summary["listening_review_package_ready"])
             self.assertEqual(summary["review_item_count"], 6)
             self.assertFalse(summary["validated_review_input"])
@@ -219,6 +243,13 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageTest(unit
                 5,
             )
             self.assertTrue(summary["objective_source_outside_soloing_repair_source_context_preserved"])
+            self.assertTrue(
+                summary["objective_source_outside_soloing_repair_schema_context_preserved"]
+            )
+            self.assertEqual(
+                summary["objective_source_outside_soloing_repair_objective_schema_version"],
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+            )
             for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[f"objective_{key}"], SOURCE_CONTEXT[key])
             self.assertEqual(
@@ -251,6 +282,11 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageTest(unit
                 5,
             )
             self.assertTrue(summary["source_outside_soloing_repair_source_context_preserved"])
+            self.assertTrue(summary["source_outside_soloing_repair_schema_context_preserved"])
+            self.assertEqual(
+                summary["source_outside_soloing_repair_objective_schema_version"],
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+            )
             for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[key], SOURCE_CONTEXT[key])
             self.assertEqual(
@@ -284,7 +320,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageTest(unit
                 build_listening_review_package_report(
                     audio_package_report=audio_package_report(root, quality_claim=True),
                     output_dir=root / "review_package",
-                    issue_number=1104,
+                    issue_number=1188,
                     expected_count=6,
                 )
 
@@ -299,7 +335,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageTest(unit
                 build_listening_review_package_report(
                     audio_package_report=source,
                     output_dir=root / "review_package",
-                    issue_number=1104,
+                    issue_number=1188,
                     expected_count=6,
                 )
 
@@ -314,7 +350,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageTest(unit
                 build_listening_review_package_report(
                     audio_package_report=source,
                     output_dir=root / "review_package",
-                    issue_number=1104,
+                    issue_number=1188,
                     expected_count=6,
                 )
 
@@ -331,7 +367,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageTest(unit
                 build_listening_review_package_report(
                     audio_package_report=source,
                     output_dir=root / "review_package",
-                    issue_number=1104,
+                    issue_number=1188,
                     expected_count=6,
                 )
 
@@ -348,7 +384,37 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageTest(unit
                 build_listening_review_package_report(
                     audio_package_report=source,
                     output_dir=root / "review_package",
-                    issue_number=1104,
+                    issue_number=1188,
+                    expected_count=6,
+                )
+
+    def test_rejects_source_schema_version_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = audio_package_report(root)
+            source["source_schema_versions"]["songlike_melody_contour_repair_sweep"] = "old"
+            with self.assertRaises(
+                StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError
+            ):
+                build_listening_review_package_report(
+                    audio_package_report=source,
+                    output_dir=root / "review_package",
+                    issue_number=1188,
+                    expected_count=6,
+                )
+
+    def test_rejects_false_schema_context_preserved(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = audio_package_report(root)
+            source["summary"]["source_outside_soloing_repair_schema_context_preserved"] = False
+            with self.assertRaises(
+                StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageError
+            ):
+                build_listening_review_package_report(
+                    audio_package_report=source,
+                    output_dir=root / "review_package",
+                    issue_number=1188,
                     expected_count=6,
                 )
 
@@ -357,7 +423,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairListeningReviewPackageTest(unit
         self.assertEqual(NEXT_BOUNDARY, "stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard")
         self.assertEqual(
             SCHEMA_VERSION,
-            "stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package_v4",
+            "stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package_v5",
         )
 
 


### PR DESCRIPTION
## Summary
- songlike melody contour repair listening review package schema v5 적용
- Issue #1186 audio package v5 및 upstream source schema chain 검증/전파
- outside-soloing schema context, objective schema version, source-context preserved flag 검증/전파
- README, CURRENT_STATUS, CORE_PLAN, AGENTS handoff 갱신

## Context
- 이전 작업: Issue #1186 songlike melody contour repair audio package source-context refresh
- 주요 측정값: rendered WAV `6`, duration `18.849s-18.992s`, technical WAV validation `true`
- review package 상태: review item `6`, validated review input `false`
- 검토 대상: listening review package 진입 시 audio v5 schema와 upstream source schema chain 보존 여부

## Scope
- `scripts/build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py`
- `tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py`
- `scripts/agent_harness.sh`
- README / CURRENT_STATUS / CORE_PLAN / AGENTS handoff 문서

## Validation
- `.venv/bin/python -m py_compile scripts/build_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package.py`
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_audio tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-listening-review-package`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk
- listening preference 입력 미검증 상태 유지
- musical/audio quality claim 제외
- 다음 검토 대상: listening review input guard source-context refresh

Closes #1188
