### PR TITLE
Stage B MIDI-to-solo larger sample repeatability sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ raw model generation은 note grammar가 자주 깨졌다.
 - listening input guard: validated input `false`, preference fill `false`, next `objective_only_next_decision`
 - objective-only decision: candidate `8`, selected objective candidates `4`, musical quality claim `false`
 - next boundary: `music_transformer_solo_yield_larger_sample_repeatability_sweep`
+- larger sample repeatability: total candidates `48`, strict `47 / 48`, grammar-valid `48 / 48`
+- larger sample min case strict rate: `0.9167`, rendered WAV files `12`, musical quality claim `false`
 
 ## 결과 파일
 
@@ -104,6 +106,7 @@ Report:
 - `docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_CANDIDATE_LISTENING_PACKAGE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_LISTENING_INPUT_GUARD_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_REPEATABILITY_SWEEP_2026-06-11.md`
 
 ## 실행 방법
 
@@ -173,4 +176,5 @@ Report:
 - listening review input guard
 - objective-only next decision
 - larger sample repeatability sweep
+- larger sample candidate listening review package
 - 더 긴 4마디 phrase로 확장 검토

--- a/docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_REPEATABILITY_SWEEP_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_REPEATABILITY_SWEEP_2026-06-11.md
@@ -1,0 +1,55 @@
+# Stage B MIDI-to-Solo Chord Progression Yield Sweep
+
+## Summary
+
+- checkpoint generation used: `true`
+- constrained decoding used: `true`
+- case count: `4`
+- sample count: `48`
+- duration mode: `fill`
+- valid yield: `47` / `48`
+- strict yield: `47` / `48`
+- grammar yield: `48` / `48`
+- strict yield rate: `0.9792`
+- min case strict yield rate: `0.9167`
+- selected MIDI candidates: `12`
+- rendered WAV files: `12`
+- total yield floor passed: `true`
+- all case yield floor passed: `true`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_candidate_listening_review`
+
+## Cases
+
+| case | chords | seed | strict | valid | grammar | strict rate | avg notes | avg dead air | package |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---|
+| `minor_backdoor` | `Cm7,F7,Bbmaj7,Ebmaj7` | 1200 | 11/12 | 11/12 | 12/12 | 0.9167 | 16.55 | 0.5885 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1232_fill_n10_sample12_repeatability/packages/01_minor_backdoor_seed_1200/solo_yield_package.json` |
+| `major_ii_v_turnaround` | `Dm7,G7,Cmaj7,A7` | 1241 | 12/12 | 12/12 | 12/12 | 1.0000 | 17.42 | 0.6102 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1232_fill_n10_sample12_repeatability/packages/02_major_ii_v_turnaround_seed_1241/solo_yield_package.json` |
+| `dominant_cycle` | `Em7,A7,Dmaj7,G7` | 1282 | 12/12 | 12/12 | 12/12 | 1.0000 | 16.83 | 0.6089 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1232_fill_n10_sample12_repeatability/packages/03_dominant_cycle_seed_1282/solo_yield_package.json` |
+| `rhythm_turnaround` | `Bbmaj7,G7,Cm7,F7` | 1323 | 12/12 | 12/12 | 12/12 | 1.0000 | 16.50 | 0.6349 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1232_fill_n10_sample12_repeatability/packages/04_rhythm_turnaround_seed_1323/solo_yield_package.json` |
+
+## Failing Cases
+
+- `none`
+
+## WAV Files
+
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1232_fill_n10_sample12_repeatability/packages/01_minor_backdoor_seed_1200/audio/candidate_01_sample_11.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1232_fill_n10_sample12_repeatability/packages/01_minor_backdoor_seed_1200/audio/candidate_02_sample_07.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1232_fill_n10_sample12_repeatability/packages/01_minor_backdoor_seed_1200/audio/candidate_03_sample_06.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1232_fill_n10_sample12_repeatability/packages/02_major_ii_v_turnaround_seed_1241/audio/candidate_01_sample_10.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1232_fill_n10_sample12_repeatability/packages/02_major_ii_v_turnaround_seed_1241/audio/candidate_02_sample_02.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1232_fill_n10_sample12_repeatability/packages/02_major_ii_v_turnaround_seed_1241/audio/candidate_03_sample_07.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1232_fill_n10_sample12_repeatability/packages/03_dominant_cycle_seed_1282/audio/candidate_01_sample_06.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1232_fill_n10_sample12_repeatability/packages/03_dominant_cycle_seed_1282/audio/candidate_02_sample_05.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1232_fill_n10_sample12_repeatability/packages/03_dominant_cycle_seed_1282/audio/candidate_03_sample_07.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1232_fill_n10_sample12_repeatability/packages/04_rhythm_turnaround_seed_1323/audio/candidate_01_sample_06.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1232_fill_n10_sample12_repeatability/packages/04_rhythm_turnaround_seed_1323/audio/candidate_02_sample_02.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1232_fill_n10_sample12_repeatability/packages/04_rhythm_turnaround_seed_1323/audio/candidate_03_sample_12.wav`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`


### PR DESCRIPTION
## Summary
- Stage B MIDI-to-solo larger sample repeatability sweep 기록
- 4 progression, 총 48 후보 기준 objective gate 수율 재측정
- strict 47/48, grammar 48/48, min case strict rate 0.9167
- rendered WAV 12개 생성 경로 기록

## Context
- Issue #1224 repaired progression retry: strict 24/24, grammar 24/24
- Issue #1230 objective-only next decision: next boundary larger sample repeatability sweep
- 청취 입력 미확인 상태이므로 음악적 품질 claim 제외
- 확인 대상: 후보 수 증가 후 objective gate 수율 유지 여부

## Scope
- 기존 chord progression sweep script 실행 결과 문서화
- sample_count per case 12, total candidates 48
- duration_mode fill, note_groups_per_bar 10 유지
- README evidence와 다음 작업 갱신

## Validation
- .venv/bin/python scripts/run_music_transformer_solo_yield_sweep.py --output_root outputs/music_transformer_finetune_mvp/solo_yield_sweep --run_id issue_1232_fill_n10_sample12_repeatability --sample_count 12 --top_n 3 --seed_start 1200 --seed_stride 41 --duration_mode fill --note_groups_per_bar 10 --min_total_strict_yield_rate 0.8 --min_case_strict_yield_rate 0.75 --min_cases 4 --require_no_quality_claim --doc_path docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_REPEATABILITY_SWEEP_2026-06-11.md
- .venv/bin/python -m py_compile scripts/run_music_transformer_solo_yield_sweep.py scripts/build_music_transformer_solo_yield_package.py
- git diff --check
- rg -n "codex|Codex|CODEX|ChatGPT|Claude|assistant" README.md docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_REPEATABILITY_SWEEP_2026-06-11.md
- bash scripts/agent_harness.sh quick

## Risk
- 1개 후보 strict/valid gate 미통과
- floor 기준은 통과했지만 품질 선호 판단 없음
- 2마디 candidate 범위 유지

## Follow-up
- larger sample candidate listening review package
- 사람 기준 청취 입력 확보 전까지 preference fill 차단 유지
- 4마디 phrase 확장 검토

Closes #1232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive report documenting test run results with yield statistics and validation metrics.
  * Updated project documentation with latest test results summary and available resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->