### PR TITLE
Stage B MIDI-to-solo final handoff summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,27 +111,25 @@ raw model generation은 note grammar가 자주 깨졌다.
 
 ## 결과 파일
 
-MIDI:
+최신 리뷰 패키지:
 
-- `outputs/music_transformer_finetune_mvp/solo_yield_mvp/constrained_chord_swing_top5/generated/candidate_01_sample_20.mid`
-- `outputs/music_transformer_finetune_mvp/solo_yield_mvp/constrained_chord_swing_top5/generated/candidate_02_sample_16.mid`
-- `outputs/music_transformer_finetune_mvp/solo_yield_mvp/constrained_chord_swing_top5/generated/candidate_03_sample_12.mid`
-- `outputs/music_transformer_finetune_mvp/solo_yield_mvp/constrained_chord_swing_top5/generated/candidate_04_sample_06.mid`
-- `outputs/music_transformer_finetune_mvp/solo_yield_mvp/constrained_chord_swing_top5/generated/candidate_05_sample_04.mid`
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/listening_review_package.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/listening_review_package.json`
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/listening_review_input_template.json`
 
-WAV:
+MIDI 후보:
 
-- `outputs/music_transformer_finetune_mvp/solo_yield_mvp/constrained_chord_swing_top5/audio/candidate_01_sample_20.wav`
-- `outputs/music_transformer_finetune_mvp/solo_yield_mvp/constrained_chord_swing_top5/audio/candidate_02_sample_16.wav`
-- `outputs/music_transformer_finetune_mvp/solo_yield_mvp/constrained_chord_swing_top5/audio/candidate_03_sample_12.wav`
-- `outputs/music_transformer_finetune_mvp/solo_yield_mvp/constrained_chord_swing_top5/audio/candidate_04_sample_06.wav`
-- `outputs/music_transformer_finetune_mvp/solo_yield_mvp/constrained_chord_swing_top5/audio/candidate_05_sample_04.wav`
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/midi/`
+
+WAV 후보:
+
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/audio/`
 
 Report:
 
-- `outputs/music_transformer_finetune_mvp/stage_b_solo_yield_probe/constrained_chord_swing_20/report.json`
-- `outputs/music_transformer_finetune_mvp/solo_yield_mvp/constrained_chord_swing_top5/solo_yield_package.json`
-- `outputs/music_transformer_finetune_mvp/solo_yield_mvp/constrained_chord_swing_top5/solo_yield_package.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_final_status_audit/issue_1256_final_status_audit/final_status_audit.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_final_status_audit/issue_1256_final_status_audit/final_status_audit_summary.json`
+- `outputs/music_transformer_finetune_mvp/solo_yield_objective_next_decision/issue_1254_4bar_repaired_objective_next_decision/objective_next_decision.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_CHORD_PROGRESSION_YIELD_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_YIELD_FAILURE_CASE_REVIEW_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_DEAD_AIR_REPAIR_SWEEP_2026-06-11.md`
@@ -153,6 +151,7 @@ Report:
 - `docs/STAGE_B_MIDI_TO_SOLO_4BAR_REPAIRED_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_FINAL_STATUS_AUDIT_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_README_FINAL_EVIDENCE_REFRESH_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_FINAL_HANDOFF_SUMMARY_2026-06-11.md`
 
 ## 실행 방법
 
@@ -213,27 +212,8 @@ Report:
 
 ## 다음 작업
 
-- top 5 WAV 청취 리뷰
-- 사람이 rejected로 판단한 후보의 공통 실패 원인 기록
-- `Dm7, G7, Cmaj7, A7` progression 실패 원인 분석
-- dead-air repair sweep
-- `fill_n10` repair variant 기준 full progression retry sweep
-- retry top candidates listening review
-- listening review input guard
-- objective-only next decision
-- larger sample repeatability sweep
-- larger sample candidate listening review package
-- larger sample listening input guard
-- larger sample objective-only next decision
-- 4bar phrase expansion probe
-- 4bar candidate listening review package
-- 4bar listening input guard
-- 4bar objective-only next decision
-- 4bar dead-air repair sweep
-- 4bar repaired candidate listening review package
-- 4bar repaired input guard
-- 4bar repaired objective-only next decision
-- final status audit
-- README final evidence refresh
-- final handoff summary
-- 더 긴 4마디 phrase로 확장 검토
+- repaired 4bar top8 WAV/MIDI 청취 리뷰
+- 청취 결과 기준 keep/reject 후보 기록
+- rejected 후보 공통 실패 원인 라벨링
+- 음악적 품질 claim 여부는 청취 리뷰 이후 재판단
+- 다음 품질 개선 후보: dead-air 추가 완화, phrase tension/release, chord-tone landing, outside-soloing pitch-role

--- a/docs/STAGE_B_MIDI_TO_SOLO_FINAL_HANDOFF_SUMMARY_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_FINAL_HANDOFF_SUMMARY_2026-06-11.md
@@ -1,0 +1,83 @@
+# Stage B MIDI-to-Solo Final Handoff Summary
+
+## Summary
+
+- boundary: `music_transformer_solo_yield_final_handoff_summary`
+- source final status audit: `music_transformer_solo_yield_final_status_audit_v1`
+- technical MVP evidence ready: `true`
+- checkpoint generation used: `true`
+- constrained decoding used: `true`
+- review package ready: `true`
+- musical quality claimed: `false`
+- validated listening input present: `false`
+- raw artifact upload required: `false`
+
+## Completed Scope
+
+- MIDI token sequence 기반 Music Transformer 계열 checkpoint 학습
+- checkpoint logits 기반 constrained generation
+- chord context 기반 2-4마디 solo candidate 생성
+- generated token to MIDI decode
+- objective metric 기반 candidate ranking
+- MIDI grammar / strict review gate 적용
+- top candidate MIDI export
+- FluidSynth 기반 WAV render
+- listening review package 생성
+- review input pending 상태에서 preference fill 차단
+- final status audit 기준 technical evidence ready 판정
+
+## Current Evidence
+
+- case count: `4`
+- sample count: `24`
+- strict yield: `22 / 24`
+- grammar yield: `24 / 24`
+- strict yield rate: `0.9167`
+- min case strict yield rate: `0.8333`
+- rendered WAV files: `8`
+- repaired candidate count: `8`
+- selected objective candidates: `4`
+- objective dead-air range: `0.5152 - 0.7241`
+
+## Current Review Package
+
+- package: `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/listening_review_package.md`
+- package JSON: `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/listening_review_package.json`
+- review input template: `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/listening_review_input_template.json`
+- MIDI directory: `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/midi/`
+- WAV directory: `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/audio/`
+
+## Candidate Set
+
+- `candidate_01_minor_backdoor_rank_01`
+- `candidate_02_minor_backdoor_rank_02`
+- `candidate_03_major_ii_v_turnaround_rank_01`
+- `candidate_04_major_ii_v_turnaround_rank_02`
+- `candidate_05_dominant_cycle_rank_01`
+- `candidate_06_dominant_cycle_rank_02`
+- `candidate_07_rhythm_turnaround_rank_01`
+- `candidate_08_rhythm_turnaround_rank_02`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`
+- `Brad_style_adaptation`
+- `full_input_MIDI_understanding`
+
+## Next Decision
+
+- repaired 4bar top8 WAV/MIDI 청취 리뷰
+- keep/reject candidate 기록
+- rejected candidate 공통 실패 원인 라벨링
+- 음악적 품질 claim 여부 재판단
+- 필요 시 다음 repair target 선택: dead-air 추가 완화, phrase tension/release, chord-tone landing, outside-soloing pitch-role
+
+## Validation Sources
+
+- `docs/STAGE_B_MIDI_TO_SOLO_FINAL_STATUS_AUDIT_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_README_FINAL_EVIDENCE_REFRESH_2026-06-11.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_final_status_audit/issue_1256_final_status_audit/final_status_audit_summary.json`
+- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/listening_review_package_summary.json`


### PR DESCRIPTION
## Summary
- final handoff summary 문서 추가
- README 결과 파일 목록을 4bar repaired top8 review package 기준으로 갱신
- 남은 작업 목록을 청취 리뷰와 품질 claim 재판단 경계로 축소

## Context
- #1256 final status audit 기준 technical evidence ready=true
- strict 22/24, grammar 24/24, rendered WAV 8
- #1258 README final evidence refresh 이후 상단 evidence는 최신 상태
- README 하단 결과 파일과 다음 작업 목록에 과거 top5 및 완료된 작업 항목 잔존
- musical quality claim=false, validated listening input=false

## Scope
- `docs/STAGE_B_MIDI_TO_SOLO_FINAL_HANDOFF_SUMMARY_2026-06-11.md` 추가
- current review package, candidate set, current evidence, not-proven boundary 정리
- README 결과 파일 경로를 `issue_1250_4bar_repaired_top8_listening_package` 기준으로 갱신
- README 다음 작업을 청취 리뷰, 실패 원인 라벨링, 품질 claim 재판단으로 정리

## Validation
- git diff --check
- rg -n "codex|Codex|CODEX|ChatGPT|Claude|assistant" README.md docs/STAGE_B_MIDI_TO_SOLO_FINAL_HANDOFF_SUMMARY_2026-06-11.md
- bash scripts/agent_harness.sh quick

## Risk
- 문서 변경만 포함
- 생성 코드와 산출물 파일 변경 없음
- 음악적 품질 claim 추가 없음
- raw artifact upload 제외

## Follow-up
- repaired 4bar top8 WAV/MIDI 청취 리뷰
- keep/reject 후보 기록
- rejected 후보 공통 실패 원인 라벨링

Closes #1260
