### PR TITLE
Stage B MIDI-to-solo 4bar objective-only next decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ raw model generation은 note grammar가 자주 깨졌다.
 - 4bar listening package: MIDI `8`, WAV `8`, review input template ready
 - 4bar input guard: validated input `false`, preference fill `false`, pending candidate fields `24`
 - next boundary: `music_transformer_solo_yield_objective_only_next_decision`
+- 4bar objective-only decision: candidate `8`, selected objective candidates `4`, dead-air range `0.6552 - 0.7692`
+- next boundary: `music_transformer_solo_yield_4bar_dead_air_repair_sweep`
 
 ## 결과 파일
 
@@ -123,6 +125,7 @@ Report:
 - `docs/STAGE_B_MIDI_TO_SOLO_4BAR_PHRASE_EXPANSION_PROBE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_4BAR_LISTENING_PACKAGE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_4BAR_LISTENING_INPUT_GUARD_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_4BAR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md`
 
 ## 실행 방법
 
@@ -199,4 +202,5 @@ Report:
 - 4bar candidate listening review package
 - 4bar listening input guard
 - 4bar objective-only next decision
+- 4bar dead-air repair sweep
 - 더 긴 4마디 phrase로 확장 검토

--- a/docs/STAGE_B_MIDI_TO_SOLO_4BAR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_4BAR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md
@@ -1,0 +1,29 @@
+# Music Transformer Solo Yield Objective-Only Next Decision
+
+## Summary
+
+- candidate count: `8`
+- selected objective candidates: `4`
+- score range: `232.436` - `234.793`
+- note count range: `27` - `30`
+- dead-air range: `0.6552` - `0.7692`
+- validated listening input present: `false`
+- preference fill allowed: `false`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_4bar_dead_air_repair_sweep`
+
+## Selected Objective Candidates
+
+| review | case | score | notes | dead air | WAV |
+|---:|---|---:|---:|---:|---|
+| 5 | `dominant_cycle` | 234.793 | 30 | 0.6897 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1242_4bar_top8_listening_package/audio/candidate_05_dominant_cycle_rank_01.wav` |
+| 3 | `major_ii_v_turnaround` | 234.223 | 27 | 0.7692 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1242_4bar_top8_listening_package/audio/candidate_03_major_ii_v_turnaround_rank_01.wav` |
+| 4 | `major_ii_v_turnaround` | 234.005 | 27 | 0.6923 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1242_4bar_top8_listening_package/audio/candidate_04_major_ii_v_turnaround_rank_02.wav` |
+| 6 | `dominant_cycle` | 233.650 | 30 | 0.6552 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1242_4bar_top8_listening_package/audio/candidate_06_dominant_cycle_rank_02.wav` |
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`


### PR DESCRIPTION
## Summary
- Stage B MIDI-to-solo 4bar objective-only next decision 기록
- 8개 후보 중 objective 상위 4개 선정
- selected candidate dead-air range 0.6552-0.7692
- next boundary: 4bar dead-air repair sweep

## Context
- Issue #1244 input guard: validated input=false, preference fill=false, pending candidate fields=24
- Issue #1240 4bar expansion: strict 20/24, grammar 24/24
- floor는 통과했지만 selected 4bar 후보 dead-air 비율이 높게 관측
- 청취 입력 없이 품질 claim 불가

## Scope
- 4bar package/guard 기준 objective decision 실행
- selected objective candidates 기록
- next boundary를 4bar dead-air repair sweep으로 지정
- README evidence와 다음 작업 갱신

## Validation
- .venv/bin/python scripts/decide_music_transformer_solo_yield_objective_next.py --package_report outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1242_4bar_top8_listening_package/listening_review_package.json --guard_report outputs/music_transformer_finetune_mvp/solo_yield_listening_input_guard/issue_1244_4bar_listening_input_guard/listening_input_guard.json --output_root outputs/music_transformer_finetune_mvp/solo_yield_objective_next_decision --run_id issue_1246_4bar_objective_next_decision --top_n 4 --pending_next_boundary music_transformer_solo_yield_4bar_dead_air_repair_sweep --pending_reason "4bar expansion passed floor but dead-air remains elevated; repair density before quality claim" --require_no_quality_claim --doc_path docs/STAGE_B_MIDI_TO_SOLO_4BAR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md
- .venv/bin/python -m unittest tests/test_music_transformer_solo_yield_objective_next.py
- .venv/bin/python -m py_compile scripts/decide_music_transformer_solo_yield_objective_next.py tests/test_music_transformer_solo_yield_objective_next.py
- git diff --check
- rg -n "codex|Codex|CODEX|ChatGPT|Claude|assistant" README.md docs/STAGE_B_MIDI_TO_SOLO_4BAR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md
- bash scripts/agent_harness.sh quick

## Risk
- 음악적 품질 판단 미포함
- dead-air repair 대상은 objective metric 기반 판단
- 사람 기준 청취 선호 입력 없음

## Follow-up
- 4bar dead-air repair sweep
- repair 후 strict/grammar/dead-air 재측정
- 필요 시 4bar repair audio package

Closes #1246