### PR TITLE
Stage B MIDI-to-solo 4bar repaired input guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ raw model generation은 note grammar가 자주 깨졌다.
 - 4bar dead-air repair: strict `20 / 24 -> 22 / 24`, case avg dead-air range `0.7171 - 0.7571 -> 0.6340 - 0.6545`
 - rejected repair variant: `note_groups_per_bar=10`, `max_sequence=192`, reason checkpoint `model_max_sequence=160`
 - 4bar repaired listening package: MIDI `8`, WAV `8`, review input template ready
+- 4bar repaired input guard: validated input `false`, preference fill `false`, pending candidate fields `24`
+- next boundary: `music_transformer_solo_yield_objective_only_next_decision`
 
 ## 결과 파일
 
@@ -131,6 +133,7 @@ Report:
 - `docs/STAGE_B_MIDI_TO_SOLO_4BAR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_4BAR_DEAD_AIR_REPAIR_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_4BAR_REPAIRED_LISTENING_PACKAGE_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_4BAR_REPAIRED_INPUT_GUARD_2026-06-11.md`
 
 ## 실행 방법
 
@@ -210,4 +213,5 @@ Report:
 - 4bar dead-air repair sweep
 - 4bar repaired candidate listening review package
 - 4bar repaired input guard
+- 4bar repaired objective-only next decision
 - 더 긴 4마디 phrase로 확장 검토

--- a/docs/STAGE_B_MIDI_TO_SOLO_4BAR_REPAIRED_INPUT_GUARD_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_4BAR_REPAIRED_INPUT_GUARD_2026-06-11.md
@@ -1,0 +1,32 @@
+# Music Transformer Solo Yield Listening Input Guard
+
+## Summary
+
+- source candidate count: `8`
+- listening input path: `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/listening_review_input_template.json`
+- validated listening input present: `false`
+- preference fill allowed: `false`
+- objective-only next decision required: `true`
+- pending status: `true`
+- pending overall decision: `true`
+- pending candidate field count: `24`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_objective_only_next_decision`
+
+## Pending Candidate Fields
+
+- review `1`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `2`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `3`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `4`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `5`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `6`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `7`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `8`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`


### PR DESCRIPTION
## Summary
- Stage B MIDI-to-solo 4bar repaired input guard 기록
- source candidate count 8
- validated listening input=false, preference fill=false
- pending candidate field count 24
- next boundary: objective-only next decision

## Context
- Issue #1250 repaired listening package 결과: MIDI 8개, WAV 8개, review input template 생성
- review input template은 pending 상태
- 청취 입력 없이 선호/품질 판단 불가
- objective-only 경로 유지 필요

## Scope
- listening input guard 실행 결과 문서화
- pending status, pending overall decision, pending candidate fields 기록
- README evidence와 다음 작업 갱신

## Validation
- .venv/bin/python scripts/guard_music_transformer_solo_yield_listening_input.py --package_report outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/listening_review_package.json --output_root outputs/music_transformer_finetune_mvp/solo_yield_listening_input_guard --run_id issue_1252_4bar_repaired_input_guard --require_no_quality_claim --doc_path docs/STAGE_B_MIDI_TO_SOLO_4BAR_REPAIRED_INPUT_GUARD_2026-06-11.md
- .venv/bin/python -m py_compile scripts/guard_music_transformer_solo_yield_listening_input.py scripts/build_music_transformer_solo_yield_listening_package.py
- git diff --check
- rg -n "codex|Codex|CODEX|ChatGPT|Claude|assistant" README.md docs/STAGE_B_MIDI_TO_SOLO_4BAR_REPAIRED_INPUT_GUARD_2026-06-11.md
- bash scripts/agent_harness.sh quick

## Risk
- 사람 기준 청취 입력 미포함
- objective-only next decision은 품질 판단 아님
- repaired 후보 기준 pending candidate fields 24 유지

## Follow-up
- 4bar repaired objective-only next decision
- 4bar repaired final handoff 또는 추가 repair 판단

Closes #1252