### PR TITLE
Stage B MIDI-to-solo chord role balance repair listening input guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MIDI 데이터를 token sequence로 변환하고, Music Transformer 계열 symbo
 - 2마디 후보 생성: strict `24 / 24`, grammar-valid `24 / 24`
 - 4마디 확장 후보 생성: strict `20 / 24`, grammar-valid `24 / 24`
 - 4마디 dead-air repair 이후: strict `22 / 24`, grammar-valid `24 / 24`
-- chord role balance repair listening package: MIDI `8`, WAV `8`, review input template `true`, next `chord_role_balance_repair_listening_input_guard`
+- chord role balance repair listening input guard: pending fields `24`, preference fill `false`, next `chord_role_balance_repair_objective_only_next_decision`
 - final status audit: technical evidence ready `true`
 - 음악적 품질 claim: `false`
 - 사람 기준 청취 선호 입력: `false`
@@ -136,6 +136,8 @@ raw model generation은 note grammar가 자주 깨졌다.
 - next boundary: `music_transformer_solo_yield_chord_role_balance_repair_listening_package`
 - chord role balance repair listening package: MIDI `8`, WAV `8`, review input template `true`, validated listening input `false`, preference fill `false`
 - next boundary: `music_transformer_solo_yield_chord_role_balance_repair_listening_input_guard`
+- chord role balance repair listening input guard: schema matched `true`, pending candidate fields `24`, objective-only next decision required `true`
+- next boundary: `music_transformer_solo_yield_chord_role_balance_repair_objective_only_next_decision`
 
 ## 결과 파일
 
@@ -190,6 +192,7 @@ Report:
 - `docs/STAGE_B_MIDI_TO_SOLO_CHORD_ROLE_BALANCE_REPAIR_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_CHORD_ROLE_BALANCE_REPAIR_AUDIO_PACKAGE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_CHORD_ROLE_BALANCE_REPAIR_LISTENING_PACKAGE_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_CHORD_ROLE_BALANCE_REPAIR_LISTENING_INPUT_GUARD_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_AUDIO_PACKAGE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_LISTENING_PACKAGE_2026-06-11.md`

--- a/docs/STAGE_B_MIDI_TO_SOLO_CHORD_ROLE_BALANCE_REPAIR_LISTENING_INPUT_GUARD_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_CHORD_ROLE_BALANCE_REPAIR_LISTENING_INPUT_GUARD_2026-06-11.md
@@ -1,0 +1,34 @@
+# Music Transformer Solo Yield Chord Role Balance Repair Listening Input Guard
+
+## Summary
+
+- boundary: `music_transformer_solo_yield_chord_role_balance_repair_listening_input_guard`
+- source candidate count: `8`
+- listening input path: `outputs/music_transformer_finetune_mvp/solo_yield_chord_role_balance_repair_listening_review/issue_1288_chord_role_balance_listening_package/listening_review_input_template.json`
+- schema matched: `true`
+- validated listening input present: `false`
+- preference fill allowed: `false`
+- objective-only next decision required: `true`
+- pending status: `true`
+- pending overall decision: `true`
+- pending candidate field count: `24`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_chord_role_balance_repair_objective_only_next_decision`
+
+## Pending Candidate Fields
+
+- review `1`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `2`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `3`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `4`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `5`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `6`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `7`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+- review `8`: `decision,usable_as_jazz_solo_phrase,primary_failure`
+
+## Not Proven
+
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`

--- a/scripts/guard_music_transformer_solo_yield_chord_role_balance_listening_input.py
+++ b/scripts/guard_music_transformer_solo_yield_chord_role_balance_listening_input.py
@@ -1,0 +1,393 @@
+"""Guard listening input for chord-role-balance repaired solo-yield candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+from scripts.build_music_transformer_solo_yield_chord_role_balance_listening_package import (  # noqa: E402
+    INPUT_SCHEMA_VERSION,
+    SCHEMA_VERSION as SOURCE_PACKAGE_SCHEMA_VERSION,
+    build_listening_package,
+    load_or_build_audio_package,
+)
+
+
+SCHEMA_VERSION = "music_transformer_solo_yield_chord_role_balance_listening_input_guard_v1"
+BOUNDARY = "music_transformer_solo_yield_chord_role_balance_repair_listening_input_guard"
+NEXT_BOUNDARY_PENDING = "music_transformer_solo_yield_chord_role_balance_repair_objective_only_next_decision"
+NEXT_BOUNDARY_REVIEWED = "music_transformer_solo_yield_chord_role_balance_repair_listening_review_fill"
+
+
+class SoloYieldChordRoleBalanceListeningInputGuardError(ValueError):
+    pass
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise SoloYieldChordRoleBalanceListeningInputGuardError(f"json not found: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _require_no_quality_claim(readiness: dict[str, Any]) -> None:
+    claimed = [
+        key
+        for key in (
+            "audio_rendered_quality_claimed",
+            "musical_quality_claimed",
+            "artist_style_claimed",
+            "production_ready_claimed",
+        )
+        if bool(readiness.get(key, False))
+    ]
+    if claimed:
+        raise SoloYieldChordRoleBalanceListeningInputGuardError(f"unexpected quality claim: {claimed}")
+
+
+def validate_package(package_report: dict[str, Any]) -> dict[str, Any]:
+    if str(package_report.get("schema_version") or "") != SOURCE_PACKAGE_SCHEMA_VERSION:
+        raise SoloYieldChordRoleBalanceListeningInputGuardError("source package schema required")
+    readiness = _dict(package_report.get("readiness"))
+    _require_no_quality_claim(readiness)
+    candidate_count = _int(package_report.get("candidate_count"))
+    if candidate_count <= 0:
+        raise SoloYieldChordRoleBalanceListeningInputGuardError("candidate count required")
+    if not bool(readiness.get("listening_package_ready", False)):
+        raise SoloYieldChordRoleBalanceListeningInputGuardError("source package readiness required")
+    if _int(readiness.get("candidate_midi_files_copied")) != candidate_count:
+        raise SoloYieldChordRoleBalanceListeningInputGuardError("MIDI copy count mismatch")
+    if _int(readiness.get("candidate_wav_files_copied")) != candidate_count:
+        raise SoloYieldChordRoleBalanceListeningInputGuardError("WAV copy count mismatch")
+    if not bool(readiness.get("review_input_template_written", False)):
+        raise SoloYieldChordRoleBalanceListeningInputGuardError("review input template required")
+    return {
+        "candidate_count": candidate_count,
+        "output_dir": str(package_report.get("output_dir") or ""),
+        "validated_listening_input_present": bool(readiness.get("validated_listening_input_present", False)),
+        "preference_fill_allowed": bool(readiness.get("preference_fill_allowed", False)),
+    }
+
+
+def pending_candidate_fields(candidate: dict[str, Any]) -> list[str]:
+    pending: list[str] = []
+    if str(candidate.get("decision") or "pending") == "pending":
+        pending.append("decision")
+    if candidate.get("usable_as_jazz_solo_phrase") is None:
+        pending.append("usable_as_jazz_solo_phrase")
+    if candidate.get("primary_failure") is None:
+        pending.append("primary_failure")
+    return pending
+
+
+def validate_input(input_report: dict[str, Any], *, candidate_count: int) -> dict[str, Any]:
+    schema_matched = str(input_report.get("schema_version") or "") == INPUT_SCHEMA_VERSION
+    candidates = [_dict(row) for row in _list(input_report.get("candidates"))]
+    pending_status = str(input_report.get("review_status") or "pending") != "reviewed"
+    pending_overall = str(input_report.get("overall_decision") or "pending") == "pending"
+    pending_fields = {
+        str(_int(row.get("review_index"))): pending_candidate_fields(row)
+        for row in candidates
+        if pending_candidate_fields(row)
+    }
+    candidate_count_matched = len(candidates) == int(candidate_count)
+    validated = bool(
+        schema_matched
+        and candidate_count_matched
+        and not pending_status
+        and not pending_overall
+        and not pending_fields
+    )
+    return {
+        "schema_matched": schema_matched,
+        "validated_listening_input_present": validated,
+        "candidate_count_matched": candidate_count_matched,
+        "input_candidate_count": len(candidates),
+        "expected_candidate_count": int(candidate_count),
+        "pending_status": pending_status,
+        "pending_overall_decision": pending_overall,
+        "pending_candidate_field_count": sum(len(fields) for fields in pending_fields.values()),
+        "pending_candidate_fields": pending_fields,
+    }
+
+
+def load_or_build_package(
+    *,
+    package_report_path: Path,
+    output_dir: Path,
+    audio_package_report_path: Path,
+    repair_sweep_report_path: Path,
+    source_repair_sweep_report_path: Path,
+    objective_decision_report_path: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+    min_candidates: int,
+) -> dict[str, Any]:
+    if package_report_path.exists():
+        return read_json(package_report_path)
+    audio_package = load_or_build_audio_package(
+        audio_package_report_path=audio_package_report_path,
+        output_dir=output_dir / "source_audio_build",
+        repair_sweep_report_path=repair_sweep_report_path,
+        source_repair_sweep_report_path=source_repair_sweep_report_path,
+        objective_decision_report_path=objective_decision_report_path,
+        renderer_path=renderer_path,
+        soundfont_path=soundfont_path,
+        sample_rate=int(sample_rate),
+    )
+    return build_listening_package(
+        audio_package,
+        output_dir=output_dir / "source_listening_package",
+        min_candidates=int(min_candidates),
+    )
+
+
+def build_guard_report(
+    package_report: dict[str, Any],
+    *,
+    output_dir: Path,
+    listening_input_path: Path | None,
+) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    package_validation = validate_package(package_report)
+    default_input_path = Path(package_validation["output_dir"]) / "listening_review_input_template.json"
+    input_path = listening_input_path or default_input_path
+    input_validation = validate_input(
+        read_json(input_path),
+        candidate_count=_int(package_validation["candidate_count"]),
+    )
+    preference_fill_allowed = bool(input_validation["validated_listening_input_present"])
+    readiness = {
+        "listening_input_guard_completed": True,
+        "source_package_ready": True,
+        "validated_listening_input_present": preference_fill_allowed,
+        "preference_fill_allowed": preference_fill_allowed,
+        "objective_only_next_decision_required": not preference_fill_allowed,
+        "audio_rendered_quality_claimed": False,
+        "musical_quality_claimed": False,
+        "artist_style_claimed": False,
+        "production_ready_claimed": False,
+    }
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "boundary": BOUNDARY,
+        "source_package": {
+            "schema_version": package_report.get("schema_version"),
+            "output_dir": package_validation["output_dir"],
+            "candidate_count": package_validation["candidate_count"],
+            "source_validated_listening_input_present": package_validation[
+                "validated_listening_input_present"
+            ],
+            "source_preference_fill_allowed": package_validation["preference_fill_allowed"],
+        },
+        "listening_input_path": str(input_path),
+        "input_validation": input_validation,
+        "readiness": readiness,
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "next_boundary": NEXT_BOUNDARY_REVIEWED if preference_fill_allowed else NEXT_BOUNDARY_PENDING,
+            "critical_user_input_required": False,
+            "reason": (
+                "validated listening input present"
+                if preference_fill_allowed
+                else "listening input pending; route to objective-only next decision without quality claim"
+            ),
+        },
+        "not_proven": [
+            "human_audio_preference",
+            "stable_jazz_solo_quality",
+            "artist_level_long_solo_generation",
+            "production_ready_improviser",
+        ],
+    }
+    write_json(output_dir / "chord_role_balance_repair_listening_input_guard.json", report)
+    write_json(
+        output_dir / "chord_role_balance_repair_listening_input_guard_summary.json",
+        validate_report(report, require_no_quality_claim=True),
+    )
+    write_text(output_dir / "chord_role_balance_repair_listening_input_guard.md", markdown_report(report))
+    return report
+
+
+def validate_report(report: dict[str, Any], *, require_no_quality_claim: bool) -> dict[str, Any]:
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise SoloYieldChordRoleBalanceListeningInputGuardError("schema version mismatch")
+    readiness = _dict(report.get("readiness"))
+    if require_no_quality_claim:
+        _require_no_quality_claim(readiness)
+    validation = _dict(report.get("input_validation"))
+    decision = _dict(report.get("decision"))
+    return {
+        "schema_version": str(report.get("schema_version") or ""),
+        "boundary": str(report.get("boundary") or ""),
+        "candidate_count": _int(_dict(report.get("source_package")).get("candidate_count")),
+        "schema_matched": bool(validation.get("schema_matched", False)),
+        "validated_listening_input_present": bool(validation.get("validated_listening_input_present", False)),
+        "preference_fill_allowed": bool(readiness.get("preference_fill_allowed", True)),
+        "objective_only_next_decision_required": bool(
+            readiness.get("objective_only_next_decision_required", False)
+        ),
+        "pending_status": bool(validation.get("pending_status", False)),
+        "pending_overall_decision": bool(validation.get("pending_overall_decision", False)),
+        "pending_candidate_field_count": _int(validation.get("pending_candidate_field_count")),
+        "musical_quality_claimed": bool(readiness.get("musical_quality_claimed", True)),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    validation = report["input_validation"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    lines = [
+        "# Music Transformer Solo Yield Chord Role Balance Repair Listening Input Guard",
+        "",
+        "## Summary",
+        "",
+        f"- boundary: `{report['boundary']}`",
+        f"- source candidate count: `{report['source_package']['candidate_count']}`",
+        f"- listening input path: `{report['listening_input_path']}`",
+        f"- schema matched: `{_bool_token(validation['schema_matched'])}`",
+        f"- validated listening input present: `{_bool_token(validation['validated_listening_input_present'])}`",
+        f"- preference fill allowed: `{_bool_token(readiness['preference_fill_allowed'])}`",
+        f"- objective-only next decision required: `{_bool_token(readiness['objective_only_next_decision_required'])}`",
+        f"- pending status: `{_bool_token(validation['pending_status'])}`",
+        f"- pending overall decision: `{_bool_token(validation['pending_overall_decision'])}`",
+        f"- pending candidate field count: `{validation['pending_candidate_field_count']}`",
+        f"- musical quality claimed: `{_bool_token(readiness['musical_quality_claimed'])}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        "",
+        "## Pending Candidate Fields",
+        "",
+    ]
+    pending = _dict(validation.get("pending_candidate_fields"))
+    if pending:
+        for review_index, fields in pending.items():
+            lines.append(f"- review `{review_index}`: `{','.join(str(field) for field in fields)}`")
+    else:
+        lines.append("- `none`")
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Guard chord role balance repair listening input")
+    parser.add_argument(
+        "--package_report",
+        type=str,
+        default=(
+            "outputs/music_transformer_finetune_mvp/solo_yield_chord_role_balance_repair_listening_review/"
+            "issue_1288_chord_role_balance_listening_package/listening_review_package.json"
+        ),
+    )
+    parser.add_argument(
+        "--audio_package_report",
+        type=str,
+        default=(
+            "outputs/music_transformer_finetune_mvp/solo_yield_chord_role_balance_repair_audio/"
+            "issue_1286_chord_role_balance_audio_package/chord_role_balance_repair_audio_package.json"
+        ),
+    )
+    parser.add_argument(
+        "--repair_sweep_report",
+        type=str,
+        default=(
+            "outputs/music_transformer_finetune_mvp/solo_yield_chord_role_balance_repair/"
+            "issue_1284_chord_role_balance_repair_sweep/chord_role_balance_repair_sweep.json"
+        ),
+    )
+    parser.add_argument(
+        "--source_repair_sweep_report",
+        type=str,
+        default=(
+            "outputs/music_transformer_finetune_mvp/solo_yield_phrase_direction_repair/"
+            "issue_1274_phrase_direction_repair_sweep/phrase_direction_repair_sweep.json"
+        ),
+    )
+    parser.add_argument(
+        "--objective_decision_report",
+        type=str,
+        default=(
+            "outputs/music_transformer_finetune_mvp/solo_yield_phrase_direction_repair_objective_next/"
+            "issue_1282_phrase_direction_objective_next/"
+            "phrase_direction_objective_next_decision.json"
+        ),
+    )
+    parser.add_argument("--listening_input", type=str, default="")
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/music_transformer_finetune_mvp/solo_yield_chord_role_balance_repair_listening_input_guard",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--renderer", type=str, default="")
+    parser.add_argument("--soundfont", type=str, default="")
+    parser.add_argument("--sample_rate", type=int, default=44100)
+    parser.add_argument("--min_candidates", type=int, default=8)
+    parser.add_argument("--require_no_quality_claim", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    package_report = load_or_build_package(
+        package_report_path=Path(args.package_report),
+        output_dir=output_dir,
+        audio_package_report_path=Path(args.audio_package_report),
+        repair_sweep_report_path=Path(args.repair_sweep_report),
+        source_repair_sweep_report_path=Path(args.source_repair_sweep_report),
+        objective_decision_report_path=Path(args.objective_decision_report),
+        renderer_path=str(args.renderer or ""),
+        soundfont_path=str(args.soundfont or ""),
+        sample_rate=int(args.sample_rate),
+        min_candidates=int(args.min_candidates),
+    )
+    listening_input_path = Path(args.listening_input) if args.listening_input else None
+    report = build_guard_report(
+        package_report,
+        output_dir=output_dir,
+        listening_input_path=listening_input_path,
+    )
+    summary = validate_report(report, require_no_quality_claim=bool(args.require_no_quality_claim))
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown_report(report))
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_music_transformer_solo_yield_chord_role_balance_listening_input_guard.py
+++ b/tests/test_music_transformer_solo_yield_chord_role_balance_listening_input_guard.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.assess_stage_b_generic_base_readiness import write_json
+from scripts.guard_music_transformer_solo_yield_chord_role_balance_listening_input import (
+    BOUNDARY,
+    INPUT_SCHEMA_VERSION,
+    NEXT_BOUNDARY_PENDING,
+    NEXT_BOUNDARY_REVIEWED,
+    SCHEMA_VERSION,
+    SOURCE_PACKAGE_SCHEMA_VERSION,
+    SoloYieldChordRoleBalanceListeningInputGuardError,
+    build_guard_report,
+    validate_report,
+)
+
+
+def input_template(*, reviewed: bool = False) -> dict:
+    return {
+        "schema_version": INPUT_SCHEMA_VERSION,
+        "review_status": "reviewed" if reviewed else "pending",
+        "overall_decision": "keep_candidate_1" if reviewed else "pending",
+        "preferred_review_index": 1 if reviewed else None,
+        "candidates": [
+            {
+                "review_index": 1,
+                "case_label": "minor_backdoor",
+                "decision": "keep" if reviewed else "pending",
+                "usable_as_jazz_solo_phrase": True if reviewed else None,
+                "primary_failure": "none" if reviewed else None,
+                "notes": "",
+            },
+            {
+                "review_index": 2,
+                "case_label": "dominant_cycle",
+                "decision": "reject" if reviewed else "pending",
+                "usable_as_jazz_solo_phrase": False if reviewed else None,
+                "primary_failure": "too_mechanical" if reviewed else None,
+                "notes": "",
+            },
+        ],
+    }
+
+
+def package_report(root: Path, *, quality_claim: bool = False, reviewed: bool = False) -> dict:
+    package_dir = root / "package"
+    package_dir.mkdir(parents=True, exist_ok=True)
+    write_json(package_dir / "listening_review_input_template.json", input_template(reviewed=reviewed))
+    return {
+        "schema_version": SOURCE_PACKAGE_SCHEMA_VERSION,
+        "output_dir": str(package_dir),
+        "candidate_count": 2,
+        "readiness": {
+            "listening_package_ready": True,
+            "candidate_midi_files_copied": 2,
+            "candidate_wav_files_copied": 2,
+            "review_input_template_written": True,
+            "validated_listening_input_present": False,
+            "preference_fill_allowed": False,
+            "audio_rendered_quality_claimed": False,
+            "musical_quality_claimed": quality_claim,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+    }
+
+
+class MusicTransformerSoloYieldChordRoleBalanceListeningInputGuardTest(unittest.TestCase):
+    def test_pending_template_blocks_preference_fill(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            report = build_guard_report(
+                package_report(root),
+                output_dir=root / "guard",
+                listening_input_path=None,
+            )
+        summary = validate_report(report, require_no_quality_claim=True)
+
+        self.assertEqual(summary["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(summary["boundary"], BOUNDARY)
+        self.assertEqual(summary["candidate_count"], 2)
+        self.assertTrue(summary["schema_matched"])
+        self.assertFalse(summary["validated_listening_input_present"])
+        self.assertFalse(summary["preference_fill_allowed"])
+        self.assertTrue(summary["objective_only_next_decision_required"])
+        self.assertEqual(summary["pending_candidate_field_count"], 6)
+        self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY_PENDING)
+
+    def test_reviewed_template_allows_preference_fill(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            report = build_guard_report(
+                package_report(root, reviewed=True),
+                output_dir=root / "guard",
+                listening_input_path=None,
+            )
+        summary = validate_report(report, require_no_quality_claim=True)
+
+        self.assertTrue(summary["validated_listening_input_present"])
+        self.assertTrue(summary["preference_fill_allowed"])
+        self.assertFalse(summary["objective_only_next_decision_required"])
+        self.assertEqual(summary["pending_candidate_field_count"], 0)
+        self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY_REVIEWED)
+
+    def test_rejects_source_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with self.assertRaises(SoloYieldChordRoleBalanceListeningInputGuardError):
+                build_guard_report(
+                    package_report(root, quality_claim=True),
+                    output_dir=root / "guard",
+                    listening_input_path=None,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- chord role balance repair listening input guard 추가
- pending review input 검출
- preference fill 차단 유지
- objective-only next decision route 기록

## Context

- #1288 listening package 결과
- candidate count: `8`
- MIDI files copied: `8`
- WAV files copied: `8`
- review input template written: `true`
- validated listening input: `false`
- preference fill allowed: `false`
- next boundary: `music_transformer_solo_yield_chord_role_balance_repair_listening_input_guard`

## Scope

- source package schema/readiness 검증
- listening input schema 및 candidate count 검증
- pending status, overall decision, candidate field 집계
- preference fill allowed false 검증
- objective-only next decision route 기록

## Validation

- `.venv/bin/python -m unittest tests/test_music_transformer_solo_yield_chord_role_balance_listening_input_guard.py`
- `.venv/bin/python scripts/guard_music_transformer_solo_yield_chord_role_balance_listening_input.py --run_id issue_1290_chord_role_balance_input_guard --doc_path docs/STAGE_B_MIDI_TO_SOLO_CHORD_ROLE_BALANCE_REPAIR_LISTENING_INPUT_GUARD_2026-06-11.md --soundfont /Users/ohhalim/.local/share/soundfonts/generaluser-gs/v1.471.sf2 --require_no_quality_claim`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Result

- schema matched: `true`
- validated listening input: `false`
- preference fill allowed: `false`
- pending candidate fields: `24`
- objective-only next decision required: `true`
- musical quality claim: `false`

## Risk

- 청취 선호 입력 부재
- musical quality claim 없음
- objective-only next decision에서 다음 target 분리 필요

## Follow-up

- chord role balance repair objective-only next decision

Closes #1290
