### PR TITLE
Stage B MIDI-to-solo 4bar dead-air repair sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ raw model generation은 note grammar가 자주 깨졌다.
 - next boundary: `music_transformer_solo_yield_objective_only_next_decision`
 - 4bar objective-only decision: candidate `8`, selected objective candidates `4`, dead-air range `0.6552 - 0.7692`
 - next boundary: `music_transformer_solo_yield_4bar_dead_air_repair_sweep`
+- 4bar dead-air repair: strict `20 / 24 -> 22 / 24`, case avg dead-air range `0.7171 - 0.7571 -> 0.6340 - 0.6545`
+- rejected repair variant: `note_groups_per_bar=10`, `max_sequence=192`, reason checkpoint `model_max_sequence=160`
 
 ## 결과 파일
 
@@ -126,6 +128,7 @@ Report:
 - `docs/STAGE_B_MIDI_TO_SOLO_4BAR_LISTENING_PACKAGE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_4BAR_LISTENING_INPUT_GUARD_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_4BAR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_4BAR_DEAD_AIR_REPAIR_SWEEP_2026-06-11.md`
 
 ## 실행 방법
 
@@ -203,4 +206,5 @@ Report:
 - 4bar listening input guard
 - 4bar objective-only next decision
 - 4bar dead-air repair sweep
+- 4bar repaired candidate listening review package
 - 더 긴 4마디 phrase로 확장 검토

--- a/docs/STAGE_B_MIDI_TO_SOLO_4BAR_DEAD_AIR_REPAIR_SWEEP_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_4BAR_DEAD_AIR_REPAIR_SWEEP_2026-06-11.md
@@ -1,0 +1,63 @@
+# Stage B MIDI-to-Solo Chord Progression Yield Sweep
+
+## Summary
+
+- checkpoint generation used: `true`
+- constrained decoding used: `true`
+- case count: `4`
+- sample count: `24`
+- duration mode: `fill`
+- valid yield: `22` / `24`
+- strict yield: `22` / `24`
+- grammar yield: `24` / `24`
+- strict yield rate: `0.9167`
+- min case strict yield rate: `0.8333`
+- selected MIDI candidates: `8`
+- rendered WAV files: `8`
+- total yield floor passed: `true`
+- all case yield floor passed: `true`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_candidate_listening_review`
+
+## Repair Context
+
+- source 4bar strict yield: `20` / `24`
+- source 4bar grammar yield: `24` / `24`
+- source 4bar case avg dead-air range: `0.7171` - `0.7571`
+- repair variant: `note_groups_per_bar=9`, `max_sequence=160`
+- repair strict yield: `22` / `24`
+- repair grammar yield: `24` / `24`
+- repair case avg dead-air range: `0.6340` - `0.6545`
+- rejected variant: `note_groups_per_bar=10`, `max_sequence=192`
+- rejected reason: checkpoint `model_max_sequence=160` positional encoding limit
+
+## Cases
+
+| case | chords | seed | strict | valid | grammar | strict rate | avg notes | avg dead air | package |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---|
+| `minor_backdoor` | `Cm7,F7,Bbmaj7,Ebmaj7` | 1700 | 5/6 | 5/6 | 6/6 | 0.8333 | 31.80 | 0.6340 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1248_4bar_dead_air_repair_n9_seq160/packages/01_minor_backdoor_seed_1700/solo_yield_package.json` |
+| `major_ii_v_turnaround` | `Dm7,G7,Cmaj7,A7` | 1743 | 6/6 | 6/6 | 6/6 | 1.0000 | 31.83 | 0.6545 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1248_4bar_dead_air_repair_n9_seq160/packages/02_major_ii_v_turnaround_seed_1743/solo_yield_package.json` |
+| `dominant_cycle` | `Em7,A7,Dmaj7,G7` | 1786 | 6/6 | 6/6 | 6/6 | 1.0000 | 31.00 | 0.6347 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1248_4bar_dead_air_repair_n9_seq160/packages/03_dominant_cycle_seed_1786/solo_yield_package.json` |
+| `rhythm_turnaround` | `Bbmaj7,G7,Cm7,F7` | 1829 | 5/6 | 5/6 | 6/6 | 0.8333 | 30.00 | 0.6353 | `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1248_4bar_dead_air_repair_n9_seq160/packages/04_rhythm_turnaround_seed_1829/solo_yield_package.json` |
+
+## Failing Cases
+
+- `none`
+
+## WAV Files
+
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1248_4bar_dead_air_repair_n9_seq160/packages/01_minor_backdoor_seed_1700/audio/candidate_01_sample_04.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1248_4bar_dead_air_repair_n9_seq160/packages/01_minor_backdoor_seed_1700/audio/candidate_02_sample_06.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1248_4bar_dead_air_repair_n9_seq160/packages/02_major_ii_v_turnaround_seed_1743/audio/candidate_01_sample_01.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1248_4bar_dead_air_repair_n9_seq160/packages/02_major_ii_v_turnaround_seed_1743/audio/candidate_02_sample_06.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1248_4bar_dead_air_repair_n9_seq160/packages/03_dominant_cycle_seed_1786/audio/candidate_01_sample_03.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1248_4bar_dead_air_repair_n9_seq160/packages/03_dominant_cycle_seed_1786/audio/candidate_02_sample_02.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1248_4bar_dead_air_repair_n9_seq160/packages/04_rhythm_turnaround_seed_1829/audio/candidate_01_sample_05.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1248_4bar_dead_air_repair_n9_seq160/packages/04_rhythm_turnaround_seed_1829/audio/candidate_02_sample_04.wav`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`


### PR DESCRIPTION
## Summary
- Stage B MIDI-to-solo 4bar dead-air repair sweep 기록
- repair variant: note_groups_per_bar=9, max_sequence=160
- strict 20/24 -> 22/24
- case avg dead-air range 0.7171-0.7571 -> 0.6340-0.6545

## Context
- Issue #1246 objective decision: selected 4bar candidate dead-air range 0.6552-0.7692
- Issue #1240 4bar expansion: strict 20/24, grammar 24/24
- floor는 통과했지만 빈 구간 비율이 높게 관측
- 청취 입력 없이 objective metric 기준 repair 대상 선택

## Scope
- 4bar repair sweep 실행 결과 문서화
- note_groups_per_bar=9, max_sequence=160 조건 기록
- note_groups_per_bar=10, max_sequence=192 제외 사유 기록
- README evidence와 다음 작업 갱신

## Validation
- .venv/bin/python scripts/run_music_transformer_solo_yield_sweep.py --output_root outputs/music_transformer_finetune_mvp/solo_yield_sweep --run_id issue_1248_4bar_dead_air_repair_n9_seq160 --sample_count 6 --top_n 2 --seed_start 1700 --seed_stride 43 --bars 4 --duration_mode fill --note_groups_per_bar 9 --max_sequence 160 --min_total_strict_yield_rate 0.5 --min_case_strict_yield_rate 0.25 --min_cases 4 --require_no_quality_claim --doc_path docs/STAGE_B_MIDI_TO_SOLO_4BAR_DEAD_AIR_REPAIR_SWEEP_2026-06-11.md
- .venv/bin/python -m py_compile scripts/run_music_transformer_solo_yield_sweep.py scripts/run_stage_b_generation_probe.py
- git diff --check
- rg -n "codex|Codex|CODEX|ChatGPT|Claude|assistant" README.md docs/STAGE_B_MIDI_TO_SOLO_4BAR_DEAD_AIR_REPAIR_SWEEP_2026-06-11.md
- bash scripts/agent_harness.sh quick

## Excluded
- note_groups_per_bar=10, max_sequence=192
- reason: checkpoint model_max_sequence=160 positional encoding limit

## Risk
- objective metric 개선이 음악적 품질 보장 아님
- strict/grammar 수율은 통과했지만 청취 선호 입력 없음
- 4bar density 증가에 따른 phrasing 품질 미검증

## Follow-up
- 4bar repaired candidate listening review package
- 4bar repaired input guard
- 4bar repaired objective-only next decision

Closes #1248