### PR TITLE
Stage B MIDI-to-solo larger sample listening input guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ raw model generation은 note grammar가 자주 깨졌다.
 - larger sample repeatability: total candidates `48`, strict `47 / 48`, grammar-valid `48 / 48`
 - larger sample min case strict rate: `0.9167`, rendered WAV files `12`, musical quality claim `false`
 - larger sample listening package: MIDI `12`, WAV `12`, review input template ready
+- larger sample input guard: validated input `false`, preference fill `false`, pending candidate fields `36`
+- next boundary: `music_transformer_solo_yield_objective_only_next_decision`
 
 ## 결과 파일
 
@@ -109,6 +111,7 @@ Report:
 - `docs/STAGE_B_MIDI_TO_SOLO_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_REPEATABILITY_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_PACKAGE_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_INPUT_GUARD_2026-06-11.md`
 
 ## 실행 방법
 
@@ -180,4 +183,5 @@ Report:
 - larger sample repeatability sweep
 - larger sample candidate listening review package
 - larger sample listening input guard
+- larger sample objective-only next decision
 - 더 긴 4마디 phrase로 확장 검토

--- a/docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_INPUT_GUARD_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_INPUT_GUARD_2026-06-11.md
@@ -1,0 +1,36 @@
+# Music Transformer Solo Yield Listening Input Guard
+
+## Summary
+
+- source candidate count: `12`
+- listening input path: `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/listening_review_input_template.json`
+- validated listening input present: `false`
+- preference fill allowed: `false`
+- objective-only next decision required: `true`
+- pending status: `true`
+- pending overall decision: `true`
+- pending candidate field count: `36`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_objective_only_next_decision`
+
+## Pending Candidate Fields
+
+- review `1`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `2`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `3`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `4`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `5`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `6`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `7`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `8`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `9`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `10`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `11`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `12`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`


### PR DESCRIPTION
## Summary
- Stage B MIDI-to-solo larger sample listening input guard 기록
- source candidate count 12
- validated listening input=false, preference fill=false
- pending candidate field count 36
- next boundary: objective-only next decision

## Context
- Issue #1234 listening package 결과: MIDI 12개, WAV 12개, review input template 생성
- review input template은 pending 상태
- 청취 입력 없이 선호/품질 판단 불가
- objective-only 경로 유지 필요

## Scope
- listening input guard 실행 결과 문서화
- pending status, pending overall decision, pending candidate fields 기록
- README evidence와 다음 작업 갱신

## Validation
- .venv/bin/python scripts/guard_music_transformer_solo_yield_listening_input.py --package_report outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/listening_review_package.json --output_root outputs/music_transformer_finetune_mvp/solo_yield_listening_input_guard --run_id issue_1236_larger_sample_listening_input_guard --require_no_quality_claim --doc_path docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_INPUT_GUARD_2026-06-11.md
- .venv/bin/python -m py_compile scripts/guard_music_transformer_solo_yield_listening_input.py scripts/build_music_transformer_solo_yield_listening_package.py
- git diff --check
- rg -n "codex|Codex|CODEX|ChatGPT|Claude|assistant" README.md docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_INPUT_GUARD_2026-06-11.md
- bash scripts/agent_harness.sh quick

## Risk
- 사람 기준 청취 입력 미포함
- objective-only next decision은 품질 판단 아님
- pending candidate fields 36 유지

## Follow-up
- larger sample objective-only next decision
- 후보 수 증가 기준 다음 검증 단위 선택
- 4마디 phrase 확장 검토

Closes #1236