### PR TITLE
Stage B MIDI-to-solo 4bar repaired listening package

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ raw model generation은 note grammar가 자주 깨졌다.
 - next boundary: `music_transformer_solo_yield_4bar_dead_air_repair_sweep`
 - 4bar dead-air repair: strict `20 / 24 -> 22 / 24`, case avg dead-air range `0.7171 - 0.7571 -> 0.6340 - 0.6545`
 - rejected repair variant: `note_groups_per_bar=10`, `max_sequence=192`, reason checkpoint `model_max_sequence=160`
+- 4bar repaired listening package: MIDI `8`, WAV `8`, review input template ready
 
 ## 결과 파일
 
@@ -129,6 +130,7 @@ Report:
 - `docs/STAGE_B_MIDI_TO_SOLO_4BAR_LISTENING_INPUT_GUARD_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_4BAR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_4BAR_DEAD_AIR_REPAIR_SWEEP_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_4BAR_REPAIRED_LISTENING_PACKAGE_2026-06-11.md`
 
 ## 실행 방법
 
@@ -207,4 +209,5 @@ Report:
 - 4bar objective-only next decision
 - 4bar dead-air repair sweep
 - 4bar repaired candidate listening review package
+- 4bar repaired input guard
 - 더 긴 4마디 phrase로 확장 검토

--- a/docs/STAGE_B_MIDI_TO_SOLO_4BAR_REPAIRED_LISTENING_PACKAGE_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_4BAR_REPAIRED_LISTENING_PACKAGE_2026-06-11.md
@@ -1,0 +1,37 @@
+# Music Transformer Solo Yield Listening Review Package
+
+## Summary
+
+- source strict yield: `22` / `24`
+- source strict yield rate: `0.9167`
+- source rendered audio files: `8`
+- review candidate count: `8`
+- MIDI files copied: `8`
+- WAV files copied: `8`
+- validated listening input present: `false`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_listening_input_guard`
+
+## Candidates
+
+| review | case | chords | score | notes | dead air | WAV | MIDI |
+|---:|---|---|---:|---:|---:|---|---|
+| 1 | `minor_backdoor` | `Cm7,F7,Bbmaj7,Ebmaj7` | 233.043 | 33 | 0.5938 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/audio/candidate_01_minor_backdoor_rank_01.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/midi/candidate_01_minor_backdoor_rank_01.mid` |
+| 2 | `minor_backdoor` | `Cm7,F7,Bbmaj7,Ebmaj7` | 232.244 | 34 | 0.5152 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/audio/candidate_02_minor_backdoor_rank_02.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/midi/candidate_02_minor_backdoor_rank_02.mid` |
+| 3 | `major_ii_v_turnaround` | `Dm7,G7,Cmaj7,A7` | 233.571 | 32 | 0.6452 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/audio/candidate_03_major_ii_v_turnaround_rank_01.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/midi/candidate_03_major_ii_v_turnaround_rank_01.mid` |
+| 4 | `major_ii_v_turnaround` | `Dm7,G7,Cmaj7,A7` | 233.042 | 32 | 0.5484 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/audio/candidate_04_major_ii_v_turnaround_rank_02.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/midi/candidate_04_major_ii_v_turnaround_rank_02.mid` |
+| 5 | `dominant_cycle` | `Em7,A7,Dmaj7,G7` | 232.884 | 30 | 0.7241 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/audio/candidate_05_dominant_cycle_rank_01.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/midi/candidate_05_dominant_cycle_rank_01.mid` |
+| 6 | `dominant_cycle` | `Em7,A7,Dmaj7,G7` | 232.832 | 28 | 0.6667 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/audio/candidate_06_dominant_cycle_rank_02.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/midi/candidate_06_dominant_cycle_rank_02.mid` |
+| 7 | `rhythm_turnaround` | `Bbmaj7,G7,Cm7,F7` | 232.963 | 29 | 0.7143 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/audio/candidate_07_rhythm_turnaround_rank_01.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/midi/candidate_07_rhythm_turnaround_rank_01.mid` |
+| 8 | `rhythm_turnaround` | `Bbmaj7,G7,Cm7,F7` | 232.486 | 31 | 0.6000 | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/audio/candidate_08_rhythm_turnaround_rank_02.wav` | `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/midi/candidate_08_rhythm_turnaround_rank_02.mid` |
+
+## Review Input
+
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/listening_review_input_template.json`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`


### PR DESCRIPTION
## Summary
- Stage B MIDI-to-solo 4bar repaired listening review package 기록
- 후보 MIDI 8개, WAV 8개 복사
- review input template 생성
- validated listening input=false, musical quality claim=false 유지

## Context
- Issue #1248 4bar dead-air repair 결과: strict 22/24, grammar 24/24
- case avg dead-air range 0.6340-0.6545
- rendered WAV files 8
- 청취 입력 전까지 preference/quality 판단 제외

## Scope
- repaired sweep report 기반 listening package 생성
- candidate path, score, note count, dead-air metric 기록
- review input template 경로 기록
- README evidence와 다음 작업 갱신

## Validation
- .venv/bin/python scripts/build_music_transformer_solo_yield_listening_package.py --sweep_report outputs/music_transformer_finetune_mvp/solo_yield_sweep/issue_1248_4bar_dead_air_repair_n9_seq160/solo_yield_sweep_report.json --output_root outputs/music_transformer_finetune_mvp/solo_yield_listening_review --run_id issue_1250_4bar_repaired_top8_listening_package --max_candidates 8 --min_candidates 8 --require_no_quality_claim --doc_path docs/STAGE_B_MIDI_TO_SOLO_4BAR_REPAIRED_LISTENING_PACKAGE_2026-06-11.md
- .venv/bin/python -m py_compile scripts/build_music_transformer_solo_yield_listening_package.py scripts/run_music_transformer_solo_yield_sweep.py
- git diff --check
- rg -n "codex|Codex|CODEX|ChatGPT|Claude|assistant" README.md docs/STAGE_B_MIDI_TO_SOLO_4BAR_REPAIRED_LISTENING_PACKAGE_2026-06-11.md
- bash scripts/agent_harness.sh quick

## Risk
- 청취 선호 입력 미포함
- objective score 기반 후보 정렬만 제공
- dead-air 개선이 음악적 품질 보장 아님

## Follow-up
- 4bar repaired input guard
- 4bar repaired objective-only next decision
- 필요 시 4bar repaired audio review handoff

Closes #1250