### PR TITLE
Stage B MIDI-to-solo repaired top8 objective failure review

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ raw model generation은 note grammar가 자주 깨졌다.
 - final status audit: technical evidence ready `true`, strict `22 / 24`, grammar-valid `24 / 24`, rendered WAV `8`
 - final status audit claim boundary: musical quality claim `false`, raw artifact upload required `false`
 - next boundary: `music_transformer_solo_yield_readme_final_evidence_refresh`
+- 4bar repaired top8 objective failure review: final landing not chord-tone `8 / 8`, package low chord-tone ratio `8 / 8`, MIDI low chord-tone ratio `6 / 8`, dead-air still high `3 / 8`
+- next boundary: `music_transformer_solo_yield_chord_tone_landing_repair_sweep`
 
 ## 결과 파일
 
@@ -152,6 +154,7 @@ Report:
 - `docs/STAGE_B_MIDI_TO_SOLO_FINAL_STATUS_AUDIT_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_README_FINAL_EVIDENCE_REFRESH_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_FINAL_HANDOFF_SUMMARY_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_TOP8_OBJECTIVE_FAILURE_REVIEW_2026-06-11.md`
 
 ## 실행 방법
 
@@ -212,8 +215,10 @@ Report:
 
 ## 다음 작업
 
-- repaired 4bar top8 WAV/MIDI 청취 리뷰
+- chord-tone landing repair sweep
+- repair 후 strict / grammar / final landing 지표 비교
+- repaired candidate listening package 갱신
+- WAV/MIDI 청취 리뷰
 - 청취 결과 기준 keep/reject 후보 기록
-- rejected 후보 공통 실패 원인 라벨링
 - 음악적 품질 claim 여부는 청취 리뷰 이후 재판단
-- 다음 품질 개선 후보: dead-air 추가 완화, phrase tension/release, chord-tone landing, outside-soloing pitch-role
+- 다음 품질 개선 후보: dead-air 추가 완화, phrase tension/release, outside-soloing pitch-role

--- a/docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_TOP8_OBJECTIVE_FAILURE_REVIEW_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_TOP8_OBJECTIVE_FAILURE_REVIEW_2026-06-11.md
@@ -1,0 +1,81 @@
+# Music Transformer Solo Yield Repaired Top8 Objective Failure Review
+
+## Summary
+
+- candidate count: `8`
+- failed candidate count: `8`
+- final landing not chord tone: `8`
+- package low chord-tone ratio: `8`
+- MIDI low chord-tone ratio: `6`
+- dead-air still high: `3`
+- selected next target: `chord_tone_landing_repair`
+- next boundary: `music_transformer_solo_yield_chord_tone_landing_repair_sweep`
+- musical quality claimed: `false`
+
+## Failure Label Counts
+
+- `dead_air_still_high`: `3`
+- `final_landing_not_chord_tone`: `8`
+- `low_note_count_for_4bar`: `2`
+- `midi_low_chord_tone_ratio`: `6`
+- `package_low_chord_tone_ratio`: `8`
+- `weak_direction_change`: `2`
+- `wide_interval_review`: `2`
+
+## Candidates
+
+- candidate `1` / `minor_backdoor`
+  - labels: `final_landing_not_chord_tone`, `package_low_chord_tone_ratio`, `midi_low_chord_tone_ratio`
+  - package dead-air: `0.5938`
+  - package chord-tone ratio: `0.4444`
+  - MIDI chord-tone ratio: `0.4848`
+  - final landing: `65` over `Ebmaj7`, chord-tone `false`
+- candidate `2` / `minor_backdoor`
+  - labels: `final_landing_not_chord_tone`, `package_low_chord_tone_ratio`, `midi_low_chord_tone_ratio`, `weak_direction_change`, `wide_interval_review`
+  - package dead-air: `0.5152`
+  - package chord-tone ratio: `0.4444`
+  - MIDI chord-tone ratio: `0.4412`
+  - final landing: `72` over `Ebmaj7`, chord-tone `false`
+- candidate `3` / `major_ii_v_turnaround`
+  - labels: `final_landing_not_chord_tone`, `package_low_chord_tone_ratio`, `midi_low_chord_tone_ratio`, `wide_interval_review`
+  - package dead-air: `0.6452`
+  - package chord-tone ratio: `0.4444`
+  - MIDI chord-tone ratio: `0.4375`
+  - final landing: `77` over `A7`, chord-tone `false`
+- candidate `4` / `major_ii_v_turnaround`
+  - labels: `final_landing_not_chord_tone`, `package_low_chord_tone_ratio`, `midi_low_chord_tone_ratio`
+  - package dead-air: `0.5484`
+  - package chord-tone ratio: `0.4444`
+  - MIDI chord-tone ratio: `0.4688`
+  - final landing: `71` over `A7`, chord-tone `false`
+- candidate `5` / `dominant_cycle`
+  - labels: `final_landing_not_chord_tone`, `package_low_chord_tone_ratio`, `dead_air_still_high`
+  - package dead-air: `0.7241`
+  - package chord-tone ratio: `0.4444`
+  - MIDI chord-tone ratio: `0.5000`
+  - final landing: `72` over `G7`, chord-tone `false`
+- candidate `6` / `dominant_cycle`
+  - labels: `final_landing_not_chord_tone`, `package_low_chord_tone_ratio`, `dead_air_still_high`, `low_note_count_for_4bar`
+  - package dead-air: `0.6667`
+  - package chord-tone ratio: `0.4444`
+  - MIDI chord-tone ratio: `0.5714`
+  - final landing: `75` over `G7`, chord-tone `false`
+- candidate `7` / `rhythm_turnaround`
+  - labels: `final_landing_not_chord_tone`, `package_low_chord_tone_ratio`, `midi_low_chord_tone_ratio`, `dead_air_still_high`, `low_note_count_for_4bar`
+  - package dead-air: `0.7143`
+  - package chord-tone ratio: `0.4444`
+  - MIDI chord-tone ratio: `0.4483`
+  - final landing: `76` over `F7`, chord-tone `false`
+- candidate `8` / `rhythm_turnaround`
+  - labels: `final_landing_not_chord_tone`, `package_low_chord_tone_ratio`, `midi_low_chord_tone_ratio`, `weak_direction_change`
+  - package dead-air: `0.6000`
+  - package chord-tone ratio: `0.4444`
+  - MIDI chord-tone ratio: `0.4839`
+  - final landing: `70` over `F7`, chord-tone `false`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`

--- a/scripts/review_music_transformer_solo_yield_repaired_top8_objective_failures.py
+++ b/scripts/review_music_transformer_solo_yield_repaired_top8_objective_failures.py
@@ -1,0 +1,425 @@
+"""Review repaired top8 Music Transformer solo candidates from objective MIDI evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from statistics import mean
+from typing import Any
+
+import pretty_midi
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from inference.app.fallback import parse_chord  # noqa: E402
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+
+
+SCHEMA_VERSION = "music_transformer_solo_yield_repaired_top8_objective_failure_review_v1"
+BOUNDARY = "music_transformer_solo_yield_repaired_top8_objective_failure_review"
+NEXT_BOUNDARY = "music_transformer_solo_yield_chord_tone_landing_repair_sweep"
+SELECTED_TARGET = "chord_tone_landing_repair"
+
+
+class SoloYieldRepairedTop8ObjectiveFailureReviewError(ValueError):
+    pass
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise SoloYieldRepairedTop8ObjectiveFailureReviewError(f"json not found: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _require_no_quality_claim(report: dict[str, Any]) -> None:
+    readiness = _dict(report.get("readiness"))
+    claimed = [
+        key
+        for key in ("musical_quality_claimed", "artist_style_claimed", "production_ready_claimed")
+        if bool(readiness.get(key, False))
+    ]
+    if claimed:
+        raise SoloYieldRepairedTop8ObjectiveFailureReviewError(
+            f"unexpected quality claim: {claimed}"
+        )
+
+
+def _load_notes(midi_path: Path) -> list[pretty_midi.Note]:
+    if not midi_path.exists():
+        raise SoloYieldRepairedTop8ObjectiveFailureReviewError(f"MIDI file missing: {midi_path}")
+    midi = pretty_midi.PrettyMIDI(str(midi_path))
+    notes: list[pretty_midi.Note] = []
+    for instrument in midi.instruments:
+        if not instrument.is_drum:
+            notes.extend(instrument.notes)
+    return sorted(notes, key=lambda note: (float(note.start), int(note.pitch)))
+
+
+def _chord_tone_pcs(chord: str) -> set[int]:
+    root_pc, intervals = parse_chord(chord)
+    return {(root_pc + interval) % 12 for interval in intervals}
+
+
+def _chord_index_for_note(note: pretty_midi.Note, *, start: float, duration: float, chord_count: int) -> int:
+    if chord_count <= 1 or duration <= 0:
+        return 0
+    ratio = max(0.0, min(0.999999, (float(note.start) - start) / duration))
+    return min(chord_count - 1, int(ratio * chord_count))
+
+
+def _direction_change_ratio(pitches: list[int]) -> float:
+    if len(pitches) < 3:
+        return 0.0
+    signs: list[int] = []
+    for left, right in zip(pitches, pitches[1:]):
+        delta = int(right) - int(left)
+        if delta > 0:
+            signs.append(1)
+        elif delta < 0:
+            signs.append(-1)
+    if len(signs) < 2:
+        return 0.0
+    changes = sum(1 for left, right in zip(signs, signs[1:]) if left != right)
+    return changes / max(1, len(signs) - 1)
+
+
+def midi_profile(candidate: dict[str, Any]) -> dict[str, Any]:
+    midi_path = Path(str(candidate.get("review_midi_path") or ""))
+    chords = [item.strip() for item in str(candidate.get("chords") or "").split(",") if item.strip()]
+    if not chords:
+        raise SoloYieldRepairedTop8ObjectiveFailureReviewError("candidate chords required")
+    notes = _load_notes(midi_path)
+    if not notes:
+        return {
+            "midi_note_count": 0,
+            "midi_unique_pitch_count": 0,
+            "midi_pitch_span": 0,
+            "midi_max_abs_interval": 0,
+            "midi_direction_change_ratio": 0.0,
+            "midi_max_gap_seconds": 0.0,
+            "midi_avg_gap_seconds": 0.0,
+            "midi_chord_tone_ratio": 0.0,
+            "midi_tension_ratio": 0.0,
+            "final_landing_chord": chords[-1],
+            "final_landing_pitch": None,
+            "final_landing_is_chord_tone": False,
+        }
+
+    starts = [float(note.start) for note in notes]
+    pitches = [int(note.pitch) for note in notes]
+    phrase_start = min(starts)
+    phrase_end = max(float(note.end) for note in notes)
+    phrase_duration = max(1e-6, phrase_end - phrase_start)
+    gaps = [max(0.0, starts[index] - starts[index - 1]) for index in range(1, len(starts))]
+    intervals = [abs(pitches[index] - pitches[index - 1]) for index in range(1, len(pitches))]
+
+    chord_tone_count = 0
+    for note in notes:
+        chord_index = _chord_index_for_note(
+            note,
+            start=phrase_start,
+            duration=phrase_duration,
+            chord_count=len(chords),
+        )
+        if int(note.pitch) % 12 in _chord_tone_pcs(chords[chord_index]):
+            chord_tone_count += 1
+
+    final_note = notes[-1]
+    final_chord_index = _chord_index_for_note(
+        final_note,
+        start=phrase_start,
+        duration=phrase_duration,
+        chord_count=len(chords),
+    )
+    final_chord = chords[final_chord_index]
+    final_is_chord_tone = int(final_note.pitch) % 12 in _chord_tone_pcs(final_chord)
+    chord_tone_ratio = chord_tone_count / max(1, len(notes))
+
+    return {
+        "midi_note_count": len(notes),
+        "midi_unique_pitch_count": len(set(pitches)),
+        "midi_pitch_span": max(pitches) - min(pitches),
+        "midi_max_abs_interval": max(intervals or [0]),
+        "midi_direction_change_ratio": _direction_change_ratio(pitches),
+        "midi_max_gap_seconds": max(gaps or [0.0]),
+        "midi_avg_gap_seconds": mean(gaps) if gaps else 0.0,
+        "midi_chord_tone_ratio": chord_tone_ratio,
+        "midi_tension_ratio": 1.0 - chord_tone_ratio,
+        "final_landing_chord": final_chord,
+        "final_landing_pitch": int(final_note.pitch),
+        "final_landing_is_chord_tone": final_is_chord_tone,
+    }
+
+
+def failure_labels(candidate: dict[str, Any], profile: dict[str, Any]) -> list[str]:
+    labels: list[str] = []
+    if not bool(profile.get("final_landing_is_chord_tone", False)):
+        labels.append("final_landing_not_chord_tone")
+    if _float(candidate.get("chord_tone_ratio")) < 0.50:
+        labels.append("package_low_chord_tone_ratio")
+    if _float(profile.get("midi_chord_tone_ratio")) < 0.50:
+        labels.append("midi_low_chord_tone_ratio")
+    if _float(candidate.get("dead_air_ratio")) >= 0.65:
+        labels.append("dead_air_still_high")
+    if _float(candidate.get("direction_change_ratio")) < 0.50:
+        labels.append("weak_direction_change")
+    if _int(candidate.get("note_count")) < 30:
+        labels.append("low_note_count_for_4bar")
+    if _int(profile.get("midi_max_abs_interval")) >= 8:
+        labels.append("wide_interval_review")
+    return labels
+
+
+def _select_next_target(label_counts: Counter[str], candidate_count: int) -> tuple[str, str]:
+    if label_counts.get("final_landing_not_chord_tone", 0) >= max(1, candidate_count // 2):
+        return SELECTED_TARGET, NEXT_BOUNDARY
+    if label_counts.get("package_low_chord_tone_ratio", 0) >= max(1, candidate_count // 2):
+        return "chord_role_balance_repair", "music_transformer_solo_yield_chord_role_balance_repair_sweep"
+    if label_counts.get("dead_air_still_high", 0) > 0:
+        return "dead_air_aftercare", "music_transformer_solo_yield_dead_air_aftercare_sweep"
+    return "listening_review_required", "music_transformer_solo_yield_listening_review"
+
+
+def build_objective_failure_review(
+    package_report: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if str(package_report.get("schema_version") or "") != "music_transformer_solo_yield_listening_package_v1":
+        raise SoloYieldRepairedTop8ObjectiveFailureReviewError("listening package schema required")
+    _require_no_quality_claim(package_report)
+    candidates = [_dict(item) for item in _list(package_report.get("candidates"))]
+    rows: list[dict[str, Any]] = []
+    label_counts: Counter[str] = Counter()
+    for candidate in candidates:
+        profile = midi_profile(candidate)
+        labels = failure_labels(candidate, profile)
+        label_counts.update(labels)
+        rows.append(
+            {
+                "review_index": _int(candidate.get("review_index")),
+                "case_label": str(candidate.get("case_label") or ""),
+                "chords": str(candidate.get("chords") or ""),
+                "review_midi_path": str(candidate.get("review_midi_path") or ""),
+                "review_wav_path": str(candidate.get("review_wav_path") or ""),
+                "package_metrics": {
+                    "note_count": _int(candidate.get("note_count")),
+                    "unique_pitch_count": _int(candidate.get("unique_pitch_count")),
+                    "dead_air_ratio": _float(candidate.get("dead_air_ratio")),
+                    "direction_change_ratio": _float(candidate.get("direction_change_ratio")),
+                    "syncopated_onset_ratio": _float(candidate.get("syncopated_onset_ratio")),
+                    "chord_tone_ratio": _float(candidate.get("chord_tone_ratio")),
+                    "tension_ratio": _float(candidate.get("tension_ratio")),
+                    "score": _float(candidate.get("score")),
+                },
+                "midi_profile": profile,
+                "failure_labels": labels,
+            }
+        )
+
+    selected_target, next_boundary = _select_next_target(label_counts, len(rows))
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "boundary": BOUNDARY,
+        "source_package": {
+            "schema_version": package_report.get("schema_version"),
+            "output_dir": package_report.get("output_dir"),
+            "candidate_count": _int(package_report.get("candidate_count")),
+        },
+        "candidate_count": len(rows),
+        "candidates": rows,
+        "aggregate": {
+            "failure_label_counts": dict(sorted(label_counts.items())),
+            "failed_candidate_count": sum(1 for row in rows if row["failure_labels"]),
+            "candidate_without_failure_label_count": sum(1 for row in rows if not row["failure_labels"]),
+            "final_landing_not_chord_tone_count": label_counts.get("final_landing_not_chord_tone", 0),
+            "package_low_chord_tone_ratio_count": label_counts.get("package_low_chord_tone_ratio", 0),
+            "midi_low_chord_tone_ratio_count": label_counts.get("midi_low_chord_tone_ratio", 0),
+            "dead_air_still_high_count": label_counts.get("dead_air_still_high", 0),
+        },
+        "readiness": {
+            "objective_failure_review_completed": True,
+            "validated_listening_input_present": False,
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "selected_next_target": selected_target,
+            "next_boundary": next_boundary,
+            "critical_user_input_required": False,
+            "reason": (
+                "objective review found repeated final landing and chord-role failures; "
+                "route to pitch-role repair without quality claim"
+            ),
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "stable_jazz_solo_quality",
+            "artist_level_long_solo_generation",
+            "production_ready_improviser",
+        ],
+    }
+    write_json(output_dir / "objective_failure_review.json", report)
+    write_json(output_dir / "objective_failure_review_summary.json", validate_report(report))
+    write_text(output_dir / "objective_failure_review.md", markdown_report(report))
+    return report
+
+
+def validate_report(report: dict[str, Any], *, min_candidates: int = 1) -> dict[str, Any]:
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise SoloYieldRepairedTop8ObjectiveFailureReviewError("schema version mismatch")
+    readiness = _dict(report.get("readiness"))
+    aggregate = _dict(report.get("aggregate"))
+    decision = _dict(report.get("decision"))
+    candidate_count = _int(report.get("candidate_count"))
+    if candidate_count < int(min_candidates):
+        raise SoloYieldRepairedTop8ObjectiveFailureReviewError("candidate count below requirement")
+    if not bool(readiness.get("objective_failure_review_completed", False)):
+        raise SoloYieldRepairedTop8ObjectiveFailureReviewError("objective failure review completion required")
+    claimed = [
+        key
+        for key in ("musical_quality_claimed", "artist_style_claimed", "production_ready_claimed")
+        if bool(readiness.get(key, True))
+    ]
+    if claimed:
+        raise SoloYieldRepairedTop8ObjectiveFailureReviewError(f"unexpected quality claim: {claimed}")
+    label_counts = _dict(aggregate.get("failure_label_counts"))
+    return {
+        "schema_version": str(report.get("schema_version") or ""),
+        "candidate_count": candidate_count,
+        "failed_candidate_count": _int(aggregate.get("failed_candidate_count")),
+        "final_landing_not_chord_tone_count": _int(
+            aggregate.get("final_landing_not_chord_tone_count")
+        ),
+        "package_low_chord_tone_ratio_count": _int(
+            aggregate.get("package_low_chord_tone_ratio_count")
+        ),
+        "midi_low_chord_tone_ratio_count": _int(aggregate.get("midi_low_chord_tone_ratio_count")),
+        "dead_air_still_high_count": _int(aggregate.get("dead_air_still_high_count")),
+        "failure_label_type_count": len(label_counts),
+        "selected_next_target": str(decision.get("selected_next_target") or ""),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+        "musical_quality_claimed": bool(readiness.get("musical_quality_claimed", True)),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    aggregate = report["aggregate"]
+    decision = report["decision"]
+    readiness = report["readiness"]
+    lines = [
+        "# Music Transformer Solo Yield Repaired Top8 Objective Failure Review",
+        "",
+        "## Summary",
+        "",
+        f"- candidate count: `{report['candidate_count']}`",
+        f"- failed candidate count: `{aggregate['failed_candidate_count']}`",
+        f"- final landing not chord tone: `{aggregate['final_landing_not_chord_tone_count']}`",
+        f"- package low chord-tone ratio: `{aggregate['package_low_chord_tone_ratio_count']}`",
+        f"- MIDI low chord-tone ratio: `{aggregate['midi_low_chord_tone_ratio_count']}`",
+        f"- dead-air still high: `{aggregate['dead_air_still_high_count']}`",
+        f"- selected next target: `{decision['selected_next_target']}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        f"- musical quality claimed: `{_bool_token(readiness['musical_quality_claimed'])}`",
+        "",
+        "## Failure Label Counts",
+        "",
+    ]
+    for label, count in sorted(aggregate["failure_label_counts"].items()):
+        lines.append(f"- `{label}`: `{count}`")
+    lines.extend(["", "## Candidates", ""])
+    for row in report.get("candidates", []):
+        metrics = row["package_metrics"]
+        profile = row["midi_profile"]
+        labels = ", ".join(f"`{label}`" for label in row["failure_labels"]) or "`none`"
+        lines.extend(
+            [
+                f"- candidate `{row['review_index']}` / `{row['case_label']}`",
+                f"  - labels: {labels}",
+                f"  - package dead-air: `{float(metrics['dead_air_ratio']):.4f}`",
+                f"  - package chord-tone ratio: `{float(metrics['chord_tone_ratio']):.4f}`",
+                f"  - MIDI chord-tone ratio: `{float(profile['midi_chord_tone_ratio']):.4f}`",
+                f"  - final landing: `{profile['final_landing_pitch']}` over `{profile['final_landing_chord']}`, chord-tone `{_bool_token(profile['final_landing_is_chord_tone'])}`",
+            ]
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Review repaired top8 objective failure labels")
+    parser.add_argument(
+        "--package_report",
+        type=str,
+        default=(
+            "outputs/music_transformer_finetune_mvp/solo_yield_listening_review/"
+            "issue_1250_4bar_repaired_top8_listening_package/listening_review_package.json"
+        ),
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/music_transformer_finetune_mvp/solo_yield_objective_failure_review",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--min_candidates", type=int, default=8)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    report = build_objective_failure_review(
+        read_json(Path(args.package_report)),
+        output_dir=output_dir,
+    )
+    summary = validate_report(report, min_candidates=int(args.min_candidates))
+    write_json(output_dir / "objective_failure_review_summary.json", summary)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown_report(report))
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_music_transformer_solo_yield_repaired_top8_objective_failure_review.py
+++ b/tests/test_music_transformer_solo_yield_repaired_top8_objective_failure_review.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import pretty_midi
+
+from scripts.review_music_transformer_solo_yield_repaired_top8_objective_failures import (
+    NEXT_BOUNDARY,
+    SCHEMA_VERSION,
+    SELECTED_TARGET,
+    SoloYieldRepairedTop8ObjectiveFailureReviewError,
+    build_objective_failure_review,
+    validate_report,
+)
+
+
+def write_midi(path: Path, pitches: list[int]) -> None:
+    midi = pretty_midi.PrettyMIDI(initial_tempo=124)
+    instrument = pretty_midi.Instrument(program=0)
+    for index, pitch in enumerate(pitches):
+        start = index * 0.25
+        instrument.notes.append(
+            pretty_midi.Note(velocity=90, pitch=int(pitch), start=start, end=start + 0.12)
+        )
+    midi.instruments.append(instrument)
+    midi.write(str(path))
+
+
+def package_report(root: Path, *, quality_claim: bool = False) -> dict:
+    paths = [root / f"candidate_{index}.mid" for index in range(1, 4)]
+    write_midi(paths[0], [61, 63, 66, 68, 73, 75, 78, 80])
+    write_midi(paths[1], [60, 64, 67, 71, 65, 69, 72, 75])
+    write_midi(paths[2], [62, 66, 69, 73, 77, 74, 70, 68])
+    return {
+        "schema_version": "music_transformer_solo_yield_listening_package_v1",
+        "output_dir": str(root / "package"),
+        "candidate_count": 3,
+        "candidates": [
+            {
+                "review_index": 1,
+                "case_label": "minor_backdoor",
+                "chords": "Cm7,F7,Bbmaj7,Ebmaj7",
+                "review_midi_path": str(paths[0]),
+                "review_wav_path": str(root / "candidate_1.wav"),
+                "note_count": 28,
+                "unique_pitch_count": 8,
+                "dead_air_ratio": 0.72,
+                "direction_change_ratio": 0.30,
+                "syncopated_onset_ratio": 0.75,
+                "chord_tone_ratio": 0.44,
+                "tension_ratio": 0.16,
+                "score": 230.0,
+            },
+            {
+                "review_index": 2,
+                "case_label": "major_ii_v_turnaround",
+                "chords": "Dm7,G7,Cmaj7,A7",
+                "review_midi_path": str(paths[1]),
+                "review_wav_path": str(root / "candidate_2.wav"),
+                "note_count": 33,
+                "unique_pitch_count": 8,
+                "dead_air_ratio": 0.51,
+                "direction_change_ratio": 0.55,
+                "syncopated_onset_ratio": 0.82,
+                "chord_tone_ratio": 0.44,
+                "tension_ratio": 0.12,
+                "score": 231.0,
+            },
+            {
+                "review_index": 3,
+                "case_label": "dominant_cycle",
+                "chords": "Em7,A7,Dmaj7,G7",
+                "review_midi_path": str(paths[2]),
+                "review_wav_path": str(root / "candidate_3.wav"),
+                "note_count": 31,
+                "unique_pitch_count": 8,
+                "dead_air_ratio": 0.66,
+                "direction_change_ratio": 0.58,
+                "syncopated_onset_ratio": 0.78,
+                "chord_tone_ratio": 0.44,
+                "tension_ratio": 0.14,
+                "score": 232.0,
+            },
+        ],
+        "readiness": {
+            "musical_quality_claimed": quality_claim,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+    }
+
+
+class MusicTransformerSoloYieldRepairedTop8ObjectiveFailureReviewTest(unittest.TestCase):
+    def test_builds_objective_failure_review_without_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            report = build_objective_failure_review(
+                package_report(root),
+                output_dir=root / "review",
+            )
+        summary = validate_report(report, min_candidates=3)
+
+        self.assertEqual(summary["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(summary["candidate_count"], 3)
+        self.assertEqual(summary["failed_candidate_count"], 3)
+        self.assertGreaterEqual(summary["final_landing_not_chord_tone_count"], 2)
+        self.assertGreaterEqual(summary["package_low_chord_tone_ratio_count"], 3)
+        self.assertEqual(summary["selected_next_target"], SELECTED_TARGET)
+        self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
+        self.assertFalse(summary["musical_quality_claimed"])
+
+    def test_rejects_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with self.assertRaises(SoloYieldRepairedTop8ObjectiveFailureReviewError):
+                build_objective_failure_review(
+                    package_report(root, quality_claim=True),
+                    output_dir=root / "review",
+                )
+
+    def test_rejects_missing_midi_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            report = package_report(root)
+            Path(report["candidates"][0]["review_midi_path"]).unlink()
+            with self.assertRaises(SoloYieldRepairedTop8ObjectiveFailureReviewError):
+                build_objective_failure_review(report, output_dir=root / "review")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- repaired 4bar top8 후보 objective failure review 추가
- listening package metric과 실제 MIDI note 기반 failure label 산출
- README 현재 확인 결과와 다음 repair target 갱신

## Context
- #1260 final handoff 기준 current review package: `issue_1250_4bar_repaired_top8_listening_package`
- final status audit: strict 22/24, grammar 24/24, rendered WAV 8
- validated listening input=false, musical quality claim=false
- 청취 입력 없이 진행 가능한 다음 분기: MIDI note/objective metric 기반 실패 후보 분리
- 기존 candidate failure labeling script는 이전 source-context chain 결합도가 높아 latest top8 review에는 별도 경량 리뷰 필요

## Scope
- `review_music_transformer_solo_yield_repaired_top8_objective_failures.py` 추가
- top8 MIDI note profile 산출: final landing, chord-tone ratio, interval, gap, direction change
- failure label aggregate 산출
- next repair target: `chord_tone_landing_repair`
- README evidence와 다음 작업 갱신

## Result
- candidate count: 8
- failed candidate count: 8
- final landing not chord-tone: 8/8
- package low chord-tone ratio: 8/8
- MIDI low chord-tone ratio: 6/8
- dead-air still high: 3/8
- selected next boundary: `music_transformer_solo_yield_chord_tone_landing_repair_sweep`
- musical quality claimed: false

## Validation
- .venv/bin/python -m unittest tests/test_music_transformer_solo_yield_repaired_top8_objective_failure_review.py
- .venv/bin/python scripts/review_music_transformer_solo_yield_repaired_top8_objective_failures.py --run_id issue_1262_repaired_top8_objective_review --doc_path docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_TOP8_OBJECTIVE_FAILURE_REVIEW_2026-06-11.md --min_candidates 8
- git diff --check
- rg -n "codex|Codex|CODEX|ChatGPT|Claude|assistant" README.md docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_TOP8_OBJECTIVE_FAILURE_REVIEW_2026-06-11.md scripts/review_music_transformer_solo_yield_repaired_top8_objective_failures.py tests/test_music_transformer_solo_yield_repaired_top8_objective_failure_review.py
- bash scripts/agent_harness.sh quick

## Risk
- objective metric 기반 라벨링만 포함
- 사람 기준 청취 선호 판단 제외
- 생성 코드 변경 없음
- 음악적 품질 claim 추가 없음

## Follow-up
- chord-tone landing repair sweep
- repair 후 strict / grammar / final landing 지표 비교
- repaired candidate listening package 갱신

Closes #1262


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated progress tracking with expanded next steps and objectives for Stage B jazz solo generation.
  * Added new objective failure review documentation with metrics and evaluated candidate results.

* **Tests**
  * Added unit tests for objective failure review functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->