### PR TITLE
Stage B MIDI-to-solo larger sample objective-only next decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ raw model generation은 note grammar가 자주 깨졌다.
 - larger sample listening package: MIDI `12`, WAV `12`, review input template ready
 - larger sample input guard: validated input `false`, preference fill `false`, pending candidate fields `36`
 - next boundary: `music_transformer_solo_yield_objective_only_next_decision`
+- larger sample objective-only decision: candidate `12`, selected objective candidates `6`, musical quality claim `false`
+- next boundary: `music_transformer_solo_yield_4bar_phrase_expansion_probe`
 
 ## 결과 파일
 
@@ -112,6 +114,7 @@ Report:
 - `docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_REPEATABILITY_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_PACKAGE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_INPUT_GUARD_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md`
 
 ## 실행 방법
 
@@ -184,4 +187,5 @@ Report:
 - larger sample candidate listening review package
 - larger sample listening input guard
 - larger sample objective-only next decision
+- 4bar phrase expansion probe
 - 더 긴 4마디 phrase로 확장 검토

--- a/docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md
@@ -1,0 +1,31 @@
+# Music Transformer Solo Yield Objective-Only Next Decision
+
+## Summary
+
+- candidate count: `12`
+- selected objective candidates: `6`
+- score range: `228.613` - `231.259`
+- note count range: `17` - `19`
+- dead-air range: `0.4375` - `0.6471`
+- validated listening input present: `false`
+- preference fill allowed: `false`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_4bar_phrase_expansion_probe`
+
+## Selected Objective Candidates
+
+| review | case | score | notes | dead air | WAV |
+|---:|---|---:|---:|---:|---|
+| 10 | `rhythm_turnaround` | 231.259 | 18 | 0.5882 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_10_rhythm_turnaround_rank_01.wav` |
+| 7 | `dominant_cycle` | 230.626 | 19 | 0.5000 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_07_dominant_cycle_rank_01.wav` |
+| 4 | `major_ii_v_turnaround` | 230.283 | 18 | 0.5882 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_04_major_ii_v_turnaround_rank_01.wav` |
+| 1 | `minor_backdoor` | 230.026 | 17 | 0.5625 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_01_minor_backdoor_rank_01.wav` |
+| 8 | `dominant_cycle` | 230.020 | 18 | 0.5882 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_08_dominant_cycle_rank_02.wav` |
+| 11 | `rhythm_turnaround` | 229.886 | 18 | 0.5294 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/audio/candidate_11_rhythm_turnaround_rank_02.wav` |
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`

--- a/scripts/decide_music_transformer_solo_yield_objective_next.py
+++ b/scripts/decide_music_transformer_solo_yield_objective_next.py
@@ -93,6 +93,8 @@ def build_decision(
     *,
     output_dir: Path,
     top_n: int,
+    pending_next_boundary: str = "music_transformer_solo_yield_larger_sample_repeatability_sweep",
+    pending_reason: str = "listening input pending; objective yield is clean, so increase sample count before quality claim",
 ) -> dict[str, Any]:
     output_dir.mkdir(parents=True, exist_ok=True)
     guard_readiness = _dict(guard_report.get("readiness"))
@@ -100,8 +102,8 @@ def build_decision(
         next_boundary = "music_transformer_solo_yield_listening_review_fill"
         reason = "validated listening input present"
     else:
-        next_boundary = "music_transformer_solo_yield_larger_sample_repeatability_sweep"
-        reason = "listening input pending; objective yield is clean, so increase sample count before quality claim"
+        next_boundary = pending_next_boundary
+        reason = pending_reason
     candidates = [_dict(row) for row in _list(package_report.get("candidates"))]
     ranked = rank_candidates(candidates)
     selected = ranked[: int(top_n)]
@@ -121,6 +123,11 @@ def build_decision(
                 _dict(guard_report.get("input_validation")).get("validated_listening_input_present", False)
             ),
             "preference_fill_allowed": bool(guard_readiness.get("preference_fill_allowed", False)),
+        },
+        "request": {
+            "top_n": int(top_n),
+            "pending_next_boundary": pending_next_boundary,
+            "pending_reason": pending_reason,
         },
         "objective_summary": objective_summary(candidates),
         "selected_objective_candidates": selected,
@@ -233,6 +240,16 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run_id", type=str, default=None)
     parser.add_argument("--top_n", type=int, default=4)
+    parser.add_argument(
+        "--pending_next_boundary",
+        type=str,
+        default="music_transformer_solo_yield_larger_sample_repeatability_sweep",
+    )
+    parser.add_argument(
+        "--pending_reason",
+        type=str,
+        default="listening input pending; objective yield is clean, so increase sample count before quality claim",
+    )
     parser.add_argument("--doc_path", type=str, default="")
     parser.add_argument("--require_no_quality_claim", action="store_true")
     return parser
@@ -247,6 +264,8 @@ def main() -> int:
         read_json(Path(args.guard_report)),
         output_dir=output_dir,
         top_n=int(args.top_n),
+        pending_next_boundary=str(args.pending_next_boundary),
+        pending_reason=str(args.pending_reason),
     )
     summary = validate_report(report, require_no_quality_claim=bool(args.require_no_quality_claim))
     if args.doc_path:

--- a/tests/test_music_transformer_solo_yield_objective_next.py
+++ b/tests/test_music_transformer_solo_yield_objective_next.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.decide_music_transformer_solo_yield_objective_next import (
+    build_decision,
+    validate_report,
+)
+
+
+def package_report() -> dict:
+    return {
+        "schema_version": "music_transformer_solo_yield_listening_package_v1",
+        "output_dir": "outputs/package",
+        "candidate_count": 3,
+        "candidates": [
+            {
+                "review_index": 1,
+                "case_label": "minor_backdoor",
+                "score": 230.0,
+                "note_count": 17,
+                "dead_air_ratio": 0.5,
+                "direction_change_ratio": 0.4,
+                "syncopated_onset_ratio": 0.3,
+                "review_wav_path": "outputs/package/audio/candidate_01.wav",
+            },
+            {
+                "review_index": 2,
+                "case_label": "dominant_cycle",
+                "score": 232.0,
+                "note_count": 18,
+                "dead_air_ratio": 0.6,
+                "direction_change_ratio": 0.5,
+                "syncopated_onset_ratio": 0.2,
+                "review_wav_path": "outputs/package/audio/candidate_02.wav",
+            },
+            {
+                "review_index": 3,
+                "case_label": "rhythm_turnaround",
+                "score": 231.0,
+                "note_count": 19,
+                "dead_air_ratio": 0.4,
+                "direction_change_ratio": 0.2,
+                "syncopated_onset_ratio": 0.4,
+                "review_wav_path": "outputs/package/audio/candidate_03.wav",
+            },
+        ],
+    }
+
+
+def guard_report(*, preference_fill_allowed: bool = False) -> dict:
+    return {
+        "schema_version": "music_transformer_solo_yield_listening_input_guard_v1",
+        "output_dir": "outputs/guard",
+        "input_validation": {
+            "validated_listening_input_present": preference_fill_allowed,
+        },
+        "readiness": {
+            "preference_fill_allowed": preference_fill_allowed,
+        },
+    }
+
+
+class MusicTransformerSoloYieldObjectiveNextTest(unittest.TestCase):
+    def test_pending_input_keeps_default_next_boundary(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            report = build_decision(
+                package_report(),
+                guard_report(),
+                output_dir=Path(temp_dir) / "decision",
+                top_n=2,
+            )
+        summary = validate_report(report, require_no_quality_claim=True)
+
+        self.assertEqual(summary["candidate_count"], 3)
+        self.assertEqual(summary["selected_objective_candidate_count"], 2)
+        self.assertFalse(summary["validated_listening_input_present"])
+        self.assertFalse(summary["preference_fill_allowed"])
+        self.assertEqual(
+            summary["next_boundary"],
+            "music_transformer_solo_yield_larger_sample_repeatability_sweep",
+        )
+
+    def test_pending_input_accepts_explicit_next_boundary(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            report = build_decision(
+                package_report(),
+                guard_report(),
+                output_dir=Path(temp_dir) / "decision",
+                top_n=2,
+                pending_next_boundary="music_transformer_solo_yield_4bar_phrase_expansion_probe",
+                pending_reason="larger sample objective package complete; expand phrase length",
+            )
+        summary = validate_report(report, require_no_quality_claim=True)
+
+        self.assertEqual(
+            summary["next_boundary"],
+            "music_transformer_solo_yield_4bar_phrase_expansion_probe",
+        )
+        self.assertEqual(
+            report["decision"]["reason"],
+            "larger sample objective package complete; expand phrase length",
+        )
+
+    def test_validated_input_routes_to_preference_fill(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            report = build_decision(
+                package_report(),
+                guard_report(preference_fill_allowed=True),
+                output_dir=Path(temp_dir) / "decision",
+                top_n=2,
+                pending_next_boundary="music_transformer_solo_yield_4bar_phrase_expansion_probe",
+            )
+        summary = validate_report(report, require_no_quality_claim=True)
+
+        self.assertTrue(summary["validated_listening_input_present"])
+        self.assertTrue(summary["preference_fill_allowed"])
+        self.assertEqual(summary["next_boundary"], "music_transformer_solo_yield_listening_review_fill")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Stage B MIDI-to-solo larger sample objective-only next decision 기록
- pending listening input 상태에서 다음 boundary 명시 옵션 추가
- 12개 후보 중 objective 상위 6개 선정
- next boundary: 4bar phrase expansion probe

## Context
- Issue #1236 input guard: validated input=false, preference fill=false, pending candidate fields=36
- 기존 objective decision 기본 next boundary는 larger sample repeatability sweep
- larger sample repeatability는 Issue #1232에서 완료
- 동일 boundary 반복 방지 및 다음 검증 단위 지정 필요

## Scope
- objective decision script에 pending next boundary 옵션 추가
- 기존 기본값 유지
- larger sample package/guard 기준 objective decision 문서화
- focused unit test 추가
- README evidence와 다음 작업 갱신

## Validation
- .venv/bin/python scripts/decide_music_transformer_solo_yield_objective_next.py --package_report outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1234_larger_sample_top12_listening_package/listening_review_package.json --guard_report outputs/music_transformer_finetune_mvp/solo_yield_listening_input_guard/issue_1236_larger_sample_listening_input_guard/listening_input_guard.json --output_root outputs/music_transformer_finetune_mvp/solo_yield_objective_next_decision --run_id issue_1238_larger_sample_objective_next_decision --top_n 6 --pending_next_boundary music_transformer_solo_yield_4bar_phrase_expansion_probe --pending_reason "larger sample objective package complete; expand phrase length before quality claim" --require_no_quality_claim --doc_path docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md
- .venv/bin/python -m unittest tests/test_music_transformer_solo_yield_objective_next.py
- .venv/bin/python -m py_compile scripts/decide_music_transformer_solo_yield_objective_next.py tests/test_music_transformer_solo_yield_objective_next.py
- git diff --check
- rg -n "codex|Codex|CODEX|ChatGPT|Claude|assistant" README.md docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md scripts/decide_music_transformer_solo_yield_objective_next.py tests/test_music_transformer_solo_yield_objective_next.py
- bash scripts/agent_harness.sh quick

## Risk
- 청취 입력 없는 objective-only 판단
- 음악적 품질 claim 제외
- 4bar 확장은 다음 검증 단위이며 현재 PR 범위 아님

## Follow-up
- 4bar phrase expansion probe
- 4마디 후보 strict/grammar/pass-rate 측정
- 필요 시 4bar audio package 생성

Closes #1238