### PR TITLE
Stage B MIDI-to-solo larger sample listening package

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ raw model generation은 note grammar가 자주 깨졌다.
 - next boundary: `music_transformer_solo_yield_larger_sample_repeatability_sweep`
 - larger sample repeatability: total candidates `48`, strict `47 / 48`, grammar-valid `48 / 48`
 - larger sample min case strict rate: `0.9167`, rendered WAV files `12`, musical quality claim `false`
+- larger sample listening package: MIDI `12`, WAV `12`, review input template ready
 
 ## 결과 파일
 
@@ -107,6 +108,7 @@ Report:
 - `docs/STAGE_B_MIDI_TO_SOLO_LISTENING_INPUT_GUARD_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_REPEATABILITY_SWEEP_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_PACKAGE_2026-06-11.md`
 
 ## 실행 방법
 
@@ -177,4 +179,5 @@ Report:
 - objective-only next decision
 - larger sample repeatability sweep
 - larger sample candidate listening review package
+- larger sample listening input guard
 - 더 긴 4마디 phrase로 확장 검토

--- a/docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_PACKAGE_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_PACKAGE_2026-06-11.md
@@ -1,0 +1,41 @@
+# Music Transformer Solo Yield Listening Review Package
+
+## Summary
+
+- source strict yield: `47` / `48`
+- source strict yield rate: `0.9792`
+- source rendered audio files: `12`
+- review candidate count: `12`
+- MIDI files copied: `12`
+- WAV files copied: `12`
+- validated listening input present: `false`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_listening_input_guard`
+
+## Candidates
+
+| review | case | chords | score | notes | dead air | WAV | MIDI |
+|---:|---|---|---:|---:|---:|---|---|
+| 1 | `minor_backdoor` | `Cm7,F7,Bbmaj7,Ebmaj7` | 230.026 | 17 | 0.5625 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_01_minor_backdoor_rank_01.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/midi/candidate_01_minor_backdoor_rank_01.mid` |
+| 2 | `minor_backdoor` | `Cm7,F7,Bbmaj7,Ebmaj7` | 229.765 | 17 | 0.6250 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_02_minor_backdoor_rank_02.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/midi/candidate_02_minor_backdoor_rank_02.mid` |
+| 3 | `minor_backdoor` | `Cm7,F7,Bbmaj7,Ebmaj7` | 228.613 | 17 | 0.4375 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_03_minor_backdoor_rank_03.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/midi/candidate_03_minor_backdoor_rank_03.mid` |
+| 4 | `major_ii_v_turnaround` | `Dm7,G7,Cmaj7,A7` | 230.283 | 18 | 0.5882 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_04_major_ii_v_turnaround_rank_01.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/midi/candidate_04_major_ii_v_turnaround_rank_01.mid` |
+| 5 | `major_ii_v_turnaround` | `Dm7,G7,Cmaj7,A7` | 229.244 | 18 | 0.6471 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_05_major_ii_v_turnaround_rank_02.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/midi/candidate_05_major_ii_v_turnaround_rank_02.mid` |
+| 6 | `major_ii_v_turnaround` | `Dm7,G7,Cmaj7,A7` | 228.966 | 17 | 0.5625 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_06_major_ii_v_turnaround_rank_03.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/midi/candidate_06_major_ii_v_turnaround_rank_03.mid` |
+| 7 | `dominant_cycle` | `Em7,A7,Dmaj7,G7` | 230.626 | 19 | 0.5000 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_07_dominant_cycle_rank_01.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/midi/candidate_07_dominant_cycle_rank_01.mid` |
+| 8 | `dominant_cycle` | `Em7,A7,Dmaj7,G7` | 230.020 | 18 | 0.5882 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_08_dominant_cycle_rank_02.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/midi/candidate_08_dominant_cycle_rank_02.mid` |
+| 9 | `dominant_cycle` | `Em7,A7,Dmaj7,G7` | 229.321 | 17 | 0.5625 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_09_dominant_cycle_rank_03.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/midi/candidate_09_dominant_cycle_rank_03.mid` |
+| 10 | `rhythm_turnaround` | `Bbmaj7,G7,Cm7,F7` | 231.259 | 18 | 0.5882 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_10_rhythm_turnaround_rank_01.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/midi/candidate_10_rhythm_turnaround_rank_01.mid` |
+| 11 | `rhythm_turnaround` | `Bbmaj7,G7,Cm7,F7` | 229.886 | 18 | 0.5294 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_11_rhythm_turnaround_rank_02.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/midi/candidate_11_rhythm_turnaround_rank_02.mid` |
+| 12 | `rhythm_turnaround` | `Bbmaj7,G7,Cm7,F7` | 229.321 | 17 | 0.6250 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_12_rhythm_turnaround_rank_03.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/midi/candidate_12_rhythm_turnaround_rank_03.mid` |
+
+## Review Input
+
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/listening_review_input_template.json`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`


### PR DESCRIPTION
## Summary
- Stage B MIDI-to-solo larger sample listening review package 기록
- 후보 MIDI 12개, WAV 12개 복사
- review input template 생성
- validated listening input=false, musical quality claim=false 유지

## Context
- Issue #1232 larger sample repeatability 결과: strict 47/48, grammar 48/48
- rendered WAV files 12
- 다음 검토 대상: candidate listening review package
- 청취 입력 전까지 preference/quality 판단 제외

## Scope
- larger sample sweep report 기반 listening package 생성
- candidate path, score, note count, dead-air metric 기록
- review input template 경로 기록
- README evidence와 다음 작업 갱신

## Validation
- .venv/bin/python scripts/build_music_transformer_solo_yield_listening_package.py --sweep_report outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1232_fill_n10_sample12_repeatability/solo_yield_sweep_report.json --output_root outputs/music_transformer_finetune_mvp/solo_yield_listening_review --run_id issue_1234_larger_sample_top12_listening_package --max_candidates 12 --min_candidates 12 --require_no_quality_claim --doc_path docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_PACKAGE_2026-06-11.md
- .venv/bin/python -m py_compile scripts/build_music_transformer_solo_yield_listening_package.py scripts/run_music_transformer_solo_yield_sweep.py
- git diff --check
- rg -n "codex|Codex|CODEX|ChatGPT|Claude|assistant" README.md docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_PACKAGE_2026-06-11.md
- bash scripts/agent_harness.sh quick

## Risk
- 청취 선호 입력 미포함
- objective score 기반 후보 정렬만 제공
- 2마디 후보 범위 유지

## Follow-up
- larger sample listening input guard
- pending review fields 확인
- 4마디 phrase 확장 검토

Closes #1234