### PR TITLE
Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Current handoff scope:
 - Latest songlike melody contour repair listening review package completed: Issue #1188, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh.
 - Latest songlike melody contour repair listening review input guard completed: Issue #1190, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh.
 - Latest songlike melody contour repair objective-only next decision completed: Issue #1192, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh.
-- Latest songlike melody contour repair follow-up decision completed: Issue #1110, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh.
+- Latest songlike melody contour repair follow-up decision completed: Issue #1194, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair sweep completed: Issue #1112, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair audio package completed: Issue #1114, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair listening review package completed: Issue #1116, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1148, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh.
+- Open issue queue after Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour repair listening review package: `Issue #1188`
 - latest songlike melody contour repair listening review input guard: `Issue #1190`
 - latest songlike melody contour repair objective-only next decision: `Issue #1192`
-- latest songlike melody contour repair follow-up decision: `Issue #1110`
+- latest songlike melody contour repair follow-up decision: `Issue #1194`
 - latest songlike melody contour phrase/rhythm repair sweep: `Issue #1112`
 - latest songlike melody contour phrase/rhythm repair audio package: `Issue #1114`
 - latest songlike melody contour phrase/rhythm repair listening review package: `Issue #1116`
@@ -50,7 +50,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1150`
 - latest README evidence refresh: `Issue #1152`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after songlike melody contour repair objective-only next decision source-context refresh merge: `0`
+- open issue queue after songlike melody contour repair follow-up decision source-context refresh merge: `0`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
@@ -485,13 +485,23 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - songlike contour objective next bridge repair sweep source outside-soloing source context preserved: `true`
 - songlike contour follow-up required: `true`
 - songlike contour follow-up decision completed: `true`
+- songlike contour follow-up schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision_v5`
+- songlike contour follow-up source objective next schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next_v5`
+- songlike contour follow-up source repair sweep schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`
+- songlike contour follow-up source input guard schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard_v5`
+- songlike contour follow-up source listening review package schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package_v5`
+- songlike contour follow-up source audio package schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package_v5`
 - songlike contour follow-up selected next target: `songlike_melody_contour_phrase_rhythm_repair_sweep`
 - songlike contour follow-up primary remaining failure labels: `phrase_shape_missing_tension_release`, `rhythmic_monotony`
 - songlike contour follow-up source risk: `5 -> 2`
 - songlike contour follow-up current risk after / delta: `0 / 2`
+- songlike contour follow-up objective source outside-soloing schema context preserved: `true`
+- songlike contour follow-up objective source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - songlike contour follow-up objective follow-up objective source outside-soloing source context preserved: `true`
 - songlike contour follow-up objective follow-up repair sweep source outside-soloing source context preserved: `true`
 - songlike contour follow-up objective bridge repair sweep source outside-soloing source context preserved: `true`
+- songlike contour follow-up repair sweep source outside-soloing schema context preserved: `true`
+- songlike contour follow-up repair sweep source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - songlike contour follow-up repair sweep follow-up objective source outside-soloing source context preserved: `true`
 - songlike contour follow-up repair sweep follow-up repair sweep source outside-soloing source context preserved: `true`
 - songlike contour follow-up repair sweep bridge repair sweep source outside-soloing source context preserved: `true`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -13380,7 +13380,7 @@ Issue #1192는 Issue #1190 input guard v5의 pending input 상태, source schema
 
 ## 9.245 Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh
 
-Issue #1110은 Issue #1108 objective-only next decision과 songlike contour repair sweep의 source-context preserved flag 3개를 follow-up decision targets/readiness까지 보존한 작업이다.
+Issue #1194는 Issue #1192 objective-only next decision v5와 songlike contour repair sweep v5의 source schema chain, source-context, schema-context를 follow-up decision targets/readiness까지 보존한 작업이다.
 
 결과:
 
@@ -13388,6 +13388,12 @@ Issue #1110은 Issue #1108 objective-only next decision과 songlike contour repa
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
 - source boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
 - repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision_v5`
+- source objective next schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next_v5`
+- source repair sweep schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`
+- source input guard schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard_v5`
+- source listening review package schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package_v5`
+- source audio package schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package_v5`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
 - selected target: `songlike_melody_contour_phrase_rhythm_repair_sweep`
 - follow-up decision completed: `true`
@@ -13401,9 +13407,13 @@ Issue #1110은 Issue #1108 objective-only next decision과 songlike contour repa
 - technical regression count: `0`
 - objective source outside-soloing repair evidence ready: `true`
 - objective source outside-soloing source context preserved: `true`
+- objective source outside-soloing schema context preserved: `true`
+- objective source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - objective preserved source-context flags: `3 / 3`
 - repair sweep source outside-soloing repair evidence ready: `true`
 - repair sweep source outside-soloing source context preserved: `true`
+- repair sweep source outside-soloing schema context preserved: `true`
+- repair sweep source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - repair sweep preserved source-context flags: `3 / 3`
 - source outside-soloing source pitch-role risk: `5 -> 2`
 - source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
@@ -13416,16 +13426,16 @@ Issue #1110은 Issue #1108 objective-only next decision과 songlike contour repa
 
 판단:
 
-- follow-up decision source validation에 #1108 objective summary와 repair sweep preserved flag 3개 포함.
-- follow-up targets와 readiness에 objective/repair sweep source-context preserved flag 보존.
-- preserved flag false 입력은 validation error로 차단.
+- follow-up decision source validation에 #1192 objective next v5와 repair sweep v5 schema chain 포함.
+- follow-up targets와 readiness에 objective/repair sweep source-context 및 schema-context flag 보존.
+- source schema mismatch, schema-context false, preserved flag false 입력은 validation error로 차단.
 - 남은 primary failure label 2개 기준 phrase/rhythm repair sweep 선택.
 - human/audio preference와 musical quality claim 제외 유지.
 
 검증:
 
-- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
-- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_followup.py`
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_followup.py tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-followup-decision`
 - `bash scripts/agent_harness.sh quick`

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -33,7 +33,7 @@
 - latest songlike melody contour repair listening review package: Issue #1188, Stage B MIDI-to-solo songlike melody contour repair listening review package source-context refresh
 - latest songlike melody contour repair listening review input guard: Issue #1190, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh
 - latest songlike melody contour repair objective-only next decision: Issue #1192, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh
-- latest songlike melody contour repair follow-up decision: Issue #1110, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh
+- latest songlike melody contour repair follow-up decision: Issue #1194, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh
 - latest songlike melody contour phrase/rhythm repair sweep: Issue #1112, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh
 - latest songlike melody contour phrase/rhythm repair audio package: Issue #1114, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh
 - latest songlike melody contour phrase/rhythm repair listening review package: Issue #1116, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1150, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh`
+- open issue queue after Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -4031,7 +4031,7 @@ Issue #1024는 Issue #1022 input guard의 pending input 상태와 source-context
 
 ## 9.245 Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh
 
-Issue #1110은 Issue #1108 objective-only next decision과 songlike contour repair sweep의 source-context preserved flag 3개를 follow-up decision targets/readiness까지 보존한 작업이다.
+Issue #1194는 Issue #1192 objective-only next decision v5와 songlike contour repair sweep v5의 source schema chain, source-context, schema-context를 follow-up decision targets/readiness까지 보존한 작업이다.
 
 결과:
 
@@ -4039,6 +4039,12 @@ Issue #1110은 Issue #1108 objective-only next decision과 songlike contour repa
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
 - source boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
 - repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision_v5`
+- source objective next schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next_v5`
+- source repair sweep schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`
+- source input guard schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard_v5`
+- source listening review package schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package_v5`
+- source audio package schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package_v5`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
 - selected target: `songlike_melody_contour_phrase_rhythm_repair_sweep`
 - follow-up decision completed: `true`
@@ -4052,9 +4058,13 @@ Issue #1110은 Issue #1108 objective-only next decision과 songlike contour repa
 - technical regression count: `0`
 - objective source outside-soloing repair evidence ready: `true`
 - objective source outside-soloing source context preserved: `true`
+- objective source outside-soloing schema context preserved: `true`
+- objective source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - objective preserved source-context flags: `3 / 3`
 - repair sweep source outside-soloing repair evidence ready: `true`
 - repair sweep source outside-soloing source context preserved: `true`
+- repair sweep source outside-soloing schema context preserved: `true`
+- repair sweep source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - repair sweep preserved source-context flags: `3 / 3`
 - source outside-soloing source pitch-role risk: `5 -> 2`
 - source outside-soloing current repair pitch-role risk after / delta: `0 / 2`
@@ -4067,16 +4077,16 @@ Issue #1110은 Issue #1108 objective-only next decision과 songlike contour repa
 
 판단:
 
-- follow-up decision source validation에 #1108 objective summary와 repair sweep preserved flag 3개 포함.
-- follow-up targets와 readiness에 objective/repair sweep source-context preserved flag 보존.
-- preserved flag false 입력은 validation error로 차단.
+- follow-up decision source validation에 #1192 objective next v5와 repair sweep v5 schema chain 포함.
+- follow-up targets와 readiness에 objective/repair sweep source-context 및 schema-context flag 보존.
+- source schema mismatch, schema-context false, preserved flag false 입력은 validation error로 차단.
 - 남은 primary failure label 2개 기준 phrase/rhythm repair sweep 선택.
 - human/audio preference와 musical quality claim 제외 유지.
 
 검증:
 
-- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
-- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_followup.py`
+- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
+- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_followup.py tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-followup-decision`
 - `bash scripts/agent_harness.sh quick`

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -5,6 +5,12 @@
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
 - source boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
 - repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision_v5`
+- source objective next schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next_v5`
+- source repair sweep schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`
+- source input guard schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard_v5`
+- source listening review package schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package_v5`
+- source audio package schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package_v5`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
 - selected target: `songlike_melody_contour_phrase_rhythm_repair_sweep`
 - primary remaining failure labels: `phrase_shape_missing_tension_release,rhythmic_monotony`
@@ -18,6 +24,8 @@
 - objective source outside-soloing repair evidence ready: `true`
 - objective source outside-soloing repair WAV count: `6`
 - objective source outside-soloing source context preserved: `true`
+- objective source outside-soloing schema context preserved: `true`
+- objective source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - objective source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - objective source outside-soloing source repair targeted: `false`
 - objective source outside-soloing source residual risk preserved: `true`
@@ -30,6 +38,8 @@
 - objective bridge repair sweep source outside-soloing source context preserved: `true`
 - repair sweep source outside-soloing repair evidence ready: `true`
 - repair sweep source outside-soloing source context preserved: `true`
+- repair sweep source outside-soloing schema context preserved: `true`
+- repair sweep source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - repair sweep source outside-soloing source pitch-role risk before / after / delta: `5` / `2` / `3`
 - repair sweep source outside-soloing source repair targeted: `false`
 - repair sweep source outside-soloing source residual risk preserved: `true`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6476,7 +6476,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision() {
     --objective_next_report "$objective_report" \
     --repair_sweep_report "$sweep_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_REPAIR_FOLLOWUP_DECISION_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1110 \
+    --issue_number 1194 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep \
     --expected_target songlike_melody_contour_phrase_rhythm_repair_sweep \

--- a/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_followup.py
+++ b/scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_followup.py
@@ -20,10 +20,19 @@ from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
 )
 from scripts.decide_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next import (  # noqa: E402
     BOUNDARY as OBJECTIVE_NEXT_BOUNDARY,
+    EXPECTED_SOURCE_SCHEMA_VERSIONS as OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS,
     FOLLOWUP_DECISION_NEXT_BOUNDARY,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    SCHEMA_VERSION as OBJECTIVE_NEXT_SCHEMA_VERSION,
+    StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextError,
+    validate_objective_next_report,
 )
 from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep import (  # noqa: E402
     BOUNDARY as REPAIR_SWEEP_BOUNDARY,
+    NEXT_BOUNDARY as REPAIR_SWEEP_NEXT_BOUNDARY,
+    SCHEMA_VERSION as REPAIR_SWEEP_SCHEMA_VERSION,
+    StageBMidiToSoloSonglikeMelodyContourRepairSweepError,
+    validate_songlike_melody_contour_repair_sweep_report,
 )
 
 
@@ -34,11 +43,16 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError(ValueErro
 BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep"
 SELECTED_TARGET = "songlike_melody_contour_phrase_rhythm_repair_sweep"
-SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision_v4"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision_v5"
 TIE_TARGET_LABELS = (
     "phrase_shape_missing_tension_release",
     "rhythmic_monotony",
 )
+EXPECTED_SOURCE_SCHEMA_VERSIONS = {
+    "songlike_melody_contour_repair_objective_next": OBJECTIVE_NEXT_SCHEMA_VERSION,
+    **OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS,
+    "songlike_melody_contour_repair_sweep": REPAIR_SWEEP_SCHEMA_VERSION,
+}
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -80,6 +94,20 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
         )
 
 
+def _validate_source_schema_versions(
+    source_schema_versions: dict[str, Any],
+    *,
+    label: str,
+) -> dict[str, str]:
+    normalized = {key: str(value) for key, value in source_schema_versions.items()}
+    for key, expected in EXPECTED_SOURCE_SCHEMA_VERSIONS.items():
+        if str(normalized.get(key) or "") != expected:
+            raise StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError(
+                f"{label} source schema version mismatch: {key}"
+            )
+    return normalized
+
+
 def _bridge_source_context_fields(source: dict[str, Any], *, label: str) -> dict[str, Any]:
     for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
         if key not in source or source[key] is None:
@@ -103,6 +131,12 @@ def _source_context_fields(source: dict[str, Any], *, label: str) -> dict[str, A
                 "objective_source_outside_soloing_repair_source_context_preserved",
                 False,
             )
+        ),
+        "objective_source_outside_soloing_repair_schema_context_preserved": bool(
+            source.get("objective_source_outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "objective_source_outside_soloing_repair_objective_schema_version": str(
+            source.get("objective_source_outside_soloing_repair_objective_schema_version") or ""
         ),
         "objective_source_outside_soloing_repair_wav_count": _int(
             source.get("objective_source_outside_soloing_repair_wav_count")
@@ -145,6 +179,12 @@ def _source_context_fields(source: dict[str, Any], *, label: str) -> dict[str, A
         ),
         "source_outside_soloing_repair_source_context_preserved": bool(
             source.get("source_outside_soloing_repair_source_context_preserved", False)
+        ),
+        "source_outside_soloing_repair_schema_context_preserved": bool(
+            source.get("source_outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "source_outside_soloing_repair_objective_schema_version": str(
+            source.get("source_outside_soloing_repair_objective_schema_version") or ""
         ),
         "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             source.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
@@ -202,6 +242,17 @@ def _validate_source_context(source: dict[str, Any], *, base: str, label: str) -
         raise StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError(
             f"{label} source context preservation required"
         )
+    if not bool(source.get(f"{base}_schema_context_preserved", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError(
+            f"{label} schema context preservation required"
+        )
+    if (
+        str(source.get(f"{base}_objective_schema_version") or "")
+        != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+    ):
+        raise StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError(
+            f"{label} objective schema version mismatch"
+        )
     if not bool(source.get(f"{base}_source_residual_risk_preserved", False)):
         raise StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError(
             f"{label} source residual risk preservation required"
@@ -248,6 +299,28 @@ def validate_objective_next_source(report: dict[str, Any]) -> dict[str, Any]:
     readiness = _dict(report.get("readiness"))
     decision = _dict(report.get("decision"))
     summary = _dict(report.get("objective_summary"))
+    try:
+        objective_summary = validate_objective_next_report(
+            report,
+            expected_boundary=OBJECTIVE_NEXT_BOUNDARY,
+            expected_next_boundary=FOLLOWUP_DECISION_NEXT_BOUNDARY,
+            require_objective_decision=True,
+            require_followup_required=True,
+            require_no_quality_claim=True,
+        )
+    except StageBMidiToSoloSonglikeMelodyContourRepairObjectiveNextError as exc:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError(
+            str(exc)
+        ) from exc
+    source_schema_versions = _validate_source_schema_versions(
+        {
+            "songlike_melody_contour_repair_objective_next": (
+                objective_summary.get("schema_version")
+            ),
+            **_dict(report.get("source_schema_versions")),
+        },
+        label="songlike melody contour repair objective next",
+    )
     if str(report.get("boundary") or "") != OBJECTIVE_NEXT_BOUNDARY:
         raise StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError(
             "songlike contour objective-only next decision boundary required"
@@ -323,6 +396,79 @@ def validate_objective_next_source(report: dict[str, Any]) -> dict[str, Any]:
     _require_no_quality_claim(readiness, label="objective next readiness")
     return {
         "boundary": OBJECTIVE_NEXT_BOUNDARY,
+        "schema_version": str(objective_summary.get("schema_version") or ""),
+        "source_schema_versions": source_schema_versions,
+        "source_songlike_melody_contour_repair_listening_review_input_guard_schema_version": str(
+            objective_summary.get(
+                "source_songlike_melody_contour_repair_listening_review_input_guard_schema_version"
+            )
+            or ""
+        ),
+        "source_songlike_melody_contour_repair_listening_review_package_schema_version": str(
+            objective_summary.get(
+                "source_songlike_melody_contour_repair_listening_review_package_schema_version"
+            )
+            or ""
+        ),
+        "source_songlike_melody_contour_repair_audio_package_schema_version": str(
+            objective_summary.get("source_songlike_melody_contour_repair_audio_package_schema_version")
+            or ""
+        ),
+        "source_songlike_melody_contour_repair_sweep_schema_version": str(
+            objective_summary.get("source_songlike_melody_contour_repair_sweep_schema_version")
+            or ""
+        ),
+        "source_targeted_quality_repair_followup_schema_version": str(
+            objective_summary.get("source_targeted_quality_repair_followup_schema_version")
+            or ""
+        ),
+        "source_targeted_quality_repair_objective_next_schema_version": str(
+            objective_summary.get("source_targeted_quality_repair_objective_next_schema_version")
+            or ""
+        ),
+        "source_targeted_quality_repair_sweep_schema_version": str(
+            objective_summary.get("source_targeted_quality_repair_sweep_schema_version") or ""
+        ),
+        "source_targeted_quality_repair_listening_review_input_guard_schema_version": str(
+            objective_summary.get(
+                "source_targeted_quality_repair_listening_review_input_guard_schema_version"
+            )
+            or ""
+        ),
+        "source_targeted_quality_repair_listening_review_package_schema_version": str(
+            objective_summary.get(
+                "source_targeted_quality_repair_listening_review_package_schema_version"
+            )
+            or ""
+        ),
+        "source_targeted_quality_repair_audio_package_schema_version": str(
+            objective_summary.get("source_targeted_quality_repair_audio_package_schema_version")
+            or ""
+        ),
+        "source_candidate_failure_labeling_schema_version": str(
+            objective_summary.get("source_candidate_failure_labeling_schema_version") or ""
+        ),
+        "source_quality_rubric_schema_version": str(
+            objective_summary.get("source_quality_rubric_schema_version") or ""
+        ),
+        "source_post_mvp_plan_schema_version": str(
+            objective_summary.get("source_post_mvp_plan_schema_version") or ""
+        ),
+        "source_final_status_schema_version": str(
+            objective_summary.get("source_final_status_schema_version") or ""
+        ),
+        "source_delivery_package_schema_version": str(
+            objective_summary.get("source_delivery_package_schema_version") or ""
+        ),
+        "source_listening_gap_schema_version": str(
+            objective_summary.get("source_listening_gap_schema_version") or ""
+        ),
+        "source_quality_gap_schema_version": str(
+            objective_summary.get("source_quality_gap_schema_version") or ""
+        ),
+        "source_current_evidence_schema_version": str(
+            objective_summary.get("source_current_evidence_schema_version") or ""
+        ),
         "review_item_count": _int(summary.get("review_item_count")),
         "rendered_audio_file_count": _int(summary.get("rendered_audio_file_count")),
         "failure_label_delta": _int(summary.get("failure_label_delta")),
@@ -366,6 +512,21 @@ def validate_repair_sweep_source(report: dict[str, Any]) -> dict[str, Any]:
     decision = _dict(report.get("decision"))
     aggregate = _dict(report.get("aggregate"))
     rows = _list(report.get("candidate_repairs"))
+    try:
+        sweep_summary = validate_songlike_melody_contour_repair_sweep_report(
+            report,
+            expected_boundary=REPAIR_SWEEP_BOUNDARY,
+            expected_next_boundary=REPAIR_SWEEP_NEXT_BOUNDARY,
+            min_candidate_count=6,
+            require_sweep_completed=True,
+            require_target_supported=True,
+            require_songlike_delta=True,
+            require_no_quality_claim=True,
+        )
+    except StageBMidiToSoloSonglikeMelodyContourRepairSweepError as exc:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError(
+            str(exc)
+        ) from exc
     if str(report.get("boundary") or "") != REPAIR_SWEEP_BOUNDARY:
         raise StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError(
             "songlike melody contour repair sweep boundary required"
@@ -449,6 +610,55 @@ def validate_repair_sweep_source(report: dict[str, Any]) -> dict[str, Any]:
         )
     return {
         "boundary": REPAIR_SWEEP_BOUNDARY,
+        "schema_version": str(sweep_summary.get("schema_version") or ""),
+        "source_targeted_quality_repair_followup_schema_version": str(
+            sweep_summary.get("source_targeted_quality_repair_followup_schema_version") or ""
+        ),
+        "source_targeted_quality_repair_objective_next_schema_version": str(
+            sweep_summary.get("source_targeted_quality_repair_objective_next_schema_version") or ""
+        ),
+        "source_targeted_quality_repair_sweep_schema_version": str(
+            sweep_summary.get("source_targeted_quality_repair_sweep_schema_version") or ""
+        ),
+        "source_targeted_quality_repair_listening_review_input_guard_schema_version": str(
+            sweep_summary.get(
+                "source_targeted_quality_repair_listening_review_input_guard_schema_version"
+            )
+            or ""
+        ),
+        "source_targeted_quality_repair_listening_review_package_schema_version": str(
+            sweep_summary.get(
+                "source_targeted_quality_repair_listening_review_package_schema_version"
+            )
+            or ""
+        ),
+        "source_targeted_quality_repair_audio_package_schema_version": str(
+            sweep_summary.get("source_targeted_quality_repair_audio_package_schema_version") or ""
+        ),
+        "source_candidate_failure_labeling_schema_version": str(
+            sweep_summary.get("source_candidate_failure_labeling_schema_version") or ""
+        ),
+        "source_quality_rubric_schema_version": str(
+            sweep_summary.get("source_quality_rubric_schema_version") or ""
+        ),
+        "source_post_mvp_plan_schema_version": str(
+            sweep_summary.get("source_post_mvp_plan_schema_version") or ""
+        ),
+        "source_final_status_schema_version": str(
+            sweep_summary.get("source_final_status_schema_version") or ""
+        ),
+        "source_delivery_package_schema_version": str(
+            sweep_summary.get("source_delivery_package_schema_version") or ""
+        ),
+        "source_listening_gap_schema_version": str(
+            sweep_summary.get("source_listening_gap_schema_version") or ""
+        ),
+        "source_quality_gap_schema_version": str(
+            sweep_summary.get("source_quality_gap_schema_version") or ""
+        ),
+        "source_current_evidence_schema_version": str(
+            sweep_summary.get("source_current_evidence_schema_version") or ""
+        ),
         "candidate_count": _int(aggregate.get("candidate_count")),
         "source_total_failure_label_count": _int(
             aggregate.get("source_total_failure_label_count")
@@ -491,6 +701,14 @@ def build_followup_decision_report(
 ) -> dict[str, Any]:
     objective = validate_objective_next_source(objective_next_report)
     sweep = validate_repair_sweep_source(repair_sweep_report)
+    source_schema_versions = _validate_source_schema_versions(
+        {
+            "songlike_melody_contour_repair_objective_next": objective["schema_version"],
+            **objective["source_schema_versions"],
+            "songlike_melody_contour_repair_sweep": sweep["schema_version"],
+        },
+        label="songlike melody contour repair follow-up decision",
+    )
     objective_source_context = _objective_context_for_followup(objective)
     repair_sweep_source_context = _repair_sweep_context_for_followup(sweep)
     primary_labels = [str(label) for label in _list(sweep["primary_remaining_failure_labels"])]
@@ -513,6 +731,7 @@ def build_followup_decision_report(
         "boundary": BOUNDARY,
         "source_boundary": objective["boundary"],
         "repair_sweep_boundary": sweep["boundary"],
+        "source_schema_versions": source_schema_versions,
         "objective_summary": objective,
         "repair_sweep_summary": sweep,
         "selected_next_target": {
@@ -646,6 +865,15 @@ def validate_followup_decision_report(
     selected = _dict(report.get("selected_next_target"))
     sweep = _dict(report.get("repair_sweep_summary"))
     targets = _dict(report.get("followup_targets"))
+    source_schema_versions = _dict(report.get("source_schema_versions"))
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError(
+            "songlike melody contour repair follow-up decision schema version mismatch"
+        )
+    _validate_source_schema_versions(
+        source_schema_versions,
+        label="songlike melody contour repair follow-up decision",
+    )
     if expected_boundary and boundary != expected_boundary:
         raise StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError(
             f"expected boundary {expected_boundary}, got {boundary}"
@@ -686,12 +914,99 @@ def validate_followup_decision_report(
         raise StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError(
             "critical user input should not be required"
         )
+    for prefix in ("objective", "repair_sweep"):
+        if not bool(
+            readiness.get(
+                f"{prefix}_source_outside_soloing_repair_schema_context_preserved",
+                False,
+            )
+        ):
+            raise StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError(
+                f"{prefix} outside-soloing schema context preservation required"
+            )
+        if (
+            str(
+                readiness.get(
+                    f"{prefix}_source_outside_soloing_repair_objective_schema_version"
+                )
+                or ""
+            )
+            != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+        ):
+            raise StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError(
+                f"{prefix} outside-soloing objective schema version mismatch"
+            )
     if require_no_quality_claim:
         _require_no_quality_claim(readiness, label="follow-up readiness")
     return {
         "boundary": boundary,
         "source_boundary": str(report.get("source_boundary") or ""),
         "repair_sweep_boundary": str(report.get("repair_sweep_boundary") or ""),
+        "schema_version": str(report.get("schema_version") or ""),
+        "source_songlike_melody_contour_repair_objective_next_schema_version": str(
+            source_schema_versions.get("songlike_melody_contour_repair_objective_next") or ""
+        ),
+        "source_songlike_melody_contour_repair_sweep_schema_version": str(
+            source_schema_versions.get("songlike_melody_contour_repair_sweep") or ""
+        ),
+        "source_songlike_melody_contour_repair_listening_review_input_guard_schema_version": str(
+            source_schema_versions.get(
+                "songlike_melody_contour_repair_listening_review_input_guard"
+            )
+            or ""
+        ),
+        "source_songlike_melody_contour_repair_listening_review_package_schema_version": str(
+            source_schema_versions.get(
+                "songlike_melody_contour_repair_listening_review_package"
+            )
+            or ""
+        ),
+        "source_songlike_melody_contour_repair_audio_package_schema_version": str(
+            source_schema_versions.get("songlike_melody_contour_repair_audio_package") or ""
+        ),
+        "source_targeted_quality_repair_followup_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_followup_decision") or ""
+        ),
+        "source_targeted_quality_repair_objective_next_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_objective_next") or ""
+        ),
+        "source_targeted_quality_repair_sweep_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_sweep") or ""
+        ),
+        "source_targeted_quality_repair_listening_review_input_guard_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_listening_review_input_guard")
+            or ""
+        ),
+        "source_targeted_quality_repair_listening_review_package_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_listening_review_package") or ""
+        ),
+        "source_targeted_quality_repair_audio_package_schema_version": str(
+            source_schema_versions.get("targeted_quality_repair_audio_package") or ""
+        ),
+        "source_candidate_failure_labeling_schema_version": str(
+            source_schema_versions.get("candidate_failure_labeling") or ""
+        ),
+        "source_quality_rubric_schema_version": str(
+            source_schema_versions.get("quality_rubric_baseline") or ""
+        ),
+        "source_post_mvp_plan_schema_version": str(
+            source_schema_versions.get("post_mvp_quality_iteration_plan") or ""
+        ),
+        "source_final_status_schema_version": str(
+            source_schema_versions.get("final_status_audit") or ""
+        ),
+        "source_delivery_package_schema_version": str(
+            source_schema_versions.get("delivery_package") or ""
+        ),
+        "source_listening_gap_schema_version": str(
+            source_schema_versions.get("listening_review_quality_gap") or ""
+        ),
+        "source_quality_gap_schema_version": str(
+            source_schema_versions.get("quality_gap_decision") or ""
+        ),
+        "source_current_evidence_schema_version": str(
+            source_schema_versions.get("current_evidence") or ""
+        ),
         "next_boundary": str(decision.get("next_boundary") or ""),
         "selected_target": str(selected.get("selected_target") or ""),
         "followup_decision_completed": bool(
@@ -739,6 +1054,12 @@ def validate_followup_decision_report(
         ),
         "objective_source_outside_soloing_repair_source_context_preserved": bool(
             targets.get("objective_source_outside_soloing_repair_source_context_preserved", False)
+        ),
+        "objective_source_outside_soloing_repair_schema_context_preserved": bool(
+            targets.get("objective_source_outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "objective_source_outside_soloing_repair_objective_schema_version": str(
+            targets.get("objective_source_outside_soloing_repair_objective_schema_version") or ""
         ),
         "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             targets.get(
@@ -791,6 +1112,16 @@ def validate_followup_decision_report(
                 "repair_sweep_source_outside_soloing_repair_source_context_preserved",
                 False,
             )
+        ),
+        "repair_sweep_source_outside_soloing_repair_schema_context_preserved": bool(
+            targets.get(
+                "repair_sweep_source_outside_soloing_repair_schema_context_preserved",
+                False,
+            )
+        ),
+        "repair_sweep_source_outside_soloing_repair_objective_schema_version": str(
+            targets.get("repair_sweep_source_outside_soloing_repair_objective_schema_version")
+            or ""
         ),
         "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             targets.get(
@@ -847,6 +1178,12 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- boundary: `{report['boundary']}`",
         f"- source boundary: `{report['source_boundary']}`",
         f"- repair sweep boundary: `{report['repair_sweep_boundary']}`",
+        f"- schema version: `{report['schema_version']}`",
+        f"- source objective next schema version: `{report['source_schema_versions']['songlike_melody_contour_repair_objective_next']}`",
+        f"- source repair sweep schema version: `{report['source_schema_versions']['songlike_melody_contour_repair_sweep']}`",
+        f"- source input guard schema version: `{report['source_schema_versions']['songlike_melody_contour_repair_listening_review_input_guard']}`",
+        f"- source listening review package schema version: `{report['source_schema_versions']['songlike_melody_contour_repair_listening_review_package']}`",
+        f"- source audio package schema version: `{report['source_schema_versions']['songlike_melody_contour_repair_audio_package']}`",
         f"- next boundary: `{decision['next_boundary']}`",
         f"- selected target: `{selected['selected_target']}`",
         f"- primary remaining failure labels: `{','.join(selected['primary_remaining_failure_labels'])}`",
@@ -860,6 +1197,8 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- objective source outside-soloing repair evidence ready: `{_bool_token(readiness['objective_source_outside_soloing_repair_evidence_ready'])}`",
         f"- objective source outside-soloing repair WAV count: `{readiness['objective_source_outside_soloing_repair_wav_count']}`",
         f"- objective source outside-soloing source context preserved: `{_bool_token(readiness['objective_source_outside_soloing_repair_source_context_preserved'])}`",
+        f"- objective source outside-soloing schema context preserved: `{_bool_token(readiness['objective_source_outside_soloing_repair_schema_context_preserved'])}`",
+        f"- objective source outside-soloing objective schema version: `{readiness['objective_source_outside_soloing_repair_objective_schema_version']}`",
         f"- objective source outside-soloing source pitch-role risk before / after / delta: `{readiness['objective_source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{readiness['objective_source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{readiness['objective_source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- objective source outside-soloing source repair targeted: `{_bool_token(readiness['objective_source_outside_soloing_repair_source_targeted'])}`",
         f"- objective source outside-soloing source residual risk preserved: `{_bool_token(readiness['objective_source_outside_soloing_repair_source_residual_risk_preserved'])}`",
@@ -872,6 +1211,8 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- objective bridge repair sweep source outside-soloing source context preserved: `{_bool_token(readiness['objective_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- repair sweep source outside-soloing repair evidence ready: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_evidence_ready'])}`",
         f"- repair sweep source outside-soloing source context preserved: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_source_context_preserved'])}`",
+        f"- repair sweep source outside-soloing schema context preserved: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_schema_context_preserved'])}`",
+        f"- repair sweep source outside-soloing objective schema version: `{readiness['repair_sweep_source_outside_soloing_repair_objective_schema_version']}`",
         f"- repair sweep source outside-soloing source pitch-role risk before / after / delta: `{readiness['repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before']}` / `{readiness['repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after']}` / `{readiness['repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta']}`",
         f"- repair sweep source outside-soloing source repair targeted: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_source_targeted'])}`",
         f"- repair sweep source outside-soloing source residual risk preserved: `{_bool_token(readiness['repair_sweep_source_outside_soloing_repair_source_residual_risk_preserved'])}`",
@@ -932,7 +1273,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=1110)
+    parser.add_argument("--issue_number", type=int, default=1194)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--expected_target", type=str, default="")

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision.py
@@ -17,9 +17,15 @@ from scripts.decide_stage_b_midi_to_solo_songlike_melody_contour_repair_followup
 )
 from scripts.decide_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next import (
     BOUNDARY as OBJECTIVE_NEXT_BOUNDARY,
+    EXPECTED_SOURCE_SCHEMA_VERSIONS as OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+    SCHEMA_VERSION as OBJECTIVE_NEXT_SCHEMA_VERSION,
 )
 from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep import (
     BOUNDARY as SWEEP_BOUNDARY,
+    EXPECTED_SOURCE_SCHEMA_VERSIONS as SWEEP_SOURCE_SCHEMA_VERSIONS,
+    NEXT_BOUNDARY as SWEEP_NEXT_BOUNDARY,
+    SCHEMA_VERSION as SWEEP_SCHEMA_VERSION,
 )
 
 
@@ -53,8 +59,82 @@ SOURCE_CONTEXT = {
 
 def objective_next_report(*, quality_claim: bool = False) -> dict:
     return {
+        "schema_version": OBJECTIVE_NEXT_SCHEMA_VERSION,
         "boundary": OBJECTIVE_NEXT_BOUNDARY,
+        "source_schema_versions": dict(OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS),
         "objective_summary": {
+            "source_songlike_melody_contour_repair_listening_review_input_guard_schema_version": (
+                OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                    "songlike_melody_contour_repair_listening_review_input_guard"
+                ]
+            ),
+            "source_songlike_melody_contour_repair_listening_review_package_schema_version": (
+                OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                    "songlike_melody_contour_repair_listening_review_package"
+                ]
+            ),
+            "source_songlike_melody_contour_repair_audio_package_schema_version": (
+                OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                    "songlike_melody_contour_repair_audio_package"
+                ]
+            ),
+            "source_songlike_melody_contour_repair_sweep_schema_version": (
+                OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                    "songlike_melody_contour_repair_sweep"
+                ]
+            ),
+            "source_targeted_quality_repair_followup_schema_version": (
+                OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                    "targeted_quality_repair_followup_decision"
+                ]
+            ),
+            "source_targeted_quality_repair_objective_next_schema_version": (
+                OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                    "targeted_quality_repair_objective_next"
+                ]
+            ),
+            "source_targeted_quality_repair_sweep_schema_version": (
+                OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS["targeted_quality_repair_sweep"]
+            ),
+            "source_targeted_quality_repair_listening_review_input_guard_schema_version": (
+                OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                    "targeted_quality_repair_listening_review_input_guard"
+                ]
+            ),
+            "source_targeted_quality_repair_listening_review_package_schema_version": (
+                OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                    "targeted_quality_repair_listening_review_package"
+                ]
+            ),
+            "source_targeted_quality_repair_audio_package_schema_version": (
+                OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                    "targeted_quality_repair_audio_package"
+                ]
+            ),
+            "source_candidate_failure_labeling_schema_version": (
+                OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS["candidate_failure_labeling"]
+            ),
+            "source_quality_rubric_schema_version": OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                "quality_rubric_baseline"
+            ],
+            "source_post_mvp_plan_schema_version": OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                "post_mvp_quality_iteration_plan"
+            ],
+            "source_final_status_schema_version": OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                "final_status_audit"
+            ],
+            "source_delivery_package_schema_version": OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                "delivery_package"
+            ],
+            "source_listening_gap_schema_version": OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                "listening_review_quality_gap"
+            ],
+            "source_quality_gap_schema_version": OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                "quality_gap_decision"
+            ],
+            "source_current_evidence_schema_version": OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS[
+                "current_evidence"
+            ],
             "review_item_count": 6,
             "validated_review_input_present": False,
             "preference_fill_allowed": False,
@@ -64,6 +144,10 @@ def objective_next_report(*, quality_claim: bool = False) -> dict:
             "songlike_failure_delta": 5,
             "source_outside_soloing_repair_evidence_ready": True,
             "objective_source_outside_soloing_repair_source_context_preserved": True,
+            "objective_source_outside_soloing_repair_schema_context_preserved": True,
+            "objective_source_outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "objective_source_outside_soloing_repair_wav_count": 6,
             "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
@@ -75,6 +159,10 @@ def objective_next_report(*, quality_claim: bool = False) -> dict:
             "objective_source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
             "source_outside_soloing_repair_source_context_preserved": True,
+            "source_outside_soloing_repair_schema_context_preserved": True,
+            "source_outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
             "source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
             "source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
@@ -108,7 +196,9 @@ def objective_next_report(*, quality_claim: bool = False) -> dict:
 
 def repair_sweep_report(*, technical_regression_count: int = 0) -> dict:
     return {
+        "schema_version": SWEEP_SCHEMA_VERSION,
         "boundary": SWEEP_BOUNDARY,
+        "source_schema_versions": dict(SWEEP_SOURCE_SCHEMA_VERSIONS),
         "candidate_repairs": [
             {
                 "repaired_labeling": {
@@ -123,9 +213,13 @@ def repair_sweep_report(*, technical_regression_count: int = 0) -> dict:
         ],
         "aggregate": {
             "candidate_count": 6,
+            "target_supported": True,
             "source_total_failure_label_count": 8,
             "repaired_total_failure_label_count": 4,
             "failure_label_delta": 4,
+            "source_songlike_failure_count": 5,
+            "repaired_songlike_failure_count": 0,
+            "songlike_failure_delta": 5,
             "improved_candidate_count": 4,
             "technical_regression_count": technical_regression_count,
             "repaired_failure_counts": {
@@ -134,6 +228,10 @@ def repair_sweep_report(*, technical_regression_count: int = 0) -> dict:
             },
             "source_outside_soloing_repair_evidence_ready": True,
             "objective_source_outside_soloing_repair_source_context_preserved": True,
+            "objective_source_outside_soloing_repair_schema_context_preserved": True,
+            "objective_source_outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "objective_source_outside_soloing_repair_wav_count": 6,
             "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
@@ -145,6 +243,10 @@ def repair_sweep_report(*, technical_regression_count: int = 0) -> dict:
             "objective_source_outside_soloing_repair_pitch_role_risk_delta": 2,
             "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
             "source_outside_soloing_repair_source_context_preserved": True,
+            "source_outside_soloing_repair_schema_context_preserved": True,
+            "source_outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
             "source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
             "source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
@@ -169,6 +271,7 @@ def repair_sweep_report(*, technical_regression_count: int = 0) -> dict:
             "production_ready_claimed": False,
         },
         "decision": {
+            "next_boundary": SWEEP_NEXT_BOUNDARY,
             "critical_user_input_required": False,
         },
     }
@@ -181,7 +284,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
                 objective_next_report=objective_next_report(),
                 repair_sweep_report=repair_sweep_report(),
                 output_dir=Path(tmp) / "followup",
-                issue_number=1110,
+                issue_number=1194,
             )
             summary = validate_followup_decision_report(
                 report,
@@ -194,7 +297,18 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
             )
 
             self.assertEqual(report["schema_version"], SCHEMA_VERSION)
-            self.assertEqual(report["issue_number"], 1110)
+            self.assertEqual(report["issue_number"], 1194)
+            self.assertEqual(summary["schema_version"], SCHEMA_VERSION)
+            self.assertEqual(
+                summary["source_songlike_melody_contour_repair_objective_next_schema_version"],
+                OBJECTIVE_NEXT_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                summary["source_songlike_melody_contour_repair_sweep_schema_version"],
+                SWEEP_SCHEMA_VERSION,
+            )
+            for key, expected in OBJECTIVE_NEXT_SOURCE_SCHEMA_VERSIONS.items():
+                self.assertEqual(report["source_schema_versions"][key], expected)
             self.assertTrue(summary["followup_decision_completed"])
             self.assertTrue(summary["phrase_rhythm_tie_target_selected"])
             self.assertEqual(
@@ -208,6 +322,13 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
             self.assertEqual(summary["objective_source_outside_soloing_repair_wav_count"], 6)
             self.assertTrue(
                 summary["objective_source_outside_soloing_repair_source_context_preserved"]
+            )
+            self.assertTrue(
+                summary["objective_source_outside_soloing_repair_schema_context_preserved"]
+            )
+            self.assertEqual(
+                summary["objective_source_outside_soloing_repair_objective_schema_version"],
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
             )
             for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[f"objective_{key}"], SOURCE_CONTEXT[key])
@@ -243,6 +364,13 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
             self.assertTrue(summary["repair_sweep_source_outside_soloing_repair_evidence_ready"])
             self.assertTrue(
                 summary["repair_sweep_source_outside_soloing_repair_source_context_preserved"]
+            )
+            self.assertTrue(
+                summary["repair_sweep_source_outside_soloing_repair_schema_context_preserved"]
+            )
+            self.assertEqual(
+                summary["repair_sweep_source_outside_soloing_repair_objective_schema_version"],
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
             )
             for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[f"repair_sweep_{key}"], SOURCE_CONTEXT[key])
@@ -293,7 +421,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
                     objective_next_report=objective_next_report(quality_claim=True),
                     repair_sweep_report=repair_sweep_report(),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1110,
+                    issue_number=1194,
                 )
 
     def test_rejects_technical_regression(self) -> None:
@@ -305,7 +433,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
                     objective_next_report=objective_next_report(),
                     repair_sweep_report=repair_sweep_report(technical_regression_count=1),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1110,
+                    issue_number=1194,
                 )
 
     def test_rejects_missing_outside_soloing_context(self) -> None:
@@ -319,7 +447,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
                     objective_next_report=objective_next_report(),
                     repair_sweep_report=source,
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1110,
+                    issue_number=1194,
                 )
 
     def test_rejects_source_context_delta_mismatch(self) -> None:
@@ -333,7 +461,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
                     objective_next_report=objective_next_report(),
                     repair_sweep_report=source,
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1110,
+                    issue_number=1194,
                 )
 
     def test_rejects_missing_bridge_source_context(self) -> None:
@@ -347,7 +475,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
                     objective_next_report=source,
                     repair_sweep_report=repair_sweep_report(),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1110,
+                    issue_number=1194,
                 )
 
     def test_rejects_source_context_preservation_flag_false(self) -> None:
@@ -363,7 +491,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
                     objective_next_report=source,
                     repair_sweep_report=repair_sweep_report(),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1110,
+                    issue_number=1194,
                 )
 
     def test_rejects_false_bridge_source_context_preserved_field(self) -> None:
@@ -379,7 +507,39 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
                     objective_next_report=source,
                     repair_sweep_report=repair_sweep_report(),
                     output_dir=Path(tmp) / "followup",
-                    issue_number=1110,
+                    issue_number=1194,
+                )
+
+    def test_rejects_objective_source_schema_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = objective_next_report()
+            source["source_schema_versions"][
+                "songlike_melody_contour_repair_listening_review_input_guard"
+            ] = "stale"
+            with self.assertRaises(
+                StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError
+            ):
+                build_followup_decision_report(
+                    objective_next_report=source,
+                    repair_sweep_report=repair_sweep_report(),
+                    output_dir=Path(tmp) / "followup",
+                    issue_number=1194,
+                )
+
+    def test_rejects_false_schema_context_preserved(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = repair_sweep_report()
+            source["aggregate"][
+                "source_outside_soloing_repair_schema_context_preserved"
+            ] = False
+            with self.assertRaises(
+                StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError
+            ):
+                build_followup_decision_report(
+                    objective_next_report=objective_next_report(),
+                    repair_sweep_report=source,
+                    output_dir=Path(tmp) / "followup",
+                    issue_number=1194,
                 )
 
     def test_constants_are_stable(self) -> None:
@@ -388,7 +548,7 @@ class StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionTest(unittest.T
         self.assertEqual(SELECTED_TARGET, "songlike_melody_contour_phrase_rhythm_repair_sweep")
         self.assertEqual(
             SCHEMA_VERSION,
-            "stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision_v4",
+            "stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision_v5",
         )
 
 


### PR DESCRIPTION
## Summary
- follow-up decision schema v5
- objective-next v5 source validation reuse
- songlike repair sweep v5 source validation reuse
- source schema chain validation
- objective/repair sweep outside-soloing schema-context preservation
- README, current status, core plan, handoff scope update

## Context
- Previous completed boundary: Issue #1192 objective-only next decision source-context refresh
- source objective-next schema: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next_v5`
- source repair sweep schema: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`
- source input guard schema: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard_v5`
- source listening review package schema: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package_v5`
- source audio package schema: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package_v5`
- primary remaining labels: `phrase_shape_missing_tension_release`, `rhythmic_monotony`
- primary remaining failure count: `2`
- source outside-soloing risk: `5 -> 2`
- current repair residual pitch-role risk: `0`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Scope
- follow-up report schema: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision_v5`
- source schema version mismatch block
- schema-context false block
- preserved flag false block
- selected next target retained: `songlike_melody_contour_phrase_rhythm_repair_sweep`

## Validation
- `.venv/bin/python -m py_compile scripts/decide_stage_b_midi_to_solo_songlike_melody_contour_repair_followup.py tests/test_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision.py`
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-repair-followup-decision`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- public diff scan for implementation-tool names: no matches

## Risk
- listening review input pending
- `outside_soloing_without_context` not evaluable remains `6`
- `weak_chord_tone_landing` not evaluable remains `6`
- musical quality claim excluded
- next boundary: phrase/rhythm repair sweep source-context refresh

Closes #1194
