### PR TITLE
Stage B MIDI-to-solo chord-tone landing repair listening package

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MIDI 데이터를 token sequence로 변환하고, Music Transformer 계열 symbo
 - 2마디 후보 생성: strict `24 / 24`, grammar-valid `24 / 24`
 - 4마디 확장 후보 생성: strict `20 / 24`, grammar-valid `24 / 24`
 - 4마디 dead-air repair 이후: strict `22 / 24`, grammar-valid `24 / 24`
-- repaired 4bar review package: MIDI `8`, WAV `8`
+- chord-tone landing repair listening package: MIDI `8`, WAV `8`
 - final status audit: technical evidence ready `true`
 - 음악적 품질 claim: `false`
 - 사람 기준 청취 선호 입력: `false`
@@ -114,22 +114,24 @@ raw model generation은 note grammar가 자주 깨졌다.
 - next boundary: `music_transformer_solo_yield_chord_tone_landing_repair_audio_package`
 - chord-tone landing repair audio package: rendered WAV `8`, technical WAV validation `true`, duration range `10.725s - 10.739s`
 - next boundary: `music_transformer_solo_yield_chord_tone_landing_repair_listening_package`
+- chord-tone landing repair listening package: MIDI `8`, WAV `8`, review input template `true`, validated listening input `false`, preference fill `false`
+- next boundary: `music_transformer_solo_yield_chord_tone_landing_repair_listening_input_guard`
 
 ## 결과 파일
 
 최신 리뷰 패키지:
 
-- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/listening_review_package.md`
-- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/listening_review_package.json`
-- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/listening_review_input_template.json`
+- `outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair_listening_review/issue_1268_chord_tone_landing_listening_package/listening_review_package.md`
+- `outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair_listening_review/issue_1268_chord_tone_landing_listening_package/listening_review_package.json`
+- `outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair_listening_review/issue_1268_chord_tone_landing_listening_package/listening_review_input_template.json`
 
 MIDI 후보:
 
-- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/midi/`
+- `outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair_listening_review/issue_1268_chord_tone_landing_listening_package/midi/`
 
 WAV 후보:
 
-- `outputs/music_transformer_finetune_mvp/solo_yield_listening_review/issue_1250_4bar_repaired_top8_listening_package/audio/`
+- `outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair_listening_review/issue_1268_chord_tone_landing_listening_package/audio/`
 
 Report:
 
@@ -161,6 +163,7 @@ Report:
 - `docs/STAGE_B_MIDI_TO_SOLO_REPAIRED_TOP8_OBJECTIVE_FAILURE_REVIEW_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_CHORD_TONE_LANDING_REPAIR_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_CHORD_TONE_LANDING_REPAIR_AUDIO_PACKAGE_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_CHORD_TONE_LANDING_REPAIR_LISTENING_PACKAGE_2026-06-11.md`
 
 ## 실행 방법
 
@@ -221,8 +224,9 @@ Report:
 
 ## 다음 작업
 
-- chord-tone landing repair listening package 생성
-- repaired MIDI/WAV review input template 갱신
+- chord-tone landing repair listening input guard
+- validated listening input 존재 여부 확인
+- pending 상태면 objective-only next decision 기록
 - WAV/MIDI 청취 리뷰
 - 청취 결과 기준 keep/reject 후보 기록
 - 음악적 품질 claim 여부는 청취 리뷰 이후 재판단

--- a/docs/STAGE_B_MIDI_TO_SOLO_CHORD_TONE_LANDING_REPAIR_LISTENING_PACKAGE_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_CHORD_TONE_LANDING_REPAIR_LISTENING_PACKAGE_2026-06-11.md
@@ -1,0 +1,68 @@
+# Music Transformer Solo Yield Chord-Tone Landing Repair Listening Package
+
+## Summary
+
+- source rendered WAV count: `8`
+- source technical WAV validation: `true`
+- review candidate count: `8`
+- MIDI files copied: `8`
+- WAV files copied: `8`
+- review input template written: `true`
+- validated listening input present: `false`
+- preference fill allowed: `false`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_chord_tone_landing_repair_listening_input_guard`
+
+## Candidates
+
+- candidate `1` / `minor_backdoor`
+  - MIDI: `outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair_listening_review/issue_1268_chord_tone_landing_listening_package/midi/candidate_01_minor_backdoor_chord_tone_landing_repair.mid`
+  - WAV: `outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair_listening_review/issue_1268_chord_tone_landing_listening_package/audio/candidate_01_minor_backdoor_chord_tone_landing_repair.wav`
+  - duration: `10.739`
+  - sample rate: `44100`
+- candidate `2` / `minor_backdoor`
+  - MIDI: `outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair_listening_review/issue_1268_chord_tone_landing_listening_package/midi/candidate_02_minor_backdoor_chord_tone_landing_repair.mid`
+  - WAV: `outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair_listening_review/issue_1268_chord_tone_landing_listening_package/audio/candidate_02_minor_backdoor_chord_tone_landing_repair.wav`
+  - duration: `10.738`
+  - sample rate: `44100`
+- candidate `3` / `major_ii_v_turnaround`
+  - MIDI: `outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair_listening_review/issue_1268_chord_tone_landing_listening_package/midi/candidate_03_major_ii_v_turnaround_chord_tone_landing_repair.mid`
+  - WAV: `outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair_listening_review/issue_1268_chord_tone_landing_listening_package/audio/candidate_03_major_ii_v_turnaround_chord_tone_landing_repair.wav`
+  - duration: `10.735`
+  - sample rate: `44100`
+- candidate `4` / `major_ii_v_turnaround`
+  - MIDI: `outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair_listening_review/issue_1268_chord_tone_landing_listening_package/midi/candidate_04_major_ii_v_turnaround_chord_tone_landing_repair.mid`
+  - WAV: `outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair_listening_review/issue_1268_chord_tone_landing_listening_package/audio/candidate_04_major_ii_v_turnaround_chord_tone_landing_repair.wav`
+  - duration: `10.738`
+  - sample rate: `44100`
+- candidate `5` / `dominant_cycle`
+  - MIDI: `outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair_listening_review/issue_1268_chord_tone_landing_listening_package/midi/candidate_05_dominant_cycle_chord_tone_landing_repair.mid`
+  - WAV: `outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair_listening_review/issue_1268_chord_tone_landing_listening_package/audio/candidate_05_dominant_cycle_chord_tone_landing_repair.wav`
+  - duration: `10.738`
+  - sample rate: `44100`
+- candidate `6` / `dominant_cycle`
+  - MIDI: `outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair_listening_review/issue_1268_chord_tone_landing_listening_package/midi/candidate_06_dominant_cycle_chord_tone_landing_repair.mid`
+  - WAV: `outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair_listening_review/issue_1268_chord_tone_landing_listening_package/audio/candidate_06_dominant_cycle_chord_tone_landing_repair.wav`
+  - duration: `10.725`
+  - sample rate: `44100`
+- candidate `7` / `rhythm_turnaround`
+  - MIDI: `outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair_listening_review/issue_1268_chord_tone_landing_listening_package/midi/candidate_07_rhythm_turnaround_chord_tone_landing_repair.mid`
+  - WAV: `outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair_listening_review/issue_1268_chord_tone_landing_listening_package/audio/candidate_07_rhythm_turnaround_chord_tone_landing_repair.wav`
+  - duration: `10.735`
+  - sample rate: `44100`
+- candidate `8` / `rhythm_turnaround`
+  - MIDI: `outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair_listening_review/issue_1268_chord_tone_landing_listening_package/midi/candidate_08_rhythm_turnaround_chord_tone_landing_repair.mid`
+  - WAV: `outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair_listening_review/issue_1268_chord_tone_landing_listening_package/audio/candidate_08_rhythm_turnaround_chord_tone_landing_repair.wav`
+  - duration: `10.738`
+  - sample rate: `44100`
+
+## Review Input
+
+- `outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair_listening_review/issue_1268_chord_tone_landing_listening_package/listening_review_input_template.json`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`

--- a/scripts/build_music_transformer_solo_yield_chord_tone_landing_listening_package.py
+++ b/scripts/build_music_transformer_solo_yield_chord_tone_landing_listening_package.py
@@ -1,0 +1,379 @@
+"""Build listening package for chord-tone landing repaired solo-yield candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+from scripts.render_music_transformer_solo_yield_chord_tone_landing_repair_audio import (  # noqa: E402
+    SCHEMA_VERSION as AUDIO_PACKAGE_SCHEMA_VERSION,
+    build_audio_package,
+    load_or_build_repair_sweep,
+    read_json,
+)
+from scripts.render_stage_b_midi_to_solo_candidate_audio import sha256_file, wav_meta  # noqa: E402
+
+
+SCHEMA_VERSION = "music_transformer_solo_yield_chord_tone_landing_listening_package_v1"
+BOUNDARY = "music_transformer_solo_yield_chord_tone_landing_repair_listening_package"
+NEXT_BOUNDARY = "music_transformer_solo_yield_chord_tone_landing_repair_listening_input_guard"
+
+
+class SoloYieldChordToneLandingListeningPackageError(ValueError):
+    pass
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(report: dict[str, Any]) -> None:
+    readiness = _dict(report.get("readiness"))
+    claimed = [
+        key
+        for key in ("audio_rendered_quality_claimed", "musical_quality_claimed", "artist_style_claimed", "production_ready_claimed")
+        if bool(readiness.get(key, False))
+    ]
+    if claimed:
+        raise SoloYieldChordToneLandingListeningPackageError(f"unexpected quality claim: {claimed}")
+
+
+def _validate_audio_package(report: dict[str, Any], *, min_candidates: int) -> list[dict[str, Any]]:
+    if str(report.get("schema_version") or "") != AUDIO_PACKAGE_SCHEMA_VERSION:
+        raise SoloYieldChordToneLandingListeningPackageError("audio package schema required")
+    _require_no_quality_claim(report)
+    aggregate = _dict(report.get("aggregate"))
+    if not bool(aggregate.get("technical_wav_validation", False)):
+        raise SoloYieldChordToneLandingListeningPackageError("technical WAV validation required")
+    rows = [_dict(item) for item in _list(report.get("rendered_audio_files"))]
+    if len(rows) < int(min_candidates):
+        raise SoloYieldChordToneLandingListeningPackageError("rendered audio file count below requirement")
+    for row in rows:
+        midi_path = Path(str(row.get("repaired_midi_path") or ""))
+        wav_path = Path(str(_dict(row.get("wav_file")).get("path") or ""))
+        if not midi_path.exists():
+            raise SoloYieldChordToneLandingListeningPackageError(f"MIDI missing: {midi_path}")
+        if not wav_path.exists():
+            raise SoloYieldChordToneLandingListeningPackageError(f"WAV missing: {wav_path}")
+    return rows
+
+
+def build_review_input_template(candidates: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "schema_version": "music_transformer_solo_yield_chord_tone_landing_listening_input_v1",
+        "review_status": "pending",
+        "reviewer_notes": "",
+        "overall_decision": "pending",
+        "preferred_review_index": None,
+        "candidates": [
+            {
+                "review_index": _int(row.get("review_index")),
+                "case_label": str(row.get("case_label") or ""),
+                "decision": "pending",
+                "usable_as_jazz_solo_phrase": None,
+                "primary_failure": None,
+                "notes": "",
+            }
+            for row in candidates
+        ],
+        "allowed_primary_failures": [
+            "not_solo_like",
+            "too_mechanical",
+            "too_sparse",
+            "too_dense",
+            "rhythm_not_swinging",
+            "outside_harmony",
+            "weak_phrase_shape",
+            "audio_render_issue",
+            "none",
+        ],
+    }
+
+
+def copy_candidates(audio_rows: list[dict[str, Any]], *, output_dir: Path) -> list[dict[str, Any]]:
+    midi_dir = output_dir / "midi"
+    audio_dir = output_dir / "audio"
+    midi_dir.mkdir(parents=True, exist_ok=True)
+    audio_dir.mkdir(parents=True, exist_ok=True)
+    copied: list[dict[str, Any]] = []
+    for row in audio_rows:
+        review_index = _int(row.get("review_index"))
+        case_label = str(row.get("case_label") or "candidate")
+        source_midi = Path(str(row.get("repaired_midi_path") or ""))
+        source_wav = Path(str(_dict(row.get("wav_file")).get("path") or ""))
+        target_stem = f"candidate_{review_index:02d}_{case_label}_chord_tone_landing_repair"
+        target_midi = midi_dir / f"{target_stem}.mid"
+        target_wav = audio_dir / f"{target_stem}.wav"
+        shutil.copy2(source_midi, target_midi)
+        shutil.copy2(source_wav, target_wav)
+        copied.append(
+            {
+                "review_index": review_index,
+                "case_label": case_label,
+                "source_midi_path": str(source_midi),
+                "source_wav_path": str(source_wav),
+                "review_midi_path": str(target_midi),
+                "review_wav_path": str(target_wav),
+                "review_midi_sha256": sha256_file(target_midi),
+                "review_wav_file": wav_meta(target_wav),
+            }
+        )
+    return copied
+
+
+def build_listening_package(
+    audio_package: dict[str, Any],
+    *,
+    output_dir: Path,
+    min_candidates: int,
+) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    audio_rows = _validate_audio_package(audio_package, min_candidates=int(min_candidates))
+    candidates = copy_candidates(audio_rows[: int(min_candidates)], output_dir=output_dir)
+    review_input_template = build_review_input_template(candidates)
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "boundary": BOUNDARY,
+        "source_audio_package": {
+            "schema_version": audio_package.get("schema_version"),
+            "output_dir": audio_package.get("output_dir"),
+            "rendered_wav_count": _int(_dict(audio_package.get("aggregate")).get("rendered_wav_count")),
+            "technical_wav_validation": bool(
+                _dict(audio_package.get("aggregate")).get("technical_wav_validation", False)
+            ),
+        },
+        "candidate_count": len(candidates),
+        "candidates": candidates,
+        "review_input_template": review_input_template,
+        "readiness": {
+            "listening_package_ready": bool(candidates),
+            "candidate_midi_files_copied": len(candidates),
+            "candidate_wav_files_copied": len(candidates),
+            "review_input_template_written": True,
+            "validated_listening_input_present": False,
+            "preference_fill_allowed": False,
+            "audio_rendered_quality_claimed": False,
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "selected_next_target": "chord_tone_landing_repair_listening_input_guard",
+            "next_boundary": NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+            "reason": "MIDI/WAV review package ready; preference input remains pending",
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "stable_jazz_solo_quality",
+            "artist_level_long_solo_generation",
+            "production_ready_improviser",
+        ],
+    }
+    write_json(output_dir / "listening_review_package.json", report)
+    write_json(output_dir / "listening_review_input_template.json", review_input_template)
+    write_text(output_dir / "listening_review_package.md", markdown_report(report))
+    write_json(output_dir / "listening_review_package_summary.json", validate_report(report))
+    return report
+
+
+def load_or_build_audio_package(
+    *,
+    audio_package_report_path: Path,
+    output_dir: Path,
+    repair_sweep_report_path: Path,
+    package_report_path: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+) -> dict[str, Any]:
+    if audio_package_report_path.exists():
+        return read_json(audio_package_report_path)
+    repair_sweep = load_or_build_repair_sweep(
+        repair_sweep_report_path=repair_sweep_report_path,
+        output_dir=output_dir / "source_repair_build",
+        package_report_path=package_report_path,
+    )
+    return build_audio_package(
+        repair_sweep,
+        output_dir=output_dir / "source_audio_package",
+        renderer_path=renderer_path,
+        soundfont_path=soundfont_path,
+        sample_rate=sample_rate,
+    )
+
+
+def validate_report(report: dict[str, Any], *, min_candidates: int = 1) -> dict[str, Any]:
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise SoloYieldChordToneLandingListeningPackageError("schema version mismatch")
+    readiness = _dict(report.get("readiness"))
+    candidate_count = _int(report.get("candidate_count"))
+    if candidate_count < int(min_candidates):
+        raise SoloYieldChordToneLandingListeningPackageError("candidate count below requirement")
+    if not bool(readiness.get("listening_package_ready", False)):
+        raise SoloYieldChordToneLandingListeningPackageError("listening package readiness required")
+    claimed = [
+        key
+        for key in ("audio_rendered_quality_claimed", "musical_quality_claimed", "artist_style_claimed", "production_ready_claimed")
+        if bool(readiness.get(key, True))
+    ]
+    if claimed:
+        raise SoloYieldChordToneLandingListeningPackageError(f"unexpected quality claim: {claimed}")
+    decision = _dict(report.get("decision"))
+    return {
+        "schema_version": str(report.get("schema_version") or ""),
+        "candidate_count": candidate_count,
+        "candidate_midi_files_copied": _int(readiness.get("candidate_midi_files_copied")),
+        "candidate_wav_files_copied": _int(readiness.get("candidate_wav_files_copied")),
+        "review_input_template_written": bool(readiness.get("review_input_template_written", False)),
+        "validated_listening_input_present": bool(readiness.get("validated_listening_input_present", True)),
+        "preference_fill_allowed": bool(readiness.get("preference_fill_allowed", True)),
+        "audio_rendered_quality_claimed": bool(readiness.get("audio_rendered_quality_claimed", True)),
+        "musical_quality_claimed": bool(readiness.get("musical_quality_claimed", True)),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    readiness = report["readiness"]
+    decision = report["decision"]
+    source = report["source_audio_package"]
+    lines = [
+        "# Music Transformer Solo Yield Chord-Tone Landing Repair Listening Package",
+        "",
+        "## Summary",
+        "",
+        f"- source rendered WAV count: `{source['rendered_wav_count']}`",
+        f"- source technical WAV validation: `{_bool_token(source['technical_wav_validation'])}`",
+        f"- review candidate count: `{report['candidate_count']}`",
+        f"- MIDI files copied: `{readiness['candidate_midi_files_copied']}`",
+        f"- WAV files copied: `{readiness['candidate_wav_files_copied']}`",
+        f"- review input template written: `{_bool_token(readiness['review_input_template_written'])}`",
+        f"- validated listening input present: `{_bool_token(readiness['validated_listening_input_present'])}`",
+        f"- preference fill allowed: `{_bool_token(readiness['preference_fill_allowed'])}`",
+        f"- musical quality claimed: `{_bool_token(readiness['musical_quality_claimed'])}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        "",
+        "## Candidates",
+        "",
+    ]
+    for row in report.get("candidates", []):
+        wav = row["review_wav_file"]
+        lines.extend(
+            [
+                f"- candidate `{row['review_index']}` / `{row['case_label']}`",
+                f"  - MIDI: `{row['review_midi_path']}`",
+                f"  - WAV: `{row['review_wav_path']}`",
+                f"  - duration: `{float(wav['duration_seconds']):.3f}`",
+                f"  - sample rate: `{wav['sample_rate']}`",
+            ]
+        )
+    lines.extend(["", "## Review Input", "", f"- `{report['output_dir']}/listening_review_input_template.json`"])
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build chord-tone landing repair listening package")
+    parser.add_argument(
+        "--audio_package_report",
+        type=str,
+        default=(
+            "outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair_audio/"
+            "issue_1266_chord_tone_landing_audio_package/chord_tone_landing_repair_audio_package.json"
+        ),
+    )
+    parser.add_argument(
+        "--repair_sweep_report",
+        type=str,
+        default=(
+            "outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair/"
+            "issue_1264_chord_tone_landing_repair/chord_tone_landing_repair_sweep.json"
+        ),
+    )
+    parser.add_argument(
+        "--package_report",
+        type=str,
+        default=(
+            "outputs/music_transformer_finetune_mvp/solo_yield_listening_review/"
+            "issue_1250_4bar_repaired_top8_listening_package/listening_review_package.json"
+        ),
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/music_transformer_finetune_mvp/solo_yield_chord_tone_landing_repair_listening_review",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--renderer", type=str, default="")
+    parser.add_argument("--soundfont", type=str, default="")
+    parser.add_argument("--sample_rate", type=int, default=44100)
+    parser.add_argument("--min_candidates", type=int, default=8)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    audio_package = load_or_build_audio_package(
+        audio_package_report_path=Path(args.audio_package_report),
+        output_dir=output_dir,
+        repair_sweep_report_path=Path(args.repair_sweep_report),
+        package_report_path=Path(args.package_report),
+        renderer_path=str(args.renderer or ""),
+        soundfont_path=str(args.soundfont or ""),
+        sample_rate=int(args.sample_rate),
+    )
+    report = build_listening_package(
+        audio_package,
+        output_dir=output_dir,
+        min_candidates=int(args.min_candidates),
+    )
+    summary = validate_report(report, min_candidates=int(args.min_candidates))
+    write_json(output_dir / "listening_review_package_summary.json", summary)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown_report(report))
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_music_transformer_solo_yield_chord_tone_landing_listening_package.py
+++ b/tests/test_music_transformer_solo_yield_chord_tone_landing_listening_package.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+import wave
+from pathlib import Path
+
+import pretty_midi
+
+from scripts.build_music_transformer_solo_yield_chord_tone_landing_listening_package import (
+    NEXT_BOUNDARY,
+    SCHEMA_VERSION,
+    SoloYieldChordToneLandingListeningPackageError,
+    build_listening_package,
+    validate_report,
+)
+from scripts.render_stage_b_midi_to_solo_candidate_audio import wav_meta
+
+
+def write_midi(path: Path) -> None:
+    midi = pretty_midi.PrettyMIDI(initial_tempo=124)
+    instrument = pretty_midi.Instrument(program=0)
+    instrument.notes.append(pretty_midi.Note(velocity=90, pitch=60, start=0.0, end=0.25))
+    midi.instruments.append(instrument)
+    midi.write(str(path))
+
+
+def write_wav(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(22050)
+        handle.writeframes(b"\x00\x00" * 22050)
+
+
+def audio_package(root: Path, *, quality_claim: bool = False) -> dict:
+    midi_paths = [root / f"candidate_{index}.mid" for index in range(1, 3)]
+    wav_paths = [root / f"candidate_{index}.wav" for index in range(1, 3)]
+    for midi_path, wav_path in zip(midi_paths, wav_paths):
+        write_midi(midi_path)
+        write_wav(wav_path)
+    return {
+        "schema_version": "music_transformer_solo_yield_chord_tone_landing_repair_audio_package_v1",
+        "output_dir": str(root / "audio_package"),
+        "rendered_audio_files": [
+            {
+                "review_index": 1,
+                "case_label": "minor_backdoor",
+                "repaired_midi_path": str(midi_paths[0]),
+                "wav_file": wav_meta(wav_paths[0]),
+            },
+            {
+                "review_index": 2,
+                "case_label": "dominant_cycle",
+                "repaired_midi_path": str(midi_paths[1]),
+                "wav_file": wav_meta(wav_paths[1]),
+            },
+        ],
+        "aggregate": {
+            "rendered_wav_count": 2,
+            "technical_wav_validation": True,
+        },
+        "readiness": {
+            "audio_rendered_quality_claimed": False,
+            "musical_quality_claimed": quality_claim,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+    }
+
+
+class MusicTransformerSoloYieldChordToneLandingListeningPackageTest(unittest.TestCase):
+    def test_builds_listening_package_without_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            report = build_listening_package(
+                audio_package(root),
+                output_dir=root / "listening",
+                min_candidates=2,
+            )
+        summary = validate_report(report, min_candidates=2)
+
+        self.assertEqual(summary["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(summary["candidate_count"], 2)
+        self.assertEqual(summary["candidate_midi_files_copied"], 2)
+        self.assertEqual(summary["candidate_wav_files_copied"], 2)
+        self.assertTrue(summary["review_input_template_written"])
+        self.assertFalse(summary["validated_listening_input_present"])
+        self.assertFalse(summary["preference_fill_allowed"])
+        self.assertFalse(summary["musical_quality_claimed"])
+        self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
+
+    def test_rejects_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with self.assertRaises(SoloYieldChordToneLandingListeningPackageError):
+                build_listening_package(
+                    audio_package(root, quality_claim=True),
+                    output_dir=root / "listening",
+                    min_candidates=2,
+                )
+
+    def test_rejects_missing_wav(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = audio_package(root)
+            Path(source["rendered_audio_files"][0]["wav_file"]["path"]).unlink()
+            with self.assertRaises(SoloYieldChordToneLandingListeningPackageError):
+                build_listening_package(source, output_dir=root / "listening", min_candidates=2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- chord-tone landing repair 결과 기준 listening review package 생성
- repaired MIDI/WAV 8개 review package로 복사
- review input template 생성 및 pending 상태 고정
- README 최신 evidence와 다음 boundary 갱신

## Context

- #1266 audio package 결과: rendered WAV `8`, technical WAV validation `true`
- 이전 objective failure review 결과: final landing not chord-tone `8 / 8 -> 0 / 8` repair 완료
- 현재 청취 입력 상태: validated input `false`, preference fill `false`
- 제외 범위: 음악적 품질 claim, artist-level solo claim, production-ready claim

## Scope

- listening package builder 추가
- review input template schema 추가
- missing MIDI/WAV 및 quality claim guard 추가
- package summary/doc 생성
- README 결과 경계 갱신

## Validation

- `.venv/bin/python -m unittest tests/test_music_transformer_solo_yield_chord_tone_landing_listening_package.py`
- `.venv/bin/python scripts/build_music_transformer_solo_yield_chord_tone_landing_listening_package.py --run_id issue_1268_chord_tone_landing_listening_package --doc_path docs/STAGE_B_MIDI_TO_SOLO_CHORD_TONE_LANDING_REPAIR_LISTENING_PACKAGE_2026-06-11.md --min_candidates 8`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Risk

- WAV/MIDI package 생성만 검증
- 청취 선호와 음악적 품질 미검증
- raw output artifact는 repository commit 대상 제외

## Follow-up

- chord-tone landing repair listening input guard
- pending input이면 objective-only next decision 기록

Closes #1268