### PR TITLE
Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Current handoff scope:
 - Latest songlike melody contour repair listening review input guard completed: Issue #1190, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh.
 - Latest songlike melody contour repair objective-only next decision completed: Issue #1192, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh.
 - Latest songlike melody contour repair follow-up decision completed: Issue #1194, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh.
-- Latest songlike melody contour phrase/rhythm repair sweep completed: Issue #1112, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh.
+- Latest songlike melody contour phrase/rhythm repair sweep completed: Issue #1196, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair audio package completed: Issue #1114, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair listening review package completed: Issue #1116, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh.
 - Latest songlike melody contour phrase/rhythm repair listening review input guard completed: Issue #1118, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh.
@@ -55,8 +55,8 @@ Current handoff scope:
 - Latest songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision completed: Issue #1148, Stage B MIDI-to-solo songlike melody contour phrase/rhythm chord-tone landing outside-soloing repair objective-only next decision source-context refresh.
 - Latest documentation issue completed: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh.
 - Current branch should be `main` before starting new work.
-- Open issue queue after Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh merge: `0`.
-- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh.
+- Open issue queue after Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh merge: `0`.
+- Recommended next issue: Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh.
 
 Do not expand into Spring Boot, realtime DAW/plugin work, SaaS, UI, or deployment unless the user explicitly asks for that new scope.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest songlike melody contour repair listening review input guard: `Issue #1190`
 - latest songlike melody contour repair objective-only next decision: `Issue #1192`
 - latest songlike melody contour repair follow-up decision: `Issue #1194`
-- latest songlike melody contour phrase/rhythm repair sweep: `Issue #1112`
+- latest songlike melody contour phrase/rhythm repair sweep: `Issue #1196`
 - latest songlike melody contour phrase/rhythm repair audio package: `Issue #1114`
 - latest songlike melody contour phrase/rhythm repair listening review package: `Issue #1116`
 - latest songlike melody contour phrase/rhythm repair listening review input guard: `Issue #1118`
@@ -50,7 +50,8 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - latest MVP current evidence consolidation: `Issue #1150`
 - latest README evidence refresh: `Issue #1152`
 - latest functional boundary: `stage_b_midi_to_solo_mvp_delivery_package`
-- open issue queue after songlike melody contour repair follow-up decision source-context refresh merge: `0`
+- open issue queue after songlike melody contour phrase/rhythm repair sweep source-context refresh merge: `0`
+- next recommended issue: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh`
 - latest evidence boundary: `stage_b_midi_to_solo_mvp_delivery_package`
 - current evidence boundary: `stage_b_midi_to_solo_mvp_current_evidence_consolidation`
 - current evidence schema version: `stage_b_midi_to_solo_mvp_current_evidence_consolidation_v4`
@@ -507,11 +508,15 @@ Symbolic MIDI 기반 jazz piano solo-line 생성 파이프라인.
 - songlike contour follow-up repair sweep bridge repair sweep source outside-soloing source context preserved: `true`
 - songlike contour follow-up technical regression count: `0`
 - songlike contour phrase/rhythm repair sweep completed: `true`
+- songlike contour phrase/rhythm repair sweep schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep_v5`
+- songlike contour phrase/rhythm source follow-up schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision_v5`
+- songlike contour phrase/rhythm source repair sweep schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`
 - songlike contour phrase/rhythm failure count: `4 -> 1`
 - songlike contour phrase/rhythm failure delta: `3`
 - songlike contour phrase/rhythm total failure labels: `4 -> 1`
 - songlike contour phrase/rhythm source risk: `5 -> 2`
 - songlike contour phrase/rhythm current risk after / delta: `0 / 2`
+- songlike contour phrase/rhythm source schema-context preserved: `true`
 - songlike contour phrase/rhythm technical regression count: `0`
 - songlike contour phrase/rhythm audio package ready: `true`
 - songlike contour phrase/rhythm rendered audio file count: `6`

--- a/docs/CORE_PLAN.md
+++ b/docs/CORE_PLAN.md
@@ -414,7 +414,7 @@ MVP가 끝났다고 볼 수 있는 조건:
 - MIDI-to-solo songlike melody contour repair listening review input guard: schema `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard_v5`, source listening review schema `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package_v5`, preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/schema-context preserved flags `true`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision`
 - MIDI-to-solo songlike melody contour repair objective-only next decision: follow-up required `true`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, current quality claim ready `false`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
 - MIDI-to-solo songlike melody contour repair follow-up decision: selected target `songlike_melody_contour_phrase_rhythm_repair_sweep`, primary labels `phrase_shape_missing_tension_release,rhythmic_monotony`, objective and repair sweep source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, objective/sweep outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
-- MIDI-to-solo songlike melody contour phrase/rhythm repair sweep: phrase/rhythm failure `4 -> 1`, total failure labels `4 -> 1`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
+- MIDI-to-solo songlike melody contour phrase/rhythm repair sweep: schema `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep_v5`, source follow-up schema `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision_v5`, source repair sweep schema `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`, phrase/rhythm failure `4 -> 1`, total failure labels `4 -> 1`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/schema-context preserved flags `true`, source/repaired outside-soloing not evaluable `6/6`, technical regression `0`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair audio package: rendered WAV `6`, duration `18.871s-19.000s`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, technical validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_package`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package: review items `6`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source-context preserved flags `3/3`, source/repaired outside-soloing not evaluable `6/6`, technical WAV validation `true`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_listening_review_input_guard`
 - MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard: preference fill `false`, validated input `false`, source risk `5 -> 2`, current repair risk after/delta `0/2`, source/repaired outside-soloing not evaluable `6/6`, quality/preference claim `false`, next boundary `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_objective_only_next_decision`
@@ -11069,13 +11069,17 @@ Issue #1026은 Issue #1024 objective-only next decision과 songlike melody conto
 
 ## 9.204 Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh
 
-Issue #1112는 Issue #1110 follow-up decision에서 선택된 phrase/rhythm repair sweep에 source/current outside-soloing context를 보존한 작업이다.
+Issue #1196은 Issue #1194 follow-up decision v5와 songlike contour repair sweep v5의 source schema chain, source-context, schema-context를 phrase/rhythm repair sweep까지 보존한 작업이다.
 
 결과:
 
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
 - source boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
 - source repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep_v5`
+- source follow-up schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision_v5`
+- source objective next schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next_v5`
+- source repair sweep schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
 - selected target: `songlike_melody_contour_phrase_rhythm_repair_audio_package`
 - candidate count: `6`
@@ -11086,7 +11090,9 @@ Issue #1112는 Issue #1110 follow-up decision에서 선택된 phrase/rhythm repa
 - improved candidate count: `2`
 - technical regression count: `0`
 - objective source outside-soloing repair source context preserved: `true`
+- objective source outside-soloing repair schema context preserved: `true`
 - source outside-soloing repair source context preserved: `true`
+- source outside-soloing repair schema context preserved: `true`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`
@@ -11099,15 +11105,15 @@ Issue #1112는 Issue #1110 follow-up decision에서 선택된 phrase/rhythm repa
 
 판단:
 
-- phrase/rhythm repair sweep validation에 follow-up/source sweep source-context preserved 조건 유지.
+- phrase/rhythm repair sweep validation에 follow-up decision v5와 source repair sweep v5 schema chain 포함.
+- source schema mismatch, repair sweep schema mismatch, schema-context false 입력은 validation error로 차단.
 - required source-context key와 preserved flag true 조건을 aggregate/readiness/validation summary까지 보존.
-- stale quality rubric baseline run_id를 source-context refresh 기준으로 교체.
 - 다음 boundary는 phrase/rhythm repair audio package source-context refresh.
 
 검증:
 
 - `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
-- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-sweep`
 - `bash scripts/agent_harness.sh quick`

--- a/docs/CURRENT_STATUS_AND_PLAN.md
+++ b/docs/CURRENT_STATUS_AND_PLAN.md
@@ -34,7 +34,7 @@
 - latest songlike melody contour repair listening review input guard: Issue #1190, Stage B MIDI-to-solo songlike melody contour repair listening review input guard source-context refresh
 - latest songlike melody contour repair objective-only next decision: Issue #1192, Stage B MIDI-to-solo songlike melody contour repair objective-only next decision source-context refresh
 - latest songlike melody contour repair follow-up decision: Issue #1194, Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh
-- latest songlike melody contour phrase/rhythm repair sweep: Issue #1112, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh
+- latest songlike melody contour phrase/rhythm repair sweep: Issue #1196, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh
 - latest songlike melody contour phrase/rhythm repair audio package: Issue #1114, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh
 - latest songlike melody contour phrase/rhythm repair listening review package: Issue #1116, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review package source-context refresh
 - latest songlike melody contour phrase/rhythm repair listening review input guard: Issue #1118, Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair listening review input guard source-context refresh
@@ -56,8 +56,8 @@
 - latest MVP current evidence consolidation: Issue #1150, Stage B MIDI-to-solo MVP current evidence consolidation source-context refresh
 - latest README evidence refresh: Issue #1152, Stage B MIDI-to-solo README evidence source-context refresh
 - latest handoff sync: Issue #896, Stage B MIDI-to-solo handoff status sync
-- open issue queue after Stage B MIDI-to-solo songlike melody contour repair follow-up decision source-context refresh merge: `0`
-- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh`
+- open issue queue after Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair sweep source-context refresh merge: `0`
+- 다음 권장 이슈: `Stage B MIDI-to-solo songlike melody contour phrase/rhythm repair audio package source-context refresh`
 
 현재 범위가 아닌 것:
 
@@ -203,6 +203,12 @@
 - MIDI-to-solo musical quality claim: `false`
 - 다음 repair target: `songlike_melody_contour_phrase_rhythm_repair_sweep`
 - songlike melody contour phrase/rhythm repair sweep source-context refresh 완료
+- source follow-up schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision_v5`
+- source objective next schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next_v5`
+- source repair sweep schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`
+- source input guard schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard_v5`
+- source listening review package schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package_v5`
+- source audio package schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package_v5`
 - candidate count: `6`
 - total failure labels: `4 -> 1`
 - failure label delta: `3`
@@ -214,6 +220,8 @@
 - source outside-soloing source pitch-role risk delta: `3`
 - source outside-soloing source repair targeted: `false`
 - source outside-soloing source residual risk preserved: `true`
+- objective source outside-soloing schema context preserved: `true`
+- source outside-soloing schema context preserved: `true`
 - source outside-soloing current repair pitch-role risk count after / delta: `0 / 2`
 - source/repaired outside-soloing not evaluable count: `6/6`
 - repaired not evaluable counts: `outside_soloing_without_context=6`, `weak_chord_tone_landing=6`
@@ -4149,14 +4157,15 @@ Issue #1026은 Issue #1024 objective-only next decision과 songlike melody conto
 
 ## Stage B MIDI-to-Solo Songlike Melody Contour Phrase/Rhythm Repair Sweep Source Context Refresh Result
 
-Issue #1112는 Issue #1110 follow-up decision에서 선택된 phrase/rhythm repair sweep에 source/current outside-soloing context를 보존한 작업이다.
+Issue #1196은 Issue #1194 follow-up decision v5와 songlike contour repair sweep v5의 source schema chain, source-context, schema-context를 phrase/rhythm repair sweep까지 보존한 작업이다.
 
 변경:
 
-- phrase/rhythm repair sweep input validation에 source-context preserved flag 필수화
-- follow-up decision과 source repair sweep의 required source-context key 일치 검증 추가
+- phrase/rhythm repair sweep input validation에 follow-up decision v5 schema chain 필수화
+- source repair sweep v5 schema version mismatch 차단
+- source-context preserved flag와 schema-context preserved flag 필수화
+- follow-up decision과 source repair sweep의 required source-context key 일치 검증
 - objective/source context를 aggregate/readiness/validation summary까지 전파
-- stale quality rubric baseline run_id를 source-context refresh 기준으로 교체
 
 결과:
 
@@ -4164,6 +4173,13 @@ Issue #1112는 Issue #1110 follow-up decision에서 선택된 phrase/rhythm repa
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
 - source boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
 - source repair sweep boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep`
+- schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep_v5`
+- source follow-up schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision_v5`
+- source objective next schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next_v5`
+- source repair sweep schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`
+- source input guard schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard_v5`
+- source listening review package schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package_v5`
+- source audio package schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package_v5`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
 - selected target: `songlike_melody_contour_phrase_rhythm_repair_audio_package`
 - candidate count: `6`
@@ -4174,7 +4190,9 @@ Issue #1112는 Issue #1110 follow-up decision에서 선택된 phrase/rhythm repa
 - improved candidate count: `2`
 - technical regression count: `0`
 - objective source outside-soloing source context preserved: `true`
+- objective source outside-soloing schema context preserved: `true`
 - source outside-soloing source context preserved: `true`
+- source outside-soloing schema context preserved: `true`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`
@@ -4186,15 +4204,16 @@ Issue #1112는 Issue #1110 follow-up decision에서 선택된 phrase/rhythm repa
 
 판단:
 
-- phrase/rhythm repair sweep에서 target label 감소 확인.
-- source-context preserved flag `3/3` 보존 확인.
+- phrase/rhythm repair sweep에서 target label `4 -> 1` 감소 확인.
+- source schema mismatch, repair sweep schema mismatch, schema-context false 입력은 validation error로 차단.
+- source-context preserved flag와 schema-context preserved flag 보존 확인.
 - outside-soloing과 weak chord-tone landing은 context 부재로 quality claim 제외 유지.
 - 다음 boundary는 audio package source-context refresh.
 
 검증:
 
 - `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
-- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py`
+- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py`
 - `bash -n scripts/agent_harness.sh`
 - `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-sweep`
 - `bash scripts/agent_harness.sh quick`

--- a/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md
@@ -4,6 +4,13 @@
 
 - boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
 - source boundary: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision`
+- schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep_v5`
+- source follow-up schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision_v5`
+- source objective next schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next_v5`
+- source repair sweep schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`
+- source input guard schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_input_guard_v5`
+- source listening review package schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_listening_review_package_v5`
+- source audio package schema version: `stage_b_midi_to_solo_songlike_melody_contour_repair_audio_package_v5`
 - next boundary: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`
 - selected target: `songlike_melody_contour_phrase_rhythm_repair_audio_package`
 - candidate count: `6`
@@ -15,7 +22,11 @@
 - technical regression count: `0`
 - source outside-soloing repair evidence ready: `true`
 - objective source outside-soloing source context preserved: `true`
+- objective source outside-soloing schema context preserved: `true`
+- objective source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - source outside-soloing source context preserved: `true`
+- source outside-soloing schema context preserved: `true`
+- source outside-soloing objective schema version: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_chord_tone_landing_outside_soloing_repair_objective_next_v4`
 - follow-up objective source outside-soloing source context preserved: `true`
 - follow-up repair sweep source outside-soloing source context preserved: `true`
 - bridge repair sweep source outside-soloing source context preserved: `true`

--- a/scripts/agent_harness.sh
+++ b/scripts/agent_harness.sh
@@ -6512,7 +6512,7 @@ run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep() {
     --source_repair_sweep "$source_sweep_report" \
     --rubric_baseline "$rubric_report" \
     --doc_path docs/STAGE_B_MIDI_TO_SOLO_SONGLIKE_MELODY_CONTOUR_PHRASE_RHYTHM_REPAIR_SWEEP_SOURCE_CONTEXT_REFRESH_2026-06-11.md \
-    --issue_number 1112 \
+    --issue_number 1196 \
     --expected_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep \
     --expected_next_boundary stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package \
     --min_candidate_count 6 \

--- a/scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py
+++ b/scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py
@@ -19,11 +19,16 @@ from scripts.assess_stage_b_generic_base_readiness import read_json, write_json,
 from scripts.audit_stage_b_midi_to_solo_final_status import (  # noqa: E402
     BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
     BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
 )
 from scripts.decide_stage_b_midi_to_solo_songlike_melody_contour_repair_followup import (  # noqa: E402
     BOUNDARY as FOLLOWUP_BOUNDARY,
+    EXPECTED_SOURCE_SCHEMA_VERSIONS as FOLLOWUP_SOURCE_SCHEMA_VERSIONS,
     NEXT_BOUNDARY as FOLLOWUP_NEXT_BOUNDARY,
     SELECTED_TARGET as FOLLOWUP_SELECTED_TARGET,
+    SCHEMA_VERSION as FOLLOWUP_SCHEMA_VERSION,
+    StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError,
+    validate_followup_decision_report,
 )
 from scripts.label_stage_b_midi_to_solo_candidate_failures import (  # noqa: E402
     analyze_candidate_midi,
@@ -32,6 +37,7 @@ from scripts.label_stage_b_midi_to_solo_candidate_failures import (  # noqa: E40
 )
 from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep import (  # noqa: E402
     BOUNDARY as SOURCE_REPAIR_SWEEP_BOUNDARY,
+    SCHEMA_VERSION as SOURCE_REPAIR_SWEEP_SCHEMA_VERSION,
 )
 
 
@@ -42,11 +48,16 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(ValueErr
 BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep"
 NEXT_BOUNDARY = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package"
 SELECTED_TARGET = "songlike_melody_contour_phrase_rhythm_repair_audio_package"
-SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep_v4"
+SCHEMA_VERSION = "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep_v5"
 PHRASE_LABEL = "phrase_shape_missing_tension_release"
 RHYTHM_LABEL = "rhythmic_monotony"
 TARGET_LABELS = (PHRASE_LABEL, RHYTHM_LABEL)
 BAR_SECONDS = 2.0
+EXPECTED_SOURCE_SCHEMA_VERSIONS = {
+    "songlike_melody_contour_repair_followup_decision": FOLLOWUP_SCHEMA_VERSION,
+    **FOLLOWUP_SOURCE_SCHEMA_VERSIONS,
+    "songlike_melody_contour_repair_sweep": SOURCE_REPAIR_SWEEP_SCHEMA_VERSION,
+}
 
 QUALITY_CLAIM_KEYS = [
     "human_audio_preference_claimed",
@@ -95,6 +106,20 @@ def _require_no_quality_claim(container: dict[str, Any], *, label: str) -> None:
         )
 
 
+def _validate_source_schema_versions(
+    source_schema_versions: dict[str, Any],
+    *,
+    label: str,
+) -> dict[str, str]:
+    normalized = {key: str(value) for key, value in source_schema_versions.items()}
+    for key, expected in EXPECTED_SOURCE_SCHEMA_VERSIONS.items():
+        if str(normalized.get(key) or "") != expected:
+            raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+                f"{label} source schema version mismatch: {key}"
+            )
+    return normalized
+
+
 def _bridge_source_context_fields(
     source: dict[str, Any],
     *,
@@ -134,6 +159,12 @@ def _source_context_fields(
         ),
         "source_outside_soloing_repair_source_context_preserved": bool(
             source.get(f"{prefix}_source_context_preserved", False)
+        ),
+        "source_outside_soloing_repair_schema_context_preserved": bool(
+            source.get(f"{prefix}_schema_context_preserved", False)
+        ),
+        "source_outside_soloing_repair_objective_schema_version": str(
+            source.get(f"{prefix}_objective_schema_version") or ""
         ),
         "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             source.get(f"{prefix}_source_pitch_role_risk_count_before")
@@ -205,6 +236,17 @@ def _validate_source_context(context: dict[str, Any], *, label: str) -> None:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
             f"{label} source context preservation required"
         )
+    if not bool(context.get("source_outside_soloing_repair_schema_context_preserved", False)):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            f"{label} schema context preservation required"
+        )
+    if (
+        str(context.get("source_outside_soloing_repair_objective_schema_version") or "")
+        != OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+    ):
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            f"{label} objective schema version mismatch"
+        )
     if not bool(
         context.get("source_outside_soloing_repair_source_residual_risk_preserved", False)
     ):
@@ -260,6 +302,29 @@ def validate_followup_decision(report: dict[str, Any]) -> dict[str, Any]:
     decision = _dict(report.get("decision"))
     selected = _dict(report.get("selected_next_target"))
     sweep = _dict(report.get("repair_sweep_summary"))
+    try:
+        upstream_summary = validate_followup_decision_report(
+            report,
+            expected_boundary=FOLLOWUP_BOUNDARY,
+            expected_next_boundary=FOLLOWUP_NEXT_BOUNDARY,
+            expected_target=FOLLOWUP_SELECTED_TARGET,
+            require_followup_decision=True,
+            require_phrase_rhythm_tie_target=True,
+            require_no_quality_claim=True,
+        )
+    except StageBMidiToSoloSonglikeMelodyContourRepairFollowupDecisionError as exc:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            str(exc)
+        ) from exc
+    source_schema_versions = _validate_source_schema_versions(
+        {
+            "songlike_melody_contour_repair_followup_decision": (
+                upstream_summary.get("schema_version")
+            ),
+            **_dict(report.get("source_schema_versions")),
+        },
+        label="songlike melody contour phrase/rhythm repair sweep follow-up source",
+    )
     if str(report.get("boundary") or "") != FOLLOWUP_BOUNDARY:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
             "songlike contour follow-up decision boundary required"
@@ -344,6 +409,8 @@ def validate_followup_decision(report: dict[str, Any]) -> dict[str, Any]:
         )
     _require_no_quality_claim(readiness, label="follow-up readiness")
     return {
+        "schema_version": str(upstream_summary.get("schema_version") or ""),
+        "source_schema_versions": source_schema_versions,
         "candidate_count": _int(readiness.get("candidate_count")),
         "source_total_failure_label_count": _int(
             readiness.get("source_total_failure_label_count")
@@ -388,6 +455,10 @@ def validate_source_repair_sweep(report: dict[str, Any]) -> dict[str, Any]:
     readiness = _dict(report.get("readiness"))
     aggregate = _dict(report.get("aggregate"))
     rows = [_dict(item) for item in _list(report.get("candidate_repairs"))]
+    if str(report.get("schema_version") or "") != SOURCE_REPAIR_SWEEP_SCHEMA_VERSION:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            "songlike contour repair sweep source schema version mismatch"
+        )
     if str(report.get("boundary") or "") != SOURCE_REPAIR_SWEEP_BOUNDARY:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
             "songlike contour repair sweep source required"
@@ -430,7 +501,11 @@ def validate_source_repair_sweep(report: dict[str, Any]) -> dict[str, Any]:
             "source repair row count below 6"
         )
     _require_no_quality_claim(readiness, label="songlike contour repair readiness")
-    return {"rows": rows, **source_context}
+    return {
+        "schema_version": str(report.get("schema_version") or ""),
+        "rows": rows,
+        **source_context,
+    }
 
 
 def density_patterns() -> list[list[int]]:
@@ -627,6 +702,14 @@ def build_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
 ) -> dict[str, Any]:
     followup = validate_followup_decision(followup_decision)
     source = validate_source_repair_sweep(source_repair_sweep)
+    source_schema_versions = _validate_source_schema_versions(
+        {
+            "songlike_melody_contour_repair_followup_decision": followup["schema_version"],
+            **_dict(followup.get("source_schema_versions")),
+            "songlike_melody_contour_repair_sweep": source["schema_version"],
+        },
+        label="songlike melody contour phrase/rhythm repair sweep",
+    )
     source_rows = [_dict(item) for item in _list(source.get("rows"))]
     source_context = {
         key: value
@@ -727,6 +810,7 @@ def build_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
         "boundary": BOUNDARY,
         "source_boundary": FOLLOWUP_BOUNDARY,
         "source_repair_sweep_boundary": SOURCE_REPAIR_SWEEP_BOUNDARY,
+        "source_schema_versions": source_schema_versions,
         "candidate_repairs": relabeled,
         "aggregate": {
             "candidate_count": len(relabeled),
@@ -845,6 +929,15 @@ def validate_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
     decision = _dict(report.get("decision"))
     aggregate = _dict(report.get("aggregate"))
     repairs = _list(report.get("candidate_repairs"))
+    source_schema_versions = _dict(report.get("source_schema_versions"))
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
+            "songlike melody contour phrase/rhythm repair sweep schema version mismatch"
+        )
+    _validate_source_schema_versions(
+        source_schema_versions,
+        label="songlike melody contour phrase/rhythm repair sweep",
+    )
     if expected_boundary and boundary != expected_boundary:
         raise StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError(
             f"expected boundary {expected_boundary}, got {boundary}"
@@ -916,9 +1009,36 @@ def validate_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
         _require_no_quality_claim(readiness, label="songlike contour repair readiness")
     return {
         "boundary": boundary,
+        "schema_version": str(report.get("schema_version") or ""),
         "source_boundary": str(report.get("source_boundary") or ""),
         "source_repair_sweep_boundary": str(
             report.get("source_repair_sweep_boundary") or ""
+        ),
+        "source_songlike_melody_contour_repair_followup_schema_version": str(
+            source_schema_versions.get("songlike_melody_contour_repair_followup_decision")
+            or ""
+        ),
+        "source_songlike_melody_contour_repair_objective_next_schema_version": str(
+            source_schema_versions.get("songlike_melody_contour_repair_objective_next")
+            or ""
+        ),
+        "source_songlike_melody_contour_repair_sweep_schema_version": str(
+            source_schema_versions.get("songlike_melody_contour_repair_sweep") or ""
+        ),
+        "source_songlike_melody_contour_repair_listening_review_input_guard_schema_version": str(
+            source_schema_versions.get(
+                "songlike_melody_contour_repair_listening_review_input_guard"
+            )
+            or ""
+        ),
+        "source_songlike_melody_contour_repair_listening_review_package_schema_version": str(
+            source_schema_versions.get(
+                "songlike_melody_contour_repair_listening_review_package"
+            )
+            or ""
+        ),
+        "source_songlike_melody_contour_repair_audio_package_schema_version": str(
+            source_schema_versions.get("songlike_melody_contour_repair_audio_package") or ""
         ),
         "next_boundary": str(decision.get("next_boundary") or ""),
         "selected_target": str(
@@ -964,12 +1084,24 @@ def validate_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
         "objective_source_outside_soloing_repair_source_context_preserved": bool(
             aggregate.get("objective_source_outside_soloing_repair_source_context_preserved", False)
         ),
+        "objective_source_outside_soloing_repair_schema_context_preserved": bool(
+            aggregate.get("objective_source_outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "objective_source_outside_soloing_repair_objective_schema_version": str(
+            aggregate.get("objective_source_outside_soloing_repair_objective_schema_version") or ""
+        ),
         **{
             f"objective_{key}": aggregate.get(f"objective_{key}")
             for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS
         },
         "source_outside_soloing_repair_source_context_preserved": bool(
             aggregate.get("source_outside_soloing_repair_source_context_preserved", False)
+        ),
+        "source_outside_soloing_repair_schema_context_preserved": bool(
+            aggregate.get("source_outside_soloing_repair_schema_context_preserved", False)
+        ),
+        "source_outside_soloing_repair_objective_schema_version": str(
+            aggregate.get("source_outside_soloing_repair_objective_schema_version") or ""
         ),
         "source_outside_soloing_repair_source_pitch_role_risk_count_before": _int(
             aggregate.get("source_outside_soloing_repair_source_pitch_role_risk_count_before")
@@ -1025,6 +1157,13 @@ def markdown_report(report: dict[str, Any]) -> str:
         "",
         f"- boundary: `{report['boundary']}`",
         f"- source boundary: `{report['source_boundary']}`",
+        f"- schema version: `{report['schema_version']}`",
+        f"- source follow-up schema version: `{report['source_schema_versions']['songlike_melody_contour_repair_followup_decision']}`",
+        f"- source objective next schema version: `{report['source_schema_versions']['songlike_melody_contour_repair_objective_next']}`",
+        f"- source repair sweep schema version: `{report['source_schema_versions']['songlike_melody_contour_repair_sweep']}`",
+        f"- source input guard schema version: `{report['source_schema_versions']['songlike_melody_contour_repair_listening_review_input_guard']}`",
+        f"- source listening review package schema version: `{report['source_schema_versions']['songlike_melody_contour_repair_listening_review_package']}`",
+        f"- source audio package schema version: `{report['source_schema_versions']['songlike_melody_contour_repair_audio_package']}`",
         f"- next boundary: `{decision['next_boundary']}`",
         f"- selected target: `{selected['selected_target']}`",
         f"- candidate count: `{aggregate['candidate_count']}`",
@@ -1036,7 +1175,11 @@ def markdown_report(report: dict[str, Any]) -> str:
         f"- technical regression count: `{aggregate['technical_regression_count']}`",
         f"- source outside-soloing repair evidence ready: `{_bool_token(aggregate['source_outside_soloing_repair_evidence_ready'])}`",
         f"- objective source outside-soloing source context preserved: `{_bool_token(aggregate['objective_source_outside_soloing_repair_source_context_preserved'])}`",
+        f"- objective source outside-soloing schema context preserved: `{_bool_token(aggregate['objective_source_outside_soloing_repair_schema_context_preserved'])}`",
+        f"- objective source outside-soloing objective schema version: `{aggregate['objective_source_outside_soloing_repair_objective_schema_version']}`",
         f"- source outside-soloing source context preserved: `{_bool_token(aggregate['source_outside_soloing_repair_source_context_preserved'])}`",
+        f"- source outside-soloing schema context preserved: `{_bool_token(aggregate['source_outside_soloing_repair_schema_context_preserved'])}`",
+        f"- source outside-soloing objective schema version: `{aggregate['source_outside_soloing_repair_objective_schema_version']}`",
         f"- follow-up objective source outside-soloing source context preserved: `{_bool_token(aggregate['followup_objective_source_outside_soloing_source_context_preserved'])}`",
         f"- follow-up repair sweep source outside-soloing source context preserved: `{_bool_token(aggregate['followup_repair_sweep_source_outside_soloing_source_context_preserved'])}`",
         f"- bridge repair sweep source outside-soloing source context preserved: `{_bool_token(aggregate['repair_sweep_source_outside_soloing_source_context_preserved'])}`",
@@ -1098,7 +1241,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--doc_path", type=str, default="")
-    parser.add_argument("--issue_number", type=int, default=944)
+    parser.add_argument("--issue_number", type=int, default=1196)
     parser.add_argument("--expected_boundary", type=str, default="")
     parser.add_argument("--expected_next_boundary", type=str, default="")
     parser.add_argument("--min_candidate_count", type=int, default=6)

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio.py
@@ -12,6 +12,7 @@ import pretty_midi
 from scripts.audit_stage_b_midi_to_solo_final_status import (
     BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS,
     BRIDGE_SOURCE_CONTEXT_PRESERVED_KEYS,
+    OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
 )
 from scripts.render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio import (
     BOUNDARY,
@@ -23,7 +24,9 @@ from scripts.render_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_r
 )
 from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep import (
     BOUNDARY as SOURCE_BOUNDARY,
+    EXPECTED_SOURCE_SCHEMA_VERSIONS as SOURCE_EXPECTED_SCHEMA_VERSIONS,
     NEXT_BOUNDARY as SOURCE_NEXT_BOUNDARY,
+    SCHEMA_VERSION as SOURCE_SCHEMA_VERSION,
 )
 
 
@@ -36,6 +39,10 @@ SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
     "followup_objective_source_outside_soloing_source_context_preserved": True,
+    "followup_objective_source_outside_soloing_schema_context_preserved": True,
+    "followup_objective_source_outside_soloing_objective_schema_version": (
+        OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+    ),
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
@@ -44,6 +51,10 @@ SOURCE_CONTEXT = {
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
     "followup_repair_sweep_source_outside_soloing_source_context_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_schema_context_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_objective_schema_version": (
+        OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+    ),
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
@@ -52,6 +63,10 @@ SOURCE_CONTEXT = {
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
     "repair_sweep_source_outside_soloing_source_context_preserved": True,
+    "repair_sweep_source_outside_soloing_schema_context_preserved": True,
+    "repair_sweep_source_outside_soloing_objective_schema_version": (
+        OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+    ),
 }
 
 
@@ -121,7 +136,9 @@ def source_report(root: Path, *, quality_claim: bool = False) -> dict:
             }
         )
     return {
+        "schema_version": SOURCE_SCHEMA_VERSION,
         "boundary": SOURCE_BOUNDARY,
+        "source_schema_versions": dict(SOURCE_EXPECTED_SCHEMA_VERSIONS),
         "candidate_repairs": repairs,
         "aggregate": {
             "candidate_count": 6,
@@ -139,6 +156,10 @@ def source_report(root: Path, *, quality_claim: bool = False) -> dict:
             "source_outside_soloing_repair_evidence_ready": True,
             "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
             "objective_source_outside_soloing_repair_source_context_preserved": True,
+            "objective_source_outside_soloing_repair_schema_context_preserved": True,
+            "objective_source_outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
             "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
             "objective_source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
@@ -149,6 +170,10 @@ def source_report(root: Path, *, quality_claim: bool = False) -> dict:
             **{f"objective_{key}": value for key, value in SOURCE_CONTEXT.items()},
             "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
             "source_outside_soloing_repair_source_context_preserved": True,
+            "source_outside_soloing_repair_schema_context_preserved": True,
+            "source_outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
             "source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
             "source_outside_soloing_repair_source_pitch_role_risk_delta": 3,

--- a/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py
+++ b/tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py
@@ -19,8 +19,10 @@ from scripts.build_stage_b_midi_to_solo_quality_rubric_baseline import (
 )
 from scripts.decide_stage_b_midi_to_solo_songlike_melody_contour_repair_followup import (
     BOUNDARY as FOLLOWUP_BOUNDARY,
+    EXPECTED_SOURCE_SCHEMA_VERSIONS as FOLLOWUP_SOURCE_SCHEMA_VERSIONS,
     NEXT_BOUNDARY as FOLLOWUP_NEXT_BOUNDARY,
     SELECTED_TARGET as FOLLOWUP_SELECTED_TARGET,
+    SCHEMA_VERSION as FOLLOWUP_SCHEMA_VERSION,
     TIE_TARGET_LABELS,
 )
 from scripts.plan_stage_b_midi_to_solo_post_mvp_quality_iteration import (
@@ -40,6 +42,7 @@ from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repa
 )
 from scripts.run_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep import (
     BOUNDARY as SOURCE_SWEEP_BOUNDARY,
+    SCHEMA_VERSION as SOURCE_SWEEP_SCHEMA_VERSION,
 )
 
 
@@ -52,6 +55,10 @@ SOURCE_CONTEXT = {
     "followup_objective_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_objective_source_outside_soloing_current_pitch_role_risk_delta": 2,
     "followup_objective_source_outside_soloing_source_context_preserved": True,
+    "followup_objective_source_outside_soloing_schema_context_preserved": True,
+    "followup_objective_source_outside_soloing_objective_schema_version": (
+        OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+    ),
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "followup_repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
@@ -60,6 +67,10 @@ SOURCE_CONTEXT = {
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "followup_repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
     "followup_repair_sweep_source_outside_soloing_source_context_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_schema_context_preserved": True,
+    "followup_repair_sweep_source_outside_soloing_objective_schema_version": (
+        OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+    ),
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_before": 5,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_count_after": 2,
     "repair_sweep_source_outside_soloing_source_pitch_role_risk_delta": 3,
@@ -68,6 +79,10 @@ SOURCE_CONTEXT = {
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_count_after": 0,
     "repair_sweep_source_outside_soloing_current_pitch_role_risk_delta": 2,
     "repair_sweep_source_outside_soloing_source_context_preserved": True,
+    "repair_sweep_source_outside_soloing_schema_context_preserved": True,
+    "repair_sweep_source_outside_soloing_objective_schema_version": (
+        OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+    ),
 }
 
 
@@ -154,19 +169,79 @@ def rubric_baseline(root: Path) -> dict:
 
 
 def followup_decision(*, quality_claim: bool = False) -> dict:
+    objective_context = {
+        "objective_source_outside_soloing_repair_evidence_ready": True,
+        "objective_source_outside_soloing_repair_wav_count": 6,
+        "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+        "objective_source_outside_soloing_repair_source_context_preserved": True,
+        "objective_source_outside_soloing_repair_schema_context_preserved": True,
+        "objective_source_outside_soloing_repair_objective_schema_version": (
+            OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+        ),
+        "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
+        "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
+        "objective_source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
+        "objective_source_outside_soloing_repair_source_targeted": False,
+        "objective_source_outside_soloing_repair_source_residual_risk_preserved": True,
+        "objective_source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+        "objective_source_outside_soloing_repair_pitch_role_risk_delta": 2,
+        "objective_source_outside_soloing_not_evaluable_count": 6,
+        "objective_repaired_outside_soloing_not_evaluable_count": 6,
+        **{f"objective_{key}": value for key, value in SOURCE_CONTEXT.items()},
+    }
+    repair_sweep_context = {
+        "repair_sweep_source_outside_soloing_repair_evidence_ready": True,
+        "repair_sweep_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
+        "repair_sweep_source_outside_soloing_repair_source_context_preserved": True,
+        "repair_sweep_source_outside_soloing_repair_schema_context_preserved": True,
+        "repair_sweep_source_outside_soloing_repair_objective_schema_version": (
+            OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+        ),
+        "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
+        "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
+        "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
+        "repair_sweep_source_outside_soloing_repair_source_targeted": False,
+        "repair_sweep_source_outside_soloing_repair_source_residual_risk_preserved": True,
+        "repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after": 0,
+        "repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta": 2,
+        "repair_sweep_source_outside_soloing_not_evaluable_count": 6,
+        "repair_sweep_repaired_outside_soloing_not_evaluable_count": 6,
+        **{f"repair_sweep_{key}": value for key, value in SOURCE_CONTEXT.items()},
+    }
     return {
+        "schema_version": FOLLOWUP_SCHEMA_VERSION,
         "boundary": FOLLOWUP_BOUNDARY,
+        "source_boundary": "stage_b_midi_to_solo_songlike_melody_contour_repair_objective_only_next_decision",
+        "repair_sweep_boundary": SOURCE_SWEEP_BOUNDARY,
+        "source_schema_versions": dict(FOLLOWUP_SOURCE_SCHEMA_VERSIONS),
         "repair_sweep_summary": {
             "remaining_failure_counts": {
                 "phrase_shape_missing_tension_release": 2,
                 "rhythmic_monotony": 2,
-            }
+            },
+            "not_evaluable_counts": {
+                "outside_soloing_without_context": 6,
+                "weak_chord_tone_landing": 6,
+            },
         },
         "selected_next_target": {
             "selected_target": FOLLOWUP_SELECTED_TARGET,
             "selected_next_boundary": FOLLOWUP_NEXT_BOUNDARY,
             "primary_remaining_failure_labels": list(TIE_TARGET_LABELS),
             "primary_remaining_failure_count": 2,
+        },
+        "followup_targets": {
+            "primary_labels": list(TIE_TARGET_LABELS),
+            "secondary_failure_counts": {
+                "phrase_shape_missing_tension_release": 2,
+                "rhythmic_monotony": 2,
+            },
+            "not_evaluable_counts": {
+                "outside_soloing_without_context": 6,
+                "weak_chord_tone_landing": 6,
+            },
+            **objective_context,
+            **repair_sweep_context,
         },
         "readiness": {
             "followup_decision_completed": True,
@@ -176,33 +251,8 @@ def followup_decision(*, quality_claim: bool = False) -> dict:
             "repaired_total_failure_label_count": 4,
             "failure_label_delta": 4,
             "technical_regression_count": 0,
-            "objective_source_outside_soloing_repair_evidence_ready": True,
-            "objective_source_outside_soloing_repair_wav_count": 6,
-            "objective_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
-            "objective_source_outside_soloing_repair_source_context_preserved": True,
-            "objective_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
-            "objective_source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
-            "objective_source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
-            "objective_source_outside_soloing_repair_source_targeted": False,
-            "objective_source_outside_soloing_repair_source_residual_risk_preserved": True,
-            "objective_source_outside_soloing_repair_pitch_role_risk_count_after": 0,
-            "objective_source_outside_soloing_repair_pitch_role_risk_delta": 2,
-            "objective_source_outside_soloing_not_evaluable_count": 6,
-            "objective_repaired_outside_soloing_not_evaluable_count": 6,
-            **{f"objective_{key}": value for key, value in SOURCE_CONTEXT.items()},
-            "repair_sweep_source_outside_soloing_repair_evidence_ready": True,
-            "repair_sweep_source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
-            "repair_sweep_source_outside_soloing_repair_source_context_preserved": True,
-            "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
-            "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
-            "repair_sweep_source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
-            "repair_sweep_source_outside_soloing_repair_source_targeted": False,
-            "repair_sweep_source_outside_soloing_repair_source_residual_risk_preserved": True,
-            "repair_sweep_source_outside_soloing_repair_pitch_role_risk_count_after": 0,
-            "repair_sweep_source_outside_soloing_repair_pitch_role_risk_delta": 2,
-            "repair_sweep_source_outside_soloing_not_evaluable_count": 6,
-            "repair_sweep_repaired_outside_soloing_not_evaluable_count": 6,
-            **{f"repair_sweep_{key}": value for key, value in SOURCE_CONTEXT.items()},
+            **objective_context,
+            **repair_sweep_context,
             "human_audio_preference_claimed": False,
             "midi_to_solo_musical_quality_claimed": quality_claim,
             "audio_rendered_quality_claimed": False,
@@ -229,6 +279,7 @@ def source_repair_sweep(*, technical_regression_count: int = 0) -> dict:
         ["phrase_shape_missing_tension_release"],
     ]
     return {
+        "schema_version": SOURCE_SWEEP_SCHEMA_VERSION,
         "boundary": SOURCE_SWEEP_BOUNDARY,
         "candidate_repairs": [
             {
@@ -262,6 +313,10 @@ def source_repair_sweep(*, technical_regression_count: int = 0) -> dict:
             "source_outside_soloing_repair_evidence_ready": True,
             "source_outside_soloing_repair_source_objective_pitch_role_risk_count": 5,
             "source_outside_soloing_repair_source_context_preserved": True,
+            "source_outside_soloing_repair_schema_context_preserved": True,
+            "source_outside_soloing_repair_objective_schema_version": (
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION
+            ),
             "source_outside_soloing_repair_source_pitch_role_risk_count_before": 5,
             "source_outside_soloing_repair_source_pitch_role_risk_count_after": 2,
             "source_outside_soloing_repair_source_pitch_role_risk_delta": 3,
@@ -329,11 +384,31 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepTest(
             self.assertGreater(summary["phrase_rhythm_failure_delta"], 0)
             self.assertEqual(summary["technical_regression_count"], 0)
             self.assertTrue(summary["source_outside_soloing_repair_evidence_ready"])
+            self.assertEqual(report["schema_version"], SCHEMA_VERSION)
+            self.assertEqual(
+                summary["source_songlike_melody_contour_repair_followup_schema_version"],
+                FOLLOWUP_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                summary["source_songlike_melody_contour_repair_sweep_schema_version"],
+                SOURCE_SWEEP_SCHEMA_VERSION,
+            )
             self.assertTrue(
                 summary["objective_source_outside_soloing_repair_source_context_preserved"]
             )
+            self.assertTrue(
+                summary["objective_source_outside_soloing_repair_schema_context_preserved"]
+            )
+            self.assertEqual(
+                summary["objective_source_outside_soloing_repair_objective_schema_version"],
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+            )
             self.assertTrue(summary["source_outside_soloing_repair_source_context_preserved"])
-            self.assertEqual(report["schema_version"], SCHEMA_VERSION)
+            self.assertTrue(summary["source_outside_soloing_repair_schema_context_preserved"])
+            self.assertEqual(
+                summary["source_outside_soloing_repair_objective_schema_version"],
+                OUTSIDE_SOLOING_REPAIR_OBJECTIVE_SCHEMA_VERSION,
+            )
             for key in BRIDGE_REQUIRED_SOURCE_CONTEXT_KEYS:
                 self.assertEqual(summary[f"objective_{key}"], SOURCE_CONTEXT[key])
                 self.assertEqual(summary[key], SOURCE_CONTEXT[key])
@@ -390,6 +465,38 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepTest(
                 build_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
                     followup_decision=followup_decision(),
                     source_repair_sweep=source_repair_sweep(technical_regression_count=1),
+                    rubric_baseline=rubric_baseline(Path(tmp)),
+                    output_dir=Path(tmp) / "phrase_rhythm_repair",
+                    issue_number=1112,
+                )
+
+    def test_rejects_followup_source_schema_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = followup_decision()
+            source["source_schema_versions"][
+                "songlike_melody_contour_repair_objective_next"
+            ] = "stale"
+            with self.assertRaises(
+                StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError
+            ):
+                build_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
+                    followup_decision=source,
+                    source_repair_sweep=source_repair_sweep(),
+                    rubric_baseline=rubric_baseline(Path(tmp)),
+                    output_dir=Path(tmp) / "phrase_rhythm_repair",
+                    issue_number=1112,
+                )
+
+    def test_rejects_source_sweep_schema_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = source_repair_sweep()
+            source["schema_version"] = "stale"
+            with self.assertRaises(
+                StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError
+            ):
+                build_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
+                    followup_decision=followup_decision(),
+                    source_repair_sweep=source,
                     rubric_baseline=rubric_baseline(Path(tmp)),
                     output_dir=Path(tmp) / "phrase_rhythm_repair",
                     issue_number=1112,
@@ -474,6 +581,23 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepTest(
                     issue_number=1112,
                 )
 
+    def test_rejects_schema_context_preservation_flag_false(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = followup_decision()
+            source["readiness"][
+                "repair_sweep_source_outside_soloing_repair_schema_context_preserved"
+            ] = False
+            with self.assertRaises(
+                StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepError
+            ):
+                build_songlike_melody_contour_phrase_rhythm_repair_sweep_report(
+                    followup_decision=source,
+                    source_repair_sweep=source_repair_sweep(),
+                    rubric_baseline=rubric_baseline(Path(tmp)),
+                    output_dir=Path(tmp) / "phrase_rhythm_repair",
+                    issue_number=1112,
+                )
+
     def test_constants_are_stable(self) -> None:
         self.assertEqual(
             BOUNDARY,
@@ -489,7 +613,7 @@ class StageBMidiToSoloSonglikeMelodyContourPhraseRhythmRepairSweepTest(
         )
         self.assertEqual(
             SCHEMA_VERSION,
-            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep_v4",
+            "stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep_v5",
         )
 
 


### PR DESCRIPTION
## Summary
- phrase/rhythm repair sweep schema v5
- follow-up decision v5 source validation reuse
- source repair sweep v5 schema mismatch guard
- source schema chain preservation
- outside-soloing schema-context preservation
- downstream audio fixture v5 contract update
- README, current status, core plan, handoff scope update

## Context
- Previous completed boundary: Issue #1194 follow-up decision source-context refresh
- selected next target: `songlike_melody_contour_phrase_rhythm_repair_sweep`
- source follow-up schema: `stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision_v5`
- source objective-next schema: `stage_b_midi_to_solo_songlike_melody_contour_repair_objective_next_v5`
- source repair sweep schema: `stage_b_midi_to_solo_songlike_melody_contour_repair_sweep_v5`
- phrase/rhythm failure count: `4 -> 1`
- total failure labels: `4 -> 1`
- technical regression count: `0`
- source outside-soloing risk: `5 -> 2`
- current repair residual pitch-role risk: `0`
- human/audio preference claim: `false`
- MIDI-to-solo musical quality claim: `false`

## Scope
- report schema: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep_v5`
- follow-up source schema mismatch block
- repair sweep source schema mismatch block
- schema-context false block
- source-context preserved false block
- next boundary retained: `stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio_package`

## Validation
- `.venv/bin/python -m py_compile scripts/run_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py tests/test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep.py`
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_followup_decision tests.test_stage_b_midi_to_solo_songlike_melody_contour_repair_sweep tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_sweep`
- `bash -n scripts/agent_harness.sh`
- `bash scripts/agent_harness.sh stage-b-midi-to-solo-songlike-melody-contour-phrase-rhythm-repair-sweep`
- `.venv/bin/python -m unittest tests.test_stage_b_midi_to_solo_songlike_melody_contour_phrase_rhythm_repair_audio`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`
- public diff scan for implementation-tool names: no matches

## Risk
- listening review input pending
- `outside_soloing_without_context` remains not evaluable: `6`
- `weak_chord_tone_landing` remains not evaluable: `6`
- remaining repaired failure count: `rhythmic_monotony=1`
- musical quality claim excluded
- next boundary: phrase/rhythm repair audio package source-context refresh

Closes #1196
