### PR TITLE
Stage B MIDI-to-solo 4bar phrase expansion probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ raw model generation은 note grammar가 자주 깨졌다.
 - next boundary: `music_transformer_solo_yield_objective_only_next_decision`
 - larger sample objective-only decision: candidate `12`, selected objective candidates `6`, musical quality claim `false`
 - next boundary: `music_transformer_solo_yield_4bar_phrase_expansion_probe`
+- 4bar phrase expansion: total candidates `24`, strict `20 / 24`, grammar-valid `24 / 24`
+- 4bar min case strict rate: `0.6667`, rendered WAV files `8`, musical quality claim `false`
 
 ## 결과 파일
 
@@ -115,6 +117,7 @@ Report:
 - `docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_PACKAGE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_LISTENING_INPUT_GUARD_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_4BAR_PHRASE_EXPANSION_PROBE_2026-06-11.md`
 
 ## 실행 방법
 
@@ -188,4 +191,5 @@ Report:
 - larger sample listening input guard
 - larger sample objective-only next decision
 - 4bar phrase expansion probe
+- 4bar candidate listening review package
 - 더 긴 4마디 phrase로 확장 검토

--- a/docs/STAGE_B_MIDI_TO_SOLO_4BAR_PHRASE_EXPANSION_PROBE_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_4BAR_PHRASE_EXPANSION_PROBE_2026-06-11.md
@@ -1,0 +1,51 @@
+# Stage B MIDI-to-Solo Chord Progression Yield Sweep
+
+## Summary
+
+- checkpoint generation used: `true`
+- constrained decoding used: `true`
+- case count: `4`
+- sample count: `24`
+- duration mode: `fill`
+- valid yield: `20` / `24`
+- strict yield: `20` / `24`
+- grammar yield: `24` / `24`
+- strict yield rate: `0.8333`
+- min case strict yield rate: `0.6667`
+- selected MIDI candidates: `8`
+- rendered WAV files: `8`
+- total yield floor passed: `true`
+- all case yield floor passed: `true`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_candidate_listening_review`
+
+## Cases
+
+| case | chords | seed | strict | valid | grammar | strict rate | avg notes | avg dead air | package |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---|
+| `minor_backdoor` | `Cm7,F7,Bbmaj7,Ebmaj7` | 1500 | 4/6 | 4/6 | 6/6 | 0.6667 | 27.75 | 0.7571 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1240_4bar_phrase_expansion_probe/packages/01_minor_backdoor_seed_1500/solo_yield_package.json` |
+| `major_ii_v_turnaround` | `Dm7,G7,Cmaj7,A7` | 1543 | 6/6 | 6/6 | 6/6 | 1.0000 | 27.33 | 0.7526 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1240_4bar_phrase_expansion_probe/packages/02_major_ii_v_turnaround_seed_1543/solo_yield_package.json` |
+| `dominant_cycle` | `Em7,A7,Dmaj7,G7` | 1586 | 5/6 | 5/6 | 6/6 | 0.8333 | 29.20 | 0.7171 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1240_4bar_phrase_expansion_probe/packages/03_dominant_cycle_seed_1586/solo_yield_package.json` |
+| `rhythm_turnaround` | `Bbmaj7,G7,Cm7,F7` | 1629 | 5/6 | 5/6 | 6/6 | 0.8333 | 28.00 | 0.7337 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1240_4bar_phrase_expansion_probe/packages/04_rhythm_turnaround_seed_1629/solo_yield_package.json` |
+
+## Failing Cases
+
+- `none`
+
+## WAV Files
+
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1240_4bar_phrase_expansion_probe/packages/01_minor_backdoor_seed_1500/audio/candidate_01_sample_06.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1240_4bar_phrase_expansion_probe/packages/01_minor_backdoor_seed_1500/audio/candidate_02_sample_04.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1240_4bar_phrase_expansion_probe/packages/02_major_ii_v_turnaround_seed_1543/audio/candidate_01_sample_01.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1240_4bar_phrase_expansion_probe/packages/02_major_ii_v_turnaround_seed_1543/audio/candidate_02_sample_04.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1240_4bar_phrase_expansion_probe/packages/03_dominant_cycle_seed_1586/audio/candidate_01_sample_06.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1240_4bar_phrase_expansion_probe/packages/03_dominant_cycle_seed_1586/audio/candidate_02_sample_03.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1240_4bar_phrase_expansion_probe/packages/04_rhythm_turnaround_seed_1629/audio/candidate_01_sample_02.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1240_4bar_phrase_expansion_probe/packages/04_rhythm_turnaround_seed_1629/audio/candidate_02_sample_05.wav`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`


### PR DESCRIPTION
## Summary
- Stage B MIDI-to-solo 4bar phrase expansion probe 기록
- 4 progression, 4마디, 총 24 후보 sweep
- strict 20/24, grammar 24/24, min case strict rate 0.6667
- rendered WAV 8개 생성 경로 기록

## Context
- Issue #1238 objective-only decision: next boundary 4bar phrase expansion probe
- 2마디 larger sample 결과: strict 47/48, grammar 48/48
- 4마디 확장 시 sequence/note-count 압박 가능
- 확인 대상: 4마디 조건에서 objective gate 유지 여부

## Scope
- 기존 chord progression sweep script 재사용
- bars=4, sample_count per case=6
- duration_mode fill, note_groups_per_bar=8, max_sequence=160
- README evidence와 다음 작업 갱신

## Validation
- .venv/bin/python scripts/run_music_transformer_solo_yield_sweep.py --output_root outputs/music_transformer_finetune_mvp/solo_yield_sweep --run_id issue_1240_4bar_phrase_expansion_probe --sample_count 6 --top_n 2 --seed_start 1500 --seed_stride 43 --bars 4 --duration_mode fill --note_groups_per_bar 8 --max_sequence 160 --min_total_strict_yield_rate 0.5 --min_case_strict_yield_rate 0.25 --min_cases 4 --require_no_quality_claim --doc_path docs/STAGE_B_MIDI_TO_SOLO_4BAR_PHRASE_EXPANSION_PROBE_2026-06-11.md
- .venv/bin/python -m py_compile scripts/run_music_transformer_solo_yield_sweep.py scripts/build_music_transformer_solo_yield_package.py
- git diff --check
- rg -n "codex|Codex|CODEX|ChatGPT|Claude|assistant" README.md docs/STAGE_B_MIDI_TO_SOLO_4BAR_PHRASE_EXPANSION_PROBE_2026-06-11.md
- bash scripts/agent_harness.sh quick

## Risk
- 4개 후보 strict/valid gate 미통과
- 2마디 대비 strict yield 하락
- 음악적 품질 claim 제외

## Follow-up
- 4bar candidate listening review package
- 4bar input guard
- 4bar objective-only next decision

Closes #1240