### PR TITLE
Stage B MIDI-to-solo density aftercare audio package

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MIDI 데이터를 token sequence로 변환하고, Music Transformer 계열 symbo
 - 2마디 후보 생성: strict `24 / 24`, grammar-valid `24 / 24`
 - 4마디 확장 후보 생성: strict `20 / 24`, grammar-valid `24 / 24`
 - 4마디 dead-air repair 이후: strict `22 / 24`, grammar-valid `24 / 24`
-- density aftercare sweep: low note count `2 / 8 -> 0 / 8`, inserted notes `3`, next `density_aftercare_audio_package`
+- density aftercare audio package: WAV `8`, technical validation `true`, next `density_aftercare_listening_package`
 - final status audit: technical evidence ready `true`
 - 음악적 품질 claim: `false`
 - 사람 기준 청취 선호 입력: `false`
@@ -142,6 +142,8 @@ raw model generation은 note grammar가 자주 깨졌다.
 - next boundary: `music_transformer_solo_yield_density_aftercare_sweep`
 - density aftercare sweep: low note count `2 / 8 -> 0 / 8`, inserted note `3`, chord-tone ratio decrease `0`, weak direction residual `0 / 8`, final landing residual `0 / 8`, wide interval review `1 / 8 -> 1 / 8`
 - next boundary: `music_transformer_solo_yield_density_aftercare_audio_package`
+- density aftercare audio package: rendered WAV `8`, technical WAV validation `true`, duration range `10.725s - 10.739s`
+- next boundary: `music_transformer_solo_yield_density_aftercare_listening_package`
 
 ## 결과 파일
 
@@ -199,6 +201,7 @@ Report:
 - `docs/STAGE_B_MIDI_TO_SOLO_CHORD_ROLE_BALANCE_REPAIR_LISTENING_INPUT_GUARD_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_CHORD_ROLE_BALANCE_REPAIR_OBJECTIVE_ONLY_NEXT_DECISION_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_DENSITY_AFTERCARE_SWEEP_2026-06-11.md`
+- `docs/STAGE_B_MIDI_TO_SOLO_DENSITY_AFTERCARE_AUDIO_PACKAGE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_SWEEP_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_AUDIO_PACKAGE_2026-06-11.md`
 - `docs/STAGE_B_MIDI_TO_SOLO_PHRASE_DIRECTION_REPAIR_LISTENING_PACKAGE_2026-06-11.md`

--- a/docs/STAGE_B_MIDI_TO_SOLO_DENSITY_AFTERCARE_AUDIO_PACKAGE_2026-06-11.md
+++ b/docs/STAGE_B_MIDI_TO_SOLO_DENSITY_AFTERCARE_AUDIO_PACKAGE_2026-06-11.md
@@ -1,0 +1,68 @@
+# Music Transformer Solo Yield Density Aftercare Audio Package
+
+## Summary
+
+- source repaired MIDI count: `8`
+- source low note count: `2 -> 0`
+- source inserted note total: `3`
+- source chord-tone ratio decrease count: `0`
+- source weak direction-change after: `0`
+- source final landing not chord-tone after: `0`
+- source wide interval review: `1 -> 1`
+- rendered WAV count: `8`
+- technical WAV validation: `true`
+- WAV duration range: `10.725 - 10.739`
+- audio rendered quality claimed: `false`
+- musical quality claimed: `false`
+- next boundary: `music_transformer_solo_yield_density_aftercare_listening_package`
+
+## Rendered Files
+
+- candidate `1` / `minor_backdoor`
+  - MIDI: `outputs/music_transformer_finetune_mvp/solo_yield_density_aftercare/issue_1294_density_aftercare_sweep/midi/candidate_01_minor_backdoor_density_aftercare.mid`
+  - WAV: `outputs/music_transformer_finetune_mvp/solo_yield_density_aftercare_audio/issue_1296_density_aftercare_audio_package/audio/candidate_01_minor_backdoor_density_aftercare.wav`
+  - duration: `10.739`
+  - sample rate: `44100`
+- candidate `2` / `minor_backdoor`
+  - MIDI: `outputs/music_transformer_finetune_mvp/solo_yield_density_aftercare/issue_1294_density_aftercare_sweep/midi/candidate_02_minor_backdoor_density_aftercare.mid`
+  - WAV: `outputs/music_transformer_finetune_mvp/solo_yield_density_aftercare_audio/issue_1296_density_aftercare_audio_package/audio/candidate_02_minor_backdoor_density_aftercare.wav`
+  - duration: `10.738`
+  - sample rate: `44100`
+- candidate `3` / `major_ii_v_turnaround`
+  - MIDI: `outputs/music_transformer_finetune_mvp/solo_yield_density_aftercare/issue_1294_density_aftercare_sweep/midi/candidate_03_major_ii_v_turnaround_density_aftercare.mid`
+  - WAV: `outputs/music_transformer_finetune_mvp/solo_yield_density_aftercare_audio/issue_1296_density_aftercare_audio_package/audio/candidate_03_major_ii_v_turnaround_density_aftercare.wav`
+  - duration: `10.735`
+  - sample rate: `44100`
+- candidate `4` / `major_ii_v_turnaround`
+  - MIDI: `outputs/music_transformer_finetune_mvp/solo_yield_density_aftercare/issue_1294_density_aftercare_sweep/midi/candidate_04_major_ii_v_turnaround_density_aftercare.mid`
+  - WAV: `outputs/music_transformer_finetune_mvp/solo_yield_density_aftercare_audio/issue_1296_density_aftercare_audio_package/audio/candidate_04_major_ii_v_turnaround_density_aftercare.wav`
+  - duration: `10.738`
+  - sample rate: `44100`
+- candidate `5` / `dominant_cycle`
+  - MIDI: `outputs/music_transformer_finetune_mvp/solo_yield_density_aftercare/issue_1294_density_aftercare_sweep/midi/candidate_05_dominant_cycle_density_aftercare.mid`
+  - WAV: `outputs/music_transformer_finetune_mvp/solo_yield_density_aftercare_audio/issue_1296_density_aftercare_audio_package/audio/candidate_05_dominant_cycle_density_aftercare.wav`
+  - duration: `10.738`
+  - sample rate: `44100`
+- candidate `6` / `dominant_cycle`
+  - MIDI: `outputs/music_transformer_finetune_mvp/solo_yield_density_aftercare/issue_1294_density_aftercare_sweep/midi/candidate_06_dominant_cycle_density_aftercare.mid`
+  - WAV: `outputs/music_transformer_finetune_mvp/solo_yield_density_aftercare_audio/issue_1296_density_aftercare_audio_package/audio/candidate_06_dominant_cycle_density_aftercare.wav`
+  - duration: `10.725`
+  - sample rate: `44100`
+- candidate `7` / `rhythm_turnaround`
+  - MIDI: `outputs/music_transformer_finetune_mvp/solo_yield_density_aftercare/issue_1294_density_aftercare_sweep/midi/candidate_07_rhythm_turnaround_density_aftercare.mid`
+  - WAV: `outputs/music_transformer_finetune_mvp/solo_yield_density_aftercare_audio/issue_1296_density_aftercare_audio_package/audio/candidate_07_rhythm_turnaround_density_aftercare.wav`
+  - duration: `10.735`
+  - sample rate: `44100`
+- candidate `8` / `rhythm_turnaround`
+  - MIDI: `outputs/music_transformer_finetune_mvp/solo_yield_density_aftercare/issue_1294_density_aftercare_sweep/midi/candidate_08_rhythm_turnaround_density_aftercare.mid`
+  - WAV: `outputs/music_transformer_finetune_mvp/solo_yield_density_aftercare_audio/issue_1296_density_aftercare_audio_package/audio/candidate_08_rhythm_turnaround_density_aftercare.wav`
+  - duration: `10.738`
+  - sample rate: `44100`
+
+## Not Proven
+
+- `audio_rendered_quality`
+- `human_audio_preference`
+- `stable_jazz_solo_quality`
+- `artist_level_long_solo_generation`
+- `production_ready_improviser`

--- a/scripts/render_music_transformer_solo_yield_density_aftercare_audio.py
+++ b/scripts/render_music_transformer_solo_yield_density_aftercare_audio.py
@@ -1,0 +1,422 @@
+"""Render density-aftercare repaired solo-yield MIDI candidates to WAV."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.assess_stage_b_generic_base_readiness import write_json, write_text  # noqa: E402
+from scripts.render_stage_b_midi_to_solo_candidate_audio import (  # noqa: E402
+    resolve_soundfont,
+    sha256_file,
+    wav_meta,
+)
+from scripts.run_music_transformer_solo_yield_density_aftercare_sweep import (  # noqa: E402
+    SCHEMA_VERSION as DENSITY_REPAIR_SCHEMA_VERSION,
+    build_repair_sweep,
+    read_json,
+)
+
+
+SCHEMA_VERSION = "music_transformer_solo_yield_density_aftercare_audio_package_v1"
+BOUNDARY = "music_transformer_solo_yield_density_aftercare_audio_package"
+NEXT_BOUNDARY = "music_transformer_solo_yield_density_aftercare_listening_package"
+CommandRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+
+class SoloYieldDensityAftercareAudioPackageError(ValueError):
+    pass
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bool_token(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _require_no_quality_claim(report: dict[str, Any]) -> None:
+    readiness = _dict(report.get("readiness"))
+    claimed = [
+        key
+        for key in (
+            "audio_rendered_quality_claimed",
+            "musical_quality_claimed",
+            "artist_style_claimed",
+            "production_ready_claimed",
+        )
+        if bool(readiness.get(key, False))
+    ]
+    if claimed:
+        raise SoloYieldDensityAftercareAudioPackageError(f"unexpected quality claim: {claimed}")
+
+
+def _validate_repair_sweep(report: dict[str, Any]) -> list[dict[str, Any]]:
+    if str(report.get("schema_version") or "") != DENSITY_REPAIR_SCHEMA_VERSION:
+        raise SoloYieldDensityAftercareAudioPackageError("density aftercare repair schema required")
+    _require_no_quality_claim(report)
+    aggregate = _dict(report.get("aggregate"))
+    if not bool(aggregate.get("target_supported", False)):
+        raise SoloYieldDensityAftercareAudioPackageError("target support required")
+    rows = [_dict(item) for item in _list(report.get("candidate_repairs"))]
+    if not rows:
+        raise SoloYieldDensityAftercareAudioPackageError("candidate repairs required")
+    for row in rows:
+        midi_path = Path(str(row.get("repaired_midi_path") or ""))
+        if not midi_path.exists():
+            raise SoloYieldDensityAftercareAudioPackageError(f"repaired MIDI missing: {midi_path}")
+    return rows
+
+
+def load_or_build_repair_sweep(
+    *,
+    repair_sweep_report_path: Path,
+    output_dir: Path,
+    source_repair_sweep_report_path: Path,
+    objective_decision_report_path: Path,
+) -> dict[str, Any]:
+    if repair_sweep_report_path.exists():
+        return read_json(repair_sweep_report_path)
+    return build_repair_sweep(
+        source_repair_sweep=read_json(source_repair_sweep_report_path),
+        objective_decision=read_json(objective_decision_report_path),
+        output_dir=output_dir / "source_density_aftercare",
+    )
+
+
+def build_render_plan(
+    repairs: list[dict[str, Any]],
+    *,
+    output_dir: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+) -> list[dict[str, Any]]:
+    renderer = Path(renderer_path)
+    soundfont = Path(soundfont_path).expanduser()
+    if not renderer.exists():
+        raise SoloYieldDensityAftercareAudioPackageError(f"renderer not found: {renderer}")
+    if not soundfont.exists():
+        raise SoloYieldDensityAftercareAudioPackageError(f"soundfont not found: {soundfont}")
+    plan: list[dict[str, Any]] = []
+    for row in repairs:
+        review_index = _int(row.get("review_index"))
+        case_label = str(row.get("case_label") or "candidate")
+        source_midi = Path(str(row.get("repaired_midi_path") or ""))
+        wav_path = output_dir / "audio" / f"candidate_{review_index:02d}_{case_label}_density_aftercare.wav"
+        plan.append(
+            {
+                "review_index": review_index,
+                "case_label": case_label,
+                "repaired_midi_path": str(source_midi),
+                "source_midi_path": str(row.get("source_midi_path") or ""),
+                "wav_path": str(wav_path),
+                "command": [
+                    str(renderer),
+                    "-ni",
+                    "-F",
+                    str(wav_path),
+                    "-r",
+                    str(int(sample_rate)),
+                    str(soundfont),
+                    str(source_midi),
+                ],
+            }
+        )
+    return plan
+
+
+def default_runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(list(command), check=False, text=True, capture_output=True)
+
+
+def execute_render_plan(plan: list[dict[str, Any]], *, runner: CommandRunner = default_runner) -> list[dict[str, Any]]:
+    rendered: list[dict[str, Any]] = []
+    for item in plan:
+        wav_path = Path(str(item["wav_path"]))
+        wav_path.parent.mkdir(parents=True, exist_ok=True)
+        completed = runner(item["command"])
+        if completed.returncode != 0:
+            raise SoloYieldDensityAftercareAudioPackageError(
+                f"render failed for candidate {item['review_index']}: {completed.stderr or completed.stdout}"
+            )
+        rendered.append(
+            {
+                "review_index": item["review_index"],
+                "case_label": item["case_label"],
+                "source_midi_path": item["source_midi_path"],
+                "repaired_midi_path": item["repaired_midi_path"],
+                "wav_file": wav_meta(wav_path),
+                "command": list(item["command"]),
+                "stdout_tail": (completed.stdout or "")[-1000:],
+                "stderr_tail": (completed.stderr or "")[-1000:],
+            }
+        )
+    return rendered
+
+
+def build_audio_package(
+    repair_sweep: dict[str, Any],
+    *,
+    output_dir: Path,
+    renderer_path: str,
+    soundfont_path: str,
+    sample_rate: int,
+    runner: CommandRunner = default_runner,
+) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    repairs = _validate_repair_sweep(repair_sweep)
+    resolved_renderer = renderer_path or shutil.which("fluidsynth") or ""
+    resolved_soundfont = resolve_soundfont(soundfont_path)
+    plan = build_render_plan(
+        repairs,
+        output_dir=output_dir,
+        renderer_path=resolved_renderer,
+        soundfont_path=resolved_soundfont,
+        sample_rate=int(sample_rate),
+    )
+    rendered = execute_render_plan(plan, runner=runner)
+    durations = [_float(_dict(item.get("wav_file")).get("duration_seconds")) for item in rendered]
+    source_aggregate = _dict(repair_sweep.get("aggregate"))
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "output_dir": str(output_dir),
+        "boundary": BOUNDARY,
+        "source_repair_sweep": {
+            "schema_version": repair_sweep.get("schema_version"),
+            "output_dir": repair_sweep.get("output_dir"),
+            "candidate_count": _int(source_aggregate.get("candidate_count")),
+            "repaired_midi_count": _int(source_aggregate.get("repaired_midi_count")),
+            "low_note_count_before": _int(source_aggregate.get("low_note_count_before")),
+            "low_note_count_after": _int(source_aggregate.get("low_note_count_after")),
+            "inserted_note_total": _int(source_aggregate.get("inserted_note_total")),
+            "chord_tone_ratio_decrease_count": _int(
+                source_aggregate.get("chord_tone_ratio_decrease_count")
+            ),
+            "weak_direction_change_count_after": _int(
+                source_aggregate.get("weak_direction_change_count_after")
+            ),
+            "final_landing_not_chord_tone_count_after": _int(
+                source_aggregate.get("final_landing_not_chord_tone_count_after")
+            ),
+            "wide_interval_review_count_before": _int(
+                source_aggregate.get("wide_interval_review_count_before")
+            ),
+            "wide_interval_review_count_after": _int(
+                source_aggregate.get("wide_interval_review_count_after")
+            ),
+        },
+        "renderer": {
+            "name": "fluidsynth",
+            "path": resolved_renderer,
+        },
+        "soundfont": {
+            "path": str(Path(resolved_soundfont).expanduser()),
+            "sha256": sha256_file(Path(resolved_soundfont).expanduser()),
+        },
+        "rendered_audio_files": rendered,
+        "aggregate": {
+            "rendered_wav_count": len(rendered),
+            "technical_wav_validation": len(rendered) == len(repairs),
+            "wav_duration_min_seconds": min(durations) if durations else 0.0,
+            "wav_duration_max_seconds": max(durations) if durations else 0.0,
+            "sample_rate": int(sample_rate),
+        },
+        "readiness": {
+            "audio_package_completed": True,
+            "technical_wav_validation": len(rendered) == len(repairs),
+            "validated_listening_input_present": False,
+            "audio_rendered_quality_claimed": False,
+            "musical_quality_claimed": False,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+        "decision": {
+            "current_boundary": BOUNDARY,
+            "selected_next_target": "density_aftercare_listening_package",
+            "next_boundary": NEXT_BOUNDARY,
+            "critical_user_input_required": False,
+            "reason": "density-aftercare repaired MIDI rendered to WAV for technical listening package",
+        },
+        "not_proven": [
+            "audio_rendered_quality",
+            "human_audio_preference",
+            "stable_jazz_solo_quality",
+            "artist_level_long_solo_generation",
+            "production_ready_improviser",
+        ],
+    }
+    write_json(output_dir / "density_aftercare_audio_package.json", report)
+    write_json(output_dir / "density_aftercare_audio_package_summary.json", validate_report(report))
+    write_text(output_dir / "density_aftercare_audio_package.md", markdown_report(report))
+    return report
+
+
+def validate_report(report: dict[str, Any], *, min_wav_count: int = 1) -> dict[str, Any]:
+    if str(report.get("schema_version") or "") != SCHEMA_VERSION:
+        raise SoloYieldDensityAftercareAudioPackageError("schema version mismatch")
+    readiness = _dict(report.get("readiness"))
+    aggregate = _dict(report.get("aggregate"))
+    rendered_count = _int(aggregate.get("rendered_wav_count"))
+    if rendered_count < int(min_wav_count):
+        raise SoloYieldDensityAftercareAudioPackageError("rendered WAV count below requirement")
+    if not bool(readiness.get("audio_package_completed", False)):
+        raise SoloYieldDensityAftercareAudioPackageError("audio package completion required")
+    if not bool(aggregate.get("technical_wav_validation", False)):
+        raise SoloYieldDensityAftercareAudioPackageError("technical WAV validation required")
+    _require_no_quality_claim(report)
+    decision = _dict(report.get("decision"))
+    return {
+        "schema_version": str(report.get("schema_version") or ""),
+        "rendered_wav_count": rendered_count,
+        "technical_wav_validation": bool(aggregate.get("technical_wav_validation", False)),
+        "wav_duration_min_seconds": _float(aggregate.get("wav_duration_min_seconds")),
+        "wav_duration_max_seconds": _float(aggregate.get("wav_duration_max_seconds")),
+        "sample_rate": _int(aggregate.get("sample_rate")),
+        "audio_rendered_quality_claimed": bool(readiness.get("audio_rendered_quality_claimed", True)),
+        "musical_quality_claimed": bool(readiness.get("musical_quality_claimed", True)),
+        "next_boundary": str(decision.get("next_boundary") or ""),
+    }
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    source = report["source_repair_sweep"]
+    aggregate = report["aggregate"]
+    readiness = report["readiness"]
+    decision = report["decision"]
+    lines = [
+        "# Music Transformer Solo Yield Density Aftercare Audio Package",
+        "",
+        "## Summary",
+        "",
+        f"- source repaired MIDI count: `{source['repaired_midi_count']}`",
+        f"- source low note count: `{source['low_note_count_before']} -> {source['low_note_count_after']}`",
+        f"- source inserted note total: `{source['inserted_note_total']}`",
+        f"- source chord-tone ratio decrease count: `{source['chord_tone_ratio_decrease_count']}`",
+        f"- source weak direction-change after: `{source['weak_direction_change_count_after']}`",
+        f"- source final landing not chord-tone after: `{source['final_landing_not_chord_tone_count_after']}`",
+        f"- source wide interval review: `{source['wide_interval_review_count_before']} -> {source['wide_interval_review_count_after']}`",
+        f"- rendered WAV count: `{aggregate['rendered_wav_count']}`",
+        f"- technical WAV validation: `{_bool_token(aggregate['technical_wav_validation'])}`",
+        f"- WAV duration range: `{float(aggregate['wav_duration_min_seconds']):.3f} - {float(aggregate['wav_duration_max_seconds']):.3f}`",
+        f"- audio rendered quality claimed: `{_bool_token(readiness['audio_rendered_quality_claimed'])}`",
+        f"- musical quality claimed: `{_bool_token(readiness['musical_quality_claimed'])}`",
+        f"- next boundary: `{decision['next_boundary']}`",
+        "",
+        "## Rendered Files",
+        "",
+    ]
+    for item in report.get("rendered_audio_files", []):
+        wav = item["wav_file"]
+        lines.extend(
+            [
+                f"- candidate `{item['review_index']}` / `{item['case_label']}`",
+                f"  - MIDI: `{item['repaired_midi_path']}`",
+                f"  - WAV: `{wav['path']}`",
+                f"  - duration: `{float(wav['duration_seconds']):.3f}`",
+                f"  - sample rate: `{wav['sample_rate']}`",
+            ]
+        )
+    lines.extend(["", "## Not Proven", ""])
+    for item in report.get("not_proven", []):
+        lines.append(f"- `{item}`")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Render density aftercare repaired MIDI to WAV")
+    parser.add_argument(
+        "--repair_sweep_report",
+        type=str,
+        default=(
+            "outputs/music_transformer_finetune_mvp/solo_yield_density_aftercare/"
+            "issue_1294_density_aftercare_sweep/density_aftercare_sweep.json"
+        ),
+    )
+    parser.add_argument(
+        "--source_repair_sweep_report",
+        type=str,
+        default=(
+            "outputs/music_transformer_finetune_mvp/solo_yield_chord_role_balance_repair/"
+            "issue_1284_chord_role_balance_repair_sweep/chord_role_balance_repair_sweep.json"
+        ),
+    )
+    parser.add_argument(
+        "--objective_decision_report",
+        type=str,
+        default=(
+            "outputs/music_transformer_finetune_mvp/solo_yield_chord_role_balance_repair_objective_next/"
+            "issue_1292_chord_role_balance_objective_next/"
+            "chord_role_balance_objective_next_decision.json"
+        ),
+    )
+    parser.add_argument(
+        "--output_root",
+        type=str,
+        default="outputs/music_transformer_finetune_mvp/solo_yield_density_aftercare_audio",
+    )
+    parser.add_argument("--run_id", type=str, default=None)
+    parser.add_argument("--doc_path", type=str, default="")
+    parser.add_argument("--renderer", type=str, default=shutil.which("fluidsynth") or "")
+    parser.add_argument("--soundfont", type=str, default="")
+    parser.add_argument("--sample_rate", type=int, default=44100)
+    parser.add_argument("--min_wav_count", type=int, default=8)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_root) / run_id
+    repair_sweep = load_or_build_repair_sweep(
+        repair_sweep_report_path=Path(args.repair_sweep_report),
+        output_dir=output_dir,
+        source_repair_sweep_report_path=Path(args.source_repair_sweep_report),
+        objective_decision_report_path=Path(args.objective_decision_report),
+    )
+    report = build_audio_package(
+        repair_sweep,
+        output_dir=output_dir,
+        renderer_path=str(args.renderer or ""),
+        soundfont_path=str(args.soundfont or ""),
+        sample_rate=int(args.sample_rate),
+    )
+    summary = validate_report(report, min_wav_count=int(args.min_wav_count))
+    write_json(output_dir / "density_aftercare_audio_package_summary.json", summary)
+    if args.doc_path:
+        write_text(Path(args.doc_path), markdown_report(report))
+    print(json.dumps(summary, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_music_transformer_solo_yield_density_aftercare_audio.py
+++ b/tests/test_music_transformer_solo_yield_density_aftercare_audio.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+import wave
+from pathlib import Path
+from typing import Sequence
+
+import pretty_midi
+
+from scripts.render_music_transformer_solo_yield_density_aftercare_audio import (
+    NEXT_BOUNDARY,
+    SCHEMA_VERSION,
+    SoloYieldDensityAftercareAudioPackageError,
+    build_audio_package,
+    validate_report,
+)
+from scripts.run_music_transformer_solo_yield_density_aftercare_sweep import (
+    SCHEMA_VERSION as DENSITY_REPAIR_SCHEMA_VERSION,
+)
+
+
+def write_midi(path: Path) -> None:
+    midi = pretty_midi.PrettyMIDI(initial_tempo=124)
+    instrument = pretty_midi.Instrument(program=0)
+    instrument.notes.append(pretty_midi.Note(velocity=90, pitch=60, start=0.0, end=0.25))
+    instrument.notes.append(pretty_midi.Note(velocity=90, pitch=64, start=0.5, end=0.75))
+    midi.instruments.append(instrument)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    midi.write(str(path))
+
+
+def write_wav(path: Path, *, sample_rate: int = 44100) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(sample_rate)
+        handle.writeframes(b"\x00\x00" * sample_rate)
+
+
+def fake_runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    wav_path = Path(command[list(command).index("-F") + 1])
+    sample_rate = int(command[list(command).index("-r") + 1])
+    write_wav(wav_path, sample_rate=sample_rate)
+    return subprocess.CompletedProcess(list(command), 0, stdout="rendered", stderr="")
+
+
+def repair_sweep(root: Path, *, quality_claim: bool = False) -> dict:
+    midi_paths = [root / f"candidate_{index}.mid" for index in range(1, 3)]
+    for path in midi_paths:
+        write_midi(path)
+    return {
+        "schema_version": DENSITY_REPAIR_SCHEMA_VERSION,
+        "output_dir": str(root / "repair"),
+        "candidate_repairs": [
+            {
+                "review_index": 1,
+                "case_label": "minor_backdoor",
+                "source_midi_path": str(midi_paths[0]),
+                "repaired_midi_path": str(midi_paths[0]),
+            },
+            {
+                "review_index": 2,
+                "case_label": "dominant_cycle",
+                "source_midi_path": str(midi_paths[1]),
+                "repaired_midi_path": str(midi_paths[1]),
+            },
+        ],
+        "aggregate": {
+            "candidate_count": 2,
+            "repaired_midi_count": 2,
+            "target_supported": True,
+            "low_note_count_before": 1,
+            "low_note_count_after": 0,
+            "inserted_note_total": 2,
+            "chord_tone_ratio_decrease_count": 0,
+            "weak_direction_change_count_after": 0,
+            "final_landing_not_chord_tone_count_after": 0,
+            "wide_interval_review_count_before": 1,
+            "wide_interval_review_count_after": 1,
+        },
+        "readiness": {
+            "audio_rendered_quality_claimed": False,
+            "musical_quality_claimed": quality_claim,
+            "artist_style_claimed": False,
+            "production_ready_claimed": False,
+        },
+    }
+
+
+class MusicTransformerSoloYieldDensityAftercareAudioTest(unittest.TestCase):
+    def test_renders_density_repaired_midi_wavs_without_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            soundfont = root / "soundfont.sf2"
+            renderer.write_text("#!/bin/sh\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            report = build_audio_package(
+                repair_sweep(root),
+                output_dir=root / "audio",
+                renderer_path=str(renderer),
+                soundfont_path=str(soundfont),
+                sample_rate=22050,
+                runner=fake_runner,
+            )
+        summary = validate_report(report, min_wav_count=2)
+
+        self.assertEqual(summary["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(summary["rendered_wav_count"], 2)
+        self.assertTrue(summary["technical_wav_validation"])
+        self.assertEqual(summary["sample_rate"], 22050)
+        self.assertFalse(summary["audio_rendered_quality_claimed"])
+        self.assertFalse(summary["musical_quality_claimed"])
+        self.assertEqual(summary["next_boundary"], NEXT_BOUNDARY)
+
+    def test_rejects_quality_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            soundfont = root / "soundfont.sf2"
+            renderer.write_text("#!/bin/sh\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            with self.assertRaises(SoloYieldDensityAftercareAudioPackageError):
+                build_audio_package(
+                    repair_sweep(root, quality_claim=True),
+                    output_dir=root / "audio",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(soundfont),
+                    sample_rate=22050,
+                    runner=fake_runner,
+                )
+
+    def test_rejects_missing_repaired_midi(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            renderer = root / "fluidsynth"
+            soundfont = root / "soundfont.sf2"
+            renderer.write_text("#!/bin/sh\n", encoding="utf-8")
+            soundfont.write_bytes(b"sf2")
+            source = repair_sweep(root)
+            Path(source["candidate_repairs"][0]["repaired_midi_path"]).unlink()
+            with self.assertRaises(SoloYieldDensityAftercareAudioPackageError):
+                build_audio_package(
+                    source,
+                    output_dir=root / "audio",
+                    renderer_path=str(renderer),
+                    soundfont_path=str(soundfont),
+                    sample_rate=22050,
+                    runner=fake_runner,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- density aftercare audio package 추가
- repaired MIDI `8`개 WAV 렌더링
- WAV technical metadata 검증
- README 최신 evidence 갱신

## Context

- #1294 density aftercare sweep 결과
- repaired MIDI count: `8`
- low note count: `2 / 8 -> 0 / 8`
- inserted notes: `3`
- chord-tone ratio decrease: `0`
- weak direction residual: `0 / 8`
- final landing residual: `0 / 8`
- next boundary: `music_transformer_solo_yield_density_aftercare_audio_package`

## Scope

- repair sweep source schema 검증
- repaired MIDI existence 검증
- fluidsynth 기반 WAV render package 생성
- WAV technical metadata 검증
- musical quality claim 차단

## Validation

- `.venv/bin/python -m unittest tests/test_music_transformer_solo_yield_density_aftercare_audio.py`
- `.venv/bin/python scripts/render_music_transformer_solo_yield_density_aftercare_audio.py --run_id issue_1296_density_aftercare_audio_package --doc_path docs/STAGE_B_MIDI_TO_SOLO_DENSITY_AFTERCARE_AUDIO_PACKAGE_2026-06-11.md --soundfont /Users/ohhalim/.local/share/soundfonts/generaluser-gs/v1.471.sf2`
- `bash scripts/agent_harness.sh quick`
- `git diff --check`

## Result

- rendered WAV count: `8`
- technical WAV validation: `true`
- duration range: `10.725s - 10.739s`
- sample rate: `44100`
- audio rendered quality claim: `false`
- musical quality claim: `false`

## Risk

- audio rendering은 technical artifact 생성 범위
- 청취 선호 또는 musical quality claim 없음
- 다음 listening package에서 review 입력 경계 필요

## Follow-up

- density aftercare listening package

Closes #1296
