### PR TITLE
Stage B MIDI-to-solo 4bar listening input guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ raw model generation은 note grammar가 자주 깨졌다.
 - 4bar phrase expansion: total candidates `24`, strict `20 / 24`, grammar-valid `24 / 24`
 - 4bar min case strict rate: `0.6667`, rendered WAV files `8`, musical quality claim `false`
 - 4bar listening package: MIDI `8`, WAV `8`, review input template ready
+- 4bar input guard: validated input `false`, preference fill `false`, pending candidate fields `24`
+- next boundary: `music_transformer_solo_yield_objective_only_next_decision`
 
 ## 결과 파일
 
@@ -120,6 +122,7 @@ Report:
 - `docs/STAGE_B_MIDI_TO_SOLO_LARGER_SAMPLE_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_4BAR_PHRASE_EXPANSION_PROBE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_4BAR_LISTENING_PACKAGE_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_4BAR_LISTENING_INPUT_GUARD_2026-06-11.md`
 
 ## 실행 방법
 
@@ -195,4 +198,5 @@ Report:
 - 4bar phrase expansion probe
 - 4bar candidate listening review package
 - 4bar listening input guard
+- 4bar objective-only next decision
 - 더 긴 4마디 phrase로 확장 검토

--- a/docs/STAGE_B_MIDI_TO_SOLO_4BAR_LISTENING_INPUT_GUARD_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_4BAR_LISTENING_INPUT_GUARD_2026-06-11.md
@@ -1,0 +1,32 @@
+# Music Transformer Solo Yield Listening Input Guard
+
+## Summary
+
+- source candidate count: `8`
+- listening input path: `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1242_4bar_top8_listening_package/listening_review_input_template.json`
+- validated listening input present: `false`
+- preference fill allowed: `false`
+- objective-only next decision required: `true`
+- pending status: `true`
+- pending overall decision: `true`
+- pending candidate field count: `24`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_objective_only_next_decision`
+
+## Pending Candidate Fields
+
+- review `1`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `2`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `3`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `4`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `5`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `6`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `7`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `8`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`


### PR DESCRIPTION
## Summary
- Stage B MIDI-to-solo 4bar listening input guard 기록
- source candidate count 8
- validated listening input=false, preference fill=false
- pending candidate field count 24
- next boundary: objective-only next decision

## Context
- Issue #1242 4bar listening package 결과: MIDI 8개, WAV 8개, review input template 생성
- review input template은 pending 상태
- 청취 입력 없이 선호/품질 판단 불가
- objective-only 경로 유지 필요

## Scope
- listening input guard 실행 결과 문서화
- pending status, pending overall decision, pending candidate fields 기록
- README evidence와 다음 작업 갱신

## Validation
- .venv/bin/python scripts/guard_music_transformer_solo_yield_listening_input.py --package_report outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1242_4bar_top8_listening_package/listening_review_package.json --output_root outputs/music_transformer_finetune_mvp/solo_yield_listening_input_guard --run_id issue_1244_4bar_listening_input_guard --require_no_quality_claim --doc_path docs/STAGE_B_MIDI_TO_SOLO_4BAR_LISTENING_INPUT_GUARD_2026-06-11.md
- .venv/bin/python -m py_compile scripts/guard_music_transformer_solo_yield_listening_input.py scripts/build_music_transformer_solo_yield_listening_package.py
- git diff --check
- rg -n "codex|Codex|CODEX|ChatGPT|Claude|assistant" README.md docs/STAGE_B_MIDI_TO_SOLO_4BAR_LISTENING_INPUT_GUARD_2026-06-11.md
- bash scripts/agent_harness.sh quick

## Risk
- 사람 기준 청취 입력 미포함
- objective-only next decision은 품질 판단 아님
- pending candidate fields 24 유지

## Follow-up
- 4bar objective-only next decision
- 4bar dead-air/coverage repair 여부 판단
- 필요 시 4bar repair sweep

Closes #1244